### PR TITLE
install the `src` CLI when installing via homebrew

### DIFF
--- a/enterprise/dev/app/goreleaser.yaml
+++ b/enterprise/dev/app/goreleaser.yaml
@@ -122,6 +122,7 @@ brews:
     dependencies:
       - name: git
       - name: redis
+      - name: sourcegraph/src-cli/src-cli
 
 announce:
   slack:


### PR DESCRIPTION
When installing Sourcegraph App via Homebrew, add the `src` CLI as a Homebrew dependency because it is used for Batch Changes and code intel autoindexing.




## Test plan

Run `brew install sourcegraph/sourcegraph-app/sourcegraph` and note that it installs the `src` CLI.