### PR TITLE
fix broken go-cmp link

### DIFF
--- a/doc/dev/background-information/languages/testing_go_code.md
+++ b/doc/dev/background-information/languages/testing_go_code.md
@@ -97,7 +97,7 @@ func TestSprocket(t *testing.T) {
 
 ### Asserting expected complex values
 
-Expected values that are not simple scalars (really, anything not comparable with `==`) should use [go-cmp](https://github.com/google/go-cmp/cmp) to create a highly-readable diff string.
+Expected values that are not simple scalars (really, anything not comparable with `==`) should use [go-cmp](https://github.com/google/go-cmp) to create a highly-readable diff string.
 
 ```go
 import "github.com/google/go-cmp/cmp"


### PR DESCRIPTION

## Test plan

documentation change - search for "go-cmp" and click link
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
