### PR TITLE
sg: implement buf format linter

### DIFF
--- a/dev/sg/buf/buf.go
+++ b/dev/sg/buf/buf.go
@@ -1,0 +1,55 @@
+// Package buf defines shared functionality and utilities for the buf cli.
+package buf
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var dependencies = []dependency{
+	"github.com/bufbuild/buf/cmd/buf@v1.11.0",
+	"github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1",
+	"google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1",
+}
+
+// InstallDependencies installs the dependencies required to run the buf cli.
+func InstallDependencies(ctx context.Context, out *std.Output) error {
+	rootDir, err := root.RepositoryRoot()
+	if err != nil {
+		return errors.Wrap(err, "finding repository root")
+	}
+
+	gobin := filepath.Join(rootDir, ".bin")
+
+	for _, d := range dependencies {
+		if err := d.install(ctx, gobin, out); err != nil {
+			return errors.Wrapf(err, "installing dependency %q", d)
+		}
+	}
+
+	return nil
+}
+
+type dependency string
+
+func (d dependency) String() string { return string(d) }
+
+func (d dependency) install(ctx context.Context, gobin string, out *std.Output) error {
+	err := run.Cmd(ctx, "go", "install", d.String()).
+		Environ(os.Environ()).
+		Env(map[string]string{
+			"GOBIN": gobin,
+		}).
+		Run().
+		StreamLines(out.Verbose)
+	if err != nil {
+		return errors.Wrapf(err, "go install %s returned an error", d)
+	}
+	return nil
+}

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -51,5 +51,5 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
-	return proto.Generate(ctx)
+	return proto.Generate(ctx, verbose)
 }

--- a/dev/sg/internal/generate/proto/proto.go
+++ b/dev/sg/internal/generate/proto/proto.go
@@ -84,12 +84,19 @@ func Generate(ctx context.Context, verboseOutput bool) *generate.Report {
 
 func FindGeneratedFiles(dir string) ([]string, error) {
 	var paths []string
-	err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		if strings.HasSuffix(path, ".pb.go") {
+
+	err := filepath.WalkDir(dir, root.SkipGitIgnoreWalkFunc(func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !entry.IsDir() && strings.HasSuffix(path, ".pb.go") {
 			paths = append(paths, path)
 		}
+
 		return nil
-	})
+	}))
+
 	return paths, err
 }
 

