### PR TITLE
web: keep config for tests

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -103,7 +103,7 @@ const config = {
     IS_PERSISTENT_CACHE_ENABLED &&
     getCacheConfig({ invalidateCacheFiles: [path.resolve(__dirname, 'babel.config.js')] }),
   optimization: {
-    minimize: IS_PRODUCTION,
+    minimize: IS_PRODUCTION && !INTEGRATION_TESTS,
     minimizer: [getTerserPlugin(), new CssMinimizerWebpackPlugin()],
     splitChunks: {
       cacheGroups: {
@@ -150,7 +150,7 @@ const config = {
     globalObject: 'self',
     pathinfo: false,
   },
-  devtool: IS_PRODUCTION ? 'source-map' : WEBPACK_DEVELOPMENT_DEVTOOL,
+  devtool: IS_PRODUCTION && !INTEGRATION_TESTS ? 'source-map' : WEBPACK_DEVELOPMENT_DEVTOOL,
   plugins: [
     new webpack.DefinePlugin({
       'process.env': mapValues(RUNTIME_ENV_VARIABLES, JSON.stringify),


### PR DESCRIPTION
## Context

Keep the dev tool config for integration tests.

## Test plan

1. sg run web-integration-build-prod
2. sg test web-integration

## App preview:

- [Web](https://sg-web-vb-keep-devtool.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
