### PR TITLE
Add two warnings in docs for recent bugs

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -267,8 +267,6 @@ to Sourcegraph](../external_service/gitlab.md#repository-syncing).
 
 ### How to control user sign-up and sign-in with GitLab auth provider
 
-> WARNING: GitLab offers an additional user permission level, [minimal access](https://docs.gitlab.com/ee/user/permissions.html#users-with-minimal-access), for Premium and Ultimate tier customers. Sourcegraph currently does not support this tier level and will not prevent these users from signing up if using this Sourcegraph configuration option. Contact your support representitive with any further questions. 
-
 You can use the following filters to control how users can create accounts and sign in to your Sourcegraph instance via the GitLab auth provider.
 
 **allowSignup**
@@ -301,6 +299,8 @@ You can use the following filters to control how users can create accounts and s
   If combined with `"allowSignup": false`, an admin should first create the user account so that the user can sign in with GitLab.
 
   If combined with `"allowSignup": true` or with `allowSignup` unset, only members of  the allowed groups or subgroups can create their accounts in Sourcegraph via GitLab authentitcation.
+
+> WARNING: Users will require a minimum access level of `Guest` in at least one of the specified groups in order to gain access to Sourcegraph. GitLab offers a lower user permission level, [Minimal Access](https://docs.gitlab.com/ee/user/permissions.html#users-with-minimal-access), for Premium and Ultimate tier customers, which is often used to configure SAML SSO on GitLab. Sourcegraph does not currently support the `Minimal Access` access level, and users with this access level will not be allowed to sign in. In these cases it is recommended to create a subgroup and add all users that require access to Sourcegraph to that subgroup with a minimum access level of `Guest`, and then add that subgroup to the `allowGroups` list.
 
   ```json
     {

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -267,6 +267,8 @@ to Sourcegraph](../external_service/gitlab.md#repository-syncing).
 
 ### How to control user sign-up and sign-in with GitLab auth provider
 
+> WARNING: GitLab offers an additional user permission level, [minimal access](https://docs.gitlab.com/ee/user/permissions.html#users-with-minimal-access), for Premium and Ultimate tier customers. Sourcegraph currently does not support this tier level and will not prevent these users from signing up if using this Sourcegraph configuration option. Contact your support representitive with any further questions. 
+
 You can use the following filters to control how users can create accounts and sign in to your Sourcegraph instance via the GitLab auth provider.
 
 **allowSignup**

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -212,6 +212,6 @@ It may be the case that you'd like to temporarily disable all `git` and API requ
 
 ### Testing Code Host Connections
 
-> WARNING: Sourcegraph 4.4 customers are reporting a bug with the test connection functionality when Sourcegraph is running behind a proxy which blocks TCP dial. This causes repositories to stop syncing. If you're experiencing this issue, please contact your support representative or email us at [support@sourcegraph.com](mailto:support@sourcegraph.com).
+> WARNING: Sourcegraph 4.4.0 customers are reporting a bug where the connection test is failing when Sourcegraph is running behind proxies where TCP dial cannot be used with ports 80/443. This causes repositories to stop syncing. If you're experiencing this issue, please upgrade to 4.4.1 where normal HTTP requests are used instead.
 
 In Sourcegraph 4.4, site administrators have the ability to test a code host connection via the site-admin UI to improve the debuggability when something goes wrong. This check confirms that Sourcegraph has the ability to connect with the respective code host via TCP dial. 

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -209,3 +209,9 @@ It may be the case that you'd like to temporarily disable all `git` and API requ
 "gitMaxCodehostRequestsPerSecond": 0,
 "gitMaxConcurrentClones": 0
 ```
+
+### Testing Code Host Connections
+
+> WARNING: Sourcegraph 4.4 customers are reporting a bug with the test connection functionality when Sourcegraph is running behind a proxy which blocks TCP dial. This causes repositories to stop syncing. If you're experiencing this issue, please contact your support representative or email us at [support@sourcegraph.com](mailto:support@sourcegraph.com).
+
+In Sourcegraph 4.4, site administrators have the ability to test a code host connection via the site-admin UI to improve the debuggability when something goes wrong. This check confirms that Sourcegraph has the ability to connect with the respective code host via TCP dial. 


### PR DESCRIPTION
Add warnings in documentation for: 

- TCP dial issue with certain proxies
- Minimal access level in GitLab not being respected


## Test plan
Docs-change only, testing locally. 

