### PR TITLE
Add note about kubectl-apply-all.sh script

### DIFF
--- a/doc/admin/deploy/kubernetes/update.md
+++ b/doc/admin/deploy/kubernetes/update.md
@@ -36,6 +36,9 @@ Then, deploy the updated version of Sourcegraph to your Kubernetes cluster:
 ./kubectl-apply-all.sh
 ```
 
+> NOTE: By default, this script applies our base manifests using [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply) with a variety of arguments specific to the [reference repository](./index.md#reference-repository)'s layout.
+> If you have specific commands that should be run whenever you apply your manifests, you should modify this script as needed. For example, if you use [overlays to make changes to the manifests](./configure.md#overlays), you should modify this script to apply your generated cluster instead.
+
 Monitor the status of the deployment to determine its success.
 
 ```bash


### PR DESCRIPTION
Added the note about modifying the kubectl-apply-all.sh script if you are using an overlay to prevent applying the base manifests.

## Test plan
Doc update.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
