### PR TITLE
Always use UTC in GraphQL DateTime type

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -72,7 +71,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 					ID:                  string(marshalBatchChangesCredentialID(cred.ID, true)),
 					ExternalServiceKind: extsvc.TypeToKind(cred.ExternalServiceType),
 					ExternalServiceURL:  cred.ExternalServiceID,
-					CreatedAt:           cred.CreatedAt.Format(time.RFC3339),
+					CreatedAt:           marshalDateTime(t, cred.CreatedAt),
 					IsSiteCredential:    true,
 				},
 			},
@@ -182,7 +181,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 					ID:                  string(marshalBatchChangesCredentialID(siteCred.ID, true)),
 					ExternalServiceKind: extsvc.TypeToKind(siteCred.ExternalServiceType),
 					ExternalServiceURL:  siteCred.ExternalServiceID,
-					CreatedAt:           siteCred.CreatedAt.Format(time.RFC3339),
+					CreatedAt:           marshalDateTime(t, siteCred.CreatedAt),
 					IsSiteCredential:    true,
 				},
 			},
@@ -193,7 +192,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 					ID:                  string(marshalBatchChangesCredentialID(userCred.ID, false)),
 					ExternalServiceKind: extsvc.TypeToKind(userCred.ExternalServiceType),
 					ExternalServiceURL:  userCred.ExternalServiceID,
-					CreatedAt:           userCred.CreatedAt.Format(time.RFC3339),
+					CreatedAt:           marshalDateTime(t, userCred.CreatedAt),
 					IsSiteCredential:    false,
 				},
 			},

--- a/internal/gqlutil/datetime.go
+++ b/internal/gqlutil/datetime.go
@@ -24,7 +24,7 @@ func (DateTime) ImplementsGraphQLType(name string) bool {
 }
 
 func (v DateTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Time.Format(time.RFC3339))
+	return json.Marshal(v.Time.UTC().Format(time.RFC3339))
 }
 
 func (v *DateTime) UnmarshalGraphQL(input any) error {
@@ -36,6 +36,6 @@ func (v *DateTime) UnmarshalGraphQL(input any) error {
 	if err != nil {
 		return err
 	}
-	*v = DateTime{Time: t}
+	*v = DateTime{Time: t.UTC()}
 	return nil
 }


### PR DESCRIPTION
We expect Sourcegraph to return UTC timestamps, but recently learned that is not necessarily always the case. This fixes it. This also fixes a bug where tests started failing locally after our override of TZ didn't run before time.Time was first used anymore.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
