### PR TITLE
Milan/disable codehost connection checks

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -182,6 +182,10 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
                         headingElement="h2"
                         actions={
                             <div className="d-flex align-items-center justify-content-between">
+                                {/*
+                                // TODO: disabling availability checks for now because of a problem this causes to customers behind
+                                // proxies that block TCP dial calls.
+                                // We should fix the checks in a followup release.
                                 <div className="align-self-start">
                                     <Tooltip
                                         content={
@@ -200,7 +204,7 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
                                             <Icon aria-hidden={true} svgPath={mdiConnection} /> Test connection
                                         </Button>
                                     </Tooltip>
-                                </div>
+                                </div> */}
                                 {editingEnabled && (
                                     <div className="flex-grow-1 ml-1">
                                         <Tooltip content="Edit code host connection settings">

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -57,11 +57,15 @@ const externalServiceIDKind = "ExternalService"
 // availabilityCheck indicates which code host types have an availability check implemented. For any
 // new code hosts where this check is implemented, add a new entry for the respective kind and set
 // the value to true.
+//
+// TODO: disabling availability checks for now because of a problem this causes to customers behind
+// proxies that block TCP dial calls.
+// We should fix the checks in a followup release.
 var availabilityCheck = map[string]bool{
-	extsvc.KindGitHub:          true,
-	extsvc.KindGitLab:          true,
-	extsvc.KindBitbucketServer: true,
-	extsvc.KindBitbucketCloud:  true,
+	extsvc.KindGitHub:          false,
+	extsvc.KindGitLab:          false,
+	extsvc.KindBitbucketServer: false,
+	extsvc.KindBitbucketCloud:  false,
 }
 
 func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*externalServiceResolver, error) {

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -725,74 +726,77 @@ func TestExternalServices(t *testing.T) {
 			}
 		`,
 		},
-		{
-			Schema: mustParseGraphQLSchema(t, db),
-			Label:  "Check connection",
-			Query: `
-				{
-					externalServices() {
-						nodes {
-							id
-							checkConnection {
-								... on ExternalServiceAvailable {
-									lastCheckedAt
-								}
-								... on ExternalServiceUnavailable {
-									suspectedReason
-								}
-								... on ExternalServiceAvailabilityUnknown {
-									implementationNote
-								}
-							}
-							hasConnectionCheck
-						}
-					}
-				}
-			`,
-			ExpectedResult: fmt.Sprintf(`
-			{
-				"externalServices": {
-					"nodes": [
-						{
-							"id": "RXh0ZXJuYWxTZXJ2aWNlOjE=",
-							"checkConnection": {
-								"implementationNote": "not implemented"
-							},
-							"hasConnectionCheck": false
-						},
-						{
-							"id": "RXh0ZXJuYWxTZXJ2aWNlOjI=",
-							"checkConnection": {
-								"suspectedReason": "failed to connect"
-							},
-							"hasConnectionCheck": true
-						},
-						{
-							"id": "RXh0ZXJuYWxTZXJ2aWNlOjM=",
-							"checkConnection": {
-								"lastCheckedAt": %q
-							},
-							"hasConnectionCheck": true
-						},
-						{
-							"id": "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
-							"checkConnection": {
-								"implementationNote": "not implemented"
-							},
-							"hasConnectionCheck": false
-						},
-						{
-							"id": "RXh0ZXJuYWxTZXJ2aWNlOjU=",
-							"checkConnection": {
-								"implementationNote": "not implemented"
-							},
-							"hasConnectionCheck": false
-						}
-					]
-				}
-			}
-			`, mockLastCheckedAt.Format("2006-01-02T15:04:05Z")),
-		},
+		// TODO: disabling availability checks for now because of a problem this causes to customers behind
+		// proxies that block TCP dial calls.
+		// We should fix the checks in a followup release.
+		// {
+		// 	Schema: mustParseGraphQLSchema(t, db),
+		// 	Label:  "Check connection",
+		// 	Query: `
+		// 		{
+		// 			externalServices() {
+		// 				nodes {
+		// 					id
+		// 					checkConnection {
+		// 						... on ExternalServiceAvailable {
+		// 							lastCheckedAt
+		// 						}
+		// 						... on ExternalServiceUnavailable {
+		// 							suspectedReason
+		// 						}
+		// 						... on ExternalServiceAvailabilityUnknown {
+		// 							implementationNote
+		// 						}
+		// 					}
+		// 					hasConnectionCheck
+		// 				}
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedResult: fmt.Sprintf(`
+		// 	{
+		// 		"externalServices": {
+		// 			"nodes": [
+		// 				{
+		// 					"id": "RXh0ZXJuYWxTZXJ2aWNlOjE=",
+		// 					"checkConnection": {
+		// 						"implementationNote": "not implemented"
+		// 					},
+		// 					"hasConnectionCheck": false
+		// 				},
+		// 				{
+		// 					"id": "RXh0ZXJuYWxTZXJ2aWNlOjI=",
+		// 					"checkConnection": {
+		// 						"suspectedReason": "failed to connect"
+		// 					},
+		// 					"hasConnectionCheck": true
+		// 				},
+		// 				{
+		// 					"id": "RXh0ZXJuYWxTZXJ2aWNlOjM=",
+		// 					"checkConnection": {
+		// 						"lastCheckedAt": %q
+		// 					},
+		// 					"hasConnectionCheck": true
+		// 				},
+		// 				{
+		// 					"id": "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
+		// 					"checkConnection": {
+		// 						"implementationNote": "not implemented"
+		// 					},
+		// 					"hasConnectionCheck": false
+		// 				},
+		// 				{
+		// 					"id": "RXh0ZXJuYWxTZXJ2aWNlOjU=",
+		// 					"checkConnection": {
+		// 						"implementationNote": "not implemented"
+		// 					},
+		// 					"hasConnectionCheck": false
+		// 				}
+		// 			]
+		// 		}
+		// 	}
+		// 	`, mockLastCheckedAt.Format("2006-01-02T15:04:05Z")),
+		// },
 		{
 			Schema: mustParseGraphQLSchema(t, db),
 			Label:  "PageInfo included, using first",

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -543,9 +543,12 @@ func (s *Syncer) SyncExternalService(
 		return err
 	}
 
-	if err := src.CheckConnection(ctx); err != nil {
-		return err
-	}
+	// TODO: disabling availability checks for now because of a problem this causes to customers behind
+	// proxies that block TCP dial calls.
+	// We should fix the checks in a followup release.
+	// if err := src.CheckConnection(ctx); err != nil {
+	// 	return err
+	// }
 
 	results := make(chan SourceResult)
 	go func() {


### PR DESCRIPTION
Disable connection checks for code hosts

This is currently implemetned as TCP dial to the code host. We have customers
behing a proxy, that disallows TCP dial, which means this check will always fail
for them, which is a false positive. On top of that, we do this check in repo
syncer as well. If the check fails, we disable repo syncing.

We decided a safer approach for now is to disable the feature and create a patch
release, so that we can unblock the affected customers.

We will fix these checks in a followup PR.

Related: https://github.com/sourcegraph/sourcegraph/issues/46915

## Test plan

Testing manually locally.
