### PR TITLE
Database: convert `Transact` to `WithTransact` for stores that don't use their transactions

### DIFF
--- a/internal/database/executors.go
+++ b/internal/database/executors.go
@@ -14,8 +14,7 @@ import (
 
 type ExecutorStore interface {
 	basestore.ShareableStore
-	Transact(context.Context) (ExecutorStore, error)
-	Done(error) error
+	WithTransact(context.Context, func(ExecutorStore) error) error
 	Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
 	With(basestore.ShareableStore) ExecutorStore
 
@@ -72,9 +71,10 @@ func ExecutorsWith(other basestore.ShareableStore) ExecutorStore {
 	}
 }
 
-func (s *executorStore) Transact(ctx context.Context) (ExecutorStore, error) {
-	txBase, err := s.Store.Transact(ctx)
-	return &executorStore{Store: txBase}, err
+func (s *executorStore) WithTransact(ctx context.Context, f func(ExecutorStore) error) error {
+	return s.Store.WithTransact(ctx, func(tx *basestore.Store) error {
+		return f(&executorStore{Store: tx})
+	})
 }
 
 func (s *executorStore) With(other basestore.ShareableStore) ExecutorStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -28614,12 +28614,12 @@ type MockOrgMemberStore struct {
 	// RemoveFunc is an instance of a mock function object controlling the
 	// behavior of the method Remove.
 	RemoveFunc *OrgMemberStoreRemoveFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *OrgMemberStoreTransactFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OrgMemberStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *OrgMemberStoreWithTransactFunc
 }
 
 // NewMockOrgMemberStore creates a new mock of the OrgMemberStore interface.
@@ -28671,13 +28671,13 @@ func NewMockOrgMemberStore() *MockOrgMemberStore {
 				return
 			},
 		},
-		TransactFunc: &OrgMemberStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 OrgMemberStore, r1 error) {
+		WithFunc: &OrgMemberStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 OrgMemberStore) {
 				return
 			},
 		},
-		WithFunc: &OrgMemberStoreWithFunc{
-			defaultHook: func(basestore.ShareableStore) (r0 OrgMemberStore) {
+		WithTransactFunc: &OrgMemberStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OrgMemberStore) error) (r0 error) {
 				return
 			},
 		},
@@ -28733,14 +28733,14 @@ func NewStrictMockOrgMemberStore() *MockOrgMemberStore {
 				panic("unexpected invocation of MockOrgMemberStore.Remove")
 			},
 		},
-		TransactFunc: &OrgMemberStoreTransactFunc{
-			defaultHook: func(context.Context) (OrgMemberStore, error) {
-				panic("unexpected invocation of MockOrgMemberStore.Transact")
-			},
-		},
 		WithFunc: &OrgMemberStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OrgMemberStore {
 				panic("unexpected invocation of MockOrgMemberStore.With")
+			},
+		},
+		WithTransactFunc: &OrgMemberStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OrgMemberStore) error) error {
+				panic("unexpected invocation of MockOrgMemberStore.WithTransact")
 			},
 		},
 	}
