### PR TITLE
[Permissions] make perms job cleanup worker interval configurable

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
@@ -30,6 +31,48 @@ func (p *permissionSyncJobCleaner) Config() []env.Config {
 	return nil
 }
 
+const defaultCleanupInterval = time.Minute
+
+var cleanupInterval = defaultCleanupInterval
+
+var watchConfOnce = sync.Once{}
+
+func loadCleanupIntervalFromConf() {
+	seconds := conf.Get().PermissionsSyncJobCleanupInterval
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	fmt.Printf("seconds: %d\n", seconds)
+	if seconds <= 0 {
+		cleanupInterval = defaultCleanupInterval
+	} else {
+		cleanupInterval = time.Duration(seconds) * time.Second
+	}
+}
+
 func (p *permissionSyncJobCleaner) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
@@ -46,19 +89,26 @@ func (p *permissionSyncJobCleaner) Routines(_ context.Context, observationCtx *o
 		Metrics: m,
 	})
 
+	watchConfOnce.Do(func() {
+		loadCleanupIntervalFromConf()
+		conf.Watch(loadCleanupIntervalFromConf)
+	})
+
 	return []goroutine.BackgroundRoutine{
-		goroutine.NewPeriodicGoroutineWithMetrics(
+		goroutine.NewPeriodicGoroutineWithMetricsAndDynamicInterval(
 			context.Background(),
 			"auth.permission_sync_job_cleaner",
 			p.Description(),
-			1*time.Minute, goroutine.HandlerFunc(
+			func() time.Duration { return cleanupInterval },
+			goroutine.HandlerFunc(
 				func(ctx context.Context) error {
 					start := time.Now()
 					cleanedJobs, err := cleanJobs(ctx, db)
 					m.Observe(time.Since(start).Seconds(), float64(cleanedJobs), &err)
 					return err
 				},
-			), operation,
+			),
+			operation,
 		)}, nil
 }
 

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
@@ -39,33 +39,6 @@ var watchConfOnce = sync.Once{}
 
 func loadCleanupIntervalFromConf() {
 	seconds := conf.Get().PermissionsSyncJobCleanupInterval
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
-	fmt.Printf("seconds: %d\n", seconds)
 	if seconds <= 0 {
 		cleanupInterval = defaultCleanupInterval
 	} else {
@@ -90,7 +63,6 @@ func (p *permissionSyncJobCleaner) Routines(_ context.Context, observationCtx *o
 	})
 
 	watchConfOnce.Do(func() {
-		loadCleanupIntervalFromConf()
 		conf.Watch(loadCleanupIntervalFromConf)
 	})
 

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+type getIntervalFunc func() time.Duration
+
 // PeriodicGoroutine represents a goroutine whose main behavior is reinvoked periodically.
 //
 // See
@@ -23,7 +25,7 @@ type PeriodicGoroutine struct {
 	description string
 	jobName     string
 	recorder    *recorder.Recorder
-	interval    time.Duration
+	getInterval getIntervalFunc
 	handler     unifiedHandler
 	operation   *observation.Operation
 	clock       glock.Clock
@@ -100,10 +102,14 @@ func NewPeriodicGoroutine(ctx context.Context, name, description string, interva
 // NewPeriodicGoroutineWithMetrics creates a new PeriodicGoroutine with the given handler. The context provided will propagate into
 // the executing goroutine and will terminate the goroutine if cancelled.
 func NewPeriodicGoroutineWithMetrics(ctx context.Context, name, description string, interval time.Duration, handler Handler, operation *observation.Operation) *PeriodicGoroutine {
-	return newPeriodicGoroutine(ctx, name, description, interval, handler, operation, glock.NewRealClock())
+	return newPeriodicGoroutine(ctx, name, description, func() time.Duration { return interval }, handler, operation, glock.NewRealClock())
 }
 
-func newPeriodicGoroutine(ctx context.Context, name, description string, interval time.Duration, handler Handler, operation *observation.Operation, clock glock.Clock) *PeriodicGoroutine {
+func NewPeriodicGoroutineWithMetricsAndDynamicInterval(ctx context.Context, name, description string, getInterval getIntervalFunc, handler Handler, operation *observation.Operation) *PeriodicGoroutine {
+	return newPeriodicGoroutine(ctx, name, description, getInterval, handler, operation, glock.NewRealClock())
+}
+
+func newPeriodicGoroutine(ctx context.Context, name, description string, getInterval getIntervalFunc, handler Handler, operation *observation.Operation, clock glock.Clock) *PeriodicGoroutine {
 	ctx, cancel := context.WithCancel(ctx)
 
 	var h unifiedHandler
@@ -121,7 +127,7 @@ func newPeriodicGoroutine(ctx context.Context, name, description string, interva
 		name:        name,
 		description: description,
 		handler:     h,
-		interval:    interval,
+		getInterval: getInterval,
 		operation:   operation,
 		clock:       clock,
 		ctx:         ctx,
@@ -145,6 +151,7 @@ loop:
 		duration := time.Since(start)
 		if r.recorder != nil {
 			go r.recorder.LogRun(r, duration, err)
+			r.recorder.SaveKnownRoutine(r)
 		}
 
 		if shutdown {
@@ -154,7 +161,7 @@ loop:
 		}
 
 		select {
-		case <-r.clock.After(r.interval):
+		case <-r.clock.After(r.getInterval()):
 		case <-r.ctx.Done():
 			break loop
 		}
@@ -193,7 +200,7 @@ func (r *PeriodicGoroutine) Description() string {
 }
 
 func (r *PeriodicGoroutine) Interval() time.Duration {
-	return r.interval
+	return r.getInterval()
 }
 
 func (r *PeriodicGoroutine) JobName() string {

--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -20,13 +20,47 @@ func TestPeriodicGoroutine(t *testing.T) {
 		return nil
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", func() time.Duration { return time.Second }, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called
 	clock.BlockingAdvance(time.Second)
 	<-called
 	clock.BlockingAdvance(time.Second)
+	<-called
+	goroutine.Stop()
+
+	if calls := len(handler.HandleFunc.History()); calls != 4 {
+		t.Errorf("unexpected number of handler invocations. want=%d have=%d", 4, calls)
+	}
+}
+
+func TestPeriodicGoroutineWithDynamicInterval(t *testing.T) {
+	clock := glock.NewMockClock()
+	handler := NewMockHandler()
+	called := make(chan struct{}, 1)
+
+	handler.HandleFunc.SetDefaultHook(func(ctx context.Context) error {
+		called <- struct{}{}
+		return nil
+	})
+
+	seconds := 1
+
+	// intervals: 1 -> 2 -> 3 ...
+	getInterval := func() time.Duration {
+		duration := time.Duration(seconds) * time.Second
+		seconds += 1
+		return duration
+	}
+
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", getInterval, handler, nil, clock)
+	go goroutine.Start()
+	clock.BlockingAdvance(time.Second)
+	<-called
+	clock.BlockingAdvance(2 * time.Second)
+	<-called
+	clock.BlockingAdvance(3 * time.Second)
 	<-called
 	goroutine.Stop()
 
@@ -51,7 +85,7 @@ func TestPeriodicGoroutineError(t *testing.T) {
 		return err
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", func() time.Duration { return time.Second }, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called
@@ -81,7 +115,7 @@ func TestPeriodicGoroutineContextError(t *testing.T) {
 		return ctx.Err()
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", func() time.Duration { return time.Second }, handler, nil, clock)
 	go goroutine.Start()
 	<-called
 	goroutine.Stop()
@@ -105,7 +139,7 @@ func TestPeriodicGoroutineFinalizer(t *testing.T) {
 		return nil
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", func() time.Duration { return time.Second }, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called

--- a/internal/goroutine/recorder/recorder.go
+++ b/internal/goroutine/recorder/recorder.go
@@ -60,7 +60,7 @@ func (m *Recorder) RegistrationDone() {
 
 	// Save/update all known recordables
 	for _, r := range m.recordables {
-		m.saveKnownRoutine(r)
+		m.SaveKnownRoutine(r)
 	}
 }
 
@@ -93,8 +93,8 @@ func (m *Recorder) saveKnownHostName() {
 	}
 }
 
-// saveKnownRoutine updates the routine in Redis. Also adds it to the list of known recordables if it doesn’t exist.
-func (m *Recorder) saveKnownRoutine(recordable Recordable) {
+// SaveKnownRoutine updates the routine in Redis. Also adds it to the list of known recordables if it doesn’t exist.
+func (m *Recorder) SaveKnownRoutine(recordable Recordable) {
 	r := serializableRoutineInfo{
 		Name:        recordable.Name(),
 		Type:        recordable.Type(),

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2455,6 +2455,8 @@ type SiteConfiguration struct {
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
+	// PermissionsSyncJobCleanupInterval description: Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.
+	PermissionsSyncJobCleanupInterval int `json:"permissions.syncJobCleanupInterval,omitempty"`
 	// PermissionsSyncJobsHistorySize description: The number of last repo/user permission jobs to keep for history.
 	PermissionsSyncJobsHistorySize *int `json:"permissions.syncJobsHistorySize,omitempty"`
 	// PermissionsSyncOldestRepos description: Number of repo permissions to schedule for syncing in single scheduler iteration.
@@ -2612,6 +2614,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "organizationInvitations")
 	delete(m, "outboundRequestLogLimit")
 	delete(m, "parentSourcegraph")
+	delete(m, "permissions.syncJobCleanupInterval")
 	delete(m, "permissions.syncJobsHistorySize")
 	delete(m, "permissions.syncOldestRepos")
 	delete(m, "permissions.syncOldestUsers")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -959,6 +959,12 @@
       "minimum": 5,
       "!go": { "pointer": true }
     },
+    "permissions.syncJobCleanupInterval": {
+      "description": "Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.",
+      "type": "integer",
+      "default": 60,
+      "minimum": 1
+    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",


### PR DESCRIPTION
Make `periodicGoroutine` accept the `getInterval` func to enable having a dynamic interval. Use that to integrate the perm syncer jobs cleaner with site config.

https://www.loom.com/share/a57d0441ea0040c89648a04775c250d3

## Test plan
- update site config
- check for changes in cleaner schedule.
