### PR TITLE
fix executor logging pointer instead of dereferenced value

### DIFF
--- a/enterprise/cmd/executor/internal/command/logger.go
+++ b/enterprise/cmd/executor/internal/command/logger.go
@@ -221,10 +221,10 @@ func (l *logger) syncLogEntry(handle *entryHandle, entryID int, old workerutil.E
 			"outLen", len(current.Out),
 		)
 		if current.ExitCode != nil {
-			logArgs = append(logArgs, "exitCode", current.ExitCode)
+			logArgs = append(logArgs, "exitCode", *current.ExitCode)
 		}
 		if current.DurationMs != nil {
-			logArgs = append(logArgs, "durationMs", current.DurationMs)
+			logArgs = append(logArgs, "durationMs", *current.DurationMs)
 		}
 
 		log15.Debug("Updating executor log entry", logArgs...)


### PR DESCRIPTION
While using executors recently I noticed the logged values were pointers. This fixes that to print the correct values
## Test plan
- Manual testing

**Before:**
```
t=2023-01-25T12:19:13+0000 lvl=dbug msg="Updating executor log entry" jobID=3 repositoryName=github.com/jac/c8r commit=5af7ced20e3993fa99f46e67457bd458bc99fc0d entryID=8 key=step.docker.indexer outLen=1448 exitCode=0xc00036ab98 durationMs=0xc00036aba0
```
*exitCode=0xc00036ab98 durationMs=0xc00036aba0*
**After:**
```
t=2023-01-25T12:10:19+0000 lvl=dbug msg="Updating executor log entry" jobID=1 repositoryName=github.com/jac/c8r commit=5af7ced20e3993fa99f46e67457bd458bc99fc0d entryID=8 key=step.docker.indexer outLen=1448 exitCode=0 durationMs=167402
```
*exitCode=0 durationMs=167402*