### PR TITLE
set meta noindex on doc pages that are not for the current version

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -58,13 +58,8 @@
 {{end}}
 
 {{define "head"}}
-    {{ if .Content }}
-        {{ if contains .Content.Path "insights" }}
-            <!-- don't index embargoed insights pages -->
-            <meta name="robots" content="noindex">
-        {{end}}
-    {{ else if .ContentVersion }}
-        <!-- don't index version pages -->
+    {{ if .ContentVersion }}
+        <!-- don't index pages from older versions -->
         <meta name="robots" content="noindex">
     {{ end }}
 {{end}}


### PR DESCRIPTION
Fixes a bug where noindex was not being set correctly on doc pages on non-current versions. This bug was introduced when new code was added to the template to also noindex pages related to Code Insights for the early 2021 launch. That embargo is no longer needed, so we can remove that code altogether.

## Test plan

After this change, visiting a page with an `@version` in the URL such as https://docs.sourcegraph.com/@3.1/dev/roadmap and inspecting the source should reveal a meta noindex tag.