### PR TITLE
Database: replace `Transact()` with `WithTransact()` on `ExecutorSecretStore`

### DIFF
--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -118,7 +118,7 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 
 	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
 
-	var secret *database.ExecutorSecret
+	var oldSecret *database.ExecutorSecret
 	err = store.WithTransact(ctx, func(tx database.ExecutorSecretStore) error {
 		secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
 		if err != nil {
@@ -138,13 +138,14 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 			return err
 		}
 
+		oldSecret = secret
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &executorSecretResolver{db: r.db, secret: secret}, nil
+	return &executorSecretResolver{db: r.db, secret: oldSecret}, nil
 }
 
 type DeleteExecutorSecretArgs struct {

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -101,7 +101,7 @@ type UpdateExecutorSecretArgs struct {
 	Value string
 }
 
-func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateExecutorSecretArgs) (_ *executorSecretResolver, err error) {
+func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateExecutorSecretArgs) (*executorSecretResolver, error) {
 	scope, id, err := unmarshalExecutorSecretID(args.ID)
 	if err != nil {
 		return nil, err
@@ -118,27 +118,29 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 
 	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
 
-	tx, err := store.Transact(ctx)
+	var secret *database.ExecutorSecret
+	err = store.WithTransact(ctx, func(tx database.ExecutorSecretStore) error {
+		secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
+		if err != nil {
+			return err
+		}
+
+		// 🚨 SECURITY: Check namespace access.
+		if err := checkNamespaceAccess(ctx, database.NewDBWith(r.logger, tx), secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+			return err
+		}
+
+		if err := validateExecutorSecret(secret, args.Value); err != nil {
+			return err
+		}
+
+		if err := tx.Update(ctx, args.Scope.ToDatabaseScope(), secret, args.Value); err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
-	if err != nil {
-		return nil, err
-	}
-
-	// 🚨 SECURITY: Check namespace access.
-	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
-		return nil, err
-	}
-
-	if err := validateExecutorSecret(secret, args.Value); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Update(ctx, args.Scope.ToDatabaseScope(), secret, args.Value); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +152,7 @@ type DeleteExecutorSecretArgs struct {
 	Scope ExecutorSecretScope
 }
 
-func (r *schemaResolver) DeleteExecutorSecret(ctx context.Context, args DeleteExecutorSecretArgs) (_ *EmptyResponse, err error) {
+func (r *schemaResolver) DeleteExecutorSecret(ctx context.Context, args DeleteExecutorSecretArgs) (*EmptyResponse, error) {
 	scope, id, err := unmarshalExecutorSecretID(args.ID)
 	if err != nil {
 		return nil, err
@@ -167,23 +169,24 @@ func (r *schemaResolver) DeleteExecutorSecret(ctx context.Context, args DeleteEx
 
 	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
 
-	tx, err := store.Transact(ctx)
+	err = store.WithTransact(ctx, func(tx database.ExecutorSecretStore) error {
+		secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
+		if err != nil {
+			return err
+		}
+
+		// 🚨 SECURITY: Check namespace access.
+		if err := checkNamespaceAccess(ctx, database.NewDBWith(r.logger, tx), secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+			return err
+		}
+
+		if err := tx.Delete(ctx, args.Scope.ToDatabaseScope(), id); err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
-	if err != nil {
-		return nil, err
-	}
-
-	// 🚨 SECURITY: Check namespace access.
-	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Delete(ctx, args.Scope.ToDatabaseScope(), id); err != nil {
 		return nil, err
 	}
 

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -84,7 +84,6 @@ func (ExecutorSecretNotFoundErr) NotFound() bool {
 type ExecutorSecretStore interface {
 	basestore.ShareableStore
 	With(basestore.ShareableStore) ExecutorSecretStore
-	Transact(context.Context) (ExecutorSecretStore, error)
 	WithTransact(context.Context, func(ExecutorSecretStore) error) error
 	Done(err error) error
 	ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, error)

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -15367,6 +15367,9 @@ type MockExecutorSecretStore struct {
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *ExecutorSecretStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *ExecutorSecretStoreWithTransactFunc
 }
 
 // NewMockExecutorSecretStore creates a new mock of the ExecutorSecretStore
@@ -15426,6 +15429,11 @@ func NewMockExecutorSecretStore() *MockExecutorSecretStore {
 		},
 		WithFunc: &ExecutorSecretStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 ExecutorSecretStore) {
+				return
+			},
+		},
+		WithTransactFunc: &ExecutorSecretStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(ExecutorSecretStore) error) (r0 error) {
 				return
 			},
 		},
@@ -15492,6 +15500,11 @@ func NewStrictMockExecutorSecretStore() *MockExecutorSecretStore {
 				panic("unexpected invocation of MockExecutorSecretStore.With")
 			},
 		},
+		WithTransactFunc: &ExecutorSecretStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(ExecutorSecretStore) error) error {
+				panic("unexpected invocation of MockExecutorSecretStore.WithTransact")
+			},
+		},
 	}
 }
 
@@ -15532,6 +15545,9 @@ func NewMockExecutorSecretStoreFrom(i ExecutorSecretStore) *MockExecutorSecretSt
 		},
 		WithFunc: &ExecutorSecretStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &ExecutorSecretStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -16717,6 +16733,114 @@ func (c ExecutorSecretStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ExecutorSecretStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockExecutorSecretStore instance is
+// invoked.
+type ExecutorSecretStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(ExecutorSecretStore) error) error
+	hooks       []func(context.Context, func(ExecutorSecretStore) error) error
+	history     []ExecutorSecretStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) WithTransact(v0 context.Context, v1 func(ExecutorSecretStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(ExecutorSecretStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockExecutorSecretStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(ExecutorSecretStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockExecutorSecretStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretStoreWithTransactFunc) PushHook(hook func(context.Context, func(ExecutorSecretStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(ExecutorSecretStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(ExecutorSecretStore) error) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreWithTransactFunc) nextHook() func(context.Context, func(ExecutorSecretStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreWithTransactFunc) appendCall(r0 ExecutorSecretStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretStoreWithTransactFunc) History() []ExecutorSecretStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of
+// MockExecutorSecretStore.
+type ExecutorSecretStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(ExecutorSecretStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -15358,9 +15358,6 @@ type MockExecutorSecretStore struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
 	ListFunc *ExecutorSecretStoreListFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *ExecutorSecretStoreTransactFunc
 	// UpdateFunc is an instance of a mock function object controlling the
 	// behavior of the method Update.
 	UpdateFunc *ExecutorSecretStoreUpdateFunc
@@ -15414,11 +15411,6 @@ func NewMockExecutorSecretStore() *MockExecutorSecretStore {
 		},
 		ListFunc: &ExecutorSecretStoreListFunc{
 			defaultHook: func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (r0 []*ExecutorSecret, r1 int, r2 error) {
-				return
-			},
-		},
-		TransactFunc: &ExecutorSecretStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 ExecutorSecretStore, r1 error) {
 				return
 			},
 		},
@@ -15485,11 +15477,6 @@ func NewStrictMockExecutorSecretStore() *MockExecutorSecretStore {
 				panic("unexpected invocation of MockExecutorSecretStore.List")
 			},
 		},
-		TransactFunc: &ExecutorSecretStoreTransactFunc{
-			defaultHook: func(context.Context) (ExecutorSecretStore, error) {
-				panic("unexpected invocation of MockExecutorSecretStore.Transact")
-			},
-		},
 		UpdateFunc: &ExecutorSecretStoreUpdateFunc{
 			defaultHook: func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
 				panic("unexpected invocation of MockExecutorSecretStore.Update")
@@ -15536,9 +15523,6 @@ func NewMockExecutorSecretStoreFrom(i ExecutorSecretStore) *MockExecutorSecretSt
 		},
 		ListFunc: &ExecutorSecretStoreListFunc{
 			defaultHook: i.List,
-		},
-		TransactFunc: &ExecutorSecretStoreTransactFunc{
-			defaultHook: i.Transact,
 		},
 		UpdateFunc: &ExecutorSecretStoreUpdateFunc{
 			defaultHook: i.Update,
@@ -16416,111 +16400,6 @@ func (c ExecutorSecretStoreListFuncCall) Args() []interface{} {
 // invocation.
 func (c ExecutorSecretStoreListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// ExecutorSecretStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockExecutorSecretStore instance is invoked.
-type ExecutorSecretStoreTransactFunc struct {
-	defaultHook func(context.Context) (ExecutorSecretStore, error)
-	hooks       []func(context.Context) (ExecutorSecretStore, error)
-	history     []ExecutorSecretStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockExecutorSecretStore) Transact(v0 context.Context) (ExecutorSecretStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(ExecutorSecretStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockExecutorSecretStore instance is invoked and the hook queue
-// is empty.
-func (f *ExecutorSecretStoreTransactFunc) SetDefaultHook(hook func(context.Context) (ExecutorSecretStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockExecutorSecretStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *ExecutorSecretStoreTransactFunc) PushHook(hook func(context.Context) (ExecutorSecretStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ExecutorSecretStoreTransactFunc) SetDefaultReturn(r0 ExecutorSecretStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (ExecutorSecretStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ExecutorSecretStoreTransactFunc) PushReturn(r0 ExecutorSecretStore, r1 error) {
-	f.PushHook(func(context.Context) (ExecutorSecretStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *ExecutorSecretStoreTransactFunc) nextHook() func(context.Context) (ExecutorSecretStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ExecutorSecretStoreTransactFunc) appendCall(r0 ExecutorSecretStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ExecutorSecretStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *ExecutorSecretStoreTransactFunc) History() []ExecutorSecretStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]ExecutorSecretStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ExecutorSecretStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of MockExecutorSecretStore.
-type ExecutorSecretStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 ExecutorSecretStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ExecutorSecretStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ExecutorSecretStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // ExecutorSecretStoreUpdateFunc describes the behavior when the Update


### PR DESCRIPTION
Hi backend devs! I'm pinging you all on this because this PR is representative of a change that I'd like to make more broadly across our backend, and I'd like to explain _why_ and _how_ so next time you're working with transactions, you can try out the new pattern 🙂 

# Motivation

The way we currently use transactions extremely easy to mess up in subtle ways. Let's use the following example, which is pretty representative of the current pattern of using transactions.

```go
func doInTransaction(ctx context.Context, db DB) (err error) {
	tx, err := db.Transact(ctx)
	if err != nil {
		return err
	}
	defer func() { err = tx.Done(err) }()

	err = doThing1(ctx, tx)
	if err != nil {
		return err
	}
	if err := doThing2(ctx, tx); err != nil {
		return err
	}
	return nil
}
```

All the examples below are things I've seen written or written myself before realizing they're wrong.

First (and most commonly missed), the return value _must_ be a named return value. If it is not, `tx.Done()` might be checking the wrong value, causing you to commit a transaction that should be rolled back. The even trickier part about this is that, in some cases, it will still look like it's working correctly. In the above example, an error from `doThing1` will update the value of `err`, which will be seen by the deferred function. However, an error from `doThing2` will _not_ update the value of the `err` on line 2 because the `if err := ...` block defines a _new_ `err` variable, so `tx.Done(err)` will still see a `nil`-valued `err`.

Second, you _must_ call `tx.Done()` inside another closure. `defer tx.Done(err)` feels like the natural way to use the API, but arguments to deferred functions are evaluated at defer time, not at the time when the defer is executed. This means that `tx.Done(err)` will always see a `nil`-valued `err`. Additionally, this ignores any errors that may be generated by commit/rollback of the transaction. 

Third (and maybe most insidious), you _must not panic_ during a transaction. If there is a panic during a transaction (e.g. `doThing2` panics), `err` will still be `nil`-valued, so the transaction will still be committed even though it only partially executed.

# Proposed solution (this PR)

We can fix all three of these issues by refining our transaction API. The new `WithTransact` style of transactions (introdued in https://github.com/sourcegraph/sourcegraph/pull/46814) only lets you use the transaction object within the scope of the provided callback. If your callback returns an error, the transaction will be rolled back. If your callback panics, your transaction will be rolled back. You no longer need to worry about whether your `defer` is using the right `err` variable.

Example:

```go
func doInTransaction(ctx context.Context, db DB) (err error) {
	return db.WithTransact(ctx, func(tx DB) error {
		if err := doThing1(ctx, tx); err != nil {
			return err
		}
		if err := doThing2(ctx, tx); err != nil {
			return err
		}
		return nil
	})
}
```

# Game Plan

Assuming there are no objections to this new pattern, I'm just gonna rip off the band-aid and migrate all the stores over the next copule of days. I got most of it done in an evening, so I might as well finish the job.

## Test plan

Relying on unit tests for `ExecutorSecretStore`. `WithTransact` on `basestore.Store` is already well-tested.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
