### PR TITLE
gRPC: add panic handling interceptors

### DIFF
--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -194,7 +194,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	grpcServer := grpc.NewServer(grpcdefaults.ServerOptions()...)
+	grpcServer := grpc.NewServer(grpcdefaults.ServerOptions(logger)...)
 	reflection.Register(grpcServer)
 	grpcServer.RegisterService(&proto.Searcher_ServiceDesc, &search.Server{
 		Service: service,

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -97,7 +97,7 @@ func NewHandler(
 
 	// Initialize the gRPC server
 	grpcServer := grpc.NewServer(
-		defaults.ServerOptions()...,
+		defaults.ServerOptions(rootLogger)...,
 	)
 	grpcServer.RegisterService(&proto.Symbols_ServiceDesc, &grpcService{
 		searchFunc:   searchFuncWrapper,

--- a/internal/grpc/panics.go
+++ b/internal/grpc/panics.go
@@ -1,0 +1,49 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newPanicErr(val any) error {
+	return status.Errorf(codes.Internal, "panic during execution: %v", val)
+}
+
+func NewStreamPanicCatcher(logger log.Logger) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		defer func() {
+			if val := recover(); val != nil {
+				err = newPanicErr(val)
+				logger.Error(
+					"caught panic",
+					log.String("method", info.FullMethod),
+					log.Error(err),
+				)
+			}
+		}()
+
+		return handler(srv, ss)
+	}
+}
+
+func NewUnaryPanicCatcher(logger log.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		defer func() {
+			if val := recover(); val != nil {
+				err = newPanicErr(val)
+				logger.Error(
+					"caught panic",
+					log.String("method", info.FullMethod),
+					log.Error(err),
+				)
+			}
+		}()
+
+		return handler(ctx, req)
+	}
+}

--- a/internal/grpc/panics_test.go
+++ b/internal/grpc/panics_test.go
@@ -20,7 +20,7 @@ func TestStreamPanicCatcher(t *testing.T) {
 		nil,
 		nil,
 		&grpc.StreamServerInfo{FullMethod: "testmethod"},
-		func(srv interface{}, ss grpc.ServerStream) error {
+		func(_ interface{}, _ grpc.ServerStream) error {
 			panic("ouch")
 		},
 	)

--- a/internal/grpc/panics_test.go
+++ b/internal/grpc/panics_test.go
@@ -1,0 +1,53 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStreamPanicCatcher(t *testing.T) {
+	logger, getLogs := logtest.Captured(t)
+
+	streamInterceptor := NewStreamPanicCatcher(logger)
+	err := streamInterceptor(
+		nil,
+		nil,
+		&grpc.StreamServerInfo{FullMethod: "testmethod"},
+		func(srv interface{}, ss grpc.ServerStream) error {
+			panic("ouch")
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	logs := getLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, log.LevelError, logs[0].Level)
+}
+
+func TestUnaryPanicCatcher(t *testing.T) {
+	logger, getLogs := logtest.Captured(t)
+
+	unaryInterceptor := NewUnaryPanicCatcher(logger)
+	_, err := unaryInterceptor(
+		nil,
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: "testmethod"},
+		func(_ context.Context, _ interface{}) (interface{}, error) {
+			panic("ouch")
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	logs := getLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, log.LevelError, logs[0].Level)
+}


### PR DESCRIPTION
Most of our HTTP APIs add a top-level panic handler so that we don't crash the process when a request panics. Symbols is no exception. However, when we switched to the gRPC implementation, that wasn't implemented, so an existing panic caused symbols to start crashing. 

This adds an interceptor to the default set of gRPC options that logs the error and makes the RPC return an internal error with some details.

## Test plan

Added unit tests. Manually tested to ensure that it fixes the issue with the existing panic crashing symbols.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
