### PR TITLE
remove db dependency from gitserver client

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -81,7 +81,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	t.Run("authenticated as user, using invalid scopes", func(t *testing.T) {
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		db := database.NewMockDB()
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
 		if err == nil {
 			t.Error("err == nil")
 		}
@@ -98,7 +98,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx, &createAccessTokenInput{
+		result, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx, &createAccessTokenInput{
 			User:   uid1GQLID,
 			Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
 			Note:   "n",
@@ -226,7 +226,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), nil)
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -245,7 +245,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: differentNonSiteAdminUID})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -266,7 +266,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(orig)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx,
 			&createAccessTokenInput{
 				User:   MarshalUserID(1),
 				Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
@@ -288,7 +288,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(orig)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateAccessToken(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient()).CreateAccessToken(ctx,
 			&createAccessTokenInput{
 				User:   MarshalUserID(1),
 				Scopes: []string{authz.ScopeUserAll},
@@ -390,7 +390,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
 
 		ctx := actor.WithActor(context.Background(), nil)
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -410,7 +410,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: differentNonSiteAdminUID})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}

--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -25,7 +25,7 @@ func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 		if r.gitCommitResolver != nil {
 			return
 		}
-		gitserverClient := gitserver.NewClient(r.db)
+		gitserverClient := gitserver.NewClient()
 		repoResolver := NewRepositoryResolver(r.db, gitserverClient, r.Repo.ToRepo())
 		r.gitCommitResolver = NewGitCommitResolver(r.db, gitserverClient, repoResolver, r.CommitMatch.Commit.ID, &r.CommitMatch.Commit)
 	})

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -29,7 +29,7 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 		db := database.NewDB(logger, dbtest.NewDB(logger, t))
 		act := actor.Actor{UID: 1}
 		ctx := actor.WithActor(context.Background(), &act)
-		sr := newSchemaResolver(db, gitserver.NewClient(db))
+		sr := newSchemaResolver(db, gitserver.NewClient())
 
 		spec := extsvc.AccountSpec{
 			ServiceType: extsvc.TypeGitHub,

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -43,7 +43,7 @@ func TestAddExternalService(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).AddExternalService(ctx, &addExternalServiceArgs{})
+		result, err := newSchemaResolver(db, gitserver.NewClient()).AddExternalService(ctx, &addExternalServiceArgs{})
 		if want := auth.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %q", want, err)
 		}
