### PR TITLE
web: debug RR6 migration issue

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -6,7 +6,7 @@ import { ApolloProvider } from '@apollo/client'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import { Route, Router } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
+import { CompatRoute, CompatRouter } from 'react-router-dom-v5-compat'
 import { combineLatest, from, Subscription, fromEvent, of, Subject, Observable } from 'rxjs'
 import { first, startWith, switchMap } from 'rxjs/operators'
 import * as uuid from 'uuid'
@@ -93,6 +93,7 @@ import { observeLocation } from './util/location'
 import { siteSubjectNoAdmin, viewerSubjectFromSettings } from './util/settings'
 
 import styles from './SourcegraphWebApp.module.scss'
+import { XCompatRoute } from './XCompatRoute'
 
 export interface SourcegraphWebAppProps
     extends CodeIntelligenceProps,
@@ -361,8 +362,8 @@ export class SourcegraphWebApp extends React.Component<
             >
                 <Router history={history} key={0}>
                     <CompatRouter>
-                        <Route
-                            path="/"
+                        <XCompatRoute
+                            pathV6="/*"
                             render={routeComponentProps => (
                                 <Layout
                                     {...props}

--- a/client/web/src/XCompatRoute.tsx
+++ b/client/web/src/XCompatRoute.tsx
@@ -1,0 +1,20 @@
+import { RouteProps, Route as RouteV5 } from 'react-router-dom'
+import { Route as RouteV6, Routes } from 'react-router-dom-v5-compat'
+
+type Props = RouteProps & {
+    pathV6: string
+}
+
+/**
+ * Compatibility Route component to help us migrate from `react-router-dom` v5 to
+ * v6. It renders a V5 route inside of a V6 route.
+ *
+ * It takes an intersection type of V5 RouteProps and a pathV6 prop.
+ */
+export function XCompatRoute({ pathV6, ...rest }: Props): JSX.Element {
+    return (
+        <Routes location={rest.location}>
+            <RouteV6 path={pathV6} element={<RouteV5 {...rest} />} />
+        </Routes>
+    )
+}

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -9,16 +9,20 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+import { H2, Text } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../../components/HeroPage'
+import { EnterprisePageRoutes } from '../../../routes.constants'
+import { XCompatRoute } from '../../../XCompatRoute'
 import type { BatchChangeClosePageProps } from '../close/BatchChangeClosePage'
 import type { CreateBatchChangePageProps } from '../create/CreateBatchChangePage'
 import type { BatchChangeDetailsPageProps } from '../detail/BatchChangeDetailsPage'
 import { TabName } from '../detail/BatchChangeDetailsTabs'
 import type { BatchChangeListPageProps, NamespaceBatchChangeListPageProps } from '../list/BatchChangeListPage'
 import type { BatchChangePreviewPageProps } from '../preview/BatchChangePreviewPage'
+import { Page } from '../../../components/Page'
 
 const BatchChangeListPage = lazyComponent<BatchChangeListPageProps, 'BatchChangeListPage'>(
     () => import('../list/BatchChangeListPage'),
@@ -61,28 +65,32 @@ export const GlobalBatchChangesArea: React.FunctionComponent<React.PropsWithChil
     ...props
 }) => (
     <div className="w-100">
-        <Switch>
-            <CompatRoute path={match.url} exact={true}>
-                <BatchChangeListPage
-                    headingElement="h1"
-                    canCreate={Boolean(authenticatedUser) && !isSourcegraphDotCom}
-                    authenticatedUser={authenticatedUser}
-                    isSourcegraphDotCom={isSourcegraphDotCom}
-                    {...props}
-                    location={location}
-                />
-            </CompatRoute>
-            {!isSourcegraphDotCom && (
-                <CompatRoute path={`${match.url}/create`} exact={true}>
-                    <AuthenticatedCreateBatchChangePage
-                        {...props}
+        <Page>
+            <H2>GlobalCodeMonitoringArea content</H2>
+            <Text className="mb-5">`match.url` value is: {match.url}</Text>
+            <Switch>
+                <XCompatRoute pathV6="" path={match.url} exact={true}>
+                    <BatchChangeListPage
                         headingElement="h1"
+                        canCreate={Boolean(authenticatedUser) && !isSourcegraphDotCom}
                         authenticatedUser={authenticatedUser}
+                        isSourcegraphDotCom={isSourcegraphDotCom}
+                        {...props}
+                        location={location}
                     />
-                </CompatRoute>
-            )}
-            <CompatRoute component={NotFoundPage} key="hardcoded-key" />
-        </Switch>
+                </XCompatRoute>
+                {!isSourcegraphDotCom && (
+                    <CompatRoute path={`${match.url}/create`} exact={true}>
+                        <AuthenticatedCreateBatchChangePage
+                            {...props}
+                            headingElement="h1"
+                            authenticatedUser={authenticatedUser}
+                        />
+                    </CompatRoute>
+                )}
+                <CompatRoute component={NotFoundPage} key="hardcoded-key" />
+            </Switch>
+        </Page>
     </div>
 )
 

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
 import { RouteComponentProps, Switch } from 'react-router'
-import { CompatRoute } from 'react-router-dom-v5-compat'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+import { H2, Text } from '@sourcegraph/wildcard'
 
+import { XCompatRoute } from '../../../XCompatRoute'
 import { AuthenticatedUser } from '../../../auth'
 import { Page } from '../../../components/Page'
 
@@ -32,28 +33,39 @@ const ManageCodeMonitorPage = lazyComponent(() => import('../ManageCodeMonitorPa
 export const GlobalCodeMonitoringArea: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     match,
     ...outerProps
-}) => (
-    <div className="w-100">
-        <Page>
-            <Switch>
-                <CompatRoute
-                    path=""
-                    render={(props: RouteComponentProps<{}>) => <CodeMonitoringPage {...outerProps} {...props} />}
-                    exact={true}
-                />
-                <CompatRoute
-                    path="new"
-                    render={(props: RouteComponentProps<{}>) => <CreateCodeMonitorPage {...outerProps} {...props} />}
-                    exact={true}
-                />
-                <CompatRoute
-                    path={`${match.path}/:id`}
-                    render={(props: RouteComponentProps<{ id: string }>) => (
-                        <ManageCodeMonitorPage {...outerProps} {...props} />
-                    )}
-                    exact={true}
-                />
-            </Switch>
-        </Page>
-    </div>
-)
+}) => {
+    console.log('GlobalCodeMonitoringArea', match)
+
+    return (
+        <div className="w-100">
+            <Page>
+                <H2>GlobalCodeMonitoringArea content</H2>
+                <Text className="mb-5">`match.url` value is: {match.url}</Text>
+                <Switch>
+                    <XCompatRoute
+                        path="/code-monitoring/new"
+                        pathV6="new"
+                        render={(props: RouteComponentProps<{}>) => (
+                            <CreateCodeMonitorPage {...outerProps} {...props} />
+                        )}
+                    />
+                    <XCompatRoute
+                        path="/code-monitoring/:id"
+                        pathV6=":id"
+                        render={(props: RouteComponentProps<{ id: string }>) => {
+                            console.log('render route ManageCodeMonitorPage')
+
+                            return <ManageCodeMonitorPage {...outerProps} {...props} />
+                        }}
+                        exact={true}
+                    />
+                    <XCompatRoute
+                        path="/code-monitoring"
+                        pathV6=""
+                        render={(props: RouteComponentProps<{}>) => <CodeMonitoringPage {...outerProps} {...props} />}
+                    />
+                </Switch>
+            </Page>
+        </div>
+    )
+}


### PR DESCRIPTION
## Context

I discovered two issues with the `CompatRoute`:
1. `path="*"` doesn't work correctly because of https://github.com/remix-run/react-router/blame/4d915e3305df5b01f51abdeb1c01bf442453522e/packages/react-router-dom-v5-compat/lib/components.tsx#L18
2. Nested routes in Switch don't work properly because RR6 and RR5 paths
should be different before migration. It seems that the CompatRoute
still renders the element if the RR5 path is not specified. See implementation here:
https://github.com/remix-run/react-router/blob/4d915e3305df5b01f51abdeb1c01bf442453522e/packages/react-router-dom-v5-compat/lib/components.tsx#L21

More context:
1. https://github.com/remix-run/react-router/issues/9558#issuecomment-1315168000
2. https://github.com/remix-run/react-router/discussions/9509

We can implement an ugly migration keeping both RR5 and RR6 path props. On migration completion, we can remove `path` and rename `pathV6` or whatever seems the best combination.

## Test plan

`sg start web-standalone`

## App preview:

- [Web](https://sg-web-vb-debug-switch-compat-route.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

