### PR TITLE
[Permissions] add foreign keys for subjects to sync jobs table

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/stretchr/testify/require"
 )
@@ -39,11 +40,24 @@ func TestPermsSyncerWorkerCleaner(t *testing.T) {
 	user, err := db.Users().Create(ctx, database.NewUser{Username: "horse"})
 	require.NoError(t, err)
 
+	// create repos
+	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
+	err = db.Repos().Create(ctx, &repo1)
+	require.NoError(t, err)
+
+	repo2 := types.Repo{Name: "test-repo-2", ID: 102}
+	err = db.Repos().Create(ctx, &repo2)
+	require.NoError(t, err)
+
+	repo3 := types.Repo{Name: "test-repo-3", ID: 103}
+	err = db.Repos().Create(ctx, &repo3)
+	require.NoError(t, err)
+
 	// Adding some jobs for user and repos.
 	addSyncJobs(t, ctx, db, "user_id", int(user.ID))
-	addSyncJobs(t, ctx, db, "repository_id", 1)
-	addSyncJobs(t, ctx, db, "repository_id", 2)
-	addSyncJobs(t, ctx, db, "repository_id", 3)
+	addSyncJobs(t, ctx, db, "repository_id", int(repo1.ID))
+	addSyncJobs(t, ctx, db, "repository_id", int(repo2.ID))
+	addSyncJobs(t, ctx, db, "repository_id", int(repo3.ID))
 
 	// We should have 20 jobs now.
 	jobs, err := store.List(ctx, database.ListPermissionSyncJobOpts{})

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
@@ -75,22 +75,36 @@ func TestPermsSyncerWorker_Store_Dequeue_Order(t *testing.T) {
 	}
 
 	if _, err := dbt.ExecContext(context.Background(), `
+		INSERT INTO users (id, username)
+		VALUES (1, 'test_user_1')
+	`); err != nil {
+		t.Fatalf("unexpected error creating user: %s", err)
+	}
+
+	if _, err := dbt.ExecContext(context.Background(), `
+		INSERT INTO repo (id, name)
+		VALUES (1, 'test_repo_1')
+	`); err != nil {
+		t.Fatalf("unexpected error creating repo: %s", err)
+	}
+
+	if _, err := dbt.ExecContext(context.Background(), `
 		INSERT INTO permission_sync_jobs (id, state, user_id, repository_id, priority, process_after, reason)
 		VALUES
 			(1, 'queued', 1, null, 0, null, 'test'),
-			(2, 'queued', 0, null, 0, null, 'test'),
+			(2, 'queued', null, 1, 0, null, 'test'),
 			(3, 'queued', 1, null, 5, null, 'test'),
-			(4, 'queued', 0, null, 5, null, 'test'),
+			(4, 'queued', null, 1, 5, null, 'test'),
 			(5, 'queued', 1, null, 10, null, 'test'),
-			(6, 'queued', 0, null, 10, null, 'test'),
+			(6, 'queued', null, 1, 10, null, 'test'),
 			(7, 'queued', 1, null, 10, NOW() - '1 minute'::interval, 'test'),
-			(8, 'queued', 0, null, 10, NOW() - '2 minute'::interval, 'test'),
+			(8, 'queued', null, 1, 10, NOW() - '2 minute'::interval, 'test'),
 			(9, 'queued', 1, null, 5, NOW() - '1 minute'::interval, 'test'),
-			(10, 'queued', 0, null, 5, NOW() - '2 minute'::interval, 'test'),
+			(10, 'queued', null, 1, 5, NOW() - '2 minute'::interval, 'test'),
 			(11, 'queued', 1, null, 0, NOW() - '1 minute'::interval, 'test'),
-			(12, 'queued', 0, null, 0, NOW() - '2 minute'::interval, 'test'),
+			(12, 'queued', null, 1, 0, NOW() - '2 minute'::interval, 'test'),
 			(13, 'processing', 1, null, 10, null, 'test'),
-			(14, 'completed', 0, null, 10, null, 'test'),
+			(14, 'completed', null, 1, 10, null, 'test'),
 			(15, 'cancelled', 1, null, 10, null, 'test'),
 			(16, 'queued', 1, null, 10, NOW() + '2 minute'::interval, 'test')
 	`); err != nil {

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -2,15 +2,18 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,23 +38,36 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	require.NoError(t, err)
 
 	store := PermissionSyncJobsWith(logger, db)
+	usersStore := UsersWith(logger, db)
+	reposStore := ReposWith(logger, db)
+
+	// create users
+	user1, err := usersStore.Create(ctx, NewUser{Username: "test-user-1"})
+	require.NoError(t, err)
+	user2, err := usersStore.Create(ctx, NewUser{Username: "test-user-2"})
+	require.NoError(t, err)
+
+	// create repo
+	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
+	err = reposStore.Create(ctx, &repo1)
+	require.NoError(t, err)
 
 	jobs, err := store.List(ctx, ListPermissionSyncJobOpts{})
 	require.NoError(t, err)
 	require.Len(t, jobs, 0, "jobs returned even though database is empty")
 
 	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
-	err = store.CreateRepoSyncJob(ctx, 99, opts)
+	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), opts)
 	require.NoError(t, err)
 
 	processAfter := clock.Now().Add(5 * time.Minute)
 	opts = PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
