### PR TITLE
Make `sg start app` work

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -30,6 +30,7 @@ Use this to start your Sourcegraph environment!
 Available comamndsets in `sg.config.yaml`:
 
 * api-only
+* app
 * batches 🦡
 * codeintel
 * dotcom
@@ -37,12 +38,10 @@ Available comamndsets in `sg.config.yaml`:
 * enterprise-codeinsights
 * enterprise-codeintel 🧠
 * enterprise-e2e
-* enterprise-single-program
 * iam
 * monitoring
 * monitoring-alerts
 * oss
-* oss-single-program
 * oss-web-standalone
 * oss-web-standalone-prod
 * otel

--- a/enterprise/cmd/sourcegraph/README.md
+++ b/enterprise/cmd/sourcegraph/README.md
@@ -7,7 +7,7 @@ Sourcegraph App is a single-binary distribution of Sourcegraph that runs on your
 ## Development
 
 ```shell
-sg start enterprise-single-program
+sg start app
 ```
 
 ## Usage
@@ -42,4 +42,4 @@ enterprise/dev/app/release.sh --snapshot
 
 The builds are written to the `dist` directory.
 
-If you just need a local build for your current platform, run `sg start enterprise-single-program` (as mentioned in the [Development](#development) section) and then grab the `.bin/sourcegraph` binary. This binary does not have the web bundle (JavaScript/CSS) embedded into it.
+If you just need a local build for your current platform, run `sg start app` (as mentioned in the [Development](#development) section) and then grab the `.bin/sourcegraph` binary. This binary does not have the web bundle (JavaScript/CSS) embedded into it.

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -90,7 +90,7 @@ type dependencies struct {
 }
 
 func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps dependencies) error {
-	return migrations.RegisterAll(runner, noDelay, []migrations.TaggedMigrator{
+	migrators := []migrations.TaggedMigrator{
 		iam.NewSubscriptionAccountNumberMigrator(deps.store, 500),
 		iam.NewLicenseKeyFieldsMigrator(deps.store, 500),
 		batches.NewSSHMigratorWithDB(deps.store, deps.keyring.BatchChangesCredentialKey, 5),
@@ -99,8 +99,13 @@ func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps
 		codeintel.NewReferencesLocationsCountMigrator(deps.codeIntelStore, 1000, 0),
 		codeintel.NewDocumentColumnSplitMigrator(deps.codeIntelStore, 100, 0),
 		codeintel.NewSCIPMigrator(deps.store, deps.codeIntelStore),
-		insights.NewMigrator(deps.store, deps.insightsStore),
-		insightsrecordingtimes.NewRecordingTimesMigrator(deps.insightsStore, 500),
-		insightsBackfiller.NewMigrator(deps.insightsStore, glock.NewRealClock(), 10),
-	})
+	}
+	if deps.insightsStore != nil {
+		migrators = append(migrators,
+			insights.NewMigrator(deps.store, deps.insightsStore),
+			insightsrecordingtimes.NewRecordingTimesMigrator(deps.insightsStore, 500),
+			insightsBackfiller.NewMigrator(deps.insightsStore, glock.NewRealClock(), 10),
+		)
+	}
+	return migrations.RegisterAll(runner, noDelay, migrators)
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1120,10 +1120,14 @@ commandsets:
       - otel-collector
       - jaeger
 
-  enterprise-single-program:
+  app:
     requiresDevPrivate: true
+    env:
+      # TODO(slimsag): remove the need for this
+      BLOBSTORE_DATA_DIR: /tmp/blobstore-data
     checks:
       - docker
+      # TODO: App's dependency on Redis will be removed.
       - redis
       - postgres
       - git
@@ -1131,19 +1135,7 @@ commandsets:
       - sourcegraph
       - docsite
       - web
-      - syntax-highlighter
-      - caddy
-
-  oss-single-program:
-    checks:
-      - docker
-      - redis
-      - postgres
-      - git
-    commands:
-      - sourcegraph-oss
-      - docsite
-      - oss-web
+      # TODO: App's dependency on syntax-highlighter will be removed.
       - syntax-highlighter
       - caddy
 


### PR DESCRIPTION
- Adds sg config for `sg start app` (renamed from `enterprise-single-program`). Also adds comments and a temporarily necessary env var.
- Do not register insights migrators if Code Insights is disabled. Fixes a panic upon startup in backfillerv2Migrator when running App (the single binary) in local dev.

## Test plan

Run `sg start app`.