### PR TITLE
batches: exclude archived, deleted changesets from completion percentage calculation

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -48,7 +48,7 @@ const batchChangeDefaults: BatchChangeFields = {
         merged: 2,
         draft: 1,
         open: 2,
-        total: 10,
+        total: 29,
         archived: 18,
         unpublished: 4,
     },

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from 'react-router'
 import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Badge, Container, Icon, Tab, TabPanel, TabPanels } from '@sourcegraph/wildcard'
+import { Badge, Container, Icon, Link, Tab, TabPanel, TabPanels, Text } from '@sourcegraph/wildcard'
 
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { resetFilteredConnectionURLQuery } from '../../../components/FilteredConnection'
@@ -268,6 +268,16 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                     )}
                 </TabPanel>
                 <TabPanel>
+                    <Text className="my-3">
+                        Archived changesets are changesets created and published by an earlier version of the batch spec
+                        that are no longer in scope of the most recent one. They are still associated with the batch
+                        change, but they will be closed on the code host. They do not count towards the batch change
+                        completion percentage. See our{' '}
+                        <Link to="/help/batch_changes/how-tos/updating_a_batch_change#removing-changesets">
+                            how-to guide
+                        </Link>{' '}
+                        for more information.
+                    </Text>
                     <BatchChangeChangesets
                         batchChangeID={batchChange.id}
                         batchChangeState={batchChange.state}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -269,10 +269,10 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 </TabPanel>
                 <TabPanel>
                     <Text className="my-3">
-                        Archived changesets are changesets created and published by an earlier version of the batch spec
-                        that are no longer in scope of the most recent one. They are still associated with the batch
-                        change, but they will be closed on the code host. They do not count towards the batch change
-                        completion percentage. See our{' '}
+                        Archived changesets are changesets created and published by an earlier version of the batch
+                        change to workspaces that are no longer in scope of the current version. They are still
+                        associated with the batch change, but they will be closed on the code host. They do not count
+                        towards the batch change completion percentage. See our{' '}
                         <Link to="/help/batch_changes/how-tos/updating_a_batch_change#removing-changesets">
                             how-to guide
                         </Link>{' '}

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -39,7 +39,7 @@ export const Draft: Story = () => (
     </WebStory>
 )
 
-export const Open: Story = args => (
+export const Open: Story<OpenArgs> = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -70,6 +70,16 @@ export const Open: Story = args => (
         )}
     </WebStory>
 )