@@ -28778,11 +28778,11 @@ func NewMockOrgMemberStoreFrom(i OrgMemberStore) *MockOrgMemberStore {
 		RemoveFunc: &OrgMemberStoreRemoveFunc{
 			defaultHook: i.Remove,
 		},
-		TransactFunc: &OrgMemberStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		WithFunc: &OrgMemberStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &OrgMemberStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -29767,111 +29767,6 @@ func (c OrgMemberStoreRemoveFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// OrgMemberStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockOrgMemberStore instance is invoked.
-type OrgMemberStoreTransactFunc struct {
-	defaultHook func(context.Context) (OrgMemberStore, error)
-	hooks       []func(context.Context) (OrgMemberStore, error)
-	history     []OrgMemberStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockOrgMemberStore) Transact(v0 context.Context) (OrgMemberStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(OrgMemberStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockOrgMemberStore instance is invoked and the hook queue is
-// empty.
-func (f *OrgMemberStoreTransactFunc) SetDefaultHook(hook func(context.Context) (OrgMemberStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockOrgMemberStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *OrgMemberStoreTransactFunc) PushHook(hook func(context.Context) (OrgMemberStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OrgMemberStoreTransactFunc) SetDefaultReturn(r0 OrgMemberStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (OrgMemberStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgMemberStoreTransactFunc) PushReturn(r0 OrgMemberStore, r1 error) {
-	f.PushHook(func(context.Context) (OrgMemberStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *OrgMemberStoreTransactFunc) nextHook() func(context.Context) (OrgMemberStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OrgMemberStoreTransactFunc) appendCall(r0 OrgMemberStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OrgMemberStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *OrgMemberStoreTransactFunc) History() []OrgMemberStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]OrgMemberStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OrgMemberStoreTransactFuncCall is an object that describes an invocation
-// of method Transact on an instance of MockOrgMemberStore.
-type OrgMemberStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 OrgMemberStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OrgMemberStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OrgMemberStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // OrgMemberStoreWithFunc describes the behavior when the With method of the
 // parent MockOrgMemberStore instance is invoked.
 type OrgMemberStoreWithFunc struct {
@@ -29971,6 +29866,111 @@ func (c OrgMemberStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c OrgMemberStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// OrgMemberStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockOrgMemberStore instance is invoked.
+type OrgMemberStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(OrgMemberStore) error) error
+	hooks       []func(context.Context, func(OrgMemberStore) error) error
+	history     []OrgMemberStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockOrgMemberStore) WithTransact(v0 context.Context, v1 func(OrgMemberStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(OrgMemberStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockOrgMemberStore instance is invoked and the hook queue
+// is empty.
+func (f *OrgMemberStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(OrgMemberStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockOrgMemberStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *OrgMemberStoreWithTransactFunc) PushHook(hook func(context.Context, func(OrgMemberStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OrgMemberStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(OrgMemberStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OrgMemberStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(OrgMemberStore) error) error {
+		return r0
+	})
+}
+
+func (f *OrgMemberStoreWithTransactFunc) nextHook() func(context.Context, func(OrgMemberStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OrgMemberStoreWithTransactFunc) appendCall(r0 OrgMemberStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OrgMemberStoreWithTransactFuncCall objects
+// describing the invocations of this function.
+func (f *OrgMemberStoreWithTransactFunc) History() []OrgMemberStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]OrgMemberStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OrgMemberStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of MockOrgMemberStore.
+type OrgMemberStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(OrgMemberStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OrgMemberStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OrgMemberStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -14095,12 +14095,12 @@ type MockExecutorSecretAccessLogStore struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
 	ListFunc *ExecutorSecretAccessLogStoreListFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *ExecutorSecretAccessLogStoreTransactFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *ExecutorSecretAccessLogStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *ExecutorSecretAccessLogStoreWithTransactFunc
 }
 
 // NewMockExecutorSecretAccessLogStore creates a new mock of the
@@ -14133,13 +14133,13 @@ func NewMockExecutorSecretAccessLogStore() *MockExecutorSecretAccessLogStore {
 				return
 			},
 		},
-		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 ExecutorSecretAccessLogStore, r1 error) {
+		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 ExecutorSecretAccessLogStore) {
 				return
 			},
 		},
-		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
-			defaultHook: func(basestore.ShareableStore) (r0 ExecutorSecretAccessLogStore) {
+		WithTransactFunc: &ExecutorSecretAccessLogStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(ExecutorSecretAccessLogStore) error) (r0 error) {
 				return
 			},
 		},
@@ -14176,14 +14176,14 @@ func NewStrictMockExecutorSecretAccessLogStore() *MockExecutorSecretAccessLogSto
 				panic("unexpected invocation of MockExecutorSecretAccessLogStore.List")
 			},
 		},
-		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
-			defaultHook: func(context.Context) (ExecutorSecretAccessLogStore, error) {
-				panic("unexpected invocation of MockExecutorSecretAccessLogStore.Transact")
-			},
-		},
 		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) ExecutorSecretAccessLogStore {
 				panic("unexpected invocation of MockExecutorSecretAccessLogStore.With")
+			},
+		},
+		WithTransactFunc: &ExecutorSecretAccessLogStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(ExecutorSecretAccessLogStore) error) error {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.WithTransact")
 			},
 		},
 	}
@@ -14209,11 +14209,11 @@ func NewMockExecutorSecretAccessLogStoreFrom(i ExecutorSecretAccessLogStore) *Mo
 		ListFunc: &ExecutorSecretAccessLogStoreListFunc{
 			defaultHook: i.List,
 		},
-		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &ExecutorSecretAccessLogStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -14764,115 +14764,6 @@ func (c ExecutorSecretAccessLogStoreListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// ExecutorSecretAccessLogStoreTransactFunc describes the behavior when the
-// Transact method of the parent MockExecutorSecretAccessLogStore instance
-// is invoked.
-type ExecutorSecretAccessLogStoreTransactFunc struct {
-	defaultHook func(context.Context) (ExecutorSecretAccessLogStore, error)
-	hooks       []func(context.Context) (ExecutorSecretAccessLogStore, error)
-	history     []ExecutorSecretAccessLogStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockExecutorSecretAccessLogStore) Transact(v0 context.Context) (ExecutorSecretAccessLogStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(ExecutorSecretAccessLogStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockExecutorSecretAccessLogStore instance is invoked and the
-// hook queue is empty.
-func (f *ExecutorSecretAccessLogStoreTransactFunc) SetDefaultHook(hook func(context.Context) (ExecutorSecretAccessLogStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockExecutorSecretAccessLogStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *ExecutorSecretAccessLogStoreTransactFunc) PushHook(hook func(context.Context) (ExecutorSecretAccessLogStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ExecutorSecretAccessLogStoreTransactFunc) SetDefaultReturn(r0 ExecutorSecretAccessLogStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (ExecutorSecretAccessLogStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ExecutorSecretAccessLogStoreTransactFunc) PushReturn(r0 ExecutorSecretAccessLogStore, r1 error) {
-	f.PushHook(func(context.Context) (ExecutorSecretAccessLogStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *ExecutorSecretAccessLogStoreTransactFunc) nextHook() func(context.Context) (ExecutorSecretAccessLogStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ExecutorSecretAccessLogStoreTransactFunc) appendCall(r0 ExecutorSecretAccessLogStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// ExecutorSecretAccessLogStoreTransactFuncCall objects describing the
-// invocations of this function.
-func (f *ExecutorSecretAccessLogStoreTransactFunc) History() []ExecutorSecretAccessLogStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]ExecutorSecretAccessLogStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ExecutorSecretAccessLogStoreTransactFuncCall is an object that describes
-// an invocation of method Transact on an instance of
-// MockExecutorSecretAccessLogStore.
-type ExecutorSecretAccessLogStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 ExecutorSecretAccessLogStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ExecutorSecretAccessLogStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ExecutorSecretAccessLogStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // ExecutorSecretAccessLogStoreWithFunc describes the behavior when the With
 // method of the parent MockExecutorSecretAccessLogStore instance is
 // invoked.
@@ -14975,6 +14866,115 @@ func (c ExecutorSecretAccessLogStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ExecutorSecretAccessLogStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretAccessLogStoreWithTransactFunc describes the behavior when
+// the WithTransact method of the parent MockExecutorSecretAccessLogStore
+// instance is invoked.
+type ExecutorSecretAccessLogStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(ExecutorSecretAccessLogStore) error) error
+	hooks       []func(context.Context, func(ExecutorSecretAccessLogStore) error) error
+	history     []ExecutorSecretAccessLogStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) WithTransact(v0 context.Context, v1 func(ExecutorSecretAccessLogStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(ExecutorSecretAccessLogStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockExecutorSecretAccessLogStore instance is invoked and
+// the hook queue is empty.
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(ExecutorSecretAccessLogStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockExecutorSecretAccessLogStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) PushHook(hook func(context.Context, func(ExecutorSecretAccessLogStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(ExecutorSecretAccessLogStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(ExecutorSecretAccessLogStore) error) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) nextHook() func(context.Context, func(ExecutorSecretAccessLogStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) appendCall(r0 ExecutorSecretAccessLogStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// ExecutorSecretAccessLogStoreWithTransactFuncCall objects describing the
+// invocations of this function.
+func (f *ExecutorSecretAccessLogStoreWithTransactFunc) History() []ExecutorSecretAccessLogStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreWithTransactFuncCall is an object that
+// describes an invocation of method WithTransact on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(ExecutorSecretAccessLogStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -47791,15 +47791,15 @@ type MockUserCredentialsStore struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
 	ListFunc *UserCredentialsStoreListFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *UserCredentialsStoreTransactFunc
 	// UpdateFunc is an instance of a mock function object controlling the
 	// behavior of the method Update.
 	UpdateFunc *UserCredentialsStoreUpdateFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *UserCredentialsStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *UserCredentialsStoreWithTransactFunc
 }
 
 // NewMockUserCredentialsStore creates a new mock of the
@@ -47837,11 +47837,6 @@ func NewMockUserCredentialsStore() *MockUserCredentialsStore {
 				return
 			},
 		},
-		TransactFunc: &UserCredentialsStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 UserCredentialsStore, r1 error) {
-				return
-			},
-		},
 		UpdateFunc: &UserCredentialsStoreUpdateFunc{
 			defaultHook: func(context.Context, *UserCredential) (r0 error) {
 				return
@@ -47849,6 +47844,11 @@ func NewMockUserCredentialsStore() *MockUserCredentialsStore {
 		},
 		WithFunc: &UserCredentialsStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 UserCredentialsStore) {
+				return
+			},
+		},
+		WithTransactFunc: &UserCredentialsStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(UserCredentialsStore) error) (r0 error) {
 				return
 			},
 		},
@@ -47890,11 +47890,6 @@ func NewStrictMockUserCredentialsStore() *MockUserCredentialsStore {
 				panic("unexpected invocation of MockUserCredentialsStore.List")
 			},
 		},
-		TransactFunc: &UserCredentialsStoreTransactFunc{
-			defaultHook: func(context.Context) (UserCredentialsStore, error) {
-				panic("unexpected invocation of MockUserCredentialsStore.Transact")
-			},
-		},
 		UpdateFunc: &UserCredentialsStoreUpdateFunc{
 			defaultHook: func(context.Context, *UserCredential) error {
 				panic("unexpected invocation of MockUserCredentialsStore.Update")
@@ -47903,6 +47898,11 @@ func NewStrictMockUserCredentialsStore() *MockUserCredentialsStore {
 		WithFunc: &UserCredentialsStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) UserCredentialsStore {
 				panic("unexpected invocation of MockUserCredentialsStore.With")
+			},
+		},
+		WithTransactFunc: &UserCredentialsStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(UserCredentialsStore) error) error {
+				panic("unexpected invocation of MockUserCredentialsStore.WithTransact")
 			},
 		},
 	}
@@ -47931,14 +47931,14 @@ func NewMockUserCredentialsStoreFrom(i UserCredentialsStore) *MockUserCredential
 		ListFunc: &UserCredentialsStoreListFunc{
 			defaultHook: i.List,
 		},
-		TransactFunc: &UserCredentialsStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		UpdateFunc: &UserCredentialsStoreUpdateFunc{
 			defaultHook: i.Update,
 		},
 		WithFunc: &UserCredentialsStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &UserCredentialsStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -48587,111 +48587,6 @@ func (c UserCredentialsStoreListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// UserCredentialsStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockUserCredentialsStore instance is invoked.
-type UserCredentialsStoreTransactFunc struct {
-	defaultHook func(context.Context) (UserCredentialsStore, error)
-	hooks       []func(context.Context) (UserCredentialsStore, error)
-	history     []UserCredentialsStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockUserCredentialsStore) Transact(v0 context.Context) (UserCredentialsStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(UserCredentialsStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockUserCredentialsStore instance is invoked and the hook
-// queue is empty.
-func (f *UserCredentialsStoreTransactFunc) SetDefaultHook(hook func(context.Context) (UserCredentialsStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockUserCredentialsStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *UserCredentialsStoreTransactFunc) PushHook(hook func(context.Context) (UserCredentialsStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *UserCredentialsStoreTransactFunc) SetDefaultReturn(r0 UserCredentialsStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (UserCredentialsStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *UserCredentialsStoreTransactFunc) PushReturn(r0 UserCredentialsStore, r1 error) {
-	f.PushHook(func(context.Context) (UserCredentialsStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *UserCredentialsStoreTransactFunc) nextHook() func(context.Context) (UserCredentialsStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *UserCredentialsStoreTransactFunc) appendCall(r0 UserCredentialsStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of UserCredentialsStoreTransactFuncCall
-// objects describing the invocations of this function.
-func (f *UserCredentialsStoreTransactFunc) History() []UserCredentialsStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]UserCredentialsStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// UserCredentialsStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of MockUserCredentialsStore.
-type UserCredentialsStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 UserCredentialsStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c UserCredentialsStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c UserCredentialsStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // UserCredentialsStoreUpdateFunc describes the behavior when the Update
 // method of the parent MockUserCredentialsStore instance is invoked.
 type UserCredentialsStoreUpdateFunc struct {
@@ -48896,6 +48791,114 @@ func (c UserCredentialsStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserCredentialsStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// UserCredentialsStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockUserCredentialsStore instance is
+// invoked.
+type UserCredentialsStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(UserCredentialsStore) error) error
+	hooks       []func(context.Context, func(UserCredentialsStore) error) error
+	history     []UserCredentialsStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockUserCredentialsStore) WithTransact(v0 context.Context, v1 func(UserCredentialsStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(UserCredentialsStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockUserCredentialsStore instance is invoked and the hook
+// queue is empty.
+func (f *UserCredentialsStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(UserCredentialsStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockUserCredentialsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserCredentialsStoreWithTransactFunc) PushHook(hook func(context.Context, func(UserCredentialsStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserCredentialsStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(UserCredentialsStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserCredentialsStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(UserCredentialsStore) error) error {
+		return r0
+	})
+}
+
+func (f *UserCredentialsStoreWithTransactFunc) nextHook() func(context.Context, func(UserCredentialsStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserCredentialsStoreWithTransactFunc) appendCall(r0 UserCredentialsStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserCredentialsStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *UserCredentialsStoreWithTransactFunc) History() []UserCredentialsStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]UserCredentialsStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserCredentialsStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of
+// MockUserCredentialsStore.
+type UserCredentialsStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(UserCredentialsStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserCredentialsStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserCredentialsStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -31855,12 +31855,12 @@ type MockOutboundWebhookJobStore struct {
 	// QueryFunc is an instance of a mock function object controlling the
 	// behavior of the method Query.
 	QueryFunc *OutboundWebhookJobStoreQueryFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *OutboundWebhookJobStoreTransactFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OutboundWebhookJobStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *OutboundWebhookJobStoreWithTransactFunc
 }
 
 // NewMockOutboundWebhookJobStore creates a new mock of the
@@ -31898,13 +31898,13 @@ func NewMockOutboundWebhookJobStore() *MockOutboundWebhookJobStore {
 				return
 			},
 		},
-		TransactFunc: &OutboundWebhookJobStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 OutboundWebhookJobStore, r1 error) {
+		WithFunc: &OutboundWebhookJobStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 OutboundWebhookJobStore) {
 				return
 			},
 		},
-		WithFunc: &OutboundWebhookJobStoreWithFunc{
-			defaultHook: func(basestore.ShareableStore) (r0 OutboundWebhookJobStore) {
+		WithTransactFunc: &OutboundWebhookJobStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OutboundWebhookJobStore) error) (r0 error) {
 				return
 			},
 		},
@@ -31946,14 +31946,14 @@ func NewStrictMockOutboundWebhookJobStore() *MockOutboundWebhookJobStore {
 				panic("unexpected invocation of MockOutboundWebhookJobStore.Query")
 			},
 		},
-		TransactFunc: &OutboundWebhookJobStoreTransactFunc{
-			defaultHook: func(context.Context) (OutboundWebhookJobStore, error) {
-				panic("unexpected invocation of MockOutboundWebhookJobStore.Transact")
-			},
-		},
 		WithFunc: &OutboundWebhookJobStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OutboundWebhookJobStore {
 				panic("unexpected invocation of MockOutboundWebhookJobStore.With")
+			},
+		},
+		WithTransactFunc: &OutboundWebhookJobStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OutboundWebhookJobStore) error) error {
+				panic("unexpected invocation of MockOutboundWebhookJobStore.WithTransact")
 			},
 		},
 	}
@@ -31982,11 +31982,11 @@ func NewMockOutboundWebhookJobStoreFrom(i OutboundWebhookJobStore) *MockOutbound
 		QueryFunc: &OutboundWebhookJobStoreQueryFunc{
 			defaultHook: i.Query,
 		},
-		TransactFunc: &OutboundWebhookJobStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		WithFunc: &OutboundWebhookJobStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &OutboundWebhookJobStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -32634,114 +32634,6 @@ func (c OutboundWebhookJobStoreQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// OutboundWebhookJobStoreTransactFunc describes the behavior when the
-// Transact method of the parent MockOutboundWebhookJobStore instance is
-// invoked.
-type OutboundWebhookJobStoreTransactFunc struct {
-	defaultHook func(context.Context) (OutboundWebhookJobStore, error)
-	hooks       []func(context.Context) (OutboundWebhookJobStore, error)
-	history     []OutboundWebhookJobStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockOutboundWebhookJobStore) Transact(v0 context.Context) (OutboundWebhookJobStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(OutboundWebhookJobStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockOutboundWebhookJobStore instance is invoked and the hook
-// queue is empty.
-func (f *OutboundWebhookJobStoreTransactFunc) SetDefaultHook(hook func(context.Context) (OutboundWebhookJobStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockOutboundWebhookJobStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *OutboundWebhookJobStoreTransactFunc) PushHook(hook func(context.Context) (OutboundWebhookJobStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OutboundWebhookJobStoreTransactFunc) SetDefaultReturn(r0 OutboundWebhookJobStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (OutboundWebhookJobStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OutboundWebhookJobStoreTransactFunc) PushReturn(r0 OutboundWebhookJobStore, r1 error) {
-	f.PushHook(func(context.Context) (OutboundWebhookJobStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *OutboundWebhookJobStoreTransactFunc) nextHook() func(context.Context) (OutboundWebhookJobStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OutboundWebhookJobStoreTransactFunc) appendCall(r0 OutboundWebhookJobStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OutboundWebhookJobStoreTransactFuncCall
-// objects describing the invocations of this function.
-func (f *OutboundWebhookJobStoreTransactFunc) History() []OutboundWebhookJobStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]OutboundWebhookJobStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OutboundWebhookJobStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of
-// MockOutboundWebhookJobStore.
-type OutboundWebhookJobStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 OutboundWebhookJobStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OutboundWebhookJobStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OutboundWebhookJobStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // OutboundWebhookJobStoreWithFunc describes the behavior when the With
 // method of the parent MockOutboundWebhookJobStore instance is invoked.
 type OutboundWebhookJobStoreWithFunc struct {
@@ -32844,6 +32736,114 @@ func (c OutboundWebhookJobStoreWithFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// OutboundWebhookJobStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockOutboundWebhookJobStore instance is
+// invoked.
+type OutboundWebhookJobStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(OutboundWebhookJobStore) error) error
+	hooks       []func(context.Context, func(OutboundWebhookJobStore) error) error
+	history     []OutboundWebhookJobStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockOutboundWebhookJobStore) WithTransact(v0 context.Context, v1 func(OutboundWebhookJobStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(OutboundWebhookJobStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockOutboundWebhookJobStore instance is invoked and the
+// hook queue is empty.
+func (f *OutboundWebhookJobStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(OutboundWebhookJobStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockOutboundWebhookJobStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *OutboundWebhookJobStoreWithTransactFunc) PushHook(hook func(context.Context, func(OutboundWebhookJobStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OutboundWebhookJobStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(OutboundWebhookJobStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OutboundWebhookJobStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(OutboundWebhookJobStore) error) error {
+		return r0
+	})
+}
+
+func (f *OutboundWebhookJobStoreWithTransactFunc) nextHook() func(context.Context, func(OutboundWebhookJobStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OutboundWebhookJobStoreWithTransactFunc) appendCall(r0 OutboundWebhookJobStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OutboundWebhookJobStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *OutboundWebhookJobStoreWithTransactFunc) History() []OutboundWebhookJobStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]OutboundWebhookJobStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OutboundWebhookJobStoreWithTransactFuncCall is an object that describes
+// an invocation of method WithTransact on an instance of
+// MockOutboundWebhookJobStore.
+type OutboundWebhookJobStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(OutboundWebhookJobStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OutboundWebhookJobStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OutboundWebhookJobStoreWithTransactFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
 // MockOutboundWebhookLogStore is a mock implementation of the
 // OutboundWebhookLogStore interface (from the package
 // github.com/sourcegraph/sourcegraph/internal/database) used for unit
@@ -32867,12 +32867,12 @@ type MockOutboundWebhookLogStore struct {
 	// QueryFunc is an instance of a mock function object controlling the
 	// behavior of the method Query.
 	QueryFunc *OutboundWebhookLogStoreQueryFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *OutboundWebhookLogStoreTransactFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OutboundWebhookLogStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *OutboundWebhookLogStoreWithTransactFunc
 }
 
 // NewMockOutboundWebhookLogStore creates a new mock of the
@@ -32910,13 +32910,13 @@ func NewMockOutboundWebhookLogStore() *MockOutboundWebhookLogStore {
 				return
 			},
 		},
-		TransactFunc: &OutboundWebhookLogStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 OutboundWebhookLogStore, r1 error) {
+		WithFunc: &OutboundWebhookLogStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 OutboundWebhookLogStore) {
 				return
 			},
 		},
-		WithFunc: &OutboundWebhookLogStoreWithFunc{
-			defaultHook: func(basestore.ShareableStore) (r0 OutboundWebhookLogStore) {
+		WithTransactFunc: &OutboundWebhookLogStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OutboundWebhookLogStore) error) (r0 error) {
 				return
 			},
 		},
@@ -32958,14 +32958,14 @@ func NewStrictMockOutboundWebhookLogStore() *MockOutboundWebhookLogStore {
 				panic("unexpected invocation of MockOutboundWebhookLogStore.Query")
 			},
 		},
-		TransactFunc: &OutboundWebhookLogStoreTransactFunc{
-			defaultHook: func(context.Context) (OutboundWebhookLogStore, error) {
-				panic("unexpected invocation of MockOutboundWebhookLogStore.Transact")
-			},
-		},
 		WithFunc: &OutboundWebhookLogStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OutboundWebhookLogStore {
 				panic("unexpected invocation of MockOutboundWebhookLogStore.With")
+			},
+		},
+		WithTransactFunc: &OutboundWebhookLogStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OutboundWebhookLogStore) error) error {
+				panic("unexpected invocation of MockOutboundWebhookLogStore.WithTransact")
 			},
 		},
 	}
@@ -32994,11 +32994,11 @@ func NewMockOutboundWebhookLogStoreFrom(i OutboundWebhookLogStore) *MockOutbound
 		QueryFunc: &OutboundWebhookLogStoreQueryFunc{
 			defaultHook: i.Query,
 		},
-		TransactFunc: &OutboundWebhookLogStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		WithFunc: &OutboundWebhookLogStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &OutboundWebhookLogStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -33646,114 +33646,6 @@ func (c OutboundWebhookLogStoreQueryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// OutboundWebhookLogStoreTransactFunc describes the behavior when the
-// Transact method of the parent MockOutboundWebhookLogStore instance is
-// invoked.
-type OutboundWebhookLogStoreTransactFunc struct {
-	defaultHook func(context.Context) (OutboundWebhookLogStore, error)
-	hooks       []func(context.Context) (OutboundWebhookLogStore, error)
-	history     []OutboundWebhookLogStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockOutboundWebhookLogStore) Transact(v0 context.Context) (OutboundWebhookLogStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(OutboundWebhookLogStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockOutboundWebhookLogStore instance is invoked and the hook
-// queue is empty.
-func (f *OutboundWebhookLogStoreTransactFunc) SetDefaultHook(hook func(context.Context) (OutboundWebhookLogStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockOutboundWebhookLogStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *OutboundWebhookLogStoreTransactFunc) PushHook(hook func(context.Context) (OutboundWebhookLogStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OutboundWebhookLogStoreTransactFunc) SetDefaultReturn(r0 OutboundWebhookLogStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (OutboundWebhookLogStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OutboundWebhookLogStoreTransactFunc) PushReturn(r0 OutboundWebhookLogStore, r1 error) {
-	f.PushHook(func(context.Context) (OutboundWebhookLogStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *OutboundWebhookLogStoreTransactFunc) nextHook() func(context.Context) (OutboundWebhookLogStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OutboundWebhookLogStoreTransactFunc) appendCall(r0 OutboundWebhookLogStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OutboundWebhookLogStoreTransactFuncCall
-// objects describing the invocations of this function.
-func (f *OutboundWebhookLogStoreTransactFunc) History() []OutboundWebhookLogStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]OutboundWebhookLogStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OutboundWebhookLogStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of
-// MockOutboundWebhookLogStore.
-type OutboundWebhookLogStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 OutboundWebhookLogStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OutboundWebhookLogStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OutboundWebhookLogStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // OutboundWebhookLogStoreWithFunc describes the behavior when the With
 // method of the parent MockOutboundWebhookLogStore instance is invoked.
 type OutboundWebhookLogStoreWithFunc struct {
@@ -33853,6 +33745,114 @@ func (c OutboundWebhookLogStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c OutboundWebhookLogStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// OutboundWebhookLogStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockOutboundWebhookLogStore instance is
+// invoked.
+type OutboundWebhookLogStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(OutboundWebhookLogStore) error) error
+	hooks       []func(context.Context, func(OutboundWebhookLogStore) error) error
+	history     []OutboundWebhookLogStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockOutboundWebhookLogStore) WithTransact(v0 context.Context, v1 func(OutboundWebhookLogStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(OutboundWebhookLogStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockOutboundWebhookLogStore instance is invoked and the
+// hook queue is empty.
+func (f *OutboundWebhookLogStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(OutboundWebhookLogStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockOutboundWebhookLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *OutboundWebhookLogStoreWithTransactFunc) PushHook(hook func(context.Context, func(OutboundWebhookLogStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OutboundWebhookLogStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(OutboundWebhookLogStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OutboundWebhookLogStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(OutboundWebhookLogStore) error) error {
+		return r0
+	})
+}
+
+func (f *OutboundWebhookLogStoreWithTransactFunc) nextHook() func(context.Context, func(OutboundWebhookLogStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OutboundWebhookLogStoreWithTransactFunc) appendCall(r0 OutboundWebhookLogStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OutboundWebhookLogStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *OutboundWebhookLogStoreWithTransactFunc) History() []OutboundWebhookLogStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]OutboundWebhookLogStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OutboundWebhookLogStoreWithTransactFuncCall is an object that describes
+// an invocation of method WithTransact on an instance of
+// MockOutboundWebhookLogStore.
+type OutboundWebhookLogStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(OutboundWebhookLogStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OutboundWebhookLogStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OutboundWebhookLogStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -26837,9 +26837,6 @@ type MockOrgInvitationStore struct {
 	// RevokeFunc is an instance of a mock function object controlling the
 	// behavior of the method Revoke.
 	RevokeFunc *OrgInvitationStoreRevokeFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *OrgInvitationStoreTransactFunc
 	// UpdateEmailSentTimestampFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateEmailSentTimestamp.
 	UpdateEmailSentTimestampFunc *OrgInvitationStoreUpdateEmailSentTimestampFunc
@@ -26849,6 +26846,9 @@ type MockOrgInvitationStore struct {
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *OrgInvitationStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *OrgInvitationStoreWithTransactFunc
 }
 
 // NewMockOrgInvitationStore creates a new mock of the OrgInvitationStore
@@ -26906,11 +26906,6 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 				return
 			},
 		},
-		TransactFunc: &OrgInvitationStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 OrgInvitationStore, r1 error) {
-				return
-			},
-		},
 		UpdateEmailSentTimestampFunc: &OrgInvitationStoreUpdateEmailSentTimestampFunc{
 			defaultHook: func(context.Context, int64) (r0 error) {
 				return
@@ -26923,6 +26918,11 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 		},
 		WithFunc: &OrgInvitationStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 OrgInvitationStore) {
+				return
+			},
+		},
+		WithTransactFunc: &OrgInvitationStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OrgInvitationStore) error) (r0 error) {
 				return
 			},
 		},
@@ -26984,11 +26984,6 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 				panic("unexpected invocation of MockOrgInvitationStore.Revoke")
 			},
 		},
-		TransactFunc: &OrgInvitationStoreTransactFunc{
-			defaultHook: func(context.Context) (OrgInvitationStore, error) {
-				panic("unexpected invocation of MockOrgInvitationStore.Transact")
-			},
-		},
 		UpdateEmailSentTimestampFunc: &OrgInvitationStoreUpdateEmailSentTimestampFunc{
 			defaultHook: func(context.Context, int64) error {
 				panic("unexpected invocation of MockOrgInvitationStore.UpdateEmailSentTimestamp")
@@ -27002,6 +26997,11 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 		WithFunc: &OrgInvitationStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) OrgInvitationStore {
 				panic("unexpected invocation of MockOrgInvitationStore.With")
+			},
+		},
+		WithTransactFunc: &OrgInvitationStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(OrgInvitationStore) error) error {
+				panic("unexpected invocation of MockOrgInvitationStore.WithTransact")
 			},
 		},
 	}
@@ -27042,9 +27042,6 @@ func NewMockOrgInvitationStoreFrom(i OrgInvitationStore) *MockOrgInvitationStore
 		RevokeFunc: &OrgInvitationStoreRevokeFunc{
 			defaultHook: i.Revoke,
 		},
-		TransactFunc: &OrgInvitationStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		UpdateEmailSentTimestampFunc: &OrgInvitationStoreUpdateEmailSentTimestampFunc{
 			defaultHook: i.UpdateEmailSentTimestamp,
 		},
@@ -27053,6 +27050,9 @@ func NewMockOrgInvitationStoreFrom(i OrgInvitationStore) *MockOrgInvitationStore
 		},
 		WithFunc: &OrgInvitationStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &OrgInvitationStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -28153,111 +28153,6 @@ func (c OrgInvitationStoreRevokeFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// OrgInvitationStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockOrgInvitationStore instance is invoked.
-type OrgInvitationStoreTransactFunc struct {
-	defaultHook func(context.Context) (OrgInvitationStore, error)
-	hooks       []func(context.Context) (OrgInvitationStore, error)
-	history     []OrgInvitationStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockOrgInvitationStore) Transact(v0 context.Context) (OrgInvitationStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(OrgInvitationStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockOrgInvitationStore instance is invoked and the hook queue
-// is empty.
-func (f *OrgInvitationStoreTransactFunc) SetDefaultHook(hook func(context.Context) (OrgInvitationStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockOrgInvitationStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *OrgInvitationStoreTransactFunc) PushHook(hook func(context.Context) (OrgInvitationStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *OrgInvitationStoreTransactFunc) SetDefaultReturn(r0 OrgInvitationStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (OrgInvitationStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgInvitationStoreTransactFunc) PushReturn(r0 OrgInvitationStore, r1 error) {
-	f.PushHook(func(context.Context) (OrgInvitationStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *OrgInvitationStoreTransactFunc) nextHook() func(context.Context) (OrgInvitationStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *OrgInvitationStoreTransactFunc) appendCall(r0 OrgInvitationStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of OrgInvitationStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *OrgInvitationStoreTransactFunc) History() []OrgInvitationStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]OrgInvitationStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// OrgInvitationStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of MockOrgInvitationStore.
-type OrgInvitationStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 OrgInvitationStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c OrgInvitationStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c OrgInvitationStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // OrgInvitationStoreUpdateEmailSentTimestampFunc describes the behavior
 // when the UpdateEmailSentTimestamp method of the parent
 // MockOrgInvitationStore instance is invoked.
@@ -28577,6 +28472,113 @@ func (c OrgInvitationStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c OrgInvitationStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// OrgInvitationStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockOrgInvitationStore instance is
+// invoked.
+type OrgInvitationStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(OrgInvitationStore) error) error
+	hooks       []func(context.Context, func(OrgInvitationStore) error) error
+	history     []OrgInvitationStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockOrgInvitationStore) WithTransact(v0 context.Context, v1 func(OrgInvitationStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(OrgInvitationStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockOrgInvitationStore instance is invoked and the hook
+// queue is empty.
+func (f *OrgInvitationStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(OrgInvitationStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockOrgInvitationStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *OrgInvitationStoreWithTransactFunc) PushHook(hook func(context.Context, func(OrgInvitationStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OrgInvitationStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(OrgInvitationStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OrgInvitationStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(OrgInvitationStore) error) error {
+		return r0
+	})
+}
+
+func (f *OrgInvitationStoreWithTransactFunc) nextHook() func(context.Context, func(OrgInvitationStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OrgInvitationStoreWithTransactFunc) appendCall(r0 OrgInvitationStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of OrgInvitationStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *OrgInvitationStoreWithTransactFunc) History() []OrgInvitationStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]OrgInvitationStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OrgInvitationStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of
+// MockOrgInvitationStore.
+type OrgInvitationStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(OrgInvitationStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OrgInvitationStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OrgInvitationStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -40053,15 +40053,15 @@ type MockSavedSearchStore struct {
 	// object controlling the behavior of the method
 	// ListSavedSearchesByUserID.
 	ListSavedSearchesByUserIDFunc *SavedSearchStoreListSavedSearchesByUserIDFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *SavedSearchStoreTransactFunc
 	// UpdateFunc is an instance of a mock function object controlling the
 	// behavior of the method Update.
 	UpdateFunc *SavedSearchStoreUpdateFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *SavedSearchStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *SavedSearchStoreWithTransactFunc
 }
 
 // NewMockSavedSearchStore creates a new mock of the SavedSearchStore
@@ -40119,11 +40119,6 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 				return
 			},
 		},
-		TransactFunc: &SavedSearchStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 SavedSearchStore, r1 error) {
-				return
-			},
-		},
 		UpdateFunc: &SavedSearchStoreUpdateFunc{
 			defaultHook: func(context.Context, *types.SavedSearch) (r0 *types.SavedSearch, r1 error) {
 				return
@@ -40131,6 +40126,11 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 		},
 		WithFunc: &SavedSearchStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 SavedSearchStore) {
+				return
+			},
+		},
+		WithTransactFunc: &SavedSearchStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(SavedSearchStore) error) (r0 error) {
 				return
 			},
 		},
@@ -40191,11 +40191,6 @@ func NewStrictMockSavedSearchStore() *MockSavedSearchStore {
 				panic("unexpected invocation of MockSavedSearchStore.ListSavedSearchesByUserID")
 			},
 		},
-		TransactFunc: &SavedSearchStoreTransactFunc{
-			defaultHook: func(context.Context) (SavedSearchStore, error) {
-				panic("unexpected invocation of MockSavedSearchStore.Transact")
-			},
-		},
 		UpdateFunc: &SavedSearchStoreUpdateFunc{
 			defaultHook: func(context.Context, *types.SavedSearch) (*types.SavedSearch, error) {
 				panic("unexpected invocation of MockSavedSearchStore.Update")
@@ -40204,6 +40199,11 @@ func NewStrictMockSavedSearchStore() *MockSavedSearchStore {
 		WithFunc: &SavedSearchStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) SavedSearchStore {
 				panic("unexpected invocation of MockSavedSearchStore.With")
+			},
+		},
+		WithTransactFunc: &SavedSearchStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(SavedSearchStore) error) error {
+				panic("unexpected invocation of MockSavedSearchStore.WithTransact")
 			},
 		},
 	}
@@ -40244,14 +40244,14 @@ func NewMockSavedSearchStoreFrom(i SavedSearchStore) *MockSavedSearchStore {
 		ListSavedSearchesByUserIDFunc: &SavedSearchStoreListSavedSearchesByUserIDFunc{
 			defaultHook: i.ListSavedSearchesByUserID,
 		},
-		TransactFunc: &SavedSearchStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		UpdateFunc: &SavedSearchStoreUpdateFunc{
 			defaultHook: i.Update,
 		},
 		WithFunc: &SavedSearchStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &SavedSearchStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -41343,111 +41343,6 @@ func (c SavedSearchStoreListSavedSearchesByUserIDFuncCall) Results() []interface
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// SavedSearchStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockSavedSearchStore instance is invoked.
-type SavedSearchStoreTransactFunc struct {
-	defaultHook func(context.Context) (SavedSearchStore, error)
-	hooks       []func(context.Context) (SavedSearchStore, error)
-	history     []SavedSearchStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockSavedSearchStore) Transact(v0 context.Context) (SavedSearchStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(SavedSearchStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockSavedSearchStore instance is invoked and the hook queue is
-// empty.
-func (f *SavedSearchStoreTransactFunc) SetDefaultHook(hook func(context.Context) (SavedSearchStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockSavedSearchStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *SavedSearchStoreTransactFunc) PushHook(hook func(context.Context) (SavedSearchStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SavedSearchStoreTransactFunc) SetDefaultReturn(r0 SavedSearchStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (SavedSearchStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SavedSearchStoreTransactFunc) PushReturn(r0 SavedSearchStore, r1 error) {
-	f.PushHook(func(context.Context) (SavedSearchStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *SavedSearchStoreTransactFunc) nextHook() func(context.Context) (SavedSearchStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SavedSearchStoreTransactFunc) appendCall(r0 SavedSearchStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of SavedSearchStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *SavedSearchStoreTransactFunc) History() []SavedSearchStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]SavedSearchStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SavedSearchStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of MockSavedSearchStore.
-type SavedSearchStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 SavedSearchStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SavedSearchStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SavedSearchStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // SavedSearchStoreUpdateFunc describes the behavior when the Update method
 // of the parent MockSavedSearchStore instance is invoked.
 type SavedSearchStoreUpdateFunc struct {
@@ -41655,6 +41550,112 @@ func (c SavedSearchStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c SavedSearchStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// SavedSearchStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockSavedSearchStore instance is
+// invoked.
+type SavedSearchStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(SavedSearchStore) error) error
+	hooks       []func(context.Context, func(SavedSearchStore) error) error
+	history     []SavedSearchStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockSavedSearchStore) WithTransact(v0 context.Context, v1 func(SavedSearchStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(SavedSearchStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockSavedSearchStore instance is invoked and the hook queue
+// is empty.
+func (f *SavedSearchStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(SavedSearchStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockSavedSearchStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *SavedSearchStoreWithTransactFunc) PushHook(hook func(context.Context, func(SavedSearchStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *SavedSearchStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(SavedSearchStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *SavedSearchStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(SavedSearchStore) error) error {
+		return r0
+	})
+}
+
+func (f *SavedSearchStoreWithTransactFunc) nextHook() func(context.Context, func(SavedSearchStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *SavedSearchStoreWithTransactFunc) appendCall(r0 SavedSearchStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of SavedSearchStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *SavedSearchStoreWithTransactFunc) History() []SavedSearchStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]SavedSearchStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// SavedSearchStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of MockSavedSearchStore.
+type SavedSearchStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(SavedSearchStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c SavedSearchStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c SavedSearchStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -20561,9 +20561,6 @@ type MockFeatureFlagStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *FeatureFlagStoreHandleFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *FeatureFlagStoreTransactFunc
 	// UpdateFeatureFlagFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateFeatureFlag.
 	UpdateFeatureFlagFunc *FeatureFlagStoreUpdateFeatureFlagFunc
@@ -20573,6 +20570,9 @@ type MockFeatureFlagStore struct {
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *FeatureFlagStoreWithFunc
+	// WithTransactFunc is an instance of a mock function object controlling
+	// the behavior of the method WithTransact.
+	WithTransactFunc *FeatureFlagStoreWithTransactFunc
 }
 
 // NewMockFeatureFlagStore creates a new mock of the FeatureFlagStore
@@ -20665,11 +20665,6 @@ func NewMockFeatureFlagStore() *MockFeatureFlagStore {
 				return
 			},
 		},
-		TransactFunc: &FeatureFlagStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 FeatureFlagStore, r1 error) {
-				return
-			},
-		},
 		UpdateFeatureFlagFunc: &FeatureFlagStoreUpdateFeatureFlagFunc{
 			defaultHook: func(context.Context, *featureflag.FeatureFlag) (r0 *featureflag.FeatureFlag, r1 error) {
 				return
@@ -20682,6 +20677,11 @@ func NewMockFeatureFlagStore() *MockFeatureFlagStore {
 		},
 		WithFunc: &FeatureFlagStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) (r0 FeatureFlagStore) {
+				return
+			},
+		},
+		WithTransactFunc: &FeatureFlagStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(FeatureFlagStore) error) (r0 error) {
 				return
 			},
 		},
@@ -20777,11 +20777,6 @@ func NewStrictMockFeatureFlagStore() *MockFeatureFlagStore {
 				panic("unexpected invocation of MockFeatureFlagStore.Handle")
 			},
 		},
-		TransactFunc: &FeatureFlagStoreTransactFunc{
-			defaultHook: func(context.Context) (FeatureFlagStore, error) {
-				panic("unexpected invocation of MockFeatureFlagStore.Transact")
-			},
-		},
 		UpdateFeatureFlagFunc: &FeatureFlagStoreUpdateFeatureFlagFunc{
 			defaultHook: func(context.Context, *featureflag.FeatureFlag) (*featureflag.FeatureFlag, error) {
 				panic("unexpected invocation of MockFeatureFlagStore.UpdateFeatureFlag")
@@ -20795,6 +20790,11 @@ func NewStrictMockFeatureFlagStore() *MockFeatureFlagStore {
 		WithFunc: &FeatureFlagStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) FeatureFlagStore {
 				panic("unexpected invocation of MockFeatureFlagStore.With")
+			},
+		},
+		WithTransactFunc: &FeatureFlagStoreWithTransactFunc{
+			defaultHook: func(context.Context, func(FeatureFlagStore) error) error {
+				panic("unexpected invocation of MockFeatureFlagStore.WithTransact")
 			},
 		},
 	}
@@ -20856,9 +20856,6 @@ func NewMockFeatureFlagStoreFrom(i FeatureFlagStore) *MockFeatureFlagStore {
 		HandleFunc: &FeatureFlagStoreHandleFunc{
 			defaultHook: i.Handle,
 		},
-		TransactFunc: &FeatureFlagStoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		UpdateFeatureFlagFunc: &FeatureFlagStoreUpdateFeatureFlagFunc{
 			defaultHook: i.UpdateFeatureFlag,
 		},
@@ -20867,6 +20864,9 @@ func NewMockFeatureFlagStoreFrom(i FeatureFlagStore) *MockFeatureFlagStore {
 		},
 		WithFunc: &FeatureFlagStoreWithFunc{
 			defaultHook: i.With,
+		},
+		WithTransactFunc: &FeatureFlagStoreWithTransactFunc{
+			defaultHook: i.WithTransact,
 		},
 	}
 }
@@ -22747,111 +22747,6 @@ func (c FeatureFlagStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// FeatureFlagStoreTransactFunc describes the behavior when the Transact
-// method of the parent MockFeatureFlagStore instance is invoked.
-type FeatureFlagStoreTransactFunc struct {
-	defaultHook func(context.Context) (FeatureFlagStore, error)
-	hooks       []func(context.Context) (FeatureFlagStore, error)
-	history     []FeatureFlagStoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockFeatureFlagStore) Transact(v0 context.Context) (FeatureFlagStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(FeatureFlagStoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockFeatureFlagStore instance is invoked and the hook queue is
-// empty.
-func (f *FeatureFlagStoreTransactFunc) SetDefaultHook(hook func(context.Context) (FeatureFlagStore, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockFeatureFlagStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *FeatureFlagStoreTransactFunc) PushHook(hook func(context.Context) (FeatureFlagStore, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *FeatureFlagStoreTransactFunc) SetDefaultReturn(r0 FeatureFlagStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (FeatureFlagStore, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *FeatureFlagStoreTransactFunc) PushReturn(r0 FeatureFlagStore, r1 error) {
-	f.PushHook(func(context.Context) (FeatureFlagStore, error) {
-		return r0, r1
-	})
-}
-
-func (f *FeatureFlagStoreTransactFunc) nextHook() func(context.Context) (FeatureFlagStore, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *FeatureFlagStoreTransactFunc) appendCall(r0 FeatureFlagStoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of FeatureFlagStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *FeatureFlagStoreTransactFunc) History() []FeatureFlagStoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]FeatureFlagStoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// FeatureFlagStoreTransactFuncCall is an object that describes an
-// invocation of method Transact on an instance of MockFeatureFlagStore.
-type FeatureFlagStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 FeatureFlagStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c FeatureFlagStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c FeatureFlagStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // FeatureFlagStoreUpdateFeatureFlagFunc describes the behavior when the
 // UpdateFeatureFlag method of the parent MockFeatureFlagStore instance is
 // invoked.
@@ -23181,6 +23076,112 @@ func (c FeatureFlagStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c FeatureFlagStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// FeatureFlagStoreWithTransactFunc describes the behavior when the
+// WithTransact method of the parent MockFeatureFlagStore instance is
+// invoked.
+type FeatureFlagStoreWithTransactFunc struct {
+	defaultHook func(context.Context, func(FeatureFlagStore) error) error
+	hooks       []func(context.Context, func(FeatureFlagStore) error) error
+	history     []FeatureFlagStoreWithTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransact delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockFeatureFlagStore) WithTransact(v0 context.Context, v1 func(FeatureFlagStore) error) error {
+	r0 := m.WithTransactFunc.nextHook()(v0, v1)
+	m.WithTransactFunc.appendCall(FeatureFlagStoreWithTransactFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransact method
+// of the parent MockFeatureFlagStore instance is invoked and the hook queue
+// is empty.
+func (f *FeatureFlagStoreWithTransactFunc) SetDefaultHook(hook func(context.Context, func(FeatureFlagStore) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransact method of the parent MockFeatureFlagStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *FeatureFlagStoreWithTransactFunc) PushHook(hook func(context.Context, func(FeatureFlagStore) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *FeatureFlagStoreWithTransactFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(FeatureFlagStore) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *FeatureFlagStoreWithTransactFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(FeatureFlagStore) error) error {
+		return r0
+	})
+}
+
+func (f *FeatureFlagStoreWithTransactFunc) nextHook() func(context.Context, func(FeatureFlagStore) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *FeatureFlagStoreWithTransactFunc) appendCall(r0 FeatureFlagStoreWithTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of FeatureFlagStoreWithTransactFuncCall
+// objects describing the invocations of this function.
+func (f *FeatureFlagStoreWithTransactFunc) History() []FeatureFlagStoreWithTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]FeatureFlagStoreWithTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// FeatureFlagStoreWithTransactFuncCall is an object that describes an
+// invocation of method WithTransact on an instance of MockFeatureFlagStore.
+type FeatureFlagStoreWithTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(FeatureFlagStore) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c FeatureFlagStoreWithTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c FeatureFlagStoreWithTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/phabricator.go
+++ b/internal/database/phabricator.go
@@ -20,7 +20,7 @@ type PhabricatorStore interface {
 	CreateIfNotExists(ctx context.Context, callsign string, name api.RepoName, phabURL string) (*types.PhabricatorRepo, error)
 	CreateOrUpdate(ctx context.Context, callsign string, name api.RepoName, phabURL string) (*types.PhabricatorRepo, error)
 	GetByName(context.Context, api.RepoName) (*types.PhabricatorRepo, error)
-	Transact(context.Context) (PhabricatorStore, error)
+	WithTransact(context.Context, func(PhabricatorStore) error) error
 	With(basestore.ShareableStore) PhabricatorStore
 	basestore.ShareableStore
 }
@@ -39,9 +39,10 @@ func (s *phabricatorStore) With(other basestore.ShareableStore) PhabricatorStore
 	return &phabricatorStore{Store: s.Store.With(other)}
 }
 
-func (s *phabricatorStore) Transact(ctx context.Context) (PhabricatorStore, error) {
-	txBase, err := s.Store.Transact(ctx)
-	return &phabricatorStore{Store: txBase}, err
+func (s *phabricatorStore) WithTransact(ctx context.Context, f func(PhabricatorStore) error) error {
+	return s.Store.WithTransact(ctx, func(tx *basestore.Store) error {
+		return f(&phabricatorStore{Store: tx})
+	})
 }
 
 type errPhabricatorRepoNotFound struct {


### PR DESCRIPTION
This PR replaces `Transact` with `WithTransact` on every store that does not use its transact method. This should be a very safe change since none of these methods are actually used -- they only exist for standardization. 

Stacked on #47118 

## Test plan

Build passes. All changes are unused, so this should be safe. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
