### PR TITLE
Make Wolfi CI pipelines smarter

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -83,6 +83,14 @@ The default run type.
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan sg
   - Upload build trace
 
+- Pipeline for `WolfiPackages` changes:
+  - **Metadata**: Pipeline metadata
+  - Upload build trace
+
+- Pipeline for `WolfiBaseImages` changes:
+  - **Metadata**: Pipeline metadata
+  - Upload build trace
+
 ### Bazel Exp Branch
 
 The run type for branches matching `bzl/`.
@@ -110,8 +118,6 @@ sg ci build wolfi
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- Package dependency foobar
-- Build stuff foobar
 - Upload build trace
 
 ### Release branch nightly healthcheck build

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -25,6 +25,8 @@ const (
 	SVG
 	Shell
 	DockerImages
+	WolfiPackages
+	WolfiBaseImages
 
 	// All indicates all changes should be considered included in this diff, except None.
 	All
@@ -170,6 +172,16 @@ func ParseDiff(files []string) (diff Diff) {
 			// quite a while.
 			f.Close()
 		}
+
+		// Affects Wolfi packages
+		if strings.HasPrefix(p, "wolfi-packages/") && strings.HasSuffix(p, ".yaml") {
+			diff |= WolfiPackages
+		}
+
+		// Affects Wolfi base images
+		if strings.HasPrefix(p, "wolfi-images/") && strings.HasSuffix(p, ".yaml") {
+			diff |= WolfiBaseImages
+		}
 	}
 	return
 }
