### PR TITLE
build: standardize scss import statements

### DIFF
--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -1,4 +1,4 @@
-@import '../../wildcard/src/global-styles/colors';
+@import 'wildcard/src/global-styles/colors';
 
 :root {
     --border-color: rgba(0, 0, 0, 0.125);
@@ -23,11 +23,11 @@
     }
 }
 
-@import '../../wildcard/src/global-styles/functions.scss';
-@import '../../wildcard/src/global-styles/variables.scss';
-@import '../../wildcard/src/global-styles/mixins.scss';
-@import '../../wildcard/src/global-styles/utilities/text';
-@import '../../wildcard/src/global-styles/utilities/screenreaders';
-@import '../../wildcard/src/global-styles/icons';
+@import 'wildcard/src/global-styles/functions';
+@import 'wildcard/src/global-styles/variables';
+@import 'wildcard/src/global-styles/mixins';
+@import 'wildcard/src/global-styles/utilities/text';
+@import 'wildcard/src/global-styles/utilities/screenreaders';
+@import 'wildcard/src/global-styles/icons';
 @import './highlight';
 @import './shared';

--- a/client/browser/src/branded.scss
+++ b/client/browser/src/branded.scss
@@ -1,4 +1,4 @@
 // CSS entry point for branded contexts (options menu and after-install page)
 // global CSS classes etc can be used freely here (in opposite to the content page styles in app.scss)
 
-@import '../../wildcard/src/global-styles/index.scss';
+@import 'wildcard/src/global-styles';

--- a/client/jetbrains/webview/src/index.scss
+++ b/client/jetbrains/webview/src/index.scss
@@ -1,1 +1,1 @@
-@import '../../../wildcard/src/global-styles/index.scss';
+@import 'wildcard/src/global-styles';

--- a/client/vscode/src/webview/index.scss
+++ b/client/vscode/src/webview/index.scss
@@ -2,9 +2,9 @@
 @import '@reach/tabs/styles';
 
 @import 'wildcard/src/global-styles/base';
-@import './theming/highlight.scss';
-@import './theming/monaco.scss';
-@import '@vscode/codicons/dist/codicon.css';
+@import './theming/highlight';
+@import './theming/monaco';
+@import '@vscode/codicons/dist/codicon';
 
 :root {
     // v2/debt: redefine our CSS variables using VS Code's CSS variables

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -4,12 +4,12 @@ It should import all component stylesheets.
 */
 
 // Global libraries styles
-@import 'react-grid-layout/css/styles.css';
+@import 'react-grid-layout/css/styles';
 
 // Use duplicate selectors for the light-theme
 // stylelint-disable no-duplicate-selectors
 
-@import '../../wildcard/src/global-styles/index.scss';
+@import 'wildcard/src/global-styles';
 
 // Document highlight is the background color for tokens which are matched with
 // a result from a document highlight provider. e.g. for references of the token
@@ -28,7 +28,7 @@ It should import all component stylesheets.
     text-decoration: inherit;
 
     &:focus {
-        background-color: rgba($blue, 0.1);
+        background-color: rgba(var(--blue), 0.1);
     }
 }
 

--- a/client/web/src/api/graphiql-theme.scss
+++ b/client/web/src/api/graphiql-theme.scss
@@ -13,7 +13,7 @@
 
 @use 'wildcard/src/global-styles/forms';
 
-@import 'graphiql/graphiql.css';
+@import 'graphiql/graphiql';
 
 /* stylelint-disable selector-class-pattern */
 /* stylelint-disable declaration-property-unit-allowed-list */

--- a/client/wildcard/src/components/Modal/Modal.module.scss
+++ b/client/wildcard/src/components/Modal/Modal.module.scss
@@ -1,4 +1,4 @@
-@import '@reach/dialog/styles.css';
+@import '@reach/dialog/styles';
 
 :root {
     --modal-body-padding: 1.5rem;

--- a/client/wildcard/src/global-styles/base.scss
+++ b/client/wildcard/src/global-styles/base.scss
@@ -1,8 +1,8 @@
-@import './colors.scss';
-@import './variables.scss';
+@import './colors';
+@import './variables';
 
-@import './functions.scss';
-@import './mixins.scss';
+@import './functions';
+@import './mixins';
 @import './reboot';
 @import './utilities';
 @import './breakpoints';
@@ -41,10 +41,10 @@ input[type='checkbox'] {
     }
 }
 
-@import 'react-resizable/css/styles.css';
+@import 'react-resizable/css/styles';
 // Global styles provided by @reach packages. Should be imported once in the global scope.
-@import '@reach/combobox/styles.css';
-@import '@reach/menu-button/styles.css';
+@import '@reach/combobox/styles';
+@import '@reach/menu-button/styles';
 
 // stylelint-disable-next-line selector-max-id
 html,

--- a/client/wildcard/src/global-styles/forms.scss
+++ b/client/wildcard/src/global-styles/forms.scss
@@ -1,4 +1,4 @@
-@import 'wildcard/src/global-styles/breakpoints';
+@import './breakpoints';
 
 :root {
     --form-group-margin-bottom: 1rem;

--- a/client/wildcard/src/global-styles/index.scss
+++ b/client/wildcard/src/global-styles/index.scss
@@ -1,5 +1,5 @@
 // The VSCode extension uses its syntax-highlighting theme,
 // that's why we need a separate base.scss entry point for all branded styles without syntax highlighting.
 // Client applications that want to inherit the default theme fully should use this file as a base theme.
-@import './base.scss';
+@import './base';
 @import './highlight';


### PR DESCRIPTION
Different types of sass imports are handled in different steps of the build today. Some imports are inlined by sass (those with `.scss` or no extension in the import), other imports (those with the `.css` extension in the import) remain as css `@import`s within the compiled-css and are then handled by webpack at bundle-time.

This PR normalizes the imports so they are all handled by the sass compiler. This way the dependencies are not carried forward to the bundling step. Under bazel carrying those dependencies forward is a bit of a hassle while also not allowing them to be cached as well. This also makes the final js a bit less complicated since there is no runtime css imports anymore.

## Test plan

I'm not sure, what's the best way to test that visuals haven't changed?

## App preview:

- [Web](https://sg-web-bazel-consistent-sass-imports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

