### PR TITLE
insights: Update ping value to include repo-search to global/scoped

### DIFF
--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -215,7 +215,7 @@ const pingSeriesType = `
 CONCAT(
    CASE WHEN ((generation_method = 'search' or generation_method = 'search-compute') and generated_from_capture_groups) THEN 'capture-groups' ELSE generation_method END,
     '::',
-   CASE WHEN (cardinality(repositories) = 0 or repositories is null) THEN 'global' ELSE 'scoped' END,
+   CASE WHEN (repositories IS NOT NULL AND cardinality(repositories) > 0) THEN 'scoped' WHEN repository_criteria IS NOT NULL THEN 'repo-search' ELSE 'global' END,
     '::',
    CASE WHEN (just_in_time = true) THEN 'jit' ELSE 'recorded' END
     ) as ping_series_type


### PR DESCRIPTION
With a third option for scoping insights (global, scoped - named repos, repo search) update the ping generation logic to include to match.  I also reordered the cases to match the order in which they background processing checks to try to ensure any conflicts would be handled in the same manor.

closes https://github.com/sourcegraph/sourcegraph/issues/46983

## Test plan
manual test of ping query 

| presentation\_type | ping\_series\_type | count |
| :--- | :--- | :--- |
| LINE | search::global::recorded | 3 |
| LINE | search::repo-search::recorded | 3 |
| LINE | search::scoped::recorded | 1 |
| PIE | language-stats::scoped::jit | 1 |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
