### PR TITLE
Implement old ".." behavior in new file tree

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -17,6 +17,7 @@ export type FeatureFlagName =
     | 'plg-enable-add-codehost-widget'
     | 'enable-rbac'
     | 'accessible-file-tree'
+    | 'accessible-file-tree-always-load-ancestors'
 
 interface OrgFlagOverride {
     orgID: string


### PR DESCRIPTION
Part of #12916 

As part of #12916 we discussed what we should do with the old behavior where full-reloads (and shared links) into a subtree are only loading entries of the current directory and appending a `..`. We decided to bring it to the new implementation as well as close to the old implementation as possible so that we can properly test it against the new behavior of always loading sibling entries. 

This is a cheap way of doing so. I first wanted to go down the road of doing the bookkeeping and updating the tree state and all its IDs when I realized that I could just throw away the file tree and recreate it from a different root. This is mimicking what we had before. 

## Test plan

https://user-images.githubusercontent.com/458591/214364123-3b9d7ba1-ee11-4585-a018-ea22e14254cf.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-file-tree-old-dot-dot-behavior.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
