### PR TITLE
permissions-center: introduce minimum bound for sync job history items.

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -956,6 +956,7 @@
       "description": "The number of last repo/user permission jobs to keep for history.",
       "type": "integer",
       "default": 5,
+      "minimum": 5,
       "!go": { "pointer": true }
     },
     "branding": {


### PR DESCRIPTION
Test plan:
CI.

Part of https://github.com/sourcegraph/sourcegraph/issues/46318