### PR TITLE
Background job dashboard: Update interval info at each run

### DIFF
--- a/internal/goroutine/recorder/recorder.go
+++ b/internal/goroutine/recorder/recorder.go
@@ -144,6 +144,9 @@ func (m *Recorder) LogRun(r Recordable, duration time.Duration, runErr error) {
 		m.logger.Error("failed to save run stats", log.Error(err))
 	}
 
+	// Update routine, just in case its interval changed
+	m.SaveKnownRoutine(r)
+
 	// Update host's and job's “last seen” dates
 	m.saveKnownHostName()
 	m.saveKnownJobName(r.JobName())


### PR DESCRIPTION
- Follow-up for https://github.com/sourcegraph/sourcegraph/pull/46981/

This PR makes the dynamic intervals update on the background job dashboard.

In the current solution, `PeriodicGoroutine` _pulls_ the interval from `permissionSyncJobCleaner` at each run. To reliably display the latest interval on the dashboard, we need to update Redis with each run.

Note: If `permissionSyncJobCleaner` _pushed_ the interval via a `setInterval()` method, then we could update the interval in Redis every time the interval changes. I think it's not a big deal because the Redis write is a cheap operation, but if that ever becomes a problem, a refactor to a `setInterval()` solution might be an option.

## Test plan

Tested it here: https://www.loom.com/share/c15ba627f2ea411f947f01ccf84d5bb0