### PR TITLE
fix repo/rev pages spacing

### DIFF
--- a/client/web/src/components/Breadcrumbs.tsx
+++ b/client/web/src/components/Breadcrumbs.tsx
@@ -155,7 +155,7 @@ export const Breadcrumbs: React.FunctionComponent<
     React.PropsWithChildren<{ breadcrumbs: BreadcrumbAtDepth[]; location: H.Location; className?: string }>
 > = ({ breadcrumbs, location, className }) => (
     <nav
-        className={classNames('d-flex container-fluid flex-shrink-past-contents pl-3 pr-0', className)}
+        className={classNames('d-flex container-fluid flex-shrink-past-contents px-0', className)}
         aria-label="Breadcrumbs"
     >
         {sortBy(breadcrumbs, 'depth')

--- a/client/web/src/repo/RepoHeader.module.scss
+++ b/client/web/src/repo/RepoHeader.module.scss
@@ -21,6 +21,10 @@
     }
 }
 
+.action-list {
+    gap: 0.625rem;
+}
+
 .action-list-item:not(:empty) {
     /* Have a small gap between buttons so they are visually distinct when pressed */
     /* stylelint-disable-next-line declaration-property-unit-allowed-list */

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -201,7 +201,7 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
     )
 
     return (
-        <nav data-testid="repo-header" className={classNames('navbar navbar-expand', styles.repoHeader)}>
+        <nav data-testid="repo-header" className={classNames('navbar navbar-expand', 'px-3', styles.repoHeader)}>
             <div className="d-flex align-items-center flex-shrink-past-contents">
                 {/* Breadcrumb for the nav elements */}
                 <Breadcrumbs

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -231,7 +231,7 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                 )}
             >
                 {isLarge ? (
-                    <ul className="navbar-nav">
+                    <ul className={classNames('navbar-nav', styles.actionList)}>
                         {rightActions.map((a, index) => (
                             <li className={classNames('nav-item', styles.actionListItem)} key={a.id || index}>
                                 {a.element}

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -215,7 +215,7 @@ export const RepoRevisionContainer: React.FunctionComponent<React.PropsWithChild
 
     return (
         <>
-            <RepoRevisionWrapper className="pl-3">
+            <RepoRevisionWrapper className="px-3">
                 <Switch>
                     {props.routes.map(
                         ({ path, render, exact, condition = () => true }) =>

--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.module.scss
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.module.scss
@@ -11,4 +11,8 @@
 .action {
     margin-right: 0.625rem;
     padding: 0.25rem;
+
+    &:last-child {
+        margin-right: 0;
+    }
 }

--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.module.scss
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.module.scss
@@ -9,10 +9,5 @@
 }
 
 .action {
-    margin-right: 0.625rem;
     padding: 0.25rem;
-
-    &:last-child {
-        margin-right: 0;
-    }
 }


### PR DESCRIPTION
Adds extra spacing to the right for symmetry. 

|Before|After|
|--|--|
|<img width="1320" alt="Screenshot 2023-01-30 at 10 33 36" src="https://user-images.githubusercontent.com/25318659/215426796-7bd4dfd0-d07f-4766-a1ba-8e6c63ef2d16.png"><img width="1320" alt="Screenshot 2023-01-30 at 10 33 18" src="https://user-images.githubusercontent.com/25318659/215426814-f669b1ec-261b-4529-b88e-5c889257ccaa.png">|<img width="1320" alt="Screenshot 2023-01-30 at 10 31 41" src="https://user-images.githubusercontent.com/25318659/215427465-8472c956-9ff8-4792-9a72-93ef795225bb.png"><img width="1320" alt="Screenshot 2023-01-30 at 10 32 23" src="https://user-images.githubusercontent.com/25318659/215427457-807b6a68-8ea2-44c9-b69b-1c6e9bb43bb7.png">|


## Test plan
Tested manually (screenshots attached).
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-repo-rev-pages.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