+
+interface OpenArgs {
+    closed: number
+    deleted: number
+    merged: number
+    draft: number
+    open: number
+    archived: number
+    unpublished: number
+}
 
 Open.argTypes = {
     closed: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -39,7 +39,7 @@ export const Draft: Story = () => (
     </WebStory>
 )
 
-export const Open: Story = () => (
+export const Open: Story = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -47,14 +47,21 @@ export const Open: Story = () => (
                 batchChange={{
                     changesetsStats: {
                         __typename: 'ChangesetsStats',
-                        closed: 10,
-                        deleted: 10,
-                        merged: 10,
-                        draft: 5,
-                        open: 10,
-                        total: 100,
-                        archived: 18,
-                        unpublished: 55,
+                        closed: args.closed,
+                        deleted: args.deleted,
+                        merged: args.merged,
+                        draft: args.draft,
+                        open: args.open,
+                        total:
+                            args.closed +
+                            args.deleted +
+                            args.merged +
+                            args.draft +
+                            args.open +
+                            args.archived +
+                            args.unpublished,
+                        archived: args.archived,
+                        unpublished: args.unpublished,
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
                     state: BatchChangeState.OPEN,
@@ -63,6 +70,37 @@ export const Open: Story = () => (
         )}
     </WebStory>
 )
+
+Open.argTypes = {
+    closed: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    deleted: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    merged: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    draft: {
+        control: { type: 'number' },
+        defaultValue: 5,
+    },
+    open: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    archived: {
+        control: { type: 'number' },
+        defaultValue: 18,
+    },
+    unpublished: {
+        control: { type: 'number' },
+        defaultValue: 55,
+    },
+}
 
 export const OpenAndComplete: Story = () => (
     <WebStory>
@@ -78,7 +116,7 @@ export const OpenAndComplete: Story = () => (
                         draft: 0,
                         open: 0,
                         archived: 18,
-                        total: 100,
+                        total: 118,
                         unpublished: 0,
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
@@ -105,7 +143,7 @@ export const Closed: Story = () => (
                         draft: 0,
                         open: 10,
                         archived: 18,
-                        total: 100,
+                        total: 118,
                         unpublished: 60,
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -25,7 +25,7 @@ import {
 import styles from './BatchChangeStatsCard.module.scss'
 
 const ARCHIVED_TOOLTIP =
-    'Changesets created by an earlier spec that are not in scope of the spec anymore are archived in the batch change and closed on the code host. They do not count towards the completion percentage.'
+    'Changesets created by an earlier version of the batch change for repos that are not in scope anymore are archived in the batch change and closed on the code host. They do not count towards the completion percentage.'
 
 interface BatchChangeStatsCardProps {
     batchChange: Pick<BatchChangeFields, 'diffStat' | 'changesetsStats' | 'state'>
@@ -41,6 +41,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
     className,
 }) => {
     const { changesetsStats: stats, diffStat } = batchChange
+    // TODO: We should just compute this and `isCompleted` on the backend batch change resolver.
     const percentComplete =
         // We don't count archived or deleted changesets when computing the percentage.
         stats.total === 0 ? 0 : ((stats.closed + stats.merged) / (stats.total - stats.archived - stats.deleted)) * 100

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -37,8 +37,11 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
     className,
 }) => {
     const { changesetsStats: stats, diffStat } = batchChange
-    const percentComplete = stats.total === 0 ? 0 : ((stats.closed + stats.merged + stats.deleted) / stats.total) * 100
-    const isCompleted = stats.closed + stats.merged + stats.deleted === stats.total
+    const percentComplete =
+        // We don't count archived or deleted changesets when computing the percentage.
+        stats.total === 0 ? 0 : ((stats.closed + stats.merged) / (stats.total - stats.archived - stats.deleted)) * 100
+    const isCompleted =
+        stats.total !== 0 && stats.closed + stats.merged === stats.total - stats.archived - stats.deleted
     let BatchChangeStatusIcon = ProgressCheckIcon
     if (isCompleted) {
         BatchChangeStatusIcon = CheckCircleOutlineIcon

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
+import { mdiInformationOutline } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 
 import { pluralize } from '@sourcegraph/common'
-import { Badge, Icon, Heading, H3, H4 } from '@sourcegraph/wildcard'
+import { Badge, Icon, Heading, H3, H4, Tooltip } from '@sourcegraph/wildcard'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchChangeFields } from '../../../graphql-operations'
@@ -22,6 +23,9 @@ import {
 } from './changesets/ChangesetStatusCell'
 
 import styles from './BatchChangeStatsCard.module.scss'
+
+const ARCHIVED_TOOLTIP =
+    'Changesets created by an earlier spec that are not in scope of the spec anymore are archived in the batch change and closed on the code host. They do not count towards the completion percentage.'
 
 interface BatchChangeStatsCardProps {
     batchChange: Pick<BatchChangeFields, 'diffStat' | 'changesetsStats' | 'state'>
@@ -124,6 +128,13 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                             <H4 className="font-weight-normal text-muted m-0">
                                 {stats.archived}{' '}
                                 <VisuallyHidden>{pluralize('changeset', stats.archived)}</VisuallyHidden> archived
+                                <Tooltip content={ARCHIVED_TOOLTIP}>
+                                    <Icon
+                                        aria-label={ARCHIVED_TOOLTIP}
+                                        svgPath={mdiInformationOutline}
+                                        className="ml-1"
+                                    />
+                                </Tooltip>
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 pl-2 text-truncate')}

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -357,7 +357,7 @@ function mockCommonGraphQLResponses(
                     deleted: 1,
                     merged: 3,
                     open: 8,
-                    total: 19,
+                    total: 37,
                     archived: 18,
                     unpublished: 3,
                     draft: 2,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46830.

This was surfaced [in Slack](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1674224577396439) and felt like a reasonable change.

The completion percentage is now defined based on two values: the total "actionable changesets" as the denominator, which is defined as the total minus any archived and deleted changesets; and the total "completed changesets" as the numerator, which is defined as the sum of merged and closed changesets.

There's been confusion about how the completion percentage is calculated at times before, as well as confusion over what "archived" means and how that's factored in to this percentage. For this reason, I've added an info icon + tooltip and a short description to the top of the archived changesets list, in the style of several of our admin pages where the contents of the container are explained in brief just above it. This description includes a link to the docs, too. You can see these changes below: 

![image](https://user-images.githubusercontent.com/8942601/214142420-39d5aa14-fdc6-49b4-ab42-e5ca3d933874.png)

cc @danielmarquespt

Open to wording suggestions. 🙂

## Test plan

Updated storybooks to use control knobs to test how different changeset stats affect the percentage. As in the screenshot above, you can verify archived was not included in the batch change completion percentage.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-dont-count-archived-percent.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
