### PR TITLE
Add setup wizard basic UI

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { ApolloProvider } from '@apollo/client'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
-import { Route, Router } from 'react-router'
+import { Route, Switch, Router } from 'react-router'
 import { CompatRouter } from 'react-router-dom-v5-compat'
 import { combineLatest, from, Subscription, fromEvent, of, Subject, Observable } from 'rxjs'
 import { first, startWith, switchMap } from 'rxjs/operators'
@@ -74,6 +74,7 @@ import type { LayoutRouteProps } from './routes'
 import { EnterprisePageRoutes } from './routes.constants'
 import { parseSearchURL, getQueryStateFromLocation, SearchAggregationProps } from './search'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
+import { SetupWizard } from './setup-wizard'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
 import {
@@ -361,44 +362,49 @@ export class SourcegraphWebApp extends React.Component<
             >
                 <Router history={history} key={0}>
                     <CompatRouter>
-                        <Route
-                            path="/"
-                            render={routeComponentProps => (
-                                <Layout
-                                    {...props}
-                                    {...routeComponentProps}
-                                    authenticatedUser={authenticatedUser}
-                                    viewerSubject={this.state.viewerSubject}
-                                    settingsCascade={this.state.settingsCascade}
-                                    batchChangesEnabled={this.props.batchChangesEnabled}
-                                    batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                        this.state.settingsCascade
-                                    )}
-                                    batchChangesWebhookLogsEnabled={window.context.batchChangesWebhookLogsEnabled}
-                                    // Search query
-                                    fetchHighlightedFileLineRanges={this.fetchHighlightedFileLineRanges}
-                                    // Extensions
-                                    platformContext={this.platformContext}
-                                    extensionsController={this.extensionsController}
-                                    telemetryService={eventLogger}
-                                    isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                    searchContextsEnabled={this.props.searchContextsEnabled}
-                                    selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                    setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
-                                    getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                                    fetchSearchContexts={fetchSearchContexts}
-                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                    fetchSearchContext={fetchSearchContext}
-                                    createSearchContext={createSearchContext}
-                                    updateSearchContext={updateSearchContext}
-                                    deleteSearchContext={deleteSearchContext}
-                                    isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                                    globbing={this.state.globbing}
-                                    streamSearch={aggregateStreamingSearch}
-                                    onCreateNotebookFromNotepad={this.onCreateNotebook}
-                                />
-                            )}
-                        />
+                        <Switch>
+                            <Route path="/setup" exact={true}>
+                                <SetupWizard />
+                            </Route>
+                            <Route
+                                path="/"
+                                render={routeComponentProps => (
+                                    <Layout
+                                        {...props}
+                                        {...routeComponentProps}
+                                        authenticatedUser={authenticatedUser}
+                                        viewerSubject={this.state.viewerSubject}
+                                        settingsCascade={this.state.settingsCascade}
+                                        batchChangesEnabled={this.props.batchChangesEnabled}
+                                        batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
+                                            this.state.settingsCascade
+                                        )}
+                                        batchChangesWebhookLogsEnabled={window.context.batchChangesWebhookLogsEnabled}
+                                        // Search query
+                                        fetchHighlightedFileLineRanges={this.fetchHighlightedFileLineRanges}
+                                        // Extensions
+                                        platformContext={this.platformContext}
+                                        extensionsController={this.extensionsController}
+                                        telemetryService={eventLogger}
+                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                        searchContextsEnabled={this.props.searchContextsEnabled}
+                                        selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                                        setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
+                                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                                        fetchSearchContexts={fetchSearchContexts}
+                                        fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                        fetchSearchContext={fetchSearchContext}
+                                        createSearchContext={createSearchContext}
+                                        updateSearchContext={updateSearchContext}
+                                        deleteSearchContext={deleteSearchContext}
+                                        isSearchContextSpecAvailable={isSearchContextSpecAvailable}
+                                        globbing={this.state.globbing}
+                                        streamSearch={aggregateStreamingSearch}
+                                        onCreateNotebookFromNotepad={this.onCreateNotebook}
+                                    />
+                                )}
+                            />
+                        </Switch>
                     </CompatRouter>
                 </Router>
                 {this.extensionsController !== null && window.context.enableLegacyExtensions ? (

--- a/client/web/src/setup-wizard/Setup.module.scss
+++ b/client/web/src/setup-wizard/Setup.module.scss
@@ -1,0 +1,19 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    width: 70%;
+    max-width: 600px;
+    margin: 6rem auto;
+    padding-bottom: 2rem;
+}
+
+.logo {
+    align-self: center;
+    width: 20rem;
+}
+
+.description {
+    align-self: center;
+    margin-top: 1.5rem;
+    margin-bottom: 3rem;
+}

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -1,0 +1,45 @@
+import { FC, useState } from 'react'
+
+import { Text } from '@sourcegraph/wildcard'
+
+import { BrandLogo } from '../components/branding/BrandLogo'
+import { ThemePreference, useTheme } from '../theme'
+
+import { SetupTabs, SetupList, SetupTab, SetupSteps } from './components/SetupTabs'
+import { AddRepositoriesStep } from './steps/AddRepositoriesStep'
+import { CloningRepositoriesStep } from './steps/CloningRepositoriesStep'
+import { ConnectToCodeHostStep } from './steps/ConnectToCodeHostsStep'
+
+import styles from './Setup.module.scss'
+
+export const SetupWizard: FC = props => {
+    const {} = props
+
+    const [step, setStep] = useState(0)
+
+    // Enforce the right class is added on the body for supporting different
+    // themes based on user OS preferences
+    const { enhancedThemePreference } = useTheme()
+    const isLightTheme = enhancedThemePreference === ThemePreference.Light
+
+    return (
+        <div className={styles.root}>
+            <BrandLogo variant="logo" isLightTheme={isLightTheme} className={styles.logo} />
+
+            <Text className={styles.description}>Single docker setup - Version 4.4</Text>
+
+            <SetupTabs activeTabIndex={step} defaultActiveIndex={0} onTabChange={setStep}>
+                <SetupList>
+                    <SetupTab index={0}>Connect to code hosts</SetupTab>
+                    <SetupTab index={1}>Add Repositories</SetupTab>
+                    <SetupTab index={2}>Finish</SetupTab>
+                </SetupList>
+                <SetupSteps>
+                    <ConnectToCodeHostStep />
+                    <AddRepositoriesStep />
+                    <CloningRepositoriesStep />
+                </SetupSteps>
+            </SetupTabs>
+        </div>
+    )
+}

--- a/client/web/src/setup-wizard/components/SetupTabs.module.scss
+++ b/client/web/src/setup-wizard/components/SetupTabs.module.scss
@@ -1,0 +1,39 @@
+.tabs {
+    background-color: unset;
+}
+
+.header-list {
+    display: flex;
+}
+
+.tab {
+    &[data-selected] {
+        border-bottom: 2px solid var(--primary) !important;
+    }
+
+    &--completed {
+        border-bottom: 2px solid var(--primary) !important;
+    }
+}
+
+.panels {
+    margin-top: 0;
+    padding: 1rem;
+    border-top-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-top: none !important;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    margin: 1rem -1rem -1rem -1rem;
+    border-top: 1px solid var(--border-color);
+
+    &-skip {
+        margin-right: auto;
+    }
+}

--- a/client/web/src/setup-wizard/components/SetupTabs.tsx
+++ b/client/web/src/setup-wizard/components/SetupTabs.tsx
@@ -1,0 +1,128 @@
+import { createContext, FC, PropsWithChildren, useContext } from 'react'
+
+import classNames from 'classnames'
+import { noop } from 'lodash'
+
+import {
+    Button,
+    Card,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
+    TabListProps,
+    TabPanelsProps,
+    useTabsContext,
+} from '@sourcegraph/wildcard'
+
+import styles from './SetupTabs.module.scss'
+
+interface SetupTabsContextData {
+    onTabChange: (index: number) => void
+}
+
+const SetupTabsContext = createContext<SetupTabsContextData>({
+    onTabChange: noop,
+})
+
+interface SetupTabsProps {
+    activeTabIndex: number
+    defaultActiveIndex: number
+    onTabChange: (activeIndex: number) => void
+}
+
+/**
+ * The root visual element for the setup Tabs UI wizard layout. Enforces
+ * the right layout and internal state for completed, current and further setup steps
+ */
+export const SetupTabs: FC<PropsWithChildren<SetupTabsProps>> = props => {
+    const { activeTabIndex, defaultActiveIndex, children, onTabChange } = props
+
+    return (
+        <SetupTabsContext.Provider value={{ onTabChange }}>
+            <Tabs
+                lazy={true}
+                behavior="forceRender"
+                size="large"
+                index={activeTabIndex}
+                defaultIndex={defaultActiveIndex}
+                className={styles.tabs}
+                onChange={onTabChange}
+            >
+                {children}
+            </Tabs>
+        </SetupTabsContext.Provider>
+    )
+}
+
+/** UI component to declare list of steps headers (tabs) UI */
+export const SetupList: FC<PropsWithChildren<TabListProps>> = props => (
+    <TabList {...props} className={classNames(styles.headerList, props.className)} />
+)
+
+interface SetupTabProps {
+    index: number
+}
+
+export const SetupTab: FC<PropsWithChildren<SetupTabProps>> = props => {
+    const { index, children } = props
+    const { selectedIndex } = useTabsContext()
+
+    return (
+        <Tab
+            disabled={index !== selectedIndex}
+            className={classNames(styles.tab, { [styles.tabCompleted]: selectedIndex > index })}
+        >
+            {children}
+        </Tab>
+    )
+}
+
+export const SetupSteps: FC<PropsWithChildren<TabPanelsProps>> = props => (
+    <TabPanels {...props} as={Card} className={classNames(styles.panels, props.className)} />
+)
+
+export { TabPanel as SetupStep }
+
+interface SetupStepActions {
+    nextAvailable: boolean
+    finish?: boolean
+    onSkip?: () => void
+    onComplete?: () => void
+}
+
+export const SetupStepActions: FC<SetupStepActions> = props => {
+    const { nextAvailable, finish, onSkip, onComplete } = props
+
+    const { selectedIndex } = useTabsContext()
+    const { onTabChange } = useContext(SetupTabsContext)
+
+    const isFirstStep = selectedIndex === 0
+
+    return (
+        <footer className={styles.actions}>
+            {!finish && (
+                <>
+                    <Button variant="secondary" className={styles.actionsSkip} onClick={onSkip}>
+                        Skip setup
+                    </Button>
+                    {!isFirstStep && (
+                        <Button variant="secondary" outline={true} onClick={() => onTabChange(selectedIndex - 1)}>
+                            Previous step
+                        </Button>
+                    )}
+                    <Button variant="primary" disabled={!nextAvailable} onClick={() => onTabChange(selectedIndex + 1)}>
+                        Next
+                    </Button>
+                </>
+            )}
+
+            {finish && (
+                <Button variant="primary" className="ml-auto" onClick={onComplete}>
+                    Go to search!
+                </Button>
+            )}
+        </footer>
+    )
+}

--- a/client/web/src/setup-wizard/index.ts
+++ b/client/web/src/setup-wizard/index.ts
@@ -1,0 +1,1 @@
+export { SetupWizard } from './SetupWizard'

--- a/client/web/src/setup-wizard/steps/AddRepositoriesStep.module.scss
+++ b/client/web/src/setup-wizard/steps/AddRepositoriesStep.module.scss
@@ -1,0 +1,27 @@
+.repositories-root {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    margin-bottom: 0.75rem;
+    margin-left: 0.5rem;
+}
+
+.item {
+    display: flex;
+    align-items: center;
+}
+
+.icon {
+    margin-right: 0.25rem;
+}
+
+.checkbox {
+    position: static;
+    margin-right: 0.75rem;
+}

--- a/client/web/src/setup-wizard/steps/AddRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/steps/AddRepositoriesStep.tsx
@@ -1,0 +1,166 @@
+import { FC, useState } from 'react'
+
+import { mdiBitbucket, mdiGithub, mdiGitlab } from '@mdi/js'
+
+import { Checkbox, Icon, Input, RadioButton, RadioButtonProps } from '@sourcegraph/wildcard'
+
+import { SetupStep, SetupStepActions } from '../components/SetupTabs'
+
+import styles from './AddRepositoriesStep.module.scss'
+
+enum RepositoriesPickingMode {
+    All,
+    OrganizationsList,
+    SelectedRepositories,
+}
+
+export const AddRepositoriesStep: FC = props => {
+    const [mode, setMode] = useState<RepositoriesPickingMode>(RepositoriesPickingMode.All)
+
+    return (
+        <SetupStep>
+            {/* eslint-disable-next-line react/forbid-elements */}
+            <form className={styles.repositoriesRoot}>
+                <RadioButton
+                    id="mode-1"
+                    name="repositories-mode"
+                    value="all-repositories"
+                    label="All repositories"
+                    message="We will try to resolve all reachable by your access token repositories (private repositories, all repositories from your organizations"
+                    checked={mode === RepositoriesPickingMode.All}
+                    onChange={() => setMode(RepositoriesPickingMode.All)}
+                />
+
+                <RadioButtonWithContent
+                    id="mode-2"
+                    name="repositories-mode"
+                    value="org-repositories"
+                    label="Sync all repositories from selected organizations"
+                    message="We will try to resolve all repositories within selected organizations"
+                    checked={mode === RepositoriesPickingMode.OrganizationsList}
+                    onChange={() => setMode(RepositoriesPickingMode.OrganizationsList)}
+                >
+                    <OrganizationsList />
+                </RadioButtonWithContent>
+
+                <RadioButtonWithContent
+                    id="mode-3"
+                    name="repositories-mode"
+                    value="selected-repositories"
+                    label="Sync selected repositories"
+                    message="Pick a specific set of repositories"
+                    checked={mode === RepositoriesPickingMode.SelectedRepositories}
+                    onChange={() => setMode(RepositoriesPickingMode.SelectedRepositories)}
+                >
+                    <RepositoriesList />
+                </RadioButtonWithContent>
+            </form>
+
+            <SetupStepActions nextAvailable={true} />
+        </SetupStep>
+    )
+}
+
+const RadioButtonWithContent: FC<RadioButtonProps> = props => {
+    const { checked, className, children, ...attributes } = props
+
+    return (
+        <fieldset className={className}>
+            <RadioButton {...attributes} checked={checked} />
+            {checked && <div className="ml-4 mt-2">{children}</div>}
+        </fieldset>
+    )
+}
+
+const OrganizationsList: FC = () => (
+    <section>
+        <Input
+            label="Search organizations"
+            placeholder="sourcegraph/"
+            autoFocus={true}
+            variant="small"
+            className="mb-2"
+        />
+
+        <ul className={styles.list}>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                Sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} /> My
+                Personal organization
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGitlab} className={styles.icon} /> Gitlab org
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiBitbucket} className={styles.icon} />{' '}
+                BitBucket org
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiBitbucket} className={styles.icon} />{' '}
+                Experiment project org
+            </li>
+        </ul>
+    </section>
+)
+
+const RepositoriesList: FC = () => (
+    <section>
+        <Input
+            label="Search repositories"
+            placeholder="sourcegraph/sourcegraph"
+            autoFocus={true}
+            variant="small"
+            className="mb-2"
+        />
+
+        <ul className={styles.list}>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                sourcegraph/sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                sourcegraph/sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGitlab} className={styles.icon} />{' '}
+                vovakulikov/looper
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiBitbucket} className={styles.icon} />{' '}
+                vovakulikov/tokio
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiBitbucket} className={styles.icon} />{' '}
+                vovakulikov/go-private
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                sourcegraph/sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGitlab} className={styles.icon} />{' '}
+                vovakulikov/looper
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                sourcegraph/sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGitlab} className={styles.icon} />{' '}
+                vovakulikov/looper
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGithub} className={styles.icon} />{' '}
+                sourcegraph/sourcegraph
+            </li>
+            <li className={styles.item}>
+                <Checkbox className={styles.checkbox} /> <Icon svgPath={mdiGitlab} className={styles.icon} />{' '}
+                vovakulikov/looper
+            </li>
+        </ul>
+    </section>
+)

