### PR TITLE
Ranking: remove ENABLE_EXPERIMENTAL_RANKING env variable

### DIFF
--- a/enterprise/internal/codeintel/ranking/init.go
+++ b/enterprise/internal/codeintel/ranking/init.go
@@ -2,7 +2,6 @@ package ranking
 
 import (
 	"context"
-	"os"
 
 	"cloud.google.com/go/storage"
 	"github.com/sourcegraph/log"
@@ -31,7 +30,7 @@ func NewService(
 	}
 
 	resultsBucket := func() *storage.BucketHandle {
-		if resultsBucketCredentialsFile == "" && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
+		if resultsBucketCredentialsFile == "" {
 			return nil
 		}
 

--- a/enterprise/internal/codeintel/ranking/internal/background/loader.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/loader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/csv"
 	"io"
-	"os"
 	"strconv"
 	"time"
 
@@ -63,11 +62,7 @@ const (
 )
 
 func (l *rankLoader) loadRanks(ctx context.Context, config RankLoaderConfig) (err error) {
-	if !envvar.SourcegraphDotComMode() && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
-		return nil
-	}
-	if l.resultsBucket == nil {
-		l.logger.Warn("No result bucket is configured")
+	if !envvar.SourcegraphDotComMode() || l.resultsBucket == nil {
 		return nil
 	}
 

--- a/enterprise/internal/codeintel/ranking/internal/background/loader.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/loader.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/log"
 	"google.golang.org/api/iterator"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/ranking/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -62,7 +61,7 @@ const (
 )
 
 func (l *rankLoader) loadRanks(ctx context.Context, config RankLoaderConfig) (err error) {
-	if !envvar.SourcegraphDotComMode() || l.resultsBucket == nil {
+	if l.resultsBucket == nil {
 		return nil
 	}
 

--- a/enterprise/internal/codeintel/ranking/internal/background/merger.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/merger.go
@@ -10,7 +10,6 @@ import (
 
 	"cloud.google.com/go/storage"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/ranking/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -54,7 +53,7 @@ func NewRankMerger(
 }
 
 func (m *rankMerger) mergeRanks(ctx context.Context, config RankMergerConfig) (err error) {
-	if !envvar.SourcegraphDotComMode() || m.resultsBucket == nil {
+	if m.resultsBucket == nil {
 		return nil
 	}
 

--- a/enterprise/internal/codeintel/ranking/internal/background/merger.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/merger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -55,7 +54,7 @@ func NewRankMerger(
 }
 
 func (m *rankMerger) mergeRanks(ctx context.Context, config RankMergerConfig) (err error) {
-	if !envvar.SourcegraphDotComMode() && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
+	if !envvar.SourcegraphDotComMode() || m.resultsBucket == nil {
 		return nil
 	}
 

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -2,7 +2,6 @@ package uploads
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -42,7 +41,7 @@ func NewService(
 	locker := locker.NewWith(db, "codeintel")
 
 	rankingBucket := func() *storage.BucketHandle {
-		if rankingBucketCredentialsFile == "" && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
+		if rankingBucketCredentialsFile == "" {
 			return nil
 		}
 


### PR DESCRIPTION
This helps consolidate all the ranking-related config to just a couple feature
flags. These checks are already gated by other config like the results bucket
credentials file.

## Test plan

Existing automated tests, light manual test with `sg start dotcom`
