### PR TITLE
Fix initial page load for files in the project root

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -83,9 +83,13 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
     const { telemetryService, onExpandParent, alwaysLoadAncestors } = props
 
     // Ensure that the initial file path does not update when the props change
-    const [initialFilePath] = useState(
-        props.initialFilePathIsDirectory ? props.initialFilePath : dirname(props.initialFilePath)
-    )
+    const [initialFilePath] = useState(() => {
+        let path = props.initialFilePathIsDirectory ? props.initialFilePath : dirname(props.initialFilePath)
+        if (path === '.') {
+            path = ''
+        }
+        return path
+    })
     const [treeData, setTreeData] = useState<TreeData | null>(null)
 
     const navigate = useNavigate()


### PR DESCRIPTION
Part of #12916 

This fixes an issue when files are opened in the project root. `dirname()` returns `.` for the project root but the GraphQL query expects `` for the project root. 

## Before

<img width="1089" alt="Screenshot 2023-01-27 at 16 15 26" src="https://user-images.githubusercontent.com/458591/215120819-0d6f1542-9014-40ad-8692-b66a9327d8d4.png">

## Test plan

<img width="1190" alt="Screenshot 2023-01-27 at 16 13 34" src="https://user-images.githubusercontent.com/458591/215120874-ae70fa55-7625-4cb7-8e3b-86a7a7bd680c.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-single-file-load-sidebar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