--- a/dev/sg/internal/generate/proto/proto.go
+++ b/dev/sg/internal/generate/proto/proto.go
@@ -64,9 +64,13 @@ func Generate(ctx context.Context, verboseOutput bool) *generate.Report {
 	gobin := filepath.Join(rootDir, ".bin")
 	for _, p := range bufGenFilePaths {
 		dir := filepath.Dir(p)
-		os.Chdir(dir)
+		err := os.Chdir(dir)
+		if err != nil {
+			err = errors.Wrapf(err, "changing directory to %q", dir)
+			return &generate.Report{Err: err}
+		}
 
-		err := runBufGenerate(ctx, gobin, &sb)
+		err = runBufGenerate(ctx, gobin, &sb)
 		if err != nil {
 			return &generate.Report{Output: sb.String(), Err: err}
 		}

--- a/dev/sg/internal/generate/proto/proto.go
+++ b/dev/sg/internal/generate/proto/proto.go
@@ -10,19 +10,15 @@ import (
 	"time"
 
 	"github.com/sourcegraph/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var dependencies = []dependency{
-	"github.com/bufbuild/buf/cmd/buf@v1.11.0",
-	"github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1",
-	"google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1",
-}
-
-func Generate(ctx context.Context) *generate.Report {
+func Generate(ctx context.Context, verboseOutput bool) *generate.Report {
 	// Save working directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -41,13 +37,11 @@ func Generate(ctx context.Context) *generate.Report {
 	if err != nil {
 		return &generate.Report{Err: err}
 	}
-	gobin := filepath.Join(rootDir, ".bin")
 
-	// Install dependencies into $ROOT/.bin
-	for _, d := range dependencies {
-		if err := d.install(ctx, gobin, &sb); err != nil {
-			return &generate.Report{Err: err}
-		}
+	output := std.NewOutput(&sb, verboseOutput)
+	err = buf.InstallDependencies(ctx, output)
+	if err != nil {
+		return &generate.Report{Output: sb.String(), Err: err}
 	}
 
 	// Run buf generate in every directory with buf.gen.yaml
@@ -66,11 +60,15 @@ func Generate(ctx context.Context) *generate.Report {
 	if err != nil {
 		return &generate.Report{Err: err}
 	}
+
+	gobin := filepath.Join(rootDir, ".bin")
 	for _, p := range bufGenFilePaths {
 		dir := filepath.Dir(p)
 		os.Chdir(dir)
-		if err := runBufGenerate(ctx, gobin, &sb); err != nil {
-			return &generate.Report{Err: err}
+
+		err := runBufGenerate(ctx, gobin, &sb)
+		if err != nil {
+			return &generate.Report{Output: sb.String(), Err: err}
 		}
 	}
 
@@ -89,24 +87,6 @@ func FindGeneratedFiles(dir string) ([]string, error) {
 		return nil
 	})
 	return paths, err
-}
-
-type dependency string
-
-func (d dependency) String() string { return string(d) }
-
-func (d dependency) install(ctx context.Context, gobin string, w io.Writer) error {
-	err := run.Cmd(ctx, "go", "install", d.String()).
-		Environ(os.Environ()).
-		Env(map[string]string{
-			"GOBIN": gobin,
-		}).
-		Run().
-		Stream(w)
-	if err != nil {
-		return errors.Wrapf(err, "go install %s returned an error", d)
-	}
-	return nil
 }
 
 func runBufGenerate(ctx context.Context, gobin string, w io.Writer) error {

--- a/dev/sg/linters/buf.go
+++ b/dev/sg/linters/buf.go
@@ -1,0 +1,151 @@
+package linters
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sourcegraph/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var bufFormat = &linter{
+	Name: "Buf Format",
+	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "getting current working directory")
+		}
+		defer func() {
+			os.Chdir(cwd)
+		}()
+
+		rootDir, err := root.RepositoryRoot()
+		if err != nil {
+			return errors.Wrap(err, "getting repository root")
+		}
+
+		os.Chdir(rootDir)
+
+		err = buf.InstallDependencies(ctx, out)
+		if err != nil {
+			return errors.Wrap(err, "installing buf dependencies")
+		}
+
+		protoFiles, err := findProtoFiles(rootDir)
+		if err != nil {
+			return errors.Wrapf(err, "finding .proto files")
+		}
+
+		bufArgs := []string{
+			"format",
+			"--diff",
+			"--exit-code",
+		}
+
+		for _, file := range protoFiles {
+			bufArgs = append(bufArgs, "--path", file)
+		}
+
+		gobin := filepath.Join(rootDir, ".bin")
+		return runBuf(ctx, gobin, out, bufArgs...)
+	},
+
+	Fix: func(ctx context.Context, cio check.IO, args *repo.State) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "getting current working directory")
+		}
+		defer func() {
+			os.Chdir(cwd)
+		}()
+
+		rootDir, err := root.RepositoryRoot()
+		if err != nil {
+			return errors.Wrap(err, "getting repository root")
+		}
+
+		os.Chdir(rootDir)
+
+		err = buf.InstallDependencies(ctx, cio.Output)
+		if err != nil {
+			return errors.Wrap(err, "installing buf dependencies")
+		}
+
+		protoFiles, err := findProtoFiles(rootDir)
+		if err != nil {
+			return errors.Wrapf(err, "finding .proto files")
+		}
+
+		bufArgs := []string{
+			"format",
+			"--write",
+		}
+
+		for _, file := range protoFiles {
+			bufArgs = append(bufArgs, "--path", file)
+		}
+
+		gobin := filepath.Join(rootDir, ".bin")
+		return runBuf(ctx, gobin, cio.Output, bufArgs...)
+	},
+}
+
+func findProtoFiles(dir string) ([]string, error) {
+	var files []string
+
+	err := filepath.WalkDir(dir, root.SkipGitIgnoreWalkFunc(func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) == ".proto" {
+			relPath, err := filepath.Rel(dir, path)
+			if err != nil {
+				return errors.Wrapf(err, "getting relative path for .proto file %q (base %q)", path, dir)
+			}
+
+			files = append(files, relPath)
+		}
+
+		return nil
+	}))
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "walking %q to find proto files", dir)
+	}
+
+	return files, nil
+}
+
+func runBuf(ctx context.Context, gobin string, out *std.Output, parameters ...string) error {
+	bufPath := filepath.Join(gobin, "buf")
+
+	arguments := []string{bufPath}
+	arguments = append(arguments, parameters...)
+
+	err := run.Cmd(ctx, arguments...).
+		Environ(os.Environ()).
+		Env(map[string]string{
+			"GOBIN": gobin,
+		}).
+		Run().
+		StreamLines(out.Write)
+	if err != nil {
+		commandStr := fmt.Sprintf("buf %s", strings.Join(parameters, " "))
+		return errors.Wrapf(err, "%q returned an error", commandStr)
+	}
+	return nil
+}

