### PR TITLE
search: Fix query input overflow behavior on search home page

### DIFF
--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -180,7 +180,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
                 <div data-search-page-input-container={true} className={styles.inputContainer}>
                     <TraceSpanProvider name="SearchBox">
-                        <div className="d-flex flex-grow-1">{input}</div>
+                        <div className="d-flex flex-grow-1 w-100">{input}</div>
                     </TraceSpanProvider>
                 </div>
                 <Notices className="my-3 text-center" location="home" settingsCascade={props.settingsCascade} />


### PR DESCRIPTION
As reported here https://sourcegraph.slack.com/archives/C020S8AT3LN/p1674511890273459, the search input is overflowing the container when the input is really long. This only happens on the search homepage, it works as expected on the search result page.

Before/after video: 

https://user-images.githubusercontent.com/179026/214568254-7ecd9371-b50f-49be-b6d1-a9d3667caec5.mp4




## Test plan

Manual testing, see video.

## App preview:

- [Web](https://sg-web-fkling-fix-search-home-input.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
