### PR TITLE
Dev: update check for custom ctags executable

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -6,8 +6,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -eu
 
 # If CTAGS_COMMAND is set to a custom executable, we don't need to build the
-# image. See ./universal-ctags-dev.
-if [[ "${CTAGS_COMMAND}" != "cmd/symbols/universal-ctags-dev" ]]; then
+# image. See /dev/universal-ctags-dev.
+if [[ "${CTAGS_COMMAND}" != "dev/universal-ctags-dev" ]]; then
   echo "CTAGS_COMMAND set to custom executable. Building of Docker image not necessary."
   exit 0
 fi


### PR DESCRIPTION
We recently renamed the default CTAGS_COMMAND, but didn't update the docker
build script with the new default. This meant we would skip building the image
during installation.

Follow-up to #45198

## Test plan

Tested locally -- with this update, I can now build the image. This fixed my
original problem, where `sg start` would complain about missing ctags.