### PR TITLE
Add support for projects and repos that have names with spaces for ADO

### DIFF
--- a/internal/repos/azuredevops_test.go
+++ b/internal/repos/azuredevops_test.go
@@ -15,10 +15,10 @@ func TestAzureDevOpsSource_ListRepos(t *testing.T) {
 		Url:      "https://dev.azure.com",
 		Username: "testuser",
 		Token:    "testtoken",
-		Orgs:     []string{"sgtestazure"},
+		Projects: []string{"sgtestazure/sgtestazure", "sgtestazure/sg test with spaces"},
 		Exclude: []*schema.ExcludedAzureDevOpsServerRepo{
 			{
-				Name: "sgtestazure/sgtestazure2",
+				Name: "sg test with spaces/sg test with spaces",
 			},
 			{
 				Pattern: "^sgtestazure/sgtestazure[3-9]",

--- a/internal/repos/testdata/sources/AZUREDEVOPS/TestAzureDevOpsSource_ListRepos
+++ b/internal/repos/testdata/sources/AZUREDEVOPS/TestAzureDevOpsSource_ListRepos
@@ -1,6 +1,45 @@
 [
   {
    "ID": 0,
+   "Name": "dev.azure.com/sgtestazure2",
+   "URI": "dev.azure.com/sgtestazure2",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "d66c87ea-6548-4a67-9f1f-560528393e73",
+    "ServiceType": "azuredevops",
+    "ServiceID": "https://dev.azure.com/"
+   },
+   "Sources": {
+    "extsvc:azuredevops:0": {
+     "ID": "extsvc:azuredevops:0",
+     "CloneURL": "https://dev.azure.com/sgtestazure2"
+    }
+   },
+   "Metadata": {
+    "id": "d66c87ea-6548-4a67-9f1f-560528393e73",
+    "name": "sgtestazure2",
+    "remoteURL": "https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure2",
+    "url": "https://dev.azure.com/sgtestazure/dc493f7d-0b57-4de2-a59b-3f74ff3ea334/_apis/git/repositories/d66c87ea-6548-4a67-9f1f-560528393e73",
+    "sshUrl": "git@ssh.dev.azure.com:v3/sgtestazure/sgtestazure/sgtestazure2",
+    "webUrl": "https://dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure2",
+    "isDisabled": false,
+    "project": {
+     "id": "dc493f7d-0b57-4de2-a59b-3f74ff3ea334",
+     "name": "sgtestazure",
+     "state": "wellFormed",
+     "revision": 11,
+     "visibility": "private"
+    }
+   }
+  },
+  {
+   "ID": 0,
    "Name": "dev.azure.com/sgtestazure",
    "URI": "dev.azure.com/sgtestazure",
    "Description": "",
@@ -34,6 +73,45 @@
      "name": "sgtestazure",
      "state": "wellFormed",
      "revision": 11,
+     "visibility": "private"
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "dev.azure.com/sg test with spaces 2",
+   "URI": "dev.azure.com/sg test with spaces 2",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "00e0ad0a-66df-4dc2-bd1b-4c34e05b9225",
+    "ServiceType": "azuredevops",
+    "ServiceID": "https://dev.azure.com/"
+   },
+   "Sources": {
+    "extsvc:azuredevops:0": {
+     "ID": "extsvc:azuredevops:0",
+     "CloneURL": "https://dev.azure.com/sg%20test%20with%20spaces%202"
+    }
+   },
+   "Metadata": {
+    "id": "00e0ad0a-66df-4dc2-bd1b-4c34e05b9225",
+    "name": "sg test with spaces 2",
+    "remoteURL": "https://sgtestazure@dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces%202",
+    "url": "https://dev.azure.com/sgtestazure/8c1230da-3631-41e8-8df3-c94a705227d8/_apis/git/repositories/00e0ad0a-66df-4dc2-bd1b-4c34e05b9225",
+    "sshUrl": "git@ssh.dev.azure.com:v3/sgtestazure/sg%20test%20with%20spaces/sg%20test%20with%20spaces%202",
+    "webUrl": "https://dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces%202",
+    "isDisabled": false,
+    "project": {
+     "id": "8c1230da-3631-41e8-8df3-c94a705227d8",
+     "name": "sg test with spaces",
+     "state": "wellFormed",
+     "revision": 19,
      "visibility": "private"
     }
    }

--- a/internal/repos/testdata/sources/TestAzureDevOpsSource_ListRepos.yaml
+++ b/internal/repos/testdata/sources/TestAzureDevOpsSource_ListRepos.yaml
@@ -5,7 +5,7 @@ interactions:
     body: ""
     form: {}
     headers: {}
-    url: https://dev.azure.com/sgtestazure/_apis/git/repositories?api-version=7.0
+    url: https://dev.azure.com/sgtestazure/sgtestazure/_apis/git/repositories?api-version=7.0
     method: GET
   response:
     body: '{"value":[{"id":"2128ab2d-8459-4359-9939-221e92f3aeb1","name":"sgtestazure3","url":"https://dev.azure.com/sgtestazure/dc493f7d-0b57-4de2-a59b-3f74ff3ea334/_apis/git/repositories/2128ab2d-8459-4359-9939-221e92f3aeb1","project":{"id":"dc493f7d-0b57-4de2-a59b-3f74ff3ea334","name":"sgtestazure","url":"https://dev.azure.com/sgtestazure/_apis/projects/dc493f7d-0b57-4de2-a59b-3f74ff3ea334","state":"wellFormed","revision":11,"visibility":"private","lastUpdateTime":"2023-01-20T19:22:47.403Z"},"defaultBranch":"refs/heads/master","size":1076199250,"remoteUrl":"https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure3","sshUrl":"git@ssh.dev.azure.com:v3/sgtestazure/sgtestazure/sgtestazure3","webUrl":"https://dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure3","isDisabled":false,"isInMaintenance":false},{"id":"d66c87ea-6548-4a67-9f1f-560528393e73","name":"sgtestazure2","url":"https://dev.azure.com/sgtestazure/dc493f7d-0b57-4de2-a59b-3f74ff3ea334/_apis/git/repositories/d66c87ea-6548-4a67-9f1f-560528393e73","project":{"id":"dc493f7d-0b57-4de2-a59b-3f74ff3ea334","name":"sgtestazure","url":"https://dev.azure.com/sgtestazure/_apis/projects/dc493f7d-0b57-4de2-a59b-3f74ff3ea334","state":"wellFormed","revision":11,"visibility":"private","lastUpdateTime":"2023-01-20T19:22:47.403Z"},"defaultBranch":"refs/heads/main","size":726,"remoteUrl":"https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure2","sshUrl":"git@ssh.dev.azure.com:v3/sgtestazure/sgtestazure/sgtestazure2","webUrl":"https://dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure2","isDisabled":false,"isInMaintenance":false},{"id":"c4d186ef-18a6-4de4-a610-aa9ebd4e1faa","name":"sgtestazure","url":"https://dev.azure.com/sgtestazure/dc493f7d-0b57-4de2-a59b-3f74ff3ea334/_apis/git/repositories/c4d186ef-18a6-4de4-a610-aa9ebd4e1faa","project":{"id":"dc493f7d-0b57-4de2-a59b-3f74ff3ea334","name":"sgtestazure","url":"https://dev.azure.com/sgtestazure/_apis/projects/dc493f7d-0b57-4de2-a59b-3f74ff3ea334","state":"wellFormed","revision":11,"visibility":"private","lastUpdateTime":"2023-01-20T19:22:47.403Z"},"defaultBranch":"refs/heads/master","size":3688420,"remoteUrl":"https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure","sshUrl":"git@ssh.dev.azure.com:v3/sgtestazure/sgtestazure/sgtestazure","webUrl":"https://dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure","isDisabled":false,"isInMaintenance":false}],"count":3}'
@@ -13,13 +13,13 @@ interactions:
       Access-Control-Expose-Headers:
       - Request-Context
       Activityid:
-      - b7e8f968-7fc5-4b2f-9a0e-cb723b27c10a
+      - a7a5b050-c2e8-44e2-bb0e-2cda929b332e
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Content-Type:
       - application/json; charset=utf-8; api-version=7.0
       Date:
-      - Mon, 23 Jan 2023 22:42:50 GMT
+      - Tue, 24 Jan 2023 19:16:36 GMT
       Expires:
       - "-1"
       P3p:
@@ -38,13 +38,68 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Msedge-Ref:
-      - 'Ref A: AE9B67408584445184D1CFBBEFCCE092 Ref B: YTO01EDGE0709 Ref C: 2023-01-23T22:42:50Z'
+      - 'Ref A: 6ACDBF5455AF4A74AD8354ABC8EF64F2 Ref B: YTO01EDGE0722 Ref C: 2023-01-24T19:16:36Z'
       X-Tfs-Processid:
-      - e968aadd-28b1-429b-9a38-36d96f9657ba
+      - ac359a4d-dc5e-4561-b051-2a78bbebe0b3
       X-Tfs-Session:
-      - b7e8f968-7fc5-4b2f-9a0e-cb723b27c10a
+      - a7a5b050-c2e8-44e2-bb0e-2cda929b332e
       X-Vss-E2eid:
-      - b7e8f968-7fc5-4b2f-9a0e-cb723b27c10a
+      - a7a5b050-c2e8-44e2-bb0e-2cda929b332e
+      X-Vss-Senderdeploymentid:
+      - 4ff21e82-8865-0b2e-ffe8-9598818f8190
+      X-Vss-Userdata:
+      - 473dec3e-03d7-6147-b106-0b0a7f766a92:idan.varsano@sourcegraph.com
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_apis/git/repositories?api-version=7.0
+    method: GET
+  response:
+    body: '{"value":[{"id":"7a7a0959-9c79-47f5-9d42-319c735179ce","name":"sg test
+      with spaces","url":"https://dev.azure.com/sgtestazure/8c1230da-3631-41e8-8df3-c94a705227d8/_apis/git/repositories/7a7a0959-9c79-47f5-9d42-319c735179ce","project":{"id":"8c1230da-3631-41e8-8df3-c94a705227d8","name":"sg
+      test with spaces","description":"test project with spaces","url":"https://dev.azure.com/sgtestazure/_apis/projects/8c1230da-3631-41e8-8df3-c94a705227d8","state":"wellFormed","revision":19,"visibility":"private","lastUpdateTime":"2023-01-24T18:08:42.87Z"},"size":0,"remoteUrl":"https://sgtestazure@dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces","sshUrl":"git@ssh.dev.azure.com:v3/sgtestazure/sg%20test%20with%20spaces/sg%20test%20with%20spaces","webUrl":"https://dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces","isDisabled":false,"isInMaintenance":false},{"id":"00e0ad0a-66df-4dc2-bd1b-4c34e05b9225","name":"sg
+      test with spaces 2","url":"https://dev.azure.com/sgtestazure/8c1230da-3631-41e8-8df3-c94a705227d8/_apis/git/repositories/00e0ad0a-66df-4dc2-bd1b-4c34e05b9225","project":{"id":"8c1230da-3631-41e8-8df3-c94a705227d8","name":"sg
+      test with spaces","description":"test project with spaces","url":"https://dev.azure.com/sgtestazure/_apis/projects/8c1230da-3631-41e8-8df3-c94a705227d8","state":"wellFormed","revision":19,"visibility":"private","lastUpdateTime":"2023-01-24T18:08:42.87Z"},"defaultBranch":"refs/heads/main","size":726,"remoteUrl":"https://sgtestazure@dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces%202","sshUrl":"git@ssh.dev.azure.com:v3/sgtestazure/sg%20test%20with%20spaces/sg%20test%20with%20spaces%202","webUrl":"https://dev.azure.com/sgtestazure/sg%20test%20with%20spaces/_git/sg%20test%20with%20spaces%202","isDisabled":false,"isInMaintenance":false}],"count":2}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Request-Context
+      Activityid:
+      - fd7b4e17-b8a5-4fa6-bdac-f8d4b967f2b1
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8; api-version=7.0
+      Date:
+      - Tue, 24 Jan 2023 19:16:36 GMT
+      Expires:
+      - "-1"
+      P3p:
+      - CP="CAO DSP COR ADMa DEV CONo TELo CUR PSA PSD TAI IVDo OUR SAMi BUS DEM NAV
+        STA UNI COM INT PHY ONL FIN PUR LOC CNT"
+      Pragma:
+      - no-cache
+      Request-Context:
+      - appId=cid-v1:72d31d95-1757-44f5-b910-a46611808454
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Msedge-Ref:
+      - 'Ref A: F6944D8BAA8B4A29895FA3FB83F5C90A Ref B: YTO01EDGE0722 Ref C: 2023-01-24T19:16:36Z'
+      X-Tfs-Processid:
+      - 026df187-6454-40fd-b7a9-db86dca40836
+      X-Tfs-Session:
+      - fd7b4e17-b8a5-4fa6-bdac-f8d4b967f2b1
+      X-Vss-E2eid:
+      - fd7b4e17-b8a5-4fa6-bdac-f8d4b967f2b1
       X-Vss-Senderdeploymentid:
       - 4ff21e82-8865-0b2e-ffe8-9598818f8190
       X-Vss-Userdata:

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -32,7 +32,7 @@
     "projects": {
       "description": "An array of projects \"org/project\" strings specifying which Azure DevOps whose repositories should be mirrored on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+( [\\w.-]+)*$" },
       "examples": [["org/project"]]
     },
     "orgs": {
@@ -54,7 +54,7 @@
           "name": {
             "description": "The name of an Azure DevOps Services/Server project and repository (\"projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^~?[\\w-]+/[\\w.-]+$"
+            "pattern": "^~?[\\w.-]+( [\\w.-]+)*/[\\w.-]+( [\\w.-]+)*?$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of an Azure DevOps Services/Server repo.",

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -32,7 +32,7 @@
     "projects": {
       "description": "An array of projects \"org/project\" strings specifying which Azure DevOps whose repositories should be mirrored on Sourcegraph.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+( [\\w.-]+)*$" },
+      "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+([ ]*[\\w.-]+)*$" },
       "examples": [["org/project"]]
     },
     "orgs": {
@@ -54,7 +54,7 @@
           "name": {
             "description": "The name of an Azure DevOps Services/Server project and repository (\"projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^~?[\\w.-]+( [\\w.-]+)*/[\\w.-]+( [\\w.-]+)*?$"
+            "pattern": "^~?[\\w.-]+([ ]*[\\w.-]+)*/[\\w.-]+([ ]*[\\w.-]+)*?$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of an Azure DevOps Services/Server repo.",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46736

Added support for repos and projects that have names with spaces (azure allows spaces for repo and project names but not org names).

## Test plan
Updated test to accommodate for this

### Code Host config
![image](https://user-images.githubusercontent.com/20795805/214388633-26221f94-00a2-409e-bf03-e13c6bc6b922.png)

### Repo is Cloned
![image](https://user-images.githubusercontent.com/20795805/214388766-84e73a65-e327-4633-8fe9-fff061b52e73.png)

### Search:
![image](https://user-images.githubusercontent.com/20795805/214392226-465d7dfc-e620-4d5d-918c-8deac2f8825e.png)

### Clicking on a search result:
![image](https://user-images.githubusercontent.com/20795805/214393027-0f63f992-a826-4d7f-87e9-81e4b5fcd53a.png)
