### PR TITLE
Clarify executors status and CE instructions

### DIFF
--- a/doc/admin/executors.md
+++ b/doc/admin/executors.md
@@ -21,7 +21,14 @@ Executors are Sourcegraph's solution for running untrusted code in a secure and 
 
 ## Installation
 
-To deploy executors to target your Sourcegraph instance, [follow our deployment guide](deploy_executors.md). We currently provide resources to deploy on Google Cloud, AWS, and bare-metal machines.
+To deploy executors to target your Sourcegraph instance, [follow our deployment guide](deploy_executors.md).
+
+There are two supported installation paths (in Beta):
+
+- Deploy with Terraform on AWS or GCP (Beta). Sourcegraph provides Terraform modules and AMIs for [supported regions](./deploy_executors.md).
+- Deploy [binaries](./deploy_executors_binary.md) (beta).
+
+> NOTE: Note to Sourcegraph Customer Engineers and Implementation Engineers: please reach out to the product and engineering teams in #wg-shipping-executors for any discussion about deployment modes other than the two documented paths above. We expect large customers (Large Enterprise and Strategic) to have complex and heterogenous requirements not addressed by the deployment models currently in Beta out of the box. Reach out to the product/eng team in #wg-shipping-executors early in the process to collect requirements and discuss present and future implementation options.
 
 ## Why use executors?
 

--- a/doc/admin/executors.md
+++ b/doc/admin/executors.md
@@ -25,10 +25,10 @@ To deploy executors to target your Sourcegraph instance, [follow our deployment 
 
 There are two supported installation paths (in Beta):
 
-- Deploy with Terraform on AWS or GCP (Beta). Sourcegraph provides Terraform modules and AMIs for [supported regions](./deploy_executors.md).
-- Deploy [binaries](./deploy_executors_binary.md) (beta).
+- <span class="badge badge-beta">Beta</span> Deploy with Terraform on AWS or GCP. Sourcegraph provides Terraform modules and AMIs for [supported regions](./deploy_executors.md).
+- <span class="badge badge-beta">Beta</span> Deploy [binaries](./deploy_executors_binary.md).
 
-> NOTE: Note to Sourcegraph Customer Engineers and Implementation Engineers: please reach out to the product and engineering teams in #wg-shipping-executors for any discussion about deployment modes other than the two documented paths above. We expect large customers (Large Enterprise and Strategic) to have complex and heterogenous requirements not addressed by the deployment models currently in Beta out of the box. Reach out to the product/eng team in #wg-shipping-executors early in the process to collect requirements and discuss present and future implementation options.
+> NOTE: Note to Sourcegraph Customer Engineers and Implementation Engineers: please reach out to the product and engineering teams in #wg-shipping-executors for any discussion about deployment modes other than the two documented paths above. We expect large customers (Large Enterprise and Strategic) to have complex and heterogenous requirements not addressed by the deployment models currently in Beta out of the box. Reach out in #wg-shipping-executors early in the process to collect requirements and discuss present and future implementation options.
 
 ## Why use executors?
 

--- a/doc/admin/executors.md
+++ b/doc/admin/executors.md
@@ -28,7 +28,7 @@ There are two supported installation paths (in Beta):
 - <span class="badge badge-beta">Beta</span> Deploy with Terraform on AWS or GCP. Sourcegraph provides Terraform modules and AMIs for [supported regions](./deploy_executors.md).
 - <span class="badge badge-beta">Beta</span> Deploy [binaries](./deploy_executors_binary.md).
 
-> NOTE: Note to Sourcegraph Customer Engineers and Implementation Engineers: please reach out to the product and engineering teams in #wg-shipping-executors for any discussion about deployment modes other than the two documented paths above. We expect large customers (Large Enterprise and Strategic) to have complex and heterogenous requirements not addressed by the deployment models currently in Beta out of the box. Reach out in #wg-shipping-executors early in the process to collect requirements and discuss present and future implementation options.
+> NOTE: Note to all Technical Success team members: please reach out to the product and engineering teams in #wg-shipping-executors for any discussion about deployment modes other than the two documented paths above. We expect large customers (Large Enterprise and Strategic) to have complex and heterogenous requirements not addressed by the deployment models currently in Beta out of the box. Reach out in #wg-shipping-executors early in the process to collect requirements and discuss present and future implementation options.
 
 ## Why use executors?
 

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -13,8 +13,8 @@ Administration is usually handled by site administrators are the admins responsi
 - [PostgreSQL configuration](config/postgres-conf.md)
 - [Using external services (PostgreSQL, Redis, S3/GCS)](external_services/index.md)
 - <span class="badge badge-experimental">Experimental</span> [Validation](validation.md)
-- <span class="badge badge-experimental">Experimental</span> [Executors](executors.md)
-- <span class="badge badge-experimental">Experimental</span> [Deploy executors](deploy_executors.md)
+- <span class="badge badge-beta">Beta</span> [Executors](executors.md)
+- <span class="badge badge-beta">Beta</span> [Deploy executors](deploy_executors.md)
 
 ## [Upgrade Sourcegraph](updates/index.md)
 


### PR DESCRIPTION
Document executors supported paths in Beta, and what to do outside the supported path.

## Test plan

Visual check: docs only
