### PR TITLE
Code Insights: Fixes repositories query preview link

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
@@ -229,7 +229,7 @@ function SmartSearchQueryRepoField(props: SmartSearchQueryRepoFieldProps): React
     }
 
     const queryState = disabled ? EMPTY_QUERY_STATA : value
-    const previewQuery = value.query ? `${value.query} archived:yes fork:yes count:all` : value.query
+    const previewQuery = value.query ? `(${value.query}) archived:yes fork:yes count:all` : value.query
     const fieldStatus = getDefaultInputStatus(repoQuery, value => value.query)
     const LabelComponent = label ? Label : 'div'
 

--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
@@ -133,7 +133,7 @@ function RepositoriesURLsPicker(props: RepositoriesURLsPickerProps): ReactElemen
     return (
         <Input
             as={RepositoriesField}
-            message="Use a full repo URL (github.com/...). Separate repositories with commas"
+            message="Use a list of repository names separated with commas"
             placeholder="Example: github.com/sourcegraph/sourcegraph"
             aria-labelledby={ariaLabelledby}
             value={fieldValue}
@@ -229,6 +229,7 @@ function SmartSearchQueryRepoField(props: SmartSearchQueryRepoFieldProps): React
     }
 
     const queryState = disabled ? EMPTY_QUERY_STATA : value
+    const previewQuery = value.query ? `${value.query} archived:yes fork:yes count:all` : value.query
     const fieldStatus = getDefaultInputStatus(repoQuery, value => value.query)
     const LabelComponent = label ? Label : 'div'
 
@@ -256,7 +257,7 @@ function SmartSearchQueryRepoField(props: SmartSearchQueryRepoFieldProps): React
                 />
 
                 <MonacoPreviewLink
-                    query={value.query}
+                    query={previewQuery}
                     patternType={SearchPatternType.standard}
                     className={styles.repoLabelPreviewLink}
                     tabIndex={disabled ? -1 : 0}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/46920

By default on the backend we use repositories query with archived:true forked:true and count:all, we disallow these three filters in user input. In this PR I added these three in the client link generation logic. We could use query field from the API but since this is async API and we don't want to disabled preview link every time we fetch repositories count and did this on the client. 

Also this PR fixes small copy problem for the repositories list field.

## Test plan
- Make sure that preview link uses all three filters that insight backend uses for gathering repositories by repo query

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-paper-cut-insight-repo-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
