### PR TITLE
Code Insights: Fix new insight repositories UI

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
@@ -39,13 +39,13 @@ export function getCaptureGroupInsightCreateInput(
     insight: MinimalCaptureGroupInsightData,
     dashboardId: string | null
 ): LineChartSearchInsightInput {
-    const { step, repositories, filters, title } = insight
+    const { step, repositories, repoQuery, filters, title } = insight
     const [unit, value] = getStepInterval(step)
 
     const input: LineChartSearchInsightInput = {
         repositoryScope: {
             repositories: insight.repositories,
-            repositoryCriteria: insight.repoQuery,
+            repositoryCriteria: repoQuery || null,
         },
         dataSeries: [
             {
@@ -84,7 +84,7 @@ export function getSearchInsightCreateInput(
     const input: LineChartSearchInsightInput = {
         repositoryScope: {
             repositories,
-            repositoryCriteria: repoQuery,
+            repositoryCriteria: repoQuery || null,
         },
         dataSeries: insight.series.map<LineChartSearchInsightDataSeriesInput>(series => ({
             query: series.query,

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/update-insight/serializators.ts
@@ -20,7 +20,7 @@ export function getSearchInsightUpdateInput(insight: MinimalSearchBasedInsightDa
     return {
         repositoryScope: {
             repositories,
-            repositoryCriteria: repoQuery,
+            repositoryCriteria: repoQuery || null,
         },
         dataSeries: series.map<LineChartSearchInsightDataSeriesInput>(series => ({
             seriesId: series.id,
@@ -50,7 +50,7 @@ export function getCaptureGroupInsightUpdateInput(
     const [unit, value] = getStepInterval(step)
 
     return {
-        repositoryScope: { repositories, repositoryCriteria: repoQuery },
+        repositoryScope: { repositories, repositoryCriteria: repoQuery || null },
         dataSeries: [
             {
                 query,

--- a/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
@@ -44,6 +44,7 @@ export const LineChartLivePreview: FC<LineChartLivePreviewProps> = props => {
 
     const settings = useDebounce(
         useDeepMemo({
+            disabled,
             repoScope: getSanitizedRepositoryScope(repositories, repoQuery, repoMode),
             step: { [step]: stepValue },
             series: series.map(srs => {
@@ -63,7 +64,10 @@ export const LineChartLivePreview: FC<LineChartLivePreviewProps> = props => {
     )
 
     const { state, refetch } = useLivePreviewSeriesInsight({
-        skip: disabled,
+        // If disabled goes from true to false then cancel live preview series fetching
+        // immediately, when it goes from false to true wait a little *use debounced
+        // value only when run preview search
+        skip: disabled || settings.disabled,
         ...settings,
     })
 

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -190,7 +190,7 @@ describe('Code insight edit insight page', () => {
             input: {
                 repositoryScope: {
                     repositories: ['github.com/sourcegraph/sourcegraph', 'github.com/sourcegraph/about'],
-                    repositoryCriteria: '',
+                    repositoryCriteria: null,
                 },
                 dataSeries: [
                     {


### PR DESCRIPTION
It turned out that if we provide `repositories` list and `repositoryCriteria` fields where repositoryCriteria is empty string then backend will through a validation error that we need to provide up to 1 repositories setting. This PR fixes this problem and provide null when `repositoryCriteria` is not specified

## Test plan
- Create search and capture code insights (creation flow should be successful regardless of what field you use - repositories or repositoryCriteria - search box repositories field)
- Try to update search or capture code insights (both should be updated as expected)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-repo-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
