### PR TITLE
fix off by 1 in samples due to exclusive time interval

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -328,7 +328,6 @@ func getRecordedSeriesPointOpts(ctx context.Context, db database.DB, timeseriesS
 	if err != nil {
 		return nil, errors.Wrap(err, "GetOffsetNRecordingTime")
 	}
-	fmt.Println(fmt.Sprintf("oldest: %s", oldest.String()))
 	if !oldest.IsZero() {
 		opts.From = &oldest
 	}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -328,8 +328,9 @@ func getRecordedSeriesPointOpts(ctx context.Context, db database.DB, timeseriesS
 	if err != nil {
 		return nil, errors.Wrap(err, "GetOffsetNRecordingTime")
 	}
+	fmt.Println(fmt.Sprintf("oldest: %s", oldest.String()))
 	if !oldest.IsZero() {
-		opts.After = &oldest
+		opts.From = &oldest
 	}
 
 	includeRepo := func(regex ...string) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/47064

The resolver was using an exclusive time interval to select samples. I don't see any reason this would have affected only hourly as in the issue description, it was certainly reproducing all over and this is the only callsite in the resolver chain that selects times.

## Test plan
![CleanShot 2023-01-30 at 11 21 33](https://user-images.githubusercontent.com/5090588/215563017-c22d2323-d60e-47e8-8cf2-a418fadabf83.gif)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
