### PR TITLE
user: make resetting an avatar possible.

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -249,7 +249,7 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 		}
 	}
 
-	if args.AvatarURL != nil {
+	if args.AvatarURL != nil && len(*args.AvatarURL) > 0 {
 		if len(*args.AvatarURL) > 3000 {
 			return nil, errors.New("avatar URL exceeded 3000 characters")
 		}

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -503,6 +503,44 @@ func TestUpdateUser(t *testing.T) {
 		}
 	})
 
+	t.Run("success with an empty avatarURL", func(t *testing.T) {
+		users := database.NewMockUserStore()
+		users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+			return &types.User{
+				ID:       id,
+				Username: strconv.Itoa(int(id)),
+			}, nil
+		})
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+		users.UpdateFunc.SetDefaultReturn(nil)
+		db.UsersFunc.SetDefaultReturn(users)
+
+		RunTests(t, []*Test{
+			{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+			mutation {
+				updateUser(
+					user: "VXNlcjox",
+					username: "alice.bob-chris-",
+					avatarURL: ""
+				) {
+					username
+				}
+			}
+		`,
+				ExpectedResult: `
+			{
+				"updateUser": {
+					"username": "1"
+				}
+			}
+		`,
+			},
+		})
+
+	})
+
 	t.Run("success", func(t *testing.T) {
 		users := database.NewMockUserStore()
 		users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {


### PR DESCRIPTION
Previously submitting an empty avatar URL resulted in an error, and it was basically impossible to remove an avatar.

Test plan:
Added a GraphQL test to verify it.

Randomly found during a call with @kopancek and @thenamankumar.

### Before
https://user-images.githubusercontent.com/94846361/214612635-aca9739a-26c5-4b36-8731-6a235b000822.mp4

### After
https://user-images.githubusercontent.com/94846361/214612587-04001d83-7bfa-4e72-927f-bc2f86352d79.mp4