### PR TITLE
web: inline-source-maps for integration tests

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -150,7 +150,9 @@ const config = {
     globalObject: 'self',
     pathinfo: false,
   },
-  devtool: IS_PRODUCTION && !INTEGRATION_TESTS ? 'source-map' : WEBPACK_DEVELOPMENT_DEVTOOL,
+  // Inline source maps for integration tests to preserve readable stack traces.
+  // See related issue here: https://github.com/puppeteer/puppeteer/issues/985
+  devtool: IS_PRODUCTION ? (INTEGRATION_TESTS ? 'inline-source-map' : 'source-map') : WEBPACK_DEVELOPMENT_DEVTOOL,
   plugins: [
     new webpack.DefinePlugin({
       'process.env': mapValues(RUNTIME_ENV_VARIABLES, JSON.stringify),


### PR DESCRIPTION
## Context

Inline source maps for integration tests to preserve readable stack traces.

## Test plan

1. sg run web-integration-build-prod
2. sg test web-integration


## App preview:

- [Web](https://sg-web-vb-integration-tests-source-maps.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
