### PR TITLE
build: set module type to commonjs for client tsconfig projects

### DIFF
--- a/client/branded/tsconfig.json
+++ b/client/branded/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "module": "esnext",
+    "module": "commonjs",
     "sourceRoot": "src",
     "baseUrl": ".",
     "paths": {

--- a/client/observability-client/tsconfig.json
+++ b/client/observability-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
+    "module": "commonjs",
     "baseUrl": ".",
     "jsx": "react-jsx",
     "rootDir": ".",

--- a/client/shared/tsconfig.json
+++ b/client/shared/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "module": "esnext",
+    "module": "commonjs",
     "sourceRoot": "src",
     "baseUrl": ".",
     "paths": {

--- a/client/wildcard/tsconfig.json
+++ b/client/wildcard/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "module": "esnext",
+    "module": "commonjs",
     "sourceRoot": "src",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
When these are treated as npm packages under pnpm they are placed within a `node_modules` directory so jest doesn't transform them to commonjs by default. Instead of opting in to transform them this treats them the same as the other `client/*` projects.

Was there a reason these few were not commonjs already?

## Test plan

CI