### PR TITLE
[Permissions] add numeric priority and fix order for sync worker dequeue

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -378,6 +378,7 @@ func (s *Server) handleEnqueueChangesetSync(w http.ResponseWriter, r *http.Reque
 	s.respond(w, http.StatusOK, nil)
 }
 
+// TODO(naman): remove this while removing old perms syncer
 func (s *Server) handleSchedulePermsSync(w http.ResponseWriter, r *http.Request) {
 	if s.DatabaseBackedPermissionSyncerEnabled != nil && s.DatabaseBackedPermissionSyncerEnabled(r.Context()) {
 		s.Logger.Warn("Dropping schedule-perms-sync request because PermissionSyncWorker is enabled. This should not happen.")

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -128,5 +128,10 @@
     "path": "internal/database",
     "prefix": "TestRoleCreate",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestPermissionSyncJobs_CreateAndList",
+    "reason": "The column boolean column`high_priority` has been replaced by numeric column `priority`. Table not in use for 4.4."
   }
 ]

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/group"
 )
@@ -24,7 +25,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 			ID:               99,
 			UserID:           1234,
 			InvalidateCaches: true,
-			HighPriority:     true,
+			Priority:         database.HighPriorityPermissionSync,
 		})
 
 		wantMeta := &requestMeta{
@@ -46,7 +47,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 			ID:               777,
 			RepositoryID:     4567,
 			InvalidateCaches: false,
-			HighPriority:     false,
+			Priority:         database.LowPriorityPermissionSync,
 		})
 
 		wantMeta := &requestMeta{
@@ -62,6 +63,64 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 			t.Fatalf("wrong sync request: %s", diff)
 		}
 	})
