### PR TITLE
Fix global dashboard owner initial value

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -14,6 +14,8 @@ import {
     CodeInsightsBackendContext,
     CustomInsightDashboard,
     InsightsDashboardOwner,
+    InsightsDashboardOwnerType,
+    isGlobalOwner,
     isPersonalOwner,
     isVirtualDashboard,
     useInsightDashboard,
@@ -131,6 +133,20 @@ function getDashboardInitialValues(
     availableOwners: InsightsDashboardOwner[]
 ): DashboardCreationFields | undefined {
     const { title } = dashboard
+
+    const isGlobal = dashboard.owners.some(isGlobalOwner)
+    const availableGlobalOwner = availableOwners.find(
+        availableOwner => availableOwner.type === InsightsDashboardOwnerType.Global
+    )
+
+    if (isGlobal && availableGlobalOwner) {
+        // Pick any global owner from the list
+        return {
+            name: title,
+            owner: availableGlobalOwner,
+        }
+    }
+
     const owner = dashboard.owners.find(owner => availableOwners.some(availableOwner => availableOwner.id === owner.id))
 
     return {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/47063

## Test plan
- Open any personal dashboard and click Configure button in the three dot context menu next to dashboard picker 
- Check that dashboard visibility UI has valid value (personal dashboard)
- Check this for org and global dashboards 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-global-owner-dashboard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
