### PR TITLE
Ranking: use new zoekt score combination strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 replace github.com/fergusstrange/embedded-postgres => github.com/sourcegraph/embedded-postgres v1.19.1-0.20230113234230-bb62ad58a1e1
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea
+	github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2125,8 +2125,8 @@ github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef h1:fWPxLkDObzzK
 github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea h1:PfXc9P7gulVNg+uDkGN+bSkQuKAm0mwii6YRDsYBH3M=
-github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea/go.mod h1:EgK9KLlvkj/fXQYqnhlh8JuMDQxmlyhRSLchbbH/BJo=
+github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5 h1:MEvC8UWR19i4EQWMdN4AYNCkubEZYn86MPZ+ENp6JDI=
+github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5/go.mod h1:EgK9KLlvkj/fXQYqnhlh8JuMDQxmlyhRSLchbbH/BJo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -72,7 +72,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	c.aggregate = nil
 	c.sizeBytes = 0
 
-	zoekt.SortFiles(agg.Files, c.opts)
+	zoekt.SortFiles(agg.Files)
 
 	if max := c.opts.MaxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -127,11 +127,13 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// collect results before ranking.
 		searchOpts.FlushWallTime = 500 * time.Millisecond
 
-		// This enables the use of PageRank scores if they are available.
+		// This enables the use of document ranks in scoring, if they are available.
 		searchOpts.UseDocumentRanks = true
 
-		// This damps the impact of document ranks on the final ranking.
-		searchOpts.RanksDampingFactor = 0.5
+		// This controls the impact of document ranks on the final ranking. The value is set to 0.5 * 9000 (half the
+		// zoekt default), to match existing behavior where ranks are given half the priority as existing scoring
+		// signals. We plan to eventually remove this, once we experiment on real data to find a good default.
+		searchOpts.DocumentRanksWeight = 4500
 
 		return searchOpts
 	}


### PR DESCRIPTION
This commit bumps the zoekt version and adjusts the frontend logic to match.
With this change, file match scores will be summed together with document ranks
instead of being combined with reciprocal rank fusion (RRF) like they were
before.

Relates to https://github.com/sourcegraph/zoekt/pull/523

## Test plan

`sg start` with feature flag enabled to test some searches. In a future PR, I'd
like to enable the new search strategy in some integration tests (it's
currently never exercised in tests).
