### PR TITLE
go.mod: bump zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 replace github.com/fergusstrange/embedded-postgres => github.com/sourcegraph/embedded-postgres v1.19.1-0.20230113234230-bb62ad58a1e1
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea
+	github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2125,8 +2125,8 @@ github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef h1:fWPxLkDObzzK
 github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea h1:PfXc9P7gulVNg+uDkGN+bSkQuKAm0mwii6YRDsYBH3M=
-github.com/sourcegraph/zoekt v0.0.0-20230124062116-f4df546826ea/go.mod h1:EgK9KLlvkj/fXQYqnhlh8JuMDQxmlyhRSLchbbH/BJo=
+github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5 h1:MEvC8UWR19i4EQWMdN4AYNCkubEZYn86MPZ+ENp6JDI=
+github.com/sourcegraph/zoekt v0.0.0-20230127201130-f6d0aa0032d5/go.mod h1:EgK9KLlvkj/fXQYqnhlh8JuMDQxmlyhRSLchbbH/BJo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -72,7 +72,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	c.aggregate = nil
 	c.sizeBytes = 0
 
-	zoekt.SortFiles(agg.Files, c.opts)
+	zoekt.SortFiles(agg.Files)
 
 	if max := c.opts.MaxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -130,9 +130,6 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// This enables the use of PageRank scores if they are available.
 		searchOpts.UseDocumentRanks = true
 
-		// This damps the impact of document ranks on the final ranking.
-		searchOpts.RanksDampingFactor = 0.5
-
 		return searchOpts
 	}
 


### PR DESCRIPTION
The updater job failed because of the backward incompatible changes in Zoekt. I ran /dev/zoekt/update and udpated wherever the compiler complained.

- 20a30090ee monitoring: add metric that tracks the total number of search requests
- 46133b9bc8 scheduler: add some clarifying comments
- 0c03110379 webserver: use B+-tree to map ngrams to posting lists
- f6d0aa0032 Ranking: simplify score combination strategy



## Test plan
Zoekt CI
