### PR TITLE
redispool: implement in memory KeyValue via minimal interface

### DIFF
--- a/internal/redispool/NOTICE
+++ b/internal/redispool/NOTICE
@@ -1,0 +1,177 @@
+Code in "redis_conn.go" extended from go package
+"github.com/gomodule/redigo/redis"
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/internal/redispool/mem.go
+++ b/internal/redispool/mem.go
@@ -1,0 +1,28 @@
+package redispool
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryKeyValue returns an in memory KeyValue.
+func MemoryKeyValue() KeyValue {
+	var mu sync.Mutex
+	m := map[string]string{}
+	store := func(_ context.Context, key string, f NaiveUpdater) error {
+		mu.Lock()
+		defer mu.Unlock()
+		currentValue, found := m[key]
+		newValue, remove := f(currentValue, found)
+		if remove {
+			if found {
+				delete(m, key)
+			}
+		} else if currentValue != newValue {
+			m[key] = newValue
+		}
+		return nil
+	}
+
+	return FromNaiveKeyValueStore(store)
+}

--- a/internal/redispool/mem.go
+++ b/internal/redispool/mem.go
@@ -8,18 +8,18 @@ import (
 // MemoryKeyValue returns an in memory KeyValue.
 func MemoryKeyValue() KeyValue {
 	var mu sync.Mutex
-	m := map[string]string{}
+	m := map[string]NaiveValue{}
 	store := func(_ context.Context, key string, f NaiveUpdater) error {
 		mu.Lock()
 		defer mu.Unlock()
-		currentValue, found := m[key]
-		newValue, remove := f(currentValue, found)
+		before, found := m[key]
+		after, remove := f(before, found)
 		if remove {
 			if found {
 				delete(m, key)
 			}
-		} else if currentValue != newValue {
-			m[key] = newValue
+		} else if before != after {
+			m[key] = after
 		}
 		return nil
 	}

--- a/internal/redispool/naive.go
+++ b/internal/redispool/naive.go
@@ -1,0 +1,449 @@
+package redispool
+
+import (
+	"context"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// NaiveUpdater operates on the value for a key in a NaiveKeyValueStore.
+// currentValue is the current value in the store, found is if the key exists
+// in the store. newValue is the new value for it that needs to be stored, or
+// remove is true if the key should be removed.
+//
+// Note: strings are used to ensure we pass copies around and avoid mutating
+// values. They should not be treated as utf8 text.
+//
+// Note: a store should do this update atomically/under concurrency control.
+type NaiveUpdater func(currentValue string, found bool) (newValue string, remove bool)
+
+// NaiveKeyValueStore is a function on a store which runs f for key.
+//
+// This minimal function allows us to implement the full functionality of
+// KeyValue via FromNaiveKeyValueStore. This does mean for any read on key we
+// have to read the full value, and any mutation requires rewriting the full
+// value. This is usually fine, but may be an issue when backed by a large
+// Hash or List. As such this function is designed with the functionality of
+// Sourcegraph App in mind (single process, low traffic).
+type NaiveKeyValueStore func(ctx context.Context, key string, f NaiveUpdater) error
+
+// FromNaiveKeyValueStore returns a KeyValue based on the store function.
+func FromNaiveKeyValueStore(store NaiveKeyValueStore) KeyValue {
+	return &naiveKeyValue{
+		store: store,
+		ctx:   context.Background(),
+	}
+}
+
+// naiveKeyValue wraps a store to provide the KeyValue interface. Nearly all
+// operations go via maybeUpdateGroup method, sink your teeth into that first
+// to fully understand how to expand the set of methods provided.
+type naiveKeyValue struct {
+	store NaiveKeyValueStore
+	ctx   context.Context
+}
+
+func (kv *naiveKeyValue) Get(key string) Value {
+	return kv.maybeUpdateGroup(redisGroupString, key, func(v redisValue, found bool) (redisValue, updaterOp, error) {
+		return v, readOnly, nil
+	})
+}
+
+func (kv *naiveKeyValue) GetSet(key string, value any) Value {
+	var oldValue Value
+	v := kv.maybeUpdateGroup(redisGroupString, key, func(currentValue redisValue, found bool) (redisValue, updaterOp, error) {
+		if found {
+			oldValue.reply = currentValue.Reply
+		} else {
+			oldValue.err = redis.ErrNil
+		}
+
+		return redisValue{
+			Group: redisGroupString,
+			Reply: value,
+		}, write, nil
+	})
+	if v.err != nil {
+		return v
+	}
+	return oldValue
+}
+
+func (kv *naiveKeyValue) Set(key string, value any) error {
+	return kv.maybeUpdate(key, func(_ redisValue, _ bool) (redisValue, updaterOp, error) {
+		return redisValue{
+			Group: redisGroupString,
+			Reply: value,
+		}, write, nil
+	}).err
+}
+
+func (kv *naiveKeyValue) SetEx(key string, ttlSeconds int, value any) error {
+	return kv.maybeUpdate(key, func(_ redisValue, _ bool) (redisValue, updaterOp, error) {
+		return redisValue{
+			Group:        redisGroupString,
+			Reply:        value,
+			DeadlineUnix: time.Now().UTC().Unix() + int64(ttlSeconds),
+		}, write, nil
+	}).err
+}
+
+func (kv *naiveKeyValue) Incr(key string) error {
+	return kv.maybeUpdateGroup(redisGroupString, key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		if !found {
+			return redisValue{
+				Group: redisGroupString,
+				Reply: 1,
+			}, write, nil
+		}
+
+		num, err := redis.Int(value.Reply, nil)
+		if err != nil {
+			return value, readOnly, err
+		}
+
+		value.Reply = num + 1
+		return value, write, nil
+	}).err
+}
+
+func (kv *naiveKeyValue) Del(key string) error {
+	return kv.store(kv.ctx, key, func(_ string, _ bool) (string, bool) {
+		return "", true
+	})
+}
+
+func (kv *naiveKeyValue) TTL(key string) (int, error) {
+	const ttlUnset = -1
+	const ttlDoesNotExist = -2
+	var ttl int
+	err := kv.maybeUpdate(key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		if !found {
+			ttl = ttlDoesNotExist
+		} else if value.DeadlineUnix == 0 {
+			ttl = ttlUnset
+		} else {
+			ttl = int(value.DeadlineUnix - time.Now().UTC().Unix())
+			// we may have expired since doStore checked
+			if ttl <= 0 {
+				ttl = ttlDoesNotExist
+			}
+		}
+
+		return value, readOnly, nil
+	}).err
+
+	if err == redis.ErrNil {
+		// Already handled above, but just in case lets be explicit
+		ttl = ttlDoesNotExist
+		err = nil
+	}
+
+	return ttl, err
+}
+
+func (kv *naiveKeyValue) Expire(key string, ttlSeconds int) error {
+	err := kv.maybeUpdate(key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		if !found {
+			return value, readOnly, nil
+		}
+
+		value.DeadlineUnix = time.Now().UTC().Unix() + int64(ttlSeconds)
+		return value, write, nil
+	}).err
+
+	// expire does not error if the key does not exist
+	if err == redis.ErrNil {
+		err = nil
+	}
+
+	return err
+}
+
+func (kv *naiveKeyValue) HGet(key, field string) Value {
+	var reply any
+	err := kv.maybeUpdateValues(redisGroupHash, key, func(li []any) ([]any, updaterOp, error) {
+		idx, ok, err := hsetValueIndex(li, field)
+		if err != nil {
+			return li, readOnly, err
+		}
+		if !ok {
+			return li, readOnly, redis.ErrNil
+		}
+
+		reply = li[idx]
+		return li, readOnly, nil
+	}).err
+	return Value{reply: reply, err: err}
+}
+
+func (kv *naiveKeyValue) HGetAll(key string) Values {
+	return Values(kv.maybeUpdateGroup(redisGroupHash, key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		return value, readOnly, nil
+	}))
+}
+
+func (kv *naiveKeyValue) HSet(key, field string, fieldValue any) error {
+	return kv.maybeUpdateValues(redisGroupHash, key, func(li []any) ([]any, updaterOp, error) {
+		idx, ok, err := hsetValueIndex(li, field)
+		if err != nil {
+			return li, readOnly, err
+		}
+		if ok {
+			li[idx] = fieldValue
+		} else {
+			li = append(li, field, fieldValue)
+		}
+
+		return li, write, nil
+	}).err
+}
+
+func hsetValueIndex(li []any, field string) (int, bool, error) {
+	for i := 1; i < len(li); i += 2 {
+		if kk, err := redis.String(li[i-1], nil); err != nil {
+			return -1, false, err
+		} else if kk == field {
+			return i, true, nil
+		}
+	}
+	return -1, false, nil
+}
+
+func (kv *naiveKeyValue) LPush(key string, value any) error {
+	return kv.maybeUpdateValues(redisGroupList, key, func(li []any) ([]any, updaterOp, error) {
+		return append([]any{value}, li...), write, nil
+	}).err
+}
+
+func (kv *naiveKeyValue) LTrim(key string, start, stop int) error {
+	return kv.maybeUpdateValues(redisGroupList, key, func(li []any) ([]any, updaterOp, error) {
+		beforeLen := len(li)
+		li = lrange(li, start, stop)
+
+		op := readOnly
+		if len(li) != beforeLen {
+			op = write
+		}
+
+		return li, op, nil
+	}).err
+}
+
+func (kv *naiveKeyValue) LLen(key string) (int, error) {
+	var innerLi []any
+	err := kv.maybeUpdateValues(redisGroupList, key, func(li []any) ([]any, updaterOp, error) {
+		innerLi = li
+		return li, readOnly, nil
+	}).err
+	return len(innerLi), err
+}
+
+func (kv *naiveKeyValue) LRange(key string, start, stop int) Values {
+	var innerLi []any
+	err := kv.maybeUpdateValues(redisGroupList, key, func(li []any) ([]any, updaterOp, error) {
+		innerLi = li
+		return li, readOnly, nil
+	}).err
+	if err != nil {
+		return Values{err: err}
+	}
+	return Values{reply: lrange(innerLi, start, stop)}
+}
+
+func lrange(li []any, start, stop int) []any {
+	low, high := rangeOffsetsToHighLow(start, stop, len(li))
+	if high <= low {
+		return []any(nil)
+	}
+	return li[low:high]
+}
+
+func rangeOffsetsToHighLow(start, stop, size int) (low, high int) {
+	if size <= 0 {
+		return 0, 0
+	}
+
+	start = clampRangeOffset(0, size, start)
+	stop = clampRangeOffset(-1, size, stop)
+
+	// Adjust inclusive ending into exclusive for go
+	low = start
+	high = stop + 1
+
+	return low, high
+}
+
+func clampRangeOffset(low, high, offset int) int {
+	// negative offset means distance from high
+	if offset < 0 {
+		offset = high + offset
+	}
+	if offset < low {
+		return low
+	}
+	if offset >= high {
+		return high - 1
+	}
+	return offset
+}
+
+func (kv *naiveKeyValue) WithContext(ctx context.Context) KeyValue {
+	return &naiveKeyValue{
+		store: kv.store,
+		ctx:   ctx,
+	}
+}
+
+func (kv *naiveKeyValue) Pool() (pool *redis.Pool, ok bool) {
+	return nil, false
+}
+
+type updaterOp bool
+
+var (
+	write    updaterOp = true
+	readOnly updaterOp = false
+)
+
+// storeUpdater operates on the redisValue for a key and returns its new value
+// or error. See doStore for more information.
+type storeUpdater func(currentValue redisValue, found bool) (newValue redisValue, op updaterOp, err error)
+
+// maybeUpdate is a helper for NaiveKeyValueStore and NaiveUpdater. It
+// provides consistent behaviour for KeyValue as well as reducing the work
+// required for each KeyValue method. It does the following:
+//
+//   - Marshal NaiveUpdater values to and from redisValue
+//   - Handle expiration so updater does not need to.
+//   - If a value becomes nil we can delete the key. (redis behaviour)
+//   - Handle updaters that only want to read (readOnly updaterOp, error)
+func (kv *naiveKeyValue) maybeUpdate(key string, updater storeUpdater) Value {
+	var returnValue Value
+	storeErr := kv.store(kv.ctx, key, func(currentRaw string, found bool) (string, bool) {
+		var currentValue redisValue
+		defaultDelete := false
+		if found {
+			// We found the value so we can unmarshal it.
+			if err := currentValue.Unmarshal([]byte(currentRaw)); err != nil {
+				// Bad data at key, delete it and return an error
+				returnValue.err = err
+				return "", true
+			}
+
+			// The store won't expire for us, we do it here by checking at
+			// read time if the value has expired. If it has pretend we didn't
+			// find it and mark that we need to delete the value if we don't
+			// get a new one.
+			if currentValue.DeadlineUnix != 0 && time.Now().UTC().Unix() >= currentValue.DeadlineUnix {
+				found = false
+				// We need to inform the store to delete the value, unless we
+				// have a new value to takes its place.
+				defaultDelete = true
+			}
+		}
+
+		// Call out to the provided updater to get back what we need to do to
+		// the value.
+		newValue, op, err := updater(currentValue, found)
+		if err != nil {
+			// If updater fails, we tell store to keep the current value (or
+			// delete if expired).
+			returnValue.err = err
+			return currentRaw, defaultDelete
+		}
+
+		// We don't need to update the value, so set the appropriate response
+		// values based on what we found at get time.
+		if op == readOnly {
+			if found {
+				returnValue.reply = currentValue.Reply
+			} else {
+				returnValue.err = redis.ErrNil
+			}
+			return currentRaw, defaultDelete
+		}
+
+		// Redis will automatically delete keys if some value types become
+		// empty.
+		if isRedisDeleteValue(newValue) {
+			returnValue.reply = newValue.Reply
+			return "", true
+		}
+
+		// Lets convert our redisValue into bytes so we can store the new
+		// value.
+		newRaw, err := newValue.Marshal()
+		if err != nil {
+			returnValue.err = err
+			return currentRaw, defaultDelete
+		}
+		returnValue.reply = newValue.Reply
+		return string(newRaw), false
+	})
+	if storeErr != nil {
+		return Value{err: storeErr}
+	}
+	return returnValue
+}
+
+// maybeUpdateGroup is a wrapper of maybeUpdate which additionally will return
+// an error if the currentValue is not of the type group.
+func (kv *naiveKeyValue) maybeUpdateGroup(group redisGroup, key string, updater storeUpdater) Value {
+	return kv.maybeUpdate(key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		if found && value.Group != group {
+			return value, readOnly, redis.Error("WRONGTYPE Operation against a key holding the wrong kind of value")
+		}
+		return updater(value, found)
+	})
+}
+
+// valuesUpdater takes in the currentValues. If newValues is different op must
+// be write so maybeUpdateValues knows to update.
+type valuesUpdater func(currentValues []any) (newValues []any, op updaterOp, err error)
+
+// maybeUpdateValues is a specialization of maybeUpdate for all values operations
+// on key via updater.
+func (kv *naiveKeyValue) maybeUpdateValues(group redisGroup, key string, updater valuesUpdater) Values {
+	v := kv.maybeUpdateGroup(group, key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
+		var li []any
+		if found {
+			var err error
+			li, err = value.Values()
+			if err != nil {
+				return value, readOnly, err
+			}
+		} else {
+			value = redisValue{
+				Group: group,
+			}
+		}
+
+		li, op, err := updater(li)
+		value.Reply = li
+		return value, op, err
+	})
+
+	// missing is treated as empty for values
+	if v.err == redis.ErrNil {
+		return Values{reply: []any(nil)}
+	}
+
+	return Values(v)
+}
+
+// isRedisDeleteValue returns true if the redisValue is not allowed to be
+// stored. An example of this is when a list becomes empty redis will delete
+// the key.
+func isRedisDeleteValue(v redisValue) bool {
+	switch v.Group {
+	case redisGroupString:
+		return false
+	case redisGroupHash, redisGroupList:
+		vs, _ := v.Reply.([]any)
+		return len(vs) == 0
+	default:
+		return false
+	}
+}

