### PR TITLE
build: set plugin-backstage tsconfig.compilerOptions.jsx

### DIFF
--- a/client/plugin-backstage/tsconfig.json
+++ b/client/plugin-backstage/tsconfig.json
@@ -10,6 +10,7 @@
   ],
   "compilerOptions": {
     "outDir": "dist-types",
-    "rootDir": "."
+    "rootDir": ".",
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
Almost every tsconfig has this, I'm not sure why this one doesn't, but when compiling with bazel it fails when this is missing.

## Test plan

CI