### PR TITLE
Change code host connection checks to talk HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Code Insights has a new UI for the "Add or remove insights" view, which now allows you to search code insights by series label in addition to insight title. [#46538](https://github.com/sourcegraph/sourcegraph/pull/46538)
 - When SMTP is configured, users created by site admins via the "Create user" page will no longer have their email verified by default - users must verify their emails by using the "Set password" link they get sent, or have their emails verified by a site admin via the "Emails" tab in user settings or the `setUserEmailVerified` mutation. The `createUser` mutation retains the old behaviour of automatically marking emails as verified. To learn more, refer to the [SMTP and email delivery](https://docs.sourcegraph.com/admin/config/email) documentation. [#46187](https://github.com/sourcegraph/sourcegraph/pull/46187)
+- Connection checks for code host connections have been changed to talk to code host APIs directly via HTTP instead of doing DNS lookup and TCP dial. That makes them more resistant in environments where proxies are used.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Code Insights has a new UI for the "Add or remove insights" view, which now allows you to search code insights by series label in addition to insight title. [#46538](https://github.com/sourcegraph/sourcegraph/pull/46538)
 - When SMTP is configured, users created by site admins via the "Create user" page will no longer have their email verified by default - users must verify their emails by using the "Set password" link they get sent, or have their emails verified by a site admin via the "Emails" tab in user settings or the `setUserEmailVerified` mutation. The `createUser` mutation retains the old behaviour of automatically marking emails as verified. To learn more, refer to the [SMTP and email delivery](https://docs.sourcegraph.com/admin/config/email) documentation. [#46187](https://github.com/sourcegraph/sourcegraph/pull/46187)
-- Connection checks for code host connections have been changed to talk to code host APIs directly via HTTP instead of doing DNS lookup and TCP dial. That makes them more resistant in environments where proxies are used.
+- Connection checks for code host connections have been changed to talk to code host APIs directly via HTTP instead of doing DNS lookup and TCP dial. That makes them more resistant in environments where proxies are used. [#46918](https://github.com/sourcegraph/sourcegraph/pull/46918)
 
 ### Fixed
 

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -81,7 +81,11 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 }
 
 func (s BitbucketCloudSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	_, err := s.client.CurrentUser(ctx)
+	if err != nil {
+		return errors.Wrap(err, "connection check failed. could not fetch authenticated user")
+	}
+	return nil
 }
 
 // ListRepos returns all Bitbucket Cloud repositories accessible to all connections configured

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -90,7 +90,11 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 }
 
 func (s BitbucketServerSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	_, err := s.AuthenticatedUsername(ctx)
+	if err != nil {
+		return errors.Wrap(err, "connection check failed. could not fetch authenticated user")
+	}
+	return nil
 }
 
 // ListRepos returns all BitbucketServer repositories accessible to all connections configured

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -262,7 +262,11 @@ func (s *GitHubSource) Version(ctx context.Context) (string, error) {
 }
 
 func (s *GitHubSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	_, err := s.v3Client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		return errors.Wrap(err, "connection check failed. could not fetch authenticated user")
+	}
+	return nil
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -162,7 +162,11 @@ func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {
 }
 
 func (s GitLabSource) CheckConnection(ctx context.Context) error {
-	return checkConnection(s.config.Url)
+	_, err := s.client.GetUser(ctx, "")
+	if err != nil {
+		return errors.Wrap(err, "connection check failed. could not fetch authenticated user")
+	}
+	return nil
 }
 
 // ListRepos returns all GitLab repositories accessible to all connections configured

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -544,7 +544,7 @@ func (s *Syncer) SyncExternalService(
 	}
 
 	if err := src.CheckConnection(ctx); err != nil {
-		return err
+		logger.Warn("connection check failed. syncing repositories might still succeed.", log.Error(err))
 	}
 
 	results := make(chan SourceResult)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -594,16 +594,6 @@ func TestSyncerSync(t *testing.T) {
 				svcs: []*types.ExternalService{tc.svc},
 				err:  "<nil>",
 			},
-			testCase{
-				name: string(tc.repo.Name) + "/code host unavailable",
-				sourcer: repos.NewFakeSourcer(nil,
-					repos.NewFakeSource(nil, nil, nil).Unavailable(),
-				),
-				store: store,
-				now:   clock.Now,
-				svcs:  []*types.ExternalService{tc.svc},
-				err:   "fake source unavailable",
-			},
 		)
 	}
 


### PR DESCRIPTION
Full context: https://github.com/sourcegraph/sourcegraph/issues/46915

This changes the connection checks to test what we're after: can we talk to the code hosts' API via HTTP?

Because as it turns out, in some customer environments we can't do a TCP dial, because proxies block it. In that case an HTTP call makes even more sense, because if that succeeds we know we can talk to the API.

The other change in here is to not hard-fail the repository syncing if the connection check fails. Until we're confident that the checks work exactly as we want them to, we only print a warning.

cc @varsanojidan we need to do something similar for ADO but we didn't do that in this PR because we don't have an account yet and aren't confident in our abilities to properly test this (which we should for a patch release). And since ADO is not out in the wild yet.

## Test plan

- Manual testing for Gitlab.com, gitlab.sgdev.org, GitHub.com, github.sgdev.org, bitbucket.org, bitbucket.sgdev.org
- Existing unit tests for the client functions