--- a/dev/sg/linters/buf.go
+++ b/dev/sg/linters/buf.go
@@ -33,7 +33,10 @@ var bufFormat = &linter{
 			return errors.Wrap(err, "getting repository root")
 		}
 
-		os.Chdir(rootDir)
+		err = os.Chdir(rootDir)
+		if err != nil {
+			return errors.Wrap(err, "changing directory to repository root")
+		}
 
 		err = buf.InstallDependencies(ctx, out)
 		if err != nil {
@@ -73,7 +76,10 @@ var bufFormat = &linter{
 			return errors.Wrap(err, "getting repository root")
 		}
 
-		os.Chdir(rootDir)
+		err = os.Chdir(rootDir)
+		if err != nil {
+			return errors.Wrap(err, "changing directory to repository root")
+		}
 
 		err = buf.InstallDependencies(ctx, cio.Output)
 		if err != nil {
@@ -136,12 +142,11 @@ func runBuf(ctx context.Context, gobin string, out *std.Output, parameters ...st
 	arguments := []string{bufPath}
 	arguments = append(arguments, parameters...)
 
-	err := run.Cmd(ctx, arguments...).
+	err := root.Run(run.Cmd(ctx, arguments...).
 		Environ(os.Environ()).
 		Env(map[string]string{
 			"GOBIN": gobin,
-		}).
-		Run().
+		})).
 		StreamLines(out.Write)
 	if err != nil {
 		commandStr := fmt.Sprintf("buf %s", strings.Join(parameters, " "))

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -90,6 +90,13 @@ var Targets = []Target{
 			bashSyntax,
 		},
 	},
+	{
+		Name:        "proto",
+		Description: "Check protobuf code for linting errors, formatting, etc",
+		Checks: []*linter{
+			bufFormat,
+		},
+	},
 	Formatting,
 }
 
@@ -98,7 +105,6 @@ var Formatting = Target{
 	Description: "Check client code and docs for formatting errors",
 	Checks: []*linter{
 		prettier,
-		bufFormat,
 	},
 }
 

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -91,7 +91,7 @@ var Targets = []Target{
 		},
 	},
 	{
-		Name:        "buf",
+		Name:        "protobuf",
 		Description: "Check protobuf code for linting errors, formatting, etc",
 		Checks: []*linter{
 			bufFormat,

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -98,6 +98,7 @@ var Formatting = Target{
 	Description: "Check client code and docs for formatting errors",
 	Checks: []*linter{
 		prettier,
+		bufFormat,
 	},
 }
 

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -91,7 +91,7 @@ var Targets = []Target{
 		},
 	},
 	{
-		Name:        "proto",
+		Name:        "buf",
 		Description: "Check protobuf code for linting errors, formatting, etc",
 		Checks: []*linter{
 			bufFormat,

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -91,6 +91,11 @@ The default run type.
   - **Metadata**: Pipeline metadata
   - Upload build trace
 
+- Pipeline for `Protobuf` changes:
+  - **Metadata**: Pipeline metadata
+  - **Linters and static analysis**: Run sg lint
+  - Upload build trace
+
 ### Bazel Exp Branch
 
 The run type for branches matching `bzl/`.

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -461,6 +461,15 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
+### sg lint protobuf
+
+Check protobuf code for linting errors, formatting, etc.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
 ### sg lint format
 
 Check client code and docs for formatting errors.

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -27,6 +27,7 @@ const (
 	DockerImages
 	WolfiPackages
 	WolfiBaseImages
+	Protobuf
 
 	// All indicates all changes should be considered included in this diff, except None.
 	All
@@ -191,7 +192,28 @@ func ParseDiff(files []string) (diff Diff, changedFiles ChangedFiles) {
 			diff |= WolfiBaseImages
 			changedFiles[WolfiBaseImages] = append(changedFiles[WolfiBaseImages], p)
 		}
+
+		// Affects Protobuf files and configuration
+		if strings.HasSuffix(p, ".proto") {
+			diff |= Protobuf
+		}
+
+		// Affects generated Protobuf files
+		if strings.HasSuffix(p, "buf.gen.yaml") {
+			diff |= Protobuf
+		}
+
+		// Affects configuration for Buf and associated linters
+		if strings.HasSuffix(p, "buf.yaml") {
+			diff |= Protobuf
+		}
+
+		// Generated Go code from Protobuf definitions
+		if strings.HasSuffix(p, ".pb.go") {
+			diff |= Protobuf
+		}
 	}
+
 	return
 }
 
@@ -230,6 +252,8 @@ func (d Diff) String() string {
 		return "WolfiPackages"
 	case WolfiBaseImages:
 		return "WolfiBaseImages"
+	case Protobuf:
+		return "Protobuf"
 
 	case All:
 		return "All"

--- a/enterprise/dev/ci/internal/ci/changed/diff_test.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff_test.go
@@ -73,7 +73,32 @@ func TestParseDiff(t *testing.T) {
 			WolfiPackages:   []string{"wolfi-packages/package-test.yaml"},
 		},
 		doNotWantAffects: []Diff{},
-	}}
+	}, {
+		name:             "Protobuf definitions",
+		files:            []string{"cmd/searcher/messages.proto"},
+		wantAffects:      []Diff{Protobuf},
+		wantChangedFiles: make(ChangedFiles),
+		doNotWantAffects: []Diff{},
+	}, {
+		name:             "Protobuf generated code",
+		files:            []string{"cmd/searcher/messages.pb.go"},
+		wantAffects:      []Diff{Protobuf, Go},
+		wantChangedFiles: make(ChangedFiles),
+		doNotWantAffects: []Diff{},
+	}, {
+		name:             "Buf CLI module configuration",
+		files:            []string{"cmd/searcher/buf.yaml"},
+		wantAffects:      []Diff{Protobuf},
+		wantChangedFiles: make(ChangedFiles),
+		doNotWantAffects: []Diff{},
+	}, {
+		name:             "Buf CLI generated code configuration",
+		files:            []string{"cmd/searcher/buf.gen.yaml"},
+		wantAffects:      []Diff{Protobuf},
+		wantChangedFiles: make(ChangedFiles),
+		doNotWantAffects: []Diff{},
+	},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diff, changedFiles := ParseDiff(tt.files)

