### PR TITLE
nix: include bazel 6.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673704454,
-        "narHash": "sha256-5Wdj1MgdOgn3+dMFIBtg+IAYZApjF8JzwLWDPieg0C4=",
+        "lastModified": 1674971084,
+        "narHash": "sha256-YxBWj2t75Jun+NJUwr2vvtcfLwvGcazSo+pnNxpt+tU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a83ed85c14fcf242653df6f4b0974b7e1c73c6c6",
+        "rev": "22c4a7a4796a91c297a7e59078a84ec29515f86e",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -68,6 +68,9 @@ pkgs.mkShell {
     rustfmt
     libiconv
     clippy
+
+    # The future?
+    bazel_6
   ];
 
   # Startup postgres


### PR DESCRIPTION
Things seem to be progressing fast, lets get bazel installed for the nix users. One downside is this adds a huge amount of stuff to fetch from the cache (I'm looking at you java headless sdk).

Test Plan: nix develop followed by bazel version working.

