### PR TITLE
experimental search input: Add symbol suggestions

### DIFF
--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -10,3 +10,4 @@ export type {
 } from './suggestionsExtension'
 export { getEditorConfig } from './suggestionsExtension'
 export * from './optionRenderer'
+export * from './utils'

--- a/client/branded/src/search-ui/input/experimental/utils.test.ts
+++ b/client/branded/src/search-ui/input/experimental/utils.test.ts
@@ -1,0 +1,15 @@
+import { shortenPath } from './utils'
+
+describe('shortenPath', () => {
+    it('returns the original path when it is shorter than the desired length', () => {
+        expect(shortenPath('a/b/c/d/e/f/g/h', 20)).toBe('a/b/c/d/e/f/g/h')
+    })
+
+    it('returns the original path when it does not have sufficient segments', () => {
+        expect(shortenPath('thispathonlyhas/twosegements', 5)).toBe('thispathonlyhas/twosegements')
+    })
+
+    it('preserves the first and last two segements', () => {
+        expect(shortenPath('one/two/three/four/five/six/seven', 5)).toBe('one/two/.../six/seven')
+    })
+})

--- a/client/branded/src/search-ui/input/experimental/utils.ts
+++ b/client/branded/src/search-ui/input/experimental/utils.ts
@@ -3,8 +3,8 @@
  * as close to the length as possible (but doesn't gurantee it). The first two
  * and last two path segements are always visible.
  */
-export function shortenPath(path: string, desiredLength: number): string {
-    if (path.length <= desiredLength) {
+export function shortenPath(path: string, desiredChars: number): string {
+    if (path.length <= desiredChars) {
         return path
     }
 

--- a/client/branded/src/search-ui/input/experimental/utils.ts
+++ b/client/branded/src/search-ui/input/experimental/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Takes in a file path and a desired length. Will shorten the path so that it's
+ * as close to the length as possible (but doesn't gurantee it). The first two
+ * and last two path segements are always visible.
+ */
+export function shortenPath(path: string, desiredLength: number): string {
+    if (path.length <= desiredLength) {
+        return path
+    }
+
+    const parts = path.split('/')
+    if (parts.length < 5) {
+        // We need at least 5 segements to shorten the path
+        return path
+    }
+    const shortendPath = parts
+        .slice(0, 2)
+        .concat('...', ...parts.slice(-2))
+        .join('/')
+    return shortendPath.length < path.length ? shortendPath : path
+}

--- a/client/shared/src/symbols/SymbolIcon.tsx
+++ b/client/shared/src/symbols/SymbolIcon.tsx
@@ -1,31 +1,5 @@
 import * as React from 'react'
 
-import {
-    mdiCodeArray,
-    mdiCodeBraces,
-    mdiCodeNotEqual,
-    mdiCodeString,
-    mdiCube,
-    mdiCubeOutline,
-    mdiDrawingBox,
-    mdiFileDocument,
-    mdiFunction,
-    mdiKey,
-    mdiLink,
-    mdiMatrix,
-    mdiNull,
-    mdiNumeric,
-    mdiPackage,
-    mdiPiBox,
-    mdiPillar,
-    mdiPound,
-    mdiShape,
-    mdiSitemap,
-    mdiTextBox,
-    mdiTimetable,
-    mdiWeb,
-    mdiWrench,
-} from '@mdi/js'
 import classNames from 'classnames'
 import { upperFirst } from 'lodash'
 
@@ -33,69 +7,9 @@ import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { SymbolKind } from '../graphql-operations'
 
+import { getSymbolIconSVGPath } from './symbolIcons'
+
 import styles from './SymbolIcon.module.scss'
-/**
- * Returns the icon component for a given symbol kind
- */
-const getSymbolIconComponent = (kind: SymbolKind): string => {
-    switch (kind) {
-        case 'FILE':
-            return mdiFileDocument
-        case 'MODULE':
-            return mdiCodeBraces
-        case 'NAMESPACE':
-            return mdiWeb
-        case 'PACKAGE':
-            return mdiPackage
-        case 'CLASS':
-            return mdiSitemap
-        case 'METHOD':
-            return mdiCubeOutline
-        case 'PROPERTY':
-            return mdiWrench
-        case 'FIELD':
-            return mdiTextBox
-        case 'CONSTRUCTOR':
-            return mdiCubeOutline
-        case 'ENUM':
-            return mdiNumeric
-        case 'INTERFACE':
-            return mdiLink
-        case 'FUNCTION':
-            return mdiFunction
-        case 'VARIABLE':
-            return mdiCube
-        case 'CONSTANT':
-            return mdiPiBox
-        case 'STRING':
-            return mdiCodeString
-        case 'NUMBER':
-            return mdiPound
-        case 'BOOLEAN':
-            return mdiMatrix
-        case 'ARRAY':
-            return mdiCodeArray
-        case 'OBJECT':
-            return mdiDrawingBox
-        case 'KEY':
-            return mdiKey
-        case 'NULL':
-            return mdiNull
-        case 'ENUMMEMBER':
-            return mdiNumeric
-        case 'STRUCT':
-            return mdiPillar
-        case 'EVENT':
-            return mdiTimetable
-        case 'OPERATOR':
-            return mdiCodeNotEqual
-        case 'TYPEPARAMETER':
-            return mdiCube
-        case 'UNKNOWN':
-        default:
-            return mdiShape
-    }
-}
 
 interface SymbolIconProps {
     kind: SymbolKind
@@ -117,7 +31,7 @@ export const SymbolIcon: React.FunctionComponent<React.PropsWithChildren<SymbolI
             data-testid="symbol-icon"
             data-symbol-kind={kind.toLowerCase()}
             className={classNames(getSymbolIconClassName(kind), className)}
-            svgPath={getSymbolIconComponent(kind)}
+            svgPath={getSymbolIconSVGPath(kind)}
             aria-label={`Symbol kind ${kind.toLowerCase()}`}
         />
     </Tooltip>

--- a/client/shared/src/symbols/symbolIcons.ts
+++ b/client/shared/src/symbols/symbolIcons.ts
@@ -1,0 +1,88 @@
+import {
+    mdiCodeArray,
+    mdiCodeBraces,
+    mdiCodeNotEqual,
+    mdiCodeString,
+    mdiCube,
+    mdiCubeOutline,
+    mdiDrawingBox,
+    mdiFileDocument,
+    mdiFunction,
+    mdiKey,
+    mdiLink,
+    mdiMatrix,
+    mdiNull,
+    mdiNumeric,
+    mdiPackage,
+    mdiPiBox,
+    mdiPillar,
+    mdiPound,
+    mdiShape,
+    mdiSitemap,
+    mdiTextBox,
+    mdiTimetable,
+    mdiWeb,
+    mdiWrench,
+} from '@mdi/js'
+
+import { SymbolKind } from '../graphql-operations'
+
+export const getSymbolIconSVGPath = (kind: SymbolKind): string => {
+    switch (kind) {
+        case 'FILE':
+            return mdiFileDocument
+        case 'MODULE':
+            return mdiCodeBraces
+        case 'NAMESPACE':
+            return mdiWeb
+        case 'PACKAGE':
+            return mdiPackage
+        case 'CLASS':
+            return mdiSitemap
+        case 'METHOD':
+            return mdiCubeOutline
+        case 'PROPERTY':
+            return mdiWrench
+        case 'FIELD':
+            return mdiTextBox
+        case 'CONSTRUCTOR':
+            return mdiCubeOutline
+        case 'ENUM':
+            return mdiNumeric
+        case 'INTERFACE':
+            return mdiLink
+        case 'FUNCTION':
+            return mdiFunction
+        case 'VARIABLE':
+            return mdiCube
+        case 'CONSTANT':
+            return mdiPiBox
+        case 'STRING':
+            return mdiCodeString
+        case 'NUMBER':
+            return mdiPound
+        case 'BOOLEAN':
+            return mdiMatrix
+        case 'ARRAY':
+            return mdiCodeArray
+        case 'OBJECT':
+            return mdiDrawingBox
+        case 'KEY':
+            return mdiKey
+        case 'NULL':
+            return mdiNull
+        case 'ENUMMEMBER':
+            return mdiNumeric
+        case 'STRUCT':
+            return mdiPillar
+        case 'EVENT':
+            return mdiTimetable
+        case 'OPERATOR':
+            return mdiCodeNotEqual
+        case 'TYPEPARAMETER':
+            return mdiCube
+        case 'UNKNOWN':
+        default:
+            return mdiShape
+    }
+}

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -148,6 +148,7 @@ interface CodeSymbol {
     kind: SymbolKind
     name: string
     url: string
+    path: string
 }
 
 /**

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -1,6 +1,6 @@
 import { EditorState } from '@codemirror/state'
 import { mdiFilterOutline, mdiTextSearchVariant, mdiSourceRepository, mdiStar, mdiFileOutline } from '@mdi/js'
-import { extendedMatch, Fzf, FzfOptions, FzfResultItem } from 'fzf'
+import { byLengthAsc, extendedMatch, Fzf, FzfOptions, FzfResultItem } from 'fzf'
 
 import { tokenAt, tokens as queryTokens } from '@sourcegraph/branded'
 // This module implements suggestions for the experimental search input
@@ -15,6 +15,7 @@ import {
     queryRenderer,
     filterRenderer,
     filterValueRenderer,
+    shortenPath,
 } from '@sourcegraph/branded/src/search-ui/experimental'
 import { getParsedQuery } from '@sourcegraph/branded/src/search-ui/input/codemirror/parsedQuery'
 import { isDefined } from '@sourcegraph/common'
@@ -27,6 +28,7 @@ import { Node, OperatorKind } from '@sourcegraph/shared/src/search/query/parser'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { CharacterRange, Filter, PatternKind, Token } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
+import { getSymbolIconSVGPath } from '@sourcegraph/shared/src/symbols/symbolIcons'
 
 import { AuthenticatedUser } from '../../auth'
 import {
@@ -34,6 +36,9 @@ import {
     SuggestionsRepoVariables,
     SuggestionsFileResult,
     SuggestionsFileVariables,
+    SuggestionsSymbolResult,
+    SuggestionsSymbolVariables,
+    SymbolKind,
 } from '../../graphql-operations'
 
 /**
@@ -96,6 +101,28 @@ const FILE_QUERY = gql`
     }
 `
 
+const SYMBOL_QUERY = gql`
+    query SuggestionsSymbol($query: String!) {
+        search(patternType: regexp, query: $query) {
+            results {
+                results {
+                    ... on FileMatch {
+                        __typename
+                        file {
+                            path
+                        }
+                        symbols {
+                            kind
+                            url
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
 interface Repo {
     name: string
     stars: number
@@ -114,6 +141,12 @@ interface File {
     // The repository stars
     stars: number
     repository: string
+    url: string
+}
+
+interface CodeSymbol {
+    kind: SymbolKind
+    name: string
     url: string
 }
 
@@ -236,6 +269,28 @@ function toFileSuggestion(result: FzfResultItem<File>, from: number, to?: number
     }
     option.render = filterValueRenderer
     return option
+}
+
+/**
+ * Converts a File value to a (jump) target suggestion.
+ */
+function toSymbolSuggestion({ item, positions }: FzfResultItem<CodeSymbol>, from: number, to?: number): Option {
+    return {
+        label: item.name,
+        matches: positions,
+        description: shortenPath(item.path, 20),
+        icon: getSymbolIconSVGPath(item.kind),
+        action: {
+            type: 'completion',
+            insertValue: item.name + ' type:symbol ',
+            from,
+            to,
+        },
+        alternativeAction: {
+            type: 'goto',
+            url: item.url,
+        },
+    }
 }
 
 /**
@@ -467,7 +522,7 @@ function repoSuggestions(cache: Caches['repo']): InternalSource {
             results => [
                 {
                     title: 'Repositories',
-                    options: results.slice(0, 5).map(result => toRepoSuggestion(result, token.range.start)),
+                    options: results.slice(0, 3).map(result => toRepoSuggestion(result, token.range.start)),
                 },
             ],
             parsedQuery,
@@ -483,9 +538,8 @@ function repoSuggestions(cache: Caches['repo']): InternalSource {
  */
 function fileSuggestions(cache: Caches['file'], isSourcegraphDotCom?: boolean): InternalSource {
     return ({ token, tokens, parsedQuery, position }) => {
-        // Only show file suggestions when
-        // - the query contains at least one repo: filter
-        // - if this is dotcom, contains at least one context: filter that is not 'global'
+        // Only show file suggestions on dotcom if the query contains at least
+        // one context: filter that is not 'global', or a repo: filter.
         const showFileSuggestions =
             token?.type === 'pattern' &&
             (!isSourcegraphDotCom ||
@@ -515,6 +569,47 @@ function fileSuggestions(cache: Caches['file'], isSourcegraphDotCom?: boolean): 
 }
 
 /**
+ * Returns file (jump) target suggestions matching the term at the cursor,
+ * but only if the query contains suitable filters. On dotcom we only show file
+ * suggestions if the query contains at least one context: or repo: filter.
+ */
+function symbolSuggestions(cache: Caches['symbol'], isSourcegraphDotCom?: boolean): InternalSource {
+    return ({ token, tokens, parsedQuery, position }) => {
+        if (token?.type !== 'pattern') {
+            return null
+        }
+
+        // Only show symbol suggestions if the query contains a context:, repo:
+        // or file: filter. On dotcom the context must by different from
+        // "global".
+
+        if (
+            !tokens.some(
+                token =>
+                    token.type === 'filter' &&
+                    ((token.field.value === 'context' && (!isSourcegraphDotCom || token.value?.value !== 'global')) ||
+                        token.field.value === 'repo' ||
+                        token.field.value === 'file')
+            )
+        ) {
+            return null
+        }
+
+        return cache.query(
+            token.value,
+            results => [
+                {
+                    title: 'Symbols',
+                    options: results.slice(0, 5).map(result => toSymbolSuggestion(result, token.range.start)),
+                },
+            ],
+            parsedQuery,
+            position
+        )
+    }
+}
+
+/**
  * A contextual cache not only uses the provided value to find suggestions but
  * also the current (parsed) query input.
  */
@@ -524,6 +619,7 @@ interface Caches {
     repo: ContextualCache<Repo, FzfResultItem<Repo>>
     context: Cache<Context, FzfResultItem<Context>>
     file: ContextualCache<File, FzfResultItem<File>>
+    symbol: ContextualCache<CodeSymbol, FzfResultItem<CodeSymbol>>
 }
 
 interface SuggestionsSourceConfig
@@ -563,8 +659,14 @@ export const createSuggestionsSource = ({
         tiebreakers: [starTiebraker],
     }
 
+    const symbolFzfOptions: FzfOptions<CodeSymbol> = {
+        selector: item => item.name,
+        tiebreakers: [byLengthAsc],
+    }
+
     // Relevant query filters for file suggestions
     const fileFilters: Set<FilterType> = new Set([FilterType.repo, FilterType.rev, FilterType.context, FilterType.lang])
+    const symbolFilters: Set<FilterType> = new Set([...fileFilters, FilterType.file])
 
     // TODO: Initialize outside to persist cache across page navigation
     const caches: Caches = {
@@ -675,6 +777,51 @@ export const createSuggestionsSource = ({
                 return fzf.find(cleanRegex(query))
             },
         }),
+        symbol: new Cache({
+            dataCacheKey: (parsedQuery, position) =>
+                parsedQuery
+                    ? buildSuggestionQuery(
+                          parsedQuery,
+                          { start: position, end: position },
+                          token =>
+                              token.type === 'parameter' &&
+                              !!token.value &&
+                              symbolFilters.has(token.field as FilterType)
+                      )
+                    : '',
+            queryKey: (value, dataCacheKey = '') => `${dataCacheKey} type:symbol count:50 ${value}`,
+            async query(query) {
+                const response = await platformContext
+                    .requestGraphQL<SuggestionsSymbolResult, SuggestionsSymbolVariables>({
+                        request: SYMBOL_QUERY,
+                        variables: { query },
+                        mightContainPrivateInfo: true,
+                    })
+                    .toPromise()
+                return (
+                    response.data?.search?.results?.results?.reduce((results, result) => {
+                        if (result.__typename === 'FileMatch') {
+                            for (const symbol of result.symbols) {
+                                results.push([
+                                    symbol.url,
+                                    {
+                                        name: symbol.name,
+                                        kind: symbol.kind,
+                                        path: result.file.path,
+                                        url: symbol.url,
+                                    },
+                                ])
+                            }
+                        }
+                        return results
+                    }, [] as [string, CodeSymbol][]) ?? []
+                )
+            },
+            filter(files, query) {
+                const fzf = new Fzf(files, symbolFzfOptions)
+                return fzf.find(query)
+            },
+        }),
     }
 
     const sources: InternalSource[] = [
@@ -683,6 +830,7 @@ export const createSuggestionsSource = ({
         filterSuggestions,
         repoSuggestions(caches.repo),
         fileSuggestions(caches.file, isSourcegraphDotCom),
+        symbolSuggestions(caches.symbol, isSourcegraphDotCom),
     ]
 
     return (state, position) => {
@@ -748,7 +896,7 @@ class Cache<T, U, E extends any[] = []> {
         const queryKey = this.config.queryKey(value, dataCacheKey)
         let dataCache = this.dataCache
         if (dataCacheKey) {
-            dataCache = this.dataCacheByQuery.get(dataCacheKey) ?? new Map()
+            dataCache = this.dataCacheByQuery.get(dataCacheKey) ?? new Map<string, T>()
             if (!this.dataCacheByQuery.has(dataCacheKey)) {
                 this.dataCacheByQuery.set(dataCacheKey, dataCache)
             }


### PR DESCRIPTION
Similar to #46663, this PR adds symbol suggestions for completion and go to. Currently selecting a symbol for completion will also insert `type:symbol`, but that's still up for debate.

This also increases the number of file suggestions to 5 again.

How symbol suggestions are displayed to make them easy to process is also something we will iterate on.

<img width="827" alt="2023-01-29_21-27" src="https://user-images.githubusercontent.com/179026/215357229-dbaa3d0b-b7e6-44c7-ac9a-33e82174ac29.png">


## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-experimental-symbol.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