+}
+
+func TestPermsSyncerWorker_Store_Dequeue_Order(t *testing.T) {
+	logger := logtest.Scoped(t)
+	dbt := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, dbt)
+
+	if _, err := dbt.ExecContext(context.Background(), `DELETE FROM permission_sync_jobs;`); err != nil {
+		t.Fatalf("unexpected error deleting records: %s", err)
+	}
+
+	if _, err := dbt.ExecContext(context.Background(), `
+		INSERT INTO permission_sync_jobs (id, state, user_id, repository_id, priority, process_after, reason)
+		VALUES
+			(1, 'queued', 1, null, 0, null, 'test'),
+			(2, 'queued', 0, null, 0, null, 'test'),
+			(3, 'queued', 1, null, 5, null, 'test'),
+			(4, 'queued', 0, null, 5, null, 'test'),
+			(5, 'queued', 1, null, 10, null, 'test'),
+			(6, 'queued', 0, null, 10, null, 'test'),
+			(7, 'queued', 1, null, 10, NOW() - '1 minute'::interval, 'test'),
+			(8, 'queued', 0, null, 10, NOW() - '2 minute'::interval, 'test'),
+			(9, 'queued', 1, null, 5, NOW() - '1 minute'::interval, 'test'),
+			(10, 'queued', 0, null, 5, NOW() - '2 minute'::interval, 'test'),
+			(11, 'queued', 1, null, 0, NOW() - '1 minute'::interval, 'test'),
+			(12, 'queued', 0, null, 0, NOW() - '2 minute'::interval, 'test'),
+			(13, 'processing', 1, null, 10, null, 'test'),
+			(14, 'completed', 0, null, 10, null, 'test'),
+			(15, 'cancelled', 1, null, 10, null, 'test'),
+			(16, 'queued', 1, null, 10, NOW() + '2 minute'::interval, 'test')
+	`); err != nil {
+		t.Fatalf("unexpected error inserting records: %s", err)
+	}
+
+	store := MakeStore(&observation.TestContext, db.Handle())
+	jobIDs := []int{}
+	wantJobIDs := []int{5, 6, 8, 7, 3, 4, 10, 9, 1, 2, 12, 11, 0, 0, 0, 0}
+	var dequeueErr error
+	for range wantJobIDs {
+		record, _, err := store.Dequeue(context.Background(), "test", nil)
+		if err == nil {
+			if record == nil {
+				jobIDs = append(jobIDs, 0)
+			} else {
+				jobIDs = append(jobIDs, record.ID)
+			}
+		} else {
+			dequeueErr = err
+		}
+	}
+
+	if dequeueErr != nil {
+		t.Fatalf("dequeue operation failed: %s", dequeueErr)
+	}
+
+	if diff := cmp.Diff(jobIDs, wantJobIDs); diff != "" {
+		t.Fatalf("jobs dequeued in wrong order: %s", diff)
+	}
 }
 
 type dummyPermsSyncer struct {

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -65,7 +65,7 @@ func EnterpriseInit(
 
 		// If the feature flag is enabled, create job...
 		if permssync.PermissionSyncWorkerEnabled(ctx, db, observationCtx.Logger) {
-			opts := ossDB.PermissionSyncJobOpts{HighPriority: true, Reason: reason}
+			opts := ossDB.PermissionSyncJobOpts{Priority: ossDB.HighPriorityPermissionSync, Reason: reason}
 			return permsJobStore.CreateRepoSyncJob(ctx, repo, opts)
 		}
 		// ... otherwise, we just call the PermsSyncer

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -78,7 +78,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 	if PermissionSyncWorkerEnabled(ctx, db, logger) {
 		for _, userID := range req.UserIDs {
 			opts := database.PermissionSyncJobOpts{
-				HighPriority:      true,
+				Priority:          database.HighPriorityPermissionSync,
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
@@ -92,7 +92,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 
 		for _, repoID := range req.RepoIDs {
 			opts := database.PermissionSyncJobOpts{
-				HighPriority:      true,
+				Priority:          database.HighPriorityPermissionSync,
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -40,26 +40,31 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 0, "jobs returned even though database is empty")
 
-	opts := PermissionSyncJobOpts{HighPriority: true, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
+	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
 	err = store.CreateRepoSyncJob(ctx, 99, opts)
 	require.NoError(t, err)
 
 	processAfter := clock.Now().Add(5 * time.Minute)
-	opts = PermissionSyncJobOpts{HighPriority: false, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
+	opts = PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 	err = store.CreateUserSyncJob(ctx, 77, opts)
+	require.NoError(t, err)
+
+	processAfter = clock.Now().Add(5 * time.Minute)
+	opts = PermissionSyncJobOpts{Priority: LowPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
+	err = store.CreateUserSyncJob(ctx, 78, opts)
 	require.NoError(t, err)
 
 	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{})
 	require.NoError(t, err)
 
-	require.Len(t, jobs, 2, "wrong number of jobs returned")
+	require.Len(t, jobs, 3, "wrong number of jobs returned")
 
 	wantJobs := []*PermissionSyncJob{
 		{
 			ID:                jobs[0].ID,
 			State:             "queued",
 			RepositoryID:      99,
-			HighPriority:      true,
+			Priority:          HighPriorityPermissionSync,
 			InvalidateCaches:  true,
 			Reason:            ReasonManualRepoSync,
 			TriggeredByUserID: user.ID,
@@ -68,6 +73,16 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			ID:               jobs[1].ID,
 			State:            "queued",
 			UserID:           77,
+			Priority:         MediumPriorityPermissionSync,
+			InvalidateCaches: true,
+			ProcessAfter:     processAfter,
+			Reason:           ReasonManualUserSync,
+		},
+		{
+			ID:               jobs[2].ID,
+			State:            "queued",
+			UserID:           78,
+			Priority:         LowPriorityPermissionSync,
 			InvalidateCaches: true,
 			ProcessAfter:     processAfter,
 			Reason:           ReasonManualUserSync,
@@ -98,7 +113,12 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		{
 			name:     "UserID",
 			opts:     ListPermissionSyncJobOpts{UserID: jobs[1].UserID},
-			wantJobs: jobs[1:],
+			wantJobs: jobs[1:2],
+		},
+		{
+			name:     "UserID",
+			opts:     ListPermissionSyncJobOpts{UserID: jobs[2].UserID},
+			wantJobs: jobs[2:],
 		},
 	}
 
@@ -188,18 +208,56 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	require.Equal(t, allDelayedJobs[0].UserID, allDelayedJobs[0].ID-2)
 	require.Equal(t, allDelayedJobs[1].UserID, allDelayedJobs[1].ID-2)
 
-	// 5) Insert *high* priority job without process_after for user1. Check that low priority job is canceled.
-	user1HighPrioJob := PermissionSyncJobOpts{HighPriority: true, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
-	err = store.CreateUserSyncJob(ctx, 1, user1HighPrioJob)
+	// 5) Insert *medium* priority job without process_after for user1. Check that low priority job is canceled.
+	user1MediumPrioJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	err = store.CreateUserSyncJob(ctx, 1, user1MediumPrioJob)
 	require.NoError(t, err)
 
 	allUser1Jobs, err := store.List(ctx, ListPermissionSyncJobOpts{UserID: 1})
 	require.NoError(t, err)
-	// Check that we have 3 jobs for userID=1 in total (low prio (canceled), delayed, high prio).
+	// Check that we have 3 jobs for userID=1 in total (low prio (canceled), delayed, medium prio).
 	require.Len(t, allUser1Jobs, 3)
 	// Check that low prio job (ID=1) is canceled and others are not.
 	for _, job := range allUser1Jobs {
 		if job.ID == 1 {
+			require.True(t, job.Cancel)
+		} else {
+			require.False(t, job.Cancel)
+		}
+	}
+
+	// 6) Insert some medium priority jobs with process_after for both users. All of them should be inserted.
+	user1MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, ProcessAfter: fiveMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user2MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, ProcessAfter: tenMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+
+	err = store.CreateUserSyncJob(ctx, 1, user1MediumPrioDelayedJob)
+	require.NoError(t, err)
+
+	err = store.CreateUserSyncJob(ctx, 2, user2MediumPrioDelayedJob)
+	require.NoError(t, err)
+
+	allDelayedJobs, err = store.List(ctx, ListPermissionSyncJobOpts{NotNullProcessAfter: true})
+	require.NoError(t, err)
+	// Check that we have 2 delayed jobs in total.
+	require.Len(t, allDelayedJobs, 4)
+	// UserID of the job should be (jobID - 2).
+	require.Equal(t, allDelayedJobs[0].UserID, allDelayedJobs[0].ID-2)
+	require.Equal(t, allDelayedJobs[1].UserID, allDelayedJobs[1].ID-2)
+	require.Equal(t, allDelayedJobs[2].UserID, allDelayedJobs[1].ID-3)
+	require.Equal(t, allDelayedJobs[3].UserID, allDelayedJobs[1].ID-2)
+
+	// 5) Insert *high* priority job without process_after for user1. Check that medium and low priority job is canceled.
+	user1HighPrioJob := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	err = store.CreateUserSyncJob(ctx, 1, user1HighPrioJob)
+	require.NoError(t, err)
+
+	allUser1Jobs, err = store.List(ctx, ListPermissionSyncJobOpts{UserID: 1})
+	require.NoError(t, err)
+	// Check that we have 3 jobs for userID=1 in total (medium prio (canceled), delayed, high prio).
+	require.Len(t, allUser1Jobs, 5)
+	// Check that medium prio job (ID=3) is canceled and others are not.
+	for _, job := range allUser1Jobs {
+		if job.ID == 1 || job.ID == 5 {
 			require.True(t, job.Cancel)
 		} else {
 			require.False(t, job.Cancel)
@@ -216,12 +274,12 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 
 	allUser1Jobs, err = store.List(ctx, ListPermissionSyncJobOpts{UserID: 1})
 	require.NoError(t, err)
-	// Check that we still have 3 jobs for userID=1 in total (low prio (canceled), delayed, high prio).
-	require.Len(t, allUser1Jobs, 3)
+	// Check that we still have 3 jobs for userID=1 in total (low prio (canceled), medium prio (cancelled), high prio).
+	require.Len(t, allUser1Jobs, 5)
 
 	// 7) Check that not "queued" jobs doesn't affect duplicates check: let's change high prio job to "processing"
 	// and insert one low prio after that.
-	result, err := db.ExecContext(ctx, "UPDATE permission_sync_jobs SET state='processing' WHERE id=5")
+	result, err := db.ExecContext(ctx, "UPDATE permission_sync_jobs SET state='processing' WHERE id=7")
 	require.NoError(t, err)
 	updatedRows, err := result.RowsAffected()
 	require.NoError(t, err)
@@ -234,7 +292,7 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	allUser1Jobs, err = store.List(ctx, ListPermissionSyncJobOpts{UserID: 1})
 	require.NoError(t, err)
 	// Check that we now have 4 jobs for userID=1 in total (low prio (canceled), delayed, high prio (processing), NEW low prio).
-	require.Len(t, allUser1Jobs, 4)
+	require.Len(t, allUser1Jobs, 5)
 }
 
 func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -17084,19 +17084,6 @@
           "Comment": ""
         },
         {
-          "Name": "high_priority",
-          "Index": 18,
-          "TypeName": "boolean",
-          "IsNullable": false,
-          "Default": "false",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "id",
           "Index": 1,
           "TypeName": "integer",
@@ -17160,6 +17147,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "priority",
+          "Index": 21,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "0",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Specifies numeric priority for the permissions sync job."
         },
         {
           "Name": "process_after",
@@ -17296,7 +17296,7 @@
           "IsUnique": true,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX permission_sync_jobs_unique ON permission_sync_jobs USING btree (high_priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text",
+          "IndexDefinition": "CREATE UNIQUE INDEX permission_sync_jobs_unique ON permission_sync_jobs USING btree (priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2652,12 +2652,12 @@ Referenced by:
  repository_id        | integer                  |           |          | 
  user_id              | integer                  |           |          | 
  triggered_by_user_id | integer                  |           |          | 
- high_priority        | boolean                  |           | not null | false
  invalidate_caches    | boolean                  |           | not null | false
  cancellation_reason  | text                     |           |          | 
+ priority             | integer                  |           | not null | 0
 Indexes:
     "permission_sync_jobs_pkey" PRIMARY KEY, btree (id)
-    "permission_sync_jobs_unique" UNIQUE, btree (high_priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text
+    "permission_sync_jobs_unique" UNIQUE, btree (priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text
     "permission_sync_jobs_process_after" btree (process_after)
     "permission_sync_jobs_repository_id" btree (repository_id)
     "permission_sync_jobs_state" btree (state)
@@ -2670,6 +2670,8 @@ Foreign-key constraints:
 ```
 
 **cancellation_reason**: Specifies why permissions sync job was cancelled.
+
+**priority**: Specifies numeric priority for the permissions sync job.
 
 **reason**: Specifies why permissions sync job was triggered.
 

--- a/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/down.sql
+++ b/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE permission_sync_jobs ADD COLUMN IF NOT EXISTS high_priority BOOLEAN NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN permission_sync_jobs.high_priority IS 'Specifies if the permissions sync job is high priority.';
+
+ALTER TABLE permission_sync_jobs DROP COLUMN IF EXISTS priority;
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (high_priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');

--- a/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/metadata.yaml
+++ b/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_priority_to_permission_sync_jobs
+parents: [1674035302, 1674455760]

--- a/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/up.sql
+++ b/migrations/frontend/1674642349_add_priority_to_permission_sync_jobs/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE permission_sync_jobs ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';
+
+ALTER TABLE permission_sync_jobs DROP COLUMN IF EXISTS high_priority;
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3301,9 +3301,9 @@ CREATE TABLE permission_sync_jobs (
     repository_id integer,
     user_id integer,
     triggered_by_user_id integer,
-    high_priority boolean DEFAULT false NOT NULL,
     invalidate_caches boolean DEFAULT false NOT NULL,
     cancellation_reason text,
+    priority integer DEFAULT 0 NOT NULL,
     CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
 );
 
@@ -3312,6 +3312,8 @@ COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync
 COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
 
 COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
+
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';
 
 CREATE SEQUENCE permission_sync_jobs_id_seq
     AS integer
@@ -4863,7 +4865,7 @@ CREATE INDEX permission_sync_jobs_repository_id ON permission_sync_jobs USING bt
 
 CREATE INDEX permission_sync_jobs_state ON permission_sync_jobs USING btree (state);
 
-CREATE UNIQUE INDEX permission_sync_jobs_unique ON permission_sync_jobs USING btree (high_priority, user_id, repository_id, cancel, process_after) WHERE (state = 'queued'::text);
+CREATE UNIQUE INDEX permission_sync_jobs_unique ON permission_sync_jobs USING btree (priority, user_id, repository_id, cancel, process_after) WHERE (state = 'queued'::text);
 
 CREATE INDEX permission_sync_jobs_user_id ON permission_sync_jobs USING btree (user_id);
 


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/46320

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/22571395/214151314-5a4add22-0dea-48c8-bd09-ce5f002bf3a8.png">


## Test plan

- enable new db worker feature flag. observe the perms sync jobs table.