--- a/enterprise/dev/ci/internal/ci/changed/linters.go
+++ b/enterprise/dev/ci/internal/ci/changed/linters.go
@@ -11,6 +11,7 @@ var diffsWithLinters = []Diff{
 	SVG,
 	Client,
 	Shell,
+	Protobuf,
 }
 
 // GetTargets evaluates the lint targets to run over the given CI diff.

--- a/internal/own/codeowners/proto/codeowners.proto
+++ b/internal/own/codeowners/proto/codeowners.proto
@@ -19,67 +19,67 @@ option go_package = "github.com/sourcegraph/sourcegraph/internal/own/codeowners/
 //     separately. That is, an owner is potentially extracted
 //     for every section.
 message File {
-    repeated Rule rule = 1;
+  repeated Rule rule = 1;
 }
 
 // Rule associates a single pattern to match a path with an owner.
 message Rule {
-    // Patterns are familliar glob patterns that match file paths.
-    // * `filename` matches any file with that name, for example:
-    //   * `/filename` and `/src/filename` match.
-    // * `directory/path/` matches any tree of subdirectories rooted
-    //   at this pattern, for example:
-    //   * `/src/directory/path/file` matches.
-    //   * `/src/directory/path/another/directory/file` matches.
-    // * `directory/*` matches only files with specified parent,
-    //   but not descendants, for example:
-    //   * `/src/foo/bar/directory/file` matches.
-    //   * `/src/foo/bar/directory/another/file` does not match.
-    // * Any of the above can be prefixed with `/`, which further
-    //   filters the match, by requiring the file path match to be
-    //   rooted at the directory root, for `/src/dir/*`:
-    //   * `/src/dir/file` matches.
-    //   * `/main/src/dir/file` does not match, as `src` is not top-level.
-    //   * `/src/dir/another/file` does not match as `*` matches
-    //     only files directly contained in specified directory.
-    // * In the above patterns `/**/` can be used to match any sub-path
-    //   between two parts of a pattern. For example: `/docs/**/internal/`
-    //   will match `/docs/foo/bar/internal/file`.
-    // * The file part of the pattern can use a `*` wildcard like so:
-    //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
-    // * In BITBUCKET plugin, patterns that serve to exclude ownership
-    //   start with an exclamation mark `!/src/noownershere`. These are
-    //   translated to a pattern without the `!` and now owners.
-    string pattern = 1;
-    // Owners list all the parties that claim ownership over files
-    // matched by a given pattern.
-    // This list may be empty. In such case it denotes an abandoned
-    // codebase, and can be used if there is an un-owned subdirectory
-    // within otherwise owned directory structure.
-    repeated Owner owner = 2;
-    // Optionally a rule can be associated with a section name.
-    // The name must be lowercase, as the names of sections in text
-    // representation of the codeowners file are case-insensitive.
-    // Each section represents a kind-of-ownership. That is,
-    // when evaluating an owner for a path, only one rule can apply
-    // for a path, but that is within the scope of a section.
-    // For instance a CODEOWNERS file could specify a [PM] section
-    // associating product managers with codebases. This rule set
-    // can be completely independent of the others. In that case,
-    // when evaluating owners, the result also contains a separate
-    // owners for the PM section.
-    string section_name = 3;
+  // Patterns are familliar glob patterns that match file paths.
+  // * `filename` matches any file with that name, for example:
+  //   * `/filename` and `/src/filename` match.
+  // * `directory/path/` matches any tree of subdirectories rooted
+  //   at this pattern, for example:
+  //   * `/src/directory/path/file` matches.
+  //   * `/src/directory/path/another/directory/file` matches.
+  // * `directory/*` matches only files with specified parent,
+  //   but not descendants, for example:
+  //   * `/src/foo/bar/directory/file` matches.
+  //   * `/src/foo/bar/directory/another/file` does not match.
+  // * Any of the above can be prefixed with `/`, which further
+  //   filters the match, by requiring the file path match to be
+  //   rooted at the directory root, for `/src/dir/*`:
+  //   * `/src/dir/file` matches.
+  //   * `/main/src/dir/file` does not match, as `src` is not top-level.
+  //   * `/src/dir/another/file` does not match as `*` matches
+  //     only files directly contained in specified directory.
+  // * In the above patterns `/**/` can be used to match any sub-path
+  //   between two parts of a pattern. For example: `/docs/**/internal/`
+  //   will match `/docs/foo/bar/internal/file`.
+  // * The file part of the pattern can use a `*` wildcard like so:
+  //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
+  // * In BITBUCKET plugin, patterns that serve to exclude ownership
+  //   start with an exclamation mark `!/src/noownershere`. These are
+  //   translated to a pattern without the `!` and now owners.
+  string pattern = 1;
+  // Owners list all the parties that claim ownership over files
+  // matched by a given pattern.
+  // This list may be empty. In such case it denotes an abandoned
+  // codebase, and can be used if there is an un-owned subdirectory
+  // within otherwise owned directory structure.
+  repeated Owner owner = 2;
+  // Optionally a rule can be associated with a section name.
+  // The name must be lowercase, as the names of sections in text
+  // representation of the codeowners file are case-insensitive.
+  // Each section represents a kind-of-ownership. That is,
+  // when evaluating an owner for a path, only one rule can apply
+  // for a path, but that is within the scope of a section.
+  // For instance a CODEOWNERS file could specify a [PM] section
+  // associating product managers with codebases. This rule set
+  // can be completely independent of the others. In that case,
+  // when evaluating owners, the result also contains a separate
+  // owners for the PM section.
+  string section_name = 3;
 }
 
 // Owner is denoted by either a handle or an email.
 // We expect exactly one of the fields to be present.
 message Owner {
-    // Handle can refer to a user or a team defined externally.
-    // In the text config, a handle always starts with `@`.
-    // In can contain `/` to denote a sub-group.
-    // The string content of the handle stored here DOES NOT CONTAIN
-    // the initial `@` sign.
-    string handle = 1;
-    // E-mail can be used instead of a handle to denote an owner account.
-    string email = 2;
+  // Handle can refer to a user or a team defined externally.
+  // In the text config, a handle always starts with `@`.
+  // In can contain `/` to denote a sub-group.
+  // The string content of the handle stored here DOES NOT CONTAIN
+  // the initial `@` sign.
+  string handle = 1;
+  // E-mail can be used instead of a handle to denote an owner account.
+  string email = 2;
 }


