### PR TITLE
Use proper pagination for GitLab groups

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
@@ -135,12 +135,12 @@ func (s *sessionIssuerHelper) verifyUserGroups(ctx context.Context, glClient *gi
 		allowed[group] = true
 	}
 
-	var err error
 	var gitlabGroups []*gitlab.Group
-	hasNextPage := true
+	var nextPageURL *string
+	var err error
 
-	for page := 1; hasNextPage; page++ {
-		gitlabGroups, hasNextPage, err = glClient.ListGroups(ctx, page)
+	for {
+		gitlabGroups, nextPageURL, err = glClient.ListGroups(ctx, nextPageURL)
 		if err != nil {
 			return false, err
 		}
@@ -150,6 +150,10 @@ func (s *sessionIssuerHelper) verifyUserGroups(ctx context.Context, glClient *gi
 			if allowed[glGroup.FullPath] {
 				return true, nil
 			}
+		}
+
+		if nextPageURL == nil {
+			break
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
@@ -265,8 +265,8 @@ func TestSessionIssuerHelper_GetOrCreateUser(t *testing.T) {
 
 			t.Run(ci.description, func(t *testing.T) {
 
-				gitlab.MockListGroups = func(ctx context.Context, page int) (groups []*gitlab.Group, hasNextPage bool, err error) {
-					return ci.glUserGroups, false, ci.glUserGroupsErr
+				gitlab.MockListGroups = func(ctx context.Context, pageURL *string) (groups []*gitlab.Group, nextPageURL *string, err error) {
+					return ci.glUserGroups, nil, ci.glUserGroupsErr
 				}
 
 				var gotAuthUserOp *auth.GetAndSaveUserOp

--- a/internal/extsvc/gitlab/groups_test.go
+++ b/internal/extsvc/gitlab/groups_test.go
@@ -22,7 +22,7 @@ func TestListGroups(t *testing.T) {
 			responseBody: `[{"id": 1,"full_path": "group1"}]`,
 		}
 
-		groupsResponse, _, err := client.ListGroups(ctx, 1)
+		groupsResponse, _, err := client.ListGroups(ctx, nil)
 		if groupsResponse == nil {
 			t.Error("unexpected nil response")
 		}
@@ -42,7 +42,7 @@ func TestListGroups(t *testing.T) {
 			responseBody: `this is not valid JSON`,
 		}
 
-		groupsResponse, _, err := client.ListGroups(ctx, 1)
+		groupsResponse, _, err := client.ListGroups(ctx, nil)
 		if groupsResponse != nil {
 			t.Error("unexpected non-nil response")
 		}


### PR DESCRIPTION
Adjusts the GitLab ListGroups query to use GitLab's pagination headers. This is recommended in the ListGroups API docs itself: https://docs.gitlab.com/ee/api/groups.html#list-groups

## Test plan
Tests and mocks adjusted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
