### PR TITLE
Improve Markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights has a new search-powered repositories field that allows you to select repositories with Sourcegraph search syntax. [#45687](https://github.com/sourcegraph/sourcegraph/pull/45687)
 - You can now export all data for a Code Insight from the card menu or the standalone page. [#46795](https://github.com/sourcegraph/sourcegraph/pull/46795), [#46694](https://github.com/sourcegraph/sourcegraph/pull/46694)
 - Added Gerrit as an officially supported code host with permissions syncing. [#46763](https://github.com/sourcegraph/sourcegraph/pull/46763)
+- Markdown files now support `<picture>` and `<video>` elements in the rendered view. [#47074](https://github.com/sourcegraph/sourcegraph/pull/47074)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://about.sourcegraph.com/sourcegraph-4" target="_blank">
   <picture>
-    <source srcset="https://p21.p4.n0.cdn.getcloudapp.com/items/xQuxo7AA/a9e1873b-c7b2-4295-b96a-dd21c992eb63.svg" alt="Sourcegraph 4.0" width="100%" media="(prefers-color-scheme: dark)">
+    <source srcset="https://p21.p4.n0.cdn.getcloudapp.com/items/xQuxo7AA/a9e1873b-c7b2-4295-b96a-dd21c992eb63.svg" media="(prefers-color-scheme: dark)">
     <img src="https://p21.p4.n0.cdn.getcloudapp.com/items/ApuDmzGr/822118fe-e5e6-4f37-8c17-8b406437ad03.svg" alt="Sourcegraph 4.0" width="100%">
   </picture>
 </a>

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/machinebox/graphql v0.2.2
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
-	github.com/microcosm-cc/bluemonday v1.0.21
+	github.com/microcosm-cc/bluemonday v1.0.22
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/moby/buildkit v0.9.3
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f

--- a/go.sum
+++ b/go.sum
@@ -1693,6 +1693,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/microcosm-cc/bluemonday v1.0.17/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
 github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
+github.com/microcosm-cc/bluemonday v1.0.22 h1:p2tT7RNzRdCi0qmwxG+HbqD6ILkmwter1ZwVZn1oTxA=
+github.com/microcosm-cc/bluemonday v1.0.22/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -36,6 +36,12 @@ func Render(content string) (string, error) {
 		policy.AllowAttrs("type").Matching(regexp.MustCompile(`^checkbox$`)).OnElements("input")
 		policy.AllowAttrs("checked", "disabled").Matching(regexp.MustCompile(`^$`)).OnElements("input")
 		policy.AllowAttrs("class").Matching(regexp.MustCompile(`^(?:chroma-[a-zA-Z0-9\-]+)|chroma$`)).OnElements("pre", "code", "span")
+		policy.AllowAttrs("align").OnElements("img", "p")
+		policy.AllowElements("picture", "video", "track", "source")
+		policy.AllowAttrs("srcset", "src", "type", "media", "width", "height", "sizes").OnElements("source")
+		policy.AllowAttrs("playsinline", "muted", "autoplay", "loop", "controls", "width", "height", "poster", "src").OnElements("video")
+		policy.AllowAttrs("src", "kind", "srclang", "default", "label").OnElements("track")
+		policy.AddTargetBlankToFullyQualifiedLinks(true)
 
 		html.LinkAttributeFilter.Add([]byte("aria-hidden"))
 		html.LinkAttributeFilter.Add([]byte("name"))


### PR DESCRIPTION
This tweaks the new markdown renderer/sanitizer to allow more multimedia HTML like we use in our README and GitHub supports too.

Specifically:
- allows `<picture>` for dark/light mode variations of images (this fixes our README reacting to light/dark theme)
  - There was a bug in bluemonday with `<picture>` I reported and was promptly fixed, so this PR also updates the version to include it
- supports videos or GIF-like video loops and captions
- makes cross-origin links open in new tabs
- supports alignment on paragraphs

None of these allow to execute JS so should be all safe.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested manually on our README
