### PR TITLE
Add Beta product status label next to Gerrit code host definition

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -3,30 +3,12 @@ import React from 'react'
 import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Icon, Link, H3, Text, Tooltip, Badge } from '@sourcegraph/wildcard'
+import { Icon, Link, H3, Text, Tooltip, Badge, ProductStatusBadge } from '@sourcegraph/wildcard'
 
-import { ExternalServiceKind } from '../../graphql-operations'
+import { AddExternalServiceOptions } from './externalServices'
 
 import styles from './ExternalServiceCard.module.scss'
-
-interface ExternalServiceCardProps {
-    /**
-     * Title to show in the external service "button".
-     */
-    title: string
-
-    /**
-     * Icon to show in the external service "button".
-     */
-    icon: React.ComponentType<React.PropsWithChildren<{ className?: string }>>
-
-    /**
-     * A short description that will appear in the external service "button" under the title.
-     */
-    shortDescription?: string
-
-    kind: ExternalServiceKind
-
+interface ExternalServiceCardProps extends AddExternalServiceOptions {
     to?: string
 
     /**
@@ -52,8 +34,15 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
     badge = '',
     tooltip = '',
     bordered = true,
+    status,
 }) => {
-    let cardTitle = <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>{title}</H3>
+    const titleBadge = status ? <ProductStatusBadge status={status} className="ml-2" /> : null
+    let cardTitle = (
+        <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
+            {title}
+            {titleBadge}
+        </H3>
+    )
     cardTitle = tooltip ? <Tooltip content={tooltip}>{cardTitle}</Tooltip> : cardTitle
     const children = (
         <div

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -36,11 +36,10 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
     bordered = true,
     status,
 }) => {
-    const titleBadge = status ? <ProductStatusBadge status={status} className="ml-2" /> : null
     let cardTitle = (
         <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>
             {title}
-            {titleBadge}
+            {status && <ProductStatusBadge status={status} className="ml-2" />}
         </H3>
     )
     cardTitle = tooltip ? <Tooltip content={tooltip}>{cardTitle}</Tooltip> : cardTitle

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -88,6 +88,11 @@ export interface AddExternalServiceOptions {
      * Default external service configuration
      */
     defaultConfig: string
+
+    /**
+     * If present, denotes that we should show a status label, e.g. Beta or Experimental
+     */
+    status?: 'experimental' | 'beta'
 }
 
 const defaultModificationOptions: ModificationOptions = {
@@ -1276,6 +1281,7 @@ const GERRIT: AddExternalServiceOptions = {
         </div>
     ),
     editorActions: [],
+    status: 'beta',
 }
 
 const AZUREDEVOPS: AddExternalServiceOptions = {


### PR DESCRIPTION
## Description

Marks Gerrit code host connection as Beta, since we just added full support for perms syncing and made it a Tier 1 code host. 

## Screenshots

<img width="955" alt="Screenshot 2023-01-31 at 10 32 13" src="https://user-images.githubusercontent.com/9974711/215722335-5b6ab147-a81b-4709-a04c-cbdc43452acb.png">
<img width="939" alt="Screenshot 2023-01-31 at 10 32 19" src="https://user-images.githubusercontent.com/9974711/215722353-d1172423-ddea-4b2d-bac7-c5aeddb2d6d0.png">

## Test plan

Tested locally, see the screenshots


## App preview:

- [Web](https://sg-web-milan-add-beta-gerrit-badge.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
