### PR TITLE
executors: always use in-memory password for Sourcegraph App

### DIFF
--- a/cmd/frontend/graphqlbackend/executors.go
+++ b/cmd/frontend/graphqlbackend/executors.go
@@ -77,7 +77,7 @@ func (r *schemaResolver) Executors(ctx context.Context, args ExecutorsListArgs) 
 }
 
 func (r *schemaResolver) AreExecutorsConfigured() bool {
-	return conf.Get().ExecutorsAccessToken != ""
+	return conf.ExecutorsAccessToken() != ""
 }
 
 func executorByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*ExecutorResolver, error) {

--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
+	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -52,6 +54,11 @@ type Config struct {
 func (c *Config) Load() {
 	c.FrontendURL = c.Get("EXECUTOR_FRONTEND_URL", "", "The external URL of the sourcegraph instance.")
 	c.FrontendAuthorizationToken = c.Get("EXECUTOR_FRONTEND_PASSWORD", "", "The authorization token supplied to the frontend.")
+	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
+	if isSingleProgram {
+		// In single-program deployments, we respect the in-memory executor password only.
+		c.FrontendAuthorizationToken = confdefaults.SingleProgramInMemoryExecutorPassword
+	}
 	c.QueueName = c.Get("EXECUTOR_QUEUE_NAME", "", "The name of the queue to listen to.")
 	c.QueuePollInterval = c.GetInterval("EXECUTOR_QUEUE_POLL_INTERVAL", "1s", "Interval between dequeue requests.")
 	c.MaximumNumJobs = c.GetInt("EXECUTOR_MAXIMUM_NUM_JOBS", "1", "Number of virtual machines or containers that can be running at once.")

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	metricsstore "github.com/sourcegraph/sourcegraph/internal/metrics/store"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -27,7 +29,13 @@ func Init(
 	codeintelUploadHandler := enterpriseServices.NewCodeIntelUploadHandler(false)
 	batchesWorkspaceFileGetHandler := enterpriseServices.BatchesChangesFileGetHandler
 	batchesWorkspaceFileExistsHandler := enterpriseServices.BatchesChangesFileGetHandler
-	accessToken := func() string { return conf.SiteConfig().ExecutorsAccessToken }
+	accessToken := func() string {
+		isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
+		if isSingleProgram {
+			return confdefaults.SingleProgramInMemoryExecutorPassword
+		}
+		return conf.SiteConfig().ExecutorsAccessToken
+	}
 	logger := log.Scoped("executorqueue", "")
 
 	metricsStore := metricsstore.NewDistributedStore("executors:")

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -43,6 +43,14 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 	}
 }
 
+func ExecutorsAccessToken() string {
+	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
+	if isSingleProgram {
+		return confdefaults.SingleProgramInMemoryExecutorPassword
+	}
+	return Get().ExecutorsAccessToken
+}
+
 func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
 	var config []*schema.BitbucketServerConnection
 	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindBitbucketServer, &config); err != nil {

--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -91,7 +91,6 @@ var SingleProgram = conftypes.RawUnified{
 	"codeIntelAutoIndexing.enabled": true,
 	"codeIntelAutoIndexing.allowGlobalPolicies": true,
 	"executors.frontendURL": "http://host.docker.internal:3080",
-	"executors.accessToken": "` + SingleProgramInMemoryExecutorPassword + `",
 }`,
 }
 

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -112,7 +112,6 @@ func Init(logger log.Logger) {
 	// We disable the use of executors passwords, because executors only listen on `localhost` this
 	// is safe to do.
 	setDefaultEnv(logger, "EXECUTOR_FRONTEND_URL", "http://localhost:3080")
-	setDefaultEnv(logger, "EXECUTOR_FRONTEND_PASSWORD", confdefaults.SingleProgramInMemoryExecutorPassword)
 
 	setDefaultEnv(logger, "EXECUTOR_USE_FIRECRACKER", "false")
 	// TODO(sqs): TODO(single-binary): Make it so we can run multiple executors in single-program mode. Right now, you


### PR DESCRIPTION
This change makes us actually always use the in-memory password when the deployment type is Sourcegraph App.

After #46721 the executor password was randomly generated, but the site config had the randomly generated password written once, while the env var would always use the latest in-memory password. Effectively, the one saved to disk could diverge from the one in memory on the second run.

In this change I instead have us respect the in-memory password at all locations that we use the configured password, iff the deployment type is App.

## Test plan

Logically these changes should only affect app, I tested manually using `sg start enterprise-single-program`
