### PR TITLE
bandaid for oob flow deprecation on calendar api

### DIFF
--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -1,14 +1,15 @@
+import { createServer } from 'http'
+import type { IncomingMessage, Server, ServerResponse } from 'http'
+import { AddressInfo } from 'net'
+
 import { addMinutes } from 'date-fns'
 import { Credentials } from 'google-auth-library'
 import { google, calendar_v3 } from 'googleapis'
-import { createServer } from 'http'
 import { OAuth2Client } from 'googleapis-common'
 import { readFile, writeFile } from 'mz/fs'
 import open from 'open'
-import type { IncomingMessage, Server, ServerResponse } from 'http'
 
 import { readLine, cacheFolder } from './util'
-import { AddressInfo } from 'net'
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar.events']
 const TOKEN_PATH = `${cacheFolder}/google-calendar-token.json`

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -70,7 +70,8 @@ async function getAccessTokenNoCache(server: Server, oauth2Client: OAuth2Client)
         ;(async () => open(authUrl, { wait: false }).then(cp => cp.unref()))()
     })
 
-    return (await oauth2Client.getToken(authCode)).tokens
+    const { tokens } = await oauth2Client.getToken(authCode)
+    return tokens
 }
 
 export interface EventOptions {

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -124,8 +124,7 @@ export function ensureReleaseBranchUpToDate(branch: string): void {
         process.exit(1)
     }
 }
-
-// eslint-disable-next-line unicorn/prevent-abbreviations
+ 
 export async function ensureSrcCliUpToDate(): Promise<void> {
     const latestTag = await fetch('https://api.github.com/repos/sourcegraph/src-cli/releases/latest', {
         method: 'GET',

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -124,7 +124,7 @@ export function ensureReleaseBranchUpToDate(branch: string): void {
         process.exit(1)
     }
 }
- 
+
 export async function ensureSrcCliUpToDate(): Promise<void> {
     const latestTag = await fetch('https://api.github.com/repos/sourcegraph/src-cli/releases/latest', {
         method: 'GET',


### PR DESCRIPTION
OOB flow was deprecated, and Calendar API auth was not working on the release tool. 
Created a server to be able to accept creds and be able to perform the task. The server is then closed once everything is completed.

## Test plan
removed oob redirect URL from creds
pnpm run release tracking:timeline
auth through browser -- receive and successful auth message
Authentication successful! Please return to the console

```
Using versions: { upcoming: 4.5.0, previous: 4.4.0 }
Create calendar event: Security Team to Review Release Container Image Scans 4.5: 2023-02-15T18:00:00.000Z
Event "Security Team to Review Release Container Image Scans 4.5" already exists (not updating)
...
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mucles-calendar-auth-bandaid.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

