### PR TITLE
Code Insights: Use download blob flow for the insight export data action

### DIFF
--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -4,13 +4,13 @@ import classNames from 'classnames'
 
 import { LoadingSpinner, Button, ButtonProps } from '@sourcegraph/wildcard'
 
-interface Props extends ButtonProps {
+export interface LoaderButtonProps extends ButtonProps {
     loading: boolean
     label: string
     alwaysShowLabel: boolean
 }
 
-export const LoaderButton: React.FunctionComponent<React.PropsWithChildren<Partial<Props>>> = ({
+export const LoaderButton: React.FunctionComponent<React.PropsWithChildren<Partial<LoaderButtonProps>>> = ({
     loading,
     label,
     alwaysShowLabel,

--- a/client/web/src/enterprise/insights/components/DownloadFileButton.tsx
+++ b/client/web/src/enterprise/insights/components/DownloadFileButton.tsx
@@ -1,0 +1,56 @@
+import { FC, MouseEvent, useState } from 'react'
+
+import { ButtonProps } from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../../components/LoaderButton'
+
+interface DownloadFileButtonProps extends ButtonProps {
+    fileUrl: string
+    fileName: string
+    children?: string
+}
+
+export const DownloadFileButton: FC<DownloadFileButtonProps> = props => {
+    const { fileUrl, fileName, children, onClick, ...attributes } = props
+
+    const [isLoading, setLoading] = useState(false)
+
+    const handleClick = async (event: MouseEvent<HTMLButtonElement>): Promise<void> => {
+        setLoading(true)
+
+        try {
+            const file = await fetch(fileUrl, { headers: window.context.xhrHeaders })
+            const fileBlob = await file.blob()
+            const url = URL.createObjectURL(fileBlob)
+
+            syntheticDownload(url, fileName)
+
+            if (onClick) {
+                onClick(event)
+            }
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <LoaderButton
+            {...attributes}
+            label={children}
+            loading={isLoading}
+            alwaysShowLabel={true}
+            onClick={handleClick}
+        />
+    )
+}
+
+function syntheticDownload(url: string, name: string): void {
+    const element = document.createElement('a')
+    element.setAttribute('href', url)
+    element.setAttribute('download', name)
+
+    document.body.append(element)
+    element.click()
+
+    element.remove()
+}

--- a/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
@@ -1,6 +1,10 @@
 import { FC } from 'react'
 
-import { Button, Modal, Text, H2 } from '@sourcegraph/wildcard'
+import { escapeRegExp } from 'lodash'
+
+import { Modal, Text, H2 } from '@sourcegraph/wildcard'
+
+import { DownloadFileButton } from '../DownloadFileButton'
 
 interface ExportInsightDataModalProps {
     insightId: string
@@ -22,16 +26,14 @@ export const ExportInsightDataModal: FC<ExportInsightDataModalProps> = props => 
             </Text>
             <Text>This will only include data that you are permitted to see.</Text>
             <div className="d-flex justify-content-end mt-5">
-                <Button
-                    as="a"
-                    href={`/.api/insights/export/${insightId}`}
-                    autoFocus={true}
-                    download={true}
+                <DownloadFileButton
+                    fileName={escapeRegExp(insightTitle)}
+                    fileUrl={`/.api/insights/export/${insightId}`}
                     variant="primary"
                     onClick={onConfirm}
                 >
                     Export data as CSV
-                </Button>
+                </DownloadFileButton>
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -1,11 +1,13 @@
 import { FunctionComponent, useRef, useState } from 'react'
 
 import { mdiLinkVariant } from '@mdi/js'
+import { escapeRegExp } from 'lodash'
 import { useHistory } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
+import { DownloadFileButton } from '../../../../../components/DownloadFileButton'
 import { ConfirmDeleteModal } from '../../../../../components/modals/ConfirmDeleteModal'
 import { Insight, isLangStatsInsight } from '../../../../../core'
 import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
@@ -48,9 +50,13 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
         <div className={styles.container}>
             {!isLangStatsInsight(insight) && (
                 <Tooltip content="This will create a CVS archive of all data for this Code Insight, including data that has been archived. This will only include data that you are permitted to see.">
-                    <Button as="a" href={`/.api/insights/export/${insight.id}`} download={true} variant="secondary">
+                    <DownloadFileButton
+                        fileName={escapeRegExp(insight.title)}
+                        fileUrl={`/.api/insights/export/${insight.id}`}
+                        variant="secondary"
+                    >
                         Export data as CSV
-                    </Button>
+                    </DownloadFileButton>
                 </Tooltip>
             )}
 


### PR DESCRIPTION
## Background 

Originally, we used to work with just native download flow with `a` element and `download` attribute, but since our API route is behind API-like URL (means it's `/.api/insights...`) it uses different auth checks. As a result if you try to use common link with `href` with `/.api/...` URL you will have an auth error since all route under `/.api` don't use cookies as auth context info *but they use just headers for it which are not attached to the link  get request)

This PR adds new way to load files, it uses fetch and blob API with right headers in order to fix this problem with auth middleware. 

## Test plan
- Check insight export data button on the dashboard page (it should allow you to download insight archive with csv datasets)
- Check the same button on the standalone insight page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-export-data.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
