### PR TITLE
[Permissions] add perms scheduler background routine

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -159,7 +159,7 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 	// Eagerly attempt to sync permissions again. This needs to happen _after_ the
 	// transaction has committed so that it takes into account any changes triggered
 	// by the removal of the e-mail.
-	triggerPermissionsSync(ctx, logger, e.db, userID, permssync.ReasonUserEmailRemoved)
+	triggerPermissionsSync(ctx, logger, e.db, userID, database.ReasonUserEmailRemoved)
 
 	return nil
 }
@@ -230,7 +230,7 @@ func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string
 	// Eagerly attempt to sync permissions again. This needs to happen _after_ the
 	// transaction has committed so that it takes into account any changes triggered
 	// by changes in the verification status of the e-mail.
-	triggerPermissionsSync(ctx, logger, e.db, userID, permssync.ReasonUserEmailVerified)
+	triggerPermissionsSync(ctx, logger, e.db, userID, database.ReasonUserEmailVerified)
 
 	return nil
 }
@@ -462,7 +462,7 @@ Please verify your email address on Sourcegraph ({{.Host}}) by clicking this lin
 
 // triggerPermissionsSync is a helper that attempts to schedule a new permissions
 // sync for the given user.
-func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32, reason string) {
+func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32, reason database.PermissionSyncJobReason) {
 	permssync.SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{
 		UserIDs: []int32{userID},
 		Reason:  reason,

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -383,7 +383,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	}
 
 	// Enqueue a sync job. Internally this will log an error if enqueuing failed.
-	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: permssync.ReasonUserRemovedFromOrg})
+	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: database.ReasonUserRemovedFromOrg})
 
 	return nil, nil
 }
@@ -429,7 +429,7 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 	}
 
 	// Schedule permission sync for newly added user. Internally it will log an error if enqueuing failed.
-	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}, Reason: permssync.ReasonUserAddedToOrg})
+	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}, Reason: database.ReasonUserAddedToOrg})
 
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -346,7 +346,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 		}
 
 		// Schedule permission sync for user that accepted the invite. Internally it will log an error if enqueuing fails.
-		permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}, Reason: permssync.ReasonUserAcceptedOrgInvite})
+		permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}, Reason: database.ReasonUserAcceptedOrgInvite})
 	}
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -67,7 +67,7 @@ func scheduleRepoUpdate(ctx context.Context, logger log.Logger, db database.DB, 
 	permssync.SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{
 		RepoIDs: []api.RepoID{r.ID},
 		Options: opts,
-		Reason:  permssync.ReasonGitHubRepoEvent,
+		Reason:  database.ReasonGitHubRepoEvent,
 	})
 
 	return nil

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -86,7 +86,7 @@ func scheduleUserUpdate(ctx context.Context, logger log.Logger, db database.DB, 
 	permssync.SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{
 		UserIDs: ids,
 		Options: opts,
-		Reason:  permssync.ReasonGitHubUserEvent,
+		Reason:  database.ReasonGitHubUserEvent,
 	})
 
 	return nil

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -183,7 +183,7 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 		return nil, err
 	}
 
-	req := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{repoID}, Reason: permssync.ReasonManualRepoSync, TriggeredByUserID: actor.FromContext(ctx).UID}
+	req := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{repoID}, Reason: database.ReasonManualRepoSync, TriggeredByUserID: actor.FromContext(ctx).UID}
 	permssync.SchedulePermsSync(ctx, r.logger, r.db, req)
 
 	return &graphqlbackend.EmptyResponse{}, nil
@@ -204,7 +204,7 @@ func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphq
 		return nil, err
 	}
 