-	err = store.CreateUserSyncJob(ctx, 77, opts)
+	err = store.CreateUserSyncJob(ctx, user1.ID, opts)
 	require.NoError(t, err)
 
 	processAfter = clock.Now().Add(5 * time.Minute)
 	opts = PermissionSyncJobOpts{Priority: LowPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
-	err = store.CreateUserSyncJob(ctx, 78, opts)
+	err = store.CreateUserSyncJob(ctx, user2.ID, opts)
 	require.NoError(t, err)
 
 	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{})
@@ -63,7 +79,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		{
 			ID:                jobs[0].ID,
 			State:             "queued",
-			RepositoryID:      99,
+			RepositoryID:      int(repo1.ID),
 			Priority:          HighPriorityPermissionSync,
 			InvalidateCaches:  true,
 			Reason:            ReasonManualRepoSync,
@@ -72,7 +88,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		{
 			ID:               jobs[1].ID,
 			State:            "queued",
-			UserID:           77,
+			UserID:           int(user1.ID),
 			Priority:         MediumPriorityPermissionSync,
 			InvalidateCaches: true,
 			ProcessAfter:     processAfter,
@@ -81,7 +97,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		{
 			ID:               jobs[2].ID,
 			State:            "queued",
-			UserID:           78,
+			UserID:           int(user2.ID),
 			Priority:         LowPriorityPermissionSync,
 			InvalidateCaches: true,
 			ProcessAfter:     processAfter,
@@ -305,20 +321,26 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
+	reposStore := ReposWith(logger, db)
+
+	// create repo
+	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
+	err := reposStore.Create(ctx, &repo1)
+	require.NoError(t, err)
 
 	// Test that cancelling non-existent job errors out.
-	err := store.CancelQueuedJob(ctx, CancellationReasonHigherPriority, 1)
+	err = store.CancelQueuedJob(ctx, CancellationReasonHigherPriority, 1)
 	require.True(t, errcode.IsNotFound(err))
 
 	// Adding a job.
-	err = store.CreateRepoSyncJob(ctx, 1, PermissionSyncJobOpts{Reason: ReasonManualUserSync})
+	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualUserSync})
 	require.NoError(t, err)
 
 	// Cancelling a job should be successful now.
 	err = store.CancelQueuedJob(ctx, CancellationReasonHigherPriority, 1)
 	require.NoError(t, err)
 	// Checking that cancellation reason is set.
-	cancelledJob, err := store.List(ctx, ListPermissionSyncJobOpts{RepoID: 1})
+	cancelledJob, err := store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
 	require.NoError(t, err)
 	require.Len(t, cancelledJob, 1)
 	require.Equal(t, CancellationReasonHigherPriority, cancelledJob[0].CancellationReason)
@@ -328,7 +350,7 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	require.True(t, errcode.IsNotFound(err))
 
 	// Adding another job and setting it to "processing" state.
-	err = store.CreateRepoSyncJob(ctx, 1, PermissionSyncJobOpts{Reason: ReasonManualUserSync})
+	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
 	require.NoError(t, err)
 	_, err = db.ExecContext(ctx, "UPDATE permission_sync_jobs SET state='processing' WHERE id=2")
 	require.NoError(t, err)
@@ -336,4 +358,75 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	// Cancelling it errors out because it is in a state different from "queued".
 	err = store.CancelQueuedJob(ctx, CancellationReasonHigherPriority, 2)
 	require.True(t, errcode.IsNotFound(err))
+}
+
+func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	store := PermissionSyncJobsWith(logger, db)
+	reposStore := ReposWith(logger, db)
+
+	// create repo
+	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
+	err := reposStore.Create(ctx, &repo1)
+	require.NoError(t, err)
+
+	// Adding a job.
+	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
+	require.NoError(t, err)
+
+	// Checking that the job is created.
+	jobs, err := store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	// Deleting repo
+	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`DELETE FROM repo WHERE id = %d`, int(repo1.ID)))
+	require.NoError(t, err)
+
+	// Checking that the job is deleted.
+	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
+	require.NoError(t, err)
+	require.Len(t, jobs, 0)
+}
+
+func TestPermissionSyncJobs_CascadeOnUserDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	store := PermissionSyncJobsWith(logger, db)
+	usersStore := UsersWith(logger, db)
+
+	// create user
+	user1, err := usersStore.Create(ctx, NewUser{Username: "test-user-1"})
+	require.NoError(t, err)
+
+	// Adding a job.
+	err = store.CreateUserSyncJob(ctx, user1.ID, PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
+	require.NoError(t, err)
+
+	// Checking that the job is created.
+	jobs, err := store.List(ctx, ListPermissionSyncJobOpts{UserID: int(user1.ID)})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	// Deleting user
+	err = usersStore.HardDelete(ctx, user1.ID)
+	require.NoError(t, err)
+
+	// Checking that the job is deleted.
+	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{UserID: int(user1.ID)})
+	require.NoError(t, err)
+	require.Len(t, jobs, 0)
 }

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -371,7 +371,7 @@ func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
 	store := PermissionSyncJobsWith(logger, db)
 	reposStore := ReposWith(logger, db)
 
