### PR TITLE
build: ensure public interfaces are exported from packages

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.fixtures.ts
+++ b/client/branded/src/components/panel/TabbedPanelContent.fixtures.ts
@@ -9,6 +9,8 @@ import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
+import { TabbedPanelContentProps } from './TabbedPanelContent'
+
 export const panels: PanelViewData[] = [
     {
         id: 'panel_1',
@@ -68,7 +70,7 @@ export const panelMenus = {
     ],
 }
 
-export const panelProps = {
+export const panelProps: TabbedPanelContentProps = {
     repoName: 'git://github.com/foo/bar',
     fetchHighlightedFileLineRanges: () => of([]),
     isLightTheme: true,

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -44,7 +44,7 @@ import { PanelView } from './views/PanelView'
 
 import styles from './TabbedPanelContent.module.scss'
 
-interface TabbedPanelContentProps
+export interface TabbedPanelContentProps
     extends ExtensionsControllerProps,
         PlatformContextProps,
         SettingsCascadeProps,

--- a/client/browser/src/end-to-end/phabricator.test.ts
+++ b/client/browser/src/end-to-end/phabricator.test.ts
@@ -78,7 +78,7 @@ async function addPhabricatorRepo(driver: Driver): Promise<void> {
     // Activate the repo and wait for it to clone
     await driver.page.goto(PHABRICATOR_BASE_URL + '/source/jrpc/manage/')
     const activateButton = await driver.page.waitForSelector('a[href="/source/jrpc/edit/activate/"]')
-    const buttonLabel = (await (await activateButton!.getProperty('textContent')).jsonValue()).trim()
+    const buttonLabel = (await (await activateButton!.getProperty('textContent')).jsonValue<string>()).trim()
     // Don't click if it says "Deactivate Repository"
     if (buttonLabel === 'Activate Repository') {
         await activateButton!.click()


### PR DESCRIPTION
`panelProps` is public and its type must also be public. With stricter deps with a bazel build there is a compile error without this.

Without the `phabricator` change the type is inferred as `unknown`. I don't fully understand why stricter deps cause that one though 🤔 

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-missing-exports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
