### PR TITLE
Add Cody codebase setting to VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,5 +72,5 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cody.codebase": "github.com/sourcegraph/sourcegraph",
+  "cody.codebase": "github.com/sourcegraph/sourcegraph"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,5 +71,6 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cody.codebase": "github.com/sourcegraph/sourcegraph",
 }


### PR DESCRIPTION
Adds a VSCode setting that lets Cody identify the codebase we are currently working with.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* No functionality changes.