### PR TITLE
make DEV_WEB_BUILDER_OMIT_SLOW_DEPS work with pnpm

### DIFF
--- a/client/build-config/src/esbuild/packageResolutionPlugin.ts
+++ b/client/build-config/src/esbuild/packageResolutionPlugin.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve'
 import * as esbuild from 'esbuild'
 
-import { NODE_MODULES_PATH } from '../paths'
+import { NODE_MODULES_PATH, WORKSPACE_NODE_MODULES_PATHS } from '../paths'
 
 interface Resolutions {
     [fromModule: string]: string
@@ -22,7 +22,7 @@ export const packageResolutionPlugin = (resolutions: Resolutions): esbuild.Plugi
             fileSystem: new CachedInputFileSystem(fs, 4000),
             extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
             symlinks: true, // Resolve workspace symlinks
-            modules: [NODE_MODULES_PATH],
+            modules: [NODE_MODULES_PATH, ...WORKSPACE_NODE_MODULES_PATHS],
             unsafeCache: true,
         })
 


### PR DESCRIPTION
The DEV_WEB_BUILDER_OMIT_SLOW_DEPS env var is an experimental dev env var for faster builds that I sometimes use. When using it, the packageResolution plugin needs the same fix as the one for stylePlugin in https://github.com/sourcegraph/sourcegraph/pull/46452 to work with pnpm. This is a generally sensible fix that implements the correct and desirable behavior, not just a way to make a hack work.




## Test plan

Esbuild is a dev-only experimental setting, so no test plan is needed.

## App preview:

- [Web](https://sg-web-sqs-esbuild-pkgres-pnpm.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
