### PR TITLE
insights: Update repo scoping query validation to check for revisions

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -90,14 +90,15 @@ func IsValidScopeQuery(plan searchquery.Plan) (string, bool) {
 			// Only allowed filter is repo (including repo:has predicates).
 			if field != searchquery.FieldRepo {
 				return fmt.Sprintf(containsDisallowedFilter, parameter.Field), false
-			} else {
-				repoRevs, err := query.ParseRepositoryRevisions(parameter.Value)
-				if err != nil {
-					return containsInvalidExpression, false
-				}
-				if len(repoRevs.Revs) > 0 {
-					return containsDisallowedRevision, false
-				}
+			}
+			// This is a repo filter make sure no revision was specified
+			repoRevs, err := query.ParseRepositoryRevisions(parameter.Value)
+			if err != nil {
+				// This shouldn't be possible because it should have failed earlier when parsed
+				return containsInvalidExpression, false
+			}
+			if len(repoRevs.Revs) > 0 {
+				return containsDisallowedRevision, false
 			}
 		}
 	}

--- a/enterprise/internal/insights/query/querybuilder/parser_test.go
+++ b/enterprise/internal/insights/query/querybuilder/parser_test.go
@@ -263,6 +263,18 @@ func TestIsValidScopeQuery(t *testing.T) {
 			query: "repo:has.file(path:README)",
 			valid: true,
 		},
+		{
+			name:   "invalid query with rev filter",
+			query:  "repo:sourcegraph rev:mybranch",
+			reason: containsDisallowedRevision,
+			valid:  false,
+		},
+		{
+			name:   "invalid query with specified on repo filter",
+			query:  `repo:^github\.com/sourcegraph/sourcegraph$@v4.0.0`,
+			reason: containsDisallowedRevision,
+			valid:  false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Adds a check to the repo query validation that fails if a revision is provided as part of `repo:` or separately with `rev:`
## Test plan
Unit tests added
<img width="576" alt="image" src="https://user-images.githubusercontent.com/6098507/214718245-45b3c69e-fce9-4355-8baa-01188aa46c5c.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
