### PR TITLE
codeintel: Add resolvers for precise index entity

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -207,6 +207,48 @@ extend type Query {
         after: String
     ): CodeIntelligenceConfigurationPolicyConnection!
 
+    preciseIndexes(
+        """
+        If supplied, only precise indexes for the given repository will be returned.
+        """
+        repo: ID
+
+        """
+        If supplied, only precise indexes that match the given terms by their state,
+        repository name, commit, root, and indexer fields will be returned..
+        """
+        query: String
+
+        """
+        If supplied, only precise indexes in one of the provided states are returned.
+        """
+        states: [PreciseIndexState!]
+
+        """
+        If supplied, only precise indexes that are a dependency of the specified index are returned.
+        """
+        dependencyOf: ID
+
+        """
+        If supplied, only precise indexes that are a dependent of the specified index are returned.
+        """
+        dependentOf: ID
+
+        """
+        If specified, this limits the number of results per request.
+        """
+        first: Int
+
+        """
+        If specified, this indicates that the request should be paginated and to fetch results starting
+        at this cursor.
+
+        A future request can be made for more results by passing in the 'PreciseIndexConnection.pageInfo.endCursor'
+        that is returned.
+        """
+        after: String
+    ): PreciseIndexConnection!
+
     """
     The repository's LSIF uploads.
     """