-	// create repo
+	// Create repo.
 	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
 	err := reposStore.Create(ctx, &repo1)
 	require.NoError(t, err)
@@ -385,14 +385,14 @@ func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
 
-	// Deleting repo
+	// Deleting repo.
 	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`DELETE FROM repo WHERE id = %d`, int(repo1.ID)))
 	require.NoError(t, err)
 
 	// Checking that the job is deleted.
 	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
 	require.NoError(t, err)
-	require.Len(t, jobs, 0)
+	require.Empty(t, jobs)
 }
 
 func TestPermissionSyncJobs_CascadeOnUserDelete(t *testing.T) {
@@ -407,7 +407,7 @@ func TestPermissionSyncJobs_CascadeOnUserDelete(t *testing.T) {
 	store := PermissionSyncJobsWith(logger, db)
 	usersStore := UsersWith(logger, db)
 
-	// create user
+	// Create a user.
 	user1, err := usersStore.Create(ctx, NewUser{Username: "test-user-1"})
 	require.NoError(t, err)
 
@@ -420,12 +420,12 @@ func TestPermissionSyncJobs_CascadeOnUserDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
 
-	// Deleting user
+	// Deleting user.
 	err = usersStore.HardDelete(ctx, user1.ID)
 	require.NoError(t, err)
 
 	// Checking that the job is deleted.
 	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{UserID: int(user1.ID)})
 	require.NoError(t, err)
-	require.Len(t, jobs, 0)
+	require.Empty(t, jobs)
 }

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -57,7 +57,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	require.Len(t, jobs, 0, "jobs returned even though database is empty")
 
 	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
-	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), opts)
+	err = store.CreateRepoSyncJob(ctx, repo1.ID, opts)
 	require.NoError(t, err)
 
 	processAfter := clock.Now().Add(5 * time.Minute)
@@ -333,7 +333,7 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	require.True(t, errcode.IsNotFound(err))
 
 	// Adding a job.
-	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualUserSync})
+	err = store.CreateRepoSyncJob(ctx, repo1.ID, PermissionSyncJobOpts{Reason: ReasonManualUserSync})
 	require.NoError(t, err)
 
 	// Cancelling a job should be successful now.
@@ -350,7 +350,7 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	require.True(t, errcode.IsNotFound(err))
 
 	// Adding another job and setting it to "processing" state.
