### PR TITLE
Add beta tags to Gerrit docs

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -7,7 +7,7 @@ Sourcegraph supports the following ways for users to sign in:
 - [GitHub](#github)
 - [GitLab](#gitlab)
 - [Bitbucket Cloud](#bitbucket-cloud)
-- [Gerrit](#gerrit)
+- [Gerrit](#gerrit) <span class="badge badge-beta">Beta</span>
 - [SAML](saml/index.md)
 - [OpenID Connect](#openid-connect)
   - [Google Workspace (Google accounts)](#google-workspace-google-accounts)
@@ -352,6 +352,7 @@ Then add the following lines to your [site configuration](config/site_config.md)
 Replace the `clientKey` and `clientSecret` values with the values from your Bitbucket Cloud OAuth consumer.
 
 ## Gerrit
+<span class="badge badge-beta">Beta</span>
 
 To enable users to add Gerrit credentials and verify their access to repositories on Sourcegraph,
 add the following lines to your [site configuration](config/site_config.md):

--- a/doc/admin/external_service/gerrit.md
+++ b/doc/admin/external_service/gerrit.md
@@ -1,4 +1,5 @@
 # Gerrit
+<span class="badge badge-beta">Beta</span>
 
 Site admins can sync Git repositories hosted on their private Gerrit instance with Sourcegraph so that users can search and navigate the repositories.
 

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -96,7 +96,7 @@ Tier 1 code hosts are our highest level of support for code hosts. When leveragi
         <td class="indexer-implemented-y">✓</td> <!-- Batch Changes -->
       </tr>
       <tr>
-        <td>Gerrit</td>
+        <td>Gerrit <span class="badge badge-beta">Beta</span></td>
         <td>Tier 2 (Working on Tier 1)</td>
         <td class="indexer-implemented-y">✓</td> <!-- Repository Syncing -->
         <td class="indexer-implemented-y">✓</td> <!-- Permissions Syncing -->
@@ -153,7 +153,7 @@ We recognize there are other code hosts including CVS, Azure Dev Ops, SVN, and m
 - [GitLab](gitlab.md)
 - [Bitbucket Cloud](bitbucket_cloud.md)
 - [Bitbucket Server / Bitbucket Data Center](bitbucket_server.md)
-- [Gerrit](gerrit.md)
+- [Gerrit](gerrit.md) <span class="badge badge-beta">Beta</span>
 - [Other Git code hosts (using a Git URL)](other.md)
 - [Non-Git code hosts](non-git.md)
   - [Perforce](../repo/perforce.md)

--- a/doc/admin/external_service/other.md
+++ b/doc/admin/external_service/other.md
@@ -21,7 +21,7 @@ docker exec $CONTAINER ssh -p $PORT $USER@$HOSTNAME
 
 - $CONTAINER is the name or ID of your sourcegraph/server container
 - $PORT is the port on which your code host's git server is listening for connections
-- $USER is your user on your code host (Gerrit defaults to `admin`)
+- $USER is your user on your code host
 - $HOSTNAME is the hostname of your code host from within the sourcegraph/server container (e.g. `githost.example.com`)
 
 Here's an example:

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -5,7 +5,7 @@ Sourcegraph can be configured to enforce repository permissions from code hosts.
 - [GitHub / GitHub Enterprise](#github)
 - [GitLab](#gitlab)
 - [Bitbucket Server / Bitbucket Data Center](#bitbucket-server-bitbucket-data-center)
-- [Gerrit](#gerrit)
+- [Gerrit](#gerrit) <span class="badge badge-beta">Beta</span>
 - [Unified SSO](https://unknwon.io/posts/200915_setup-sourcegraph-gitlab-keycloak/)
 - [Explicit permissions API](#explicit-permissions-api)
 
@@ -264,6 +264,7 @@ By installing the [Bitbucket Server plugin](../../../integration/bitbucket_serve
 <br />
 
 ## Gerrit
+<span class="badge badge-beta">Beta</span>
 
 Prerequisite: [Add Gerrit as an authentication provider](../auth/index.md#gerrit).
 


### PR DESCRIPTION
A doc update to add `Beta` tags to the Gerrit documentation, just to manage expectations.

## Test plan

Doc update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