-	req := protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: permssync.ReasonManualUserSync, TriggeredByUserID: actor.FromContext(ctx).UID}
+	req := protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: database.ReasonManualUserSync, TriggeredByUserID: actor.FromContext(ctx).UID}
 	if args.Options != nil && args.Options.InvalidateCaches != nil && *args.Options.InvalidateCaches {
 		req.Options.InvalidateCaches = true
 	}

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -1,0 +1,321 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var _ job.Job = (*permissionSyncJobScheduler)(nil)
+
+// permissionSyncJobScheduler is a worker responsible for scheduling permissions sync jobs.
+type permissionSyncJobScheduler struct{}
+
+func (p *permissionSyncJobScheduler) Description() string {
+	return "Schedule permission sync jobs for users and repositories."
+}
+
+func (p *permissionSyncJobScheduler) Config() []env.Config {
+	return nil
+}
+
+const defaultScheduleInterval = 15 * time.Second
+
+var scheduleInterval = defaultScheduleInterval
+
+var watchConf = sync.Once{}
+
+func loadScheduleIntervalFromConf() {
+	seconds := conf.Get().PermissionsSyncScheduleInterval
+	if seconds <= 0 {
+		scheduleInterval = defaultScheduleInterval
+	} else {
+		scheduleInterval = time.Duration(seconds) * time.Second
+	}
+}
+
+func (p *permissionSyncJobScheduler) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	logger := observationCtx.Logger
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "init DB")
+	}
+
+	m := metrics.NewREDMetrics(
+		observationCtx.Registerer,
+		"permission_sync_job_scheduler",
+		metrics.WithCountHelp("Total number of permissions syncer scheduler executions."),
+	)
+	operation := observationCtx.Operation(observation.Op{
+		Name:    "PermissionsSyncer.Scheduler.Run",
+		Metrics: m,
+	})
+
+	watchConf.Do(func() {
+		conf.Watch(loadScheduleIntervalFromConf)
+	})
+
+	return []goroutine.BackgroundRoutine{
+		goroutine.NewPeriodicGoroutineWithMetricsAndDynamicInterval(
+			context.Background(),
+			"auth.permission_sync_job_scheduler",
+			p.Description(),
+			func() time.Duration { return scheduleInterval },
+			goroutine.HandlerFunc(
+				func(ctx context.Context) error {
+					if !permssync.PermissionSyncWorkerEnabled(ctx, db, logger) || permissionSyncingDisabled() {
+						// TODO(naman): convert log to debug level post testing
+						logger.Info("disabled")
+						return nil
+					}
+
+					start := time.Now()
+					count, err := scheduleJobs(ctx, db, logger)
+					m.Observe(time.Since(start).Seconds(), float64(count), &err)
+					return err
+				},
+			),
+			operation,
+		)}, nil
+}
+
+func NewPermissionSyncJobScheduler() job.Job {
+	return &permissionSyncJobScheduler{}
+}
+
+func scheduleJobs(ctx context.Context, db database.DB, logger log.Logger) (int, error) {
+	store := db.PermissionSyncJobs()
+	permsStore := edb.Perms(logger, db, timeutil.Now)
+	schedule, err := getSchedule(ctx, permsStore)
+	if err != nil {
+		return 0, err
+	}
+
+	logger.Info("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
+
+	for _, u := range schedule.Users {
+		opts := database.PermissionSyncJobOpts{Reason: u.reason, Priority: u.priority}
+		if err := store.CreateUserSyncJob(ctx, u.userID, opts); err != nil {
+			logger.Error(fmt.Sprintf("failed to create sync job for user (%d)", u.userID), log.Error(err))
+			continue
+		}
+	}
+
+	for _, r := range schedule.Repos {
+		opts := database.PermissionSyncJobOpts{Reason: r.reason, Priority: r.priority}
+		if err := store.CreateRepoSyncJob(ctx, r.repoID, opts); err != nil {
+			logger.Error(fmt.Sprintf("failed to create sync job for repo (%d)", r.repoID), log.Error(err))
+			continue
+		}
+	}
+
+	return len(schedule.Users) + len(schedule.Repos), nil
+}
+
+// schedule contains information for scheduling users and repositories.
+type schedule struct {
+	Users []scheduledUser
+	Repos []scheduledRepo
+}
+
+// scheduledUser contains information for scheduling a user.
+type scheduledUser struct {
+	reason   database.PermissionSyncJobReason
+	priority database.PermissionSyncJobPriority
+	userID   int32
+	noPerms  bool
+}
+
+// scheduledRepo contains for scheduling a repository.
+type scheduledRepo struct {
+	reason   database.PermissionSyncJobReason
+	priority database.PermissionSyncJobPriority
+	repoID   api.RepoID
+	noPerms  bool
+}
+
+// getSchedule computes schedule four lists in the following order:
+//  1. Users with no permissions, because they can't do anything meaningful (e.g. not able to search).
+//  2. Private repositories with no permissions, because those can't be viewed by anyone except site admins.
+//  3. Rolling updating user permissions over time from the oldest ones.
+//  4. Rolling updating repository permissions over time from the oldest ones.
+func getSchedule(ctx context.Context, store edb.PermsStore) (*schedule, error) {
+	schedule := new(schedule)
+
+	usersWithNoPerms, err := scheduleUsersWithNoPerms(ctx, store)
+	if err != nil {
+		return nil, errors.Wrap(err, "schedule users with no permissions")
+	}
+	schedule.Users = append(schedule.Users, usersWithNoPerms...)
+
+	reposWithNoPerms, err := scheduleReposWithNoPerms(ctx, store)
+	if err != nil {
+		return nil, errors.Wrap(err, "schedule repositories with no permissions")
+	}
+	schedule.Repos = append(schedule.Repos, reposWithNoPerms...)
+
+	userLimit, repoLimit := oldestUserPermissionsBatchSize(), oldestRepoPermissionsBatchSize()
+
+	usersWithOldestPerms, err := scheduleUsersWithOldestPerms(ctx, store, userLimit, syncUserBackoff())
+	if err != nil {
+		return nil, errors.Wrap(err, "load users with oldest permissions")
+	}
+	schedule.Users = append(schedule.Users, usersWithOldestPerms...)
+
+	reposWithOldestPerms, err := scheduleReposWithOldestPerms(ctx, store, repoLimit, syncRepoBackoff())
+	if err != nil {
+		return nil, errors.Wrap(err, "scan repositories with oldest permissions")
+	}
+	schedule.Repos = append(schedule.Repos, reposWithOldestPerms...)
+
+	return schedule, nil
+}
+
+// scheduleUsersWithNoPerms returns computed schedules for users who have no
+// permissions found in database.
+func scheduleUsersWithNoPerms(ctx context.Context, store edb.PermsStore) ([]scheduledUser, error) {
+	ids, err := store.UserIDsWithNoPerms(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	users := make([]scheduledUser, len(ids))
+	for i, id := range ids {
+		users[i] = scheduledUser{
+			userID:   id,
+			reason:   database.ReasonUserNoPermissions,
+			priority: database.MediumPriorityPermissionSync,
+			noPerms:  true,
+		}
+	}
+	return users, nil
+}
+
+// scheduleReposWithNoPerms returns computed schedules for private repositories that
+// have no permissions found in database.
+func scheduleReposWithNoPerms(ctx context.Context, store edb.PermsStore) ([]scheduledRepo, error) {
+	ids, err := store.RepoIDsWithNoPerms(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	repositories := make([]scheduledRepo, len(ids))
+	for i, id := range ids {
+		repositories[i] = scheduledRepo{
+			repoID:   id,
+			reason:   database.ReasonRepoNoPermissions,
+			priority: database.MediumPriorityPermissionSync,
+			noPerms:  true,
+		}
+	}
+	return repositories, nil
+}
+
+// scheduleUsersWithOldestPerms returns computed schedules for users who have the
+// oldest permissions in database and capped results by the limit.
+func scheduleUsersWithOldestPerms(ctx context.Context, store edb.PermsStore, limit int, age time.Duration) ([]scheduledUser, error) {
+	results, err := store.UserIDsWithOldestPerms(ctx, limit, age)
+	if err != nil {
+		return nil, err
+	}
+
+	users := make([]scheduledUser, 0, len(results))
+	for id := range results {
+		users = append(users, scheduledUser{
+			userID:   id,
+			reason:   database.ReasonUserOutdatedPermissions,
+			priority: database.LowPriorityPermissionSync,
+		})
+	}
+	return users, nil
+}
+
+// scheduleReposWithOldestPerms returns computed schedules for private repositories that
+// have oldest permissions in database.
+func scheduleReposWithOldestPerms(ctx context.Context, store edb.PermsStore, limit int, age time.Duration) ([]scheduledRepo, error) {
+	results, err := store.ReposIDsWithOldestPerms(ctx, limit, age)
+	if err != nil {
+		return nil, err
+	}
+
+	repositories := make([]scheduledRepo, 0, len(results))
+	for id := range results {
+		repositories = append(repositories, scheduledRepo{
+			repoID:   id,
+			reason:   database.ReasonRepoOutdatedPermissions,
+			priority: database.LowPriorityPermissionSync,
+		})
+	}
+	return repositories, nil
+}
+
+func oldestUserPermissionsBatchSize() int {
+	batchSize := conf.Get().PermissionsSyncOldestUsers
+	if batchSize <= 0 {
+		return 10
+	}
+	return batchSize
+}
+
+func oldestRepoPermissionsBatchSize() int {
+	batchSize := conf.Get().PermissionsSyncOldestRepos
+	if batchSize <= 0 {
+		return 10
+	}
+	return batchSize
+}
+
+var zeroBackoffDuringTest = false
+
+func syncUserBackoff() time.Duration {
+	if zeroBackoffDuringTest {
+		return time.Duration(0)
+	}
+
+	seconds := conf.Get().PermissionsSyncUsersBackoffSeconds
+	if seconds <= 0 {
+		return 60 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func syncRepoBackoff() time.Duration {
+	if zeroBackoffDuringTest {
+		return time.Duration(0)
+	}
+
+	seconds := conf.Get().PermissionsSyncReposBackoffSeconds
+	if seconds <= 0 {
+		return 60 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
+// It is not enabled if:
+//   - Permissions user mapping (aka explicit permissions API) is enabled
+//   - Not purchased with the current license
+//   - `disableAutoCodeHostSyncs` site setting is set to true
+func permissionSyncingDisabled() bool {
+	return globals.PermissionsUserMapping().Enabled ||
+		licensing.Check(licensing.FeatureACLs) != nil ||
+		conf.Get().DisableAutoCodeHostSyncs
+}

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	zeroBackoffDuringTest = true
+	t.Cleanup(func() { zeroBackoffDuringTest = false })
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	store := database.PermissionSyncJobsWith(logger, db)
+	usersStore := database.UsersWith(logger, db)
+	reposStore := database.ReposWith(logger, db)
+	permsStore := edb.Perms(logger, db, clock)
+
+	// Creating site-admin.
+	_, err := usersStore.Create(ctx, database.NewUser{Username: "admin"})
+	require.NoError(t, err)
+
+	// Creating non-private repo.
+	nonPrivateRepo := types.Repo{Name: "test-public-repo"}
+	err = reposStore.Create(ctx, &nonPrivateRepo)
+	require.NoError(t, err)
+
+	// We should have no jobs scheduled
+	runJobsTest(t, ctx, logger, db, store, []testJob{})
+
+	// Creating a user.
+	user1, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-1"})
+	require.NoError(t, err)
+
+	// Creating a repo.
+	repo1 := types.Repo{Name: "test-repo-1", Private: true}
+	err = reposStore.Create(ctx, &repo1)
+	require.NoError(t, err)
+
+	// We should have 2 jobs scheduled.
+	wantJobs := []testJob{
+		{
+			UserID:       int(user1.ID),
+			RepositoryID: 0,
+			Reason:       database.ReasonUserNoPermissions,
+			Priority:     database.MediumPriorityPermissionSync,
+		},
+		{
+			UserID:       0,
+			RepositoryID: int(repo1.ID),
+			Reason:       database.ReasonRepoNoPermissions,
+			Priority:     database.MediumPriorityPermissionSync,
+		},
+	}
+	runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+	// Touch perms for the user and repo.
+	_ = permsStore.TouchUserPermissions(ctx, user1.ID)
+	_ = permsStore.TouchRepoPermissions(ctx, int32(repo1.ID))
+
+	// We should have same 2 jobs because jobs with higher priority already exists.
+	runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+	// Creating a user.
+	user2, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-2"})
+	require.NoError(t, err)
+
+	// Creating a repo.
+	repo2 := types.Repo{Name: "test-repo-2", Private: true}
+	err = reposStore.Create(ctx, &repo2)
+	require.NoError(t, err)
+
+	// Touch perms for the user and repo.
+	_ = permsStore.TouchUserPermissions(ctx, user2.ID)
+	_ = permsStore.TouchRepoPermissions(ctx, int32(repo2.ID))
+
+	// We should have same 4 jobs scheduled including new jobs for user2 and repo2.
+	wantJobs = []testJob{
+		{
+			UserID:       int(user1.ID),
+			RepositoryID: 0,
+			Reason:       database.ReasonUserNoPermissions,
+			Priority:     database.MediumPriorityPermissionSync,
+		},
+		{
+			UserID:       0,
+			RepositoryID: int(repo1.ID),
+			Reason:       database.ReasonRepoNoPermissions,
+			Priority:     database.MediumPriorityPermissionSync,
+		},
+		{
+			UserID:       int(user2.ID),
+			RepositoryID: 0,
+			Reason:       database.ReasonUserOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+		{
+			UserID:       0,
+			RepositoryID: int(repo2.ID),
+			Reason:       database.ReasonRepoOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+	}
+	runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+	// Set user1 and repo1 schedule jobs to completed.
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`UPDATE permission_sync_jobs SET state = 'completed' WHERE user_id=%d OR repository_id=%d`, user1.ID, repo1.ID))
+	require.NoError(t, err)
+
+	// We should have 4 jobs including new jobs for user1 and repo1.
+	wantJobs = []testJob{
+		{
+			UserID:       int(user2.ID),
+			RepositoryID: 0,
+			Reason:       database.ReasonUserOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+		{
+			UserID:       0,
+			RepositoryID: int(repo2.ID),
+			Reason:       database.ReasonRepoOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+		{
+			UserID:       int(user1.ID),
+			RepositoryID: 0,
+			Reason:       database.ReasonUserOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+		{
+			UserID:       0,
+			RepositoryID: int(repo1.ID),
+			Reason:       database.ReasonRepoOutdatedPermissions,
+			Priority:     database.LowPriorityPermissionSync,
+		},
+	}
+	runJobsTest(t, ctx, logger, db, store, wantJobs)
+}
+
+type testJob struct {
+	Reason       database.PermissionSyncJobReason
+	ProcessAfter time.Time
+	RepositoryID int
+	UserID       int
+	Priority     database.PermissionSyncJobPriority
+}
+
+func runJobsTest(t *testing.T, ctx context.Context, logger log.Logger, db database.DB, store database.PermissionSyncJobStore, wantJobs []testJob) {
+	count, err := scheduleJobs(ctx, db, logger)
+	require.NoError(t, err)
+	require.Equal(t, len(wantJobs), count)
+
+	jobs, err := store.List(ctx, database.ListPermissionSyncJobOpts{State: "queued"})
+	require.NoError(t, err)
+	require.Len(t, jobs, len(wantJobs))
+
+	actualJobs := []testJob{}
+
+	for _, job := range jobs {
+		actualJob := testJob{
+			UserID:       job.UserID,
+			RepositoryID: job.RepositoryID,
+			Reason:       job.Reason,
+			Priority:     job.Priority,
+		}
+		actualJobs = append(actualJobs, actualJob)
+	}
+
+	if diff := cmp.Diff(wantJobs, actualJobs); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+var now = timeutil.Now().UnixNano()
+
+func clock() time.Time {
+	return time.Unix(0, atomic.LoadInt64(&now))
+}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -103,15 +102,15 @@ func TestPermsSyncerWorker_RepoSyncJobs(t *testing.T) {
 
 	// Adding repo perms sync jobs.
 	syncJobsStore := db.PermissionSyncJobs()
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: permssync.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(2), database.PermissionSyncJobOpts{Reason: permssync.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(2), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Adding user perms sync job, which should not be processed by current worker!
 	err = syncJobsStore.CreateUserSyncJob(ctx, user2.ID,
-		database.PermissionSyncJobOpts{Reason: permssync.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
+		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Wait for all jobs to be processed.
@@ -213,15 +212,15 @@ func TestPermsSyncerWorker_UserSyncJobs(t *testing.T) {
 	// Adding user perms sync jobs.
 	syncJobsStore := db.PermissionSyncJobs()
 	err = syncJobsStore.CreateUserSyncJob(ctx, user1.ID,
-		database.PermissionSyncJobOpts{Reason: permssync.ReasonUserOutdatedPermissions, Priority: database.LowPriorityPermissionSync})
+		database.PermissionSyncJobOpts{Reason: database.ReasonUserOutdatedPermissions, Priority: database.LowPriorityPermissionSync})
 	require.NoError(t, err)
 
 	err = syncJobsStore.CreateUserSyncJob(ctx, user2.ID,
-		database.PermissionSyncJobOpts{Reason: permssync.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
+		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Adding repo perms sync job, which should not be processed by current worker!
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: permssync.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Wait for all jobs to be processed.

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -36,7 +36,7 @@ func EnterpriseInit(
 	keyring keyring.Ring,
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
-) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID, string) error) {
+) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID, ossDB.PermissionSyncJobReason) error) {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		observationCtx.Logger.Info("enterprise edition")
@@ -58,7 +58,7 @@ func EnterpriseInit(
 	permsSyncer := authz.NewPermsSyncer(observationCtx.Logger.Scoped("PermsSyncer", "repository and user permissions syncer"), db, repoStore, permsStore, timeutil.Now, ratelimit.DefaultRegistry)
 
 	permsJobStore := db.PermissionSyncJobs()
-	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason string) error {
+	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason ossDB.PermissionSyncJobReason) error {
 		if authz.PermissionSyncingDisabled() {
 			return nil
 		}

--- a/enterprise/cmd/worker/shared/shared.go
+++ b/enterprise/cmd/worker/shared/shared.go
@@ -54,8 +54,9 @@ var additionalJobs = map[string]job.Job{
 	"codeintel-upload-graph-exporter":             codeintel.NewGraphExporterJob(),
 	"codeintel-uploadstore-expirer":               codeintel.NewPreciseCodeIntelUploadExpirer(),
 
-	"auth-sourcegraph-operator-cleaner": auth.NewSourcegraphOperatorCleaner(),
-	"auth-permission-sync-job-cleaner":  auth.NewPermissionSyncJobCleaner(),
+	"auth-sourcegraph-operator-cleaner":  auth.NewSourcegraphOperatorCleaner(),
+	"auth-permission-sync-job-cleaner":   auth.NewPermissionSyncJobCleaner(),
+	"auth-permission-sync-job-scheduler": auth.NewPermissionSyncJobScheduler(),
 
 	// Note: experimental (not documented)
 	"codeintel-ranking-sourcer": codeintel.NewRankingSourcerJob(),

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -10,41 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 )
 
-const (
-	featureFlagName = "database-permission-sync-worker"
-
-	// ReasonUserOutdatedPermissions and below are reasons of scheduled permission
-	// syncs.
-	ReasonUserOutdatedPermissions = "REASON_USER_OUTDATED_PERMS"
-	ReasonUserNoPermissions       = "REASON_USER_NO_PERMS"
-	ReasonUserEmailRemoved        = "REASON_USER_EMAIL_REMOVED"
-	ReasonUserEmailVerified       = "REASON_USER_EMAIL_VERIFIED"
-	ReasonUserAddedToOrg          = "REASON_USER_ADDED_TO_ORG"
-	ReasonUserRemovedFromOrg      = "REASON_USER_REMOVED_FROM_ORG"
-	ReasonUserAcceptedOrgInvite   = "REASON_USER_ACCEPTED_ORG_INVITE"
-	ReasonRepoOutdatedPermissions = "REASON_REPO_OUTDATED_PERMS"
-	ReasonRepoNoPermissions       = "REASON_REPO_NO_PERMS"
-	ReasonRepoUpdatedFromCodeHost = "REASON_REPO_UPDATED_FROM_CODE_HOST"
-
-	// ReasonGitHubUserEvent and below are reasons of permission syncs triggered by
-	// webhook events.
-	ReasonGitHubUserEvent                  = "REASON_GITHUB_USER_EVENT"
-	ReasonGitHubUserAddedEvent             = "REASON_GITHUB_USER_ADDED_EVENT"
-	ReasonGitHubUserRemovedEvent           = "REASON_GITHUB_USER_REMOVED_EVENT"
-	ReasonGitHubUserMembershipAddedEvent   = "REASON_GITHUB_USER_MEMBERSHIP_ADDED_EVENT"
-	ReasonGitHubUserMembershipRemovedEvent = "REASON_GITHUB_USER_MEMBERSHIP_REMOVED_EVENT"
-	ReasonGitHubTeamAddedToRepoEvent       = "REASON_GITHUB_TEAM_ADDED_TO_REPO_EVENT"
-	ReasonGitHubTeamRemovedFromRepoEvent   = "REASON_GITHUB_TEAM_REMOVED_FROM_REPO_EVENT"
-	ReasonGitHubOrgMemberAddedEvent        = "REASON_GITHUB_ORG_MEMBER_ADDED_EVENT"
-	ReasonGitHubOrgMemberRemovedEvent      = "REASON_GITHUB_ORG_MEMBER_REMOVED_EVENT"
-	ReasonGitHubRepoEvent                  = "REASON_GITHUB_REPO_EVENT"
-	ReasonGitHubRepoMadePrivateEvent       = "REASON_GITHUB_REPO_MADE_PRIVATE_EVENT"
-
-	// ReasonManualRepoSync and below are reasons of permission syncs triggered
-	// manually.
-	ReasonManualRepoSync = "REASON_MANUAL_REPO_SYNC"
-	ReasonManualUserSync = "REASON_MANUAL_USER_SYNC"
-)
+const featureFlagName = "database-permission-sync-worker"
 
 func PermissionSyncWorkerEnabled(ctx context.Context, db database.DB, logger log.Logger) bool {
 	globalFeatureFlags, err := db.FeatureFlags().GetGlobalFeatureFlags(ctx)

--- a/internal/authz/permssync/permssync_test.go
+++ b/internal/authz/permssync/permssync_test.go
@@ -28,13 +28,13 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	syncTime := time.Now().Add(13 * time.Second)
-	request := protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync, TriggeredByUserID: int32(123), ProcessAfter: syncTime}
+	request := protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: database.ReasonManualUserSync, TriggeredByUserID: int32(123), ProcessAfter: syncTime}
 	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateUserSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateRepoSyncJobFunc.History())
 	assert.Equal(t, int32(1), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg1)
 	assert.NotNil(t, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2)
-	assert.Equal(t, ReasonManualUserSync, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.Reason)
+	assert.Equal(t, database.ReasonManualUserSync, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.Reason)
 	assert.Equal(t, int32(123), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
 	assert.Equal(t, syncTime, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.ProcessAfter)
 }
@@ -55,13 +55,13 @@ func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	syncTime := time.Now().Add(37 * time.Second)
-	request := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync, ProcessAfter: syncTime}
+	request := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: database.ReasonManualRepoSync, ProcessAfter: syncTime}
 	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateRepoSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateUserSyncJobFunc.History())
 	assert.Equal(t, api.RepoID(1), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
 	assert.NotNil(t, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
-	assert.Equal(t, ReasonManualRepoSync, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.Reason)
+	assert.Equal(t, database.ReasonManualRepoSync, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.Reason)
 	assert.Equal(t, int32(0), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
 	assert.Equal(t, syncTime, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.ProcessAfter)
 }

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -30,11 +30,47 @@ const (
 	HighPriorityPermissionSync   PermissionSyncJobPriority = 10
 )
 
+type PermissionSyncJobReason string
+
+const (
+	// ReasonUserOutdatedPermissions and below are reasons of scheduled permission
+	// syncs.
+	ReasonUserOutdatedPermissions PermissionSyncJobReason = "REASON_USER_OUTDATED_PERMS"
+	ReasonUserNoPermissions       PermissionSyncJobReason = "REASON_USER_NO_PERMS"
+	ReasonUserEmailRemoved        PermissionSyncJobReason = "REASON_USER_EMAIL_REMOVED"
+	ReasonUserEmailVerified       PermissionSyncJobReason = "REASON_USER_EMAIL_VERIFIED"
+	ReasonUserAddedToOrg          PermissionSyncJobReason = "REASON_USER_ADDED_TO_ORG"
+	ReasonUserRemovedFromOrg      PermissionSyncJobReason = "REASON_USER_REMOVED_FROM_ORG"
+	ReasonUserAcceptedOrgInvite   PermissionSyncJobReason = "REASON_USER_ACCEPTED_ORG_INVITE"
+	ReasonRepoOutdatedPermissions PermissionSyncJobReason = "REASON_REPO_OUTDATED_PERMS"
+	ReasonRepoNoPermissions       PermissionSyncJobReason = "REASON_REPO_NO_PERMS"
+	ReasonRepoUpdatedFromCodeHost PermissionSyncJobReason = "REASON_REPO_UPDATED_FROM_CODE_HOST"
+
+	// ReasonGitHubUserEvent and below are reasons of permission syncs triggered by
+	// webhook events.
+	ReasonGitHubUserEvent                  PermissionSyncJobReason = "REASON_GITHUB_USER_EVENT"
+	ReasonGitHubUserAddedEvent             PermissionSyncJobReason = "REASON_GITHUB_USER_ADDED_EVENT"
+	ReasonGitHubUserRemovedEvent           PermissionSyncJobReason = "REASON_GITHUB_USER_REMOVED_EVENT"
+	ReasonGitHubUserMembershipAddedEvent   PermissionSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_ADDED_EVENT"
+	ReasonGitHubUserMembershipRemovedEvent PermissionSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_REMOVED_EVENT"
+	ReasonGitHubTeamAddedToRepoEvent       PermissionSyncJobReason = "REASON_GITHUB_TEAM_ADDED_TO_REPO_EVENT"
+	ReasonGitHubTeamRemovedFromRepoEvent   PermissionSyncJobReason = "REASON_GITHUB_TEAM_REMOVED_FROM_REPO_EVENT"
+	ReasonGitHubOrgMemberAddedEvent        PermissionSyncJobReason = "REASON_GITHUB_ORG_MEMBER_ADDED_EVENT"
+	ReasonGitHubOrgMemberRemovedEvent      PermissionSyncJobReason = "REASON_GITHUB_ORG_MEMBER_REMOVED_EVENT"
+	ReasonGitHubRepoEvent                  PermissionSyncJobReason = "REASON_GITHUB_REPO_EVENT"
+	ReasonGitHubRepoMadePrivateEvent       PermissionSyncJobReason = "REASON_GITHUB_REPO_MADE_PRIVATE_EVENT"
+
+	// ReasonManualRepoSync and below are reasons of permission syncs triggered
+	// manually.
+	ReasonManualRepoSync PermissionSyncJobReason = "REASON_MANUAL_REPO_SYNC"
+	ReasonManualUserSync PermissionSyncJobReason = "REASON_MANUAL_USER_SYNC"
+)
+
 type PermissionSyncJobOpts struct {
 	Priority          PermissionSyncJobPriority
 	InvalidateCaches  bool
 	ProcessAfter      time.Time
-	Reason            string
+	Reason            PermissionSyncJobReason
 	TriggeredByUserID int32
 }
 
@@ -243,7 +279,7 @@ type ListPermissionSyncJobOpts struct {
 	ID                  int
 	UserID              int
 	RepoID              int
-	Reason              string
+	Reason              PermissionSyncJobReason
 	State               string
 	NullProcessAfter    bool
 	NotNullProcessAfter bool
@@ -325,7 +361,7 @@ type PermissionSyncJob struct {
 	ID                 int
 	State              string
 	FailureMessage     *string
-	Reason             string
+	Reason             PermissionSyncJobReason
 	CancellationReason string
 	TriggeredByUserID  int32
 	QueuedAt           time.Time

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -16,13 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// ReasonManualRepoSync and ReasonManualUserSync are copied from permssync
-	// package to avoid import cycles.
-	ReasonManualRepoSync = "REASON_MANUAL_REPO_SYNC"
-	ReasonManualUserSync = "REASON_MANUAL_USER_SYNC"
-)
-
 func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -245,12 +246,12 @@ type ChangesetSyncResponse struct {
 // PermsSyncRequest is a request to sync permissions. The provided options are used to
 // sync all provided users and repos - to use different options, make a separate request.
 type PermsSyncRequest struct {
-	UserIDs           []int32                 `json:"user_ids"`
-	RepoIDs           []api.RepoID            `json:"repo_ids"`
-	Options           authz.FetchPermsOptions `json:"options"`
-	Reason            string                  `json:"reason"`
-	TriggeredByUserID int32                   `json:"triggered_by_user_id"`
-	ProcessAfter      time.Time               `json:"process_after"`
+	UserIDs           []int32                          `json:"user_ids"`
+	RepoIDs           []api.RepoID                     `json:"repo_ids"`
+	Options           authz.FetchPermsOptions          `json:"options"`
+	Reason            database.PermissionSyncJobReason `json:"reason"`
+	TriggeredByUserID int32                            `json:"triggered_by_user_id"`
+	ProcessAfter      time.Time                        `json:"process_after"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/46559

This PR, added perms scheduling background periodic routine which is feature flagged. When the feature flag is on, the new routine will work and the old `runSchedule` with be a noop and vice-versa. 

PermissionSyncJobReason constants are also moved to the db store. 

There were zero tests present for perms scheduling but are now added covering all the possible cases for the  new scheduler. 

## Test plan

- turn on the feature flag and check for logs. runSchedule should log disabled and auth-permission-sync-job-scheduler should log number of users & repos scheduled.
