### PR TITLE
Update release config to set next release to 4.5.0

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,16 +11,16 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "thorsten",
-    "captainGitHubUsername": "mrnugget",
+    "captainSlackUsername": "keegan",
+    "captainGitHubUsername": "keegancsmith",
     // Release versions
     "previousRelease": "4.4.0",
-    "upcomingRelease": "4.4.1",
-    "oneWorkingWeekBeforeRelease": "24 January 2023 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "20 February 2023 10:00 PST",
-    "releaseDate": "25 January 2023 10:00 PST",
-    "oneWorkingDayAfterRelease": "26 January 2023 10:00 PST",
-    "oneWorkingWeekAfterRelease": "1 February 2023 10:00 PST",
+    "upcomingRelease": "4.5.0",
+    "oneWorkingWeekBeforeRelease": "15 February 2023 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "17 February 2023 10:00 PST",
+    "releaseDate": "22 February 2023 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 February 2023 10:00 PST",
+    "oneWorkingWeekAfterRelease": "1 March 2023 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
Following post-release steps here: https://github.com/sourcegraph/sourcegraph/issues/46931


## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-update-release-config.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
