### PR TITLE
automate release upgrade guide content

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -34,7 +34,9 @@ import {
     ensureReleaseBranchUpToDate,
     ensureSrcCliEndpoint,
     ensureSrcCliUpToDate,
-    getLatestTag, getAllUpgradeGuides, updateUpgradeGuides,
+    getLatestTag,
+    getAllUpgradeGuides,
+    updateUpgradeGuides,
 } from './util'
 
 const sed = process.platform === 'linux' ? 'sed' : 'gsed'
@@ -513,7 +515,7 @@ cc @${config.captainGitHubUsername}
                             notPatchRelease
                                 ? `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version}"' enterprise/dev/ci/internal/ci/*.go`
                                 : 'echo "Skipping minimumUpgradeableVersion bump on patch release"',
-                            updateUpgradeGuides(previousVersion, nextVersion)
+                            updateUpgradeGuides(previousVersion, nextVersion),
                         ],
                         ...prBodyAndDraftState(
                             ((): string[] => {

--- a/dev/release/src/update.ts
+++ b/dev/release/src/update.ts
@@ -4,6 +4,4 @@ export const releaseTemplate = `${divider}
 
 ## Unreleased
 
-<!-- Add changes changes to this section before release. -->
-
-_Upgrade notes for the next version will appear here._`
+<!-- Add changes changes to this section before release. -->`

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -1,12 +1,13 @@
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
 import * as path from 'path'
 import * as readline from 'readline'
 
 import execa from 'execa'
 import { readFile, writeFile, mkdir } from 'mz/fs'
 import fetch from 'node-fetch'
-import { readdirSync, readFileSync, writeFileSync } from 'fs'
-import * as update from './update'
+
 import { EditFunc } from './github'
+import * as update from './update'
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
 

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -215,8 +215,6 @@ export const getAllUpgradeGuides = (previous: string, next: string): string[] =>
 
 export const updateUpgradeGuides = (previous: string, next: string): EditFunc => {
     let updateDirectory = '/doc/admin/updates'
-    // const notPatchRelease = release.patch === 0
-    // const previousNotPatchRelease = previous.patch === 0
     const notPatchRelease = next.endsWith('.0')
 
     return (directory: string): void => {

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -4,9 +4,9 @@ import * as readline from 'readline'
 import execa from 'execa'
 import { readFile, writeFile, mkdir } from 'mz/fs'
 import fetch from 'node-fetch'
-import {readdirSync, readFileSync, writeFileSync} from 'fs';
-import * as update from './update';
-import {EditFunc} from './github';
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
+import * as update from './update'
+import { EditFunc } from './github'
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
 
@@ -199,19 +199,22 @@ export async function getContainerRegistryCredential(registryHostname: string): 
 export type ContentFunc = (previousVersion: string, nextVersion: string) => string
 
 const upgradeContentGenerators: { [s: string]: ContentFunc } = {
-    'docker_compose': (previousVersion: string, nextVersion: string) => '',
-    'kubernetes': (previousVersion: string, nextVersion: string) => '',
-    'server': (previousVersion: string, nextVersion: string) => '',
-    'pure_docker': (previousVersion: string, nextVersion: string) => {
+    docker_compose: (previousVersion: string, nextVersion: string) => '',
+    kubernetes: (previousVersion: string, nextVersion: string) => '',
+    server: (previousVersion: string, nextVersion: string) => '',
+    pure_docker: (previousVersion: string, nextVersion: string) => {
         const compare = `compare/v${previousVersion}...v${nextVersion}`
         return `As a template, perform the same actions as the following diff in your own deployment: [\`Upgrade to v${nextVersion}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/${compare})
 \nFor non-standard replica builds: 
 - [\`Customer Replica 1: ➔ v${nextVersion}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1/${compare})`
-    }
+    },
 }
-export const getUpgradeGuide = (mode:string): ContentFunc => upgradeContentGenerators[mode];
+export const getUpgradeGuide = (mode: string): ContentFunc => upgradeContentGenerators[mode]
 
-export const getAllUpgradeGuides = (previous: string, next: string): string[] => Object.keys(upgradeContentGenerators).map(key => `Guide for: ${key}\n\n${upgradeContentGenerators[key](previous, next)}`)
+export const getAllUpgradeGuides = (previous: string, next: string): string[] =>
+    Object.keys(upgradeContentGenerators).map(
+        key => `Guide for: ${key}\n\n${upgradeContentGenerators[key](previous, next)}`
+    )
 
 export const updateUpgradeGuides = (previous: string, next: string): EditFunc => {
     let updateDirectory = '/doc/admin/updates'
@@ -241,7 +244,7 @@ export const updateUpgradeGuides = (previous: string, next: string): EditFunc =>
                 if (guide) {
                     content = `${content}\n\n${guide}`
                 }
-                content = content+notesHeader
+                content = content + notesHeader
                 updateContents = updateContents.replace(update.releaseTemplate, content)
             } else {
                 const prevReleaseHeaderPattern = `##\\s+v\\d\\.\\d(?:\\.\\d)? ➔ v${previous}\\s*`
@@ -255,7 +258,7 @@ export const updateUpgradeGuides = (previous: string, next: string): EditFunc =>
                 if (guide) {
                     content = `${content}\n\n${guide}`
                 }
-                content = content+notesHeader+`\n\n${prevReleaseHeader}`
+                content = content + notesHeader + `\n\n${prevReleaseHeader}`
                 updateContents = updateContents.replace(prevReleaseHeader, content)
             }
             writeFileSync(fullPath, updateContents)

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -4,6 +4,9 @@ import * as readline from 'readline'
 import execa from 'execa'
 import { readFile, writeFile, mkdir } from 'mz/fs'
 import fetch from 'node-fetch'
+import {readdirSync, readFileSync, writeFileSync} from "fs";
+import * as update from "./update";
+import {Edit, EditFunc} from "./github";
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
 
@@ -191,4 +194,64 @@ export async function getContainerRegistryCredential(registryHostname: string): 
         hostname: registryHostname,
     }
     return credential
