### PR TITLE
rbac: Create store methods for namespace_permissions

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6862,6 +6862,9 @@ type MockEnterpriseDB struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *EnterpriseDBHandleFunc
+	// NamespacePermissionsFunc is an instance of a mock function object
+	// controlling the behavior of the method NamespacePermissions.
+	NamespacePermissionsFunc *EnterpriseDBNamespacePermissionsFunc
 	// NamespacesFunc is an instance of a mock function object controlling
 	// the behavior of the method Namespaces.
 	NamespacesFunc *EnterpriseDBNamespacesFunc
@@ -7050,6 +7053,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		NamespacePermissionsFunc: &EnterpriseDBNamespacePermissionsFunc{
+			defaultHook: func() (r0 database.NamespacePermissionStore) {
 				return
 			},
 		},
@@ -7315,6 +7323,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.Handle")
 			},
 		},
+		NamespacePermissionsFunc: &EnterpriseDBNamespacePermissionsFunc{
+			defaultHook: func() database.NamespacePermissionStore {
+				panic("unexpected invocation of MockEnterpriseDB.NamespacePermissions")
+			},
+		},
 		NamespacesFunc: &EnterpriseDBNamespacesFunc{
 			defaultHook: func() database.NamespaceStore {
 				panic("unexpected invocation of MockEnterpriseDB.Namespaces")
@@ -7545,6 +7558,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
 			defaultHook: i.Handle,
+		},
+		NamespacePermissionsFunc: &EnterpriseDBNamespacePermissionsFunc{
+			defaultHook: i.NamespacePermissions,
 		},
 		NamespacesFunc: &EnterpriseDBNamespacesFunc{
 			defaultHook: i.Namespaces,
@@ -9267,6 +9283,108 @@ func (c EnterpriseDBHandleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBHandleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBNamespacePermissionsFunc describes the behavior when the
+// NamespacePermissions method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBNamespacePermissionsFunc struct {
+	defaultHook func() database.NamespacePermissionStore
+	hooks       []func() database.NamespacePermissionStore
+	history     []EnterpriseDBNamespacePermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// NamespacePermissions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) NamespacePermissions() database.NamespacePermissionStore {
+	r0 := m.NamespacePermissionsFunc.nextHook()()
+	m.NamespacePermissionsFunc.appendCall(EnterpriseDBNamespacePermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the NamespacePermissions
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBNamespacePermissionsFunc) SetDefaultHook(hook func() database.NamespacePermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NamespacePermissions method of the parent MockEnterpriseDB instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EnterpriseDBNamespacePermissionsFunc) PushHook(hook func() database.NamespacePermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBNamespacePermissionsFunc) SetDefaultReturn(r0 database.NamespacePermissionStore) {
+	f.SetDefaultHook(func() database.NamespacePermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBNamespacePermissionsFunc) PushReturn(r0 database.NamespacePermissionStore) {
+	f.PushHook(func() database.NamespacePermissionStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBNamespacePermissionsFunc) nextHook() func() database.NamespacePermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBNamespacePermissionsFunc) appendCall(r0 EnterpriseDBNamespacePermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBNamespacePermissionsFuncCall
+// objects describing the invocations of this function.
+func (f *EnterpriseDBNamespacePermissionsFunc) History() []EnterpriseDBNamespacePermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBNamespacePermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBNamespacePermissionsFuncCall is an object that describes an
+// invocation of method NamespacePermissions on an instance of
+// MockEnterpriseDB.
+type EnterpriseDBNamespacePermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.NamespacePermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBNamespacePermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBNamespacePermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/database/namespace_permissions.go
+++ b/enterprise/internal/database/namespace_permissions.go
@@ -1,0 +1,144 @@
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var namespacePermissionColumns = []*sqlf.Query{
+	sqlf.Sprintf("namespace_permissions.id"),
+	sqlf.Sprintf("namespace_permissions.namespace"),
+	sqlf.Sprintf("namespace_permissions.resource_id"),
+	sqlf.Sprintf("namespace_permissions.action"),
+	sqlf.Sprintf("namespace_permissions.user_id"),
+	sqlf.Sprintf("namespace_permissions.created_at"),
+}
+
+var namespacePermissionInsertColums = []*sqlf.Query{
+	sqlf.Sprintf("namespace_permissions.namespace"),
+	sqlf.Sprintf("namespace_permissions.resource_id"),
+	sqlf.Sprintf("namespace_permissions.action"),
+	sqlf.Sprintf("namespace_permissions.user_id"),
+}
+
+type NamespacePermissionStore interface {
+	basestore.ShareableStore
+
+	Create(context.Context, CreateNamespacePermissionOpts) (*types.NamespacePermission, error)
+	Delete(context.Context, DeleteNamespacePermissionOpts) error
+}
+
+type namespacePermissionStore struct {
+	*basestore.Store
+}
+
+var _ NamespacePermissionStore = &namespacePermissionStore{}
+
+const namespacePermissionCreateQueryFmtStr = `
+INSERT INTO
+	namespace_permissions (%s)
+	VALUES (
+		%s,
+		%s,
+		%s,
+		%s
+	)
+	RETURNING %s
+`
+
+func (n *namespacePermissionStore) Create(ctx context.Context, opts CreateNamespacePermissionOpts) (*types.NamespacePermission, error) {
+	q := sqlf.Sprintf(
+		namespacePermissionCreateQueryFmtStr,
+		sqlf.Join(namespacePermissionInsertColums, ", "),
+		opts.Namespace,
+		opts.ResourceID,
+		opts.Action,
+		opts.UserID,
+		sqlf.Join(namespacePermissionColumns, ", "),
+	)
+
+	np, err := scanNamespacePermission(n.QueryRow(ctx, q))
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning role")
+	}
+
+	return np, nil
+}
+
+const namespacePermissionDeleteQueryFmtStr = `
+DELETE FROM namespace_permissions
+WHERE %s
+`
+
+func (n *namespacePermissionStore) Delete(ctx context.Context, opts DeleteNamespacePermissionOpts) error {
+	if opts.ID == 0 {
+		return errors.New("missing namespace permission id")
+	}
+
+	q := sqlf.Sprintf(
+		namespacePermissionDeleteQueryFmtStr,
+		opts.ID,
+	)
+
+	result, err := n.ExecResult(ctx, q)
+	if err != nil {
+		return errors.Wrap(err, "running delete query")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "checking deleted rows")
+	}
+
+	if rowsAffected == 0 {
+		return errors.Wrap(&NamespacePermissionNotFoundErr{ID: opts.ID}, "failed to delete namespace permission")
+	}
+
+	return nil
+}
+
+func scanNamespacePermission(sc dbutil.Scanner) (*types.NamespacePermission, error) {
+	var np types.NamespacePermission
+	if err := sc.Scan(
+		&np.ID,
+		&np.Namespace,
+		&np.ResourceID,
+		&np.Action,
+		&np.UserID,
+		&np.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	return &np, nil
+}
+
+type DeleteNamespacePermissionOpts struct {
+	ID int64
+}
+
+type CreateNamespacePermissionOpts struct {
+	Namespace  string
+	ResourceID int64
+	Action     string
+	UserID     int32
+}
+
+type NamespacePermissionNotFoundErr struct {
+	ID int64
+}
+
+func (e *NamespacePermissionNotFoundErr) Error() string {
+	return fmt.Sprintf("namespace permission with id %d not found", e.ID)
+}
+
+func (e *NamespacePermissionNotFoundErr) NotFound() bool {
+	return true
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -31,6 +31,7 @@ type DB interface {
 	GitserverRepos() GitserverRepoStore
 	GitserverLocalClone() GitserverLocalCloneStore
 	GlobalState() GlobalStateStore
+	NamespacePermissions() NamespacePermissionStore
 	Namespaces() NamespaceStore
 	OrgInvitations() OrgInvitationStore
 	OrgMembers() OrgMemberStore
@@ -159,6 +160,10 @@ func (d *db) GitserverLocalClone() GitserverLocalCloneStore {
 
 func (d *db) GlobalState() GlobalStateStore {
 	return GlobalStateWith(d.Store)
+}
+
+func (d *db) NamespacePermissions() NamespacePermissionStore {
+	return NamespacePermissionsWith(d.Store)
 }
 
 func (d *db) Namespaces() NamespaceStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3792,6 +3792,9 @@ type MockDB struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *DBHandleFunc
+	// NamespacePermissionsFunc is an instance of a mock function object
+	// controlling the behavior of the method NamespacePermissions.
+	NamespacePermissionsFunc *DBNamespacePermissionsFunc
 	// NamespacesFunc is an instance of a mock function object controlling
 	// the behavior of the method Namespaces.
 	NamespacesFunc *DBNamespacesFunc
@@ -3969,6 +3972,11 @@ func NewMockDB() *MockDB {
 		},
 		HandleFunc: &DBHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		NamespacePermissionsFunc: &DBNamespacePermissionsFunc{
+			defaultHook: func() (r0 NamespacePermissionStore) {
 				return
 			},
 		},
@@ -4219,6 +4227,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.Handle")
 			},
 		},
+		NamespacePermissionsFunc: &DBNamespacePermissionsFunc{
+			defaultHook: func() NamespacePermissionStore {
+				panic("unexpected invocation of MockDB.NamespacePermissions")
+			},
+		},
 		NamespacesFunc: &DBNamespacesFunc{
 			defaultHook: func() NamespaceStore {
 				panic("unexpected invocation of MockDB.Namespaces")
@@ -4435,6 +4448,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		HandleFunc: &DBHandleFunc{
 			defaultHook: i.Handle,
+		},
+		NamespacePermissionsFunc: &DBNamespacePermissionsFunc{
+			defaultHook: i.NamespacePermissions,
 		},
 		NamespacesFunc: &DBNamespacesFunc{
 			defaultHook: i.Namespaces,
@@ -6035,6 +6051,105 @@ func (c DBHandleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBHandleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBNamespacePermissionsFunc describes the behavior when the
+// NamespacePermissions method of the parent MockDB instance is invoked.
+type DBNamespacePermissionsFunc struct {
+	defaultHook func() NamespacePermissionStore
+	hooks       []func() NamespacePermissionStore
+	history     []DBNamespacePermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// NamespacePermissions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) NamespacePermissions() NamespacePermissionStore {
+	r0 := m.NamespacePermissionsFunc.nextHook()()
+	m.NamespacePermissionsFunc.appendCall(DBNamespacePermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the NamespacePermissions
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBNamespacePermissionsFunc) SetDefaultHook(hook func() NamespacePermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NamespacePermissions method of the parent MockDB instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBNamespacePermissionsFunc) PushHook(hook func() NamespacePermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBNamespacePermissionsFunc) SetDefaultReturn(r0 NamespacePermissionStore) {
+	f.SetDefaultHook(func() NamespacePermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBNamespacePermissionsFunc) PushReturn(r0 NamespacePermissionStore) {
+	f.PushHook(func() NamespacePermissionStore {
+		return r0
+	})
+}
+
+func (f *DBNamespacePermissionsFunc) nextHook() func() NamespacePermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBNamespacePermissionsFunc) appendCall(r0 DBNamespacePermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBNamespacePermissionsFuncCall objects
+// describing the invocations of this function.
+func (f *DBNamespacePermissionsFunc) History() []DBNamespacePermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBNamespacePermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBNamespacePermissionsFuncCall is an object that describes an invocation
+// of method NamespacePermissions on an instance of MockDB.
+type DBNamespacePermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 NamespacePermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBNamespacePermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBNamespacePermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -39,6 +39,10 @@ type namespacePermissionStore struct {
 	*basestore.Store
 }
 
+func NamespacePermissionsWith(other basestore.ShareableStore) NamespacePermissionStore {
+	return &namespacePermissionStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
 var _ NamespacePermissionStore = &namespacePermissionStore{}
 
 const namespacePermissionCreateQueryFmtStr = `

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -5,17 +5,131 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestNamespacePermission(t *testing.T) {
+func TestCreateNamespacePermission(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 
-	t.Run("Create", func(t *testing.T) {
-		t.Parallel()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
-		// _, userID, ctx := newTestUser(ctx, t, db)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.NamespacePermissions()
+
+	user := createUserForNamespacePermission(ctx, t, db, "TestUser")
+
+	np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+		Namespace:  "TestNamespace",
+		ResourceID: 1,
+		UserID:     user.ID,
+		Action:     "READ",
 	})
+	assert.NoError(t, err)
+
+	// check that the namespace permission created esists
+	existingNp, err := store.Get(ctx, GetNamespacePermissionOpts{
+		ID: np.ID,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, existingNp)
+	assert.Equal(t, existingNp.ID, np.ID)
+}
+
+func TestDeleteNamespacePermission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.NamespacePermissions()
+
+	user := createUserForNamespacePermission(ctx, t, db, "user1")
+
+	t.Run("missing ID", func(t *testing.T) {
+		err := store.Delete(ctx, DeleteNamespacePermissionOpts{})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing namespace permission id")
+	})
+
+	t.Run("existing namespace permissions", func(t *testing.T) {
+		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+			Namespace:  "TestNamespace",
+			ResourceID: 1,
+			UserID:     user.ID,
+			Action:     "READ",
+		})
+		assert.NoError(t, err)
+
+		err = store.Delete(ctx, DeleteNamespacePermissionOpts{
+			ID: np.ID,
+		})
+		assert.NoError(t, err)
+
+		npID := np.ID
+
+		np, err = store.Get(ctx, GetNamespacePermissionOpts{ID: npID})
+		assert.Error(t, err)
+		assert.Equal(t, err, &NamespacePermissionNotFoundErr{ID: npID})
+		assert.Nil(t, np)
+	})
+
+	t.Run("non-existent namespace permission", func(t *testing.T) {
+		nonExistedNamespacePermissionID := int64(1003)
+		err := store.Delete(ctx, DeleteNamespacePermissionOpts{ID: nonExistedNamespacePermissionID})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to delete namespace permission")
+	})
+}
+
+func TestGetNamespacePermission(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.NamespacePermissions()
+
+	user := createUserForNamespacePermission(ctx, t, db, "user1")
+
+	np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+		Namespace:  "TESTNAMESPACE",
+		ResourceID: 1,
+		UserID:     user.ID,
+		Action:     "READ",
+	})
+	assert.NoError(t, err)
+
+	t.Run("missing ID", func(t *testing.T) {
+		n, err := store.Get(ctx, GetNamespacePermissionOpts{})
+		assert.Nil(t, n)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing namespace permission id")
+	})
+
+	t.Run("existing namespace permission", func(t *testing.T) {
+		n, err := store.Get(ctx, GetNamespacePermissionOpts{ID: np.ID})
+		assert.NoError(t, err)
+		assert.Equal(t, n.ID, np.ID)
+	})
+
+	t.Run("non-existent namespace permission", func(t *testing.T) {
+		npID := int64(1003)
+		n, err := store.Get(ctx, GetNamespacePermissionOpts{ID: npID})
+		assert.Nil(t, n)
+		assert.Error(t, err)
+		assert.Equal(t, err, &NamespacePermissionNotFoundErr{ID: npID})
+	})
+}
+
+func createUserForNamespacePermission(ctx context.Context, t *testing.T, db DB, name string) *types.User {
+	user, err := db.Users().Create(ctx, NewUser{
+		Username: name,
+	})
+	if err != nil {
+		t.Fatal(err)
+		return nil
+	}
+	return user
 }

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -28,6 +28,7 @@ func TestCreateNamespacePermission(t *testing.T) {
 		Action:     "READ",
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, np.UserID, user.ID)
 
 	// check that the namespace permission created esists
 	existingNp, err := store.Get(ctx, GetNamespacePermissionOpts{
@@ -112,6 +113,10 @@ func TestGetNamespacePermission(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{ID: np.ID})
 		assert.NoError(t, err)
 		assert.Equal(t, n.ID, np.ID)
+		assert.Equal(t, n.Namespace, np.Namespace)
+		assert.Equal(t, n.Action, np.Action)
+		assert.Equal(t, n.ResourceID, np.ResourceID)
+		assert.Equal(t, n.UserID, np.UserID)
 	})
 
 	t.Run("non-existent namespace permission", func(t *testing.T) {

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -1,0 +1,21 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestNamespacePermission(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+
+	t.Run("Create", func(t *testing.T) {
+		t.Parallel()
+		db := NewDB(logger, dbtest.NewDB(logger, t))
+		// _, userID, ctx := newTestUser(ctx, t, db)
+	})
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -861,6 +861,12 @@ type NamespacePermission struct {
 	CreatedAt  time.Time
 }
 
+func (n *NamespacePermission) DisplayName() string {
+	// Based on the zanzibar representation for data relations:
+	// <namespace>:<object_id>#<relation>@<user_id | user_group>
+	return fmt.Sprintf("%s:%d#%s@%d", n.Namespace, n.ResourceID, n.Action, n.UserID)
+}
+
 type OrgMemberAutocompleteSearchItem struct {
 	ID          int32
 	Username    string

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -852,6 +852,15 @@ type UserRole struct {
 	CreatedAt time.Time
 }
 
+type NamespacePermission struct {
+	ID         int64
+	Namespace  string
+	ResourceID int64
+	Action     string
+	UserID     int32
+	CreatedAt  time.Time
+}
+
 type OrgMemberAutocompleteSearchItem struct {
 	ID          int32
 	Username    string


### PR DESCRIPTION
This PR introduces a store for `NamespacePermissions`. Namespace permissions are a part of RBAC (Role-based Access Control) used to store fine-grained permissions to resources within Sourcegraph.

Example: I create a private batch change (only accessible to me), and I can share access to that Batch Change with someone else. The relationship between a private resource (belonging to someone else) and another user is then stored in the table.

The structure of the `NamespacePermission` table is as follows:

| column      | type    |
|-------------|---------|
| id          | integer |
| namespace   | string  |
| resource_id | integer |
| action      | string  |
| user_id     | string  |


## Test plan

Wrote extensive test suite, and validated that these stores make sense in the grand scheme. This is pulled out of a giant draft PR.

Closes #45457

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Added unit tests.