### PR TITLE
chore: remove unused context parameter from workers + don't lose error of `SynchronizeMetadata`.

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -104,7 +104,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		outOfBandMigrationRunner := oobmigration.NewRunnerWithDB(observationCtx, db, oobmigration.RefreshInterval)
 
 		if err := outOfBandMigrationRunner.SynchronizeMetadata(ctx); err != nil {
-			return errors.Wrap(err, "failed to synchronized out of band migration metadata")
+			return errors.Wrap(err, "failed to synchronize out of band migration metadata")
 		}
 
 		if err := oobmigration.ValidateOutOfBandMigrationRunner(ctx, db, outOfBandMigrationRunner); err != nil {

--- a/cmd/worker/internal/codeintel/crates_syncer.go
+++ b/cmd/worker/internal/codeintel/crates_syncer.go
@@ -26,7 +26,7 @@ func (j *cratesSyncerJob) Config() []env.Config {
 	return nil
 }
 
-func (j *cratesSyncerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *cratesSyncerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/encryption/encrypter_job.go
+++ b/cmd/worker/internal/encryption/encrypter_job.go
@@ -27,7 +27,7 @@ func (j *recordEncrypterJob) Config() []env.Config {
 	}
 }
 
-func (j *recordEncrypterJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *recordEncrypterJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	metrics := newMetrics(observationCtx)
 
 	db, err := workerdb.InitDB(observationCtx)

--- a/cmd/worker/internal/gitserver/servermetrics.go
+++ b/cmd/worker/internal/gitserver/servermetrics.go
@@ -28,7 +28,7 @@ func (j *metricsJob) Config() []env.Config {
 	return nil
 }
 
-func (j *metricsJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *metricsJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/migrations/init.go
+++ b/cmd/worker/internal/migrations/init.go
@@ -40,8 +40,8 @@ func (m *migrator) Routines(startupCtx context.Context, observationCtx *observat
 
 	outOfBandMigrationRunner := oobmigration.NewRunnerWithDB(observationCtx, db, oobmigration.RefreshInterval)
 
-	if outOfBandMigrationRunner.SynchronizeMetadata(startupCtx); err != nil {
-		return nil, errors.Wrap(err, "failed to synchronized out of band migration metadata")
+	if err := outOfBandMigrationRunner.SynchronizeMetadata(startupCtx); err != nil {
+		return nil, errors.Wrap(err, "failed to synchronize out of band migration metadata")
 	}
 
 	if err := m.registerMigrators(startupCtx, db, outOfBandMigrationRunner); err != nil {

--- a/cmd/worker/internal/outboundwebhooks/job.go
+++ b/cmd/worker/internal/outboundwebhooks/job.go
@@ -35,7 +35,7 @@ func (*sender) Config() []env.Config {
 	return nil
 }
 
-func (s *sender) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (s *sender) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("sender", "outbound webhook sender"))
 	ctx := actor.WithInternalActor(context.Background())
 

--- a/cmd/worker/internal/repostatistics/compactor.go
+++ b/cmd/worker/internal/repostatistics/compactor.go
@@ -29,7 +29,7 @@ func (j *compactor) Config() []env.Config {
 	return nil
 }
 
-func (j *compactor) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *compactor) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/webhooks/janitor.go
+++ b/cmd/worker/internal/webhooks/janitor.go
@@ -30,7 +30,7 @@ func (j *janitor) Config() []env.Config {
 	return nil
 }
 
-func (j *janitor) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *janitor) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/zoektrepos/zoektrepos.go
+++ b/cmd/worker/internal/zoektrepos/zoektrepos.go
@@ -31,7 +31,7 @@ func (j *updater) Config() []env.Config {
 	return nil
 }
 
-func (j *updater) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *updater) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/autoindexing_dependency_scheduler_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/autoindexing_dependency_scheduler_job.go
@@ -30,7 +30,7 @@ func (j *autoindexingDependencyScheduler) Config() []env.Config {
 	}
 }
 
-func (j *autoindexingDependencyScheduler) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *autoindexingDependencyScheduler) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/autoindexing_janitor.go
+++ b/enterprise/cmd/worker/internal/codeintel/autoindexing_janitor.go
@@ -27,7 +27,7 @@ func (j *autoindexingJanitorJob) Config() []env.Config {
 	return []env.Config{autoindexing.ConfigCleanupInst}
 }
 
-func (j *autoindexingJanitorJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *autoindexingJanitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/autoindexing_scheduler_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/autoindexing_scheduler_job.go
@@ -30,7 +30,7 @@ func (j *autoindexingScheduler) Config() []env.Config {
 	}
 }
 
-func (j *autoindexingScheduler) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *autoindexingScheduler) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph_updater_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph_updater_job.go
@@ -27,7 +27,7 @@ func (j *commitGraphUpdaterJob) Config() []env.Config {
 	}
 }
 
-func (j *commitGraphUpdaterJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *commitGraphUpdaterJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/lsifuploadstore_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifuploadstore_expirer.go
@@ -31,7 +31,7 @@ func (j *lsifuploadstoreExpirer) Config() []env.Config {
 	}
 }
 
