### PR TITLE
Various treeview fixes

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -140,7 +140,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
     const onLoadData = useCallback(
         async ({ element }: { element: TreeNode }) => {
             const fullPath = element.path
-            const alreadyLoaded = element.children?.length > 0 || treeData?.loadedIds.has(fullPath)
+            const alreadyLoaded = element.children?.length > 0 || treeData?.loadedIds.has(element.id)
             if (alreadyLoaded || !element.isBranch) {
                 return
             }

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -140,7 +140,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
     const onLoadData = useCallback(
         async ({ element }: { element: TreeNode }) => {
             const fullPath = element.path
-            const alreadyLoaded = element.children?.length > 0 || treeData?.loadedPaths.has(fullPath)
+            const alreadyLoaded = element.children?.length > 0 || treeData?.loadedIds.has(fullPath)
             if (alreadyLoaded || !element.isBranch) {
                 return
             }
@@ -154,7 +154,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             setTreeData(treeData => setLoadedPath(treeData!, fullPath))
         },
-        [defaultVariables, refetch, treeData?.loadedPaths, telemetryService]
+        [defaultVariables, refetch, treeData?.loadedIds, telemetryService]
     )
 
     const defaultSelectFiredRef = useRef<boolean>(false)
@@ -233,23 +233,21 @@ function renderNode({
 
     if (dotdot) {
         return (
-            <>
+            <Link
+                {...props}
+                to={dotdot}
+                onClick={event => {
+                    event.preventDefault()
+                    handleSelect(event)
+                }}
+            >
                 <Icon
                     svgPath={mdiFolderOutline}
                     className={classNames('mr-1', styles.icon)}
                     aria-label="Load parent directory"
                 />
-                <Link
-                    to={dotdot}
-                    tabIndex={-1}
-                    onClick={event => {
-                        event.preventDefault()
-                        handleSelect(event)
-                    }}
-                >
-                    ..
-                </Link>
-            </>
+                ..
+            </Link>
         )
     }
 
@@ -325,9 +323,9 @@ interface TreeData {
     // A map to quickly find the number ID for a node by its path
     pathToId: Map<string, number>
 
-    // A set for paths that have been loaded. We can not rely on children.length
-    // because a directory can have no children.
-    loadedPaths: Set<string>
+    // A set for node IDs that have been loaded. We can not rely on
+    // children.length because a directory can have no children.
+    loadedIds: Set<number>
 
     // The current path of the root node. An empty string for the root of the
     // tree.
@@ -338,7 +336,7 @@ function createTreeData(root: string): TreeData {
     return {
         nodes: [],
         pathToId: new Map(),
-        loadedPaths: new Set(),
+        loadedIds: new Set(),
         rootPath: root,
     }
 }
@@ -469,8 +467,12 @@ function appendNode(tree: TreeData, node: TreeNode): void {
 }
 
 function setLoadedPath(tree: TreeData, path: string): TreeData {
-    tree = { ...tree, loadedPaths: new Set(tree.loadedPaths) }
-    tree.loadedPaths.add(path)
+    tree = { ...tree, loadedIds: new Set(tree.loadedIds) }
+    const id = tree.pathToId.get(path)
+    if (!id) {
+        throw new Error(`Node ${id} is not in the tree`)
+    }
+    tree.loadedIds.add(id)
     return tree
 }
 


### PR DESCRIPTION
Part of #12916 

This include a few treeview fixes:

- Stuff that @vovakulikov mentioned in here: https://github.com/sourcegraph/sourcegraph/pull/46962#pullrequestreview-1270300990
- UI fixes to the `..` folder when opening in directories (I've not been testing this properly in my previous PR)

## Test plan

- tested locally
- CI is green

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