-	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
+	err = store.CreateRepoSyncJob(ctx, repo1.ID, PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
 	require.NoError(t, err)
 	_, err = db.ExecContext(ctx, "UPDATE permission_sync_jobs SET state='processing' WHERE id=2")
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Adding a job.
-	err = store.CreateRepoSyncJob(ctx, api.RepoID(repo1.ID), PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
+	err = store.CreateRepoSyncJob(ctx, repo1.ID, PermissionSyncJobOpts{Reason: ReasonManualRepoSync})
 	require.NoError(t, err)
 
 	// Checking that the job is created.

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -17150,7 +17150,7 @@
         },
         {
           "Name": "priority",
-          "Index": 21,
+          "Index": 18,
           "TypeName": "integer",
           "IsNullable": false,
           "Default": "0",
@@ -17350,11 +17350,25 @@
           "ConstraintDefinition": "CHECK ((user_id IS NULL) \u003c\u003e (repository_id IS NULL))"
         },
         {
+          "Name": "permission_sync_jobs_repository_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "repo",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE"
+        },
+        {
           "Name": "permission_sync_jobs_triggered_by_user_id_fkey",
           "ConstraintType": "f",
           "RefTableName": "users",
           "IsDeferrable": true,
           "ConstraintDefinition": "FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE"
+        },
+        {
+          "Name": "permission_sync_jobs_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
         }
       ],
       "Triggers": []

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2652,9 +2652,9 @@ Referenced by:
  repository_id        | integer                  |           |          | 
  user_id              | integer                  |           |          | 
  triggered_by_user_id | integer                  |           |          | 
+ priority             | integer                  |           | not null | 0
  invalidate_caches    | boolean                  |           | not null | false
  cancellation_reason  | text                     |           |          | 
