### PR TITLE
Add outline for tutorial docs page

### DIFF
--- a/doc/tutorials/index.md
+++ b/doc/tutorials/index.md
@@ -1,0 +1,101 @@
+# Sourcegraph User Tutorials
+
+*Note: Work in Progress. Full Content & Links Coming Soon*
+
+## Intro: Find Your Way Around Sourcegraph
+
+| Topic | Description |
+| ----------- | ----------- |
+| Home | TODO |
+| Notebooks | TODO |
+| Code Monitoring | TODO |
+| Settings & Configuration | TODO |
+
+## Setup: Setting up your Sourcegraph User Environment
+| Topic | Description |
+| -------- | --------|
+| Customizing your settings | TODO |
+| Using Sourcegraph with your IDE | TODO |
+| Using the Sourcegraph browser extension on your code  | TODO |host
+| Using the Sourcegraph CLI | TODO |
+| Saving Searches | TODO |
+| Search Contexts | TODO |
+
+## Concepts: Get Started Searching
+| Topic | Description |
+| -------- | --------|
+| Search features | TODO |
+| Search types | TODO |
+| Saved searches | TODO |
+| Search contexts | TODO |
+| Search Query Syntax | TODO |
+
+## Concepts: More Advanced Searching
+| Topic | Description |
+| -------- | --------|
+| Commits | TODO |
+| Multi branch | TODO |
+| AND/OR | TODO |
+| Other more advanced filters (time, diff, author, etc) | TODO |
+| Advanced Regex | TODO |
+| Structural Search | TODO |
+
+## Scenarios: Search
+| Topic | Description |
+| -------- | --------|
+| How to Space | TODO |
+
+## Concepts: Code Navigation
+| Topic | Description |
+| -------- | --------|
+| Search vs Precise | TODO |
+| Language Support | TODO |
+| Definition & Implementation | TODO |
+| References & dependencies | TODO |
+| Symbol search | TODO |
+
+
+## Concepts: Notebooks
+| Topic | Description |
+| -------- | --------|
+| Web-based vs File-based | Description |
+| Blocks | Description |
+
+
+## Concepts: Code Insights
+| Topic | Description |
+| -------- | --------|
+| Report Types | TODO |
+| Filters | TODO |
+| Dashboards | TODO |
+| Access & Sharing | TODO |
+
+
+## Scenarios: Code Insights
+| Topic | Description |
+| -------- | --------|
+| Link to how-to space | TODO |
+
+## Concepts: Batch Changes
+| Topic | Description |
+| -------- | --------|
+| Workflow | TODO |
+| Creating | TODO |
+| Viewing | TODO |
+| Publishing | TODO |
+| Updating | TODO |
+| Error Handling | TODO |
+
+
+## Scenarios: Batch Changes
+| Topic | Description |
+| -------- | --------|
+| Link to how-to space | TODO |
+
+## Concepts: Using GraphQL
+| Topic | Description |
+| -------- | --------|
+| UI vs API | TODO |
+| Access / permissions | TODO |
+| Examples | TODO |
+

--- a/doc/tutorials/index.md
+++ b/doc/tutorials/index.md
@@ -1,9 +1,9 @@
 # Sourcegraph User Tutorials
 
-*Note: Work in Progress. Full Content & Links Coming Soon*
+> ⚠️ Note: Work in Progress. Full Content & Links Coming Soon.
 
-## Intro: Find Your Way Around Sourcegraph
 
+## Find Your Way Around Sourcegraph
 | Topic | Description |
 | ----------- | ----------- |
 | Home | TODO |
@@ -11,7 +11,7 @@
 | Code Monitoring | TODO |
 | Settings & Configuration | TODO |
 
-## Setup: Setting up your Sourcegraph User Environment
+## Setting Up Your Sourcegraph User Environment
 | Topic | Description |
 | -------- | --------|
 | Customizing your settings | TODO |
@@ -21,7 +21,7 @@
 | Saving Searches | TODO |
 | Search Contexts | TODO |
 
-## Concepts: Get Started Searching
+## Get Started Searching
 | Topic | Description |
 | -------- | --------|
 | Search features | TODO |
@@ -30,7 +30,7 @@
 | Search contexts | TODO |
 | Search Query Syntax | TODO |
 
-## Concepts: More Advanced Searching
+## More Advanced Searching
 | Topic | Description |
 | -------- | --------|
 | Commits | TODO |
@@ -40,12 +40,12 @@
 | Advanced Regex | TODO |
 | Structural Search | TODO |
 
-## Scenarios: Search
+## Search Scenarios
 | Topic | Description |
 | -------- | --------|
 | How to Space | TODO |
 
-## Concepts: Code Navigation
+## Code Navigation
 | Topic | Description |
 | -------- | --------|
 | Search vs Precise | TODO |
@@ -55,28 +55,24 @@
 | Symbol search | TODO |
 
 
-## Concepts: Notebooks
+## Search Notebooks
 | Topic | Description |
 | -------- | --------|
 | Web-based vs File-based | Description |
 | Blocks | Description |
 
 
-## Concepts: Code Insights
+## Code Insights
 | Topic | Description |
 | -------- | --------|
 | Report Types | TODO |
 | Filters | TODO |
 | Dashboards | TODO |
 | Access & Sharing | TODO |
-
-
-## Scenarios: Code Insights
-| Topic | Description |
-| -------- | --------|
 | Link to how-to space | TODO |
 
-## Concepts: Batch Changes
+
+## Batch Changes
 | Topic | Description |
 | -------- | --------|
 | Workflow | TODO |
@@ -85,14 +81,10 @@
 | Publishing | TODO |
 | Updating | TODO |
 | Error Handling | TODO |
-
-
-## Scenarios: Batch Changes
-| Topic | Description |
-| -------- | --------|
 | Link to how-to space | TODO |
 
-## Concepts: Using GraphQL
+
+## Using GraphQL
 | Topic | Description |
 | -------- | --------|
 | UI vs API | TODO |


### PR DESCRIPTION
Adds a WIP outline of user-focused Sourcegraph tutorials.

FAQ:
Q: What is the purpose of this?
A: We are building out async content to help the onboarding and adoption of new users. We want a centralized docs page that we can send to customers / new users and say "_use this page to get started with Sourcegraph_".

Q: *Why are there a bunch of TODOs*?
A:  This will not yet linked from anywhere else in the docs, so while technically searchable, it won't _really_ be user-facing. We plan to "turn it on" after the Merge hackathon. We wanted to get this outline out into the world so that people can start contributing ASAP.

Q: Who can contribute to this?
A: Anyone

## Test plan
Docs only change.