### PR TITLE
ci: updated generated docs for wolfi

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -110,6 +110,7 @@ sg ci build wolfi
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
+- Package dependency foobar
 - Build stuff foobar
 - Upload build trace
 


### PR DESCRIPTION
A missing doc generation slipped in https://github.com/sourcegraph/sourcegraph/pull/46785 because we're using special branches. This fixes it.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Green CI. 