### PR TITLE
cli: add deploy-sourcegraph-k8s to release

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -574,6 +574,16 @@ cc @${config.captainGitHubUsername}
                     },
                     {
                         owner: 'sourcegraph',
+                        repo: 'deploy-sourcegraph-k8s',
+                        base: `${release.major}.${release.minor}`,
+                        head: `publish-${release.version}`,
+                        commitMessage: defaultPRMessage,
+                        title: defaultPRMessage,
+                        edits: [`sg ops update-images -pin-tag ${release.version} base/`],
+                        ...prBodyAndDraftState([]),
+                    },
+                    {
+                        owner: 'sourcegraph',
                         repo: 'deploy-sourcegraph-docker',
                         base: `${release.major}.${release.minor}`,
                         head: `publish-${release.version}`,


### PR DESCRIPTION
Add [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s/), the repo that hosts the new default k8s base cluster, to the current release pipeline

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Confirmed that running `sg ops update-images -kind k8s -t $VERSION_NUMBER base/` locally updated all the images within the repo.

## App preview:

- [Web](https://sg-web-bee-deploy-k8s-cli.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