+}
+
+export type ContentFunc = (previousVersion: string, nextVersion: string) => string
+
+const upgradeContentGenerators: { [s: string]: ContentFunc } = {
+    'docker_compose': (previousVersion: string, nextVersion: string) => '',
+    'kubernetes': (previousVersion: string, nextVersion: string) => '',
+    'server': (previousVersion: string, nextVersion: string) => '',
+    'pure_docker': (previousVersion: string, nextVersion: string) => {
+        const compare = `compare/v${previousVersion}...v${nextVersion}`
+        return `As a template, perform the same actions as the following diffs in your own deployment:
+- [\`➔ v${nextVersion}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/${compare})
+- Customer Replica 1: [\`➔ v${nextVersion}\`](https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1/${compare})`
+    }
+}
+export const getUpgradeGuide = (mode:string): ContentFunc => upgradeContentGenerators[mode];
+
+export const getAllUpgradeGuides = (previous: string, next: string): string[] => Object.keys(upgradeContentGenerators).map(key => `Guide for: ${key}\n\n${upgradeContentGenerators[key](previous, next)}`)
+
+export const updateUpgradeGuides = (previous: string, next: string): EditFunc => {
+    let updateDirectory = '/doc/admin/updates'
+    // const notPatchRelease = release.patch === 0
+    // const previousNotPatchRelease = previous.patch === 0
+    const notPatchRelease = next.endsWith('.0')
+
+    return (directory: string): void => {
+        updateDirectory = directory + updateDirectory
+        for (const file of readdirSync(updateDirectory)) {
+            if (file === 'index.md') {
+                continue
+            }
+            const fullPath = path.join(updateDirectory, file)
+            console.log(`Updating upgrade guide: ${fullPath}`)
+            let updateContents = readFileSync(fullPath).toString()
+            const releaseHeader = `## v${previous} ➔ v${next}`
+
+            if (notPatchRelease) {
+                const unreleasedHeader = '## Unreleased'
+                updateContents = updateContents.replace(unreleasedHeader, releaseHeader)
+                updateContents = updateContents.replace(update.divider, update.releaseTemplate)
+            } else {
+                const prevReleaseHeaderPattern = `##\\s+v\\d\\.\\d\\.\\d ➔ v${previous}`
+                const matches = updateContents.match(new RegExp(prevReleaseHeaderPattern))
+                if (!matches || matches.length === 0) {
+                    console.log(`Unable to find header using pattern: ${prevReleaseHeaderPattern}. Skipping.`)
+                    continue
+                }
+                const prevReleaseHeader = matches[0]
+                const mode = file.replace('.md', '')
+                const updateFunc = getUpgradeGuide(mode)
+                if (updateFunc === undefined) {
+                    console.log(`Skipping upgrade file: ${file} due to missing content generator`)
+                }
+
+                const content = getUpgradeGuide(mode)(previous, next)
+                updateContents = updateContents.replace(prevReleaseHeader, `${releaseHeader}\n\n${content}\n\n${prevReleaseHeader}`)
+            }
+            writeFileSync(fullPath, updateContents)
+        }
+    }
 }


### PR DESCRIPTION
Closes [#46805](https://github.com/sourcegraph/sourcegraph/issues/46805)

This PR automates release guide contents for both feature and patch releases. It will automatically generate release guides for pure docker, which is the only release guide that gets standardized content typically.

This also fixes an odd scenario where the tool would replace previous patched versions instead of adding a new section to the release guide.

## Test plan
I've added a command to the release tool to test this out. It can be executed with:
`pnpm run release _test:release-guide-update 4.4.1 4.4.2 $PWD` where the version arguments are the previous and next versions to test against. Here is some example output:

Pure docker minor version (note the unreleased content is moved into the appropriate header)
<img width="858" alt="CleanShot 2023-01-27 at 14 43 25@2x" src="https://user-images.githubusercontent.com/5090588/215226310-6a92abae-48d1-4a23-9959-fec765cbab0f.png">

Pure docker patch version (note the unreleased content is preserved)
<img width="682" alt="CleanShot 2023-01-27 at 16 27 47@2x" src="https://user-images.githubusercontent.com/5090588/215226534-68309591-d26e-4ff4-908b-bffdf768acac.png">

Upgrade with no content (for example Kubernetes):
<img width="672" alt="CleanShot 2023-01-27 at 16 28 03@2x" src="https://user-images.githubusercontent.com/5090588/215226571-3b72e413-9da2-4978-99a2-19078b512470.png">


## App preview:

- [Web](https://sg-web-cclark-automate-release-upgrade.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
