### PR TITLE
search: use exp/slices.Sort* in a few places

### DIFF
--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -3,11 +3,11 @@ package backend
 import (
 	"bytes"
 	"encoding/json"
-	"sort"
 
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/zoekt"
+	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -188,13 +188,12 @@ func getIndexOptions(
 		})
 	}
 
-	sort.Slice(o.Branches, func(i, j int) bool {
-		a, b := o.Branches[i].Name, o.Branches[j].Name
+	slices.SortFunc(o.Branches, func(a, b zoekt.RepositoryBranch) bool {
 		// Zoekt treats first branch as default branch, so put HEAD first
-		if a == "HEAD" || b == "HEAD" {
-			return a == "HEAD"
+		if a.Name == "HEAD" || b.Name == "HEAD" {
+			return a.Name == "HEAD"
 		}
-		return a < b
+		return a.Name < b.Name
 	})
 
 	// If the first branch is not HEAD, do not index anything. This should

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -3,12 +3,12 @@ package jobutil
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/grafana/regexp"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -209,8 +209,8 @@ func (j *fileContainsFilterJob) filterCommitMatch(ctx context.Context, searcherU
 
 func (j *fileContainsFilterJob) removeUnmatchedFileDiffs(cm *result.CommitMatch, matchedFileCounts map[string]int) result.Match {
 	// Ensure the matched ranges are sorted by start offset
-	sort.Slice(cm.DiffPreview.MatchedRanges, func(i, j int) bool {
-		return cm.DiffPreview.MatchedRanges[i].Start.Offset < cm.DiffPreview.MatchedRanges[j].End.Offset
+	slices.SortFunc(cm.DiffPreview.MatchedRanges, func(a, b result.Range) bool {
+		return a.Start.Offset < b.End.Offset
 	})
 
 	// Convert each file diff to a string so we know how much we are removing if we drop that file

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
-	"sort"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	zoektquery "github.com/sourcegraph/zoekt/query"
@@ -1284,7 +1284,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	for i, match := range matches {
 		matchKeys[i] = match.Key()
 	}
-	sort.Slice(matchKeys, func(i, j int) bool { return matchKeys[i].Less(matchKeys[j]) })
+	slices.SortFunc(matchKeys, result.Key.Less)
 
 	wantResultKeys := []result.Key{
 		{Repo: "foo", Commit: "branch3", Path: "main.go"},

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -901,7 +902,7 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 				matched = append(matched, rev)
 			}
 		}
-		sort.Slice(matched, func(i, j int) bool { return matched[i].Less(matched[j]) })
+		slices.SortFunc(matched, query.RevisionSpecifier.Less)
 		return
 	}
 
@@ -910,7 +911,7 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 		clashing = append(clashing, rev)
 	}
 	// ensure that lists are always returned in sorted order.
-	sort.Slice(clashing, func(i, j int) bool { return clashing[i].Less(clashing[j]) })
+	slices.SortFunc(matched, query.RevisionSpecifier.Less)
 	return
 }
 

--- a/internal/search/streaming/client/progress.go
+++ b/internal/search/streaming/client/progress.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"sort"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	sgapi "github.com/sourcegraph/sourcegraph/internal/api"
 	searchshared "github.com/sourcegraph/sourcegraph/internal/search"
@@ -103,9 +104,7 @@ func getRepos(stats streaming.Stats, status searchshared.RepoStatus) []sgapi.Rep
 	})
 	// Filter runs in a random order (map traversal), so we should sort to
 	// give deterministic messages between updates.
-	sort.Slice(repos, func(i, j int) bool {
-		return repos[i] < repos[j]
-	})
+	slices.Sort(repos)
 	return repos
 }
 

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -1,10 +1,10 @@
 package zoekt
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/hexops/autogold"
+	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -159,17 +159,17 @@ func queryEqual(a, b zoekt.Q) bool {
 	sortChildren := func(q zoekt.Q) zoekt.Q {
 		switch s := q.(type) {
 		case *zoekt.And:
-			sort.Slice(s.Children, func(i, j int) bool {
-				return s.Children[i].String() < s.Children[j].String()
-			})
+			slices.SortFunc(s.Children, zoektQStringLess)
 		case *zoekt.Or:
-			sort.Slice(s.Children, func(i, j int) bool {
-				return s.Children[i].String() < s.Children[j].String()
-			})
+			slices.SortFunc(s.Children, zoektQStringLess)
 		}
 		return q
 	}
 	return zoekt.Map(a, sortChildren).String() == zoekt.Map(b, sortChildren).String()
+}
+
+func zoektQStringLess(a, b zoekt.Q) bool {
+	return a.String() < b.String()
 }
 
 func computeResultTypes(types []string, b query.Basic, searchType query.SearchType) result.Types {


### PR DESCRIPTION
This makes the callsites easier to read. Additionally I quite like the pattern were you can pass in our Less functions, but by accessing them via the struct type instead of the instance.

This was done purely to see what the new API is like.

Test Plan: go test
