### PR TITLE
sg: buf: prevent buf-generate from descending into git/node_modules

### DIFF
--- a/dev/sg/root/root_test.go
+++ b/dev/sg/root/root_test.go
@@ -1,9 +1,13 @@
 package root
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCreateSGHome(t *testing.T) {
@@ -21,5 +25,153 @@ func TestCreateSGHome(t *testing.T) {
 	_, err = os.Stat(wantedHome)
 	if err != nil {
 		t.Errorf("failed to stat SG Home %q. Expected directory to be created\n", err)
+	}
+}
+
+func TestWalkGitIgnoreFunc(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		gitIgnore       string
+		additionalLines []string
+		expectedFiles   []string
+	}{
+		{
+			name: "empty gitignore + no additional lines",
+			expectedFiles: []string{
+				"foo.txt",
+
+				"bar",
+				"bar/baz.txt",
+
+				".git",
+				".git/qux.txt",
+
+				".gitignore",
+			},
+		},
+
+		{
+
+			name: "gitignore: ignore baz.txt only",
+			gitIgnore: `
+bar/baz.txt
+`,
+			expectedFiles: []string{
+				"foo.txt",
+
+				"bar",
+
+				".git",
+				".git/qux.txt",
+
+				".gitignore",
+			},
+		},
+
+		{
+
+			name: "gitignore: ignore bar folder entirely",
+			gitIgnore: `
+bar
+`,
+			expectedFiles: []string{
+				"foo.txt",
+
+				".git",
+				".git/qux.txt",
+
+				".gitignore",
+			},
+		},
+
+		{
+
+			name: "gitignore: ignore bar folder entirely / additional lines: ignore .git",
+			gitIgnore: `
+bar
+`,
+			additionalLines: []string{".git"},
+			expectedFiles: []string{
+				"foo.txt",
+
+				".gitignore",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+
+			// Setup: create file layout that looks like the following
+			// 	- foo.txt
+			// 	- bar/baz.txt
+			// 	- .git/qux.txt
+			// 	- .gitignore
+
+			for _, f := range []struct {
+				name     string
+				contents string
+			}{
+				{name: "foo.txt", contents: "foo"},
+				{name: "bar/baz.txt", contents: "baz"},
+				{name: ".git/qux.txt", contents: "qux"},
+				{name: ".gitignore", contents: test.gitIgnore},
+			} {
+
+				fileName := filepath.Join(root, f.name)
+
+				dir := filepath.Dir(fileName)
+				err := os.MkdirAll(dir, 0777)
+				if err != nil {
+					t.Fatalf("failed to create directory %q: %q", dir, err)
+				}
+
+				err = os.WriteFile(fileName, []byte(f.contents), 0777)
+				if err != nil {
+					t.Fatalf("failed to create file %q: %q", fileName, err)
+				}
+			}
+
+			// Setup: prepare walkFunction that will record the names of all files and folders
+			// that are visited.
+			var actualFiles []string
+
+			gatherWalkFn := func(path string, entry fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				relPath, err := filepath.Rel(root, path)
+				if err != nil {
+					t.Fatalf("failed to calculate relative path for %q: %q", path, err)
+				}
+
+				if relPath == "." {
+					// don't bother including the root directory
+					return nil
+				}
+
+				actualFiles = append(actualFiles, relPath)
+				return nil
+			}
+
+			// Test: call walkDir with the skipGitIgnoreWalkFunc wrapper
+			gitignorePath := filepath.Join(root, ".gitignore")
+			err := filepath.WalkDir(root, skipGitIgnoreWalkFunc(gatherWalkFn, gitignorePath, test.additionalLines...))
+			if err != nil {
+				t.Fatalf("failed to walk directory %q: %q", root, err)
+			}
+
+			// Examine: sort the actual and expected files so that we can compare them
+			// to see if we recorded the set of files that we expected
+			sort.Strings(actualFiles)
+			sort.Strings(test.expectedFiles)
+
+			if diff := cmp.Diff(test.expectedFiles, actualFiles); diff != "" {
+				t.Errorf("unexpected files (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	github.com/google/go-github/v47 v47.1.0
 	github.com/k3a/html2text v1.1.0
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sourcegraph/conc v0.1.0
 	github.com/sourcegraph/mountinfo v0.0.0-20221027185101-272dd8baaf4a
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -2006,6 +2006,8 @@ github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUcc
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=


### PR DESCRIPTION
`sg generate buf` was taking 20+ seconds on my machine to execute. 

This `generate` step first walks the entire project to discover all the `buf.gen.yaml` files. However, it descends _every_ subdirectory of the project folder. This includes files like:

```
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/.git
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/.git/info
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/.git/logs
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/.git/logs/refs
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/.git/logs/refs/heads
...
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules/yn
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules/yocto-queue
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules/zen-observable
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules/zen-observable/lib
/Users/ggilmore/dev/go/src/github.com/sourcegraph/sourcegraph/node_modules/zen-observable/scripts
```

Clearly its a waste of time to check for `buf.gen.yaml` files in the `.git/` and `node_modules/` directories.

---

I fixed the above issue by adding new helper function to our `root` package: `SkipGitIgnoreWalkFunc`. This wraps the provided `filepath.WalkDirFunc` with logic that skips iterating over files and folders that are specified in the repo's .gitignore (node_modules is specified in here) + the .git folder itself. 

After fixing this, `sg generate buf` now consistently only takes ~2s on my machine. 

## Test plan

- Manual testing for the `sg generate buf` improvements. 
- Unit tests for the new `root.SkipGitIgnoreWalkFunc` method