### PR TITLE
Search: remove incorrect adjustment to zoekt MaxWallTime

### DIFF
--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -136,10 +136,6 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		return searchOpts
 	}
 
-	if userProbablyWantsToWaitLonger := o.FileMatchLimit > limits.DefaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(o.FileMatchLimit) / float64(limits.DefaultMaxSearchResults))
-	}
-
 	if o.Selector.Root() == filter.Repository {
 		searchOpts.ShardRepoMaxMatchCount = 1
 	} else {


### PR DESCRIPTION
There's some old logic that tries to adjust SearchOptions.MaxWallTime when the
user sets a larger result limit, in order to give zoekt more time to find
matches. But for streaming search, this always fires, since we check against
the wrong default limit (we use the non-streaming limit). So we were always
adjusting the MaxWallTime to 50 seconds.

This PR removes the adjustment, since it's often broken and doesn't seem
helpful.

## Test plan

Automated tests, light manual testing