--- a/client/web/src/setup-wizard/steps/CloningRepositoriesStep.module.scss
+++ b/client/web/src/setup-wizard/steps/CloningRepositoriesStep.module.scss
@@ -1,0 +1,36 @@
+.repo-list {
+    padding: 0;
+    list-style: none;
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.repo-item {
+    & + & {
+        border-top: 1px solid var(--border-color);
+    }
+
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    color: var(--text-muted);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+
+    &-icon {
+        flex-shrink: 0;
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-right: 0.25rem;
+    }
+
+    &-description {
+        margin-top: 0.15rem;
+        flex-basis: 100%;
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        color: var(--text-muted);
+    }
+}

--- a/client/web/src/setup-wizard/steps/CloningRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/steps/CloningRepositoriesStep.tsx
@@ -1,0 +1,172 @@
+import { FC } from 'react'
+
+import { mdiBitbucket, mdiGithub, mdiGitlab } from '@mdi/js'
+import { noop } from 'lodash'
+
+import { Icon, Link, LoadingSpinner, PageSwitcher, Text } from '@sourcegraph/wildcard'
+
+import { ValueLegendList, ValueLegendListProps } from '../../site-admin/analytics/components/ValueLegendList'
+import { SetupStep, SetupStepActions } from '../components/SetupTabs'
+
+import styles from './CloningRepositoriesStep.module.scss'
+
+const items: ValueLegendListProps['items'] = [
+    {
+        value: 10,
+        description: 'Repositories',
+        color: 'var(--purple)',
+        tooltip:
+            'Total number of repositories in the Sourcegraph instance. This number might be higher than the total number of repositories in the list below in case repository permissions do not allow you to view some repositories.',
+    },
+    {
+        value: 10,
+        description: 'Not cloned',
+        color: 'var(--body-color)',
+        position: 'right',
+        tooltip: 'The number of repositories that have not been cloned yet.',
+        filter: { name: 'status', value: 'not-cloned' },
+    },
+    {
+        value: 10,
+        description: 'Cloning',
+        color: 'var(--body-color)',
+        position: 'right',
+        tooltip: 'The number of repositories that are currently being cloned.',
+        filter: { name: 'status', value: 'cloning' },
+    },
+    {
+        value: 0,
+        description: 'Cloned',
+        color: 'var(--body-color)',
+        position: 'right',
+        tooltip: 'The number of repositories that have been cloned.',
+        filter: { name: 'status', value: 'cloned' },
+    },
+    {
+        value: 0,
+        description: 'Indexed',
+        color: 'var(--body-color)',
+        position: 'right',
+        tooltip: 'The number of repositories that have been indexed for search.',
+        filter: { name: 'status', value: 'indexed' },
+    },
+    {
+        value: 0,
+        description: 'Failed',
+        color: 'var(--body-color)',
+        position: 'right',
+        tooltip: 'The number of repositories where the last syncing attempt produced an error.',
+        filter: { name: 'status', value: 'failed-fetch' },
+    },
+]
+
+interface Repository {
+    name: string
+    status: 'cloning' | 'cloned'
+    codeHost: 'github' | 'gitlab' | 'bitbucket'
+    details: string
+}
+
+const REPOSITORIES: Repository[] = [
+    {
+        name: 'sourcegraph/sourcegraph',
+        status: 'cloning',
+        codeHost: 'github',
+        details: 'Fetched 1.1 mb out of 74mb, Shard: gitserver-0',
+    },
+    {
+        name: 'sourcegraph/about',
+        status: 'cloning',
+        codeHost: 'github',
+        details: 'Fetched 10.1 mb out of 74mb, Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/tokio',
+        status: 'cloned',
+        codeHost: 'gitlab',
+        details: 'Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/pickers',
+        status: 'cloned',
+        codeHost: 'bitbucket',
+        details: 'Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/datepicker',
+        status: 'cloned',
+        codeHost: 'bitbucket',
+        details: 'Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/inputs',
+        status: 'cloned',
+        codeHost: 'bitbucket',
+        details: 'Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/grid',
+        status: 'cloned',
+        codeHost: 'bitbucket',
+        details: 'Shard: gitserver-0',
+    },
+    {
+        name: 'vovakulikov/ui-kit',
+        status: 'cloning',
+        codeHost: 'gitlab',
+        details: 'Fetched 10.1 mb out of 74mb, Shard: gitserver-0',
+    },
+]
+
+export const CloningRepositoriesStep: FC = props => (
+    <SetupStep>
+        <Text>
+            Syncing repositories. It may take a few moments to clone and index each repository. Repository statuses are
+            displayed below.
+        </Text>
+        <ValueLegendList items={items} />
+
+        <ul className={styles.repoList}>
+            {REPOSITORIES.map(repo => (
+                <RepositoryItem key={repo.name} item={repo} />
+            ))}
+        </ul>
+
+        <PageSwitcher
+            totalCount={100}
+            goToNextPage={noop}
+            goToPreviousPage={noop}
+            goToFirstPage={noop}
+            goToLastPage={noop}
+            hasNextPage={false}
+            hasPreviousPage={true}
+        />
+
+        <SetupStepActions nextAvailable={true} finish={true} />
+    </SetupStep>
+)
+
+const ICONS = {
+    github: mdiGithub,
+    gitlab: mdiGitlab,
+    bitbucket: mdiBitbucket,
+}
+
+interface RepositoryItemProps {
+    item: Repository
+}
+
+const RepositoryItem: FC<RepositoryItemProps> = props => (
+    <li className={styles.repoItem}>
+        <Icon svgPath={ICONS[props.item.codeHost]} className={styles.repoItemIcon} />{' '}
+        <Link className="mr-2">{props.item.name}</Link>{' '}
+        {props.item.status === 'cloning' ? (
+            <>
+                <LoadingSpinner className="mr-1" /> <small>Cloning</small>
+            </>
+        ) : (
+            <small>Cloned</small>
+        )}
+        <small className={styles.repoItemDescription}>{props.item.details}</small>
+    </li>
+)

--- a/client/web/src/setup-wizard/steps/ConnectToCodeHostsStep.module.scss
+++ b/client/web/src/setup-wizard/steps/ConnectToCodeHostsStep.module.scss
@@ -1,0 +1,26 @@
+.code-host-connections {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.code-host-connection-trigger {
+    display: flex;
+    justify-content: start;
+    align-items: center;
+    border: none;
+    width: 100%;
+
+    &:hover,
+    &--opened {
+        background-color: var(--body-bg) !important;
+    }
+}
+
+.collapse-section {
+    border: 1px solid var(--border-color);
+
+    &-button {
+        border: none;
+    }
+}

--- a/client/web/src/setup-wizard/steps/ConnectToCodeHostsStep.tsx
+++ b/client/web/src/setup-wizard/steps/ConnectToCodeHostsStep.tsx
@@ -1,0 +1,127 @@
+import { FC, PropsWithChildren, useState } from 'react'
+
+import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import classNames from 'classnames'
+
+import { Badge, Button, Collapse, CollapseHeader, CollapsePanel, Icon, Input, Link } from '@sourcegraph/wildcard'
+
+import { SetupStep, SetupStepActions } from '../components/SetupTabs'
+
+import styles from './ConnectToCodeHostsStep.module.scss'
+
+export const ConnectToCodeHostStep: FC = props => {
+    const [isGitLabActive] = useState(true)
+
+    return (
+        <SetupStep>
+            <section className={styles.codeHostConnections}>
+                <CollapsableFormProps name="Github">
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <form>
+                        <Input label="Access token" autoFocus={true} message={<GithubAccessTokenDescription />} />
+
+                        <Button variant="primary" className="w-100 mt-3">
+                            Connect GitHub
+                        </Button>
+                    </form>
+                </CollapsableFormProps>
+
+                <CollapsableFormProps name="GitLab" isActivated={isGitLabActive}>
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <form>
+                        <Input
+                            label="Access token"
+                            autoFocus={true}
+                            message='A GitLab access token with "api" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type "external", this token should also have "sudo" scope.'
+                        />
+
+                        <Button variant="primary" className="w-100 mt-3">
+                            Connect GitLab
+                        </Button>
+                    </form>
+                </CollapsableFormProps>
+
+                <CollapsableFormProps name="Bitbucket">
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <form>
+                        <Input
+                            label="Username"
+                            autoFocus={true}
+                            message='The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding "appPassword" field.'
+                        />
+
+                        <Input
+                            label="App password"
+                            message='The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.'
+                            className="mt-2"
+                        />
+
+                        <Button variant="primary" className="w-100 mt-3">
+                            Connect BitBucket
+                        </Button>
+                    </form>
+                </CollapsableFormProps>
+
+                <small className="mt-3">
+                    Can't find your code host? We support a lot of more than just GitHub, GitLab or BitBucket, to
+                    configure them visit <Link to="/site-admin/external-services">connect code hosts page.</Link>
+                </small>
+            </section>
+
+            <SetupStepActions nextAvailable={true} />
+        </SetupStep>
+    )
+}
+
+const GithubAccessTokenDescription: FC = () => (
+    <span>
+        A GitHub personal access token. Create one for GitHub.com at{' '}
+        <Link to="https://github.com/settings/tokens/new?description=Sourcegraph" target="_blank" rel="noopener">
+            setting page
+        </Link>{' '}
+        (for GitHub Enterprise, replace github.com with your instance's hostname). See{' '}
+        <Link
+            to="https://docs.sourcegraph.com/admin/external_service/github#github-api-token-and-access"
+            target="_blank"
+            rel="noopener"
+        >
+            Sourcegraph doc page
+        </Link>{' '}
+        for which scopes are required for which use cases.
+    </span>
+)
+
+interface CollapsableFormProps {
+    name: string
+    isActivated?: boolean
+}
+
+const CollapsableFormProps: FC<PropsWithChildren<CollapsableFormProps>> = props => {
+    const { name, isActivated, children } = props
+    const [isOpen, setOpen] = useState(false)
+
+    return (
+        <Collapse isOpen={!isActivated && isOpen} onOpenChange={setOpen}>
+            <div className={styles.collapseSection}>
+                <CollapseHeader
+                    as={Button}
+                    outline={true}
+                    variant="secondary"
+                    disabled={isActivated}
+                    className={classNames(styles.codeHostConnectionTrigger, {
+                        [styles.codeHostConnectionTriggerOpened]: isOpen,
+                    })}
+                >
+                    <Icon aria-hidden={true} svgPath={isOpen ? mdiChevronDown : mdiChevronRight} className="mr-1" />
+                    {name}
+                    {isActivated && (
+                        <Badge variant="success" className="ml-2">
+                            Connected
+                        </Badge>
+                    )}
+                </CollapseHeader>
+                {isOpen && <CollapsePanel className="p-3">{children}</CollapsePanel>}
+            </div>
+        </Collapse>
+    )
+}

--- a/client/web/src/theme.ts
+++ b/client/web/src/theme.ts
@@ -35,11 +35,11 @@ export const useTheme = (): ThemeState => {
         []
     )
     const systemIsLightTheme = useObservable(systemIsLightThemeObservable) ?? systemIsLightThemeInitialValue
-
     const [storedThemePreference, setThemePreference] = useTemporarySetting(
         'user.themePreference',
         ThemePreference.System
     )
+
     const themePreference = readStoredThemePreference(storedThemePreference)
 
     const enhancedThemePreference =
@@ -48,6 +48,13 @@ export const useTheme = (): ThemeState => {
                 ? ThemePreference.Light
                 : ThemePreference.Dark
             : themePreference
+
+    useMemo(() => {
+        const isLightTheme = enhancedThemePreference === ThemePreference.Light
+
+        document.documentElement.classList.toggle('theme-light', isLightTheme)
+        document.documentElement.classList.toggle('theme-dark', !isLightTheme)
+    }, [enhancedThemePreference])
 
     return {
         themePreference,
@@ -74,11 +81,6 @@ export interface ThemePreferenceProps {
 export const useThemeProps = (): ThemeProps & ThemePreferenceProps => {
     const { themePreference, enhancedThemePreference, setThemePreference } = useTheme()
     const isLightTheme = enhancedThemePreference === ThemePreference.Light
-
-    useMemo(() => {
-        document.documentElement.classList.toggle('theme-light', isLightTheme)
-        document.documentElement.classList.toggle('theme-dark', !isLightTheme)
-    }, [isLightTheme])
 
     return {
         isLightTheme,

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -102,6 +102,7 @@ export type { HeadingProps, HeadingElement } from './Typography'
 export type { BadgeProps, BadgeVariantType, ProductStatusType, BaseProductStatusBadgeProps } from './Badge'
 export type { ModalProps } from './Modal'
 export type { MultiComboboxProps } from './Combobox'
+export type { RadioButtonProps } from './Form/RadioButton'
 
 /**
  * Class name helpers to be used with plain DOM nodes.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46641
Part of https://github.com/sourcegraph/sourcegraph/issues/46512

Please do not merge this PR (the UI there is experimental and probably will be changed in the future)

## Test plan
- sg start web-standalone (or any other script that you use for running sg instance)
- check that /setup page has UI for the setup wizard 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-basic-setup-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

