### PR TITLE
Search: fix validation for repo filters

### DIFF
--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -156,10 +156,18 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 	}
 
 	isValidRegexp := func() error {
-		if _, err := regexp.Compile(value); err != nil {
-			return err
+		_, err := regexp.Compile(value)
+		return err
+	}
+
+	isValidRepoRegexp := func() error {
+		if negated {
+			if _, err := regexp.Compile(value); err != nil {
+				return err
+			}
 		}
-		return nil
+		_, err := ParseRepositoryRevisions(value)
+		return err
 	}
 
 	isBoolean := func() error {
@@ -239,7 +247,7 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		return satisfies(isSingular, isBoolean, isNotNegated)
 	case
 		FieldRepo:
-		return satisfies(isValidRegexp)
+		return satisfies(isValidRepoRegexp)
 	case
 		FieldContext:
 		return satisfies(isSingular, isNotNegated)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -26,6 +26,14 @@ func TestValidation(t *testing.T) {
 			want:  "error parsing regexp: missing closing ]: `[`",
 		},
 		{
+			input: "repo:\\@Query\\(\"SELECT",
+			want:  "error parsing regexp: trailing backslash at end of expression: ``",
+		},
+		{
+			input: "file:filename[2.txt",
+			want:  "error parsing regexp: missing closing ]: `[2.txt`",
+		},
+		{
 			input: "-index:yes",
 			want:  `field "index" does not support negation`,
 		},


### PR DESCRIPTION
We always validate queries before executing them to ensure each field has the
right type, there aren't conflicts between filters, etc. The validation for
repo filters was slightly incorrect, because it tested if the whole repo filter
could be parsed as a regexp. Instead we should split the filter into repo and
revs, and compile the repo part. This is because in rare cases like "[@rev]",
the whole filter is a valid regexp, but the repo part is not.

We weren't catching this case before, which meant downstream code could
encounter invalid repo filters and panic.

Closes #46761

## Test plan

New unit tests covering this case, plus file filter case (which uses a similar codepath).