### PR DESCRIPTION
This PR implements a new check for `sg` that enforces that all the .proto files are formatted using https://docs.buf.build/format/usage. 

Example output: 

(just linting): `sg lint proto`

```

base ❯ ~/geoffrey-sg lint format                                                                                                                                                                     (base) 15:22:34
👉 Running checks from target: format
❌ 1. format (11s)
❔ Prettier [SKIPPED]: skipped because another check failed
❌ Buf Format
   "buf format --diff --exit-code --path cmd/symbols/proto/symbols.proto --path internal/own/codeowners/proto/codeowners.proto --path internal/searcher/proto/searcher.proto" returned an error: exit status 100

   diff -u internal/own/codeowners/proto/codeowners.proto.orig internal/own/codeowners/proto/codeowners.proto
   --- internal/own/codeowners/proto/codeowners.proto.orig	2023-01-26 15:22:40.000000000 -0800
   +++ internal/own/codeowners/proto/codeowners.proto	2023-01-26 15:22:40.000000000 -0800
   @@ -19,69 +19,68 @@
    //     separately. That is, an owner is potentially extracted
    //     for every section.

   -
    message File {
   -         repeated Rule rule = 1;
   +  repeated Rule rule = 1;
    }

    // Rule associates a single pattern to match a path with an owner.
    message Rule {
   -    // Patterns are familliar glob patterns that match file paths.
   -    // * `filename` matches any file with that name, for example:
   -    //   * `/filename` and `/src/filename` match.
   -    // * `directory/path/` matches any tree of subdirectories rooted
   -    //   at this pattern, for example:
   -    //   * `/src/directory/path/file` matches.
   -    //   * `/src/directory/path/another/directory/file` matches.
   -    // * `directory/*` matches only files with specified parent,
   -    //   but not descendants, for example:
   -    //   * `/src/foo/bar/directory/file` matches.
   -    //   * `/src/foo/bar/directory/another/file` does not match.
   -    // * Any of the above can be prefixed with `/`, which further
   -    //   filters the match, by requiring the file path match to be
   -    //   rooted at the directory root, for `/src/dir/*`:
   -    //   * `/src/dir/file` matches.
   -    //   * `/main/src/dir/file` does not match, as `src` is not top-level.
   -    //   * `/src/dir/another/file` does not match as `*` matches
   -    //     only files directly contained in specified directory.
   -    // * In the above patterns `/**/` can be used to match any sub-path
   -    //   between two parts of a pattern. For example: `/docs/**/internal/`
   -    //   will match `/docs/foo/bar/internal/file`.
   -    // * The file part of the pattern can use a `*` wildcard like so:
   -    //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
   -    // * In BITBUCKET plugin, patterns that serve to exclude ownership
   -    //   start with an exclamation mark `!/src/noownershere`. These are
   -    //   translated to a pattern without the `!` and now owners.
   -    string pattern = 1;
   -    // Owners list all the parties that claim ownership over files
   -    // matched by a given pattern.
   -    // This list may be empty. In such case it denotes an abandoned
   -    // codebase, and can be used if there is an un-owned subdirectory
   -    // within otherwise owned directory structure.
   -    repeated Owner owner = 2;
   -    // Optionally a rule can be associated with a section name.
   -    // The name must be lowercase, as the names of sections in text
   -    // representation of the codeowners file are case-insensitive.
   -    // Each section represents a kind-of-ownership. That is,
   -    // when evaluating an owner for a path, only one rule can apply
   -    // for a path, but that is within the scope of a section.
   -    // For instance a CODEOWNERS file could specify a [PM] section
   -    // associating product managers with codebases. This rule set
   -    // can be completely independent of the others. In that case,
   -               // when evaluating owners, the result also contains a separate
   -    // owners for the PM section.
   -    string        section_name           = 3;
   +  // Patterns are familliar glob patterns that match file paths.
   +  // * `filename` matches any file with that name, for example:
   +  //   * `/filename` and `/src/filename` match.
   +  // * `directory/path/` matches any tree of subdirectories rooted
   +  //   at this pattern, for example:
   +  //   * `/src/directory/path/file` matches.
   +  //   * `/src/directory/path/another/directory/file` matches.
   +  // * `directory/*` matches only files with specified parent,
   +  //   but not descendants, for example:
   +  //   * `/src/foo/bar/directory/file` matches.
   +  //   * `/src/foo/bar/directory/another/file` does not match.
   +  // * Any of the above can be prefixed with `/`, which further
   +  //   filters the match, by requiring the file path match to be
   +  //   rooted at the directory root, for `/src/dir/*`:
   +  //   * `/src/dir/file` matches.
   +  //   * `/main/src/dir/file` does not match, as `src` is not top-level.
   +  //   * `/src/dir/another/file` does not match as `*` matches
   +  //     only files directly contained in specified directory.
   +  // * In the above patterns `/**/` can be used to match any sub-path
   +  //   between two parts of a pattern. For example: `/docs/**/internal/`
   +  //   will match `/docs/foo/bar/internal/file`.
   +  // * The file part of the pattern can use a `*` wildcard like so:
   +  //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
   +  // * In BITBUCKET plugin, patterns that serve to exclude ownership
   +  //   start with an exclamation mark `!/src/noownershere`. These are
   +  //   translated to a pattern without the `!` and now owners.
   +  string pattern = 1;
   +  // Owners list all the parties that claim ownership over files
   +  // matched by a given pattern.
   +  // This list may be empty. In such case it denotes an abandoned
   +  // codebase, and can be used if there is an un-owned subdirectory
   +  // within otherwise owned directory structure.
   +  repeated Owner owner = 2;
   +  // Optionally a rule can be associated with a section name.
   +  // The name must be lowercase, as the names of sections in text
   +  // representation of the codeowners file are case-insensitive.
   +  // Each section represents a kind-of-ownership. That is,
   +  // when evaluating an owner for a path, only one rule can apply
   +  // for a path, but that is within the scope of a section.
   +  // For instance a CODEOWNERS file could specify a [PM] section
   +  // associating product managers with codebases. This rule set
   +  // can be completely independent of the others. In that case,
   +  // when evaluating owners, the result also contains a separate
   +  // owners for the PM section.
   +  string section_name = 3;
    }

    // Owner is denoted by either a handle or an email.
    // We expect exactly one of the fields to be present.
    message Owner {
   -    // Handle can refer to a user or a team defined externally.
   -    // In the text config, a handle always starts with `@`.
   -    // In can contain `/` to denote a sub-group.
   -    // The string content of the handle stored here DOES NOT CONTAIN
   -    // the initial `@` sign.
   -    string handle = 1;
   -    // E-mail can be used instead of a handle to denote an owner account.
   -    string email = 2;
   +  // Handle can refer to a user or a team defined externally.
   +  // In the text config, a handle always starts with `@`.
   +  // In can contain `/` to denote a sub-group.
   +  // The string content of the handle stored here DOES NOT CONTAIN
   +  // the initial `@` sign.
   +  string handle = 1;
   +  // E-mail can be used instead of a handle to denote an owner account.
   +  string email = 2;
    }


   Try `sg lint -fix format` to fix this issue!

❌ 1 checks failed
```