@@ -205,6 +217,10 @@ func (d Diff) String() string {
 		return "Shell"
 	case DockerImages:
 		return "DockerImages"
+	case WolfiPackages:
+		return "WolfiPackages"
+	case WolfiBaseImages:
+		return "WolfiBaseImages"
 
 	case All:
 		return "All"

--- a/enterprise/dev/ci/internal/ci/changed/diff_test.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff_test.go
@@ -76,7 +76,6 @@ func TestParseDiff(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// TODO: Update tests
 			diff, changedFiles := ParseDiff(tt.files)
 			for _, want := range tt.wantAffects {
 				assert.True(t, diff.Has(want))

--- a/enterprise/dev/ci/internal/ci/changed/diff_test.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff_test.go
@@ -1,6 +1,7 @@
 package changed
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,42 +32,60 @@ func TestParseDiff(t *testing.T) {
 		name             string
 		files            []string
 		wantAffects      []Diff
+		wantChangedFiles ChangedFiles
 		doNotWantAffects []Diff
 	}{{
 		name:             "None",
 		files:            []string{"asdf"},
 		wantAffects:      []Diff{None},
+		wantChangedFiles: make(ChangedFiles),
 		doNotWantAffects: []Diff{Go, Client, DatabaseSchema, All},
 	}, {
 		name:             "Go",
 		files:            []string{"main.go", "func.go"},
 		wantAffects:      []Diff{Go},
+		wantChangedFiles: make(ChangedFiles),
 		doNotWantAffects: []Diff{Client, All},
 	}, {
 		name:             "go testdata",
 		files:            []string{"internal/cmd/search-blitz/queries.txt"},
 		wantAffects:      []Diff{Go},
+		wantChangedFiles: make(ChangedFiles),
 		doNotWantAffects: []Diff{Client, All},
 	}, {
 		name:             "DB schema implies Go and DB schema diff",
 		files:            []string{"migrations/file1", "migrations/file2"},
 		wantAffects:      []Diff{Go, DatabaseSchema},
+		wantChangedFiles: make(ChangedFiles),
 		doNotWantAffects: []Diff{Client, All},
 	}, {
 		name:             "Or",
 		files:            []string{"client/file1", "file2.graphql"},
 		wantAffects:      []Diff{Client | GraphQL},
+		wantChangedFiles: make(ChangedFiles),
 		doNotWantAffects: []Diff{Go, All},
+	}, {
+		name:        "Wolfi",
+		files:       []string{"wolfi-images/image-test.yaml", "wolfi-packages/package-test.yaml"},
+		wantAffects: []Diff{WolfiBaseImages, WolfiPackages},
+		wantChangedFiles: ChangedFiles{
+			WolfiBaseImages: []string{"wolfi-images/image-test.yaml"},
+			WolfiPackages:   []string{"wolfi-packages/package-test.yaml"},
+		},
+		doNotWantAffects: []Diff{},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// TODO: Update tests
-			diff, _ := ParseDiff(tt.files)
+			diff, changedFiles := ParseDiff(tt.files)
 			for _, want := range tt.wantAffects {
 				assert.True(t, diff.Has(want))
 			}
 			for _, doNotWant := range tt.doNotWantAffects {
 				assert.False(t, diff.Has(doNotWant))
+			}
+			if !reflect.DeepEqual(changedFiles, tt.wantChangedFiles) {
+				t.Errorf("wantedChangedFiles not equal:\nGot: %+v\nWant: %+v\n", changedFiles, tt.wantChangedFiles)
 			}
 		})
 	}

--- a/enterprise/dev/ci/internal/ci/changed/diff_test.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff_test.go
@@ -60,7 +60,8 @@ func TestParseDiff(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			diff := ParseDiff(tt.files)
+			// TODO: Update tests
+			diff, _ := ParseDiff(tt.files)
 			for _, want := range tt.wantAffects {
 				assert.True(t, diff.Has(want))
 			}

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -30,6 +30,8 @@ type Config struct {
 
 	// Diff denotes what has changed since the merge-base with origin/main.
 	Diff changed.Diff
+	// ChangedFiles lists files that have changed, group by diff type
+	ChangedFiles changed.ChangedFiles
 
 	// MustIncludeCommit, if non-empty, is a list of commits at least one of which must be present
 	// in the branch. If empty, then no check is enforced.
@@ -99,6 +101,8 @@ func NewConfig(now time.Time) Config {
 		changedFiles = strings.Split(strings.TrimSpace(string(output)), "\n")
 	}
 
+	// fmt.Printf("List of changed files:\n%+v\n", changedFiles)
+
 	// special tag adjustments based on run type
 	switch {
 	case runType.Is(runtype.TaggedRelease):
@@ -119,6 +123,8 @@ func NewConfig(now time.Time) Config {
 		tag = tag + "_patch"
 	}
 
+	diff, changedFilesByDiffType := changed.ParseDiff(changedFiles)
+
 	return Config{
 		RunType: runType,
 
@@ -127,7 +133,8 @@ func NewConfig(now time.Time) Config {
 		Version:           tag,
 		Commit:            commit,
 		MustIncludeCommit: mustIncludeCommits,
-		Diff:              changed.ParseDiff(changedFiles),
+		Diff:              diff,
+		ChangedFiles:      changedFilesByDiffType,
 		BuildNumber:       buildNumber,
 
 		// get flags from commit message

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -101,8 +101,6 @@ func NewConfig(now time.Time) Config {
 		changedFiles = strings.Split(strings.TrimSpace(string(output)), "\n")
 	}
 
-	// fmt.Printf("List of changed files:\n%+v\n", changedFiles)
-
 	// special tag adjustments based on run type
 	switch {
 	case runType.Is(runtype.TaggedRelease):

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -93,9 +93,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(BazelOperations())
 	case runtype.WolfiExpBranch:
 		if c.Diff.Has(changed.WolfiBaseImages) {
+			fmt.Printf("Wolfi base image changed files: %+v\n\n", c.ChangedFiles[changed.WolfiBaseImages])
 			ops.Merge(WolfiBaseImagesOperations(c.ChangedFiles[changed.WolfiBaseImages]))
 		}
 		if c.Diff.Has(changed.WolfiPackages) {
+			fmt.Printf("Wolfi package changed files: %+v\n", c.ChangedFiles[changed.WolfiPackages])
 			ops.Merge(WolfiPackagesOperations(c.ChangedFiles[changed.WolfiPackages]))
 		}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -93,10 +93,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(BazelOperations())
 	case runtype.WolfiExpBranch:
 		if c.Diff.Has(changed.WolfiBaseImages) {
-			ops.Merge(WolfiBaseImagesOperations())
+			ops.Merge(WolfiBaseImagesOperations(c.ChangedFiles[changed.WolfiBaseImages]))
 		}
 		if c.Diff.Has(changed.WolfiPackages) {
-			ops.Merge(WolfiPackagesOperations())
+			ops.Merge(WolfiPackagesOperations(c.ChangedFiles[changed.WolfiPackages]))
 		}
 
 	case runtype.PullRequest:

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -93,11 +93,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(BazelOperations())
 	case runtype.WolfiExpBranch:
 		if c.Diff.Has(changed.WolfiBaseImages) {
-			fmt.Printf("Wolfi base image changed files: %+v\n\n", c.ChangedFiles[changed.WolfiBaseImages])
 			ops.Merge(WolfiBaseImagesOperations(c.ChangedFiles[changed.WolfiBaseImages]))
 		}
 		if c.Diff.Has(changed.WolfiPackages) {
-			fmt.Printf("Wolfi package changed files: %+v\n", c.ChangedFiles[changed.WolfiPackages])
 			ops.Merge(WolfiPackagesOperations(c.ChangedFiles[changed.WolfiPackages]))
 		}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -92,7 +92,13 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.BazelExpBranch:
 		ops.Merge(BazelOperations())
 	case runtype.WolfiExpBranch:
-		ops.Merge(WolfiOperations())
+		if c.Diff.Has(changed.WolfiBaseImages) {
+			ops.Merge(WolfiBaseImagesOperations())
+		}
+		if c.Diff.Has(changed.WolfiPackages) {
+			ops.Merge(WolfiPackagesOperations())
+		}
+
 	case runtype.PullRequest:
 		// First, we set up core test operations that apply both to PRs and to other run
 		// types such as main.

--- a/enterprise/dev/ci/internal/ci/wolfi_operations.go
+++ b/enterprise/dev/ci/internal/ci/wolfi_operations.go
@@ -3,6 +3,8 @@ package ci
 import (
 	"fmt"
 
+	"github.com/sourcegraph/log"
+
 	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -14,13 +16,14 @@ var packageRegex = lazyregexp.New(`wolfi-packages\/(\w+)[.]yaml`)
 func WolfiBaseImagesOperations(changedFiles []string) *operations.Set {
 	// TODO: Should we require the image name, or the full path to the yaml file?
 	ops := operations.NewSet()
+	logger := log.Scoped("gen-pipeline", "generates the pipeline for ci")
 
 	for _, c := range changedFiles {
 		match := baseImageRegex.FindStringSubmatch(c)
 		if len(match) == 2 {
 			ops.Append(buildWolfi(match[1]))
 		} else {
-			fmt.Printf("Unable to extract base image name from '%s', matches were %+v\n", c, match)
+			logger.Fatal(fmt.Sprintf("Unable to extract base image name from '%s', matches were %+v\n", c, match))
 		}
 	}
 
@@ -30,13 +33,15 @@ func WolfiBaseImagesOperations(changedFiles []string) *operations.Set {
 func WolfiPackagesOperations(changedFiles []string) *operations.Set {
 	// TODO: Should we require the image name, or the full path to the yaml file?
 	ops := operations.NewSet()
+	logger := log.Scoped("gen-pipeline", "generates the pipeline for ci")
+	changedFiles = append(changedFiles, "hello/world")
 
 	for _, c := range changedFiles {
 		match := packageRegex.FindStringSubmatch(c)
 		if len(match) == 2 {
 			ops.Append(buildPackages(match[1]))
 		} else {
-			fmt.Printf("Unable to extract package name from '%s', matches were %+v\n", c, match)
+			logger.Fatal(fmt.Sprintf("Unable to extract package name from '%s', matches were %+v\n", c, match))
 		}
 	}
 

--- a/enterprise/dev/ci/internal/ci/wolfi_operations.go
+++ b/enterprise/dev/ci/internal/ci/wolfi_operations.go
@@ -7,10 +7,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
-func WolfiOperations() *operations.Set {
+func WolfiBaseImagesOperations() *operations.Set {
+	// TODO: Only rebuild packages that have changed
+
+	ops := operations.NewSet()
+	ops.Append(buildWolfi("foobar"))
+	return ops
+}
+
+func WolfiPackagesOperations() *operations.Set {
+	// TODO: Only rebuild packages that have changed
+
 	ops := operations.NewSet()
 	ops.Append(buildPackages("foobar"))
-	ops.Append(buildWolfi("foobar"))
 	return ops
 }
 

--- a/enterprise/dev/ci/internal/ci/wolfi_operations.go
+++ b/enterprise/dev/ci/internal/ci/wolfi_operations.go
@@ -34,7 +34,6 @@ func WolfiPackagesOperations(changedFiles []string) *operations.Set {
 	// TODO: Should we require the image name, or the full path to the yaml file?
 	ops := operations.NewSet()
 	logger := log.Scoped("gen-pipeline", "generates the pipeline for ci")
-	changedFiles = append(changedFiles, "hello/world")
 
 	for _, c := range changedFiles {
 		match := packageRegex.FindStringSubmatch(c)

--- a/enterprise/dev/ci/internal/ci/wolfi_operations.go
+++ b/enterprise/dev/ci/internal/ci/wolfi_operations.go
@@ -5,27 +5,47 @@ import (
 
 	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-func WolfiBaseImagesOperations() *operations.Set {
-	// TODO: Only rebuild packages that have changed
+var baseImageRegex = lazyregexp.New(`wolfi-images\/([^\/]+)\/\w+[.]yaml`)
+var packageRegex = lazyregexp.New(`wolfi-packages\/(\w+)[.]yaml`)
 
+func WolfiBaseImagesOperations(changedFiles []string) *operations.Set {
+	// TODO: Should we require the image name, or the full path to the yaml file?
 	ops := operations.NewSet()
-	ops.Append(buildWolfi("foobar"))
+
+	for _, c := range changedFiles {
+		match := baseImageRegex.FindStringSubmatch(c)
+		if len(match) == 2 {
+			ops.Append(buildWolfi(match[1]))
+		} else {
+			fmt.Printf("Unable to extract base image name from '%s', matches were %+v\n", c, match)
+		}
+	}
+
 	return ops
 }
 
-func WolfiPackagesOperations() *operations.Set {
-	// TODO: Only rebuild packages that have changed
-
+func WolfiPackagesOperations(changedFiles []string) *operations.Set {
+	// TODO: Should we require the image name, or the full path to the yaml file?
 	ops := operations.NewSet()
-	ops.Append(buildPackages("foobar"))
+
+	for _, c := range changedFiles {
+		match := packageRegex.FindStringSubmatch(c)
+		if len(match) == 2 {
+			ops.Append(buildPackages(match[1]))
+		} else {
+			fmt.Printf("Unable to extract package name from '%s', matches were %+v\n", c, match)
+		}
+	}
+
 	return ops
 }
 
 func buildPackages(target string) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(fmt.Sprintf(":package: Package dependency %s", target),
+		pipeline.AddStep(fmt.Sprintf(":package: Package dependency '%s'", target),
 			bk.Cmd(fmt.Sprintf("./enterprise/dev/ci/scripts/wolfi/build-package.sh %s", target)),
 			// We want to run on the bazel queue, so we have a pretty minimal agent.
 			bk.Agent("queue", "bazel"),
@@ -35,7 +55,7 @@ func buildPackages(target string) func(*bk.Pipeline) {
 
 func buildWolfi(target string) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(fmt.Sprintf(":wolf: Build stuff %s", target),
+		pipeline.AddStep(fmt.Sprintf(":wolf: Build Wolfi base image '%s'", target),
 			bk.Cmd(fmt.Sprintf("./enterprise/dev/ci/scripts/wolfi/build.sh %s", target)),
 			// We want to run on the bazel queue, so we have a pretty minimal agent.
 			bk.Agent("queue", "bazel"),

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "/root" # TODO: Only used in local Docker
 
 set -euf -o pipefail
 tmpdir=$(mktemp -d -t melange-bin.XXXXXXXX)

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
-cd "/root" # TODO: Only used in local Docker
 
 set -euf -o pipefail
 tmpdir=$(mktemp -d -t melange-bin.XXXXXXXX)

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -49,6 +49,9 @@ fi
 # NOTE: Melange relies upon a more recent version of bubblewrap than ships with Ubuntu 20.04. We therefore build a recent
 # bubblewrap release in buildkite-agent-stateless-bazel's Dockerfile, and ship it in /usr/local/bin
 
+# NOTE: Melange relies upon a more recent version of bubblewrap than ships with Ubuntu 20.04. We therefore build a recent
+# bubblewrap release in buildkite-agent-stateless-bazel's Dockerfile, and ship it in /usr/local/bin
+
 echo " * Building melange package '$name'"
 # TODO: Signing key
 melange build "$name.yaml" --arch x86_64

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -49,9 +49,6 @@ fi
 # NOTE: Melange relies upon a more recent version of bubblewrap than ships with Ubuntu 20.04. We therefore build a recent
 # bubblewrap release in buildkite-agent-stateless-bazel's Dockerfile, and ship it in /usr/local/bin
 
-# NOTE: Melange relies upon a more recent version of bubblewrap than ships with Ubuntu 20.04. We therefore build a recent
-# bubblewrap release in buildkite-agent-stateless-bazel's Dockerfile, and ship it in /usr/local/bin
-
 echo " * Building melange package '$name'"
 # TODO: Signing key
 melange build "$name.yaml" --arch x86_64

--- a/wolfi-images/foobar/apko.yaml
+++ b/wolfi-images/foobar/apko.yaml
@@ -34,4 +34,4 @@ annotations:
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://docs.sourcegraph.com/
 
-# Test change
+# MANUAL REBUILD: Wed 25 Jan 2023 10:01:49 GMT

--- a/wolfi-images/foobar/apko.yaml
+++ b/wolfi-images/foobar/apko.yaml
@@ -33,3 +33,5 @@ annotations:
   org.opencontainers.image.url: https://sourcegraph.com/
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://docs.sourcegraph.com/
+
+# Test change

--- a/wolfi-images/rebuild-images.sh
+++ b/wolfi-images/rebuild-images.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -eu -o pipefail
+
 # Run this script to rebuild all Wolfi base images.
 #
 # Normally Buildkite only rebuilds a base image when its YAML file changes - this scripts bumps a

--- a/wolfi-images/rebuild-images.sh
+++ b/wolfi-images/rebuild-images.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+# Run this script to rebuild all Wolfi base images.
+#
+# Normally Buildkite only rebuilds a base image when its YAML file changes - this scripts bumps a
+#   value in a comment to force a rebuild.
+# This is helpful to fix vulnerabilities as it will fetch the latest versions of packages.
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+COMMENT_TOKEN="MANUAL REBUILD"
+DATE=$(date)
+
+# Search Wolfi YAML files - if no matching comment exists, append it
+grep -L "$COMMENT_TOKEN" ./*/apko.yaml | xargs -I {} sh -c "echo \"\n# $COMMENT_TOKEN: \" >> {}"
+
+# Update comment to include the current date & time
+sed -i '' "s/# $COMMENT_TOKEN: .*/# $COMMENT_TOKEN: $DATE/" ./*/apko.yaml
+
+echo "Buildkite will rebuild the following base images on next push:"
+grep -l "# $COMMENT_TOKEN: $DATE" ./*/apko.yaml | sed 's/\.\/\(.*\)\/apko\.yaml/ 🐳 \1/'

--- a/wolfi-images/rebuild-images.sh
+++ b/wolfi-images/rebuild-images.sh
@@ -6,7 +6,7 @@
 #   value in a comment to force a rebuild.
 # This is helpful to fix vulnerabilities as it will fetch the latest versions of packages.
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
 COMMENT_TOKEN="MANUAL REBUILD"
 DATE=$(date)

--- a/wolfi-packages/foobar.yaml
+++ b/wolfi-packages/foobar.yaml
@@ -1,5 +1,4 @@
-# Melange-based replacement for Coursier
-# Previously packaged in the scip-java repo
+# Foobar package based on Coursier package
 
 package:
   name: coursier


### PR DESCRIPTION
- [x] Only rebuild packages and base images when something changes
- [x] Only rebuild the changed artifact
- [x] Update tests

Also need to think about a few things:
* Should there be a way to rebuild all the base images on demand? This would let us pull in new and updated packages across all images.
* What should happen if a package config changes, but the version isn't bumped? What about if the version is bumped but this version already exists in the repo?
  * Maybe we solve this at the point of upload, by refusing to overwrite existing packages in the repo and throwing a CI error then.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- [x] Manually checking buildkite pipeline`
- [ ] Run `sg ci build main-dry-run` before merging - https://buildkite.com/sourcegraph/sourcegraph/builds/195338#_