### PR TITLE
codeintel: dont emit logs for errors below service layer

### DIFF
--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -308,7 +308,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 					if errors.Is(err, ErrNoResults) {
 						return observation.EmitForNone
 					}
-					return observation.EmitForDefault
+					return observation.EmitForAll
 				},
 			})
 		}

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -73,9 +73,9 @@ func NewScheduler(
 			Metrics:           metrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.As(err, &inference.LimitError{}) {
-					return observation.EmitForDefault.Without(observation.EmitForMetrics)
+					return observation.EmitForAll.Without(observation.EmitForMetrics)
 				}
-				return observation.EmitForDefault
+				return observation.EmitForAll
 			},
 		}),
 	)

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
@@ -29,6 +29,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.enqueuer.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
@@ -35,6 +35,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.inference.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/store/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/observability.go
@@ -72,6 +72,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/observability.go
@@ -61,6 +61,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -41,6 +41,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.codenav.lsifstore.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/codenav/internal/store/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/store/observability.go
@@ -29,6 +29,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.codenav.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/codenav/observability.go
+++ b/enterprise/internal/codeintel/codenav/observability.go
@@ -40,6 +40,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.codenav.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/policies/internal/store/observability.go
+++ b/enterprise/internal/codeintel/policies/internal/store/observability.go
@@ -38,6 +38,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.policies.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/policies/observability.go
+++ b/enterprise/internal/codeintel/policies/observability.go
@@ -42,6 +42,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.policies.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/ranking/internal/store/observability.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/observability.go
@@ -28,6 +28,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.ranking.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/ranking/observability.go
+++ b/enterprise/internal/codeintel/ranking/observability.go
@@ -31,6 +31,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.ranking.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/shared/gitserver/observability.go
+++ b/enterprise/internal/codeintel/shared/gitserver/observability.go
@@ -49,10 +49,10 @@ func newOperations(observationCtx *observation.Context) *operations {
 				}
 
 				if gitdomain.IsCloneInProgress(err) {
-					return observation.EmitForDefault ^ observation.EmitForLogs
+					return observation.EmitForHoney | observation.EmitForTraces
 				}
 
-				return observation.EmitForDefault
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
 			},
 		})
 	}

--- a/enterprise/internal/codeintel/uploads/internal/background/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/observability.go
@@ -1,12 +1,9 @@
 package background
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -38,34 +35,13 @@ func newWorkerOperations(observationCtx *observation.Context) *workerOperations 
 }
 
 type operations struct {
-	updateUploadsVisibleToCommits *observation.Operation
-
 	numReconcileScansFromFrontend      prometheus.Counter
 	numReconcileDeletesFromFrontend    prometheus.Counter
 	numReconcileScansFromCodeIntelDB   prometheus.Counter
 	numReconcileDeletesFromCodeIntelDB prometheus.Counter
 }
 
-var m = new(metrics.SingletonREDMetrics)
-
 func newOperations(observationCtx *observation.Context) *operations {
-	m := m.Get(func() *metrics.REDMetrics {
-		return metrics.NewREDMetrics(
-			observationCtx.Registerer,
-			"codeintel_uploads_background",
-			metrics.WithLabels("op"),
-			metrics.WithCountHelp("Total number of method invocations."),
-		)
-	})
-
-	op := func(name string) *observation.Operation {
-		return observationCtx.Operation(observation.Op{
-			Name:              fmt.Sprintf("codeintel.uploads.background.%s", name),
-			MetricLabelValues: []string{name},
-			Metrics:           m,
-		})
-	}
-
 	counter := func(name, help string) prometheus.Counter {
 		counter := prometheus.NewCounter(prometheus.CounterOpts{
 			Name: name,
@@ -94,8 +70,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 	)
 
 	return &operations{
-		updateUploadsVisibleToCommits: op("UpdateUploadsVisibleToCommits"),
-
 		numReconcileScansFromFrontend:      numReconcileScansFromFrontend,
 		numReconcileDeletesFromFrontend:    numReconcileDeletesFromFrontend,
 		numReconcileScansFromCodeIntelDB:   numReconcileScansFromCodeIntelDB,

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -40,6 +40,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.uploads.lsifstore.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -95,6 +95,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.uploads.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/uploads/observability.go
+++ b/enterprise/internal/codeintel/uploads/observability.go
@@ -88,6 +88,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.uploads.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -39,6 +39,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.dependencies.store.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/internal/codeintel/dependencies/observability.go
+++ b/internal/codeintel/dependencies/observability.go
@@ -30,6 +30,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.dependencies.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForMetrics | observation.EmitForHoney | observation.EmitForTraces
+			},
 		})
 	}
 

--- a/internal/extsvc/jvmpackages/coursier/observability.go
+++ b/internal/extsvc/jvmpackages/coursier/observability.go
@@ -37,7 +37,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 				if err != nil && strings.Contains(err.Error(), "not found") {
 					return observation.EmitForMetrics | observation.EmitForTraces
 				}
-				return observation.EmitForDefault
+				return observation.EmitForAll
 			},
 		})
 	}

--- a/internal/extsvc/npm/observability.go
+++ b/internal/extsvc/npm/observability.go
@@ -34,7 +34,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 				if err != nil && strings.Contains(err.Error(), "not found") {
 					return observation.EmitForMetrics | observation.EmitForTraces
 				}
-				return observation.EmitForDefault
+				return observation.EmitForAll
 			},
 		})
 	}

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -35,11 +35,15 @@ const (
 	EmitForHoney
 	EmitForSentry
 
-	EmitForDefault = EmitForMetrics | EmitForLogs | EmitForTraces | EmitForHoney
+	EmitForAll = EmitForMetrics | EmitForLogs | EmitForTraces | EmitForHoney | EmitForSentry
 )
 
 func (b ErrorFilterBehaviour) Without(e ErrorFilterBehaviour) ErrorFilterBehaviour {
 	return b ^ e
+}
+
+func (b ErrorFilterBehaviour) And(e ErrorFilterBehaviour) ErrorFilterBehaviour {
+	return b | e
 }
 
 // Op configures an Operation instance.

--- a/internal/uploadhandler/observability.go
+++ b/internal/uploadhandler/observability.go
@@ -33,9 +33,9 @@ func NewOperations(observationCtx *observation.Context, prefix string) *Operatio
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				var errno syscall.Errno
 				if errors.As(err, &errno) && errno == syscall.ECONNREFUSED {
-					return observation.EmitForDefault ^ observation.EmitForSentry
+					return observation.EmitForAll.Without(observation.EmitForSentry)
 				}
-				return observation.EmitForDefault
+				return observation.EmitForAll
 			},
 		})
 	}


### PR DESCRIPTION
Before, errors bubbling up would log at every layer on the way up that was instrumented with the `observation` constructs. This means we would get e.g. multiple error logs, multiple sentry submissions for each error.

This PR addresses this by not emitting to logs/sentry for code intel at the service level and below. We intend for the consumers of the service to handle errors as necessary (emit them/ignore them/pass them further up etc).

This has the side-effect that additional fields added at the service level and below wont show up in logs/sentry. This is probably a bit of a blocker for landing

## Test plan

Ran it locally and saw that >=3 logs became 1 :)
