### PR TITLE
Worker dashboard: Modify test, fix calculation

### DIFF
--- a/internal/goroutine/recorder/common.go
+++ b/internal/goroutine/recorder/common.go
@@ -98,7 +98,7 @@ func mergeStats(a RoutineRunStats, b RoutineRunStats) RoutineRunStats {
 	} else {
 		minDurationMs = a.MinDurationMs
 	}
-	avgDurationMs := int32(math.Round(float64(a.AvgDurationMs*a.RunCount+b.AvgDurationMs*b.RunCount) / float64(a.RunCount+b.RunCount)))
+	avgDurationMs := int32(math.Round((float64(a.AvgDurationMs)*float64(a.RunCount) + float64(b.AvgDurationMs)*float64(b.RunCount)) / (float64(a.RunCount) + float64(b.RunCount))))
 	var maxDurationMs int32
 	if b.MaxDurationMs > a.MaxDurationMs {
 		maxDurationMs = b.MaxDurationMs

--- a/internal/goroutine/recorder/reader.go
+++ b/internal/goroutine/recorder/reader.go
@@ -281,7 +281,16 @@ func loadRunStats(c *rcache.Cache, jobName string, routineName string, now time.
 			if err != nil {
 				return RoutineRunStats{}, errors.Wrap(err, "deserialize stats for day")
 			}
-			stats = mergeStats(stats, statsForDay)
+			mergedStats := mergeStats(stats, statsForDay)
+
+			// Temporary code: There was a bug that messed up past averages.
+			// This block helps ignore that messed-up data.
+			// We can pretty safely remove this in four months.
+			if mergedStats.AvgDurationMs < 0 {
+				mergedStats.AvgDurationMs = stats.AvgDurationMs
+			}
+
+			stats = mergedStats
 			if stats.Since.IsZero() {
 				stats.Since = date
 			}


### PR DESCRIPTION
An int32 overflow was happening because of a wrongly constructed formula.

This PR fixes the bug and helps remove the corrupted data from calculations. This will result in inaccurate data in a maximum seven day long transient period after upgrading to this, only for the routines that were affected by the bug.
If the stats are consistent for a routine, this shouldn't be a noticeable diff after the end of the calendar day of the upgrade.

## Test plan

Automated tests should pass.