### PR TITLE
migrator: Fix drift schema resolution on downgrade command

### DIFF
--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -75,7 +75,7 @@ func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsing
 			cliutil.Drift(appName, newRunner, outputFactory, schemaFactories...),
 			cliutil.AddLog(appName, newRunner, outputFactory),
 			cliutil.Upgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, schemaFactories...),
-			cliutil.Downgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators),
+			cliutil.Downgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, schemaFactories...),
 			cliutil.RunOutOfBandMigrations(appName, newRunner, outputFactory, registerMigrators),
 		},
 	}


### PR DESCRIPTION
@DaedalusG helped me find an error with downgrade where we weren't resolving the drift, causing an error that isn't obvious how to solve.

See #47004.

For any customers using a current migrator, they can run drift independently and then use `-skip-drift-check` to get past this for the time being.

## Test plan

Validated by hand.