- priority             | integer                  |           | not null | 0
 Indexes:
     "permission_sync_jobs_pkey" PRIMARY KEY, btree (id)
     "permission_sync_jobs_unique" UNIQUE, btree (priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text
@@ -2665,7 +2665,9 @@ Indexes:
 Check constraints:
     "permission_sync_jobs_for_repo_or_user" CHECK ((user_id IS NULL) <> (repository_id IS NULL))
 Foreign-key constraints:
+    "permission_sync_jobs_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
     "permission_sync_jobs_triggered_by_user_id_fkey" FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
+    "permission_sync_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 
 ```
 
@@ -2871,6 +2873,7 @@ Referenced by:
     TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "lsif_index_configuration" CONSTRAINT "lsif_index_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "lsif_retention_configuration" CONSTRAINT "lsif_retention_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
+    TABLE "permission_sync_jobs" CONSTRAINT "permission_sync_jobs_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "repo_kvps" CONSTRAINT "repo_kvps_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "search_context_repos" CONSTRAINT "search_context_repos_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "sub_repo_permissions" CONSTRAINT "sub_repo_permissions_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
@@ -3444,6 +3447,7 @@ Referenced by:
     TABLE "outbound_webhooks" CONSTRAINT "outbound_webhooks_created_by_fkey" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
     TABLE "outbound_webhooks" CONSTRAINT "outbound_webhooks_updated_by_fkey" FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
     TABLE "permission_sync_jobs" CONSTRAINT "permission_sync_jobs_triggered_by_user_id_fkey" FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
+    TABLE "permission_sync_jobs" CONSTRAINT "permission_sync_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "product_subscriptions" CONSTRAINT "product_subscriptions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
     TABLE "registry_extension_releases" CONSTRAINT "registry_extension_releases_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     TABLE "registry_extensions" CONSTRAINT "registry_extensions_publisher_user_id_fkey" FOREIGN KEY (publisher_user_id) REFERENCES users(id)

--- a/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/down.sql
+++ b/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/down.sql
@@ -1,0 +1,46 @@
+-- We are changing the schema and we don't expect any rows yet so we can just drop
+-- the old table.
+DROP TABLE IF EXISTS permission_sync_jobs;
+
+CREATE TABLE permission_sync_jobs
+(
+    id                   SERIAL PRIMARY KEY,
+    state                TEXT                     DEFAULT 'queued',
+    reason               TEXT    NOT NULL,
+    failure_message      TEXT,
+    queued_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    started_at           TIMESTAMP WITH TIME ZONE,
+    finished_at          TIMESTAMP WITH TIME ZONE,
+    process_after        TIMESTAMP WITH TIME ZONE,
+    num_resets           INTEGER NOT NULL         DEFAULT 0,
+    num_failures         INTEGER NOT NULL         DEFAULT 0,
+    last_heartbeat_at    TIMESTAMP WITH TIME ZONE,
+    execution_logs       JSON[],
+    worker_hostname      TEXT    NOT NULL         DEFAULT '',
+    cancel               BOOLEAN NOT NULL         DEFAULT FALSE,
+
+    repository_id        INTEGER,
+    user_id              INTEGER,
+    triggered_by_user_id INTEGER REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,
+
+    priority             INTEGER NOT NULL         DEFAULT 0,
+    invalidate_caches    BOOLEAN NOT NULL         DEFAULT FALSE,
+    cancellation_reason  TEXT,
+    CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
+);
+
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_state ON permission_sync_jobs (state);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_process_after ON permission_sync_jobs (process_after);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_repository_id ON permission_sync_jobs (repository_id);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_user_id ON permission_sync_jobs (user_id);
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
+COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';

--- a/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/metadata.yaml
+++ b/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_foreign_keys_to_permission_sync_jobs
+parents: [1674480050, 1674642349]

--- a/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/up.sql
+++ b/migrations/frontend/1674669794_add_foreign_keys_to_permission_sync_jobs/up.sql
@@ -1,0 +1,46 @@
+-- We are changing the schema and we don't expect any rows yet so we can just drop
+-- the old table.
+DROP TABLE IF EXISTS permission_sync_jobs;
+
+CREATE TABLE permission_sync_jobs
+(
+    id                   SERIAL PRIMARY KEY,
+    state                TEXT                     DEFAULT 'queued',
+    reason               TEXT    NOT NULL,
+    failure_message      TEXT,
+    queued_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    started_at           TIMESTAMP WITH TIME ZONE,
+    finished_at          TIMESTAMP WITH TIME ZONE,
+    process_after        TIMESTAMP WITH TIME ZONE,
+    num_resets           INTEGER NOT NULL         DEFAULT 0,
+    num_failures         INTEGER NOT NULL         DEFAULT 0,
+    last_heartbeat_at    TIMESTAMP WITH TIME ZONE,
+    execution_logs       JSON[],
+    worker_hostname      TEXT    NOT NULL         DEFAULT '',
+    cancel               BOOLEAN NOT NULL         DEFAULT FALSE,
+
+    repository_id        INTEGER REFERENCES repo (id) ON DELETE CASCADE,
+    user_id              INTEGER REFERENCES users (id) ON DELETE CASCADE,
+    triggered_by_user_id INTEGER REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,
+
+    priority             INTEGER NOT NULL         DEFAULT 0,
+    invalidate_caches    BOOLEAN NOT NULL         DEFAULT FALSE,
+    cancellation_reason  TEXT,
+    CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
+);
+
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_state ON permission_sync_jobs (state);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_process_after ON permission_sync_jobs (process_after);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_repository_id ON permission_sync_jobs (repository_id);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_user_id ON permission_sync_jobs (user_id);
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
+COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3301,9 +3301,9 @@ CREATE TABLE permission_sync_jobs (
     repository_id integer,
     user_id integer,
     triggered_by_user_id integer,
+    priority integer DEFAULT 0 NOT NULL,
     invalidate_caches boolean DEFAULT false NOT NULL,
     cancellation_reason text,
-    priority integer DEFAULT 0 NOT NULL,
     CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
 );
 
@@ -3311,9 +3311,9 @@ COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync
 
 COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
 
-COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
-
 COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';
+
+COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
 
 CREATE SEQUENCE permission_sync_jobs_id_seq
     AS integer
@@ -5337,7 +5337,13 @@ ALTER TABLE ONLY outbound_webhooks
     ADD CONSTRAINT outbound_webhooks_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY permission_sync_jobs
+    ADD CONSTRAINT permission_sync_jobs_repository_id_fkey FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY permission_sync_jobs
     ADD CONSTRAINT permission_sync_jobs_triggered_by_user_id_fkey FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE;
+
+ALTER TABLE ONLY permission_sync_jobs
+    ADD CONSTRAINT permission_sync_jobs_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY product_licenses
     ADD CONSTRAINT product_licenses_product_subscription_id_fkey FOREIGN KEY (product_subscription_id) REFERENCES product_subscriptions(id);


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/46911

This replaces repository_id and user_id integer columns to foreign keys to their corresponding tables. 

This allows for jobs to be automatically deleted upon the deletion of the user or repo. 

TODO in a separate PR, also integration with user, repo soft delete events.


## Test plan

- turn on db worker and wait for jobs to be scheduled
- delete a user/repo
- check for jobs to be removed.