@@ -132,7 +132,7 @@ func TestUpdateExternalService(t *testing.T) {
 		db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateExternalService(ctx, &updateExternalServiceArgs{
+		result, err := newSchemaResolver(db, gitserver.NewClient()).UpdateExternalService(ctx, &updateExternalServiceArgs{
 			Input: updateExternalServiceInput{
 				ID:     "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
 				Config: strptr(""),
@@ -527,7 +527,7 @@ func TestDeleteExternalService(t *testing.T) {
 			db.UsersFunc.SetDefaultReturn(users)
 
 			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-			result, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteExternalService(ctx, &deleteExternalServiceArgs{
+			result, err := newSchemaResolver(db, gitserver.NewClient()).DeleteExternalService(ctx, &deleteExternalServiceArgs{
 				ExternalService: "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
 			})
 			if want := auth.ErrMustBeSiteAdmin; err != want {
@@ -588,7 +588,7 @@ func TestExternalServicesResolver(t *testing.T) {
 			db := database.NewMockDB()
 			db.UsersFunc.SetDefaultReturn(users)
 
-			result, err := newSchemaResolver(db, gitserver.NewClient(db)).ExternalServices(context.Background(), &ExternalServicesArgs{})
+			result, err := newSchemaResolver(db, gitserver.NewClient()).ExternalServices(context.Background(), &ExternalServicesArgs{})
 			if want := auth.ErrMustBeSiteAdmin; err != want {
 				t.Errorf("err: want %q but got %v", want, err)
 			}
@@ -609,7 +609,7 @@ func TestExternalServicesResolver(t *testing.T) {
 			db := database.NewMockDB()
 			db.UsersFunc.SetDefaultReturn(users)
 
-			_, err := newSchemaResolver(db, gitserver.NewClient(db)).ExternalServices(context.Background(), &ExternalServicesArgs{})
+			_, err := newSchemaResolver(db, gitserver.NewClient()).ExternalServices(context.Background(), &ExternalServicesArgs{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/externallink/repository_test.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository_test.go
@@ -136,7 +136,7 @@ func TestFileOrDir(t *testing.T) {
 			db := database.NewMockDB()
 			db.PhabricatorFunc.SetDefaultReturn(phabricator)
 
-			links, err := FileOrDir(context.Background(), db, gitserver.NewClient(db), repo, rev, path, isDir)
+			links, err := FileOrDir(context.Background(), db, gitserver.NewClient(), repo, rev, path, isDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -189,7 +189,7 @@ func TestFileOrDir(t *testing.T) {
 		db := database.NewMockDB()
 		db.PhabricatorFunc.SetDefaultReturn(phabricator)
 
-		links, err := FileOrDir(context.Background(), db, gitserver.NewClient(db), &types.Repo{Name: "myrepo"}, rev, path, true)
+		links, err := FileOrDir(context.Background(), db, gitserver.NewClient(), &types.Repo{Name: "myrepo"}, rev, path, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -34,11 +34,11 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 		commit: fm.Commit(),
 		stat:   CreateFileInfo(fm.Path, false),
 	}
-	return NewGitTreeEntryResolver(fm.db, gitserver.NewClient(fm.db), opts)
+	return NewGitTreeEntryResolver(fm.db, gitserver.NewClient(), opts)
 }
 
 func (fm *FileMatchResolver) Commit() *GitCommitResolver {
-	commit := NewGitCommitResolver(fm.db, gitserver.NewClient(fm.db), fm.RepoResolver, fm.CommitID, nil)
+	commit := NewGitCommitResolver(fm.db, gitserver.NewClient(), fm.RepoResolver, fm.CommitID, nil)
 	commit.inputRev = fm.InputRev
 	return commit
 }

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -23,7 +23,7 @@ import (
 func TestGitCommitResolver(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewMockDB()
-	client := gitserver.NewClient(db)
+	client := gitserver.NewClient()
 
 	commit := &gitdomain.Commit{
 		ID:      "c1",
@@ -42,7 +42,7 @@ func TestGitCommitResolver(t *testing.T) {
 	}
 
 	t.Run("URL Escaping", func(t *testing.T) {
-		repo := NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "xyz"})
+		repo := NewRepositoryResolver(db, gitserver.NewClient(), &types.Repo{Name: "xyz"})
 		commitResolver := NewGitCommitResolver(db, client, repo, "c1", commit)
 		{
 			inputRev := "master^1"
@@ -120,7 +120,7 @@ func TestGitCommitResolver(t *testing.T) {
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {
-				repo := NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "bob-repo"})
+				repo := NewRepositoryResolver(db, gitserver.NewClient(), &types.Repo{Name: "bob-repo"})
 				// We pass no commit here to test that it gets lazy loaded via
 				// the git.GetCommit mock above.
 				r := NewGitCommitResolver(db, client, repo, "c1", nil)

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -77,7 +77,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, GitObjectType, error) {
 	o.once.Do(func() {
-		obj, err := gitserver.NewClient(o.repo.db).GetObject(ctx, o.repo.RepoName(), o.revspec)
+		obj, err := gitserver.NewClient().GetObject(ctx, o.repo.RepoName(), o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := gitserver.NewClient(r.repo.db).ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
+	oid, err := gitserver.NewClient().ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -380,31 +380,31 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil, nil)
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, webhooksResolver)
+	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, webhooksResolver)
 }
 
 func NewSchema(

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -50,7 +50,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return NewGitCommitResolver(r.db, gitserver.NewClient(r.db), r.repo, r.hunk.CommitID, nil), nil
+	return NewGitCommitResolver(r.db, gitserver.NewClient(), r.repo, r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -218,7 +218,7 @@ func (r *repositoriesConnectionStore) ComputeNodes(ctx context.Context, args *da
 	opt := r.opt
 	opt.PaginationArgs = args
 
-	client := gitserver.NewClient(r.db)
+	client := gitserver.NewClient()
 	repos, err := backend.NewRepos(r.logger, r.db, client).List(ctx, opt)
 	if err != nil {
 		return nil, err
@@ -276,7 +276,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
-		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db))
+		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient())
 		for {
 			// Cursor-based pagination requires that we fetch limit+1 records, so
 			// that we know whether or not there's an additional page (or more)
@@ -318,7 +318,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 		return nil, err
 	}
 	resolvers := make([]*RepositoryResolver, 0, len(repos))
-	client := gitserver.NewClient(r.db)
+	client := gitserver.NewClient()
 	for i, repo := range repos {
 		if r.opt.LimitOffset != nil && i == r.opt.Limit {
 			break

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -94,7 +94,7 @@ func (s *repositoryContributorConnectionStore) ComputeNodes(ctx context.Context,
 
 func (s *repositoryContributorConnectionStore) compute(ctx context.Context) ([]*gitdomain.ContributorCount, error) {
 	s.once.Do(func() {
-		client := gitserver.NewClient(s.db)
+		client := gitserver.NewClient()
 		var opt gitserver.ContributorOptions
 		if s.args.RevisionRange != nil {
 			opt.Range = *s.args.RevisionRange

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -35,10 +35,9 @@ func (r *RepositoryResolver) Tags(ctx context.Context, args *refsArgs) (*gitRefC
 
 func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitRefConnectionResolver, error) {
 	var branches []*gitdomain.Branch
-	db := r.db
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		var err error
-		branches, err = gitserver.NewClient(db).ListBranches(ctx, r.RepoName(), gitserver.BranchesOptions{
+		branches, err = gitserver.NewClient().ListBranches(ctx, r.RepoName(), gitserver.BranchesOptions{
 			// We intentionally do not ask for commits here since it requires
 			// a separate git call per branch. We only need the git commits to
 			// sort by author/commit date and there are few enough branches to
@@ -105,7 +104,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var tags []*gitdomain.Tag
 	if args.Type == nil || *args.Type == gitRefTypeTag {
 		var err error
-		tags, err = gitserver.NewClient(r.db).ListTags(ctx, r.RepoName())
+		tags, err = gitserver.NewClient().ListTags(ctx, r.RepoName())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -125,7 +125,7 @@ func (r *repositoryMirrorInfoResolver) CloneInProgress(ctx context.Context) (boo
 }
 
 func (r *repositoryMirrorInfoResolver) CloneProgress(ctx context.Context) (*string, error) {
-	progress, err := gitserver.NewClient(r.db).RepoCloneProgress(ctx, r.repository.RepoName())
+	progress, err := gitserver.NewClient().RepoCloneProgress(ctx, r.repository.RepoName())
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 		return nil, errors.New("exactly one of the repository and name arguments must be set")
 	}
 
-	gsClient := gitserver.NewClient(r.db)
+	gsClient := gitserver.NewClient()
 	var repo *types.Repo
 	switch {
 	case args.Repository != nil:

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -38,7 +38,7 @@ func (r *repositoryStatsResolver) GitDirBytes(ctx context.Context) (BigInt, erro
 
 func (r *repositoryStatsResolver) computeGitDirBytes(ctx context.Context) (int64, error) {
 	r.gitDirBytesOnce.Do(func() {
-		stats, err := gitserver.NewClient(r.db).ReposStats(ctx)
+		stats, err := gitserver.NewClient().ReposStats(ctx)
 		if err != nil {
 			r.gitDirBytesErr = err
 			return

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -106,7 +106,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(), minimalRepo)
 		assertRepoResolverHydrated(ctx, t, repoResolver, hydratedRepo)
 		mockrequire.CalledOnce(t, rs.GetFunc)
 	})
@@ -121,7 +121,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(), minimalRepo)
 		_, err := repoResolver.Description(ctx)
 		require.ErrorIs(t, err, dbErr)
 
@@ -245,7 +245,7 @@ func TestRepository_KVPs(t *testing.T) {
 	repo, err := db.Repos().GetByName(ctx, "testrepo")
 	require.NoError(t, err)
 
-	schema := newSchemaResolver(db, gitserver.NewClient(db))
+	schema := newSchemaResolver(db, gitserver.NewClient())
 	gqlID := MarshalRepositoryID(repo.ID)
 
 	strPtr := func(s string) *string { return &s }

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -41,7 +41,7 @@ func TestSavedSearches(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	resolver, err := newSchemaResolver(db, gitserver.NewClient(db)).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
+	resolver, err := newSchemaResolver(db, gitserver.NewClient()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestSavedSearchesForSameUser(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	resolver, err := newSchemaResolver(db, gitserver.NewClient(db)).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
+	resolver, err := newSchemaResolver(db, gitserver.NewClient()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestSavedSearchesForDifferentUser(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	_, err := newSchemaResolver(db, gitserver.NewClient(db)).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(userID)), args)
+	_, err := newSchemaResolver(db, gitserver.NewClient()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(userID)), args)
 	if err == nil {
 		t.Error("got nil, want error to be returned for accessing saved searches of different user by non site admin.")
 	}
@@ -170,7 +170,7 @@ func TestSavedSearchesForDifferentOrg(t *testing.T) {
 		Namespace:              MarshalOrgID(key),
 	}
 
-	if _, err := newSchemaResolver(db, gitserver.NewClient(db)).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args); err != auth.ErrNotAnOrgMember {
+	if _, err := newSchemaResolver(db, gitserver.NewClient()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args); err != auth.ErrNotAnOrgMember {
 		t.Errorf("got %v+, want %v+", err, auth.ErrNotAnOrgMember)
 	}
 }
@@ -206,7 +206,7 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 		UID: userID,
 	})
 
-	savedSearch, err := newSchemaResolver(db, gitserver.NewClient(db)).savedSearchByID(ctx, ssID)
+	savedSearch, err := newSchemaResolver(db, gitserver.NewClient()).savedSearchByID(ctx, ssID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 		UID: adminID,
 	})
 
-	_, err := newSchemaResolver(db, gitserver.NewClient(db)).savedSearchByID(ctx, ssID)
+	_, err := newSchemaResolver(db, gitserver.NewClient()).savedSearchByID(ctx, ssID)
 	t.Log(err)
 	if err == nil {
 		t.Fatal("expected an error")
@@ -289,7 +289,7 @@ func TestCreateSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	userID := MarshalUserID(key)
-	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(db)).CreateSavedSearch(ctx, &struct {
+	savedSearches, err := newSchemaResolver(db, gitserver.NewClient()).CreateSavedSearch(ctx, &struct {
 		Description string
 		Query       string
 		NotifyOwner bool
@@ -317,7 +317,7 @@ func TestCreateSavedSearch(t *testing.T) {
 	}
 
 	// Ensure create saved search errors when patternType is not provided in the query.
-	_, err = newSchemaResolver(db, gitserver.NewClient(db)).CreateSavedSearch(ctx, &struct {
+	_, err = newSchemaResolver(db, gitserver.NewClient()).CreateSavedSearch(ctx, &struct {
 		Description string
 		Query       string
 		NotifyOwner bool
@@ -360,7 +360,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	userID := MarshalUserID(key)
-	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateSavedSearch(ctx, &struct {
+	savedSearches, err := newSchemaResolver(db, gitserver.NewClient()).UpdateSavedSearch(ctx, &struct {
 		ID          graphql.ID
 		Description string
 		Query       string
@@ -394,7 +394,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 	}
 
 	// Ensure update saved search errors when patternType is not provided in the query.
-	_, err = newSchemaResolver(db, gitserver.NewClient(db)).UpdateSavedSearch(ctx, &struct {
+	_, err = newSchemaResolver(db, gitserver.NewClient()).UpdateSavedSearch(ctx, &struct {
 		ID          graphql.ID
 		Description string
 		Query       string
@@ -487,7 +487,7 @@ func TestUpdateSavedSearchPermissions(t *testing.T) {
 			db.SavedSearchesFunc.SetDefaultReturn(savedSearches)
 			db.OrgMembersFunc.SetDefaultReturn(orgMembers)
 
-			_, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateSavedSearch(ctx, &struct {
+			_, err := newSchemaResolver(db, gitserver.NewClient()).UpdateSavedSearch(ctx, &struct {
 				ID          graphql.ID
 				Description string
 				Query       string
@@ -537,7 +537,7 @@ func TestDeleteSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	firstSavedSearchGraphqlID := graphql.ID("U2F2ZWRTZWFyY2g6NTI=")
-	_, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteSavedSearch(ctx, &struct {
+	_, err := newSchemaResolver(db, gitserver.NewClient()).DeleteSavedSearch(ctx, &struct {
 		ID graphql.ID
 	}{ID: firstSavedSearchGraphqlID})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -86,7 +86,7 @@ func DecodedViewerFinalSettings(ctx context.Context, db database.DB) (_ *schema.
 		return MockDecodedViewerFinalSettings, nil
 	}
 
-	cascade, err := newSchemaResolver(db, gitserver.NewClient(db)).ViewerSettings(ctx)
+	cascade, err := newSchemaResolver(db, gitserver.NewClient()).ViewerSettings(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -81,7 +81,7 @@ func (c *SearchResultsResolver) repositoryResolvers(ctx context.Context, ids []a
 		return nil, nil
 	}
 
-	gsClient := gitserver.NewClient(c.db)
+	gsClient := gitserver.NewClient()
 	resolvers := make([]*RepositoryResolver, 0, len(ids))
 	err := c.db.Repos().StreamMinimalRepos(ctx, database.ReposListOptions{
 		IDs: ids,
@@ -136,7 +136,7 @@ func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultRe
 		Rev  string
 	}
 	repoResolvers := make(map[repoKey]*RepositoryResolver, 10)
-	gsClient := gitserver.NewClient(db)
+	gsClient := gitserver.NewClient()
 	getRepoResolver := func(repoName types.MinimalRepo, rev string) *RepositoryResolver {
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
@@ -250,7 +250,7 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 		return time.Time{}, nil
 	}
 	hm := fm.ChunkMatches[0]
-	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, authz.DefaultSubRepoPermsChecker, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
+	hunks, err := gitserver.NewClient().BlameFile(ctx, authz.DefaultSubRepoPermsChecker, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
 		StartLine:    hm.Ranges[0].Start.Line,
 		EndLine:      hm.Ranges[0].Start.Line,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -30,7 +30,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 	}
 
 	logger := srs.logger.Scoped("languages", "provide stats on langauges from the search results")
-	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(srs.sr.db), matches)
+	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(), matches)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -40,7 +40,7 @@ func TestSearchResults(t *testing.T) {
 	db := database.NewMockDB()
 
 	getResults := func(t *testing.T, query, version string) []string {
-		r, err := newSchemaResolver(db, gitserver.NewClient(db)).Search(ctx, &SearchArgs{Query: query, Version: version})
+		r, err := newSchemaResolver(db, gitserver.NewClient()).Search(ctx, &SearchArgs{Query: query, Version: version})
 		require.Nil(t, err)
 
 		results, err := r.Results(ctx)

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -158,7 +158,7 @@ func TestSettingsMutation(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(db)).SettingsMutation(
+				_, err := newSchemaResolver(db, gitserver.NewClient()).SettingsMutation(
 					test.ctx,
 					&settingsMutationArgs{
 						Input: &settingsMutationGroupInput{

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -30,7 +30,7 @@ func TestDeleteUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteUser(ctx, &struct {
+		result, err := newSchemaResolver(db, gitserver.NewClient()).DeleteUser(ctx, &struct {
 			User graphql.ID
 			Hard *bool
 		}{
@@ -52,7 +52,7 @@ func TestDeleteUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(db)).DeleteUser(ctx, &struct {
+		_, err := newSchemaResolver(db, gitserver.NewClient()).DeleteUser(ctx, &struct {
 			User graphql.ID
 			Hard *bool
 		}{

--- a/cmd/frontend/graphqlbackend/site_test.go
+++ b/cmd/frontend/graphqlbackend/site_test.go
@@ -22,7 +22,7 @@ func TestSiteConfiguration(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(db)).Site().Configuration(ctx)
+		_, err := newSchemaResolver(db, gitserver.NewClient()).Site().Configuration(ctx)
 
 		if err == nil || !errors.Is(err, auth.ErrMustBeSiteAdmin) {
 			t.Fatalf("err: want %q but got %v", auth.ErrMustBeSiteAdmin, err)
@@ -34,7 +34,7 @@ func TestSiteConfigurationHistory(t *testing.T) {
 	stubs := setupSiteConfigStubs(t)
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: stubs.users[0].ID})
-	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClient(stubs.db)).Site().Configuration(ctx)
+	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClient()).Site().Configuration(ctx)
 	if err != nil {
 		t.Fatalf("failed to create schemaResolver: %v", err)
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -49,7 +49,7 @@ func TestStatusMessages(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).StatusMessages(context.Background())
+		result, err := newSchemaResolver(db, gitserver.NewClient()).StatusMessages(context.Background())
 		if want := auth.ErrNotAuthenticated; err != want {
 			t.Errorf("got err %v, want %v", err, want)
 		}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -125,7 +125,7 @@ func (r symbolResolver) Location() *locationResolver {
 		stat:   stat,
 	}
 	return &locationResolver{
-		resource: NewGitTreeEntryResolver(r.db, gitserver.NewClient(r.db), opts),
+		resource: NewGitTreeEntryResolver(r.db, gitserver.NewClient(), opts),
 		lspRange: &sr,
 	}
 }

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -19,7 +19,7 @@ import (
 )
 
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
-	return mustParseGraphQLSchemaWithClient(t, db, gitserver.NewClient(db))
+	return mustParseGraphQLSchemaWithClient(t, db, gitserver.NewClient())
 }
 
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {

--- a/cmd/frontend/graphqlbackend/user_collaborators.go
+++ b/cmd/frontend/graphqlbackend/user_collaborators.go
@@ -29,7 +29,7 @@ func (r *UserResolver) InvitableCollaborators(ctx context.Context) ([]*invitable
 	// We'll search for collaborators in 25 of the user's most-starred repositories.
 	const maxReposToScan = 25
 	db := r.db
-	gsClient := gitserver.NewClient(db)
+	gsClient := gitserver.NewClient()
 	pickedRepos, err := backend.NewRepos(r.logger, db, gsClient).List(ctx, database.ReposListOptions{
 		// SECURITY: This must be the authenticated user's ID.
 		UserID:     a.UID,

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -161,7 +161,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(db)).SetUserEmailVerified(
+				_, err := newSchemaResolver(db, gitserver.NewClient()).SetUserEmailVerified(
 					test.ctx,
 					&setUserEmailVerifiedArgs{
 						User: MarshalUserID(1),

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -303,7 +303,7 @@ func TestUpdateUser(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, Username: "2"}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateUser(context.Background(),
+		result, err := newSchemaResolver(db, gitserver.NewClient()).UpdateUser(context.Background(),
 			&updateUserArgs{
 				User: "VXNlcjox",
 			},
@@ -324,7 +324,7 @@ func TestUpdateUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateUser(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient()).UpdateUser(ctx,
 			&updateUserArgs{
 				User:     MarshalUserID(1),
 				Username: strptr("about"),
@@ -351,7 +351,7 @@ func TestUpdateUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateUser(ctx,
+		result, err := newSchemaResolver(db, gitserver.NewClient()).UpdateUser(ctx,
 			&updateUserArgs{
 				User:     "VXNlcjox",
 				Username: strptr("alice"),
@@ -454,7 +454,7 @@ func TestUpdateUser(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateUser(
+				_, err := newSchemaResolver(db, gitserver.NewClient()).UpdateUser(
 					test.ctx,
 					&updateUserArgs{
 						User: MarshalUserID(1),
@@ -490,7 +490,7 @@ func TestUpdateUser(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				_, err := newSchemaResolver(db, gitserver.NewClient(db)).UpdateUser(
+				_, err := newSchemaResolver(db, gitserver.NewClient()).UpdateUser(
 					context.Background(),
 					&updateUserArgs{
 						User:      MarshalUserID(1),

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -29,7 +29,7 @@ func editorRev(ctx context.Context, logger log.Logger, db database.DB, repoName 
 	if rev == "HEAD" {
 		return ""
 	}
-	repos := backend.NewRepos(logger, db, gitserver.NewClient(db))
+	repos := backend.NewRepos(logger, db, gitserver.NewClient())
 	repo, err := repos.GetByName(ctx, repoName)
 	if err != nil {
 		// We weren't able to fetch the repo. This means it either doesn't

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -429,7 +429,7 @@ func serveTree(db database.DB, title func(c *Common, r *http.Request) string) ha
 			w.Header().Set("X-Robots-Tag", "noindex")
 		}
 
-		handled, err := redirectTreeOrBlob(routeTree, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient(db))
+		handled, err := redirectTreeOrBlob(routeTree, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient())
 		if handled {
 			return nil
 		}
@@ -460,7 +460,7 @@ func serveRepoOrBlob(db database.DB, routeName string, title func(c *Common, r *
 			w.Header().Set("X-Robots-Tag", "noindex")
 		}
 
-		handled, err := redirectTreeOrBlob(routeName, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient(db))
+		handled, err := redirectTreeOrBlob(routeName, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient())
 		if handled {
 			return nil
 		}

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -89,7 +89,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		db.ReposFunc.SetDefaultReturn(rstore)
 		rstore.GetByNameFunc.SetDefaultReturn(&types.Repo{ID: 123}, nil)
 
-		err := serveRaw(db, gitserver.NewClient(db))(w, req)
+		err := serveRaw(db, gitserver.NewClient())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -112,7 +112,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		db.ReposFunc.SetDefaultReturn(rstore)
 		rstore.GetByNameFunc.SetDefaultReturn(nil, &database.RepoNotFoundErr{ID: 123})
 
-		err := serveRaw(db, gitserver.NewClient(db))(w, req)
+		err := serveRaw(db, gitserver.NewClient())(w, req)
 		if err == nil {
 			t.Fatal("Want error but got nil")
 		}
@@ -147,7 +147,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		db := database.NewMockDB()
-		err := serveRaw(db, gitserver.NewClient(db))(w, req)
+		err := serveRaw(db, gitserver.NewClient())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -187,7 +187,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		db := database.NewMockDB()
-		err := serveRaw(db, gitserver.NewClient(db))(w, req)
+		err := serveRaw(db, gitserver.NewClient())(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -366,7 +366,7 @@ func initRouter(db database.DB, router *mux.Router) {
 	})))
 
 	// raw
-	router.Get(routeRaw).Handler(handler(db, serveRaw(db, gitserver.NewClient(db))))
+	router.Get(routeRaw).Handler(handler(db, serveRaw(db, gitserver.NewClient())))
 
 	// All other routes that are not found.
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -205,7 +205,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.Go(func() { users.StartUpdateAggregatedUsersStatisticsTable(context.Background(), db) })
 
 	schema, err := graphqlbackend.NewSchema(db,
-		gitserver.NewClient(db),
+		gitserver.NewClient(),
 		enterprise.BatchChangesResolver,
 		enterprise.CodeIntelResolver,
 		enterprise.InsightsResolver,

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -22,7 +22,7 @@ import (
 func GetRepo(ctx context.Context, logger log.Logger, db database.DB, vars map[string]string) (*types.Repo, error) {
 	origRepo := routevar.ToRepo(vars)
 
-	repo, err := backend.NewRepos(logger, db, gitserver.NewClient(db)).GetByName(ctx, origRepo)
+	repo, err := backend.NewRepos(logger, db, gitserver.NewClient()).GetByName(ctx, origRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func GetRepo(ctx context.Context, logger log.Logger, db database.DB, vars map[st
 // getRepoRev resolves the repository and commit specified in the route vars.
 func getRepoRev(ctx context.Context, logger log.Logger, db database.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
 	repoRev := routevar.ToRepoRev(vars)
-	gsClient := gitserver.NewClient(db)
+	gsClient := gitserver.NewClient()
 	repo, err := backend.NewRepos(logger, db, gsClient).Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -153,7 +153,7 @@ func NewHandler(
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCli).Handler(trace.Route(newSrcCliVersionHandler(logger)))
 
-	gsClient := gitserver.NewClient(db)
+	gsClient := gitserver.NewClient()
 	m.Get(apirouter.GitBlameStream).Handler(trace.Route(handleStreamBlame(logger, db, gsClient)))
 
 	// Set up the src-cli version cache handler (this will effectively be a
@@ -200,7 +200,7 @@ func NewInternalHandler(
 	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
 
 	// zoekt-indexserver endpoints
-	gsClient := gitserver.NewClient(db)
+	gsClient := gitserver.NewClient()
 	indexer := &searchIndexerServer{
 		db:              db,
 		logger:          logger.Scoped("searchIndexerServer", "zoekt-indexserver endpoints"),

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	stream "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
@@ -89,8 +88,8 @@ func groupLineMatches(lineMatches []*result.LineMatch) []group {
 // DecorateFileHTML returns decorated HTML rendering of file content. If
 // successful and within bounds of timeout and line size, it returns HTML marked
 // up with highlight classes. In other cases, it returns plaintext HTML.
-func DecorateFileHTML(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string) (*highlight.HighlightedCode, error) {
-	content, err := fetchContent(ctx, db, repo, commit, path)
+func DecorateFileHTML(ctx context.Context, repo api.RepoName, commit api.CommitID, path string) (*highlight.HighlightedCode, error) {
+	content, err := fetchContent(ctx, repo, commit, path)
 	if err != nil {
 		return nil, err
 	}
@@ -119,10 +118,10 @@ func DecorateFileHTML(ctx context.Context, db database.DB, repo api.RepoName, co
 }
 
 // DecorateFileHunksHTML returns decorated file hunks given a file match.
-func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileMatch) []stream.DecoratedHunk {
+func DecorateFileHunksHTML(ctx context.Context, fm *result.FileMatch) []stream.DecoratedHunk {
 	fmt.Println("==> DecorateFileHunksHTML")
 
-	response, err := DecorateFileHTML(ctx, db, fm.Repo.Name, fm.CommitID, fm.Path)
+	response, err := DecorateFileHTML(ctx, fm.Repo.Name, fm.CommitID, fm.Path)
 	if err != nil {
 		log15.Warn("stream result decoration could not highlight file", "error", err)
 		return nil
@@ -167,8 +166,8 @@ func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileM
 	return hunks
 }
 
-func fetchContent(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string) (content []byte, err error) {
-	content, err = gitserver.NewClient(db).ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, commit, path)
+func fetchContent(ctx context.Context, repo api.RepoName, commit api.CommitID, path string) (content []byte, err error) {
+	content, err = gitserver.NewClient().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, commit, path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -598,7 +598,7 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 }
 
 func (s *Server) addrForRepo(ctx context.Context, repoName api.RepoName, gitServerAddrs gitserver.GitServerAddresses) (string, error) {
-	return gitserver.AddrForRepo(ctx, filepath.Base(os.Args[0]), s.DB, repoName, gitServerAddrs)
+	return gitserver.AddrForRepo(ctx, filepath.Base(os.Args[0]), repoName, gitServerAddrs)
 }
 
 func currentGitserverAddresses() gitserver.GitServerAddresses {

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -139,11 +139,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	// Explicitly don't scope Store logger under the parent logger
 	storeObservationCtx := observation.NewContext(log.Scoped("Store", "searcher archives store"))
 
-	db, err := frontendDB(observation.NewContext(log.Scoped("db", "server frontend db")))
-	if err != nil {
-		return errors.Wrap(err, "failed to connect to frontend database")
-	}
-	git := gitserver.NewClient(db)
+	git := gitserver.NewClient()
 
 	service := &search.Service{
 		Store: &search.Store{
@@ -175,7 +171,6 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 			MaxCacheSizeBytes: cacheSizeBytes,
 			Log:               storeObservationCtx.Logger,
 			ObservationCtx:    storeObservationCtx,
-			DB:                db,
 		},
 
 		Indexed: sharedsearch.Indexed(),

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -48,9 +47,9 @@ type gitserverClient struct {
 	operations  *operations
 }
 
-func NewClient(observationCtx *observation.Context, db database.DB) GitserverClient {
+func NewClient(observationCtx *observation.Context) GitserverClient {
 	return &gitserverClient{
-		innerClient: gitserver.NewClient(db),
+		innerClient: gitserver.NewClient(),
 		operations:  newOperations(observationCtx),
 	}
 }

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -76,7 +76,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	db := database.NewDB(logger, sqlDB)
 
 	// Run setup
-	gitserverClient := gitserver.NewClient(observationCtx, db)
+	gitserverClient := gitserver.NewClient(observationCtx)
 	repositoryFetcher := fetcher.NewRepositoryFetcher(observationCtx, gitserverClient, RepositoryFetcherConfig.MaxTotalPathsLength, int64(RepositoryFetcherConfig.MaxFileSizeKb)*1000)
 	searchFunc, handleStatus, newRoutines, ctagsBinary, err := setup(observationCtx, db, gitserverClient, repositoryFetcher)
 	if err != nil {

--- a/cmd/worker/internal/codeintel/crates_syncer.go
+++ b/cmd/worker/internal/codeintel/crates_syncer.go
@@ -32,7 +32,7 @@ func (j *cratesSyncerJob) Routines(startupCtx context.Context, observationCtx *o
 		return nil, err
 	}
 
-	gitserverClient := gitserver.NewClient(db)
+	gitserverClient := gitserver.NewClient()
 	dependenciesService := dependencies.NewService(observationCtx, db)
 
 	return dependencies.CrateSyncerJob(

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -111,7 +111,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 	}
 	resolvers := make([]*graphqlbackend.RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repos[i])
+		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), repos[i])
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -44,7 +44,7 @@ func Init(
 	bstore := store.New(db, observationCtx, keyring.Default().BatchChangesCredentialKey)
 
 	// Register enterprise services.
-	gitserverClient := gitserver.NewClient(db)
+	gitserverClient := gitserver.NewClient()
 	logger := sglog.Scoped("Batches", "batch changes webhooks")
 	enterpriseServices.BatchChangesResolver = resolvers.New(bstore, gitserverClient)
 	enterpriseServices.BatchesGitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient, logger)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -49,7 +49,7 @@ func newBatchSpecWorkspaceResolverWithRepo(store *store.Store, workspace *btypes
 		execution:    execution,
 		batchSpec:    batchSpec,
 		repo:         repo,
-		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), gitserver.NewClient(store.DatabaseDB()), repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), gitserver.NewClient(), repo),
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -159,10 +159,10 @@ func (r *batchSpecWorkspaceStepV1Resolver) DiffStat(ctx context.Context) (*graph
 
 func (r *batchSpecWorkspaceStepV1Resolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
 	if r.CachedResultFound() {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
 	if r.stepInfo.DiffFound {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.stepInfo.Diff)
 	}
 	return nil, nil
 }
@@ -326,7 +326,7 @@ func (r *batchSpecWorkspaceStepV2Resolver) Diff(ctx context.Context) (graphqlbac
 	// If a cached result was found previously, or one was generated for this step, we can
 	// use it to return a comparison resolver.
 	if r.cachedResult != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -87,7 +87,7 @@ func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend
 		store: r.store,
 		spec:  r.changesetSpec,
 		// Note: r.repo can never be nil, because Description is a VisibleChangesetSpecResolver-only field.
-		repoResolver: graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(), r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),
 	}
 
@@ -178,7 +178,7 @@ func (r *changesetDescriptionResolver) DiffStat() *graphqlbackend.DiffStat {
 }
 
 func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repoResolver, r.spec.BaseRev, r.spec.Diff)
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repoResolver, r.spec.BaseRev, r.spec.Diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
@@ -51,7 +51,7 @@ func (r *resolvedBatchSpecWorkspaceResolver) SearchResultPaths() []string {
 func (r *resolvedBatchSpecWorkspaceResolver) computeRepoResolver() *graphqlbackend.RepositoryResolver {
 	r.repoResolverOnce.Do(func() {
 		db := r.store.DatabaseDB()
-		r.repoResolver = graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.workspace.Repo)
+		r.repoResolver = graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(), r.workspace.Repo)
 	})
 
 	return r.repoResolver

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -194,7 +194,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
-		resolver := gql.NewRepositoryResolver(db, gitserver.NewClient(db), repoName.ToRepo())
+		resolver := gql.NewRepositoryResolver(db, gitserver.NewClient(), repoName.ToRepo())
 		resolver.RepoMatch.Rev = rev
 		repoResolvers[repoKey{repoName, rev}] = resolver
 		return resolver
@@ -202,7 +202,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 
 	results := make([]gql.ComputeResultResolver, 0, len(matches))
 	for _, m := range matches {
-		computeResult, err := cmd.Run(ctx, db, m)
+		computeResult, err := cmd.Run(ctx, m)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -19,14 +19,14 @@ import (
 func toComputeResult(ctx context.Context, db database.DB, cmd compute.Command, match result.Match) (out []compute.Result, _ error) {
 	if v, ok := match.(*result.CommitMatch); ok && v.DiffPreview != nil {
 		for _, diffMatch := range v.CommitToDiffMatches() {
-			result, err := cmd.Run(ctx, db, diffMatch)
+			result, err := cmd.Run(ctx, diffMatch)
 			if err != nil {
 				return nil, err
 			}
 			out = append(out, result)
 		}
 	} else {
-		result, err := cmd.Run(ctx, db, match)
+		result, err := cmd.Run(ctx, match)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/group"
 )
 
-func toComputeResult(ctx context.Context, db database.DB, cmd compute.Command, match result.Match) (out []compute.Result, _ error) {
+func toComputeResult(ctx context.Context, cmd compute.Command, match result.Match) (out []compute.Result, _ error) {
 	if v, ok := match.(*result.CommitMatch); ok && v.DiffPreview != nil {
 		for _, diffMatch := range v.CommitToDiffMatches() {
 			result, err := cmd.Run(ctx, diffMatch)
@@ -58,7 +58,7 @@ func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, se
 		for _, match := range event.Results {
 			match := match
 			g.Go(func() (Event, error) {
-				results, err := toComputeResult(ctx, db, computeCommand, match)
+				results, err := toComputeResult(ctx, computeCommand, match)
 				return Event{results, streaming.Stats{}}, err
 			}, cb)
 		}

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -20,7 +20,7 @@ import (
 func newExecutorQueueHandler(logger log.Logger, db database.DB, queueHandlers []handler.ExecutorHandler, accessToken func() string, uploadHandler http.Handler, batchesWorkspaceFileGetHandler http.Handler, batchesWorkspaceFileExistsHandler http.Handler) func() http.Handler {
 	metricsStore := metricsstore.NewDistributedStore("executors:")
 	executorStore := db.Executors()
-	gitserverClient := gitserver.NewClient(db)
+	gitserverClient := gitserver.NewClient()
 
 	factory := func() http.Handler {
 		// 🚨 SECURITY: These routes are secured by checking a token shared between services.

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -500,7 +500,7 @@ func (r *searchContextResolver) Repositories(ctx context.Context) ([]graphqlback
 
 	searchContextRepositories := make([]graphqlbackend.SearchContextRepositoryRevisionsResolver, len(repoRevs))
 	for idx, repoRev := range repoRevs {
-		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repoRev.Repo.ToRepo()), repoRev.Revisions}
+		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), repoRev.Repo.ToRepo()), repoRev.Revisions}
 	}
 	return searchContextRepositories, nil
 }

--- a/enterprise/cmd/worker/internal/batches/reconciler_job.go
+++ b/enterprise/cmd/worker/internal/batches/reconciler_job.go
@@ -47,7 +47,7 @@ func (j *reconcilerJob) Routines(_ context.Context, observationCtx *observation.
 		observationCtx,
 		bstore,
 		reconcilerStore,
-		gitserver.NewClient(bstore.DatabaseDB()),
+		gitserver.NewClient(),
 		sources.NewSourcer(httpcli.NewExternalClientFactory(
 			httpcli.NewLoggingMiddleware(observationCtx.Logger.Scoped("sourcer", "batches sourcer")),
 		)),

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -171,7 +171,7 @@ func ProvidersFromConfig(
 	}
 
 	if len(perforceConns) > 0 {
-		pfProviders, pfProblems, pfWarnings, pfInvalidConnections := perforce.NewAuthzProviders(perforceConns, db)
+		pfProviders, pfProblems, pfWarnings, pfInvalidConnections := perforce.NewAuthzProviders(perforceConns)
 		providers = append(providers, pfProviders...)
 		seriousProblems = append(seriousProblems, pfProblems...)
 		warnings = append(warnings, pfWarnings...)

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -23,9 +22,9 @@ import (
 // This constructor does not and should not directly check connectivity to external services - if
 // desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
 // to connection issues.
-func NewAuthzProviders(conns []*types.PerforceConnection, db database.DB) (ps []authz.Provider, problems []string, warnings []string, invalidConnections []string) {
+func NewAuthzProviders(conns []*types.PerforceConnection) (ps []authz.Provider, problems []string, warnings []string, invalidConnections []string) {
 	for _, c := range conns {
-		p, err := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots, db)
+		p, err := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots)
 		if err != nil {
 			invalidConnections = append(invalidConnections, extsvc.TypePerforce)
 			problems = append(problems, err.Error())
@@ -42,7 +41,6 @@ func newAuthzProvider(
 	a *schema.PerforceAuthorization,
 	host, user, password string,
 	depots []string,
-	db database.DB,
 ) (authz.Provider, error) {
 	// Call this function from ValidateAuthz if this function starts returning an error.
 	if a == nil {

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -67,7 +67,7 @@ func newAuthzProvider(
 		}
 	}
 
-	return NewProvider(logger, urn, host, user, password, depotIDs, db), nil
+	return NewProvider(logger, urn, host, user, password, depotIDs), nil
 }
 
 // ValidateAuthz validates the authorization fields of the given Perforce

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -63,7 +62,7 @@ type p4Execer interface {
 // host, user and password to talk to a Perforce Server that is the source of
 // truth for permissions. It assumes emails of Sourcegraph accounts match 1-1
 // with emails of Perforce Server users.
-func NewProvider(logger log.Logger, urn, host, user, password string, depots []extsvc.RepoID, db database.DB) *Provider {
+func NewProvider(logger log.Logger, urn, host, user, password string, depots []extsvc.RepoID) *Provider {
 	baseURL, _ := url.Parse(host)
 	return &Provider{
 		logger:             logger,
@@ -73,7 +72,7 @@ func NewProvider(logger log.Logger, urn, host, user, password string, depots []e
 		host:               host,
 		user:               user,
 		password:           password,
-		p4Execer:           gitserver.NewClient(db),
+		p4Execer:           gitserver.NewClient(),
 		cachedGroupMembers: make(map[string][]string),
 	}
 }

--- a/enterprise/internal/authz/perforce/perforce_test.go
+++ b/enterprise/internal/authz/perforce/perforce_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
@@ -86,11 +85,10 @@ cindy <cindy@example.com> (Cindy) accessed 2020/12/04
 
 func TestProvider_FetchUserPerms(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewMockDB()
 
 	t.Run("nil account", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", nil, db)
+		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", nil)
 		_, err := p.FetchUserPerms(ctx, nil, authz.FetchPermsOptions{})
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
@@ -101,7 +99,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, db)
+		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
@@ -120,7 +118,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("no user found in account data", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, db)
+		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
 		_, err := p.FetchUserPerms(ctx,
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
@@ -342,10 +340,9 @@ read user alice * -//Sourcegraph/Security/...
 func TestProvider_FetchRepoPerms(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewMockDB()
 
 	t.Run("nil repository", func(t *testing.T) {
-		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, db)
+		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
 		_, err := p.FetchRepoPerms(ctx, nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
@@ -355,7 +352,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 	})
 
 	t.Run("not the code host of the repository", func(t *testing.T) {
-		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, db)
+		p := NewProvider(logger, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
 		_, err := p.FetchRepoPerms(ctx,
 			&extsvc.Repository{
 				URI: "gitlab.com/user/repo",
@@ -441,7 +438,7 @@ Users:
 }
 
 func NewTestProvider(logger log.Logger, urn, host, user, password string, execer p4Execer) *Provider {
-	p := NewProvider(logger, urn, host, user, password, []extsvc.RepoID{}, database.NewMockDB())
+	p := NewProvider(logger, urn, host, user, password, []extsvc.RepoID{})
 	p.p4Execer = execer
 	return p
 }

--- a/enterprise/internal/batches/processor/bulk_processor.go
+++ b/enterprise/internal/batches/processor/bulk_processor.go
@@ -187,7 +187,7 @@ func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.Changese
 		b.logger.Error("Events", log.Error(err))
 		return errcode.MakeNonRetryable(err)
 	}
-	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(b.tx.DatabaseDB()), cs.Changeset, events)
+	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(), cs.Changeset, events)
 
 	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		b.logger.Error("UpsertChangesetEvents", log.Error(err))
@@ -222,7 +222,7 @@ func (b *bulkProcessor) closeChangeset(ctx context.Context) (err error) {
 		b.logger.Error("Events", log.Error(err))
 		return errcode.MakeNonRetryable(err)
 	}
-	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(b.tx.DatabaseDB()), cs.Changeset, events)
+	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(), cs.Changeset, events)
 
 	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		b.logger.Error("UpsertChangesetEvents", log.Error(err))

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -76,7 +76,7 @@ func NewWorkspaceResolver(s *store.Store) WorkspaceResolver {
 	return &workspaceResolver{
 		store:               s,
 		logger:              log.Scoped("batches.workspaceResolver", "The batch changes execution workspace resolver"),
-		gitserverClient:     gitserver.NewClient(s.DatabaseDB()),
+		gitserverClient:     gitserver.NewClient(),
 		frontendInternalURL: internalapi.Client.URL + "/.internal",
 	}
 }

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -495,7 +495,7 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	return SyncChangeset(ctx, s.syncStore, gitserver.NewClient(s.syncStore.DatabaseDB()), source, repo, cs)
+	return SyncChangeset(ctx, s.syncStore, gitserver.NewClient(), source, repo, cs)
 }
 
 // SyncChangeset refreshes the metadata of the given changeset and

--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -32,7 +32,7 @@ func NewService(
 	store := store.New(scopedContext("store", observationCtx), db)
 	symbolsClient := symbols.DefaultClient
 	repoUpdater := repoupdater.DefaultClient
-	inferenceSvc := inference.NewService(db)
+	inferenceSvc := inference.NewService()
 
 	svc := newService(scopedContext("service", observationCtx), store, uploadSvc, inferenceSvc, repoUpdater, gitserver, symbolsClient)
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
 )
@@ -23,26 +22,24 @@ type GitService interface {
 }
 
 type gitService struct {
-	db      database.DB
 	checker authz.SubRepoPermissionChecker
 }
 
-func NewDefaultGitService(checker authz.SubRepoPermissionChecker, db database.DB) GitService {
+func NewDefaultGitService(checker authz.SubRepoPermissionChecker) GitService {
 	if checker == nil {
 		checker = authz.DefaultSubRepoPermsChecker
 	}
 
 	return &gitService{
-		db:      db,
 		checker: checker,
 	}
 }
 
 func (s *gitService) ListFiles(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) ([]string, error) {
-	return gitserver.NewClient(s.db).ListFiles(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), pattern)
+	return gitserver.NewClient().ListFiles(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), pattern)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {
 	// Note: the sub-repo perms checker is nil here because all paths were already checked via a previous call to s.ListFiles
-	return gitserver.NewClient(s.db).ArchiveReader(ctx, nil, repo, opts)
+	return gitserver.NewClient().ArchiveReader(ctx, nil, repo, opts)
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/init.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
 
 var (
@@ -19,13 +17,13 @@ var (
 	maximumFileWithContentSizeBytes = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_MAXIMUM_FILE_WITH_CONTENT_SIZE_BYTES", 1024*1024, "The maximum size of the content of a single file requested by the inference script. Inference operations exceeding this limit will fail.")
 )
 
-func NewService(db database.DB) *Service {
+func NewService() *Service {
 	observationCtx := observation.NewContext(log.Scoped("inference.service", "inference service"))
 
 	return newService(
 		observationCtx,
 		luasandbox.NewService(),
-		NewDefaultGitService(nil, db),
+		NewDefaultGitService(nil),
 		ratelimit.NewInstrumentedLimiter("InferenceService", rate.NewLimiter(rate.Limit(gitserverRequestRateLimit), 1)),
 		maximumFilesWithContentCount,
 		maximumFileWithContentSizeBytes,

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -179,7 +179,7 @@ func (r *rootResolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (_ reso
 	// the same graphQL request, not across different request.
 	db := r.autoindexSvc.GetUnsafeDB()
 	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexSvc, r.uploadSvc)
-	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db))
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
 
 	index, exists, err := prefetcher.GetIndexByID(ctx, int(indexID))
 	if err != nil || !exists {
@@ -267,7 +267,7 @@ func (r *rootResolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *reso
 	// the same graphQL request, not across different request.
 	db := r.autoindexSvc.GetUnsafeDB()
 	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexSvc, r.uploadSvc)
-	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db))
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
 
 	lsifIndexResolvers := make([]resolverstubs.LSIFIndexResolver, 0, len(indexes))
 	for i := range indexes {

--- a/enterprise/internal/codeintel/codenav/transport/graphql/gitblob_lsif_data_resolver.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/gitblob_lsif_data_resolver.go
@@ -55,7 +55,7 @@ func NewGitBlobLSIFDataResolver(
 		uploadSvc:        uploadSvc,
 		policiesSvc:      policiesSvc,
 		requestState:     requestState,
-		locationResolver: sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db)),
+		locationResolver: sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient()),
 		errTracer:        errTracer,
 		operations:       operations,
 	}
@@ -288,7 +288,7 @@ func (r *gitBlobLSIFDataResolver) LSIFUploads(ctx context.Context) (_ []resolver
 
 	db := r.autoindexingSvc.GetUnsafeDB()
 	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexingSvc, r.uploadSvc)
-	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db))
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
 
 	resolvers := make([]resolverstubs.LSIFUploadResolver, 0, len(uploads))
 	for _, upload := range dbUploads {

--- a/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver.go
@@ -55,7 +55,7 @@ func (r *configurationPolicyResolver) Repository(ctx context.Context) (_ resolve
 	)
 
 	db := r.policySvc.GetUnsafeDB()
-	repo, err := backend.NewRepos(r.logger, db, gitserver.NewClient(db)).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
+	repo, err := backend.NewRepos(r.logger, db, gitserver.NewClient()).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/policies/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/root_resolver.go
@@ -235,7 +235,7 @@ func (r *rootResolver) PreviewRepositoryFilter(ctx context.Context, args *resolv
 	logger := sglog.Scoped("PreviewRepositoryFilter", "policies resolver")
 	for _, id := range ids {
 		db := r.policySvc.GetUnsafeDB()
-		repo, err := backend.NewRepos(logger, db, gitserver.NewClient(db)).Get(ctx, api.RepoID(id))
+		repo, err := backend.NewRepos(logger, db, gitserver.NewClient()).Get(ctx, api.RepoID(id))
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/codeintel/shared/gitserver/client.go
+++ b/enterprise/internal/codeintel/shared/gitserver/client.go
@@ -34,7 +34,7 @@ func New(observationCtx *observation.Context, db database.DB) *Client {
 	operations := newOperations(observationCtx)
 
 	return &Client{
-		gitserverClient: gitserver.NewClient(db),
+		gitserverClient: gitserver.NewClient(),
 		dbStore:         newWithDB(db),
 		operations:      operations,
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/configuration_policy_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/configuration_policy_resolver.go
@@ -54,7 +54,7 @@ func (r *configurationPolicyResolver) Repository(ctx context.Context) (_ resolve
 	)
 
 	db := r.svc.GetUnsafeDB()
-	repo, err := backend.NewRepos(r.logger, db, gitserver.NewClient(db)).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
+	repo, err := backend.NewRepos(r.logger, db, gitserver.NewClient()).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -69,7 +69,7 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context, args *resolverstubs.
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
-		r.content, r.contentErr = gitserver.NewClient(r.db).ReadFile(
+		r.content, r.contentErr = gitserver.NewClient().ReadFile(
 			ctx,
 			authz.DefaultSubRepoPermsChecker,
 			api.RepoName(r.commit.Repository().Name()),

--- a/enterprise/internal/codeintel/shared/resolvers/index_resolver_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_resolver_connection.go
@@ -28,7 +28,7 @@ func NewIndexConnectionResolver(autoindexingSvc AutoIndexingService, uploadsSvc 
 		policySvc:        policySvc,
 		indexesResolver:  indexesResolver,
 		prefetcher:       prefetcher,
-		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient(db)),
+		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient()),
 		errTracer:        errTracer,
 	}
 }

--- a/enterprise/internal/codeintel/shared/resolvers/summary.go
+++ b/enterprise/internal/codeintel/shared/resolvers/summary.go
@@ -41,7 +41,7 @@ func NewRepositorySummaryResolver(
 		summary:           summary,
 		availableIndexers: availableIndexers,
 		prefetcher:        prefetcher,
-		locationResolver:  NewCachedLocationResolver(db, gitserver.NewClient(db)),
+		locationResolver:  NewCachedLocationResolver(db, gitserver.NewClient()),
 		errTracer:         errTracer,
 	}
 }

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
@@ -28,7 +28,7 @@ func NewUploadConnectionResolver(uploadsSvc UploadsService, autoindexingSvc Auto
 		policySvc:        policySvc,
 		uploadsResolver:  uploadsResolver,
 		prefetcher:       prefetcher,
-		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient(db)),
+		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient()),
 		traceErrs:        traceErrs,
 	}
 }

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -36,7 +36,7 @@ func NewService(
 	gsc GitserverClient,
 ) *Service {
 	store := store.New(scopedContext("store", observationCtx), db)
-	repoStore := backend.NewRepos(scopedContext("repos", observationCtx).Logger, db, gitserver.NewClient(db))
+	repoStore := backend.NewRepos(scopedContext("repos", observationCtx).Logger, db, gitserver.NewClient())
 	lsifStore := lsifstore.New(scopedContext("lsifstore", observationCtx), codeIntelDB)
 	policyMatcher := policiesEnterprise.NewMatcher(gsc, policiesEnterprise.RetentionExtractor, true, false)
 	locker := locker.NewWith(db, "codeintel")

--- a/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver.go
@@ -65,7 +65,7 @@ func (r *rootResolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (_ res
 	// the same graphQL request, not across different request.
 	db := r.autoindexSvc.GetUnsafeDB()
 	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexSvc, r.uploadSvc)
-	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db))
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
 
 	upload, exists, err := prefetcher.GetUploadByID(ctx, int(uploadID))
 	if err != nil || !exists {

--- a/enterprise/internal/codeintel/uploads/transport/http/handler_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/handler_test.go
@@ -35,7 +35,7 @@ func TestHandleEnqueueAuth(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	repoStore := backend.NewRepos(logger, db, gitserver.NewClient(db))
+	repoStore := backend.NewRepos(logger, db, gitserver.NewClient())
 	mockDBStore := NewMockDBStore[uploads.UploadMetadata]()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 

--- a/enterprise/internal/codeintel/uploads/transport/http/init.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/init.go
@@ -35,7 +35,7 @@ func GetHandler(svc *uploads.Service, db database.DB, uploadStore uploadstore.St
 		uploadHandlerOperations := uploadhandler.NewOperations(observationCtx, "codeintel")
 
 		userStore := db.Users()
-		repoStore := backend.NewRepos(logger, db, gitserver.NewClient(db))
+		repoStore := backend.NewRepos(logger, db, gitserver.NewClient())
 
 		// Construct base handler, used in internal routes and as internal handler wrapped
 		// in the auth middleware defined on the next few lines

--- a/enterprise/internal/compute/command.go
+++ b/enterprise/internal/compute/command.go
@@ -3,13 +3,12 @@ package compute
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 type Command interface {
 	command()
-	Run(context.Context, database.DB, result.Match) (Result, error)
+	Run(context.Context, result.Match) (Result, error)
 	ToSearchPattern() string
 	String() string
 }

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/regexp"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -89,7 +88,7 @@ func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	return &MatchContext{Matches: matches, Path: fm.Path, RepositoryID: int32(fm.Repo.ID), Repository: string(fm.Repo.Name)}
 }
 
-func (c *MatchOnly) Run(_ context.Context, db database.DB, r result.Match) (Result, error) {
+func (c *MatchOnly) Run(_ context.Context, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
 		return matchOnly(m, c.ComputePattern.(*Regexp).Value), nil

--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/comby"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -123,7 +122,7 @@ func toTextExtraResult(content string, r result.Match) *TextExtra {
 	}
 }
 
-func (c *Output) Run(ctx context.Context, _ database.DB, r result.Match) (Result, error) {
+func (c *Output) Run(ctx context.Context, r result.Match) (Result, error) {
 	onlyPath := c.TypeValue == "path" // don't read file contents for file matches when we only want type:path
 	chunks := resultChunks(r, c.Kind, onlyPath)
 

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/internal/comby"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -84,7 +83,7 @@ func commitMatch(content string) result.Match {
 func TestRun(t *testing.T) {
 	test := func(q string, m result.Match) string {
 		computeQuery, _ := Parse(q)
-		res, err := computeQuery.Command.Run(context.Background(), database.NewMockDB(), m)
+		res, err := computeQuery.Command.Run(context.Background(), m)
 		if err != nil {
 			return err.Error()
 		}

--- a/enterprise/internal/compute/replace_command.go
+++ b/enterprise/internal/compute/replace_command.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -50,10 +49,10 @@ func replace(ctx context.Context, content []byte, matchPattern MatchPattern, rep
 	return &Text{Value: newContent, Kind: "replace-in-place"}, nil
 }
 
-func (c *Replace) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
+func (c *Replace) Run(ctx context.Context, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		content, err := gitserver.NewClient(db).ReadFile(ctx, authz.DefaultSubRepoPermsChecker, m.Repo.Name, m.CommitID, m.Path)
+		content, err := gitserver.NewClient().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, m.Repo.Name, m.CommitID, m.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	inttests "github.com/sourcegraph/sourcegraph/internal/gitserver/integration_tests"
@@ -24,9 +23,6 @@ func TestGetCommits(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
-	gr := database.NewMockGitserverRepoStore()
-	db.GitserverReposFunc.SetDefaultReturn(gr)
 
 	repo1 := inttests.MakeGitRepository(t, getGitCommandsWithFiles("file1", "file2")...)
 	repo2 := inttests.MakeGitRepository(t, getGitCommandsWithFiles("file3", "file4")...)
@@ -71,7 +67,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, db, inttests.GitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -120,7 +116,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 
 func TestHead(t *testing.T) {
 	inttests.InitGitserver()
-	client := gitserver.NewTestClient(http.DefaultClient, database.NewMockDB(), inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses)
 
 	t.Run("with sub-repo permissions", func(t *testing.T) {
 		gitCommands := []string{

--- a/enterprise/internal/gitserver/integration_tests/tree_test.go
+++ b/enterprise/internal/gitserver/integration_tests/tree_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	inttests "github.com/sourcegraph/sourcegraph/internal/gitserver/integration_tests"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -58,10 +57,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 		t.Fatalf("unexpected error creating sub-repo perms client: %s", err)
 	}
 
-	db := database.NewMockDB()
-	gr := database.NewMockGitserverRepoStore()
-	db.GitserverReposFunc.SetDefaultReturn(gr)
-	client := gitserver.NewTestClient(http.DefaultClient, db, inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses)
 	files, err := client.ReadDir(ctx, checker, repo, commitID, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -78,10 +78,10 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 		searchRateLimiter := limiter.SearchQueryRate()
 		historicRateLimiter := limiter.HistoricalWorkRate()
 		backfillConfig := pipeline.BackfillerConfig{
-			CompressionPlan:         compression.NewGitserverFilter(mainAppDB, logger),
+			CompressionPlan:         compression.NewGitserverFilter(logger),
 			SearchHandlers:          queryrunner.GetSearchHandlers(),
 			InsightStore:            insightsStore,
-			CommitClient:            gitserver.NewGitCommitClient(mainAppDB),
+			CommitClient:            gitserver.NewGitCommitClient(),
 			SearchPlanWorkerLimit:   1,
 			SearchRunnerWorkerLimit: 5, // TODO: move these to settings
 			SearchRateLimiter:       searchRateLimiter,

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -46,8 +45,8 @@ type commitFetcher interface {
 	RecentCommits(ctx context.Context, repoName api.RepoName, target time.Time, revision string) ([]*gitdomain.Commit, error)
 }
 
-func NewGitserverFilter(db database.DB, logger log.Logger) DataFrameFilter {
-	return &gitserverFilter{commitFetcher: gitserver.NewGitCommitClient(db), logger: logger}
+func NewGitserverFilter(logger log.Logger) DataFrameFilter {
+	return &gitserverFilter{commitFetcher: gitserver.NewGitCommitClient(), logger: logger}
 }
 
 type gitserverFilter struct {

--- a/enterprise/internal/insights/gitserver/client.go
+++ b/enterprise/internal/insights/gitserver/client.go
@@ -6,27 +6,24 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
-func NewGitCommitClient(db database.DB) *GitCommitClient {
+func NewGitCommitClient() *GitCommitClient {
 	return &GitCommitClient{
 		cachedFirstCommit: NewCachedGitFirstEverCommit(),
-		db:                db,
-		Gitclient:         gitserver.NewClient(db),
+		Gitclient:         gitserver.NewClient(),
 	}
 }
 
 type GitCommitClient struct {
 	cachedFirstCommit *CachedGitFirstEverCommit
-	db                database.DB
 	Gitclient         gitserver.Client
 }
 
 func (g *GitCommitClient) FirstCommit(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
-	return g.cachedFirstCommit.GitFirstEverCommit(ctx, g.db, repoName)
+	return g.cachedFirstCommit.GitFirstEverCommit(ctx, repoName)
 }
 func (g *GitCommitClient) RecentCommits(ctx context.Context, repoName api.RepoName, target time.Time, revision string) ([]*gitdomain.Commit, error) {
 	options := gitserver.CommitsOptions{N: 1, Before: target.Format(time.RFC3339), DateOrder: true}

--- a/enterprise/internal/insights/gitserver/first_commit.go
+++ b/enterprise/internal/insights/gitserver/first_commit.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -30,8 +29,8 @@ func isFirstCommitEmptyRepoError(err error) bool {
 	return false
 }
 
-func GitFirstEverCommit(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
-	commit, err := gitserver.NewClient(db).FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repoName)
+func GitFirstEverCommit(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
+	commit, err := gitserver.NewClient().FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repoName)
 	if err != nil && isFirstCommitEmptyRepoError(err) {
 		return nil, errors.Wrap(EmptyRepoErr, err.Error())
 	}
@@ -48,13 +47,13 @@ func NewCachedGitFirstEverCommit() *CachedGitFirstEverCommit {
 // using a map, and entries are never evicted because they are expected to be small and in general
 // unchanging.
 type CachedGitFirstEverCommit struct {
-	impl func(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error)
+	impl func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error)
 
 	mu    sync.Mutex
 	cache map[api.RepoName]*gitdomain.Commit
 }
 
-func (c *CachedGitFirstEverCommit) GitFirstEverCommit(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
+func (c *CachedGitFirstEverCommit) GitFirstEverCommit(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.cache == nil {
@@ -63,7 +62,7 @@ func (c *CachedGitFirstEverCommit) GitFirstEverCommit(ctx context.Context, db da
 	if cached, ok := c.cache[repoName]; ok {
 		return cached, nil
 	}
-	entry, err := c.impl(ctx, db, repoName)
+	entry, err := c.impl(ctx, repoName)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -70,7 +70,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 	pivoted := make(map[string]timeCounts)
 
 	for _, repository := range repositories {
-		firstCommit, err := gitserver.GitFirstEverCommit(ctx, c.db, api.RepoName(repository))
+		firstCommit, err := gitserver.GitFirstEverCommit(ctx, api.RepoName(repository))
 		if err != nil {
 			if errors.Is(err, gitserver.EmptyRepoErr) {
 				continue
@@ -90,7 +90,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 				// since we are using uncompressed plans (to avoid this problem and others) right now, each execution is standalone
 				continue
 			}
-			commits, err := gitserver.NewGitCommitClient(c.db).RecentCommits(ctx, api.RepoName(repository), execution.RecordingTime, "")
+			commits, err := gitserver.NewGitCommitClient().RecentCommits(ctx, api.RepoName(repository), execution.RecordingTime, "")
 			if err != nil {
 				return nil, errors.Wrap(err, "git.Commits")
 			} else if len(commits) < 1 {

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -53,7 +53,7 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 	timeDataPoints := []TimeDataPoint{}
 
 	for _, repository := range repositories {
-		firstCommit, err := gitserver.GitFirstEverCommit(ctx, c.db, api.RepoName(repository))
+		firstCommit, err := gitserver.GitFirstEverCommit(ctx, api.RepoName(repository))
 		if err != nil {
 			if errors.Is(err, gitserver.EmptyRepoErr) {
 				continue
@@ -73,7 +73,7 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 				// since we are using uncompressed plans (to avoid this problem and others) right now, each execution is standalone
 				continue
 			}
-			commits, err := gitserver.NewGitCommitClient(c.db).RecentCommits(ctx, api.RepoName(repository), execution.RecordingTime, "")
+			commits, err := gitserver.NewGitCommitClient().RecentCommits(ctx, api.RepoName(repository), execution.RecordingTime, "")
 			if err != nil {
 				return nil, errors.Wrap(err, "git.Commits")
 			} else if len(commits) < 1 {

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -95,7 +94,6 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 	ctx = actor.WithActor(ctx, &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
 
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
@@ -151,7 +149,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {
 			repo := MakeGitRepository(t, append(cmds, tc.extraGitCommands...)...)
-			c := NewClient(db)
+			c := NewClient()
 			commits, err := c.Commits(ctx, nil, repo, CommitsOptions{})
 			if err != nil {
 				t.Fatalf("err fetching commits: %s", err)
@@ -197,7 +195,6 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 
 func TestDiff(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewMockDB()
 
 	t.Run("invalid bases", func(t *testing.T) {
 		for _, input := range []string{
@@ -206,7 +203,7 @@ func TestDiff(t *testing.T) {
 			".foo",
 		} {
 			t.Run("invalid base: "+input, func(t *testing.T) {
-				i, err := NewClient(db).Diff(ctx, nil, DiffOptions{Base: input})
+				i, err := NewClient().Diff(ctx, nil, DiffOptions{Base: input})
 				if i != nil {
 					t.Errorf("unexpected non-nil iterator: %+v", i)
 				}
@@ -457,7 +454,7 @@ func TestRepository_BlameFile(t *testing.T) {
 		},
 	}
 
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	for label, test := range tests {
 		newestCommitID, err := client.ResolveRevision(ctx, test.repo, string(test.opt.NewestCommit), ResolveRevisionOptions{})
 		if err != nil {
@@ -499,7 +496,7 @@ func runBlameFileTest(ctx context.Context, t *testing.T, repo api.RepoName, path
 	checker authz.SubRepoPermissionChecker, label string, wantHunks []*Hunk,
 ) {
 	t.Helper()
-	hunks, err := NewClient(database.NewMockDB()).BlameFile(ctx, checker, repo, path, opt)
+	hunks, err := NewClient().BlameFile(ctx, checker, repo, path, opt)
 	if err != nil {
 		t.Errorf("%s: BlameFile(%s, %+v): %s", label, path, opt, err)
 		return
@@ -544,7 +541,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient(database.NewMockDB()).ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -576,7 +573,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient(database.NewMockDB()).ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -609,7 +606,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient(database.NewMockDB()).ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -641,7 +638,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient(database.NewMockDB()).ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -656,7 +653,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 func TestLsFiles(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) ([]string, error) {
 		return client.LsFiles(ctx, checker, repo, "HEAD")
 	})
@@ -798,7 +795,7 @@ func TestCleanDirectoriesForLsTree(t *testing.T) {
 func TestListDirectoryChildren(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	gitCommands := []string{
 		"mkdir -p dir{1..3}/sub{1..3}",
 		"touch dir1/sub1/file",
@@ -885,7 +882,7 @@ func TestListTags(t *testing.T) {
 		{Name: "t3", CommitID: "afeafc4a918c144329807df307e68899e6b65018", CreatorDate: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 	}
 
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	tags, err := client.ListTags(context.Background(), repo)
 	require.Nil(t, err)
 
@@ -946,8 +943,7 @@ func TestMerger_MergeBase(t *testing.T) {
 	defer ResetClientMocks()
 
 	ctx := context.Background()
-	db := database.NewMockDB()
-	client := NewClient(db)
+	client := NewClient()
 
 	// TODO(sqs): implement for hg
 	// TODO(sqs): make a more complex test case
@@ -1015,7 +1011,6 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
 
-	db := database.NewMockDB()
 	gitCommands := []string{
 		"touch file1",
 		"mkdir dir1",
@@ -1035,7 +1030,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	client := NewClient(db)
+	client := NewClient()
 
 	commitID := api.CommitID(ComputeCommitHash(dir, true))
 
@@ -1112,7 +1107,6 @@ func TestStat(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
 
-	db := database.NewMockDB()
 	gitCommands := []string{
 		"mkdir dir1",
 		"touch dir1/file1",
@@ -1122,7 +1116,7 @@ func TestStat(t *testing.T) {
 
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
-	client := NewClient(db)
+	client := NewClient()
 
 	commitID := api.CommitID(ComputeCommitHash(dir, true))
 
@@ -1186,7 +1180,6 @@ func TestRepository_GetCommit(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
 	gitCommands := []string{
 		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
 		"GIT_COMMITTER_NAME=c GIT_COMMITTER_EMAIL=c@c.com GIT_COMMITTER_DATE=2006-01-02T15:04:07Z git commit --allow-empty -m bar --author='a <a@a.com>' --date 2006-01-02T15:04:06Z",
@@ -1203,7 +1196,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		revisionNotFoundError bool
 	}
 
-	client := NewClient(db)
+	client := NewClient()
 	runGetCommitTests := func(checker authz.SubRepoPermissionChecker, tests map[string]testCase) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
@@ -1303,8 +1296,6 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 		UID: 1,
 	})
 
-	db := database.NewMockDB()
-
 	testCases := []struct {
 		label                 string
 		commitDates           []string
@@ -1374,7 +1365,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 		},
 	}
 
-	client := NewClient(db)
+	client := NewClient()
 	t.Run("basic", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.label, func(t *testing.T) {
@@ -1432,8 +1423,6 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 		UID: 1,
 	})
 
-	db := database.NewMockDB()
-
 	testCases := []struct {
 		commitDates []string
 		want        string
@@ -1455,7 +1444,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 			want: "2007-01-02T15:04:05Z",
 		},
 	}
-	client := NewClient(db)
+	client := NewClient()
 	t.Run("basic", func(t *testing.T) {
 		for _, tc := range testCases {
 			gitCommands := make([]string, len(tc.commitDates))
@@ -1535,8 +1524,7 @@ func TestCommitExists(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
-	client := NewClient(db)
+	client := NewClient()
 	testCommitExists := func(label string, gitCommands []string, commitID, nonExistentCommitID api.CommitID, checker authz.SubRepoPermissionChecker) {
 		t.Run(label, func(t *testing.T) {
 			repo := MakeGitRepository(t, gitCommands...)
@@ -1613,7 +1601,7 @@ func TestRepository_Commits(t *testing.T) {
 			wantTotal:   2,
 		},
 	}
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	runCommitsTests := func(checker authz.SubRepoPermissionChecker) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
@@ -1705,7 +1693,7 @@ func TestCommits_SubRepoPerms(t *testing.T) {
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
-			commits, err := NewClient(database.NewMockDB()).Commits(ctx, checker, repo, test.opt)
+			commits, err := NewClient().Commits(ctx, checker, repo, test.opt)
 			if err != nil {
 				t.Errorf("%s: Commits(): %s", label, err)
 				return
@@ -1797,7 +1785,7 @@ func TestCommits_SubRepoPerms_ReturnNCommits(t *testing.T) {
 		},
 	}
 
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
@@ -1894,7 +1882,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			repo := MakeGitRepository(t)
 			before := ""
 			after := time.Date(2022, 11, 11, 12, 10, 0, 4, time.UTC).Format(time.RFC3339)
-			_, err := NewClient(database.NewMockDB()).Commits(ctx, checker, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before})
+			_, err := NewClient().Commits(ctx, checker, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before})
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
@@ -2189,7 +2177,7 @@ func TestFilterRefDescriptions(t *testing.T) { // KEEP
 	}
 
 	checker := getTestSubRepoPermsChecker("file3")
-	client := NewClient(database.NewMockDB()).(*clientImplementor)
+	client := NewClient().(*clientImplementor)
 	filtered := client.filterRefDescriptions(ctx, repo, refDescriptions, checker)
 	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
 		"d38233a79e037d2ab8170b0d0bc0aa438473e6da": {},
@@ -2207,8 +2195,7 @@ func TestRefDescriptions(t *testing.T) { // KEEP
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
-	client := NewClient(db)
+	client := NewClient()
 	gitCommands := append(getGitCommandsWithFiles("file1", "file2"), "git checkout -b my-other-branch")
 	gitCommands = append(gitCommands, getGitCommandsWithFiles("file1-b2", "file2-b2")...)
 	gitCommands = append(gitCommands, "git checkout -b my-branch-no-access")
@@ -2256,8 +2243,7 @@ func TestCommitsUniqueToBranch(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
-	client := NewClient(db)
+	client := NewClient()
 	gitCommands := append([]string{"git checkout -b my-branch"}, getGitCommandsWithFiles("file1", "file2")...)
 	gitCommands = append(gitCommands, getGitCommandsWithFiles("file3", "file-with-no-access")...)
 	repo := MakeGitRepository(t, gitCommands...)
@@ -2301,8 +2287,7 @@ func TestCommitDate(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	db := database.NewMockDB()
-	client := NewClient(db)
+	client := NewClient()
 	gitCommands := getGitCommandsWithFiles("file1", "file2")
 	repo := MakeGitRepository(t, gitCommands...)
 
@@ -2336,8 +2321,7 @@ func TestCommitDate(t *testing.T) {
 
 func testCommits(ctx context.Context, label string, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker, wantCommits []*gitdomain.Commit, t *testing.T) {
 	t.Helper()
-	db := database.NewMockDB()
-	client := NewClient(db).(*clientImplementor)
+	client := NewClient().(*clientImplementor)
 	commits, err := client.Commits(ctx, checker, repo, opt)
 	if err != nil {
 		t.Errorf("%s: Commits(): %s", label, err)
@@ -2471,7 +2455,7 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 		Treeish:   commitID,
 		Pathspecs: []gitdomain.Pathspec{"."},
 	}
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	if _, err := client.ArchiveReader(context.Background(), checker, repo.Name, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
 	}
@@ -2506,7 +2490,7 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 		Treeish:   commitID,
 		Pathspecs: []gitdomain.Pathspec{"."},
 	}
-	client := NewClient(database.NewMockDB())
+	client := NewClient()
 	readCloser, err := client.ArchiveReader(context.Background(), checker, repo.Name, opts)
 	if err != nil {
 		t.Error("Error should not be thrown because ArchiveReader is invoked for a repo without sub-repo permissions")
@@ -2518,7 +2502,6 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
-	db := database.NewMockDB()
 	const wantData = "abcd\n"
 	repo := MakeGitRepository(t,
 		"echo abcd > file1",
@@ -2558,7 +2541,7 @@ func TestRead(t *testing.T) {
 		},
 	}
 
-	client := NewClient(db)
+	client := NewClient()
 	ClientMocks.LocalGitserver = true
 	t.Cleanup(func() {
 		ResetClientMocks()
@@ -2638,7 +2621,7 @@ func TestRead(t *testing.T) {
 func runNewFileReaderTest(ctx context.Context, t *testing.T, repo api.RepoName, commitID api.CommitID, file string,
 	checker authz.SubRepoPermissionChecker, checkFn func(*testing.T, error, []byte)) {
 	t.Helper()
-	rc, err := NewClient(database.NewMockDB()).NewFileReader(ctx, checker, repo, commitID, file)
+	rc, err := NewClient().NewFileReader(ctx, checker, repo, commitID, file)
 	if err != nil {
 		checkFn(t, err, nil)
 		return
@@ -2704,7 +2687,7 @@ func TestRepository_Branches_MergedInto(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	wantBranches := gitBranches
 	for branch, mergedInto := range wantBranches {
-		branches, err := NewClient(database.NewMockDB()).ListBranches(context.Background(), repo, BranchesOptions{MergedInto: branch})
+		branches, err := NewClient().ListBranches(context.Background(), repo, BranchesOptions{MergedInto: branch})
 		require.Nil(t, err)
 		if diff := cmp.Diff(mergedInto, branches); diff != "" {
 			t.Fatalf("branch mismatch (-want +got):\n%s", diff)
@@ -2735,7 +2718,7 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	commitToWantBranches := gitWantBranches
 	for commit, wantBranches := range commitToWantBranches {
-		branches, err := NewClient(database.NewMockDB()).ListBranches(context.Background(), repo, BranchesOptions{ContainsCommit: commit})
+		branches, err := NewClient().ListBranches(context.Background(), repo, BranchesOptions{ContainsCommit: commit})
 		require.Nil(t, err)
 
 		sort.Sort(gitdomain.Branches(branches))
@@ -2817,7 +2800,7 @@ func testBranches(t *testing.T, gitCommands []string, wantBranches []*gitdomain.
 	t.Helper()
 
 	repo := MakeGitRepository(t, gitCommands...)
-	gotBranches, err := NewClient(database.NewMockDB()).ListBranches(context.Background(), repo, options)
+	gotBranches, err := NewClient().ListBranches(context.Background(), repo, options)
 	require.Nil(t, err)
 
 	sort.Sort(gitdomain.Branches(wantBranches))
@@ -2871,7 +2854,7 @@ func TestLFSSmudge(t *testing.T) {
 	// seems to work under the assumption of a working copy.
 	repo := MakeBareGitRepository(t, gitCmds...)
 
-	c := NewClient(database.NewMockDB())
+	c := NewClient()
 	head, err := c.ResolveRevision(ctx, repo, "HEAD", ResolveRevisionOptions{})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -78,7 +78,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, db, GitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -109,7 +109,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 }
 
 func TestHead(t *testing.T) {
-	client := gitserver.NewTestClient(http.DefaultClient, database.NewMockDB(), GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
 	t.Run("basic", func(t *testing.T) {
 		gitCommands := []string{
 			"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/gitserver/integration_tests/object_test.go
+++ b/internal/gitserver/integration_tests/object_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
@@ -35,7 +34,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.NewTestClient(http.DefaultClient, database.NewMockDB(), GitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -73,7 +73,7 @@ func InitGitserver() {
 	}()
 
 	serverAddress := l.Addr().String()
-	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, db, []string{serverAddress})
+	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, []string{serverAddress})
 	GitserverAddresses = []string{serverAddress}
 }
 

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
@@ -21,9 +20,6 @@ import (
 func TestRepository_FileSystem(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	db := database.NewMockDB()
-	gr := database.NewMockGitserverRepoStore()
-	db.GitserverReposFunc.SetDefaultReturn(gr)
 
 	// In all tests, repo should contain three commits. The first commit
 	// (whose ID is in the 'first' field) has a file at dir1/file1 with the
@@ -59,7 +55,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, db, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
 	for label, test := range tests {
 		// notafile should not exist.
 		if _, err := client.Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
@@ -85,7 +81,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		if got, want := "ab771ba54f5571c99ffdae54f44acc7993d9f115", dir1Info.Sys().(gitdomain.ObjectInfo).OID().String(); got != want {
 			t.Errorf("%s: got dir1 OID %q, want %q", label, got, want)
 		}
-		client := gitserver.NewTestClient(http.DefaultClient, db, GitserverAddresses)
+		client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
 
 		// dir1 should contain one entry: file1.
 		dir1Entries, err := client.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
@@ -219,9 +215,6 @@ func TestRepository_FileSystem(t *testing.T) {
 func TestRepository_FileSystem_quoteChars(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	db := database.NewMockDB()
-	gr := database.NewMockGitserverRepoStore()
-	db.GitserverReposFunc.SetDefaultReturn(gr)
 
 	// The repo contains 3 files: one whose filename includes a
 	// non-ASCII char, one whose filename contains a double quote, and
@@ -254,7 +247,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, db, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {
@@ -294,9 +287,6 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	db := database.NewMockDB()
-	gr := database.NewMockGitserverRepoStore()
-	db.GitserverReposFunc.SetDefaultReturn(gr)
 
 	submodDir := InitGitRepository(t,
 		"touch f",
@@ -317,7 +307,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, db, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -90,7 +90,7 @@ func PurgeOldestRepos(logger log.Logger, db database.DB, limit int, perSecond fl
 // purge purges repos, returning the number of repos that were successfully purged
 func purge(ctx context.Context, logger log.Logger, db database.DB, options database.IteratePurgableReposOptions) error {
 	start := time.Now()
-	gitserverClient := gitserver.NewClient(db)
+	gitserverClient := gitserver.NewClient()
 	var (
 		total   int
 		success int

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -216,7 +216,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 				// if it doesn't exist or update it if it does. The timeout of this request depends
 				// on the value of conf.GitLongCommandTimeout() or if the passed context has a set
 				// deadline shorter than the value of this config.
-				resp, err := requestRepoUpdate(ctx, s.db, repo, 1*time.Second)
+				resp, err := requestRepoUpdate(ctx, repo, 1*time.Second)
 				if err != nil {
 					schedError.WithLabelValues("requestRepoUpdate").Inc()
 					subLogger.Error("error requesting repo update", log.Error(err), log.String("uri", string(repo.Name)))
@@ -269,8 +269,8 @@ func getCustomInterval(logger log.Logger, c *conf.Unified, repoName string) time
 }
 
 // requestRepoUpdate sends a request to gitserver to request an update.
-var requestRepoUpdate = func(ctx context.Context, db database.DB, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
-	return gitserver.NewClient(db).RequestRepoUpdate(ctx, repo.Name, since)
+var requestRepoUpdate = func(ctx context.Context, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+	return gitserver.NewClient().RequestRepoUpdate(ctx, repo.Name, since)
 }
 
 // configuredLimiter returns a mutable limiter that is

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -1424,7 +1424,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			// intentionally don't close the channel so any further receives just block
 
 			contexts := make(chan context.Context, expectedRequestCount)
-			requestRepoUpdate = func(ctx context.Context, db database.DB, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
+			requestRepoUpdate = func(ctx context.Context, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
 				select {
 				case mock := <-mockRequestRepoUpdates:
 					if !reflect.DeepEqual(mock.repo, repo) {

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -47,7 +47,7 @@ type Observer struct {
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
-	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(o.Db), o.Searcher, o.Zoekt)
+	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(), o.Searcher, o.Zoekt)
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -155,7 +155,7 @@ func (s *searchClient) JobClients() job.RuntimeClients {
 		DB:           s.db,
 		Zoekt:        s.zoekt,
 		SearcherURLs: s.searcherURLs,
-		Gitserver:    gitserver.NewClient(s.db),
+		Gitserver:    gitserver.NewClient(),
 	}
 }
 

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -52,7 +51,7 @@ func (s *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 		goroutine.Go(func() {
 			defer run.Release()
 
-			matches, err := searchInRepo(ctx, clients.DB, repoRevs, s.PatternInfo, s.Limit)
+			matches, err := searchInRepo(ctx, repoRevs, s.PatternInfo, s.Limit)
 			status, limitHit, err := search.HandleRepoSearchResult(repoRevs.Repo.ID, repoRevs.Revs, len(matches) > s.Limit, false, err)
 			stream.Send(streaming.SearchEvent{
 				Results: matches,
@@ -96,7 +95,7 @@ func (s *SymbolSearchJob) Fields(v job.Verbosity) (res []log.Field) {
 func (s *SymbolSearchJob) Children() []job.Describer       { return nil }
 func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
-func searchInRepo(ctx context.Context, db database.DB, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
+func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -113,7 +113,7 @@ func searchInRepo(ctx context.Context, db database.DB, repoRevs *search.Reposito
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commitID, err := gitserver.NewClient(db).ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{})
+	commitID, err := gitserver.NewClient().ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -38,7 +38,7 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 	var total Repositories
 
 	// Since this hits gitserver, we should use an internal actor.
-	stats, err := gitserver.NewClient(db).ReposStats(actor.WithInternalActor(ctx))
+	stats, err := gitserver.NewClient().ReposStats(actor.WithInternalActor(ctx))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The gitserver client does not use its `db` dependency, so this removes it. Turns out, we're passing a lot of DBs around just for the gitserver client.

## Test plan

Unit tests. Just removing unused arguments. I depended on gopls a lot here. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
