### PR TITLE
ci: add `TestMonthlyActiveUsersLast3Month` to flakefile

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -133,5 +133,10 @@
     "path": "internal/database",
     "prefix": "TestPermissionSyncJobs_CreateAndList",
     "reason": "The column boolean column`high_priority` has been replaced by numeric column `priority`. Table not in use for 4.4."
+  },
+  {
+    "path": "internal/adminanalytics",
+    "prefix": "TestMonthlyActiveUsersLast3Month",
+    "reason": "Month subtraction produces inconsistent results, see https://github.com/sourcegraph/sourcegraph/issues/47152"
   }
 ]


### PR DESCRIPTION
- See https://github.com/sourcegraph/sourcegraph/issues/47152 for context

I think it needs to be added to the flakefile too in order for the backcompat test to actually ignore it.

## Test plan
CI doesn't fail on this test anymore

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
