### PR TITLE
Ranking: use separate feature flags for file-based and code intel ran…

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -168,7 +168,7 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 		NumRepos:       1,
 		FileMatchLimit: int32(p.Limit),
 		Features: search.Features{
-			Ranking: true,
+			FileRanking: true,
 		},
 	}).ToSearch(ctx)
 	if deadline, ok := ctx.Deadline(); ok {

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -291,7 +291,8 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", true), // can remove flag in 4.5
-		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
+		FileRanking:             flagSet.GetBoolOr("search-file-ranking", false),
+		CodeIntelRanking:        flagSet.GetBoolOr("search-code-intel-ranking", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -337,9 +337,14 @@ type Features struct {
 	// what has changed since the indexed commit.
 	HybridSearch bool `json:"search-hybrid"`
 
-	// Ranking when true will use a our new #ranking signals and code paths
-	// for ranking results from Zoekt.
-	Ranking bool `json:"ranking"`
+	// FileRanking when true will rank results based on file scores as opposed
+	// to bucketing by repository. This uses some experimental changes to Zoekt
+	// streaming and a new frontend search aggregator.
+	FileRanking bool `json:"file-ranking"`
+
+	// CodeIntelRanking when true will incorporate ranking signals based on code
+	// intelligence when they're available (like the file reference count).
+	CodeIntelRanking bool `json:"code-intel-ranking"`
 
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -103,7 +103,15 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		searchOpts.DebugScore = true
 	}
 
-	if o.Features.Ranking {
+	if o.Features.CodeIntelRanking {
+		// This enables the use of PageRank scores if they are available.
+		searchOpts.UseDocumentRanks = true
+
+		// This damps the impact of document ranks on the final ranking.
+		searchOpts.RanksDampingFactor = 0.5
+	}
+
+	if o.Features.FileRanking {
 		limit := int(o.FileMatchLimit)
 
 		// Tell each zoekt replica to not send back more than limit results.
@@ -126,12 +134,6 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// This enables our stream based ranking were we wait upto 500ms to
 		// collect results before ranking.
 		searchOpts.FlushWallTime = 500 * time.Millisecond
-
-		// This enables the use of PageRank scores if they are available.
-		searchOpts.UseDocumentRanks = true
-
-		// This damps the impact of document ranks on the final ranking.
-		searchOpts.RanksDampingFactor = 0.5
 
 		return searchOpts
 	}


### PR DESCRIPTION
Previously we had one search feature flag for both these changes:
* Use a new zoekt execution strategy to sort results by file score instead of
bucketing by repo
* Incorporate file ranks into the score (powered by code intel)

Now this is split in two: `file-ranking` and `code-intel-ranking`. This makes
it easier to test each part of the feature to understand its effect.

## Test plan

Tested the new flags locally using `sg start` and made sure they worked as
intended.

In follow-up PRs, I'd like to add more automated tests that exercise search
feature flags -- looks like we don't have any?