### PR TITLE
Sort external service list alphabetically

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -140,6 +140,9 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 )}
                 {Object.entries(codeHostExternalServices)
                     .filter(externalService => !allowedCodeHosts || allowedCodeHosts.includes(externalService[1]))
+                    .sort(([, externalService1], [, externalService2]) =>
+                        externalService1.title.localeCompare(externalService2.title)
+                    )
                     .map(([id, externalService]) => (
                         <div className={styles.addExternalServicesPageCard} key={id}>
                             <ExternalServiceCard to={getAddURL(id)} {...externalService} />
@@ -156,6 +159,9 @@ export const AddExternalServicesPage: React.FunctionComponent<
                         {Object.entries(codeHostExternalServices)
                             .filter(
                                 externalService => allowedCodeHosts && !allowedCodeHosts.includes(externalService[1])
+                            )
+                            .sort(([, externalService1], [, externalService2]) =>
+                                externalService1.title.localeCompare(externalService2.title)
                             )
                             .map(([id, externalService]) => (
                                 <div className={styles.addExternalServicesPageCard} key={id}>


### PR DESCRIPTION
## Description

Today, we have a fixed order of code hosts in the "Add repositories" Site admin configuration page. However as we add code hosts, it's difficult to determine, where to put the newly added ones.

In this PR, the order of the external services on the page is becoming deterministic - alphabetical sorting was added. See the screenshot below:
<img width="941" alt="Screenshot 2023-01-31 at 10 09 56" src="https://user-images.githubusercontent.com/9974711/215717708-0eed8eb3-bc66-48ce-a3b9-984e4a04af66.png">

## Further improvements

We could make it better by having another category - code hosts already used on the instance being on top. But not sure how much value that would add and it's not a 20-minute job anymore.

## Test plan

Tested manually locally.

## App preview:

- [Web](https://sg-web-milan-add-repos-list-order.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
