### PR TITLE
Database: add `db.WithTransact`

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // DB is an interface that embeds dbutil.DB, adding methods to
@@ -64,6 +65,7 @@ type DB interface {
 	ZoektRepos() ZoektReposStore
 
 	Transact(context.Context) (DB, error)
+	WithTransact(context.Context, func(tx DB) error) error
 	Done(error) error
 }
 
@@ -102,6 +104,31 @@ func (d *db) Transact(ctx context.Context) (DB, error) {
 		return nil, err
 	}
 	return &db{logger: d.logger, Store: tx}, nil
+}
+
+var ErrPanicDuringTransaction = errors.New("encountered panic during transaction")
+
+func (d *db) WithTransact(ctx context.Context, f func(tx DB) error) (err error) {
+	tx, err := d.Store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	txDB := &db{logger: d.logger, Store: tx}
+
+	defer func() {
+		if r := recover(); r != nil {
+			// If we're panicking, roll back the transaction
+			// even when err is nil.
+			err = tx.Done(ErrPanicDuringTransaction)
+			// Re-throw the panic after rolling back the transaction
+			panic(r)
+		} else {
+			// If we're not panicking, roll back the transaction if the
+			// operation on the transaction failed for whatever reason.
+			err = tx.Done(err)
+		}
+	}()
+	return f(txDB)
 }
 
 func (d *db) Done(err error) error {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -113,7 +113,6 @@ func (d *db) WithTransact(ctx context.Context, f func(tx DB) error) (err error) 
 	if err != nil {
 		return err
 	}
-	txDB := &db{logger: d.logger, Store: tx}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -128,7 +127,7 @@ func (d *db) WithTransact(ctx context.Context, f func(tx DB) error) (err error) 
 			err = tx.Done(err)
 		}
 	}()
