### PR TITLE
disable flaky monthly active users test

### DIFF
--- a/internal/adminanalytics/users_test.go
+++ b/internal/adminanalytics/users_test.go
@@ -251,6 +251,8 @@ func TestUserFrequencyLastMonth(t *testing.T) {
 }
 
 func TestMonthlyActiveUsersLast3Month(t *testing.T) {
+	t.Skip("flaky test due to months rolling over")
+
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))


### PR DESCRIPTION
This disables the TestMonthlyActiveUsersLast3Month test, which fails consistently on the 31st of many months.

See https://github.com/sourcegraph/sourcegraph/issues/47152 for details

## Test plan

Tests pass after disabling

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