Example output for fix: 

```
base ❯ ~/geoffrey-sg lint -fix proto                                                                                                                                                                (base) 15:22:48
👉 Fixing checks from target: format
❌ 1. format (37s)
❌ Buf Format
   "buf format --diff --exit-code --path cmd/symbols/proto/symbols.proto --path internal/own/codeowners/proto/codeowners.proto --path internal/searcher/proto/searcher.proto" returned an error: exit status 100

   diff -u internal/own/codeowners/proto/codeowners.proto.orig internal/own/codeowners/proto/codeowners.proto
   --- internal/own/codeowners/proto/codeowners.proto.orig	2023-01-26 15:24:13.000000000 -0800
   +++ internal/own/codeowners/proto/codeowners.proto	2023-01-26 15:24:13.000000000 -0800
   @@ -19,69 +19,68 @@
    //     separately. That is, an owner is potentially extracted
    //     for every section.

   -
    message File {
   -         repeated Rule rule = 1;
   +  repeated Rule rule = 1;
    }

    // Rule associates a single pattern to match a path with an owner.
    message Rule {
   -    // Patterns are familliar glob patterns that match file paths.
   -    // * `filename` matches any file with that name, for example:
   -    //   * `/filename` and `/src/filename` match.
   -    // * `directory/path/` matches any tree of subdirectories rooted
   -    //   at this pattern, for example:
   -    //   * `/src/directory/path/file` matches.
   -    //   * `/src/directory/path/another/directory/file` matches.
   -    // * `directory/*` matches only files with specified parent,
   -    //   but not descendants, for example:
   -    //   * `/src/foo/bar/directory/file` matches.
   -    //   * `/src/foo/bar/directory/another/file` does not match.
   -    // * Any of the above can be prefixed with `/`, which further
   -    //   filters the match, by requiring the file path match to be
   -    //   rooted at the directory root, for `/src/dir/*`:
   -    //   * `/src/dir/file` matches.
   -    //   * `/main/src/dir/file` does not match, as `src` is not top-level.
   -    //   * `/src/dir/another/file` does not match as `*` matches
   -    //     only files directly contained in specified directory.
   -    // * In the above patterns `/**/` can be used to match any sub-path
   -    //   between two parts of a pattern. For example: `/docs/**/internal/`
   -    //   will match `/docs/foo/bar/internal/file`.
   -    // * The file part of the pattern can use a `*` wildcard like so:
   -    //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
   -    // * In BITBUCKET plugin, patterns that serve to exclude ownership
   -    //   start with an exclamation mark `!/src/noownershere`. These are
   -    //   translated to a pattern without the `!` and now owners.
   -    string pattern = 1;
   -    // Owners list all the parties that claim ownership over files
   -    // matched by a given pattern.
   -    // This list may be empty. In such case it denotes an abandoned
   -    // codebase, and can be used if there is an un-owned subdirectory
   -    // within otherwise owned directory structure.
   -    repeated Owner owner = 2;
   -    // Optionally a rule can be associated with a section name.
   -    // The name must be lowercase, as the names of sections in text
   -    // representation of the codeowners file are case-insensitive.
   -    // Each section represents a kind-of-ownership. That is,
   -    // when evaluating an owner for a path, only one rule can apply
   -    // for a path, but that is within the scope of a section.
   -    // For instance a CODEOWNERS file could specify a [PM] section
   -    // associating product managers with codebases. This rule set
   -    // can be completely independent of the others. In that case,
   -               // when evaluating owners, the result also contains a separate
   -    // owners for the PM section.
   -    string        section_name           = 3;
   +  // Patterns are familliar glob patterns that match file paths.
   +  // * `filename` matches any file with that name, for example:
   +  //   * `/filename` and `/src/filename` match.
   +  // * `directory/path/` matches any tree of subdirectories rooted
   +  //   at this pattern, for example:
   +  //   * `/src/directory/path/file` matches.
   +  //   * `/src/directory/path/another/directory/file` matches.
   +  // * `directory/*` matches only files with specified parent,
   +  //   but not descendants, for example:
   +  //   * `/src/foo/bar/directory/file` matches.
   +  //   * `/src/foo/bar/directory/another/file` does not match.
   +  // * Any of the above can be prefixed with `/`, which further
   +  //   filters the match, by requiring the file path match to be
   +  //   rooted at the directory root, for `/src/dir/*`:
   +  //   * `/src/dir/file` matches.
   +  //   * `/main/src/dir/file` does not match, as `src` is not top-level.
   +  //   * `/src/dir/another/file` does not match as `*` matches
   +  //     only files directly contained in specified directory.
   +  // * In the above patterns `/**/` can be used to match any sub-path
   +  //   between two parts of a pattern. For example: `/docs/**/internal/`
   +  //   will match `/docs/foo/bar/internal/file`.
   +  // * The file part of the pattern can use a `*` wildcard like so:
   +  //   `docs/*.md` will match `/src/docs/index.md` but not `/src/docs/index.js`.
   +  // * In BITBUCKET plugin, patterns that serve to exclude ownership
   +  //   start with an exclamation mark `!/src/noownershere`. These are
   +  //   translated to a pattern without the `!` and now owners.
   +  string pattern = 1;
   +  // Owners list all the parties that claim ownership over files
   +  // matched by a given pattern.
   +  // This list may be empty. In such case it denotes an abandoned
   +  // codebase, and can be used if there is an un-owned subdirectory
   +  // within otherwise owned directory structure.
   +  repeated Owner owner = 2;
   +  // Optionally a rule can be associated with a section name.
   +  // The name must be lowercase, as the names of sections in text
   +  // representation of the codeowners file are case-insensitive.
   +  // Each section represents a kind-of-ownership. That is,
   +  // when evaluating an owner for a path, only one rule can apply
   +  // for a path, but that is within the scope of a section.
   +  // For instance a CODEOWNERS file could specify a [PM] section
   +  // associating product managers with codebases. This rule set
   +  // can be completely independent of the others. In that case,
   +  // when evaluating owners, the result also contains a separate
   +  // owners for the PM section.
   +  string section_name = 3;
    }

    // Owner is denoted by either a handle or an email.
    // We expect exactly one of the fields to be present.
    message Owner {
   -    // Handle can refer to a user or a team defined externally.
   -    // In the text config, a handle always starts with `@`.
   -    // In can contain `/` to denote a sub-group.
   -    // The string content of the handle stored here DOES NOT CONTAIN
   -    // the initial `@` sign.
   -    string handle = 1;
   -    // E-mail can be used instead of a handle to denote an owner account.
   -    string email = 2;
   +  // Handle can refer to a user or a team defined externally.
   +  // In the text config, a handle always starts with `@`.
   +  // In can contain `/` to denote a sub-group.
   +  // The string content of the handle stored here DOES NOT CONTAIN
   +  // the initial `@` sign.
   +  string handle = 1;
   +  // E-mail can be used instead of a handle to denote an owner account.
   +  string email = 2;
    }


   Try `sg lint -fix format` to fix this issue!

👉 Attempting to fix 1 failed categories
Trying my hardest to fix "format" automatically...
✱ Fixing "Buf Format"...
Check "Buf Format" is satisfied now!
✅ 1. format - Done!

```
## Test plan

Manual testing.