### PR TITLE
insights: chore: remove db from previewExecutor

### DIFF
--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -28,7 +28,6 @@ type CaptureGroupExecutor struct {
 func NewCaptureGroupExecutor(postgres database.DB, clock func() time.Time) *CaptureGroupExecutor {
 	return &CaptureGroupExecutor{
 		previewExecutor: previewExecutor{
-			db:        postgres,
 			repoStore: postgres.Repos(),
 			// filter:    compression.NewHistoricalFilter(true, clock().Add(time.Hour*24*365*-1), insightsDb),
 			filter: &compression.NoopFilter{},

--- a/enterprise/internal/insights/query/compute_executor.go
+++ b/enterprise/internal/insights/query/compute_executor.go
@@ -23,7 +23,6 @@ type ComputeExecutor struct {
 func NewComputeExecutor(postgres database.DB, clock func() time.Time) *ComputeExecutor {
 	executor := ComputeExecutor{
 		previewExecutor: previewExecutor{
-			db:        postgres,
 			repoStore: postgres.Repos(),
 			filter:    &compression.NoopFilter{},
 			clock:     clock,

--- a/enterprise/internal/insights/query/preview_executor.go
+++ b/enterprise/internal/insights/query/preview_executor.go
@@ -15,7 +15,6 @@ type GeneratedTimeSeries struct {
 
 type timeCounts map[time.Time]int
 type previewExecutor struct {
-	db        database.DB
 	repoStore database.RepoStore
 	filter    compression.DataFrameFilter
 	clock     func() time.Time

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -28,7 +28,6 @@ type StreamingQueryExecutor struct {
 func NewStreamingExecutor(postgres database.DB, clock func() time.Time) *StreamingQueryExecutor {
 	return &StreamingQueryExecutor{
 		previewExecutor: previewExecutor{
-			db:        postgres,
 			repoStore: postgres.Repos(),
 			filter:    &compression.NoopFilter{},
 			clock:     clock,


### PR DESCRIPTION
after changes in https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/eabdecd94105af576df2d74bf5bc15e9e26d4cd0

we only use `repoStore` in the executors and don't need to store a reference to the db

## Test plan

Builds, db is unused