### PR TITLE
New file tree: Navigation tweaks

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -27,7 +27,6 @@ import { AuthenticatedUser } from '../auth'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { GettingStartedTour } from '../tour/GettingStartedTour'
 import { Tree } from '../tree/Tree'
-import { dirname } from '../util/path'
 
 import { RepoRevisionSidebarFileTree } from './RepoRevisionSidebarFileTree'
 import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
@@ -66,14 +65,10 @@ export const RepoRevisionSidebar: React.FunctionComponent<
 
     const [initialFilePath, setInitialFilePath] = useState<string>(props.filePath)
     const [initialFilePathIsDir, setInitialFilePathIsDir] = useState<boolean>(props.isDir)
-    const onExpandParent = useCallback(() => {
-        let parent = initialFilePathIsDir ? dirname(initialFilePath) : dirname(dirname(initialFilePath))
-        if (parent === '.') {
-            parent = ''
-        }
+    const onExpandParent = useCallback((parent: string) => {
         setInitialFilePath(parent)
         setInitialFilePathIsDir(true)
-    }, [initialFilePath, initialFilePathIsDir])
+    }, [])
 
     const handleSidebarToggle = useCallback(
         (value: boolean) => {
@@ -162,6 +157,8 @@ export const RepoRevisionSidebar: React.FunctionComponent<
                                             commitID={props.commitID}
                                             initialFilePath={initialFilePath}
                                             initialFilePathIsDirectory={initialFilePathIsDir}
+                                            filePath={props.filePath}
+                                            filePathIsDirectory={props.isDir}
                                             telemetryService={props.telemetryService}
                                             alwaysLoadAncestors={enableAccessibleFileTreeAlwaysLoadAncestors}
                                         />


### PR DESCRIPTION
Part of #46602 

This fixes two issues:

- When a file is opened that is outside the currently loaded tree, it will reload the tree with the new root. (Thank you @felixfbecker for reporting this in [Slack](https://sourcegraph.slack.com/archives/C04931KQVRC/p1674854254290479?thread_ts=1674851688.226599&cid=C04931KQVRC)).
- We now also listen to file changes and use that to update the selection if the file is inside the tree. This is helpful when navigating between files and using the browser back button and will now sync the sidebar selection.

## Test plan

https://user-images.githubusercontent.com/458591/215471679-f901d637-f815-4561-b189-0b2a2638611f.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-tweaks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
