### PR TITLE
redispool: use in memory KeyValue for Sourcegraph App

### DIFF
--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -113,7 +113,7 @@ type redisKeyValue struct {
 //
 // poolOpts is a required argument which sets defaults in the case we connect
 // to redis. If used we only override TestOnBorrow and Dial.
-func NewKeyValue(addr string, poolOpts redis.Pool) KeyValue {
+func NewKeyValue(addr string, poolOpts *redis.Pool) KeyValue {
 	if addr == MemoryKeyValueURI {
 		return MemoryKeyValue()
 	}
@@ -124,7 +124,7 @@ func NewKeyValue(addr string, poolOpts redis.Pool) KeyValue {
 	poolOpts.Dial = func() (redis.Conn, error) {
 		return dialRedis(addr)
 	}
-	return RedisKeyValue(&poolOpts)
+	return RedisKeyValue(poolOpts)
 }
 
 // RedisKeyValue returns a KeyValue backed by pool.

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -105,13 +105,16 @@ type redisKeyValue struct {
 	prefix string
 }
 
-// NewKeyValue returns a KeyValue for addr. If addr matches the scheme for in
-// memory it will return an in memory KeyValue.
+// NewKeyValue returns a KeyValue for addr. addr is treated as follows:
+//
+//  1. if addr == MemoryKeyValueURI we use a KeyValue that lives
+//     in memory of the current process.
+//  2. otherwise treat as a redis address.
 //
 // poolOpts is a required argument which sets defaults in the case we connect
 // to redis. If used we only override TestOnBorrow and Dial.
 func NewKeyValue(addr string, poolOpts redis.Pool) KeyValue {
-	if addr == memoryKeyValueURI {
+	if addr == MemoryKeyValueURI {
 		return MemoryKeyValue()
 	}
 	poolOpts.TestOnBorrow = func(c redis.Conn, t time.Time) error {

--- a/internal/redispool/mem.go
+++ b/internal/redispool/mem.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+const memoryKeyValueURI = "keyvalue:memory"
+
 // MemoryKeyValue returns an in memory KeyValue.
 func MemoryKeyValue() KeyValue {
 	var mu sync.Mutex

--- a/internal/redispool/mem.go
+++ b/internal/redispool/mem.go
@@ -5,7 +5,9 @@ import (
 	"sync"
 )
 
-const memoryKeyValueURI = "keyvalue:memory"
+// MemoryKeyValue is the special URI which is recognized by NewKeyValue to
+// create an in memory key value.
+const MemoryKeyValueURI = "keyvalue:memory"
 
 // MemoryKeyValue returns an in memory KeyValue.
 func MemoryKeyValue() KeyValue {

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -45,7 +45,7 @@ var addresses = func() struct {
 	for _, addr := range []string{
 		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),
 		fallback,
-		maybe(deploy.IsDeployTypeSingleProgram(deployType), memoryKeyValueURI),
+		maybe(deploy.IsDeployTypeSingleProgram(deployType), MemoryKeyValueURI),
 		"redis-cache:6379",
 	} {
 		if addr != "" {
@@ -58,7 +58,7 @@ var addresses = func() struct {
 	for _, addr := range []string{
 		env.Get("REDIS_STORE_ENDPOINT", "", "redis used for persistent stores (eg HTTP sessions). Default redis-store:6379"),
 		fallback,
-		maybe(deploy.IsDeployTypeSingleProgram(deployType), memoryKeyValueURI),
+		maybe(deploy.IsDeployTypeSingleProgram(deployType), MemoryKeyValueURI),
 		"redis-store:6379",
 	} {
 		if addr != "" {

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -7,35 +7,49 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var (
-	// addrCache is the network address of redis cache.
-	addrCache string
-	// addrStore is the network address of redis store.
-	addrStore string
-)
+// Set addresses. We do it as a function closure to ensure the addresses are
+// set before we create Store and Cache. Prefer in this order:
+// * Specific envvar REDIS_${NAME}_ENDPOINT
+// * Fallback envvar REDIS_ENDPOINT
+// * Default
+//
+// Additionally keep this logic in sync with cmd/server/redis.go
+var addresses = func() struct {
+	Cache string
+	Store string
+} {
+	redis := struct {
+		Cache string
+		Store string
+	}{}
 
-func init() {
-	// Set addresses. Prefer in this order:
-	// * Specific envvar REDIS_${NAME}_ENDPOINT
-	// * Fallback envvar REDIS_ENDPOINT
-	// * Default
-	//
-	// Additionally keep this logic in sync with cmd/server/redis.go
 	fallback := env.Get("REDIS_ENDPOINT", "", "redis endpoint. Used as fallback if REDIS_CACHE_ENDPOINT or REDIS_STORE_ENDPOINT is not specified.")
 
-	// addrCache
+	// maybe is a convenience which returns s if include is true, otherwise
+	// returns the empty string.
+	maybe := func(include bool, s string) string {
+		if include {
+			return s
+		}
+		return ""
+	}
+
+	deployType := deploy.Type()
+
 	for _, addr := range []string{
 		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),
 		fallback,
+		maybe(deploy.IsDeployTypeSingleProgram(deployType), memoryKeyValueURI),
 		"redis-cache:6379",
 	} {
 		if addr != "" {
-			addrCache = addr
+			redis.Cache = addr
 			break
 		}
 	}
@@ -44,14 +58,17 @@ func init() {
 	for _, addr := range []string{
 		env.Get("REDIS_STORE_ENDPOINT", "", "redis used for persistent stores (eg HTTP sessions). Default redis-store:6379"),
 		fallback,
+		maybe(deploy.IsDeployTypeSingleProgram(deployType), memoryKeyValueURI),
 		"redis-store:6379",
 	} {
 		if addr != "" {
-			addrStore = addr
+			redis.Store = addr
 			break
 		}
 	}
-}
+
+	return redis
+}()
 
 var schemeMatcher = lazyregexp.New(`^[A-Za-z][A-Za-z0-9\+\-\.]*://`)
 
@@ -75,30 +92,16 @@ func dialRedis(rawEndpoint string) (redis.Conn, error) {
 // rather than having it in-memory only.
 //
 // In Kubernetes the service is called redis-cache.
-var Cache = RedisKeyValue(&redis.Pool{
+var Cache = NewKeyValue(addresses.Cache, redis.Pool{
 	MaxIdle:     3,
 	IdleTimeout: 240 * time.Second,
-	Dial: func() (redis.Conn, error) {
-		return dialRedis(addrCache)
-	},
-	TestOnBorrow: func(c redis.Conn, t time.Time) error {
-		_, err := c.Do("PING")
-		return err
-	},
 })
 
 // Store is a redis configured for persisting data. Do not abuse this pool,
 // only use if you have data with a high write rate.
 //
 // In Kubernetes the service is called redis-store.
-var Store = RedisKeyValue(&redis.Pool{
+var Store = NewKeyValue(addresses.Store, redis.Pool{
 	MaxIdle:     10,
 	IdleTimeout: 240 * time.Second,
-	TestOnBorrow: func(c redis.Conn, t time.Time) error {
-		_, err := c.Do("PING")
-		return err
-	},
-	Dial: func() (redis.Conn, error) {
-		return dialRedis(addrStore)
-	},
 })

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -92,7 +92,7 @@ func dialRedis(rawEndpoint string) (redis.Conn, error) {
 // rather than having it in-memory only.
 //
 // In Kubernetes the service is called redis-cache.
-var Cache = NewKeyValue(addresses.Cache, redis.Pool{
+var Cache = NewKeyValue(addresses.Cache, &redis.Pool{
 	MaxIdle:     3,
 	IdleTimeout: 240 * time.Second,
 })
@@ -101,7 +101,7 @@ var Cache = NewKeyValue(addresses.Cache, redis.Pool{
 // only use if you have data with a high write rate.
 //
 // In Kubernetes the service is called redis-store.
-var Store = NewKeyValue(addresses.Store, redis.Pool{
+var Store = NewKeyValue(addresses.Store, &redis.Pool{
 	MaxIdle:     10,
 	IdleTimeout: 240 * time.Second,
 })

--- a/internal/redispool/sysreq.go
+++ b/internal/redispool/sysreq.go
@@ -13,8 +13,8 @@ import (
 var timeout, _ = time.ParseDuration(env.Get("SRC_REDIS_WAIT_FOR", "90s", "Duration to wait for Redis to become ready before quitting"))
 
 func init() {
-	sysreq.AddCheck("Redis Store", redisCheck("Store", addrStore, timeout, Store))
-	sysreq.AddCheck("Redis Cache", redisCheck("Cache", addrCache, timeout, Cache))
+	sysreq.AddCheck("Redis Store", redisCheck("Store", addresses.Store, timeout, Store))
+	sysreq.AddCheck("Redis Cache", redisCheck("Cache", addresses.Cache, timeout, Cache))
 }
 
 func redisCheck(name, addr string, timeout time.Duration, kv KeyValue) sysreq.CheckFunc {


### PR DESCRIPTION
We introduce a new function NewKeyValue which takes an address to dial redis. We then check if the address is instead referring to in memory and return an in memory key value store.

How we decide on address also had to change. We now ensure the address is set before anyone can read the address variable. Previously we had the addr accessed inside of a closure, so we didn't need that gaurentee. We then changed the logic to use in memory as the default if the deploy type is Sourcegraph App.

I expiremented with a logger to log every interaction we have with the store. On startup it generates about 3mb of logs, not so bad.

Note: this uses in memory for Store. A follow up commit will switch Store to using something persistent.

Test Plan: I ran the app with the follow command and ensured I didn't have any redis envvars set in my environment. Additionally I added logging to ensure the in memory store was used. I then did a few searches and played around a bit.

``` shell
export USE_EMBEDDED_POSTGRESQL=0
export DEPLOY_TYPE=single-program
export SRC_FRONTEND_INTERNAL=localhost:3090
export EXECUTOR_FRONTEND_PASSWORD=asdf
export SRC_DISABLE_OOBMIGRATION_VALIDATION=1
export BLOBSTORE_DATA_DIR=/tmp/blobstore-data
go run ./enterprise/cmd/sourcegraph/
```

Part of #46328
