### PR TITLE
build: set plugin-backstage tsconfig.compilerOptions.jsx

### DIFF
--- a/client/plugin-backstage/tsconfig.json
+++ b/client/plugin-backstage/tsconfig.json
@@ -10,6 +10,7 @@
   ],
   "compilerOptions": {
     "outDir": "dist-types",
-    "rootDir": "."
+    "rootDir": ".",
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
Almost every tsconfig has this, I'm not sure why this one doesn't, but when compiling with bazel it fails when this is missing.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-plugin-jsx.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
