### PR TITLE
Better distinguish between select and expand actions in mouse UI

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -191,11 +191,13 @@ function renderNode({
     isBranch,
     isExpanded,
     handleSelect,
+    props,
 }: {
     element: TreeNode
     isBranch: boolean
     isExpanded: boolean
     handleSelect: (event: React.MouseEvent) => {}
+    props: { className: string }
 }): React.ReactNode {
     const { entry, error } = element
     const submodule = entry?.submodule
@@ -203,63 +205,65 @@ function renderNode({
     const url = entry?.url
 
     if (error) {
-        return <ErrorAlert className="m-0" variant="note" error={error} />
+        return <ErrorAlert {...props} className={classNames(props.className, 'm-0')} variant="note" error={error} />
     }
 
     if (submodule) {
         const rev = submodule.commit.slice(0, 7)
         const title = `${name} @ ${rev}`
+        const tooltip = `Submodule: ${submodule.url}`
 
-        let content = <span>{title}</span>
         if (url) {
-            content = (
-                <Link
-                    to={url ?? '#'}
-                    tabIndex={-1}
-                    onClick={event => {
-                        event.preventDefault()
-                        handleSelect(event)
-                    }}
-                >
-                    {title}
-                </Link>
-            )
-        }
-
-        return (
-            <>
-                <Tooltip content={'Submodule: ' + submodule.url}>
-                    <span>
+            return (
+                <Tooltip content={tooltip}>
+                    <Link
+                        {...props}
+                        to={url}
+                        onClick={event => {
+                            event.preventDefault()
+                            handleSelect(event)
+                        }}
+                    >
                         <Icon
                             svgPath={mdiSourceRepository}
                             className={classNames('mr-1', styles.icon)}
-                            aria-label={'Submodule: ' + submodule.url}
+                            aria-label={tooltip}
                         />
-                        {content}
-                    </span>
+                        {title}
+                    </Link>
                 </Tooltip>
-            </>
+            )
+        }
+        return (
+            <Tooltip content={tooltip}>
+                <span {...props}>
+                    <Icon
+                        svgPath={mdiSourceRepository}
+                        className={classNames('mr-1', styles.icon)}
+                        aria-label={tooltip}
+                    />
+                    {title}
+                </span>
+            </Tooltip>
         )
     }
 
     return (
-        <>
+        <Link
+            {...props}
+            to={url ?? '#'}
+            onClick={event => {
+                event.preventDefault()
+                handleSelect(event)
+            }}
+        >
             <Icon
                 svgPath={isBranch ? (isExpanded ? mdiFolderOpenOutline : mdiFolderOutline) : mdiFileDocumentOutline}
                 className={classNames('mr-1', styles.icon)}
                 aria-hidden={true}
             />
-            <Link
-                to={url ?? '#'}
-                tabIndex={-1}
-                onClick={event => {
-                    event.preventDefault()
-                    handleSelect(event)
-                }}
-            >
-                {name}
-            </Link>
-        </>
+            {name}
+        </Link>
     )
 }
 

--- a/client/wildcard/src/components/Tree/Tree.module.scss
+++ b/client/wildcard/src/components/Tree/Tree.module.scss
@@ -24,9 +24,8 @@
 }
 
 .node {
-    padding: 0 0.25rem;
+    padding: 0;
     margin-right: 0.25rem;
-    min-height: 1.75rem;
     border-radius: 0.25rem;
     color: var(--text-muted);
     user-select: none;
@@ -38,14 +37,48 @@
     // stylelint-disable-next-line declaration-property-unit-allowed-list
     margin-top: 1px;
 
-    &:hover,
-    &.selected {
+    &.selected,
+    &:hover {
         background-color: var(--color-bg-2);
         color: var(--body-color);
     }
 
-    &.branch {
-        cursor: pointer;
+    .collapse-icon:hover {
+        background-color: var(--color-bg-3);
+        color: var(--body-color);
+    }
+
+    .collapse-icon {
+        min-height: 1.75rem;
+        min-width: 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-top-left-radius: 0.25rem;
+        border-bottom-left-radius: 0.25rem;
+    }
+
+    .content {
+        padding: 0.25rem 0.5rem;
+        padding-right: 0;
+        min-height: 1.75rem;
+        align-items: center;
+        border-radius: 0.25rem;
+    }
+
+    .content-in-branch {
+        padding-left: 0;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    .collapse-icon,
+    .collapse-icon > * {
+        flex-shrink: 0;
+    }
+
+    .content {
+        flex-grow: 1;
     }
 
     a {

--- a/client/wildcard/src/components/Tree/Tree.module.scss
+++ b/client/wildcard/src/components/Tree/Tree.module.scss
@@ -64,6 +64,7 @@
         min-height: 1.75rem;
         align-items: center;
         border-radius: 0.25rem;
+        flex-grow: 1;
     }
 
     .content-in-branch {
@@ -75,10 +76,6 @@
     .collapse-icon,
     .collapse-icon > * {
         flex-shrink: 0;
-    }
-
-    .content {
-        flex-grow: 1;
     }
 
     a {

--- a/client/wildcard/src/components/Tree/Tree.story.tsx
+++ b/client/wildcard/src/components/Tree/Tree.story.tsx
@@ -47,24 +47,22 @@ export const Basic: Story = () => (
     <Tree
         data={folder}
         defaultExpandedIds={[0, 1, 4, 5, 7]}
-        renderNode={({ element, isBranch, isExpanded, handleSelect }): React.ReactNode => (
-            <>
+        renderNode={({ element, isBranch, isExpanded, handleSelect, props }): React.ReactNode => (
+            <Link
+                {...props}
+                to="#"
+                onClick={event => {
+                    event.preventDefault()
+                    handleSelect(event)
+                }}
+            >
                 <Icon
                     svgPath={isBranch ? (isExpanded ? mdiFolderOpenOutline : mdiFolderOutline) : mdiFileDocumentOutline}
                     className={classNames('mr-1', styles.icon)}
                     aria-hidden={true}
                 />
-                <Link
-                    to="#"
-                    tabIndex={-1}
-                    onClick={event => {
-                        event.preventDefault()
-                        handleSelect(event)
-                    }}
-                >
-                    {element.name}
-                </Link>
-            </>
+                {element.name}
+            </Link>
         )}
     />
 )

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -78,7 +78,7 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
                         minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level)})`,
                     }}
                     data-tree-node-id={element.id}
-                    className={classNames(styles.node, isSelected && styles.selected, isBranch && styles.branch)}
+                    className={classNames(styles.node, isSelected && styles.selected)}
                 >
                     {isBranch ? (
                         // We already handle accessibility events for expansion in the <TreeView />

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -22,6 +22,7 @@ interface Props<N extends TreeNode> extends Omit<ITreeViewProps, 'nodes' | 'onSe
         isBranch: boolean
         isExpanded: boolean
         handleSelect: (event: React.MouseEvent) => {}
+        props: { className: string; tabIndex: number }
     }) => React.ReactNode
 }
 export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
@@ -60,33 +61,53 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
             isBranch: boolean
             isExpanded: boolean
             isSelected: boolean
-            getNodeProps: (props: { onClick: (event: Event) => {} }) => {}
+            getNodeProps: (props: { onClick: (event: Event) => {} }) => {
+                onClick: (event: React.MouseEvent) => {}
+            }
             level: number
             handleSelect: (event: React.MouseEvent) => {}
             handleExpand: (event: Event) => {}
-        }): React.ReactNode => (
-            <div
-                {...getNodeProps({ onClick: handleExpand })}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    marginLeft: getMarginLeft(level),
-                    minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level)})`,
-                }}
-                data-tree-node-id={element.id}
-                className={classNames(styles.node, isSelected && styles.selected, isBranch && styles.branch)}
-            >
-                {isBranch ? (
-                    <div className={classNames('mr-1', styles.icon)}>
-                        {isExpanded && element.children.length === 0 ? (
-                            <LoadingSpinner />
-                        ) : (
-                            <Icon aria-hidden={true} svgPath={isExpanded ? mdiMenuDown : mdiMenuRight} />
-                        )}
-                    </div>
-                ) : null}
-                {renderNode ? renderNode({ element, isBranch, isExpanded, handleSelect }) : null}
-            </div>
-        ),
+        }): React.ReactNode => {
+            const { onClick, ...props } = getNodeProps({ onClick: handleExpand })
+            return (
+                <div
+                    {...props}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{
+                        marginLeft: getMarginLeft(level),
+                        minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level)})`,
+                    }}
+                    data-tree-node-id={element.id}
+                    className={classNames(styles.node, isSelected && styles.selected, isBranch && styles.branch)}
+                >
+                    {isBranch ? (
+                        // We already handle accessibility events for expansion in the <TreeView />
+                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+                        <div className={classNames(styles.icon, styles.collapseIcon)} onClick={onClick}>
+                            {isExpanded && element.children.length === 0 ? (
+                                <LoadingSpinner />
+                            ) : (
+                                <Icon aria-hidden={true} svgPath={isExpanded ? mdiMenuDown : mdiMenuRight} />
+                            )}
+                        </div>
+                    ) : null}
+                    {renderNode
+                        ? renderNode({
+                              element,
+                              isBranch,
+                              isExpanded,
+                              handleSelect,
+                              props: {
+                                  className: classNames(styles.content, isBranch ? styles.contentInBranch : null),
+                                  // We don't want links or any other item inside the Tree to be focusable, as focus
+                                  // should be managed by the TreeView only.
+                                  tabIndex: -1,
+                              },
+                          })
+                        : null}
+                </div>
+            )
+        },
         [renderNode]
     )
 


### PR DESCRIPTION
Part of #12916 

Some last-minute (before we start dogfooding) fixes to the mouse UI. In the previous version, wether you expand something or select something depended on wether you clicked on the link vs. the background. This was super confusing and caused the element to be selected _and_ expanded in certain situations.

To fix this, I have now limited the expansion via mouse to only the caret. Besides the caret, all of the rest is now the link instead which will make the area much more intuitive to click (i.e hovering everywhere other than the caret will cause the link to show a hover highlight). 

It would be cool if someone can review this before the next deploy that happens in the next couple of hours :) 

## Test plan

Tested this locally and also made sure that this does _not_ impact keyboard accessibility in the slightlest.

https://user-images.githubusercontent.com/458591/214715477-706eaf64-8e52-446d-804c-d2582112223b.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-improve-expand-vs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