@@ -1068,6 +1110,157 @@ enum LSIFUploadState {
     audit log entries.
     """
     DELETED
+}
+
+"""
+A list of precise code intelligence indexes.
+"""
+type PreciseIndexConnection {
+    """
+    The current page of indexes.
+    """
+    nodes: [PreciseIndex!]!
+
+    """
+    The total number of results (over all pages) in this list.
+    """
+    totalCount: Int
+
+    """
+    Metadata about the current page of results.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+Possible states for PreciseIndexes.
+"""
+enum PreciseIndexState {
+    UPLOADING_INDEX
+    QUEUED_FOR_PROCESSING
+    PROCESSING
+    PROCESSING_ERRORED
+    COMPLETED
+    DELETING
+    DELETED
+    QUEUED_FOR_INDEXING
+    INDEXING
+    INDEXING_ERRORED
+    INDEXING_COMPLETED
+}
+
+"""
+Metadata and status about a precise code intelligence index.
+"""
+type PreciseIndex implements Node {
+    """
+    The ID.
+    """
+    id: ID!
+
+    """
+    The project for which this index provides code intelligence.
+    """
+    projectRoot: CodeIntelGitTree
+
+    """
+    The original 40-character commit commit supplied at creation.
+    """
+    inputCommit: String!
+
+    """
+    The original root supplied at creation.
+    """
+    inputRoot: String!
+
+    """
+    The original indexer name supplied at creation.
+    """
+    inputIndexer: String!
+
+    """
+    The tags, if any, associated with this commit.
+    """
+    tags: [String!]!
+
+    """
+    The indexer used to produce this index.
+    """
+    indexer: CodeIntelIndexer
+
+    """
+    The current state.
+    """
+    state: PreciseIndexState!
+
+    """
+    The time the index was queued for indexing.
+    """
+    queuedAt: DateTime
+
+    """
+    The time the index job started running.
+    """
+    indexingStartedAt: DateTime
+
+    """
+    The time the index job stopped running.
+    """
+    indexingFinishedAt: DateTime
+
+    """
+    The time the index data file was uploaded.
+    """
+    uploadedAt: DateTime
+
+    """
+    The time the upload data file started being processed.
+    """
+    processingStartedAt: DateTime
+
+    """
+    The time the upload data file stopped being processed.
+    """
+    processingFinishedAt: DateTime
+
+    """
+    The indexing or processing error message.
+    """
+    failure: String
+
+    """
+    The rank of this index job or processing job in its respective queue.
+    """
+    placeInQueue: Int
+
+    """
+    Whether or not this index has been marked for reindexing.
+    """
+    steps: IndexSteps
+
+    shouldReindex: Boolean!
+
+    """
+    Whether or not this index provides intelligence for the tip of the default branch. Find reference
+    queries will return symbols from remote repositories only when this property is true. This property
+    is updated asynchronously and is eventually consistent with the git data known by the instance.
+    """
+    isLatestForRepo: Boolean!
+
+    """
+    The list of retention policies associated with this index.
+    """
+    retentionPolicyOverview(
+        matchesOnly: Boolean!
+        query: String
+        after: String
+        first: Int
+    ): CodeIntelligenceRetentionPolicyMatchesConnection!
+
+    """
+    Audit logs representing each state change of the upload in order from earliest to latest.
+    """
+    auditLogs: [LSIFUploadAuditLog!]
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -207,6 +207,9 @@ extend type Query {
         after: String
     ): CodeIntelligenceConfigurationPolicyConnection!
 
+    """
+    Query precise code intelligence indexes.
+    """
     preciseIndexes(
         """
         If supplied, only precise indexes for the given repository will be returned.
@@ -1234,10 +1237,13 @@ type PreciseIndex implements Node {
     placeInQueue: Int
 
     """
-    Whether or not this index has been marked for reindexing.
+    The configuration and execution summary (if completed or errored) of this index job.
     """
     steps: IndexSteps
 
+    """
+    If set, this index has been marked as replaceable by a new auto-indexing job.
+    """
     shouldReindex: Boolean!
 
     """

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -233,6 +233,11 @@ func (r *NodeResolver) ToLSIFIndex() (resolverstubs.LSIFIndexResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToPreciseIndex() (resolverstubs.PreciseIndexResolver, bool) {
+	n, ok := r.Node.(resolverstubs.PreciseIndexResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToCodeIntelligenceConfigurationPolicy() (resolverstubs.CodeIntelligenceConfigurationPolicyResolver, bool) {
 	n, ok := r.Node.(resolverstubs.CodeIntelligenceConfigurationPolicyResolver)
 	return n, ok

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers.go
@@ -41,6 +41,9 @@ func (r *Resolver) NodeResolvers() map[string]gql.NodeByIDFunc {
 		"CodeIntelligenceConfigurationPolicy": func(ctx context.Context, id graphql.ID) (gql.Node, error) {
 			return r.ConfigurationPolicyByID(ctx, id)
 		},
+		"PreciseIndex": func(ctx context.Context, id graphql.ID) (gql.Node, error) {
+			return r.PreciseIndexByID(ctx, id)
+		},
 	}
 }
 
@@ -50,6 +53,14 @@ func (r *Resolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (_ resolve
 
 func (r *Resolver) LSIFUploads(ctx context.Context, args *resolverstubs.LSIFUploadsQueryArgs) (_ resolverstubs.LSIFUploadConnectionResolver, err error) {
 	return r.uploadsRootResolver.LSIFUploads(ctx, args)
+}
+
+func (r *Resolver) PreciseIndexes(ctx context.Context, args *resolverstubs.PreciseIndexesQueryArgs) (_ resolverstubs.PreciseIndexConnectionResolver, err error) {
+	return r.autoIndexingRootResolver.PreciseIndexes(ctx, args)
+}
+
+func (r *Resolver) PreciseIndexByID(ctx context.Context, id graphql.ID) (_ resolverstubs.PreciseIndexResolver, err error) {
+	return r.autoIndexingRootResolver.PreciseIndexByID(ctx, id)
 }
 
 func (r *Resolver) LSIFUploadsByRepo(ctx context.Context, args *resolverstubs.LSIFRepositoryUploadsQueryArgs) (_ resolverstubs.LSIFUploadConnectionResolver, err error) {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
@@ -53,6 +53,7 @@ type UploadsService interface {
 	GetListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) (_ []*gitdomain.Tag, err error)
 	GetUploadDocumentsForPath(ctx context.Context, bundleID int, pathPattern string) ([]string, int, error)
 	GetUploadsByIDs(ctx context.Context, ids ...int) (_ []types.Upload, err error)
+	GetUploadByID(ctx context.Context, id int) (_ types.Upload, _ bool, err error)
 }
 
 type PolicyService interface {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/mocks_test.go
@@ -3232,6 +3232,9 @@ type MockUploadsService struct {
 	// GetRecentUploadsSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentUploadsSummary.
 	GetRecentUploadsSummaryFunc *UploadsServiceGetRecentUploadsSummaryFunc
+	// GetUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method GetUploadByID.
+	GetUploadByIDFunc *UploadsServiceGetUploadByIDFunc
 	// GetUploadDocumentsForPathFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetUploadDocumentsForPath.
@@ -3265,6 +3268,11 @@ func NewMockUploadsService() *MockUploadsService {
 		},
 		GetRecentUploadsSummaryFunc: &UploadsServiceGetRecentUploadsSummaryFunc{
 			defaultHook: func(context.Context, int) (r0 []shared1.UploadsWithRepositoryNamespace, r1 error) {
+				return
+			},
+		},
+		GetUploadByIDFunc: &UploadsServiceGetUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 types.Upload, r1 bool, r2 error) {
 				return
 			},
 		},
@@ -3310,6 +3318,11 @@ func NewStrictMockUploadsService() *MockUploadsService {
 				panic("unexpected invocation of MockUploadsService.GetRecentUploadsSummary")
 			},
 		},
+		GetUploadByIDFunc: &UploadsServiceGetUploadByIDFunc{
+			defaultHook: func(context.Context, int) (types.Upload, bool, error) {
+				panic("unexpected invocation of MockUploadsService.GetUploadByID")
+			},
+		},
 		GetUploadDocumentsForPathFunc: &UploadsServiceGetUploadDocumentsForPathFunc{
 			defaultHook: func(context.Context, int, string) ([]string, int, error) {
 				panic("unexpected invocation of MockUploadsService.GetUploadDocumentsForPath")
@@ -3344,6 +3357,9 @@ func NewMockUploadsServiceFrom(i UploadsService) *MockUploadsService {
 		},
 		GetRecentUploadsSummaryFunc: &UploadsServiceGetRecentUploadsSummaryFunc{
 			defaultHook: i.GetRecentUploadsSummary,
+		},
+		GetUploadByIDFunc: &UploadsServiceGetUploadByIDFunc{
+			defaultHook: i.GetUploadByID,
 		},
 		GetUploadDocumentsForPathFunc: &UploadsServiceGetUploadDocumentsForPathFunc{
 			defaultHook: i.GetUploadDocumentsForPath,
@@ -3810,6 +3826,118 @@ func (c UploadsServiceGetRecentUploadsSummaryFuncCall) Args() []interface{} {
 // invocation.
 func (c UploadsServiceGetRecentUploadsSummaryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// UploadsServiceGetUploadByIDFunc describes the behavior when the
+// GetUploadByID method of the parent MockUploadsService instance is
+// invoked.
+type UploadsServiceGetUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (types.Upload, bool, error)
+	hooks       []func(context.Context, int) (types.Upload, bool, error)
+	history     []UploadsServiceGetUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUploadByID delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockUploadsService) GetUploadByID(v0 context.Context, v1 int) (types.Upload, bool, error) {
+	r0, r1, r2 := m.GetUploadByIDFunc.nextHook()(v0, v1)
+	m.GetUploadByIDFunc.appendCall(UploadsServiceGetUploadByIDFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the GetUploadByID method
+// of the parent MockUploadsService instance is invoked and the hook queue
+// is empty.
+func (f *UploadsServiceGetUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (types.Upload, bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUploadByID method of the parent MockUploadsService instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *UploadsServiceGetUploadByIDFunc) PushHook(hook func(context.Context, int) (types.Upload, bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UploadsServiceGetUploadByIDFunc) SetDefaultReturn(r0 types.Upload, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, int) (types.Upload, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UploadsServiceGetUploadByIDFunc) PushReturn(r0 types.Upload, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, int) (types.Upload, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *UploadsServiceGetUploadByIDFunc) nextHook() func(context.Context, int) (types.Upload, bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UploadsServiceGetUploadByIDFunc) appendCall(r0 UploadsServiceGetUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UploadsServiceGetUploadByIDFuncCall objects
+// describing the invocations of this function.
+func (f *UploadsServiceGetUploadByIDFunc) History() []UploadsServiceGetUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]UploadsServiceGetUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UploadsServiceGetUploadByIDFuncCall is an object that describes an
+// invocation of method GetUploadByID on an instance of MockUploadsService.
+type UploadsServiceGetUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 types.Upload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UploadsServiceGetUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UploadsServiceGetUploadByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // UploadsServiceGetUploadDocumentsForPathFunc describes the behavior when

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/observability.go
@@ -35,6 +35,9 @@ type operations struct {
 	repositorySummary    *observation.Operation
 	getSupportedByCtags  *observation.Operation
 	gitBlobCodeIntelInfo *observation.Operation
+
+	preciseIndexes   *observation.Operation
+	preciseIndexByID *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -81,5 +84,8 @@ func newOperations(observationCtx *observation.Context) *operations {
 		repositorySummary:    op("RepositorySummary"),
 		getSupportedByCtags:  op("GetSupportedByCtags"),
 		gitBlobCodeIntelInfo: op("GitBlobCodeIntelInfo"),
+
+		preciseIndexes:   op("PreciseIndexes"),
+		preciseIndexByID: op("PreciseIndexByID"),
 	}
 }

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
@@ -1,0 +1,610 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/opentracing/opentracing-go/log"
+
+	autoindexingshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
+	sharedresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	uploadsshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
+	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const DefaultPageSize = 50
+
+func (r *rootResolver) PreciseIndexes(ctx context.Context, args *resolverstubs.PreciseIndexesQueryArgs) (_ resolverstubs.PreciseIndexConnectionResolver, err error) {
+	ctx, errTracer, endObservation := r.operations.preciseIndexes.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
+		// log.String("uploadID", string(id)),
+	}})
+	endObservation.OnCancel(ctx, 1, observation.Args{})
+
+	pageSize := DefaultPageSize
+	if args.First != nil {
+		pageSize = int(*args.First)
+	}
+	uploadOffset := 0
+	indexOffset := 0
+	if args.After != nil {
+		parts := strings.Split(*args.After, ":")
+		if len(parts) != 2 {
+			return nil, errors.New("invalid cursor")
+		}
+
+		if parts[0] != "" {
+			v, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, errors.New("invalid cursor")
+			}
+
+			uploadOffset = v
+		}
+		if parts[1] != "" {
+			v, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, errors.New("invalid cursor")
+			}
+
+			indexOffset = v
+		}
+	}
+
+	var uploadStates, indexStates []string
+	if args.States != nil {
+		for _, state := range *args.States {
+			switch state {
+			case "QUEUED_FOR_INDEXING":
+				indexStates = append(indexStates, "queued")
+			case "INDEXING":
+				indexStates = append(indexStates, "processing")
+			case "INDEXING_ERRORED":
+				indexStates = append(indexStates, "errored")
+
+			case "UPLOADING_INDEX":
+				uploadStates = append(uploadStates, "uploading")
+			case "QUEUED_FOR_PROCESSING":
+				uploadStates = append(uploadStates, "queued")
+			case "PROCESSING":
+				uploadStates = append(uploadStates, "processing")
+			case "PROCESSING_ERRORED":
+				uploadStates = append(uploadStates, "errored")
+			case "COMPLETED":
+				uploadStates = append(uploadStates, "completed")
+			case "DELETING":
+				uploadStates = append(uploadStates, "deleting")
+			case "DELETED":
+				uploadStates = append(uploadStates, "deleted")
+
+			default:
+				return nil, errors.Newf("filtering by state %q is unsupported", state)
+			}
+		}
+	}
+	skipUploads := len(uploadStates) == 0 && len(indexStates) != 0
+	skipIndexes := len(uploadStates) != 0 && len(indexStates) == 0
+
+	var dependencyOf int
+	if args.DependencyOf != nil {
+		v, v2, err := unmarshalPreciseIndexGQLID(graphql.ID(*args.DependencyOf))
+		if err != nil {
+			return nil, err
+		}
+		if v == 0 {
+			return nil, errors.Newf("requested dependency of precise index record without data (indexid=%d)", v2)
+		}
+
+		dependencyOf = int(v)
+		skipIndexes = true
+	}
+	var dependentOf int
+	if args.DependentOf != nil {
+		v, v2, err := unmarshalPreciseIndexGQLID(graphql.ID(*args.DependentOf))
+		if err != nil {
+			return nil, err
+		}
+		if v == 0 {
+			return nil, errors.Newf("requested dependent of precise index record without data (indexid=%d)", v2)
+		}
+
+		dependentOf = int(v)
+		skipIndexes = true
+	}
+
+	var repositoryID int
+	if args.Repo != nil {
+		v, err := UnmarshalRepositoryID(*args.Repo)
+		if err != nil {
+			return nil, err
+		}
+
+		repositoryID = int(v)
+	}
+
+	term := ""
+	if args.Query != nil {
+		term = *args.Query
+	}
+
+	var uploads []types.Upload
+	totalUploadCount := 0
+	if !skipUploads {
+		if uploads, totalUploadCount, err = r.uploadSvc.GetUploads(ctx, uploadsshared.GetUploadsOptions{
+			RepositoryID: repositoryID,
+			States:       uploadStates,
+			Term:         term,
+			DependencyOf: dependencyOf,
+			DependentOf:  dependentOf,
+			Limit:        pageSize,
+			Offset:       uploadOffset,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	var indexes []types.Index
+	totalIndexCount := 0
+	if !skipIndexes {
+		if indexes, totalIndexCount, err = r.autoindexSvc.GetIndexes(ctx, autoindexingshared.GetIndexesOptions{
+			RepositoryID:  repositoryID,
+			States:        indexStates,
+			Term:          term,
+			WithoutUpload: true,
+			Limit:         pageSize,
+			Offset:        indexOffset,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	type pair struct {
+		upload *types.Upload
+		index  *types.Index
+	}
+	pairs := make([]pair, 0, pageSize)
+	addUpload := func(upload types.Upload) { pairs = append(pairs, pair{&upload, nil}) }
+	addIndex := func(index types.Index) { pairs = append(pairs, pair{nil, &index}) }
+
+	uIdx := 0
+	iIdx := 0
+	for uIdx < len(uploads) && iIdx < len(indexes) && (uIdx+iIdx) < pageSize {
+		if uploads[uIdx].UploadedAt.After(indexes[iIdx].QueuedAt) {
+			addUpload(uploads[uIdx])
+			uIdx++
+		} else {
+			addIndex(indexes[iIdx])
+			iIdx++
+		}
+	}
+	for uIdx < len(uploads) && (uIdx+iIdx) < pageSize {
+		addUpload(uploads[uIdx])
+		uIdx++
+	}
+	for iIdx < len(indexes) && (uIdx+iIdx) < pageSize {
+		addIndex(indexes[iIdx])
+		iIdx++
+	}
+
+	cursor := ""
+	if newUploadOffset := uploadOffset + uIdx; newUploadOffset < totalUploadCount {
+		cursor += strconv.Itoa(newUploadOffset)
+	}
+	cursor += ":"
+	if newIndexOffset := indexOffset + iIdx; newIndexOffset < totalIndexCount {
+		cursor += strconv.Itoa(newIndexOffset)
+	}
+	if cursor == ":" {
+		cursor = ""
+	}
+
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexSvc, r.uploadSvc)
+	db := r.autoindexSvc.GetUnsafeDB()
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
+
+	for _, pair := range pairs {
+		if pair.upload != nil && pair.upload.AssociatedIndexID != nil {
+			prefetcher.MarkIndex(*pair.upload.AssociatedIndexID)
+		}
+	}
+
+	resolvers := make([]resolverstubs.PreciseIndexResolver, 0, len(pairs))
+	for _, pair := range pairs {
+		resolver, err := NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, pair.upload, pair.index)
+		if err != nil {
+			return nil, err
+		}
+
+		resolvers = append(resolvers, resolver)
+	}
+
+	return NewPreciseIndexConnectionResolver(resolvers, totalUploadCount+totalIndexCount, cursor), nil
+}
+
+type preciseIndexConnectionResolver struct {
+	nodes      []resolverstubs.PreciseIndexResolver
+	totalCount int
+	cursor     string
+}
+
+func NewPreciseIndexConnectionResolver(
+	nodes []resolverstubs.PreciseIndexResolver,
+	totalCount int,
+	cursor string,
+) resolverstubs.PreciseIndexConnectionResolver {
+	return &preciseIndexConnectionResolver{
+		nodes:      nodes,
+		totalCount: totalCount,
+		cursor:     cursor,
+	}
+}
+
+func (r *rootResolver) PreciseIndexByID(ctx context.Context, id graphql.ID) (_ resolverstubs.PreciseIndexResolver, err error) {
+	ctx, errTracer, endObservation := r.operations.preciseIndexes.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("id", string(id)),
+	}})
+	endObservation.OnCancel(ctx, 1, observation.Args{})
+
+	var v string
+	if err := relay.UnmarshalSpec(id, &v); err != nil {
+		return nil, err
+	}
+	parts := strings.Split(v, ":")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid identifier")
+	}
+	rawID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, errors.New("invalid identifier")
+	}
+
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexSvc, r.uploadSvc)
+	db := r.autoindexSvc.GetUnsafeDB()
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient())
+
+	switch parts[0] {
+	case "U":
+		upload, ok, err := r.uploadSvc.GetUploadByID(ctx, rawID)
+		if err != nil || !ok {
+			return nil, err
+		}
+
+		return NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, &upload, nil)
+
+	case "I":
+		index, ok, err := r.autoindexSvc.GetIndexByID(ctx, rawID)
+		if err != nil || !ok {
+			return nil, err
+		}
+
+		return NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, nil, &index)
+	}
+
+	return nil, errors.New("invalid identifier")
+}
+
+func (r *preciseIndexConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.PreciseIndexResolver, error) {
+	return r.nodes, nil
+}
+
+func (r *preciseIndexConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+	count := int32(r.totalCount)
+	return &count, nil
+}
+
+func (r *preciseIndexConnectionResolver) PageInfo(ctx context.Context) (resolverstubs.PageInfo, error) {
+	if r.cursor != "" {
+		return &pageInfo{hasNextPage: true, endCursor: &r.cursor}, nil
+	}
+
+	return &pageInfo{hasNextPage: false}, nil
+}
+
+type preciseIndexResolver struct {
+	upload         *types.Upload
+	index          *types.Index
+	uploadResolver resolverstubs.LSIFUploadResolver
+	indexResolver  resolverstubs.LSIFIndexResolver
+}
+
+func NewPreciseIndexResolver(
+	ctx context.Context,
+	autoindexingSvc AutoIndexingService,
+	uploadsSvc UploadsService,
+	policySvc PolicyService,
+	prefetcher *sharedresolvers.Prefetcher,
+	locationResolver *sharedresolvers.CachedLocationResolver,
+	traceErrs *observation.ErrCollector,
+	upload *types.Upload,
+	index *types.Index,
+) (resolverstubs.PreciseIndexResolver, error) {
+	var uploadResolver resolverstubs.LSIFUploadResolver
+	if upload != nil {
+		uploadResolver = sharedresolvers.NewUploadResolver(uploadsSvc, autoindexingSvc, policySvc, *upload, prefetcher, locationResolver, traceErrs)
+
+		if upload.AssociatedIndexID != nil {
+			v, ok, err := prefetcher.GetIndexByID(ctx, *upload.AssociatedIndexID)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				index = &v
+			}
+		}
+	}
+
+	var indexResolver resolverstubs.LSIFIndexResolver
+	if index != nil {
+		indexResolver = sharedresolvers.NewIndexResolver(autoindexingSvc, uploadsSvc, policySvc, *index, prefetcher, locationResolver, traceErrs)
+	}
+
+	return &preciseIndexResolver{
+		upload:         upload,
+		index:          index,
+		uploadResolver: uploadResolver,
+		indexResolver:  indexResolver,
+	}, nil
+}
+
+func (r *preciseIndexResolver) ID() graphql.ID {
+	if r.upload != nil {
+		return relay.MarshalID("PreciseIndex", fmt.Sprintf("U:%d", r.upload.ID))
+	}
+
+	return relay.MarshalID("PreciseIndex", fmt.Sprintf("I:%d", r.index.ID))
+}
+
+func (r *preciseIndexResolver) ProjectRoot(ctx context.Context) (resolverstubs.GitTreeEntryResolver, error) {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.ProjectRoot(ctx)
+	}
+
+	return r.indexResolver.ProjectRoot(ctx)
+}
+
+func (r *preciseIndexResolver) InputCommit() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputCommit()
+	}
+
+	return r.indexResolver.InputCommit()
+}
+
+func (r *preciseIndexResolver) Tags(ctx context.Context) ([]string, error) {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.Tags(ctx)
+	}
+
+	return r.indexResolver.Tags(ctx)
+}
+
+func (r *preciseIndexResolver) InputRoot() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputRoot()
+	}
+
+	return r.indexResolver.InputRoot()
+}
+
+func (r *preciseIndexResolver) InputIndexer() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputIndexer()
+	}
+
+	return r.indexResolver.InputIndexer()
+}
+
+func (r *preciseIndexResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.Indexer()
+	}
+
+	return r.indexResolver.Indexer()
+}
+
+func (r *preciseIndexResolver) State() string {
+	if r.upload != nil {
+		switch strings.ToUpper(r.upload.State) {
+		case "UPLOADING":
+			return "UPLOADING_INDEX"
+
+		case "QUEUED":
+			return "QUEUED_FOR_PROCESSING"
+
+		case "PROCESSING":
+			return "PROCESSING"
+
+		case "FAILED":
+			fallthrough
+		case "ERRORED":
+			return "PROCESSING_ERRORED"
+
+		case "COMPLETED":
+			return "COMPLETED"
+
+		case "DELETING":
+			return "DELETING"
+
+		case "DELETED":
+			return "DELETED"
+
+		default:
+			panic(fmt.Sprintf("unrecognized upload state %q", r.upload.State))
+		}
+	}
+
+	switch strings.ToUpper(r.index.State) {
+	case "QUEUED":
+		return "QUEUED_FOR_INDEXING"
+
+	case "PROCESSING":
+		return "INDEXING"
+
+	case "FAILED":
+		fallthrough
+	case "ERRORED":
+		return "INDEXING_ERRORED"
+
+	case "COMPLETED":
+		// Should not actually occur in practice (where did upload go?)
+		return "INDEXING_COMPLETED"
+
+	default:
+		panic(fmt.Sprintf("unrecognized index state %q", r.index.State))
+	}
+}
+
+func (r *preciseIndexResolver) QueuedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		t := r.indexResolver.QueuedAt()
+		return &t
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) UploadedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		t := r.uploadResolver.UploadedAt()
+		return &t
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) IndexingStartedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		return r.indexResolver.StartedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ProcessingStartedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.StartedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) IndexingFinishedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		return r.indexResolver.FinishedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ProcessingFinishedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.FinishedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) Steps() resolverstubs.IndexStepsResolver {
+	if r.indexResolver == nil {
+		return nil
+	}
+
+	return r.indexResolver.Steps()
+}
+
+func (r *preciseIndexResolver) Failure() *string {
+	if r.upload != nil && r.upload.FailureMessage != nil {
+		return r.upload.FailureMessage
+	} else if r.index != nil {
+		return r.index.FailureMessage
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) PlaceInQueue() *int32 {
+	if r.index != nil && r.index.Rank != nil {
+		return toInt32(r.index.Rank)
+	}
+
+	if r.upload != nil && r.upload.Rank != nil {
+		return toInt32(r.upload.Rank)
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ShouldReindex(ctx context.Context) bool {
+	if r.index == nil {
+		return false
+	}
+
+	return r.index.ShouldReindex
+}
+
+func (r *preciseIndexResolver) IsLatestForRepo() bool {
+	if r.upload == nil {
+		return false
+	}
+
+	return r.upload.VisibleAtTip
+}
+
+func (r *preciseIndexResolver) RetentionPolicyOverview(ctx context.Context, args *resolverstubs.LSIFUploadRetentionPolicyMatchesArgs) (resolverstubs.CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error) {
+	if r.uploadResolver == nil {
+		return nil, nil
+	}
+
+	return r.uploadResolver.RetentionPolicyOverview(ctx, args)
+}
+
+func (r *preciseIndexResolver) AuditLogs(ctx context.Context) (*[]resolverstubs.LSIFUploadsAuditLogsResolver, error) {
+	if r.uploadResolver == nil {
+		return nil, nil
+	}
+
+	return r.uploadResolver.AuditLogs(ctx)
+}
+
+func unmarshalPreciseIndexGQLID(id graphql.ID) (uploadID int64, indexID int64, _ error) {
+	var payload string
+	if err := relay.UnmarshalSpec(id, &payload); err != nil {
+		return 0, 0, err
+	}
+
+	parts := strings.Split(payload, ":")
+	if len(parts) == 2 {
+		id, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if parts[0] == "U" {
+			return int64(id), 0, nil
+		} else if parts[0] == "I" {
+			return 0, int64(id), nil
+		}
+	}
+
+	return 0, 0, errors.New("unexpected precise index ID")
+}
+
+type pageInfo struct {
+	endCursor   *string
+	hasNextPage bool
+}
+
+func (r *pageInfo) EndCursor() *string { return r.endCursor }
+func (r *pageInfo) HasNextPage() bool  { return r.hasNextPage }

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -43,6 +43,9 @@ type AutoindexingServiceResolver interface {
 	RepositorySummary(ctx context.Context, id graphql.ID) (CodeIntelRepositorySummaryResolver, error)
 	CodeIntelligenceInferenceScript(ctx context.Context) (string, error)
 	UpdateCodeIntelligenceInferenceScript(ctx context.Context, args *UpdateCodeIntelligenceInferenceScriptArgs) (*EmptyResponse, error)
+
+	PreciseIndexByID(ctx context.Context, id graphql.ID) (PreciseIndexResolver, error)
+	PreciseIndexes(ctx context.Context, args *PreciseIndexesQueryArgs) (PreciseIndexConnectionResolver, error)
 }
 
 type UploadsServiceResolver interface {
@@ -53,6 +56,7 @@ type UploadsServiceResolver interface {
 	DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
 	DeleteLSIFUploads(ctx context.Context, args *DeleteLSIFUploadsArgs) (*EmptyResponse, error)
 }
+
 type PoliciesServiceResolver interface {
 	CodeIntelligenceConfigurationPolicies(ctx context.Context, args *CodeIntelligenceConfigurationPoliciesArgs) (CodeIntelligenceConfigurationPolicyConnectionResolver, error)
 	ConfigurationPolicyByID(ctx context.Context, id graphql.ID) (CodeIntelligenceConfigurationPolicyResolver, error)
@@ -71,6 +75,16 @@ type CodeIntelRepositorySummaryResolver interface {
 	AvailableIndexers() []InferredAvailableIndexersResolver
 }
 
+type PreciseIndexesQueryArgs struct {
+	graphqlutil.ConnectionArgs
+	After        *string
+	Repo         *graphql.ID
+	Query        *string
+	States       *[]string
+	DependencyOf *string
+	DependentOf  *string
+}
+
 type LSIFIndexConnectionResolver interface {
 	Nodes(ctx context.Context) ([]LSIFIndexResolver, error)
 	TotalCount(ctx context.Context) (*int32, error)
@@ -81,6 +95,36 @@ type LSIFUploadConnectionResolver interface {
 	Nodes(ctx context.Context) ([]LSIFUploadResolver, error)
 	TotalCount(ctx context.Context) (*int32, error)
 	PageInfo(ctx context.Context) (PageInfo, error)
+}
+
+type PreciseIndexConnectionResolver interface {
+	Nodes(ctx context.Context) ([]PreciseIndexResolver, error)
+	TotalCount(ctx context.Context) (*int32, error)
+	PageInfo(ctx context.Context) (PageInfo, error)
+}
+
+type PreciseIndexResolver interface {
+	ID() graphql.ID
+	ProjectRoot(ctx context.Context) (GitTreeEntryResolver, error)
+	InputCommit() string
+	Tags(ctx context.Context) ([]string, error)
+	InputRoot() string
+	InputIndexer() string
+	Indexer() CodeIntelIndexerResolver
+	State() string
+	QueuedAt() *gqlutil.DateTime
+	UploadedAt() *gqlutil.DateTime
+	IndexingStartedAt() *gqlutil.DateTime
+	ProcessingStartedAt() *gqlutil.DateTime
+	IndexingFinishedAt() *gqlutil.DateTime
+	ProcessingFinishedAt() *gqlutil.DateTime
+	Steps() IndexStepsResolver
+	Failure() *string
+	PlaceInQueue() *int32
+	ShouldReindex(ctx context.Context) bool
+	IsLatestForRepo() bool
+	RetentionPolicyOverview(ctx context.Context, args *LSIFUploadRetentionPolicyMatchesArgs) (CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error)
+	AuditLogs(ctx context.Context) (*[]LSIFUploadsAuditLogsResolver, error)
 }
 
 type PageInfo interface {


### PR DESCRIPTION
Pulled from #46692. This PR adds a new type of entity in the GraphQL layer that combines index and upload records. We'll eventually phase the explicit upload/index entities out, but we can do that slowly.

Requires #47047 to land.

## Test plan

Validated in the linked PR this code was pulled from. Also, it's currently inactive so we have a bit of slack time to tune it after this initial PR lands.