### PR TITLE
sort the clashing slice for determinism

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -911,7 +911,7 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 		clashing = append(clashing, rev)
 	}
 	// ensure that lists are always returned in sorted order.
-	slices.SortFunc(matched, query.RevisionSpecifier.Less)
+	slices.SortFunc(clashing, query.RevisionSpecifier.Less)
 	return
 }
 


### PR DESCRIPTION
Fix from https://github.com/sourcegraph/sourcegraph/pull/46996

## Test plan

`go test ./internal/search/repos -run TestSearchRevspecs/conflicting -count 100` passes


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