-func (j *lsifuploadstoreExpirer) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *lsifuploadstoreExpirer) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	uploadStore, err := lsifuploadstore.New(context.Background(), observationCtx, lsifuploadstoreExpirerConfigInst.LSIFUploadStoreConfig)
 	if err != nil {
 		observationCtx.Logger.Fatal("Failed to create upload store", log.Error(err))

--- a/enterprise/cmd/worker/internal/codeintel/metrics_reporter.go
+++ b/enterprise/cmd/worker/internal/codeintel/metrics_reporter.go
@@ -33,7 +33,7 @@ func (j *metricsReporterJob) Config() []env.Config {
 	}
 }
 
-func (j *metricsReporterJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *metricsReporterJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/policies_repomatcher_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/policies_repomatcher_job.go
@@ -27,7 +27,7 @@ func (j *policiesRepositoryMatcherJob) Config() []env.Config {
 	}
 }
 
-func (j *policiesRepositoryMatcherJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *policiesRepositoryMatcherJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/ranking_sourcer.go
+++ b/enterprise/cmd/worker/internal/codeintel/ranking_sourcer.go
@@ -29,7 +29,7 @@ func (j *rankingSourcerJob) Config() []env.Config {
 	}
 }
 
-func (j *rankingSourcerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *rankingSourcerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/upload_backfiller.go
+++ b/enterprise/cmd/worker/internal/codeintel/upload_backfiller.go
@@ -28,7 +28,7 @@ func (j *uploadBackfillerJob) Config() []env.Config {
 	}
 }
 
-func (j *uploadBackfillerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *uploadBackfillerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/upload_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/upload_expirer.go
@@ -28,7 +28,7 @@ func (j *uploadExpirerJob) Config() []env.Config {
 	}
 }
 
-func (j *uploadExpirerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *uploadExpirerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/upload_janitor.go
+++ b/enterprise/cmd/worker/internal/codeintel/upload_janitor.go
@@ -29,7 +29,7 @@ func (j *uploadJanitorJob) Config() []env.Config {
 	}
 }
 
-func (j *uploadJanitorJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *uploadJanitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codeintel/uploads_graph_exporter.go
+++ b/enterprise/cmd/worker/internal/codeintel/uploads_graph_exporter.go
@@ -27,7 +27,7 @@ func (j *graphExporterJob) Config() []env.Config {
 	}
 }
 
-func (j *graphExporterJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *graphExporterJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	services, err := codeintel.InitServices(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -26,7 +26,7 @@ func (j *codeMonitorJob) Config() []env.Config {
 	return []env.Config{}
 }
 
-func (j *codeMonitorJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *codeMonitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/executors/janitor_job.go
+++ b/enterprise/cmd/worker/internal/executors/janitor_job.go
@@ -24,7 +24,7 @@ func (j *janitorJob) Config() []env.Config {
 	return []env.Config{janitorConfigInst}
 }
 
-func (j *janitorJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *janitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/worker/internal/executors/metricsserver_job.go
+++ b/enterprise/cmd/worker/internal/executors/metricsserver_job.go
@@ -31,7 +31,7 @@ func (j *metricsServerJob) Config() []env.Config {
 	return []env.Config{metricsServerConfigInst}
 }
 
-func (j *metricsServerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (j *metricsServerJob) Routines(_ context.Context, _ *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	host := ""
 	if env.InsecureDev {
 		host = "127.0.0.1"

--- a/enterprise/cmd/worker/internal/insights/data_retention_job.go
+++ b/enterprise/cmd/worker/internal/insights/data_retention_job.go
@@ -24,7 +24,7 @@ func (s *insightsDataRetentionJob) Config() []env.Config {
 	return nil
 }
 
-func (s *insightsDataRetentionJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (s *insightsDataRetentionJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling insights data retention job.")
 		return []goroutine.BackgroundRoutine{}, nil

--- a/enterprise/cmd/worker/internal/insights/job.go
+++ b/enterprise/cmd/worker/internal/insights/job.go
@@ -22,7 +22,7 @@ func (s *insightsJob) Config() []env.Config {
 	return nil
 }
 
-func (s *insightsJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (s *insightsJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling background jobs.")
 		return []goroutine.BackgroundRoutine{}, nil

--- a/enterprise/cmd/worker/internal/insights/query_runner_job.go
+++ b/enterprise/cmd/worker/internal/insights/query_runner_job.go
@@ -24,7 +24,7 @@ func (s *insightsQueryRunnerJob) Config() []env.Config {
 	return nil
 }
 
-func (s *insightsQueryRunnerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (s *insightsQueryRunnerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling query runner.")
 		return []goroutine.BackgroundRoutine{}, nil

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -50,7 +50,7 @@ func (t *telemetryJob) Config() []env.Config {
 	return nil
 }
 
-func (t *telemetryJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+func (t *telemetryJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !isEnabled() {
 		return nil, nil
 	}


### PR DESCRIPTION
After creating a worker and taking a look a this code I just decided to spend 3 minutes to clean some code up.

I also noticed that one error was ignored in `cmd/worker/internal/migrations/init.go` and fixed it.

Test plan:
Not a functional change, CI should pass.