### PR TITLE
GitHub and GitLab issue native HTTP request for connection check

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -262,7 +262,9 @@ func (s *GitHubSource) Version(ctx context.Context) (string, error) {
 }
 
 func (s *GitHubSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	// On github.com the error is always going to be nil.
+	_, err := s.v3Client.GetVersion(ctx)
+	return err
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -162,7 +162,8 @@ func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {
 }
 
 func (s GitLabSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	_, err := s.client.GetVersion(ctx)
+	return err
 }
 
 // ListRepos returns all GitLab repositories accessible to all connections configured


### PR DESCRIPTION
`ConnectionCheck` reimplemented to issue a client call instead of DNS lookup and a `net.Dial`:

- For GitLab use version check.
- For GitHub use version check (except it does not work on github.com - in such case always return available).

## Test plan

Manual check for gitlab.com.
