### PR TITLE
more lenient app release script for building snapshots

### DIFF
--- a/enterprise/cmd/sourcegraph/README.md
+++ b/enterprise/cmd/sourcegraph/README.md
@@ -37,7 +37,7 @@ Check the build status in [Buildkite `app/release-snapshot` branch builds](https
 To build it locally for all platforms (without releasing, uploading, or publishing it anywhere), run:
 
 ```shell
-enterprise/dev/app/release.sh --snapshot
+VERSION=0.0.0+dev enterprise/dev/app/release.sh --snapshot
 ```
 
 The builds are written to the `dist` directory.

--- a/enterprise/dev/app/release.sh
+++ b/enterprise/dev/app/release.sh
@@ -13,21 +13,21 @@ if [ -z "${SKIP_BUILD_WEB-}" ]; then
 fi
 
 if [ -z "${GITHUB_TOKEN-}" ]; then
-  echo "Error: GITHUB_TOKEN must be set."
-  exit 1
+  echo "Warning: GITHUB_TOKEN must be set for releases. Disregard this message for local snapshot builds."
 fi
 
 if [ ! -f "$GCLOUD_APP_CREDENTIALS_FILE" ]; then
-  echo "Error: no gcloud application default credentials found. To obtain these credentials, first run:"
+  echo "Warning: no gcloud application default credentials found. To obtain these credentials, first run:"
   echo
   echo "    gcloud auth application-default login"
   echo
   echo "Or set GCLOUD_APP_CREDENTIALS_FILE to a file containing the credentials."
-  exit 1
+  echo
+  echo "Disregard this message for local snapshot builds."
 fi
 
 if [ -z "${VERSION-}" ]; then
-  echo "Error: VERSION must be set."
+  echo "Error: VERSION must be set to a valid semantic version string. Use 0.0.0+dev if unsure what else to use for a local snapshot build."
   exit 1
 fi
 


### PR DESCRIPTION
This makes it possible to run without setting `GITHUB_TOKEN` and makes other similar changes to make local snapshot builds easier.


## Test plan

n/a; dev scripting only