### PR TITLE
Add filter to remove empty queries

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/validators.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/validators.ts
@@ -26,6 +26,7 @@ const GET_CONTEXT_BY_NAME = gql`
         searchContexts(query: $query) {
             nodes {
                 spec
+                query
             }
         }
     }
@@ -49,9 +50,7 @@ export const createSearchContextValidator =
                 return error.message
             }
 
-            const {
-                searchContexts: { nodes },
-            } = data
+            const nodes = data.searchContexts.nodes.filter(node => node.query !== '')
 
             if (!nodes.some(context => context.spec === sanitizedValue)) {
                 return `We couldn't find the context ${sanitizedValue}. Please ensure the context exists.`

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -71,7 +71,7 @@ describe('Backend insight drill down filters', () => {
                 GetSearchContextByName: () => ({
                     searchContexts: {
                         __typename: 'SearchContextConnection',
-                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', "query": "" }],
+                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', query: '' }],
                     },
                 }),
 

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -71,7 +71,7 @@ describe('Backend insight drill down filters', () => {
                 GetSearchContextByName: () => ({
                     searchContexts: {
                         __typename: 'SearchContextConnection',
-                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', query: '' }],
+                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', query: 'repo:github.com/sourcegraph/sourcegraph' }],
                     },
                 }),
 

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -71,7 +71,13 @@ describe('Backend insight drill down filters', () => {
                 GetSearchContextByName: () => ({
                     searchContexts: {
                         __typename: 'SearchContextConnection',
-                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', query: 'repo:github.com/sourcegraph/sourcegraph' }],
+                        nodes: [
+                            {
+                                __typename: 'SearchContext',
+                                spec: '@sourcegraph/sourcegraph',
+                                query: 'repo:github.com/sourcegraph/sourcegraph',
+                            },
+                        ],
                     },
                 }),
 

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -71,7 +71,7 @@ describe('Backend insight drill down filters', () => {
                 GetSearchContextByName: () => ({
                     searchContexts: {
                         __typename: 'SearchContextConnection',
-                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph' }],
+                        nodes: [{ __typename: 'SearchContext', spec: '@sourcegraph/sourcegraph', "query": "" }],
                     },
                 }),
 


### PR DESCRIPTION
closes #46690 

The insight search context filter validator allows users to save the filter with a json-based search context because [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@191c391/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/validators.ts?L56) we only check if the search context exists. I added a check to filter out search contexts where the query is empty, like we do for the [suggested](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@191c391/-/blob/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.tsx?L93:15) insights component. 

## Test plan
Tested that query-based search context filters still work. 
Non-existent or json based search contexts show an error.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-gabe-insight-search-context.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
