### PR TITLE
rbac: make user_id field in `namespace_permissions` non-nullable

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -15019,7 +15019,7 @@
           "Name": "user_id",
           "Index": 5,
           "TypeName": "integer",
-          "IsNullable": true,
+          "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2269,7 +2269,7 @@ Foreign-key constraints:
  namespace   | text                     |           | not null | 
  resource_id | integer                  |           | not null | 
  action      | text                     |           | not null | 
- user_id     | integer                  |           |          | 
+ user_id     | integer                  |           | not null | 
  created_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "namespace_permissions_pkey" PRIMARY KEY, btree (id)

--- a/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/down.sql
+++ b/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE namespace_permissions ALTER COLUMN user_id DROP NOT NULL;

--- a/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/metadata.yaml
+++ b/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/metadata.yaml
@@ -1,0 +1,2 @@
+name: make_user_id_namespace_permissions_non_nullable
+parents: [1674669794]

--- a/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/up.sql
+++ b/migrations/frontend/1674952295_make_user_id_namespace_permissions_non_nullable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE namespace_permissions ALTER COLUMN user_id SET NOT NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2961,7 +2961,7 @@ CREATE TABLE namespace_permissions (
     namespace text NOT NULL,
     resource_id integer NOT NULL,
     action text NOT NULL,
-    user_id integer,
+    user_id integer NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT action_not_blank CHECK ((action <> ''::text)),
     CONSTRAINT namespace_not_blank CHECK ((namespace <> ''::text))


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Running `sg migration up` and `sg migration down` leaves the database stable.