### PR TITLE
build: use name packages in sass imports

### DIFF
--- a/client/vscode/src/webview/index.scss
+++ b/client/vscode/src/webview/index.scss
@@ -1,10 +1,10 @@
 // Global styles provided by @reach packages. Should be imported once in the global scope.
 @import '@reach/tabs/styles';
 
-@import '../../../wildcard/src/global-styles/base.scss';
+@import 'wildcard/src/global-styles/base';
 @import './theming/highlight.scss';
 @import './theming/monaco.scss';
-@import '../../../../node_modules/@vscode/codicons/dist/codicon.css';
+@import '@vscode/codicons/dist/codicon.css';
 
 :root {
     // v2/debt: redefine our CSS variables using VS Code's CSS variables

--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -11,6 +11,8 @@
  * extensibility.
  **/
 
+@use 'wildcard/src/global-styles/forms';
+
 @import 'graphiql/graphiql.css';
 
 /* stylelint-disable selector-class-pattern */


### PR DESCRIPTION
With bazel the paths will be stricter and things like relative paths into `node_modules` won't work.

For the `graphiql-theme.scss` change.. for some reason when running sass in bazel sass couldn't determine where the `@extend .form-control` should be resolved. By `@use`ing the global-style sass can find it 🤷 

## Test plan

CI, are there any visual tests to verify 100%?

## App preview:

- [Web](https://sg-web-bazel-sass-imports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
