### PR TITLE
add restore user UI

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/UserManagement/components/UsersList.tsx
@@ -11,6 +11,7 @@ import {
     mdiClose,
     mdiLock,
     mdiLockOpen,
+    mdiAccountReactivate,
 } from '@mdi/js'
 import classNames from 'classnames'
 import { formatDistanceToNowStrict, startOfDay, endOfDay } from 'date-fns'
@@ -169,6 +170,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
         handleDeleteUsersForever,
         handleForceSignOutUsers,
         handleRevokeSiteAdmin,
+        handleRecoverUsers,
         handlePromoteToSiteAdmin,
         handleUnlockUser,
         handleResetUserPassword,
@@ -313,6 +315,14 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 labelColor: 'danger',
                                 onClick: handleDeleteUsersForever,
                                 bulk: true,
+                            },
+                            {
+                                key: 'recover',
+                                label: 'Recover',
+                                icon: mdiAccountReactivate,
+                                onClick: handleRecoverUsers,
+                                bulk: true,
+                                condition: users => users.some(user => user.deletedAt),
                             },
                         ]}
                         columns={[
@@ -526,6 +536,7 @@ export interface UseUserListActionReturnType {
     handleDeleteUsersForever: ActionHandler
     handlePromoteToSiteAdmin: ActionHandler
     handleRevokeSiteAdmin: ActionHandler
+    handleRecoverUsers: ActionHandler
     handleUnlockUser: ActionHandler
     notification: { text: React.ReactNode; isError?: boolean } | undefined
     handleDismissNotification: () => void

--- a/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
@@ -6,7 +6,7 @@ import { Text } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../../components/CopyableText'
 import { randomizeUserPassword, setUserIsSiteAdmin } from '../../backend'
-import { DELETE_USERS, DELETE_USERS_FOREVER, FORCE_SIGN_OUT_USERS } from '../queries'
+import { DELETE_USERS, DELETE_USERS_FOREVER, FORCE_SIGN_OUT_USERS, RECOVER_USERS } from '../queries'
 
 import { UseUserListActionReturnType, SiteUser, getUsernames } from './UsersList'
 
@@ -14,6 +14,8 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
     const [forceSignOutUsers] = useMutation(FORCE_SIGN_OUT_USERS)
     const [deleteUsers] = useMutation(DELETE_USERS)
     const [deleteUsersForever] = useMutation(DELETE_USERS_FOREVER)
+
+    const [recoverUsers] = useMutation(RECOVER_USERS)
 
     const [notification, setNotification] = useState<UseUserListActionReturnType['notification']>()
 
@@ -102,6 +104,25 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
             }
         },
         [deleteUsersForever, onError, createOnSuccess]
+    )
+
+    const handleRecoverUsers = useCallback(
+        (users: SiteUser[]) => {
+            if (confirm('Are you sure you want to recover the selected user(s)?')) {
+                recoverUsers({ variables: { userIDs: users.map(user => user.id) } })
+                    .then(
+                        createOnSuccess(
+                            <Text as="span">
+                                Successfully recovered following {users.length} user(s):{' '}
+                                <strong>{getUsernames(users)}</strong>
+                            </Text>,
+                            true
+                        )
+                    )
+                    .catch(onError)
+            }
+        },
+        [recoverUsers, onError, createOnSuccess]
     )
 
     const handlePromoteToSiteAdmin = useCallback(
@@ -215,6 +236,7 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
         handleDeleteUsersForever,
         handlePromoteToSiteAdmin,
         handleUnlockUser,
+        handleRecoverUsers,
         handleRevokeSiteAdmin,
         handleResetUserPassword,
         handleDismissNotification,

--- a/client/web/src/site-admin/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/UserManagement/queries.tsx
@@ -81,3 +81,11 @@ export const DELETE_USERS_FOREVER = gql`
         }
     }
 `
+
+export const RECOVER_USERS = gql`
+    mutation RecoverUsers($userIDs: [ID!]!) {
+        recoverUsers(userIDs: $userIDs) {
+            alwaysNil
+        }
+    }
+`


### PR DESCRIPTION
add button for restoring users in the User Management Page for Site-Admins
Followup from https://github.com/sourcegraph/sourcegraph/pull/46654
## Test plan
Manually tested
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mucles-restore-user-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
