### PR TITLE
experimental query input: Combine "add to query" and "go to" suggestions/actions

### DIFF
--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -93,15 +93,18 @@
     display: flex;
     font-family: var(--code-font-family);
     font-size: 0.75rem;
+
+    .separator {
+        color: var(--search-filter-keyword-color);
+    }
+}
+
+.filter-field {
     color: var(--search-filter-keyword-color);
     background-color: var(--oc-blue-0);
     // border: 1px solid var(--oc-blue-1);
     border-radius: 3px;
     padding: 0;
-
-    .separator {
-        color: var(--search-filter-keyword-color);
-    }
 }
 
 .icon {

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -76,12 +76,13 @@
                     font-family: var(--font-family-base);
                     display: flex;
 
-                    > * {
+                    > [role='gridcell'] {
                         padding: 0 0.5rem;
-                    }
-
-                    > * + * {
                         border-left: 1px solid var(--border-color);
+
+                        &:first-child {
+                            border-left: 0;
+                        }
                     }
                 }
             }

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -1,68 +1,89 @@
-.suggestions {
-    &[role='grid'] {
+.container {
+    overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .footer {
+        border-top: 1px solid var(--border-color);
+        padding: 0.5rem 1.25rem;
+        flex: 0 0 auto;
+        color: var(--text-muted);
+    }
+
+    .suggestions {
         overflow-y: auto;
-    }
 
-    ul {
-        margin: 0;
-        padding: 0;
-        list-style: none;
-    }
-
-    [role='rowgroup'] {
-        border-bottom: 1px solid var(--border-color);
-        padding: 0.75rem;
-
-        &:first-of-type {
-            padding-top: 0;
+        ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+            flex: 1;
         }
 
-        &:last-of-type {
-            border: none;
-        }
+        [role='rowgroup'] {
+            border-bottom: 1px solid var(--border-color);
+            padding: 0.75rem;
 
-        // group header
-        [role='presentation'] {
-            color: var(--text-muted);
-            font-size: 0.75rem;
-            font-weight: 500;
-            margin-bottom: 0.25rem;
-            padding: 0 0.5rem;
-        }
-
-        [role='row'] {
-            display: flex;
-            align-items: center;
-            padding: 0.25rem 0.5rem;
-            border-radius: var(--border-radius);
-            font-family: var(--code-font-family);
-            font-size: 0.75rem;
-            min-height: 1.5rem;
-
-            &[aria-selected='true'] {
-                background-color: var(--subtle-bg);
-                border-radius: 4px;
+            &:first-of-type {
+                padding-top: 0;
             }
 
-            &:hover {
-                background-color: var(--color-bg-2);
-                cursor: pointer;
+            &:last-of-type {
+                border: none;
             }
 
-            .match {
-                font-weight: bold;
-            }
-
-            .description {
-                margin-left: 0.5rem;
-                color: var(--input-placeholder-color);
-            }
-
-            .note {
-                font-size: 0.75rem;
-                margin-left: auto;
+            // group header
+            [role='presentation'] {
                 color: var(--text-muted);
-                font-family: var(--font-family-base);
+                font-size: 0.75rem;
+                font-weight: 500;
+                margin-bottom: 0.25rem;
+                padding: 0 0.5rem;
+            }
+
+            [role='row'] {
+                display: flex;
+                align-items: center;
+                padding: 0.25rem 0.5rem;
+                border-radius: var(--border-radius);
+                font-family: var(--code-font-family);
+                font-size: 0.75rem;
+                min-height: 1.5rem;
+
+                &[aria-selected='true'] {
+                    background-color: var(--subtle-bg);
+                    border-radius: 4px;
+                }
+
+                &:hover {
+                    background-color: var(--color-bg-2);
+                    cursor: pointer;
+                }
+
+                .match {
+                    font-weight: bold;
+                }
+
+                .description {
+                    margin-left: 0.5rem;
+                    color: var(--input-placeholder-color);
+                }
+
+                .note {
+                    font-size: 0.75rem;
+                    margin-left: auto;
+                    color: var(--text-muted);
+                    font-family: var(--font-family-base);
+                    display: flex;
+
+                    > * {
+                        padding: 0 0.5rem;
+                    }
+
+                    > * + * {
+                        border-left: 1px solid var(--border-color);
+                    }
+                }
             }
         }
     }

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -1,21 +1,23 @@
 import React, { MouseEvent, useMemo, useState, useCallback, useLayoutEffect } from 'react'
 
+import { mdiInformationOutline } from '@mdi/js'
+import classnames from 'classnames'
+
+import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { Icon, useWindowSize } from '@sourcegraph/wildcard'
 
-import { SyntaxHighlightedSearchQuery } from '../../components'
-
-import { Group, Option } from './suggestionsExtension'
+import { Action, Group, Option } from './suggestionsExtension'
 
 import styles from './Suggestions.module.scss'
 
-function getNote(option: Option): string {
-    switch (option.type) {
+function getActionName(action: Action): string {
+    switch (action.type) {
         case 'completion':
-            return 'Add'
-        case 'target':
-            return option.note ?? 'Jump to'
+            return action.name ?? 'Add'
+        case 'goto':
+            return action.name ?? 'Go to'
         case 'command':
-            return option.note ?? ''
+            return action.name ?? 'Run'
     }
 }
 
@@ -54,7 +56,9 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
         // This is using an arbitrary 20px "margin" between the suggestions box
         // and the window border
         () => (container ? `${windowHeight - container.getBoundingClientRect().top - 20}px` : 'auto'),
-        [container, windowHeight]
+        // Recompute height when suggestions change
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [container, windowHeight, results]
     )
     const flattenedRows = useMemo(() => results.flatMap(group => group.options), [results])
     const focusedItem = flattenedRows[activeRowIndex]
@@ -74,80 +78,114 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
         <div
             ref={setContainer}
             id={id}
-            className={styles.suggestions}
-            role="grid"
+            className={styles.container}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ maxHeight }}
-            onMouseDown={handleSelection}
-            tabIndex={-1}
         >
-            {results.map((group, groupIndex) =>
-                group.options.length > 0 ? (
-                    <ul role="rowgroup" key={group.title} aria-labelledby={`${id}-${groupIndex}-label`}>
-                        <li id={`${id}-${groupIndex}-label`} role="presentation">
-                            {group.title}
-                        </li>
-                        {group.options.map((option, rowIndex) => (
-                            <li
-                                role="row"
-                                key={rowIndex}
-                                id={`${id}-${groupIndex}x${rowIndex}`}
-                                aria-selected={focusedItem === option}
-                            >
-                                {option.icon && (
-                                    <div className="pr-1">
-                                        <Icon className={styles.icon} svgPath={option.icon} aria-hidden="true" />
-                                    </div>
-                                )}
-                                <div role="gridcell">
-                                    {option.render
-                                        ? option.render(option)
-                                        : option.matches
-                                        ? [...option.value].map((char, index) =>
-                                              option.matches!.has(index) ? (
-                                                  <span key={index} className={styles.match}>
-                                                      {char}
-                                                  </span>
-                                              ) : (
-                                                  char
-                                              )
-                                          )
-                                        : option.value}
-                                </div>
-                                {option.description && (
-                                    <div role="gridcell" className={styles.description}>
-                                        {option.description}
-                                    </div>
-                                )}
-                                <div role="gridcell" className={styles.note}>
-                                    {getNote(option)}
-                                </div>
+            <div className={styles.suggestions} role="grid" onMouseDown={handleSelection} tabIndex={-1}>
+                {results.map((group, groupIndex) =>
+                    group.options.length > 0 ? (
+                        <ul role="rowgroup" key={group.title} aria-labelledby={`${id}-${groupIndex}-label`}>
+                            <li id={`${id}-${groupIndex}-label`} role="presentation">
+                                {group.title}
                             </li>
-                        ))}
-                    </ul>
-                ) : null
-            )}
+                            {group.options.map((option, rowIndex) => (
+                                <li
+                                    role="row"
+                                    key={rowIndex}
+                                    id={`${id}-${groupIndex}x${rowIndex}`}
+                                    aria-selected={focusedItem === option}
+                                >
+                                    {option.icon && (
+                                        <div className="pr-1">
+                                            <Icon className={styles.icon} svgPath={option.icon} aria-hidden="true" />
+                                        </div>
+                                    )}
+                                    <div role="gridcell">
+                                        {option.render ? (
+                                            option.render(option)
+                                        ) : option.matches ? (
+                                            <HighlightedLabel label={option.label} matches={option.matches} />
+                                        ) : (
+                                            option.label
+                                        )}
+                                    </div>
+                                    {option.description && (
+                                        <div role="gridcell" className={styles.description}>
+                                            {option.description}
+                                        </div>
+                                    )}
+                                    <div className={styles.note}>
+                                        <div role="gridcell">{getActionName(option.action)}</div>
+                                        {option.alternativeAction && (
+                                            <div role="gridcell">{getActionName(option.alternativeAction)}</div>
+                                        )}
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : null
+                )}
+            </div>
+            {focusedItem && <Footer option={focusedItem} />}
         </div>
     )
 }
 
-export const FilterOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <span className={styles.filterOption}>
-        {option.matches
-            ? [...option.value].map((char, index) =>
-                  option.matches!.has(index) ? (
-                      <span key={index} className={styles.match}>
-                          {char}
-                      </span>
-                  ) : (
-                      char
-                  )
-              )
-            : option.value}
-        <span className={styles.separator}>:</span>
-    </span>
+const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
+    <div className={classnames(styles.footer, 'd-flex align-items-center justify-content-between')}>
+        <span>
+            {option.info?.(option)}
+            {!option.info && (
+                <>
+                    <ActionInfo action={option.action} shortcut="Return" />{' '}
+                    {option.alternativeAction && (
+                        <ActionInfo action={option.alternativeAction} shortcut="Shift+Return" />
+                    )}
+                </>
+            )}
+        </span>
+        <Icon className={styles.icon} svgPath={mdiInformationOutline} aria-hidden="true" />
+    </div>
 )
 
-export const QueryOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <SyntaxHighlightedSearchQuery query={option.value} />
+const ActionInfo: React.FunctionComponent<{ action: Action; shortcut: string }> = ({ action, shortcut }) => {
+    const displayName = shortcutDisplayName(shortcut)
+    switch (action.type) {
+        case 'completion':
+            return (
+                <>
+                    Press <kbd>{displayName}</kbd> to <strong>add</strong> to your query.
+                </>
+            )
+        case 'goto':
+            return (
+                <>
+                    Press <kbd>{displayName}</kbd> to <strong>go to</strong> the suggestion.
+                </>
+            )
+        case 'command':
+            return (
+                <>
+                    Press <kbd>{displayName}</kbd> to <strong>execute</strong> the command.
+                </>
+            )
+    }
+}
+
+export const HighlightedLabel: React.FunctionComponent<{ label: string; matches: Set<number> }> = ({
+    label,
+    matches,
+}) => (
+    <>
+        {[...label].map((char, index) =>
+            matches.has(index) ? (
+                <span key={index} className={styles.match}>
+                    {char}
+                </span>
+            ) : (
+                char
+            )
+        )}
+    </>
 )

--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -1,4 +1,12 @@
 export { LazyCodeMirrorQueryInput } from './LazyCodeMirrorQueryInput'
-export type { Group, Option, Completion, Target, Command, Source, SuggestionResult } from './suggestionsExtension'
+export type {
+    Group,
+    Option,
+    CompletionAction,
+    GoToAction,
+    CommandAction,
+    Source,
+    SuggestionResult,
+} from './suggestionsExtension'
 export { getEditorConfig } from './suggestionsExtension'
-export { FilterOption, QueryOption } from './Suggestions'
+export * from './optionRenderer'

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -1,3 +1,5 @@
+import classnames from 'classnames'
+
 import { SyntaxHighlightedSearchQuery } from '../../components'
 
 import { HighlightedLabel } from './Suggestions'
@@ -6,11 +8,28 @@ import { Option } from './suggestionsExtension'
 import styles from './Suggestions.module.scss'
 
 const FilterOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <span className={styles.filterOption}>
+    <span className={classnames(styles.filterOption, styles.filterField)}>
         {option.matches ? <HighlightedLabel label={option.label} matches={option.matches} /> : option.label}
         <span className={styles.separator}>:</span>
     </span>
 )
+
+const FilterValueOption: React.FunctionComponent<{ option: Option }> = ({ option }) => {
+    const label = option.label
+    const separatorIndex = label.indexOf(':')
+    const field = label.slice(0, separatorIndex)
+    const value = label.slice(separatorIndex + 1)
+
+    return (
+        <span className={styles.filterOption}>
+            <span className={styles.filterField}>
+                {option.matches ? <HighlightedLabel label={field} matches={option.matches} /> : option.label}
+                <span className={styles.separator}>:</span>
+            </span>
+            {option.matches ? <HighlightedLabel label={value} matches={option.matches} /> : option.label}
+        </span>
+    )
+}
 
 const QueryOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
     <SyntaxHighlightedSearchQuery query={option.label} />
@@ -18,6 +37,7 @@ const QueryOption: React.FunctionComponent<{ option: Option }> = ({ option }) =>
 
 // Custom renderer for filter suggestions
 export const filterRenderer = (option: Option): React.ReactElement => <FilterOption option={option} />
+export const filterValueRenderer = (option: Option): React.ReactElement => <FilterValueOption option={option} />
 // Custom renderer for (the current) query suggestions
 export const queryRenderer = (option: Option): React.ReactElement => <QueryOption option={option} />
 export const submitQueryInfo = (): React.ReactElement => (

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -1,0 +1,27 @@
+import { SyntaxHighlightedSearchQuery } from '../../components'
+
+import { HighlightedLabel } from './Suggestions'
+import { Option } from './suggestionsExtension'
+
+import styles from './Suggestions.module.scss'
+
+const FilterOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
+    <span className={styles.filterOption}>
+        {option.matches ? <HighlightedLabel label={option.label} matches={option.matches} /> : option.label}
+        <span className={styles.separator}>:</span>
+    </span>
+)
+
+const QueryOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
+    <SyntaxHighlightedSearchQuery query={option.label} />
+)
+
+// Custom renderer for filter suggestions
+export const filterRenderer = (option: Option): React.ReactElement => <FilterOption option={option} />
+// Custom renderer for (the current) query suggestions
+export const queryRenderer = (option: Option): React.ReactElement => <QueryOption option={option} />
+export const submitQueryInfo = (): React.ReactElement => (
+    <>
+        Press <kbd>Return</kbd> to submit your query.
+    </>
+)

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -51,41 +51,62 @@ export interface SuggestionResult {
 
 export type CustomRenderer = (option: Option) => React.ReactElement
 
-export interface Command {
+export interface Option {
+    /**
+     * The label the input is matched against and shown in the UI.
+     */
+    label: string
+    /**
+     * What to do when this option is applied (via Enter)
+     */
+    action: Action
+    /**
+     * Options can have perform an alternative action when applied via
+     * Shift+Enter.
+     */
+    alternativeAction?: Action
+    /**
+     * A short description of the option, shown next to the label.
+     */
+    description?: string
+    /**
+     * The SVG path of the icon to use for this option.
+     */
+    icon?: string
+    /**
+     * If present the provided component will be used to render the label of the
+     * option.
+     */
+    render?: CustomRenderer
+    /**
+     * If present this component is rendered as footer.
+     */
+    info?: CustomRenderer
+    /**
+     * A set of character indexes. If provided the characters of at these
+     * positions in the label will be highlighted as matches.
+     */
+    matches?: Set<number>
+}
+
+export interface CommandAction {
     type: 'command'
-    value: string
     apply: (view: EditorView) => void
-    matches?: Set<number>
-    // svg path
-    icon?: string
-    render?: CustomRenderer
-    description?: string
-    note?: string
+    name?: string
 }
-export interface Target {
-    type: 'target'
-    value: string
+export interface GoToAction {
+    type: 'goto'
     url: string
-    matches?: Set<number>
-    // svg path
-    icon?: string
-    render?: CustomRenderer
-    description?: string
-    note?: string
+    name?: string
 }
-export interface Completion {
+export interface CompletionAction {
     type: 'completion'
     from: number
+    name?: string
     to?: number
-    value: string
     insertValue?: string
-    matches?: Set<number>
-    // svg path
-    icon?: string
-    render?: CustomRenderer
-    description?: string
 }
-export type Option = Command | Target | Completion
+export type Action = CommandAction | GoToAction | CompletionAction
 
 export interface Group {
     title: string
@@ -97,7 +118,7 @@ class SuggestionView {
     private root: Root
 
     private onSelect = (option: Option): void => {
-        applyOption(this.view, option)
+        applyAction(this.view, option.action, option)
         // Query input looses focus when option is selected via
         // mousedown/click. This is a necessary hack to re-focus the query
         // input.
@@ -452,21 +473,21 @@ function moveSelection(direction: 'forward' | 'backward'): CodeMirrorCommand {
     }
 }
 
-function applyOption(view: EditorView, option: Option): void {
-    switch (option.type) {
+function applyAction(view: EditorView, action: Action, option: Option): void {
+    switch (action.type) {
         case 'completion':
             {
-                const text = option.insertValue ?? option.value
+                const text = action.insertValue ?? option.label
                 view.dispatch({
                     ...view.state.changeByRange(range => {
                         if (range === view.state.selection.main) {
                             return {
                                 changes: {
-                                    from: option.from,
-                                    to: option.to ?? view.state.selection.main.head,
+                                    from: action.from,
+                                    to: action.to ?? view.state.selection.main.head,
                                     insert: text,
                                 },
-                                range: EditorSelection.cursor(option.from + text.length),
+                                range: EditorSelection.cursor(action.from + text.length),
                             }
                         }
                         return { range }
@@ -475,14 +496,14 @@ function applyOption(view: EditorView, option: Option): void {
             }
             break
         case 'command':
-            option.apply(view)
+            action.apply(view)
             break
-        case 'target':
+        case 'goto':
             {
                 const history = view.state.facet(suggestionsConfig).history
 
                 if (history) {
-                    history.push(option.url)
+                    history.push(action.url)
                 }
             }
             break
@@ -530,19 +551,16 @@ export const suggestionSource = Facet.define<Source, Source>({
                         if (!state.open || !option) {
                             return false
                         }
-                        applyOption(view, option)
+                        applyAction(view, option.action, option)
                         return true
                     },
-                },
-                {
-                    key: 'Tab',
-                    run(view) {
+                    shift(view) {
                         const state = view.state.field(suggestionsStateField)
                         const option = state.result.at(state.selectedOption)
-                        if (!state.open || !option) {
+                        if (!state.open || !option || !option.alternativeAction) {
                             return false
                         }
-                        applyOption(view, option)
+                        applyAction(view, option.alternativeAction, option)
                         return true
                     },
                 },

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -14,6 +14,7 @@ import {
     submitQueryInfo,
     queryRenderer,
     filterRenderer,
+    filterValueRenderer,
 } from '@sourcegraph/branded/src/search-ui/experimental'
 import { getParsedQuery } from '@sourcegraph/branded/src/search-ui/input/codemirror/parsedQuery'
 import { isDefined } from '@sourcegraph/common'
@@ -126,7 +127,7 @@ function toRepoSuggestion(result: FzfResultItem<Repo>, from: number, to?: number
         type: 'goto',
         url: `/${result.item.name}`,
     }
-    option.render = queryRenderer
+    option.render = filterValueRenderer
     return option
 }
 
@@ -233,7 +234,7 @@ function toFileSuggestion(result: FzfResultItem<File>, from: number, to?: number
         type: 'goto',
         url: result.item.url,
     }
-    option.render = queryRenderer
+    option.render = filterValueRenderer
     return option
 }
 

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { EditorState } from '@codemirror/state'
 import { mdiFilterOutline, mdiTextSearchVariant, mdiSourceRepository, mdiStar, mdiFileOutline } from '@mdi/js'
 import { extendedMatch, Fzf, FzfOptions, FzfResultItem } from 'fzf'
@@ -10,13 +8,12 @@ import { tokenAt, tokens as queryTokens } from '@sourcegraph/branded'
 import {
     Group,
     Option,
-    Target,
-    Completion,
     Source,
-    FilterOption,
-    QueryOption,
     getEditorConfig,
     SuggestionResult,
+    submitQueryInfo,
+    queryRenderer,
+    filterRenderer,
 } from '@sourcegraph/branded/src/search-ui/experimental'
 import { getParsedQuery } from '@sourcegraph/branded/src/search-ui/input/codemirror/parsedQuery'
 import { isDefined } from '@sourcegraph/common'
@@ -51,11 +48,6 @@ type InternalSource<T extends Token | undefined = Token | undefined> = (params: 
 }) => SuggestionResult | null
 
 const none: any[] = []
-
-// Custom renderer for filter suggestions
-const filterRenderer = (option: Option): React.ReactElement => React.createElement(FilterOption, { option })
-// Custom renderer for (the current) query suggestions
-const queryRenderer = (option: Option): React.ReactElement => React.createElement(QueryOption, { option })
 
 function starTiebraker(a: { item: { stars: number } }, b: { item: { stars: number } }): number {
     return b.item.stars - a.item.stars
@@ -125,37 +117,45 @@ interface File {
 }
 
 /**
- * Converts a Repo value to a (jump) target suggestion.
+ * Converts a Repo value to a suggestion.
  */
-function toRepoTarget({ item, positions }: FzfResultItem<Repo>): Target {
-    return {
-        type: 'target',
-        icon: mdiSourceRepository,
-        value: item.name,
-        url: `/${item.name}`,
-        matches: positions,
+function toRepoSuggestion(result: FzfResultItem<Repo>, from: number, to?: number): Option {
+    const option = toRepoCompletion(result, from, to, 'repo:')
+    option.action.name = 'Add'
+    option.alternativeAction = {
+        type: 'goto',
+        url: `/${result.item.name}`,
     }
+    option.render = queryRenderer
+    return option
 }
 
 /**
  * Converts a Repo value to a completion suggestion.
  */
-function toRepoCompletion({ item, positions }: FzfResultItem<Repo>, from: number, to?: number): Completion {
+function toRepoCompletion(
+    { item, positions }: FzfResultItem<Repo>,
+    from: number,
+    to?: number,
+    valuePrefix = ''
+): Option {
     return {
-        type: 'completion',
-        icon: mdiSourceRepository,
-        value: item.name,
-        insertValue: regexInsertText(item.name, { globbing: false }) + ' ',
+        label: valuePrefix + item.name,
         matches: positions,
-        from,
-        to,
+        icon: mdiSourceRepository,
+        action: {
+            type: 'completion',
+            insertValue: valuePrefix + regexInsertText(item.name, { globbing: false }) + ' ',
+            from,
+            to,
+        },
     }
 }
 
 /**
  * Converts a Context value to a completion suggestion.
  */
-function toContextCompletion({ item, positions }: FzfResultItem<Context>, from: number, to?: number): Completion {
+function toContextCompletion({ item, positions }: FzfResultItem<Context>, from: number, to?: number): Option {
     let description = item.default ? 'Default' : ''
     if (item.description) {
         if (item.default) {
@@ -165,65 +165,76 @@ function toContextCompletion({ item, positions }: FzfResultItem<Context>, from: 
     }
 
     return {
-        type: 'completion',
+        label: item.spec,
         // Passing an empty string is a hack to draw an "empty" icon
         icon: item.starred ? mdiStar : ' ',
-        value: item.spec,
-        insertValue: item.spec + ' ',
         description,
         matches: positions,
-        from,
-        to,
+        action: {
+            type: 'completion',
+            insertValue: item.spec + ' ',
+            from,
+            to,
+        },
     }
 }
 
 /**
  * Converts a filter to a completion suggestion.
  */
-function toFilterCompletion(filter: FilterType, from: number, to?: number): Completion {
+function toFilterCompletion(filter: FilterType, from: number, to?: number): Option {
     const definition = FILTERS[filter]
     const description =
         typeof definition.description === 'function' ? definition.description(false) : definition.description
     return {
-        type: 'completion',
+        label: filter,
         icon: mdiFilterOutline,
         render: filterRenderer,
-        value: filter,
-        insertValue: filter + ':',
         description,
-        from,
-        to,
+        action: {
+            type: 'completion',
+            insertValue: filter + ':',
+            from,
+            to,
+        },
     }
 }
 
 /**
  * Converts a File value to a completion suggestion.
  */
-function toFileCompletion({ item, positions }: FzfResultItem<File>, from: number, to?: number): Completion {
+function toFileCompletion(
+    { item, positions }: FzfResultItem<File>,
+    from: number,
+    to?: number,
+    valuePrefix = ''
+): Option {
     return {
-        type: 'completion',
+        label: valuePrefix + item.path,
         icon: mdiFileOutline,
-        value: item.path,
-        insertValue: regexInsertText(item.path, { globbing: false }) + ' ',
         description: item.repository,
         matches: positions,
-        from,
-        to,
+        action: {
+            type: 'completion',
+            insertValue: valuePrefix + regexInsertText(item.path, { globbing: false }) + ' ',
+            from,
+            to,
+        },
     }
 }
 
 /**
  * Converts a File value to a (jump) target suggestion.
  */
-function toFileTarget({ item, positions }: FzfResultItem<File>): Target {
-    return {
-        type: 'target',
-        icon: mdiFileOutline,
-        value: item.path,
-        description: item.repository,
-        url: item.url,
-        matches: positions,
+function toFileSuggestion(result: FzfResultItem<File>, from: number, to?: number): Option {
+    const option = toFileCompletion(result, from, to, 'file:')
+    option.action.name = 'Add'
+    option.alternativeAction = {
+        type: 'goto',
+        url: result.item.url,
     }
+    option.render = queryRenderer
+    return option
 }
 
 /**
@@ -235,19 +246,19 @@ const currentQuery: InternalSource = ({ token, input }) => {
         return null
     }
 
-    let value = input
-    let note = 'Search everywhere'
+    let label = input
+    let actionName = 'Search everywhere'
 
     const contextFilter = findFilter(input, FilterType.context, FilterKind.Global)
 
     if (contextFilter) {
-        value = omitFilter(input, contextFilter)
+        label = omitFilter(input, contextFilter)
         if (contextFilter.value?.value !== 'global') {
-            note = `Search '${contextFilter.value?.value ?? ''}'`
+            actionName = `Search '${contextFilter.value?.value ?? ''}'`
         }
     }
 
-    if (value.trim() === '') {
+    if (label.trim() === '') {
         return null
     }
 
@@ -257,14 +268,17 @@ const currentQuery: InternalSource = ({ token, input }) => {
                 title: '',
                 options: [
                     {
-                        type: 'command',
                         icon: mdiTextSearchVariant,
-                        value,
-                        note,
-                        apply: view => {
-                            getEditorConfig(view.state).onSubmit()
+                        label,
+                        action: {
+                            type: 'command',
+                            name: actionName,
+                            apply: view => {
+                                getEditorConfig(view.state).onSubmit()
+                            },
                         },
                         render: queryRenderer,
+                        info: submitQueryInfo,
                     },
                 ],
             },
@@ -318,6 +332,21 @@ const filterSuggestions: InternalSource = ({ tokens, token, position }) => {
     }
 
     return options.length > 0 ? { result: [{ title: 'Narrow your search', options }] } : null
+}
+
+const contextActions: Group = {
+    title: 'Actions',
+    options: [
+        {
+            label: 'Manage contexts',
+            description: 'Add, edit, remove search contexts',
+            action: {
+                type: 'goto',
+                name: 'Go to /contexts',
+                url: '/contexts',
+            },
+        },
+    ],
 }
 
 /**
@@ -377,18 +406,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                                     title: 'Search contexts',
                                     options: entries.map(entry => toContextCompletion(entry, from, to)),
                                 },
-                                {
-                                    title: 'Actions',
-                                    options: [
-                                        {
-                                            type: 'target',
-                                            value: 'Manage contexts',
-                                            description: 'Add, edit, remove search contexts',
-                                            note: 'Got to /contexts',
-                                            url: '/contexts',
-                                        },
-                                    ],
-                                },
+                                contextActions,
                             ]
                         })
                     default: {
@@ -412,16 +430,18 @@ function staticFilterValueSuggestions(token?: Token): Group | null {
     }
 
     const value = token.value
-    let options: Completion[] = resolvedFilter.definition.discreteValues(token.value, false).map(value => ({
-        type: 'completion',
-        from: token.value?.range.start ?? token.range.end,
-        to: token.value?.range.end,
-        value: value.label,
-        insertValue: (value.insertText ?? value.label) + ' ',
+    let options: Option[] = resolvedFilter.definition.discreteValues(token.value, false).map(value => ({
+        label: value.label,
+        action: {
+            type: 'completion',
+            from: token.value?.range.start ?? token.range.end,
+            to: token.value?.range.end,
+            insertValue: (value.insertText ?? value.label) + ' ',
+        },
     }))
 
     if (value && value.value !== '') {
-        const fzf = new Fzf(options, { selector: option => option.value })
+        const fzf = new Fzf(options, { selector: option => option.label })
         options = fzf.find(value.value).map(match => ({ ...match.item, matches: match.positions }))
     }
 
@@ -446,7 +466,7 @@ function repoSuggestions(cache: Caches['repo']): InternalSource {
             results => [
                 {
                     title: 'Repositories',
-                    options: results.slice(0, 5).map(toRepoTarget),
+                    options: results.slice(0, 5).map(result => toRepoSuggestion(result, token.range.start)),
                 },
             ],
             parsedQuery,
@@ -484,7 +504,7 @@ function fileSuggestions(cache: Caches['file'], isSourcegraphDotCom?: boolean): 
             results => [
                 {
                     title: 'Files',
-                    options: results.slice(0, 5).map(toFileTarget),
+                    options: results.slice(0, 5).map(result => toFileSuggestion(result, token.range.start)),
                 },
             ],
             parsedQuery,


### PR DESCRIPTION
With this commit every suggestion can have two "actions": Return applies the first/default action, Shift+Return applies the alternative action. This allows us to use, for example, repository suggestions for add the `repo:` filter + value or to directly navigate to the repository.

Additionally we show an "info" footer to let the user know how they can activate each suggestion. A default info text is created for every action but options can also overwrite the content.

**Note:** In this iteration we only support selecting either action via the keyboard. Using the mouse will always apply the first action.


https://user-images.githubusercontent.com/179026/214855513-7ab9925a-3e1b-489c-b659-2af5f3df7813.mp4




## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-experimental-combined.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