-	return f(txDB)
+	return f(&db{logger: d.logger, Store: tx})
 }
 
 func (d *db) Done(err error) error {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -194,6 +194,8 @@ func TestDBTransactions(t *testing.T) {
 				require.Equal(t, api.RepoName("test2"), r.Name)
 
 				// Before committing the transaction, repo 2 should be visible inside tx1
+				// because nested transactions are savepoints and are not isolated from
+				// one another.
 				r, err = tx1.Get(ctx, 2)
 				require.NoError(t, err)
 				require.Equal(t, api.RepoName("test2"), r.Name)
@@ -219,5 +221,223 @@ func TestDBTransactions(t *testing.T) {
 		r, err := db.Repos().Get(ctx, 1)
 		require.NoError(t, err)
 		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+}
+
+func TestDBWithTransact(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	t.Run("no transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		err := db.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+		require.NoError(t, err)
+
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("basic transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		// Lifetime of tx
+		err := db.WithTransact(ctx, func(tx DB) error {
+			repos := tx.Repos()
+			err := repos.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := repos.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction. (THIS IS A BAD PATTERN. YOU SHOULD NOT
+			// BE REFERRING TO THE OUTER DB INSIDE THE CLOSURE)
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// After committing the transaction, the repo should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("rolled back transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		err := db.WithTransact(ctx, func(tx DB) error {
+			repos := tx.Repos()
+			err := repos.Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := repos.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction. (THIS IS A BAD PATTERN. YOU SHOULD NOT
+			// BE REFERRING TO THE OUTER DB INSIDE THE CLOSURE)
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			return errors.New("force a rollback")
+		})
+		require.Error(t, err)
+
+		// After rolling back the transaction, the repo should not be visible
+		// outside the transaction
+		_, err = db.Repos().Get(ctx, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("nested transaction works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		err := db.WithTransact(ctx, func(tx1 DB) error {
+			err := tx1.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx1.Repos().Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			err = tx1.WithTransact(ctx, func(tx2 DB) error {
+				err := tx2.Repos().Create(ctx, &types.Repo{ID: 2, Name: "test2"})
+				require.NoError(t, err)
+
+				// Get inside the transaction should work
+				r, err := tx2.Repos().Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+
+				// Before committing the transaction, repo 2 should not be visible
+				// outside the transaction
+				_, err = db.Repos().Get(ctx, 2)
+				require.Error(t, err)
+
+				return nil
+			})
+			require.NoError(t, err)
+
+			// After committing the transaction, repo 2 should be visible
+			// outside of tx2, in tx1, but not outside of tx2
+			r, err = tx1.Repos().Get(ctx, 2)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test2"), r.Name)
+
+			_, err = db.Repos().Get(ctx, 2)
+			require.Error(t, err)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// After committing the transaction, repo 1 should be visible
+		// outside of the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("nested transaction rollback works", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		err := db.WithTransact(ctx, func(tx1 DB) error {
+			err := tx1.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+			require.NoError(t, err)
+
+			// Get inside the transaction should work
+			r, err := tx1.Repos().Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, api.RepoName("test1"), r.Name)
+
+			// Before committing the transaction, the repo should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 1)
+			require.Error(t, err)
+
+			err = tx1.WithTransact(ctx, func(tx2 DB) error {
+				tx2, err := tx1.Transact(ctx)
+				require.NoError(t, err)
+
+				err = tx2.Repos().Create(ctx, &types.Repo{ID: 2, Name: "test2"})
+				require.NoError(t, err)
+
+				// Get inside the transaction should work
+				r, err := tx2.Repos().Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+
+				// Before committing the transaction, repo 2 should be visible inside tx1
+				// because nested transactions are savepoints and are not isolated from
+				// one another.
+				r, err = tx1.Repos().Get(ctx, 2)
+				require.NoError(t, err)
+				require.Equal(t, api.RepoName("test2"), r.Name)
+				// but not outside the transaction
+				_, err = db.Repos().Get(ctx, 2)
+				require.Error(t, err)
+
+				return errors.New("force rollback")
+			})
+			require.Error(t, err)
+
+			// After rolling back the transaction, repo 2 should not be visible
+			// outside the transaction
+			_, err = db.Repos().Get(ctx, 2)
+			require.Error(t, err)
+			_, err = tx1.Repos().Get(ctx, 2)
+			require.Error(t, err)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// After committing the transaction, repo 1 should be visible
+		// outisde the transaction
+		r, err := db.Repos().Get(ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, api.RepoName("test1"), r.Name)
+	})
+
+	t.Run("panic during transaction rolls back", func(t *testing.T) {
+		sqlDB := dbtest.NewDB(logger, t)
+		db := NewDB(logger, sqlDB)
+
+		// Panic should be propagated
+		require.Panics(t, func() {
+			_ = db.WithTransact(ctx, func(tx1 DB) error {
+				err := tx1.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
+				require.NoError(t, err)
+
+				panic("to infinity and beyond")
+
+				return nil
+			})
+		})
+
+		// If we panic during the transaction, operations inside
+		// the transaction should be rolled back.
+		_, err := db.Repos().Get(ctx, 1)
+		require.Error(t, err)
 	})
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -376,9 +376,6 @@ func TestDBWithTransact(t *testing.T) {
 			require.Error(t, err)
 
 			err = tx1.WithTransact(ctx, func(tx2 DB) error {
-				tx2, err := tx1.Transact(ctx)
-				require.NoError(t, err)
-
 				err = tx2.Repos().Create(ctx, &types.Repo{ID: 2, Name: "test2"})
 				require.NoError(t, err)
 
@@ -430,8 +427,6 @@ func TestDBWithTransact(t *testing.T) {
 				require.NoError(t, err)
 
 				panic("to infinity and beyond")
-
-				return nil
 			})
 		})
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -243,7 +243,6 @@ func TestDBWithTransact(t *testing.T) {
 		sqlDB := dbtest.NewDB(logger, t)
 		db := NewDB(logger, sqlDB)
 
-		// Lifetime of tx
 		err := db.WithTransact(ctx, func(tx DB) error {
 			repos := tx.Repos()
 			err := repos.Create(ctx, &types.Repo{ID: 1, Name: "test1"})


### PR DESCRIPTION
Problem: with our current pattern, a panic during a transaction will usually cause the transaction to be committed, even if all operations intended to be part of the transaction have not executed.

Consider the following example:
```go
func example(ctx context.Context, db database.DB) (err error) {
	tx, err := db.Transact(ctx)
	if err != nil {
		return err
	}
	defer func() { err = tx.Done(err) }()

	err = tx.Exec("INSERT INTO test VALUES (1)")
	if err != nil {
		return err
	}
	
	panic("FATAL")

	err = tx.Exec("INSERT INTO test VALUES (2)")
	if err != nil {
		return err
	}

	return nil
}
```

The panic causes us to unroll the stack, which executes the deferred `tx.Done()`. However, `err` is `nil`, so the transaction will be committed even though the second insert statement was never executed. This breaks the atomic "all or nothing" intent of the code. 

This PR adds the new `db.WithTransact()`, which will roll back a transaction if the provided closure returns an error _or_ panics. Additionally, it makes transaction code less mistake-prone because you don't have to worry about referring to the correct `err` variable whenever doing `tx.Done()`.

```go
func example(ctx context.Context, db database.DB) err {
	db.WithTransact(ctx, func(tx database.DB) {
		err = tx.Exec("INSERT INTO test VALUES (1)")
		if err != nil {
			return err
		}

		panic("FATAL")

		err = tx.Exec("INSERT INTO test VALUES (2)")
		if err != nil {
			return err
		}

		return nil
	})
}
```

We cannot add the panic handling to `tx.Done()` because `recover()` only recovers a panic if it is called directly by the deferred function. `tx.Done()` is usually called in a closure so that it can refer to the `err` return value. 

My recommendation is that we deprecate the current `db.Transact()` pattern because it is easy to misuse and is not panic-hardy. Over time, we will replace that pattern with `WithTransact()` and eventually remove `Transact()`. 

This PR does not cover all the `Transact()` methods on the store types, so currently to take advantage of this pattern, you'll need to use a `database.DB` as your transaction target, then call one of the methods on the transaction (e.g. `tx.Repos()`) to get a more specific store. 

## Test plan

Duplicated existing transaction tests. Added a test specifically for the panic behavior. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
