### PR TITLE
CI: specifically fetch the target revision

### DIFF
--- a/dev/ci/integration/code-intel/install-src.sh
+++ b/dev/ci/integration/code-intel/install-src.sh
@@ -19,6 +19,7 @@ trap cleanup EXIT
 
 git clone git@github.com:sourcegraph/src-cli.git "${TEMP}" --depth 1
 pushd "${TEMP}"
+git fetch origin "${VERSION}" --depth 1
 git checkout "${VERSION}"
 mkdir -p "${root_dir}/.bin"
 go build -o "${root_dir}/.bin" ./cmd/src


### PR DESCRIPTION
A shallow clone will target the repo's current HEAD, which might not contain the target revision. This adds a fetch that ensures that the target revision exists locally before checking out.

## Test plan

Tested locally that the script runs without error. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
