### PR TITLE
[RFC] Add chevron to dot dot icon

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
@@ -3,3 +3,11 @@
     width: 1rem;
     height: 1rem;
 }
+
+.collapse-icon {
+    min-width: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+}

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useRef, useState } from 'react'
 
-import { mdiFileDocumentOutline, mdiSourceRepository, mdiFolderOutline, mdiFolderOpenOutline } from '@mdi/js'
+import {
+    mdiFileDocumentOutline,
+    mdiSourceRepository,
+    mdiFolderOutline,
+    mdiFolderOpenOutline,
+    mdiMenuRight,
+} from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom-v5-compat'
 
@@ -239,12 +245,18 @@ function renderNode({
         return (
             <Link
                 {...props}
+                className={classNames(props.className, 'pl-0')}
                 to={dotdot}
                 onClick={event => {
                     event.preventDefault()
                     handleSelect(event)
                 }}
             >
+                <Icon
+                    aria-hidden={true}
+                    svgPath={mdiMenuRight}
+                    className={classNames(styles.icon, styles.collapseIcon)}
+                />
                 <Icon
                     svgPath={mdiFolderOutline}
                     className={classNames('mr-1', styles.icon)}


### PR DESCRIPTION
Based on feedback from @felixfbecker:

> The `..` item is really confusing now though – it's visually a level higher than the other items, implying that all the items are children of `..` , but in file systems `..` is a child of the folder (pointing to the folder itself, like a symlink)

![image](https://user-images.githubusercontent.com/458591/215550597-5ef5d033-ce26-406c-a294-cd4c4cfda8fb.png)

My response: 

> Regarding the `..` icon: Yeah I understand, it does look odd if the folder has sub-folders. I was considering adding a collapse icon to the `..` folder as well but then we have two options and I wasn’t able to decide:
>
> 1. If we mark it as expandable, we get the same icon that we have for other icons but it will have a separate click area. That would also need a custom workaround implementing. I think this might be too confusing also
>
> 2. We can also inline the icon with the same styles as for the other folders. I’ll try that (somehow didn’t think of this before).

This PR implements approach 2. it visually looks better but it’s now super unclear why `ArrowRight` doesn’t do anything to the `..` entry:

![image](https://user-images.githubusercontent.com/458591/215550925-acd09247-4e42-4449-8737-8ba4ddca54ab.png)

## Open questions

- What do we do about the keyboard navigation issue I outlined above?

## Test plan

- Tested locally 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-dotdot-chevron.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

