### PR TITLE
add migration for code insights repo criteria query

### DIFF
--- a/migrations/codeinsights/1675113463_backfill_repo_query_selector/down.sql
+++ b/migrations/codeinsights/1675113463_backfill_repo_query_selector/down.sql
@@ -1,0 +1,1 @@
+-- no need for a down migration, this is entirely new data

--- a/migrations/codeinsights/1675113463_backfill_repo_query_selector/metadata.yaml
+++ b/migrations/codeinsights/1675113463_backfill_repo_query_selector/metadata.yaml
@@ -1,0 +1,2 @@
+name: backfill_repo_query_selector
+parents: [1674474174]

--- a/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
+++ b/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
@@ -1,3 +1,3 @@
 UPDATE insight_series
 SET repository_criteria = 'repo:.*'
-WHERE (CARDINALITY(repositories) = 0 AND generation_method != 'lang_stats');
+WHERE (CARDINALITY(repositories) = 0 AND generation_method != 'lang_stats' AND repository_criteria IS NULL);

--- a/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
+++ b/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
@@ -1,0 +1,5 @@
+UPDATE insight_series
+SET repository_criteria = 'repo:.*'
+WHERE (CARDINALITY(repositories) = 0 AND generation_method != 'lang_stats')
+
+select * from insight_series where cardinality(repositories) = 0;

--- a/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
+++ b/migrations/codeinsights/1675113463_backfill_repo_query_selector/up.sql
@@ -1,5 +1,3 @@
 UPDATE insight_series
 SET repository_criteria = 'repo:.*'
-WHERE (CARDINALITY(repositories) = 0 AND generation_method != 'lang_stats')
-
-select * from insight_series where cardinality(repositories) = 0;
+WHERE (CARDINALITY(repositories) = 0 AND generation_method != 'lang_stats');


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47066
Closes https://github.com/sourcegraph/sourcegraph/issues/45964

Migration to convert all repos insights into repo criteria insights. This also seems to fix the issue where insights backfill on update.

## Test plan
Checked the migration passed, and checked I can edit both insight and series labels without new backfills.

<img width="447" alt="CleanShot 2023-01-30 at 14 37 12@2x" src="https://user-images.githubusercontent.com/5090588/215602279-160701b4-957f-4eda-8e5a-f97c1e63c0f9.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
