### PR TITLE
gRPC: extract `exec` into a HTTP-agnostic function

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -70,6 +70,7 @@ const tempDirName = ".tmp"
 // and where it will store cache data.
 const P4HomeName = ".p4home"
 
+// UnsetExitStatus is a sentinel value for an unknown/unset exit status.
 const UnsetExitStatus = -10810
 
 // traceLogs is controlled via the env SRC_GITSERVER_TRACE. If true we trace
@@ -1842,6 +1843,7 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 	return nil
 }
 
+// execHTTP translates the results of an exec into the expected HTTP statuses and payloads
 func (s *Server) execHTTP(w http.ResponseWriter, r *http.Request, req *protocol.ExecRequest) {
 	logger := s.Logger.Scoped("exec", "").With(log.Strings("req.Args", req.Args))
 
@@ -1861,6 +1863,8 @@ func (s *Server) execHTTP(w http.ResponseWriter, r *http.Request, req *protocol.
 	w.Header().Add("Trailer", "X-Exec-Exit-Status")
 	w.Header().Add("Trailer", "X-Exec-Stderr")
 
+	// Ensure we always send declared trailers even if we didn't
+	// get an error from the exec.
 	sentTrailers := false
 	defer func() {
 		if !sentTrailers {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1740,7 +1740,6 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 				ev.AddField("actor", act.UIDString())
 				ev.AddField("ensure_revision", req.EnsureRevision)
 				ev.AddField("ensure_revision_status", ensureRevisionStatus)
-				// ev.AddField("client", r.UserAgent())
 				ev.AddField("duration_ms", duration.Milliseconds())
 				ev.AddField("stdin_size", len(req.Stdin))
 				ev.AddField("stdout_size", stdoutN)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1663,7 +1663,9 @@ type CmdError struct {
 	Err        error
 }
 
-func (e *CmdError) Error() string { return fmt.Sprintf("command exited with non-zero status") }
+func (e *CmdError) Error() string {
+	return fmt.Sprintf("command exited with non-zero status %d", e.ExitStatus)
+}
 
 func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.ExecRequest, userAgent string, w io.Writer) error {
 	// 🚨 SECURITY: Ensure that only commands in the allowed list are executed.
@@ -1832,7 +1834,7 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 	stderr := stderrBuf.String()
 	s.logIfCorrupt(ctx, req.Repo, dir, stderr)
 
-	if execErr != nil || exitStatus != UnsetExitStatus || stderr != "" {
+	if execErr != nil || exitStatus != 0 || stderr != "" {
 		return &CmdError{
 			Err:        execErr,
 			Stderr:     stderr,

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1659,13 +1659,16 @@ type NotFoundError struct {
 func (e *NotFoundError) Error() string { return "not found" }
 
 func (e *NotFoundError) As(target interface{}) bool {
-	if v, ok := target.(*errcode.HTTPErr); ok {
-		v.Err = e
-		v.Status = http.StatusNotFound
+	switch v := target.(type) {
+	case **errcode.HTTPErr:
+		*v = &errcode.HTTPErr{
+			Err:    e,
+			Status: http.StatusNotFound,
+		}
 		return true
+	default:
+		return false
 	}
-
-	return false
 }
 
 type CmdError struct {


### PR DESCRIPTION
This PR lays the framework for translating the `exec` endpoint to a gRPC endpoint. It splits the HTTP logic out of `exec` so that we can reuse the `exec` handler for the gRPC implementation.

## Test plan

The existing tests are surprisingly solid. All the error conditions are exercised. I did some manual poking around the spots that aren't covered (because they can't easily be mocked out). It's noteworthy that all the uncovered parts are special cases because we route all git operations through the same endpoint. When we have well-typed endpoints, some of these will just disappear.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
