### PR TITLE
permissions-center: add `no_perms` column to `permission_sync_jobs` table.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1691,8 +1691,6 @@ github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/microcosm-cc/bluemonday v1.0.17/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
-github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/microcosm-cc/bluemonday v1.0.22 h1:p2tT7RNzRdCi0qmwxG+HbqD6ILkmwter1ZwVZn1oTxA=
 github.com/microcosm-cc/bluemonday v1.0.22/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -17152,6 +17152,19 @@
           "Comment": ""
         },
         {
+          "Name": "no_perms",
+          "Index": 21,
+          "TypeName": "boolean",
+          "IsNullable": false,
+          "Default": "false",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "num_failures",
           "Index": 10,
           "TypeName": "integer",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2657,6 +2657,7 @@ Referenced by:
  priority             | integer                  |           | not null | 0
  invalidate_caches    | boolean                  |           | not null | false
  cancellation_reason  | text                     |           |          | 
+ no_perms             | boolean                  |           | not null | false
 Indexes:
     "permission_sync_jobs_pkey" PRIMARY KEY, btree (id)
     "permission_sync_jobs_unique" UNIQUE, btree (priority, user_id, repository_id, cancel, process_after) WHERE state = 'queued'::text

--- a/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/down.sql
+++ b/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/down.sql
@@ -1,0 +1,48 @@
+-- We are changing the schema and we don't expect any rows yet so we can just drop
+-- the old table.
+-- We are changing the schema and we don't expect any rows yet so we can just drop
+-- the old table.
+DROP TABLE IF EXISTS permission_sync_jobs;
+
+CREATE TABLE permission_sync_jobs
+(
+    id                   SERIAL PRIMARY KEY,
+    state                TEXT                     DEFAULT 'queued',
+    reason               TEXT    NOT NULL,
+    failure_message      TEXT,
+    queued_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    started_at           TIMESTAMP WITH TIME ZONE,
+    finished_at          TIMESTAMP WITH TIME ZONE,
+    process_after        TIMESTAMP WITH TIME ZONE,
+    num_resets           INTEGER NOT NULL         DEFAULT 0,
+    num_failures         INTEGER NOT NULL         DEFAULT 0,
+    last_heartbeat_at    TIMESTAMP WITH TIME ZONE,
+    execution_logs       JSON[],
+    worker_hostname      TEXT    NOT NULL         DEFAULT '',
+    cancel               BOOLEAN NOT NULL         DEFAULT FALSE,
+
+    repository_id        INTEGER REFERENCES repo (id) ON DELETE CASCADE,
+    user_id              INTEGER REFERENCES users (id) ON DELETE CASCADE,
+    triggered_by_user_id INTEGER REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,
+
+    priority             INTEGER NOT NULL         DEFAULT 0,
+    invalidate_caches    BOOLEAN NOT NULL         DEFAULT FALSE,
+    cancellation_reason  TEXT,
+    CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
+);
+
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_state ON permission_sync_jobs (state);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_process_after ON permission_sync_jobs (process_after);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_repository_id ON permission_sync_jobs (repository_id);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_user_id ON permission_sync_jobs (user_id);
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
+COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';

--- a/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/metadata.yaml
+++ b/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add no_perms column to permission_sync_jobs table
+parents: [1671463799, 1674952295]

--- a/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/up.sql
+++ b/migrations/frontend/1675155867_add_no_perms_column_to_permission_sync_jobs_table/up.sql
@@ -1,0 +1,47 @@
+-- We are changing the schema and we don't expect any rows yet so we can just drop
+-- the old table.
+DROP TABLE IF EXISTS permission_sync_jobs;
+
+CREATE TABLE permission_sync_jobs
+(
+    id                   SERIAL PRIMARY KEY,
+    state                TEXT                     DEFAULT 'queued',
+    reason               TEXT    NOT NULL,
+    failure_message      TEXT,
+    queued_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    started_at           TIMESTAMP WITH TIME ZONE,
+    finished_at          TIMESTAMP WITH TIME ZONE,
+    process_after        TIMESTAMP WITH TIME ZONE,
+    num_resets           INTEGER NOT NULL         DEFAULT 0,
+    num_failures         INTEGER NOT NULL         DEFAULT 0,
+    last_heartbeat_at    TIMESTAMP WITH TIME ZONE,
+    execution_logs       JSON[],
+    worker_hostname      TEXT    NOT NULL         DEFAULT '',
+    cancel               BOOLEAN NOT NULL         DEFAULT FALSE,
+
+    repository_id        INTEGER REFERENCES repo (id) ON DELETE CASCADE,
+    user_id              INTEGER REFERENCES users (id) ON DELETE CASCADE,
+    triggered_by_user_id INTEGER REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,
+
+    priority             INTEGER NOT NULL         DEFAULT 0,
+    invalidate_caches    BOOLEAN NOT NULL         DEFAULT FALSE,
+    cancellation_reason  TEXT,
+    no_perms             BOOLEAN NOT NULL         DEFAULT FALSE
+    CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
+);
+
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_state ON permission_sync_jobs (state);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_process_after ON permission_sync_jobs (process_after);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_repository_id ON permission_sync_jobs (repository_id);
+CREATE INDEX IF NOT EXISTS permission_sync_jobs_user_id ON permission_sync_jobs (user_id);
+
+-- this index is used as a last resort if deduplication logic fails to work.
+-- we should not enqueue more that one high priority immediate sync job (process_after IS NULL) for given repo/user.
+CREATE UNIQUE INDEX IF NOT EXISTS permission_sync_jobs_unique ON permission_sync_jobs
+    USING btree (priority, user_id, repository_id, cancel, process_after)
+    WHERE (state = 'queued');
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
+COMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';
+COMMENT ON COLUMN permission_sync_jobs.priority IS 'Specifies numeric priority for the permissions sync job.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3305,6 +3305,7 @@ CREATE TABLE permission_sync_jobs (
     priority integer DEFAULT 0 NOT NULL,
     invalidate_caches boolean DEFAULT false NOT NULL,
     cancellation_reason text,
+    no_perms boolean DEFAULT false NOT NULL,
     CONSTRAINT permission_sync_jobs_for_repo_or_user CHECK (((user_id IS NULL) <> (repository_id IS NULL)))
 );
 


### PR DESCRIPTION
This column will be used in the next commit to keep this commit as simple as possible.

Test plan:
`sg migration` up->down->up.

First part of https://github.com/sourcegraph/sourcegraph/issues/47151