### PR TITLE
Add new src_permissions table to unify repository permissions

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -959,6 +959,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "user_repo_permissions_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "users_id_seq",
       "TypeName": "bigint",
       "StartValue": 1,
@@ -21425,6 +21434,189 @@
         },
         {
           "Name": "user_public_repos_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
+      "Name": "user_repo_permissions",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 5,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('user_repo_permissions_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "repo_id",
+          "Index": 3,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "source",
+          "Index": 7,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "'sync'::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 6,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_external_account_id",
+          "Index": 4,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_id",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "user_repo_permissions_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX user_repo_permissions_pkey ON user_repo_permissions USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "user_repo_permissions_repo_id_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX user_repo_permissions_repo_id_idx ON user_repo_permissions USING btree (repo_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "user_repo_permissions_source_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX user_repo_permissions_source_idx ON user_repo_permissions USING btree (source)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "user_repo_permissions_updated_at_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX user_repo_permissions_updated_at_idx ON user_repo_permissions USING btree (updated_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "user_repo_permissions_user_external_account_id_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX user_repo_permissions_user_external_account_id_idx ON user_repo_permissions USING btree (user_external_account_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "user_repo_permissions_user_id_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX user_repo_permissions_user_id_idx ON user_repo_permissions USING btree (user_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "user_repo_permissions_repo_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "repo",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE"
+        },
+        {
+          "Name": "user_repo_permissions_user_external_account_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "user_external_accounts",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE"
+        },
+        {
+          "Name": "user_repo_permissions_user_id_fkey",
           "ConstraintType": "f",
           "RefTableName": "users",
           "IsDeferrable": false,

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -21540,6 +21540,16 @@
       ],
       "Indexes": [
         {
+          "Name": "user_repo_permissions_perms_unique_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX user_repo_permissions_perms_unique_idx ON user_repo_permissions USING btree (user_id, user_external_account_id, repo_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "user_repo_permissions_pkey",
           "IsPrimaryKey": true,
           "IsUnique": true,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2878,6 +2878,7 @@ Referenced by:
     TABLE "search_context_repos" CONSTRAINT "search_context_repos_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "sub_repo_permissions" CONSTRAINT "sub_repo_permissions_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "user_public_repos" CONSTRAINT "user_public_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
+    TABLE "user_repo_permissions" CONSTRAINT "user_repo_permissions_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "zoekt_repos" CONSTRAINT "zoekt_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 Triggers:
     trig_create_zoekt_repo_on_repo_insert AFTER INSERT ON repo FOR EACH ROW EXECUTE FUNCTION func_insert_zoekt_repo()
@@ -3304,6 +3305,8 @@ Indexes:
     "user_external_accounts_user_id" btree (user_id) WHERE deleted_at IS NULL
 Foreign-key constraints:
     "user_external_accounts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
+Referenced by:
+    TABLE "user_repo_permissions" CONSTRAINT "user_repo_permissions_user_external_account_id_fkey" FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE
 
 ```
 
@@ -3351,6 +3354,31 @@ Indexes:
 Foreign-key constraints:
     "user_public_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     "user_public_repos_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+
+```
+
+# Table "public.user_repo_permissions"
+```
+          Column          |           Type           | Collation | Nullable |                      Default                      
+--------------------------+--------------------------+-----------+----------+---------------------------------------------------
+ id                       | integer                  |           | not null | nextval('user_repo_permissions_id_seq'::regclass)
+ user_id                  | integer                  |           |          | 
+ repo_id                  | integer                  |           | not null | 
+ user_external_account_id | integer                  |           |          | 
+ created_at               | timestamp with time zone |           | not null | now()
+ updated_at               | timestamp with time zone |           | not null | now()
+ source                   | text                     |           | not null | 'sync'::text
+Indexes:
+    "user_repo_permissions_pkey" PRIMARY KEY, btree (id)
+    "user_repo_permissions_repo_id_idx" btree (repo_id)
+    "user_repo_permissions_source_idx" btree (source)
+    "user_repo_permissions_updated_at_idx" btree (updated_at)
+    "user_repo_permissions_user_external_account_id_idx" btree (user_external_account_id)
+    "user_repo_permissions_user_id_idx" btree (user_id)
+Foreign-key constraints:
+    "user_repo_permissions_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
+    "user_repo_permissions_user_external_account_id_fkey" FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE
+    "user_repo_permissions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 
 ```
 
@@ -3464,6 +3492,7 @@ Referenced by:
     TABLE "user_emails" CONSTRAINT "user_emails_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
     TABLE "user_external_accounts" CONSTRAINT "user_external_accounts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
     TABLE "user_public_repos" CONSTRAINT "user_public_repos_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "user_repo_permissions" CONSTRAINT "user_repo_permissions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "user_roles" CONSTRAINT "user_roles_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "webhooks" CONSTRAINT "webhooks_created_by_user_id_fkey" FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL
     TABLE "webhooks" CONSTRAINT "webhooks_updated_by_user_id_fkey" FOREIGN KEY (updated_by_user_id) REFERENCES users(id) ON DELETE SET NULL

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3370,6 +3370,7 @@ Foreign-key constraints:
  source                   | text                     |           | not null | 'sync'::text
 Indexes:
     "user_repo_permissions_pkey" PRIMARY KEY, btree (id)
+    "user_repo_permissions_perms_unique_idx" UNIQUE, btree (user_id, user_external_account_id, repo_id)
     "user_repo_permissions_repo_id_idx" btree (repo_id)
     "user_repo_permissions_source_idx" btree (source)
     "user_repo_permissions_updated_at_idx" btree (updated_at)

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/down.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS src_permissions;
+DROP TABLE IF EXISTS user_repo_permissions;

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/down.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS src_permissions;

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/metadata.yaml
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/metadata.yaml
@@ -1,2 +1,2 @@
-name: add_unified_source_perms_table
+name: add_user_repo_permissions_table_for_unified_permissions
 parents: [1674669794]

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/metadata.yaml
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_unified_source_perms_table
+parents: [1674669794]

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS src_permissions(
+    id SERIAL PRIMARY KEY,
+    user_id INT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    repo_id INT NOT NULL REFERENCES public.repo(id) ON DELETE CASCADE,
+    ext_account_id INT NULL REFERENCES public.user_external_accounts(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    source TEXT NOT NULL DEFAULT 'sync'
+);
+
+CREATE INDEX IF NOT EXISTS src_permissions_user_id_idx ON src_permissions(user_id);
+CREATE INDEX IF NOT EXISTS src_permissions_repo_id_idx ON src_permissions(repo_id);
+CREATE INDEX IF NOT EXISTS src_permissions_updated_at_idx ON src_permissions(updated_at);
+CREATE INDEX IF NOT EXISTS src_permissions_source_idx ON src_permissions(source);
+CREATE UNIQUE INDEX src_permissions_perm_unique_idx ON src_permissions(user_id, repo_id);
+
+END;

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS src_permissions(
     id SERIAL PRIMARY KEY,
     user_id INT NULL REFERENCES users(id) ON DELETE CASCADE,
     repo_id INT NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
-    ext_account_id INT NULL REFERENCES user_external_accounts(id) ON DELETE CASCADE,
+    user_external_account_id INT NULL REFERENCES user_external_accounts(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     source TEXT NOT NULL DEFAULT 'sync'

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
@@ -13,3 +13,4 @@ CREATE INDEX IF NOT EXISTS user_repo_permissions_repo_id_idx ON user_repo_permis
 CREATE INDEX IF NOT EXISTS user_repo_permissions_user_external_account_id_idx ON user_repo_permissions(user_external_account_id);
 CREATE INDEX IF NOT EXISTS user_repo_permissions_updated_at_idx ON user_repo_permissions(updated_at);
 CREATE INDEX IF NOT EXISTS user_repo_permissions_source_idx ON user_repo_permissions(source);
+CREATE UNIQUE INDEX IF NOT EXISTS user_repo_permissions_perms_unique_idx ON user_repo_permissions(user_id, user_external_account_id, repo_id);

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
@@ -1,10 +1,8 @@
-BEGIN;
-
 CREATE TABLE IF NOT EXISTS src_permissions(
     id SERIAL PRIMARY KEY,
-    user_id INT NULL REFERENCES public.users(id) ON DELETE CASCADE,
-    repo_id INT NOT NULL REFERENCES public.repo(id) ON DELETE CASCADE,
-    ext_account_id INT NULL REFERENCES public.user_external_accounts(id) ON DELETE CASCADE,
+    user_id INT NULL REFERENCES users(id) ON DELETE CASCADE,
+    repo_id INT NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
+    ext_account_id INT NULL REFERENCES user_external_accounts(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     source TEXT NOT NULL DEFAULT 'sync'
@@ -12,8 +10,6 @@ CREATE TABLE IF NOT EXISTS src_permissions(
 
 CREATE INDEX IF NOT EXISTS src_permissions_user_id_idx ON src_permissions(user_id);
 CREATE INDEX IF NOT EXISTS src_permissions_repo_id_idx ON src_permissions(repo_id);
+CREATE INDEX IF NOT EXISTS src_permissions_ext_account_id_idx ON src_permissions(ext_account_id);
 CREATE INDEX IF NOT EXISTS src_permissions_updated_at_idx ON src_permissions(updated_at);
 CREATE INDEX IF NOT EXISTS src_permissions_source_idx ON src_permissions(source);
-CREATE UNIQUE INDEX src_permissions_perm_unique_idx ON src_permissions(user_id, repo_id);
-
-END;

--- a/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
+++ b/migrations/frontend/1674814035_add_unified_source_perms_table/up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS src_permissions(
+CREATE TABLE IF NOT EXISTS user_repo_permissions(
     id SERIAL PRIMARY KEY,
     user_id INT NULL REFERENCES users(id) ON DELETE CASCADE,
     repo_id INT NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS src_permissions(
     source TEXT NOT NULL DEFAULT 'sync'
 );
 
-CREATE INDEX IF NOT EXISTS src_permissions_user_id_idx ON src_permissions(user_id);
-CREATE INDEX IF NOT EXISTS src_permissions_repo_id_idx ON src_permissions(repo_id);
-CREATE INDEX IF NOT EXISTS src_permissions_ext_account_id_idx ON src_permissions(ext_account_id);
-CREATE INDEX IF NOT EXISTS src_permissions_updated_at_idx ON src_permissions(updated_at);
-CREATE INDEX IF NOT EXISTS src_permissions_source_idx ON src_permissions(source);
+CREATE INDEX IF NOT EXISTS user_repo_permissions_user_id_idx ON user_repo_permissions(user_id);
+CREATE INDEX IF NOT EXISTS user_repo_permissions_repo_id_idx ON user_repo_permissions(repo_id);
+CREATE INDEX IF NOT EXISTS user_repo_permissions_user_external_account_id_idx ON user_repo_permissions(user_external_account_id);
+CREATE INDEX IF NOT EXISTS user_repo_permissions_updated_at_idx ON user_repo_permissions(updated_at);
+CREATE INDEX IF NOT EXISTS user_repo_permissions_source_idx ON user_repo_permissions(source);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3898,6 +3898,26 @@ CREATE TABLE user_public_repos (
     repo_id integer NOT NULL
 );
 
+CREATE TABLE user_repo_permissions (
+    id integer NOT NULL,
+    user_id integer,
+    repo_id integer NOT NULL,
+    user_external_account_id integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    source text DEFAULT 'sync'::text NOT NULL
+);
+
+CREATE SEQUENCE user_repo_permissions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE user_repo_permissions_id_seq OWNED BY user_repo_permissions.id;
+
 CREATE TABLE user_roles (
     user_id integer NOT NULL,
     role_id integer NOT NULL,
@@ -4149,6 +4169,8 @@ ALTER TABLE ONLY user_credentials ALTER COLUMN id SET DEFAULT nextval('user_cred
 ALTER TABLE ONLY user_external_accounts ALTER COLUMN id SET DEFAULT nextval('user_external_accounts_id_seq'::regclass);
 
 ALTER TABLE ONLY user_pending_permissions ALTER COLUMN id SET DEFAULT nextval('user_pending_permissions_id_seq'::regclass);
+
+ALTER TABLE ONLY user_repo_permissions ALTER COLUMN id SET DEFAULT nextval('user_repo_permissions_id_seq'::regclass);
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
@@ -4545,6 +4567,9 @@ ALTER TABLE ONLY user_permissions
 
 ALTER TABLE ONLY user_public_repos
     ADD CONSTRAINT user_public_repos_user_id_repo_id_key UNIQUE (user_id, repo_id);
+
+ALTER TABLE ONLY user_repo_permissions
+    ADD CONSTRAINT user_repo_permissions_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY user_roles
     ADD CONSTRAINT user_roles_pkey PRIMARY KEY (user_id, role_id);
@@ -4948,6 +4973,16 @@ CREATE UNIQUE INDEX user_emails_user_id_is_primary_idx ON user_emails USING btre
 CREATE UNIQUE INDEX user_external_accounts_account ON user_external_accounts USING btree (service_type, service_id, client_id, account_id) WHERE (deleted_at IS NULL);
 
 CREATE INDEX user_external_accounts_user_id ON user_external_accounts USING btree (user_id) WHERE (deleted_at IS NULL);
+
+CREATE INDEX user_repo_permissions_repo_id_idx ON user_repo_permissions USING btree (repo_id);
+
+CREATE INDEX user_repo_permissions_source_idx ON user_repo_permissions USING btree (source);
+
+CREATE INDEX user_repo_permissions_updated_at_idx ON user_repo_permissions USING btree (updated_at);
+
+CREATE INDEX user_repo_permissions_user_external_account_id_idx ON user_repo_permissions USING btree (user_external_account_id);
+
+CREATE INDEX user_repo_permissions_user_id_idx ON user_repo_permissions USING btree (user_id);
 
 CREATE UNIQUE INDEX users_billing_customer_id ON users USING btree (billing_customer_id) WHERE (deleted_at IS NULL);
 
@@ -5437,6 +5472,15 @@ ALTER TABLE ONLY user_public_repos
 
 ALTER TABLE ONLY user_public_repos
     ADD CONSTRAINT user_public_repos_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY user_repo_permissions
+    ADD CONSTRAINT user_repo_permissions_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY user_repo_permissions
+    ADD CONSTRAINT user_repo_permissions_user_external_account_id_fkey FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY user_repo_permissions
+    ADD CONSTRAINT user_repo_permissions_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY user_roles
     ADD CONSTRAINT user_roles_role_id_fkey FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE DEFERRABLE;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4974,6 +4974,8 @@ CREATE UNIQUE INDEX user_external_accounts_account ON user_external_accounts USI
 
 CREATE INDEX user_external_accounts_user_id ON user_external_accounts USING btree (user_id) WHERE (deleted_at IS NULL);
 
+CREATE UNIQUE INDEX user_repo_permissions_perms_unique_idx ON user_repo_permissions USING btree (user_id, user_external_account_id, repo_id);
+
 CREATE INDEX user_repo_permissions_repo_id_idx ON user_repo_permissions USING btree (repo_id);
 
 CREATE INDEX user_repo_permissions_source_idx ON user_repo_permissions USING btree (source);


### PR DESCRIPTION
This PR adds a new table to hold the source code permission data. Nothing else, to keep it small and simple.

## Test plan

Manually tested that the migration queries run successfully. Tested with `sg migration` locally.