--- a/internal/redispool/naive_test.go
+++ b/internal/redispool/naive_test.go
@@ -1,0 +1,11 @@
+package redispool_test
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
+)
+
+func TestInMemoryKeyValue(t *testing.T) {
+	testKeyValue(t, redispool.MemoryKeyValue())
+}

--- a/internal/redispool/redis.go
+++ b/internal/redispool/redis.go
@@ -9,7 +9,7 @@ import (
 
 // redisGroup is which type of data we have. We use the term group since that
 // is what redis uses in its documentation to segregate the different types of
-// commands you can run ("string", list, hash).
+// commands you can run (string, list, hash).
 type redisGroup byte
 
 const (

--- a/internal/redispool/redis.go
+++ b/internal/redispool/redis.go
@@ -1,0 +1,129 @@
+package redispool
+
+import (
+	"bytes"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// redisGroup is which type of data we have. We use the term group since that
+// is what redis uses in its documentation to segregate the different types of
+// commands you can run ("string", list, hash).
+type redisGroup byte
+
+const (
+	// redisGroupString doesn't mean the data is a string. This is the
+	// original group of command (get, set).
+	redisGroupString redisGroup = 's'
+	redisGroupList   redisGroup = 'l'
+	redisGroupHash   redisGroup = 'h'
+)
+
+// redisValue represents what we marshal into a NaiveKeyValueStore.
+type redisValue struct {
+	// Group is stored so we can enforce WRONGTYPE errors.
+	Group redisGroup
+	// Reply is the actual value the user wants to set. It is called reply to
+	// match what the redis package expects.
+	Reply any
+	// DeadlineUnix is the unix timestamp of when to expire this value, or 0
+	// if no expiry. This is a convenient way to store deadlines since redis
+	// only has 1s resolution on TTLs.
+	DeadlineUnix int64
+}
+
+func (v *redisValue) Marshal() ([]byte, error) {
+	var c conn
+
+	// Header, Group, DeadlineUnix
+	//
+	// Note: this writes a small version header which is just the character !
+	// and g. This is enough so we can change the data in the future.
+	//
+	// We are also gaurenteed to not fail these writes, so we ignore the error
+	// for convenience.
+	_ = c.bw.WriteByte('!')
+	_ = c.bw.WriteByte(byte(v.Group))
+	_ = c.writeArg(v.DeadlineUnix)
+
+	// Reply
+	switch v.Group {
+	case redisGroupString:
+		err := c.writeArg(v.Reply)
+		if err != nil {
+			return nil, err
+		}
+	case redisGroupList, redisGroupHash:
+		vs, err := v.Values()
+		if err != nil {
+			return nil, err
+		}
+		_ = c.writeLen('*', len(vs))
+		for _, el := range vs {
+			err := c.writeArg(el)
+			if err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, errors.Errorf("redis naive internal error: unkown redis group %c", byte(v.Group))
+	}
+
+	return c.bw.Bytes(), nil
+}
+
+func (v *redisValue) Unmarshal(b []byte) error {
+	c := conn{bw: *bytes.NewBuffer(b)}
+
+	// Header, Group
+	var header [2]byte
+	n, err := c.bw.Read(header[:])
+	if err != nil || n != 2 {
+		return errors.New("redis naive internal error: failed to parse value header")
+	}
+	if header[0] != '!' {
+		return errors.Errorf("redis naive internal error: expected first byte of value header to be '!' got %q", header[0])
+	}
+	v.Group = redisGroup(header[1])
+
+	// DeadlineUnix
+	v.DeadlineUnix, err = redis.Int64(c.readReply())
+	if err != nil {
+		return errors.Wrap(err, "redis naive internal error: failed to parse value deadline")
+	}
+
+	// Reply
+	v.Reply, err = c.readReply()
+	if err != nil {
+		return err
+	}
+
+	// Validation
+	switch v.Group {
+	case redisGroupString:
+		// noop
+	case redisGroupList, redisGroupHash:
+		_, err := v.Values()
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("redis naive internal error: unkown redis group %c", byte(v.Group))
+	}
+
+	return nil
+}
+
+// Values will convert v.Reply into values as well as some validation based on
+// the v.Group.
+func (v *redisValue) Values() ([]any, error) {
+	li, ok := v.Reply.([]any)
+	if !ok {
+		return nil, errors.Errorf("redis naive internal error: non list returned for redis group %c", byte(v.Group))
+	}
+	if v.Group == redisGroupHash && len(li)%2 != 0 {
+		return nil, errors.New("redis naive internal error: hash list is not divisible by 2")
+	}
+	return li, nil
+}

--- a/internal/redispool/redis_conn.go
+++ b/internal/redispool/redis_conn.go
@@ -1,0 +1,217 @@
+package redispool
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// NOTICE: The code below is adapted from "github.com/gomodule/redigo/redis"
+// so that we use the same marshalling that redigo expects for replies. See
+// file NOTICE for more information.
+
+type conn struct {
+	bw bytes.Buffer
+
+	// Scratch space for formatting argument length.
+	// '*' or '$', length, "\r\n"
+	lenScratch [32]byte
+
+	// Scratch space for formatting integers and floats.
+	numScratch [40]byte
+}
+
+func (c *conn) writeArg(arg interface{}) (err error) {
+	switch arg := arg.(type) {
+	case string:
+		return c.writeString(arg)
+	case []byte:
+		return c.writeBytes(arg)
+	case int:
+		return c.writeInt64(int64(arg))
+	case int64:
+		return c.writeInt64(arg)
+	case float64:
+		return c.writeFloat64(arg)
+	case bool:
+		if arg {
+			return c.writeString("1")
+		} else {
+			return c.writeString("0")
+		}
+	case nil:
+		return c.writeString("")
+	default:
+		// This default clause is intended to handle builtin numeric types.
+		// The function should return an error for other types, but this is not
+		// done for compatibility with previous versions of the package.
+		var buf bytes.Buffer
+		fmt.Fprint(&buf, arg)
+		return c.writeBytes(buf.Bytes())
+	}
+}
+
+func (c *conn) writeLen(prefix byte, n int) error {
+	c.lenScratch[len(c.lenScratch)-1] = '\n'
+	c.lenScratch[len(c.lenScratch)-2] = '\r'
+	i := len(c.lenScratch) - 3
+	for {
+		c.lenScratch[i] = byte('0' + n%10)
+		i -= 1
+		n = n / 10
+		if n == 0 {
+			break
+		}
+	}
+	c.lenScratch[i] = prefix
+	_, err := c.bw.Write(c.lenScratch[i:])
+	return err
+}
+
+func (c *conn) writeString(s string) error {
+	c.writeLen('$', len(s))
+	c.bw.WriteString(s)
+	_, err := c.bw.WriteString("\r\n")
+	return err
+}
+
+func (c *conn) writeBytes(p []byte) error {
+	c.writeLen('$', len(p))
+	c.bw.Write(p)
+	_, err := c.bw.WriteString("\r\n")
+	return err
+}
+
+func (c *conn) writeInt64(n int64) error {
+	return c.writeBytes(strconv.AppendInt(c.numScratch[:0], n, 10))
+}
+
+func (c *conn) writeFloat64(n float64) error {
+	return c.writeBytes(strconv.AppendFloat(c.numScratch[:0], n, 'g', -1, 64))
+}
+
+func (c *conn) readLine() ([]byte, error) {
+	p, err := c.bw.ReadBytes('\n')
+	if err == bufio.ErrBufferFull {
+		return nil, protocolError("long response line")
+	}
+	if err != nil {
+		return nil, err
+	}
+	i := len(p) - 2
+	if i < 0 || p[i] != '\r' {
+		return nil, protocolError("bad response line terminator")
+	}
+	return p[:i], nil
+}
+
+func (c *conn) readReply() (interface{}, error) {
+	line, err := c.readLine()
+	if err != nil {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, protocolError("short response line")
+	}
+	switch line[0] {
+	case '+':
+		return string(line[1:]), nil
+	case '-':
+		return redis.Error(string(line[1:])), nil
+	case ':':
+		return parseInt(line[1:])
+	case '$':
+		n, err := parseLen(line[1:])
+		if n < 0 || err != nil {
+			return nil, err
+		}
+		p := make([]byte, n)
+		_, err = io.ReadFull(&c.bw, p)
+		if err != nil {
+			return nil, err
+		}
+		if line, err := c.readLine(); err != nil {
+			return nil, err
+		} else if len(line) != 0 {
+			return nil, protocolError("bad bulk string format")
+		}
+		return p, nil
+	case '*':
+		n, err := parseLen(line[1:])
+		if n < 0 || err != nil {
+			return nil, err
+		}
+		r := make([]interface{}, n)
+		for i := range r {
+			r[i], err = c.readReply()
+			if err != nil {
+				return nil, err
+			}
+		}
+		return r, nil
+	}
+	return nil, protocolError("unexpected response line")
+}
+
+// parseLen parses bulk string and array lengths.
+func parseLen(p []byte) (int, error) {
+	if len(p) == 0 {
+		return -1, protocolError("malformed length")
+	}
+
+	if p[0] == '-' && len(p) == 2 && p[1] == '1' {
+		// handle $-1 and $-1 null replies.
+		return -1, nil
+	}
+
+	var n int
+	for _, b := range p {
+		n *= 10
+		if b < '0' || b > '9' {
+			return -1, protocolError("illegal bytes in length")
+		}
+		n += int(b - '0')
+	}
+
+	return n, nil
+}
+
+// parseInt parses an integer reply.
+func parseInt(p []byte) (interface{}, error) {
+	if len(p) == 0 {
+		return 0, protocolError("malformed integer")
+	}
+
+	var negate bool
+	if p[0] == '-' {
+		negate = true
+		p = p[1:]
+		if len(p) == 0 {
+			return 0, protocolError("malformed integer")
+		}
+	}
+
+	var n int64
+	for _, b := range p {
+		n *= 10
+		if b < '0' || b > '9' {
+			return 0, protocolError("illegal bytes in length")
+		}
+		n += int64(b - '0')
+	}
+
+	if negate {
+		n = -n
+	}
+	return n, nil
+}
+
+type protocolError string
+
+func (pe protocolError) Error() string {
+	return fmt.Sprintf("redigo: %s (possible server error or unsupported concurrent read by application)", string(pe))
+}


### PR DESCRIPTION
This implementation is targetted at making it very simple to implement a redis like store by only implementing a key value store which stores a byte slice for a key.

Right now it is unused, but has extensive test coverage as well. It will be used in the Sourcegraph App in the next commit.

Test Plan: go test

Part of #46328 
