### PR TITLE
Fix previous release in release config

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -14,7 +14,7 @@
     "captainSlackUsername": "keegan",
     "captainGitHubUsername": "keegancsmith",
     // Release versions
-    "previousRelease": "4.4.0",
+    "previousRelease": "4.4.1",
     "upcomingRelease": "4.5.0",
     "oneWorkingWeekBeforeRelease": "15 February 2023 10:00 PST",
     "threeWorkingDaysBeforeRelease": "17 February 2023 10:00 PST",


### PR DESCRIPTION
I only reverted my changes in the file, but forgot to set the `previousRelease`
correctly. Thanks to @keegancsmith for pointing it out here: https://github.com/sourcegraph/sourcegraph/pull/46979#discussion_r1087804025

## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-fix-previous-release.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
