### PR TITLE
Fix Account Security page if auth provider removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed a bug where saving default Sort & Limit filters in Code Insights did not persist [#46653](https://github.com/sourcegraph/sourcegraph/pull/46653)
 - Restored the old syntax for `repo:contains` filters that was previously removed in version 4.0.0. For now, both the old and new syntaxes are supported to allow for smooth upgrades. Users are encouraged to switch to the new syntax, since the old one may still be removed in a future version.
+- Fixed a bug where removing an auth provider would render a user's Account Security page inaccessible if they still had an external account associated with the removed auth provider. [#47092](https://github.com/sourcegraph/sourcegraph/pull/47092)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -102,7 +102,11 @@ func (r *externalAccountResolver) PublicAccountData(ctx context.Context) (*exter
 	}
 
 	if r.account.Data != nil {
-		return NewExternalAccountDataResolver(ctx, r.account)
+		res, err := NewExternalAccountDataResolver(ctx, r.account)
+		if err != nil {
+			return nil, nil
+		}
+		return res, nil
 	}
 
 	return nil, nil

--- a/cmd/frontend/graphqlbackend/external_account_data_resolver.go
+++ b/cmd/frontend/graphqlbackend/external_account_data_resolver.go
@@ -15,7 +15,7 @@ type externalAccountDataResolver struct {
 func NewExternalAccountDataResolver(ctx context.Context, account extsvc.Account) (*externalAccountDataResolver, error) {
 	data, err := publicAccountDataFromJSON(ctx, account)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 	return &externalAccountDataResolver{
 		data: data,

--- a/cmd/frontend/graphqlbackend/external_account_data_resolver.go
+++ b/cmd/frontend/graphqlbackend/external_account_data_resolver.go
@@ -15,7 +15,7 @@ type externalAccountDataResolver struct {
 func NewExternalAccountDataResolver(ctx context.Context, account extsvc.Account) (*externalAccountDataResolver, error) {
 	data, err := publicAccountDataFromJSON(ctx, account)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return &externalAccountDataResolver{
 		data: data,


### PR DESCRIPTION
Currently, if an auth provider option gets removed while a user still has an account for that auth provider, the Account security page will break:

<img width="1124" alt="Screenshot 2023-01-30 at 12 49 46" src="https://user-images.githubusercontent.com/6427795/215466135-0a296e05-4360-457d-b3fc-d55dced1f67f.png">

This PR adjusts this behaviour so that the resolver instead returns `null` for the account data, and it is accordingly ignored by the page, since 1. users cannot do anything about it, and 2. it blocks them from managing their other external accounts.

<img width="1168" alt="Screenshot 2023-01-30 at 13 03 47" src="https://user-images.githubusercontent.com/6427795/215466233-48b6cb49-df8a-4357-af60-eef1a66c2faa.png">


## Test plan

Verified manually and adjusted unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
