### PR TITLE
sg: preserve file permissions when updating `sg`

### DIFF
--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -49,7 +49,7 @@ func UpdateFileIfDifferent(path string, content []byte) (bool, error) {
 	// preserve permissions
 	// silently ignore failure to avoid breaking changes
 	if fileInfo, err := os.Stat(path); err == nil {
-		os.Chmod(f.Name(), fileInfo.Mode())
+		_ = os.Chmod(f.Name(), fileInfo.Mode())
 	}
 	return true, RenameAndSync(f.Name(), path)
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -46,6 +46,14 @@ func UpdateFileIfDifferent(path string, content []byte) (bool, error) {
 	if err := f.Close(); err != nil {
 		return false, err
 	}
+	// preserve permissions
+	fileInfo, err := os.Stat(f.Name())
+	if err != nil {
+		return false, err
+	}
+	if err = os.Chmod(f.Name(), fileInfo.Mode()); err != nil {
+		return false, err
+	}
 	return true, RenameAndSync(f.Name(), path)
 }
 

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -47,12 +47,9 @@ func UpdateFileIfDifferent(path string, content []byte) (bool, error) {
 		return false, err
 	}
 	// preserve permissions
-	fileInfo, err := os.Stat(f.Name())
-	if err != nil {
-		return false, err
-	}
-	if err = os.Chmod(f.Name(), fileInfo.Mode()); err != nil {
-		return false, err
+	// silently ignore failure to avoid breaking changes
+	if fileInfo, err := os.Stat(path); err == nil {
+		_ := os.Chmod(f.Name(), fileInfo.Mode())
 	}
 	return true, RenameAndSync(f.Name(), path)
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -49,7 +49,7 @@ func UpdateFileIfDifferent(path string, content []byte) (bool, error) {
 	// preserve permissions
 	// silently ignore failure to avoid breaking changes
 	if fileInfo, err := os.Stat(path); err == nil {
-		_ := os.Chmod(f.Name(), fileInfo.Mode())
+		os.Chmod(f.Name(), fileInfo.Mode())
 	}
 	return true, RenameAndSync(f.Name(), path)
 }


### PR DESCRIPTION
Issue #47051 can be addressed by preserving permissions on the file when writing the contents of the downloaded `sg`.

## Test plan

See issue #47051.

Ensure correct behavior.

Testing for the behavior in issue #47051 is difficult because it requires specific timing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
