### PR TITLE
Housekeeping: Rename variables to avoid collisions with packages

### DIFF
--- a/cmd/blobstore/shared/shared.go
+++ b/cmd/blobstore/shared/shared.go
@@ -60,14 +60,14 @@ func Start(ctx context.Context, observationCtx *observation.Context, config *Con
 	// Ready immediately
 	ready()
 
-	service := &blobstore.Service{
+	bsService := &blobstore.Service{
 		DataDir:        config.DataDir,
 		Log:            logger,
 		ObservationCtx: observation.NewContext(logger),
 	}
 
 	// Set up handler middleware
-	handler := actor.HTTPMiddleware(logger, service)
+	handler := actor.HTTPMiddleware(logger, bsService)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
 	handler = instrumentation.HTTPMiddleware("", handler)
 

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -312,8 +312,8 @@ func validateExecutorSecret(secret *database.ExecutorSecret, value string) error
 		if dac.CredsStore != "" {
 			return errors.New("cannot use credential stores in docker auth config set via secrets")
 		}
-		for key, auth := range dac.Auths {
-			if !bytes.Contains(auth.Auth, []byte(":")) {
+		for key, dacAuth := range dac.Auths {
+			if !bytes.Contains(dacAuth.Auth, []byte(":")) {
 				return errors.Newf("invalid credential in auths section for %q format has to be base64(username:password)", key)
 			}
 		}

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -53,15 +53,15 @@ func FileOrDir(ctx context.Context, db database.DB, client gitserver.Client, rep
 	}
 
 	if link != nil {
-		var url string
+		var urlStr string
 		if isDir {
-			url = link.Tree
+			urlStr = link.Tree
 		} else {
-			url = link.Blob
+			urlStr = link.Blob
 		}
-		if url != "" {
-			url = strings.NewReplacer("{rev}", rev, "{path}", path).Replace(url)
-			links = append(links, NewResolver(url, serviceType))
+		if urlStr != "" {
+			urlStr = strings.NewReplacer("{rev}", rev, "{path}", path).Replace(urlStr)
+			links = append(links, NewResolver(urlStr, serviceType))
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -193,15 +193,15 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 }
 
 func (r *GitCommitResolver) URL() string {
-	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + r.inputRevOrImmutableRev()
-	return url.String()
+	repoUrl := r.repoResolver.url()
+	repoUrl.Path += "/-/commit/" + r.inputRevOrImmutableRev()
+	return repoUrl.String()
 }
 
 func (r *GitCommitResolver) CanonicalURL() string {
-	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + string(r.oid)
-	return url.String()
+	repoUrl := r.repoResolver.url()
+	repoUrl.Path += "/-/commit/" + string(r.oid)
+	return repoUrl.String()
 }
 
 func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
@@ -398,7 +398,7 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // "/REPO/-/commit/REVSPEC").
 func (r *GitCommitResolver) repoRevURL() *url.URL {
 	// Dereference to copy to avoid mutation
-	url := *r.repoResolver.RepoMatch.URL()
+	repoUrl := *r.repoResolver.RepoMatch.URL()
 	var rev string
 	if r.inputRev != nil {
 		rev = *r.inputRev // use the original input rev from the user
@@ -406,14 +406,14 @@ func (r *GitCommitResolver) repoRevURL() *url.URL {
 		rev = string(r.oid)
 	}
 	if rev != "" {
-		url.Path += "@" + rev
+		repoUrl.Path += "@" + rev
 	}
-	return &url
+	return &repoUrl
 }
 
 func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 	// Dereference to copy the URL to avoid mutation
-	url := *r.repoResolver.RepoMatch.URL()
-	url.Path += "@" + string(r.oid)
-	return &url
+	repoUrl := *r.repoResolver.RepoMatch.URL()
+	repoUrl.Path += "@" + string(r.oid)
+	return &repoUrl
 }

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -14,8 +14,8 @@ import (
 )
 
 func (r *GitTreeEntryResolver) IsRoot() bool {
-	path := path.Clean(r.Path())
-	return path == "/" || path == "." || path == ""
+	cleanPath := path.Clean(r.Path())
+	return cleanPath == "/" || cleanPath == "." || cleanPath == ""
 }
 
 type gitTreeEntryConnectionArgs struct {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -215,8 +215,8 @@ func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() string {
-	url := r.commit.canonicalRepoRevURL()
-	return r.urlPath(url).String()
+	canonicalUrl := r.commit.canonicalRepoRevURL()
+	return r.urlPath(canonicalUrl).String()
 }
 
 func (r *GitTreeEntryResolver) urlPath(prefix *url.URL) *url.URL {

--- a/cmd/frontend/graphqlbackend/highlight.go
+++ b/cmd/frontend/graphqlbackend/highlight.go
@@ -83,7 +83,7 @@ func (h *HighlightedFileResolver) LineRanges(args *struct{ Ranges []highlight.Li
 
 func highlightContent(ctx context.Context, args *HighlightArgs, content, path string, metadata highlight.Metadata) (*HighlightedFileResolver, error) {
 	var (
-		result          = &HighlightedFileResolver{}
+		resolver        = &HighlightedFileResolver{}
 		err             error
 		simulateTimeout = metadata.RepoName == "github.com/sourcegraph/AlwaysHighlightTimeoutTest"
 	)
@@ -98,12 +98,12 @@ func highlightContent(ctx context.Context, args *HighlightArgs, content, path st
 		Format:             gosyntect.GetResponseFormat(args.Format),
 	})
 
-	result.aborted = aborted
-	result.response = response
+	resolver.aborted = aborted
+	resolver.response = response
 
 	if err != nil {
 		return nil, err
 	}
 
-	return result, nil
+	return resolver, nil
 }

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -115,12 +115,12 @@ func (r *schemaResolver) OutboundWebhookEventTypes(ctx context.Context) ([]Outbo
 		return nil, err
 	}
 
-	types := outbound.GetRegisteredEventTypes()
-	sort.Slice(types, func(i, j int) bool {
-		return types[i].Key < types[j].Key
+	eventTypes := outbound.GetRegisteredEventTypes()
+	sort.Slice(eventTypes, func(i, j int) bool {
+		return eventTypes[i].Key < eventTypes[j].Key
 	})
-	resolvers := make([]OutboundWebhookEventTypeResolver, len(types))
-	for i, et := range types {
+	resolvers := make([]OutboundWebhookEventTypeResolver, len(eventTypes))
+	for i, et := range eventTypes {
 		resolvers[i] = &outboundWebhookEventTypeResolver{et}
 	}
 
@@ -362,14 +362,14 @@ func (r *outboundWebhookResolver) EventTypes() ([]OutboundWebhookScopedEventType
 		return nil, err
 	}
 
-	types := make([]OutboundWebhookScopedEventTypeResolver, len(webhook.EventTypes))
+	eventTypes := make([]OutboundWebhookScopedEventTypeResolver, len(webhook.EventTypes))
 	for i, et := range webhook.EventTypes {
-		types[i] = &outboundWebhookScopedEventTypeResolver{
+		eventTypes[i] = &outboundWebhookScopedEventTypeResolver{
 			eventType: et.EventType,
 			scope:     et.Scope,
 		}
 	}
-	return types, nil
+	return eventTypes, nil
 }
 
 func (r *outboundWebhookResolver) Stats(ctx context.Context) (OutboundWebhookLogStatsResolver, error) {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -164,8 +164,8 @@ func TestRepositoryLabel(t *testing.T) {
 				ID:   api.RepoID(0),
 			},
 		}
-		result, _ := r.Label()
-		html, err := result.HTML()
+		markdown, _ := r.Label()
+		html, err := markdown.HTML()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -117,22 +117,22 @@ func TestSearch(t *testing.T) {
 			gsClient.ResolveRevisionFunc.SetDefaultHook(tc.repoRevsMock)
 
 			sr := newSchemaResolver(db, gsClient)
-			schema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&requestTracer{}))
+			gqlSchema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&requestTracer{}))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			result := schema.Exec(context.Background(), testSearchGQLQuery, "", vars)
-			if len(result.Errors) > 0 {
-				t.Fatalf("graphQL query returned errors: %+v", result.Errors)
+			response := gqlSchema.Exec(context.Background(), testSearchGQLQuery, "", vars)
+			if len(response.Errors) > 0 {
+				t.Fatalf("graphQL query returned errors: %+v", response.Errors)
 			}
-			var search struct {
+			var searchStruct struct {
 				Results Results
 			}
-			if err := json.Unmarshal(result.Data, &search); err != nil {
+			if err := json.Unmarshal(response.Data, &searchStruct); err != nil {
 				t.Fatalf("parsing JSON response: %v", err)
 			}
-			gotResults := search.Results
+			gotResults := searchStruct.Results
 			if !reflect.DeepEqual(gotResults, tc.wantResults) {
 				t.Fatalf("results = %+v, want %+v", gotResults, tc.wantResults)
 			}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -133,11 +133,11 @@ func (r *siteConfigurationResolver) ID(ctx context.Context) (int32, error) {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
-	conf, err := r.db.Conf().SiteGetLatest(ctx)
+	config, err := r.db.Conf().SiteGetLatest(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return conf.ID, nil
+	return config.ID, nil
 }
 
 func (r *siteConfigurationResolver) EffectiveContents(ctx context.Context) (JSONCString, error) {

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -109,13 +109,13 @@ func TestSiteConfigConnection(t *testing.T) {
 	stubs := setupSiteConfigStubs(t)
 
 	// Create a context with an admin user as the actor.
-	context := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+	contextWithActor := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
 	RunTests(t, []*Test{
 		{
 			Schema:  mustParseGraphQLSchema(t, stubs.db),
 			Label:   "Get first 2 site configuration history",
-			Context: context,
+			Context: contextWithActor,
 			Query: `
 			{
 			  site {
@@ -184,7 +184,7 @@ func TestSiteConfigConnection(t *testing.T) {
 		{
 			Schema:  mustParseGraphQLSchema(t, stubs.db),
 			Label:   "Get last 3 site configuration history",
-			Context: context,
+			Context: contextWithActor,
 			Query: `
 					{
 						site {
@@ -253,7 +253,7 @@ func TestSiteConfigConnection(t *testing.T) {
 		{
 			Schema:  mustParseGraphQLSchema(t, stubs.db),
 			Label:   "Get first 2 site configuration history based on an offset",
-			Context: context,
+			Context: contextWithActor,
 			Query: fmt.Sprintf(`
 			{
 				site {
@@ -322,7 +322,7 @@ func TestSiteConfigConnection(t *testing.T) {
 		{
 			Schema:  mustParseGraphQLSchema(t, stubs.db),
 			Label:   "Get last 2 site configuration history based on an offset",
-			Context: context,
+			Context: contextWithActor,
 			Query: fmt.Sprintf(`
 			{
 			  site {

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -34,11 +34,11 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 	Line      int32
 	Character int32
 }) (*symbolResolver, error) {
-	symbol, err := symbol.GetMatchAtLineCharacter(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
-	if err != nil || symbol == nil {
+	symbolMatch, err := symbol.GetMatchAtLineCharacter(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
+	if err != nil || symbolMatch == nil {
 		return nil, err
 	}
-	return &symbolResolver{r.db, r.commit, symbol}, nil
+	return &symbolResolver{r.db, r.commit, symbolMatch}, nil
 }
 
 func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
@@ -52,10 +52,10 @@ func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*sy
 	}, nil
 }
 
-func symbolResultsToResolvers(db database.DB, commit *GitCommitResolver, symbols []*result.SymbolMatch) []symbolResolver {
-	symbolResolvers := make([]symbolResolver, 0, len(symbols))
-	for _, symbol := range symbols {
-		symbolResolvers = append(symbolResolvers, toSymbolResolver(db, commit, symbol))
+func symbolResultsToResolvers(db database.DB, commit *GitCommitResolver, symbolMatches []*result.SymbolMatch) []symbolResolver {
+	symbolResolvers := make([]symbolResolver, 0, len(symbolMatches))
+	for _, symbolMatch := range symbolMatches {
+		symbolResolvers = append(symbolResolvers, toSymbolResolver(db, commit, symbolMatch))
 	}
 	return symbolResolvers
 }

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -158,10 +158,10 @@ func (r *WebhookLogConnectionResolver) Nodes(ctx context.Context) ([]*webhookLog
 
 	nodes := make([]*webhookLogResolver, len(logs))
 	db := database.NewDBWith(r.logger, r.store)
-	for i, log := range logs {
+	for i, l := range logs {
 		nodes[i] = &webhookLogResolver{
 			db:  db,
-			log: log,
+			log: l,
 		}
 	}
 
@@ -230,12 +230,12 @@ func webhookLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*web
 		return nil, err
 	}
 
-	log, err := db.WebhookLogs(keyring.Default().WebhookLogKey).GetByID(ctx, id)
+	l, err := db.WebhookLogs(keyring.Default().WebhookLogKey).GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	return &webhookLogResolver{db: db, log: log}, nil
+	return &webhookLogResolver{db: db, log: l}, nil
 }
 
 func (r *webhookLogResolver) ID() graphql.ID {

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -224,12 +224,12 @@ func addSentry(r *mux.Router) {
 			// We want to keep this short, the default client settings are not strict enough.
 			Timeout: 3 * time.Second,
 		}
-		url := fmt.Sprintf("%s/api/%s/envelope/", sentryHost, pID)
+		apiUrl := fmt.Sprintf("%s/api/%s/envelope/", sentryHost, pID)
 
 		// Asynchronously forward to Sentry, there's no need to keep holding this connection
 		// opened any longer.
 		go func() {
-			resp, err := client.Post(url, "text/plain;charset=UTF-8", bytes.NewReader(b))
+			resp, err := client.Post(apiUrl, "text/plain;charset=UTF-8", bytes.NewReader(b))
 			if err != nil || resp.StatusCode >= 400 {
 				logger.Warn("failed to forward", sglog.Error(err), sglog.Int("statusCode", resp.StatusCode))
 				return

--- a/cmd/frontend/internal/app/otlpadapter/otlp.go
+++ b/cmd/frontend/internal/app/otlpadapter/otlp.go
@@ -26,18 +26,18 @@ func newExporter(
 	switch protocol {
 	case otlpenv.ProtocolGRPC:
 		exporterFactory = otlpexporter.NewFactory()
-		config := exporterFactory.CreateDefaultConfig().(*otlpexporter.Config)
-		config.GRPCClientSettings.Endpoint = endpoint
-		config.GRPCClientSettings.TLSSetting = configtls.TLSClientSetting{
+		tempConfig := exporterFactory.CreateDefaultConfig().(*otlpexporter.Config)
+		tempConfig.GRPCClientSettings.Endpoint = endpoint
+		tempConfig.GRPCClientSettings.TLSSetting = configtls.TLSClientSetting{
 			Insecure: otlpenv.IsInsecure(endpoint),
 		}
-		signalExporterConfig = config
+		signalExporterConfig = tempConfig
 
 	case otlpenv.ProtocolHTTPJSON:
 		exporterFactory = otlphttpexporter.NewFactory()
-		config := exporterFactory.CreateDefaultConfig().(*otlphttpexporter.Config)
-		config.HTTPClientSettings.Endpoint = endpoint
-		signalExporterConfig = config
+		tempConfig := exporterFactory.CreateDefaultConfig().(*otlphttpexporter.Config)
+		tempConfig.HTTPClientSettings.Endpoint = endpoint
+		signalExporterConfig = tempConfig
 
 	default:
 		err = errors.Newf("unexpected protocol %q", protocol)

--- a/cmd/frontend/internal/app/router/old_tree_redirects.go
+++ b/cmd/frontend/internal/app/router/old_tree_redirects.go
@@ -18,11 +18,11 @@ const revSuffixNoDots = `{Rev:(?:@(?:(?:[^@=/.-]|(?:[^=/@.]{2,}))/)*(?:[^@=/.-]|
 func addOldTreeRedirectRoute(matchRouter *mux.Router) {
 	matchRouter.Path("/" + routevar.Repo + revSuffixNoDots + `/.tree{Path:.*}`).Methods("GET").Name(OldTreeRedirect).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := mux.Vars(r)
-		path := path.Clean(v["Path"])
-		if !strings.HasPrefix(path, "/") && path != "" {
-			path = "/" + path
+		cleanedPath := path.Clean(v["Path"])
+		if !strings.HasPrefix(cleanedPath, "/") && cleanedPath != "" {
+			cleanedPath = "/" + cleanedPath
 		}
 
-		http.Redirect(w, r, URLToRepoTreeEntry(api.RepoName(v["Repo"]), v["Rev"], path).String(), http.StatusMovedPermanently)
+		http.Redirect(w, r, URLToRepoTreeEntry(api.RepoName(v["Repo"]), v["Rev"], cleanedPath).String(), http.StatusMovedPermanently)
 	})
 }

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -322,11 +322,11 @@ func getAndMarshalMigratedExtensionsUsageJSON(ctx context.Context, db database.D
 func getAndMarshalCodeHostVersionsJSON(_ context.Context, _ database.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalCodeHostVersionsJSON")(&err)
 
-	versions, err := versions.GetVersions()
+	v, err := versions.GetVersions()
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(versions)
+	return json.Marshal(v)
 }
 
 func getDependencyVersions(ctx context.Context, db database.DB, logger log.Logger) (json.RawMessage, error) {

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -19,13 +19,13 @@ func TestLatestDockerVersionPushed(t *testing.T) {
 		t.Skip("Skipping due to network request against dockerhub")
 	}
 
-	url := fmt.Sprintf("https://index.docker.io/v1/repositories/sourcegraph/server/tags/%s", latestReleaseDockerServerImageBuild.Version)
-	resp, err := http.Get(url)
+	urlStr := fmt.Sprintf("https://index.docker.io/v1/repositories/sourcegraph/server/tags/%s", latestReleaseDockerServerImageBuild.Version)
+	resp, err := http.Get(urlStr)
 	if err != nil {
 		t.Skip("Failed to contact dockerhub", err)
 	}
 	if resp.StatusCode == 404 {
-		t.Fatalf("sourcegraph/server:%s does not exist on dockerhub. %s", latestReleaseDockerServerImageBuild.Version, url)
+		t.Fatalf("sourcegraph/server:%s does not exist on dockerhub. %s", latestReleaseDockerServerImageBuild.Version, urlStr)
 	}
 	if resp.StatusCode != 200 {
 		t.Skip("unexpected response from dockerhub", resp.StatusCode)
@@ -37,14 +37,14 @@ func TestLatestKubernetesVersionPushed(t *testing.T) {
 		t.Skip("Skipping due to network request")
 	}
 
-	url := fmt.Sprintf("https://github.com/sourcegraph/deploy-sourcegraph/releases/tag/v%v", latestReleaseKubernetesBuild.Version)
-	resp, err := http.Head(url)
+	urlStr := fmt.Sprintf("https://github.com/sourcegraph/deploy-sourcegraph/releases/tag/v%v", latestReleaseKubernetesBuild.Version)
+	resp, err := http.Head(urlStr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if resp.StatusCode != 200 {
-		t.Errorf("Could not find Kubernetes release %s on GitHub. Response code %s from %s, err: %v", latestReleaseKubernetesBuild.Version, resp.Status, url, err)
+		t.Errorf("Could not find Kubernetes release %s on GitHub. Response code %s from %s, err: %v", latestReleaseKubernetesBuild.Version, resp.Status, urlStr, err)
 	}
 }
 
@@ -53,14 +53,14 @@ func TestLatestDockerComposeOrPureDockerVersionPushed(t *testing.T) {
 		t.Skip("Skipping due to network request")
 	}
 
-	url := fmt.Sprintf("https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v%v", latestReleaseDockerComposeOrPureDocker.Version)
-	resp, err := http.Head(url)
+	urlStr := fmt.Sprintf("https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v%v", latestReleaseDockerComposeOrPureDocker.Version)
+	resp, err := http.Head(urlStr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if resp.StatusCode != 200 {
-		t.Errorf("Could not find Docker Compose or Pure Docker release %s on GitHub. Response code %s from %s, err: %v", latestReleaseDockerComposeOrPureDocker.Version, resp.Status, url, err)
+		t.Errorf("Could not find Docker Compose or Pure Docker release %s on GitHub. Response code %s from %s, err: %v", latestReleaseDockerComposeOrPureDocker.Version, resp.Status, urlStr, err)
 	}
 }
 

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -732,9 +732,9 @@ func replicaAddrs(deployType, countStr, serviceName, port string) (string, error
 
 func getEnv(environ []string, key string) (string, bool) {
 	key = key + "="
-	for _, env := range environ {
-		if strings.HasPrefix(env, key) {
-			return env[len(key):], true
+	for _, envVar := range environ {
+		if strings.HasPrefix(envVar, key) {
+			return envVar[len(key):], true
 		}
 	}
 	return "", false

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -130,7 +130,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	// Run enterprise setup hook
-	enterprise := enterpriseSetupHook(db, conf.DefaultClient())
+	enterpriseServices := enterpriseSetupHook(db, conf.DefaultClient())
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to create sub-repo client")
@@ -201,18 +201,18 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	schema, err := graphqlbackend.NewSchema(db,
 		gitserver.NewClient(),
-		enterprise.BatchChangesResolver,
-		enterprise.CodeIntelResolver,
-		enterprise.InsightsResolver,
-		enterprise.AuthzResolver,
-		enterprise.CodeMonitorsResolver,
-		enterprise.LicenseResolver,
-		enterprise.DotcomResolver,
-		enterprise.SearchContextsResolver,
-		enterprise.NotebooksResolver,
-		enterprise.ComputeResolver,
-		enterprise.InsightsAggregationResolver,
-		enterprise.WebhooksResolver,
+		enterpriseServices.BatchChangesResolver,
+		enterpriseServices.CodeIntelResolver,
+		enterpriseServices.InsightsResolver,
+		enterpriseServices.AuthzResolver,
+		enterpriseServices.CodeMonitorsResolver,
+		enterpriseServices.LicenseResolver,
+		enterpriseServices.DotcomResolver,
+		enterpriseServices.SearchContextsResolver,
+		enterpriseServices.NotebooksResolver,
+		enterpriseServices.ComputeResolver,
+		enterpriseServices.InsightsAggregationResolver,
+		enterpriseServices.WebhooksResolver,
 	)
 	if err != nil {
 		return err
@@ -223,12 +223,12 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return err
 	}
 
-	server, err := makeExternalAPI(db, logger, schema, enterprise, rateLimitWatcher)
+	server, err := makeExternalAPI(db, logger, schema, enterpriseServices, rateLimitWatcher)
 	if err != nil {
 		return err
 	}
 
-	internalAPI, err := makeInternalAPI(db, logger, schema, enterprise, rateLimitWatcher)
+	internalAPI, err := makeInternalAPI(db, logger, schema, enterpriseServices, rateLimitWatcher)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/httpapi/releasecache/config.go
+++ b/cmd/frontend/internal/httpapi/releasecache/config.go
@@ -73,11 +73,11 @@ func parseSiteConfig(conf *conf.Unified) (*config, error) {
 	if c.Github.Uri != "" {
 		config.urn = c.Github.Uri
 	}
-	url, err := url.Parse(config.urn)
+	configUrl, err := url.Parse(config.urn)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing GitHub URL from configuration")
 	}
-	config.api, _ = github.APIRoot(url)
+	config.api, _ = github.APIRoot(configUrl)
 
 	if c.Github.Repository != nil {
 		if c.Github.Repository.Owner != "" {

--- a/cmd/frontend/internal/httpapi/releasecache/main_test.go
+++ b/cmd/frontend/internal/httpapi/releasecache/main_test.go
@@ -30,8 +30,8 @@ func TestMain(m *testing.M) {
 }
 
 func newClientFactory(t testing.TB, name string) (*httpcli.Factory, func(testing.TB)) {
-	cassette := filepath.Join("testdata", strings.ReplaceAll(name, " ", "-"))
-	rec := newRecorder(t, cassette, update(name))
+	cassetteName := filepath.Join("testdata", strings.ReplaceAll(name, " ", "-"))
+	rec := newRecorder(t, cassetteName, update(name))
 	mw := httpcli.NewMiddleware(httpcli.GitHubProxyRedirectMiddleware)
 	return httpcli.NewFactory(mw, httptestutil.NewRecorderOpt(rec)),
 		func(t testing.TB) { save(t, rec) }

--- a/cmd/frontend/internal/httpapi/src_cli.go
+++ b/cmd/frontend/internal/httpapi/src_cli.go
@@ -129,8 +129,8 @@ func (h *srcCliVersionHandler) updateCachedVersion() (string, error) {
 		return "", errors.New("parsing minimum version")
 	}
 
-	url := fmt.Sprintf("%s/%d.%d", srcCliVersionCache, minimumVersion.Major(), minimumVersion.Minor())
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	urlStr := fmt.Sprintf("%s/%d.%d", srcCliVersionCache, minimumVersion.Major(), minimumVersion.Minor())
+	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "building request")
 	}

--- a/cmd/frontend/internal/routevar/repo_test.go
+++ b/cmd/frontend/internal/routevar/repo_test.go
@@ -115,13 +115,13 @@ func TestRepo(t *testing.T) {
 				t.Errorf("%q: got vars == %v, want %v", test.path, m.Vars, test.wantVars)
 			}
 
-			url, err := m.Route.URLPath(pairs(m.Vars)...)
+			urlPath, err := m.Route.URLPath(pairs(m.Vars)...)
 			if err != nil {
 				t.Errorf("%q: URLPath: %s", test.path, err)
 				continue
 			}
-			if url.Path != test.path {
-				t.Errorf("%q: got path == %q, want %q", test.path, url.Path, test.path)
+			if urlPath.Path != test.path {
+				t.Errorf("%q: got path == %q, want %q", test.path, urlPath.Path, test.path)
 			}
 		}
 	}
@@ -153,13 +153,13 @@ func TestRev(t *testing.T) {
 				t.Errorf("%q: got vars == %v, want %v", test.path, m.Vars, test.wantVars)
 			}
 
-			url, err := m.Route.URLPath(pairs(m.Vars)...)
+			urlPath, err := m.Route.URLPath(pairs(m.Vars)...)
 			if err != nil {
 				t.Errorf("%q: URLPath: %s", test.path, err)
 				continue
 			}
-			if url.Path != test.path {
-				t.Errorf("%q: got path == %q, want %q", test.path, url.Path, test.path)
+			if urlPath.Path != test.path {
+				t.Errorf("%q: got path == %q, want %q", test.path, urlPath.Path, test.path)
 			}
 		}
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -566,8 +566,8 @@ func GuessSource(r *http.Request) trace.SourceType {
 
 func repoIDs(results []result.Match) []api.RepoID {
 	ids := make(map[api.RepoID]struct{}, 5)
-	for _, result := range results {
-		ids[result.RepoName().ID] = struct{}{}
+	for _, r := range results {
+		ids[r.RepoName().ID] = struct{}{}
 	}
 
 	res := make([]api.RepoID, 0, len(ids))

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -342,7 +342,7 @@ func TestCleanupExpired(t *testing.T) {
 	repoPerforceGCOld := path.Join(root, "repo-perforce-gc-old", ".git")
 	repoRemoteURLScrub := path.Join(root, "repo-remote-url-scrub", ".git")
 	remote := path.Join(root, "remote", ".git")
-	for _, path := range []string{
+	for _, gitDirPath := range []string{
 		repoNew, repoOld,
 		repoGCNew, repoGCOld,
 		repoBoom, repoCorrupt,
@@ -350,7 +350,7 @@ func TestCleanupExpired(t *testing.T) {
 		repoRemoteURLScrub,
 		remote,
 	} {
-		cmd := exec.Command("git", "--bare", "init", path)
+		cmd := exec.Command("git", "--bare", "init", gitDirPath)
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)
 		}
@@ -387,7 +387,7 @@ func TestCleanupExpired(t *testing.T) {
 	writeFile(t, filepath.Join(repoGCNew, "gc.log"), []byte("warning: There are too many unreachable loose objects; run 'git prune' to remove them."))
 	writeFile(t, filepath.Join(repoGCOld, "gc.log"), []byte("warning: There are too many unreachable loose objects; run 'git prune' to remove them."))
 
-	for path, delta := range map[string]time.Duration{
+	for gitDirPath, delta := range map[string]time.Duration{
 		repoOld:           2 * repoTTL,
 		repoGCOld:         2 * repoTTLGC,
 		repoBoom:          2 * repoTTL,
@@ -396,10 +396,10 @@ func TestCleanupExpired(t *testing.T) {
 		repoPerforceGCOld: 2 * repoTTLGC,
 	} {
 		ts := time.Now().Add(-delta)
-		if err := setRecloneTime(GitDir(path), ts); err != nil {
+		if err := setRecloneTime(GitDir(gitDirPath), ts); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Chtimes(filepath.Join(path, "HEAD"), ts, ts); err != nil {
+		if err := os.Chtimes(filepath.Join(gitDirPath, "HEAD"), ts, ts); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -496,10 +496,10 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 	initRepos := func(root string) (repoExists string, repoNotExists string) {
 		repoExists = path.Join(root, "repo-exists", ".git")
 		repoNotExists = path.Join(root, "repo-not-exists", ".git")
-		for _, path := range []string{
+		for _, gitDirPath := range []string{
 			repoExists, repoNotExists,
 		} {
-			cmd := exec.Command("git", "--bare", "init", path)
+			cmd := exec.Command("git", "--bare", "init", gitDirPath)
 			if err := cmd.Run(); err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/gitserver/server/observability.go
+++ b/cmd/gitserver/server/observability.go
@@ -24,7 +24,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 	})
 	observationCtx.Registerer.MustRegister(batchLogSemaphoreWait)
 
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"gitserver_api",
 		metrics.WithLabels("op"),
@@ -35,7 +35,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("gitserver.api.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2787,12 +2787,12 @@ func setHEAD(ctx context.Context, logger log.Logger, rf *wrexec.RecordingCommand
 		// branch does not exist, pick first branch
 		cmd := exec.CommandContext(ctx, "git", "branch")
 		dir.Set(cmd)
-		list, err := cmd.Output()
+		output, err := cmd.Output()
 		if err != nil {
 			logger.Error("Failed to list branches", log.Error(err), log.String("output", string(output)))
 			return errors.Wrap(err, "failed to list branches")
 		}
-		lines := strings.Split(string(list), "\n")
+		lines := strings.Split(string(output), "\n")
 		branch := strings.TrimPrefix(strings.TrimPrefix(lines[0], "* "), "  ")
 		if branch != "" {
 			headBranch = branch

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -54,8 +54,8 @@ func (dir GitDir) Set(cmd *exec.Cmd) {
 }
 
 func (s *Server) dir(name api.RepoName) GitDir {
-	path := string(protocol.NormalizeRepo(name))
-	return GitDir(filepath.Join(s.ReposDir, filepath.FromSlash(path), ".git"))
+	p := string(protocol.NormalizeRepo(name))
+	return GitDir(filepath.Join(s.ReposDir, filepath.FromSlash(p), ".git"))
 }
 
 func (s *Server) name(dir GitDir) api.RepoName {

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -166,8 +166,8 @@ func createMaliciousJar(t *testing.T, name string) {
 	writer := zip.NewWriter(f)
 	defer writer.Close()
 
-	for _, filepath := range maliciousPaths {
-		_, err = writer.Create(filepath)
+	for _, filePath := range maliciousPaths {
+		_, err = writer.Create(filePath)
 		assert.Nil(t, err)
 	}
 

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -259,8 +259,8 @@ func TestDecompressTgz(t *testing.T) {
 			dir := t.TempDir()
 
 			var fileInfos []fileInfo
-			for _, path := range testData.paths {
-				fileInfos = append(fileInfos, fileInfo{path: path, contents: []byte("x")})
+			for _, testDataPath := range testData.paths {
+				fileInfos = append(fileInfos, fileInfo{path: testDataPath, contents: []byte("x")})
 			}
 
 			tgz := bytes.NewReader(createTgz(t, fileInfos))

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -126,7 +126,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 
 	git := gitserver.NewClient()
 
-	service := &search.Service{
+	sService := &search.Service{
 		Store: &search.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 				// We pass in a nil sub-repo permissions checker and an internal actor here since
@@ -169,10 +169,10 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 
 		Log: logger,
 	}
-	service.Store.Start()
+	sService.Store.Start()
 
 	// Set up handler middleware
-	handler := actor.HTTPMiddleware(logger, service)
+	handler := actor.HTTPMiddleware(logger, sService)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
 	handler = instrumentation.HTTPMiddleware("", handler)
 
@@ -182,7 +182,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	grpcServer := grpc.NewServer(grpcdefaults.ServerOptions(logger)...)
 	reflection.Register(grpcServer)
 	grpcServer.RegisterService(&proto.Searcher_ServiceDesc, &search.Server{
-		Service: service,
+		Service: sService,
 	})
 
 	host := ""

--- a/cmd/sitemap/main.go
+++ b/cmd/sitemap/main.go
@@ -307,7 +307,7 @@ func (g *generator) generate(ctx context.Context) error {
 			return errors.Wrap(err, "failed to write sitemap.xml.gz")
 		}
 	}
-	for index, sitemap := range sitemaps {
+	for index, sm := range sitemaps {
 		fileName := fmt.Sprintf("sitemap_%03d.xml.gz", index)
 		outFile, err := os.Create(filepath.Join(g.outDir, fileName))
 		if err != nil {
@@ -316,7 +316,7 @@ func (g *generator) generate(ctx context.Context) error {
 		defer outFile.Close()
 		writer := gzip.NewWriter(outFile)
 		defer writer.Close()
-		_, err = sitemap.WriteTo(writer)
+		_, err = sm.WriteTo(writer)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to write %s", fileName))
 		}

--- a/cmd/symbols/gitserver/observability.go
+++ b/cmd/symbols/gitserver/observability.go
@@ -13,7 +13,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"codeintel_symbols_gitserver",
 		metrics.WithLabels("op"),
@@ -24,7 +24,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.symbols.gitserver.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -130,7 +130,7 @@ func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc) http.Handler
 			return
 		}
 
-		result, err := searchFunc(r.Context(), args)
+		resultSymbols, err := searchFunc(r.Context(), args)
 		if err != nil {
 			// Ignore reporting errors where client disconnected
 			if r.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
@@ -150,7 +150,7 @@ func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc) http.Handler
 			return
 		}
 
-		if err := json.NewEncoder(w).Encode(search.SymbolsResponse{Symbols: result}); err != nil {
+		if err := json.NewEncoder(w).Encode(search.SymbolsResponse{Symbols: resultSymbols}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -63,8 +63,8 @@ func TestHandler(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(files))
 
-	parser := parser.NewParser(&observation.TestContext, parserPool, fetcher.NewRepositoryFetcher(&observation.TestContext, gitserverClient, 1000, 1_000_000), 0, 10)
-	databaseWriter := writer.NewDatabaseWriter(observation.TestContextTB(t), tmpDir, gitserverClient, parser, semaphore.NewWeighted(1))
+	symbolParser := parser.NewParser(&observation.TestContext, parserPool, fetcher.NewRepositoryFetcher(&observation.TestContext, gitserverClient, 1000, 1_000_000), 0, 10)
+	databaseWriter := writer.NewDatabaseWriter(observation.TestContextTB(t), tmpDir, gitserverClient, symbolParser, semaphore.NewWeighted(1))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	handler := NewHandler(MakeSqliteSearchFunc(observation.TestContextTB(t), cachedDatabaseWriter, database.NewMockDB()), gitserverClient.ReadFile, nil, "")
 
@@ -127,17 +127,17 @@ func TestHandler(t *testing.T) {
 
 	for label, testCase := range testCases {
 		t.Run(label, func(t *testing.T) {
-			result, err := client.Search(context.Background(), testCase.args)
+			resultSymbols, err := client.Search(context.Background(), testCase.args)
 			if err != nil {
 				t.Fatalf("unexpected error performing search: %s", err)
 			}
 
-			if result == nil {
+			if resultSymbols == nil {
 				if testCase.expected != nil {
 					t.Errorf("unexpected search result. want=%+v, have=nil", testCase.expected)
 				}
-			} else if !reflect.DeepEqual(result, testCase.expected) {
-				t.Errorf("unexpected search result. want=%+v, have=%+v", testCase.expected, result)
+			} else if !reflect.DeepEqual(resultSymbols, testCase.expected) {
+				t.Errorf("unexpected search result. want=%+v, have=%+v", testCase.expected, resultSymbols)
 			}
 		})
 	}

--- a/cmd/symbols/internal/database/store/search.go
+++ b/cmd/symbols/internal/database/store/search.go
@@ -178,17 +178,17 @@ func negate(query *sqlf.Query) *sqlf.Query {
 }
 
 func globEscape(str string) string {
-	var result strings.Builder
+	var out strings.Builder
 
 	specials := `[]*?`
 
 	for _, c := range str {
 		if strings.ContainsRune(specials, c) {
-			fmt.Fprintf(&result, "[%c]", c)
+			fmt.Fprintf(&out, "[%c]", c)
 		} else {
-			fmt.Fprintf(&result, "%c", c)
+			fmt.Fprintf(&out, "%c", c)
 		}
 	}
 
-	return result.String()
+	return out.String()
 }

--- a/cmd/symbols/observability/observability.go
+++ b/cmd/symbols/observability/observability.go
@@ -12,7 +12,7 @@ type Operations struct {
 }
 
 func NewOperations(observationCtx *observation.Context) *Operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"codeintel_symbols_api",
 		metrics.WithLabels("op", "parseAmount"),
@@ -24,7 +24,7 @@ func NewOperations(observationCtx *observation.Context) *Operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.symbols.api.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -53,17 +53,17 @@ func NewSlackNotification(id, channel string) *SlackNotification {
 
 func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel string) *NotificationClient {
 	debug := os.Getenv("BUILD_TRACKER_SLACK_DEBUG") == "1"
-	slack := slack.New(slackToken, slack.OptionDebug(debug))
+	slackClient := slack.New(slackToken, slack.OptionDebug(debug))
 
 	httpClient := http.Client{
 		Timeout: 5 * time.Second,
 	}
 	githubClient := github.NewClient(&httpClient)
-	teamResolver := team.NewTeammateResolver(githubClient, slack)
+	teamResolver := team.NewTeammateResolver(githubClient, slackClient)
 
 	return &NotificationClient{
 		logger:  logger.Scoped("notificationClient", "client which interacts with Slack and Github to send notifications"),
-		slack:   *slack,
+		slack:   *slackClient,
 		team:    teamResolver,
 		channel: channel,
 	}

--- a/dev/ci/go-backcompat/reorganize.go
+++ b/dev/ci/go-backcompat/reorganize.go
@@ -20,17 +20,17 @@ func main() {
 
 	contents := map[string]string{}
 	for _, schema := range schemas.Schemas {
-		for _, definition := range schema.Definitions.All() {
-			metadata, err := renderMetadata(definition)
+		for _, def := range schema.Definitions.All() {
+			metadata, err := renderMetadata(def)
 			if err != nil {
 				panic(err.Error())
 			}
 
-			migrationDirectory := filepath.Join(tempDirectory, schema.Name, strconv.Itoa(definition.ID))
+			migrationDirectory := filepath.Join(tempDirectory, schema.Name, strconv.Itoa(def.ID))
 
 			contents[filepath.Join(migrationDirectory, "metadata.yaml")] = string(metadata)
-			contents[filepath.Join(migrationDirectory, "up.sql")] = definition.UpQuery.Query(sqlf.PostgresBindVar)
-			contents[filepath.Join(migrationDirectory, "down.sql")] = definition.DownQuery.Query(sqlf.PostgresBindVar)
+			contents[filepath.Join(migrationDirectory, "up.sql")] = def.UpQuery.Query(sqlf.PostgresBindVar)
+			contents[filepath.Join(migrationDirectory, "down.sql")] = def.DownQuery.Query(sqlf.PostgresBindVar)
 		}
 	}
 

--- a/dev/scaletesting/codehostcopy/bitbucket/client.go
+++ b/dev/scaletesting/codehostcopy/bitbucket/client.go
@@ -244,7 +244,7 @@ func (c *Client) GetProjectByKey(ctx context.Context, key string) (*Project, err
 
 // CreateRepo creates a repo within the given project with the given name.
 func (c *Client) CreateRepo(ctx context.Context, p *Project, repoName string) (*Repo, error) {
-	url := c.url(fmt.Sprintf("/rest/api/latest/projects/%s/repos", p.Key))
+	endpointUrl := c.url(fmt.Sprintf("/rest/api/latest/projects/%s/repos", p.Key))
 
 	rawRepoData, err := json.Marshal(struct {
 		Name  string         `json:"name"`
@@ -260,7 +260,7 @@ func (c *Client) CreateRepo(ctx context.Context, p *Project, repoName string) (*
 		return nil, err
 	}
 
-	respData, err := c.post(ctx, url, rawRepoData)
+	respData, err := c.post(ctx, endpointUrl, rawRepoData)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (c *Client) CreateRepo(ctx context.Context, p *Project, repoName string) (*
 // authenticated user. Therefore, it is strongly recommended, that if you want to create a project to use the
 // BasicAuth client.
 func (c *Client) CreateProject(ctx context.Context, p *Project) (*Project, error) {
-	url := c.url("/rest/api/latest/projects")
+	endpointUrl := c.url("/rest/api/latest/projects")
 
 	rawProjectData, err := json.Marshal(struct {
 		Key       string         `json:"key"`
@@ -297,7 +297,7 @@ func (c *Client) CreateProject(ctx context.Context, p *Project) (*Project, error
 		return nil, err
 	}
 
-	respData, err := c.post(ctx, url, rawProjectData)
+	respData, err := c.post(ctx, endpointUrl, rawProjectData)
 	if err != nil {
 		return nil, err
 	}
@@ -313,8 +313,8 @@ func (c *Client) CreateProject(ctx context.Context, p *Project) (*Project, error
 
 func (c *Client) ListProjects(ctx context.Context) ([]*Project, error) {
 	var err error
-	url := c.url("/rest/api/latest/projects")
-	all, err := getAll[*Project](ctx, c, url)
+	endpointUrl := c.url("/rest/api/latest/projects")
+	all, err := getAll[*Project](ctx, c, endpointUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -343,8 +343,8 @@ func extractResults[T any](items []getResult[T]) ([]T, error) {
 
 func (c *Client) ListReposForProject(ctx context.Context, project *Project, page int, perPage int) ([]*Repo, int, error) {
 	repos := make([]*Repo, 0)
-	url := c.url(fmt.Sprintf("/rest/api/latest/projects/%s/repos", project.Key))
-	resp, err := c.getPaged(ctx, url, page, perPage)
+	endpointUrl := c.url(fmt.Sprintf("/rest/api/latest/projects/%s/repos", project.Key))
+	resp, err := c.getPaged(ctx, endpointUrl, page, perPage)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -47,8 +47,8 @@ var checks = map[string]check.CheckFunc{
 func runChecksWithName(ctx context.Context, names []string) error {
 	funcs := make(map[string]check.CheckFunc, len(names))
 	for _, name := range names {
-		if check, ok := checks[name]; ok {
-			funcs[name] = check
+		if c, ok := checks[name]; ok {
+			funcs[name] = c
 		} else {
 			return errors.Newf("check %q not found", name)
 		}
@@ -81,10 +81,10 @@ func runChecks(ctx context.Context, checks map[string]check.CheckFunc) error {
 
 	var failed []string
 
-	for name, check := range checks {
+	for name, c := range checks {
 		p := std.Out.Pending(output.Linef(output.EmojiLightbulb, output.StylePending, "Running check %q...", name))
 
-		if err := check(ctx); err != nil {
+		if err := c(ctx); err != nil {
 			p.Complete(output.Linef(output.EmojiFailure, output.StyleWarning, "Check %q failed with the following errors:", name))
 
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "%s", err))

--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -68,9 +68,9 @@ func newResource(r log.Resource) *resource.Resource {
 }
 
 func isValidVersion(spans *tracepb.ResourceSpans) bool {
-	for _, attribute := range spans.GetResource().GetAttributes() {
-		if attribute.GetKey() == sgAnalyticsVersionResourceKey {
-			return attribute.Value.GetStringValue() == sgAnalyticsVersion
+	for _, attrib := range spans.GetResource().GetAttributes() {
+		if attrib.GetKey() == sgAnalyticsVersionResourceKey {
+			return attrib.Value.GetStringValue() == sgAnalyticsVersion
 		}
 	}
 	return false

--- a/dev/sg/internal/docker/docker.go
+++ b/dev/sg/internal/docker/docker.go
@@ -113,13 +113,13 @@ func getStoreProvider(serverAddress string) (string, error) {
 		return config.CredentialsStore, nil
 	}
 
-	url, err := url.Parse(serverAddress)
+	serverUrl, err := url.Parse(serverAddress)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse server address %s", serverAddress)
 	}
 
-	if config.CredentialHelpers[url.Host] != "" {
-		return config.CredentialHelpers[url.Host], nil
+	if config.CredentialHelpers[serverUrl.Host] != "" {
+		return config.CredentialHelpers[serverUrl.Host], nil
 	}
 
 	return "", errors.Errorf("failed to find store provider or credential helper for %s", serverAddress)
@@ -131,10 +131,10 @@ func GetCredentialsFromStore(serverAddress string) (*credentials.Credentials, er
 		return nil, err
 	}
 	program := client.NewShellProgramFunc(fmt.Sprintf("docker-credential-%s", provider))
-	credentials, err := client.Get(program, serverAddress)
+	creds, err := client.Get(program, serverAddress)
 	if err != nil {
 		return nil, err
 	}
 
-	return credentials, err
+	return creds, err
 }

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -118,11 +118,11 @@ func UpdateHelm(path string, creds credentials.Credentials, pinTag string) error
 		return errors.Wrapf(err, "couldn't unmarshal %s", valuesFilePath)
 	}
 
-	var images []string
-	extraImages(values, &images)
+	var imgs []string
+	extraImages(values, &imgs)
 
 	valuesFileString := string(valuesFile)
-	for _, img := range images {
+	for _, img := range imgs {
 		var updatedImg string
 		updatedImg, err = getUpdatedImage(img, creds, pinTag)
 		if err != nil {

--- a/dev/sg/internal/migration/leaves.go
+++ b/dev/sg/internal/migration/leaves.go
@@ -44,12 +44,12 @@ func LeavesForCommit(databases []db.Database, commit string) error {
 func selectLeavesForCommit(database db.Database, ds *definition.Definitions, commit string) ([]definition.Definition, error) {
 	migrationsDir := filepath.Join("migrations", database.Name)
 
-	output, err := run.GitCmd("ls-tree", "-r", "--name-only", commit, migrationsDir)
+	gitCmdOutput, err := run.GitCmd("ls-tree", "-r", "--name-only", commit, migrationsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	ds, err = ds.Filter(parseVersions(strings.Split(output, "\n"), migrationsDir))
+	ds, err = ds.Filter(parseVersions(strings.Split(gitCmdOutput, "\n"), migrationsDir))
 	if err != nil {
 		return nil, err
 	}

--- a/dev/sg/internal/migration/revert.go
+++ b/dev/sg/internal/migration/revert.go
@@ -91,11 +91,11 @@ func Revert(databases []db.Database, commit string) error {
 func selectMigrationsDefinedInCommit(database db.Database, commit string) ([]int, error) {
 	migrationsDir := filepath.Join("migrations", database.Name)
 
-	output, err := run.GitCmd("diff", "--name-only", commit+".."+commit+"~1", migrationsDir)
+	gitCmdOutput, err := run.GitCmd("diff", "--name-only", commit+".."+commit+"~1", migrationsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	versions := parseVersions(strings.Split(output, "\n"), migrationsDir)
+	versions := parseVersions(strings.Split(gitCmdOutput, "\n"), migrationsDir)
 	return versions, nil
 }

--- a/dev/sg/internal/migration/rewrite.go
+++ b/dev/sg/internal/migration/rewrite.go
@@ -30,13 +30,13 @@ func Rewrite(database db.Database, rev string) error {
 		_ = os.RemoveAll(migrationsDirTemp)
 	}()
 
-	root, err := http.FS(fs).Open("/")
+	rootDir, err := http.FS(fs).Open("/")
 	if err != nil {
 		return err
 	}
-	defer func() { _ = root.Close() }()
+	defer func() { _ = rootDir.Close() }()
 
-	migrations, err := root.Readdir(0)
+	migrations, err := rootDir.Readdir(0)
 	if err != nil {
 		return err
 	}

--- a/dev/sg/internal/migration/util.go
+++ b/dev/sg/internal/migration/util.go
@@ -134,9 +134,9 @@ func parseVersions(lines []string, migrationsDir string) []int {
 
 // rootRelative removes the repo root prefix from the given path.
 func rootRelative(path string) string {
-	if root, _ := root.RepositoryRoot(); root != "" {
+	if repoRoot, _ := root.RepositoryRoot(); repoRoot != "" {
 		sep := string(os.PathSeparator)
-		rootWithTrailingSep := strings.TrimRight(root, sep) + sep
+		rootWithTrailingSep := strings.TrimRight(repoRoot, sep) + sep
 		return strings.TrimPrefix(path, rootWithTrailingSep)
 	}
 

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -744,14 +744,14 @@ From there, you can start exploring logs with the Grafana explore panel.
 }
 
 func buildGrafanaURL(text string, stepName string) string {
-	var base string
+	var urlWithPlaceholder string
 	if stepName == "" {
-		base = "https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22%7D%20%7C%3D%20%60_TEXT_%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-10d%22,%22to%22:%22now%22%7D%7D"
+		urlWithPlaceholder = "https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22%7D%20%7C%3D%20%60_TEXT_%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-10d%22,%22to%22:%22now%22%7D%7D"
 	} else {
-		base = "https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22,%20step_key%3D~%5C%22_STEP_%5C%22%7D%20%7C%3D%20%60_TEXT_%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-10d%22,%22to%22:%22now%22%7D%7D"
+		urlWithPlaceholder = "https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-sourcegraph-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22buildkite%5C%22,%20step_key%3D~%5C%22_STEP_%5C%22%7D%20%7C%3D%20%60_TEXT_%60%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-10d%22,%22to%22:%22now%22%7D%7D"
 	}
-	url := strings.ReplaceAll(base, "_TEXT_", text)
-	return strings.ReplaceAll(url, "_STEP_", fmt.Sprintf(".*%s.*", stepName))
+	replaced := strings.ReplaceAll(urlWithPlaceholder, "_TEXT_", text)
+	return strings.ReplaceAll(replaced, "_STEP_", fmt.Sprintf(".*%s.*", stepName))
 }
 
 func getAllowedBuildTypeArgs() []string {

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -108,9 +108,9 @@ func listSecretExec(ctx *cli.Context) error {
 }
 
 func bashCompleteSecrets() (options []string) {
-	secrets, err := loadSecrets()
+	allSecrets, err := loadSecrets()
 	if err != nil {
 		return nil
 	}
-	return secrets.Keys()
+	return allSecrets.Keys()
 }

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -253,11 +253,11 @@ func shouldUpdateDevPrivate(ctx context.Context, path, branch string) (bool, err
 		return false, err
 	}
 	// Now we check if there are any changes. If the output is empty, we're not missing out on anything.
-	output, err := sgrun.Bash(ctx, fmt.Sprintf("git diff --shortstat origin/%s", branch)).Dir(path).Run().String()
+	outputStr, err := sgrun.Bash(ctx, fmt.Sprintf("git diff --shortstat origin/%s", branch)).Dir(path).Run().String()
 	if err != nil {
 		return false, err
 	}
-	return len(output) > 0, err
+	return len(outputStr) > 0, err
 
 }
 

--- a/enterprise/cmd/executor/internal/config/consts.go
+++ b/enterprise/cmd/executor/internal/config/consts.go
@@ -89,9 +89,9 @@ func mustParseConstraint(constraint string) *semver.Constraints {
 }
 
 func mustParseCIDR(val string) *net.IPNet {
-	_, net, err := net.ParseCIDR(val)
+	_, ipNetwork, err := net.ParseCIDR(val)
 	if err != nil {
 		panic(err)
 	}
-	return net
+	return ipNetwork
 }

--- a/enterprise/cmd/executor/internal/run/run.go
+++ b/enterprise/cmd/executor/internal/run/run.go
@@ -86,15 +86,13 @@ func StandaloneRunRun(ctx context.Context, logger log.Logger, cfg *config.Config
 
 	nameSet := janitor.NewNameSet()
 	ctx, cancel := context.WithCancel(ctx)
-	worker, err := worker.NewWorker(observationCtx, nameSet, opts)
+	wrk, err := worker.NewWorker(observationCtx, nameSet, opts)
 	if err != nil {
 		cancel()
 		return err
 	}
 
-	routines := []goroutine.BackgroundRoutine{
-		worker,
-	}
+	routines := []goroutine.BackgroundRoutine{wrk}
 
 	if cfg.UseFirecracker {
 		routines = append(routines, janitor.NewOrphanedVMJanitor(
@@ -112,7 +110,7 @@ func StandaloneRunRun(ctx context.Context, logger log.Logger, cfg *config.Config
 		// in that we want a maximum runtime and/or number of jobs to be
 		// executed by a single instance, after which the service should shut
 		// down without error.
-		worker.Wait()
+		wrk.Wait()
 
 		// Once the worker has finished its current set of jobs and stops
 		// the dequeue loop, we want to finish off the rest of the sibling

--- a/enterprise/cmd/executor/internal/run/testvm.go
+++ b/enterprise/cmd/executor/internal/run/testvm.go
@@ -65,7 +65,7 @@ func createVM(ctx context.Context, config *config.Config, repositoryName, revisi
 	operations := command.NewOperations(&observation.TestContext)
 
 	hostRunner := command.NewRunner("", commandLogger, command.Options{}, operations)
-	workspace, err := workspace.NewFirecrackerWorkspace(
+	firecrackerWorkspace, err := workspace.NewFirecrackerWorkspace(
 		ctx,
 		// No need for files store in the test.
 		nil,
@@ -94,7 +94,7 @@ func createVM(ctx context.Context, config *config.Config, repositoryName, revisi
 	fopts := firecrackerOptions(config)
 	fopts.Enabled = true
 
-	runner := command.NewRunner(workspace.Path(), commandLogger, command.Options{
+	runner := command.NewRunner(firecrackerWorkspace.Path(), commandLogger, command.Options{
 		ExecutorName:       name,
 		ResourceOptions:    resourceOptions(config),
 		DockerOptions:      dockerOptions(config),

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -93,11 +93,11 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job executor.Jo
 	logger.Info("Creating workspace")
 
 	hostRunner := h.runnerFactory("", commandLogger, command.Options{}, h.operations)
-	workspace, err := h.prepareWorkspace(ctx, hostRunner, job, commandLogger)
+	ws, err := h.prepareWorkspace(ctx, hostRunner, job, commandLogger)
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare workspace")
 	}
-	defer workspace.Remove(ctx, h.options.KeepWorkspaces)
+	defer ws.Remove(ctx, h.options.KeepWorkspaces)
 
 	vmNameSuffix, err := uuid.NewRandom()
 	if err != nil {
@@ -126,7 +126,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job executor.Jo
 	if len(job.DockerAuthConfig.Auths) > 0 {
 		options.DockerOptions.DockerAuthConfig = job.DockerAuthConfig
 	}
-	runner := h.runnerFactory(workspace.Path(), commandLogger, options, h.operations)
+	runner := h.runnerFactory(ws.Path(), commandLogger, options, h.operations)
 
 	logger.Info("Setting up VM")
 
@@ -154,7 +154,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job executor.Jo
 		dockerStepCommand := command.CommandSpec{
 			Key:        key,
 			Image:      dockerStep.Image,
-			ScriptPath: workspace.ScriptFilenames()[i],
+			ScriptPath: ws.ScriptFilenames()[i],
 			Dir:        dockerStep.Dir,
 			Env:        dockerStep.Env,
 			Operation:  h.operations.Exec,

--- a/enterprise/cmd/executor/singlebinary/service.go
+++ b/enterprise/cmd/executor/singlebinary/service.go
@@ -20,20 +20,20 @@ type svc struct{}
 func (svc) Name() string { return "executor" }
 
 func (svc) Configure() (env.Config, []debugserver.Endpoint) {
-	var config config.Config
-	config.Load()
-	return &config, nil
+	var conf config.Config
+	conf.Load()
+	return &conf, nil
 }
 
 func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, cfg env.Config) error {
-	config := cfg.(*config.Config)
+	conf := cfg.(*config.Config)
 	// Always use the in-memory secret.
-	config.FrontendAuthorizationToken = confdefaults.SingleProgramInMemoryExecutorPassword
+	conf.FrontendAuthorizationToken = confdefaults.SingleProgramInMemoryExecutorPassword
 
 	// TODO(sqs) HACK(sqs): run executors for both queues
 	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
-		otherConfig := *config
-		if config.QueueName == "batches" {
+		otherConfig := *conf
+		if conf.QueueName == "batches" {
 			otherConfig.QueueName = "codeintel"
 		} else {
 			otherConfig.QueueName = "batches"
@@ -45,7 +45,7 @@ func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready
 		}()
 	}
 
-	return run.StandaloneRunRun(ctx, observationCtx.Logger, config, false)
+	return run.StandaloneRunRun(ctx, observationCtx.Logger, conf, false)
 }
 
 var Service service.Service = svc{}

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
@@ -344,7 +344,7 @@ func TestMiddleware(t *testing.T) {
 		if err := idpAuthnReq.Validate(); err != nil {
 			t.Fatal(err)
 		}
-		session := saml.Session{
+		samlSession := saml.Session{
 			ID:         "session-id",
 			CreateTime: time.Now(),
 			ExpireTime: time.Now().Add(24 * time.Hour),
@@ -354,7 +354,7 @@ func TestMiddleware(t *testing.T) {
 			UserName:  "testuser_username",
 			UserEmail: "testuser@email.com",
 		}
-		if err := (saml.DefaultAssertionMaker{}).MakeAssertion(idpAuthnReq, &session); err != nil {
+		if err := (saml.DefaultAssertionMaker{}).MakeAssertion(idpAuthnReq, &samlSession); err != nil {
 			t.Fatal(err)
 		}
 		if err := idpAuthnReq.MakeResponse(); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -69,16 +69,16 @@ func (r *batchChangeResolver) Description() *string {
 }
 
 func (r *batchChangeResolver) State() string {
-	var state btypes.BatchChangeState
+	var batchChangeState btypes.BatchChangeState
 	if r.batchChange.Closed() {
-		state = btypes.BatchChangeStateClosed
+		batchChangeState = btypes.BatchChangeStateClosed
 	} else if r.batchChange.IsDraft() {
-		state = btypes.BatchChangeStateDraft
+		batchChangeState = btypes.BatchChangeStateDraft
 	} else {
-		state = btypes.BatchChangeStateOpen
+		batchChangeState = btypes.BatchChangeStateOpen
 	}
 
-	return state.ToGraphQL()
+	return batchChangeState.ToGraphQL()
 }
 
 func (r *batchChangeResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
@@ -52,12 +52,12 @@ func (r *bulkOperationResolver) Progress() float64 {
 }
 
 func (r *bulkOperationResolver) Errors(ctx context.Context) ([]graphqlbackend.ChangesetJobErrorResolver, error) {
-	errors, err := r.store.ListBulkOperationErrors(ctx, store.ListBulkOperationErrorsOpts{BulkOperationID: r.bulkOperation.ID})
+	boErrors, err := r.store.ListBulkOperationErrors(ctx, store.ListBulkOperationErrorsOpts{BulkOperationID: r.bulkOperation.ID})
 	if err != nil {
 		return nil, err
 	}
 
-	changesetIDs := uniqueChangesetIDsForBulkOperationErrors(errors)
+	changesetIDs := uniqueChangesetIDsForBulkOperationErrors(boErrors)
 
 	changesetsByID := map[int64]*btypes.Changeset{}
 	reposByID := map[api.RepoID]*types.Repo{}
@@ -78,8 +78,8 @@ func (r *bulkOperationResolver) Errors(ctx context.Context) ([]graphqlbackend.Ch
 		}
 	}
 
-	res := make([]graphqlbackend.ChangesetJobErrorResolver, 0, len(errors))
-	for _, e := range errors {
+	res := make([]graphqlbackend.ChangesetJobErrorResolver, 0, len(boErrors))
+	for _, e := range boErrors {
 		ch := changesetsByID[e.ChangesetID]
 		repo, accessible := reposByID[ch.RepoID]
 		resolver := &changesetJobErrorResolver{store: r.store, gitserverClient: r.gitserverClient, changeset: ch, repo: repo}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -148,15 +148,15 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 		ChangesetID: r.changeset.ID,
 	}
 
-	state, err := parseBatchChangeState(args.State)
+	bcState, err := parseBatchChangeState(args.State)
 	if err != nil {
 		return nil, err
 	}
-	if state != "" {
-		opts.States = []btypes.BatchChangeState{state}
+	if bcState != "" {
+		opts.States = []btypes.BatchChangeState{bcState}
 	}
 
-	// If multiple `states` are provided, prefer them over `state`.
+	// If multiple `states` are provided, prefer them over `bcState`.
 	if args.States != nil {
 		states, err := parseBatchChangeStates(args.States)
 		if err != nil {
@@ -331,8 +331,8 @@ func (r *changesetResolver) ReviewState(ctx context.Context) *string {
 	if !r.changeset.Published() {
 		return nil
 	}
-	state := string(r.changeset.ExternalReviewState)
-	return &state
+	reviewState := string(r.changeset.ExternalReviewState)
+	return &reviewState
 }
 
 func (r *changesetResolver) CheckState() *string {
@@ -340,12 +340,12 @@ func (r *changesetResolver) CheckState() *string {
 		return nil
 	}
 
-	state := string(r.changeset.ExternalCheckState)
-	if state == string(btypes.ChangesetCheckStateUnknown) {
+	checkState := string(r.changeset.ExternalCheckState)
+	if checkState == string(btypes.ChangesetCheckStateUnknown) {
 		return nil
 	}
 
-	return &state
+	return &checkState
 }
 
 func (r *changesetResolver) Error() *string { return r.changeset.FailureMessage }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -1831,11 +1831,11 @@ func testBatchSpecWorkspacesResponse(t *testing.T, s *graphql.Schema, ctx contex
 		t.Fatalf("unexpected workspaces total count (-want +got):\n%s", diff)
 	}
 
-	types := map[string]int{}
+	typeCounts := map[string]int{}
 	for _, c := range response.Node.WorkspaceResolution.Workspaces.Nodes {
-		types[c.Typename]++
+		typeCounts[c.Typename]++
 	}
-	if diff := cmp.Diff(w.types, types); diff != "" {
+	if diff := cmp.Diff(w.types, typeCounts); diff != "" {
 		t.Fatalf("unexpected workspace types (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -130,7 +130,7 @@ func TestCreateBatchSpec(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	license := func(tags ...string) *licensing.Info { return &licensing.Info{Info: license.Info{Tags: tags}} }
+	licensingInfo := func(tags ...string) *licensing.Info { return &licensing.Info{Info: license.Info{Tags: tags}} }
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
@@ -180,22 +180,22 @@ func TestCreateBatchSpec(t *testing.T) {
 	}{
 		"batch changes license, restricted, over the limit": {
 			changesetSpecs: changesetSpecs,
-			licenseInfo:    license("starter"),
+			licenseInfo:    licensingInfo("starter"),
 			wantErr:        true,
 		},
 		"batch changes license, restricted, under the limit": {
 			changesetSpecs: changesetSpecs[0 : maxNumChangesets-1],
-			licenseInfo:    license("starter"),
+			licenseInfo:    licensingInfo("starter"),
 			wantErr:        false,
 		},
 		"batch changes license, unrestricted, over the limit": {
 			changesetSpecs: changesetSpecs,
-			licenseInfo:    license("starter", "batch-changes"),
+			licenseInfo:    licensingInfo("starter", "batch-changes"),
 			wantErr:        false,
 		},
 		"campaigns license, no limit": {
 			changesetSpecs: changesetSpecs,
-			licenseInfo:    license("starter", "campaigns"),
+			licenseInfo:    licensingInfo("starter", "campaigns"),
 			wantErr:        false,
 		},
 		"no license": {
@@ -782,12 +782,12 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 	}
 
 	// Second time should fail because namespace + name are not unique
-	errors := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
+	errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
 
-	if len(errors) != 1 {
+	if len(errs) != 1 {
 		t.Fatalf("expected single errors, but got none")
 	}
-	if have, want := errors[0].Message, service.ErrNameNotUnique.Error(); have != want {
+	if have, want := errs[0].Message, service.ErrNameNotUnique.Error(); have != want {
 		t.Fatalf("wrong error. want=%q, have=%q", want, have)
 	}
 
@@ -812,14 +812,14 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 		"name":      "not: valid:\nname",
 	}
 
-	errors = apitest.Exec(actorCtx, t, s, input3, &response, mutationCreateEmptyBatchChange)
+	errs = apitest.Exec(actorCtx, t, s, input3, &response, mutationCreateEmptyBatchChange)
 
-	if len(errors) != 1 {
+	if len(errs) != 1 {
 		t.Fatalf("expected single errors, but got none")
 	}
 
 	expError := "The batch change name can only contain word characters, dots and dashes."
-	if have, want := errors[0].Message, expError; !strings.Contains(have, "The batch change name can only contain word characters, dots and dashes.") {
+	if have, want := errs[0].Message, expError; !strings.Contains(have, "The batch change name can only contain word characters, dots and dashes.") {
 		t.Fatalf("wrong error. want to contain=%q, have=%q", want, have)
 	}
 }
@@ -879,15 +879,15 @@ func TestUpsertEmptyBatchChange(t *testing.T) {
 		"name":      "my-batch-change",
 	}
 
-	errors := apitest.Exec(actorCtx, t, s, badInput, &response, mutationUpsertEmptyBatchChange)
+	errs := apitest.Exec(actorCtx, t, s, badInput, &response, mutationUpsertEmptyBatchChange)
 
-	if len(errors) != 1 {
+	if len(errs) != 1 {
 		t.Fatalf("expected single errors")
 	}
 
 	wantError := "invalid ID \"bad_namespace-id\" for namespace"
 
-	if have, want := errors[0].Message, wantError; have != want {
+	if have, want := errs[0].Message, wantError; have != want {
 		t.Fatalf("wrong error. want=%q, have=%q", want, have)
 	}
 }
@@ -947,12 +947,12 @@ func TestCreateBatchChange(t *testing.T) {
 	}
 
 	// Second time it should fail
-	errors := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateBatchChange)
+	errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateBatchChange)
 
-	if len(errors) != 1 {
+	if len(errs) != 1 {
 		t.Fatalf("expected single errors, but got none")
 	}
-	if have, want := errors[0].Message, service.ErrMatchingBatchChangeExists.Error(); have != want {
+	if have, want := errs[0].Message, service.ErrMatchingBatchChangeExists.Error(); have != want {
 		t.Fatalf("wrong error. want=%q, have=%q", want, have)
 	}
 }
@@ -1688,12 +1688,12 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 		}
 
 		// Second time it should fail
-		errors := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateCredential)
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateCredential)
 
-		if len(errors) != 1 {
+		if len(errs) != 1 {
 			t.Fatalf("expected single errors, but got none")
 		}
-		if have, want := errors[0].Extensions["code"], "ErrDuplicateCredential"; have != want {
+		if have, want := errs[0].Extensions["code"], "ErrDuplicateCredential"; have != want {
 			t.Fatalf("wrong error code. want=%q, have=%q", want, have)
 		}
 	})
@@ -1758,12 +1758,12 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 		apitest.MustExec(actorCtx, t, s, input, &response, mutationDeleteCredential)
 
 		// Second time it should fail
-		errors := apitest.Exec(actorCtx, t, s, input, &response, mutationDeleteCredential)
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationDeleteCredential)
 
-		if len(errors) != 1 {
+		if len(errs) != 1 {
 			t.Fatalf("expected single errors, but got none")
 		}
-		if have, want := errors[0].Message, fmt.Sprintf("user credential not found: [%d]", userCred.ID); have != want {
+		if have, want := errs[0].Message, fmt.Sprintf("user credential not found: [%d]", userCred.ID); have != want {
 			t.Fatalf("wrong error code. want=%q, have=%q", want, have)
 		}
 	})
@@ -1780,12 +1780,12 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 		apitest.MustExec(actorCtx, t, s, input, &response, mutationDeleteCredential)
 
 		// Second time it should fail
-		errors := apitest.Exec(actorCtx, t, s, input, &response, mutationDeleteCredential)
+		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationDeleteCredential)
 
-		if len(errors) != 1 {
+		if len(errs) != 1 {
 			t.Fatalf("expected single errors, but got none")
 		}
-		if have, want := errors[0].Message, "no results"; have != want {
+		if have, want := errs[0].Message, "no results"; have != want {
 			t.Fatalf("wrong error code. want=%q, have=%q", want, have)
 		}
 	})

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -374,29 +374,29 @@ func TestQueryMonitor(t *testing.T) {
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	require.NoError(t, err)
 
-	schema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
+	gqlSchema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
 	require.NoError(t, err)
 
 	t.Run("query by user", func(t *testing.T) {
-		queryByUser(ctx, t, schema, r, user1, user2)
+		queryByUser(ctx, t, gqlSchema, r, user1, user2)
 	})
 	t.Run("query by ID", func(t *testing.T) {
-		queryByID(ctx, t, schema, r, m.(*monitor), user1, user2)
+		queryByID(ctx, t, gqlSchema, r, m.(*monitor), user1, user2)
 	})
 	t.Run("monitor paging", func(t *testing.T) {
-		monitorPaging(ctx, t, schema, user1)
+		monitorPaging(ctx, t, gqlSchema, user1)
 	})
 	t.Run("recipients paging", func(t *testing.T) {
-		recipientPaging(ctx, t, schema, user1, user2)
+		recipientPaging(ctx, t, gqlSchema, user1, user2)
 	})
 	t.Run("actions paging", func(t *testing.T) {
-		actionPaging(ctx, t, schema, user1)
+		actionPaging(ctx, t, gqlSchema, user1)
 	})
 	t.Run("trigger events paging", func(t *testing.T) {
-		triggerEventPaging(ctx, t, schema, user1)
+		triggerEventPaging(ctx, t, gqlSchema, user1)
 	})
 	t.Run("action events paging", func(t *testing.T) {
-		actionEventPaging(ctx, t, schema, user1)
+		actionEventPaging(ctx, t, gqlSchema, user1)
 	})
 }
 
@@ -701,7 +701,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
+	gqlSchema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
 	require.NoError(t, err)
 	updateInput := map[string]any{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),
@@ -712,7 +712,7 @@ func TestEditCodeMonitor(t *testing.T) {
 		"user2ID":   ns2,
 	}
 	got := apitest.UpdateCodeMonitorResponse{}
-	batchesApitest.MustExec(ctx, t, schema, updateInput, &got, editMonitor)
+	batchesApitest.MustExec(ctx, t, gqlSchema, updateInput, &got, editMonitor)
 
 	want := apitest.UpdateCodeMonitorResponse{
 		UpdateCodeMonitor: apitest.Monitor{

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -64,11 +64,11 @@ func (r *computeMatchResolver) Range() gql.RangeResolver {
 }
 
 func (r *computeMatchResolver) Environment() []gql.ComputeEnvironmentEntryResolver {
-	var result []gql.ComputeEnvironmentEntryResolver
+	var resolvers []gql.ComputeEnvironmentEntryResolver
 	for variable, value := range r.m.Environment {
-		result = append(result, newEnvironmentEntryResolver(variable, value))
+		resolvers = append(resolvers, newEnvironmentEntryResolver(variable, value))
 	}
-	return result
+	return resolvers
 }
 
 func newEnvironmentEntryResolver(variable string, value compute.Data) *computeEnvironmentEntryResolver {
@@ -214,8 +214,8 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 
 		repoResolver := getRepoResolver(m.RepoName(), "")
 		path, commit := pathAndCommitFromResult(m)
-		result := toComputeResultResolver(computeResult, repoResolver, path, commit)
-		results = append(results, result)
+		resolver := toComputeResultResolver(computeResult, repoResolver, path, commit)
+		results = append(results, resolver)
 	}
 	return results, nil
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -19,18 +19,18 @@ import (
 func toComputeResult(ctx context.Context, cmd compute.Command, match result.Match) (out []compute.Result, _ error) {
 	if v, ok := match.(*result.CommitMatch); ok && v.DiffPreview != nil {
 		for _, diffMatch := range v.CommitToDiffMatches() {
-			result, err := cmd.Run(ctx, diffMatch)
+			runResult, err := cmd.Run(ctx, diffMatch)
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, result)
+			out = append(out, runResult)
 		}
 	} else {
-		result, err := cmd.Run(ctx, match)
+		runResult, err := cmd.Run(ctx, match)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, result)
+		out = append(out, runResult)
 	}
 	return out, nil
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -41,7 +41,7 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 		return mocks.licenses.Create(subscriptionID, licenseKey)
 	}
 
-	uuid, err := uuid.NewRandom()
+	newUUID, err := uuid.NewRandom()
 	if err != nil {
 		return "", errors.Wrap(err, "new UUID")
 	}
@@ -54,7 +54,7 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 INSERT INTO product_licenses(id, product_subscription_id, license_key, license_version, license_tags, license_user_count, license_expires_at)
 VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id
 `,
-		uuid, subscriptionID, licenseKey, dbutil.NewNullInt64(int64(version)), pq.Array(info.Tags), dbutil.NewNullInt64(int64(info.UserCount)), dbutil.NullTime{Time: expiresAt},
+		newUUID, subscriptionID, licenseKey, dbutil.NewNullInt64(int64(version)), pq.Array(info.Tags), dbutil.NewNullInt64(int64(info.UserCount)), dbutil.NullTime{Time: expiresAt},
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -53,14 +53,14 @@ func (s dbSubscriptions) Create(ctx context.Context, userID int32, username stri
 		accountNumber = username[i+1:]
 	}
 
-	uuid, err := uuid.NewRandom()
+	newUUID, err := uuid.NewRandom()
 	if err != nil {
 		return "", errors.Wrap(err, "new UUID")
 	}
 	if err = s.db.QueryRowContext(ctx, `
 INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3) RETURNING id
 `,
-		uuid, userID, accountNumber,
+		newUUID, userID, accountNumber,
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/gitserverproxy_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/gitserverproxy_test.go
@@ -18,13 +18,13 @@ func TestGitserverProxySimple(t *testing.T) {
 	}))
 	defer originServer.Close()
 
-	url, err := url.Parse(originServer.URL)
+	originServerURL, err := url.Parse(originServer.URL)
 	if err != nil {
 		t.Fatalf("unexpected error parsing url: %s", err)
 	}
 
 	gs := NewMockGitserverClient()
-	gs.AddrForRepoFunc.PushReturn(url.Host, nil)
+	gs.AddrForRepoFunc.PushReturn(originServerURL.Host, nil)
 
 	proxyServer := httptest.NewServer(gitserverProxy(logtest.Scoped(t), gs, "/info/refs"))
 	defer proxyServer.Close()
@@ -57,13 +57,13 @@ func TestGitserverProxyTargetPath(t *testing.T) {
 	}))
 	defer originServer.Close()
 
-	url, err := url.Parse(originServer.URL)
+	originServerURL, err := url.Parse(originServer.URL)
 	if err != nil {
 		t.Fatalf("unexpected error parsing url: %s", err)
 	}
 
 	gs := NewMockGitserverClient()
-	gs.AddrForRepoFunc.PushReturn(url.Host, nil)
+	gs.AddrForRepoFunc.PushReturn(originServerURL.Host, nil)
 
 	proxyServer := httptest.NewServer(gitserverProxy(logtest.Scoped(t), gs, "/foo"))
 	defer proxyServer.Close()
@@ -89,13 +89,13 @@ func TestGitserverProxyHeaders(t *testing.T) {
 	}))
 	defer originServer.Close()
 
-	url, err := url.Parse(originServer.URL)
+	originServerURL, err := url.Parse(originServer.URL)
 	if err != nil {
 		t.Fatalf("unexpected error parsing url: %s", err)
 	}
 
 	gs := NewMockGitserverClient()
-	gs.AddrForRepoFunc.PushReturn(url.Host, nil)
+	gs.AddrForRepoFunc.PushReturn(originServerURL.Host, nil)
 
 	proxyServer := httptest.NewServer(gitserverProxy(logtest.Scoped(t), gs, "/test"))
 	defer proxyServer.Close()
@@ -137,13 +137,13 @@ func TestGitserverProxyRedirectWithPayload(t *testing.T) {
 	}))
 	defer originServer.Close()
 
-	url, err := url.Parse(originServer.URL)
+	originServerURL, err := url.Parse(originServer.URL)
 	if err != nil {
 		t.Fatalf("unexpected error parsing url: %s", err)
 	}
 
 	gs := NewMockGitserverClient()
-	gs.AddrForRepoFunc.PushReturn(url.Host, nil)
+	gs.AddrForRepoFunc.PushReturn(originServerURL.Host, nil)
 
 	proxyServer := httptest.NewServer(gitserverProxy(logtest.Scoped(t), gs, "/test"))
 	defer proxyServer.Close()

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
@@ -391,7 +391,7 @@ func TestHeartbeat(t *testing.T) {
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
 
-	executor := types.Executor{
+	exec := types.Executor{
 		Hostname:        "test-hostname",
 		QueueName:       "test-queue-name",
 		OS:              "test-os",
@@ -405,7 +405,7 @@ func TestHeartbeat(t *testing.T) {
 
 	handler := NewHandler(executorStore, metricsStore, QueueOptions[testRecord]{Store: s, RecordTransformer: recordTransformer})
 
-	if knownIDs, canceled, err := handler.heartbeat(context.Background(), executor, []int{testKnownID, 10}); err != nil {
+	if knownIDs, canceled, err := handler.heartbeat(context.Background(), exec, []int{testKnownID, 10}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	} else if diff := cmp.Diff([]int{testKnownID}, knownIDs); diff != "" {
 		t.Errorf("unexpected unknown ids (-want +got):\n%s", diff)
@@ -415,7 +415,7 @@ func TestHeartbeat(t *testing.T) {
 
 	if callCount := len(executorStore.UpsertHeartbeatFunc.History()); callCount != 1 {
 		t.Errorf("unexpected heartbeat upsert count. want=%d have=%d", 1, callCount)
-	} else if name := executorStore.UpsertHeartbeatFunc.History()[0].Arg1; name != executor {
+	} else if name := executorStore.UpsertHeartbeatFunc.History()[0].Arg1; name != exec {
 		t.Errorf("unexpected heartbeat name. want=%q have=%q", "deadbeef", name)
 	}
 }

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
@@ -307,7 +307,7 @@ func (r *Resolver) Notebooks(ctx context.Context, args graphqlbackend.ListNotebo
 	}
 
 	store := notebooks.Notebooks(r.db)
-	notebooks, err := store.ListNotebooks(ctx, pageOpts, opts)
+	nbs, err := store.ListNotebooks(ctx, pageOpts, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -318,14 +318,14 @@ func (r *Resolver) Notebooks(ctx context.Context, args graphqlbackend.ListNotebo
 	}
 
 	hasNextPage := false
-	if len(notebooks) == int(args.First)+1 {
+	if len(nbs) == int(args.First)+1 {
 		hasNextPage = true
-		notebooks = notebooks[:len(notebooks)-1]
+		nbs = nbs[:len(nbs)-1]
 	}
 
 	return &notebookConnectionResolver{
 		afterCursor: afterCursor,
-		notebooks:   r.notebooksToResolvers(notebooks),
+		notebooks:   r.notebooksToResolvers(nbs),
 		totalCount:  int32(count),
 		hasNextPage: hasNextPage,
 	}, nil

--- a/enterprise/cmd/frontend/internal/registry/stores/extensions.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/extensions.go
@@ -120,7 +120,7 @@ func (s *extensionStore) Create(ctx context.Context, publisherUserID, publisherO
 		return 0, errors.New("at most 1 of the publisher user/org may be set")
 	}
 
-	uuid, err := uuid.NewRandom()
+	newUUID, err := uuid.NewRandom()
 	if err != nil {
 		return 0, err
 	}
@@ -137,7 +137,7 @@ VALUES(
 	%s
 )
 RETURNING id`,
-		uuid,
+		newUUID,
 		publisherUserID,
 		publisherOrgID,
 		name,

--- a/enterprise/cmd/frontend/internal/repos/webhooks/handlers_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/handlers_test.go
@@ -93,15 +93,15 @@ func TestGitHubHandler(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
-		repos, err := repoStore.List(ctx, database.ReposListOptions{Names: []string{string(req.Repo)}})
+		repositories, err := repoStore.List(ctx, database.ReposListOptions{Names: []string{string(req.Repo)}})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		}
-		if len(repos) != 1 {
-			http.Error(w, fmt.Sprintf("expected 1 repo, got %v", len(repos)), http.StatusNotFound)
+		if len(repositories) != 1 {
+			http.Error(w, fmt.Sprintf("expected 1 repo, got %v", len(repositories)), http.StatusNotFound)
 		}
 
-		repo := repos[0]
+		repo := repositories[0]
 		res := &protocol.RepoUpdateResponse{
 			ID:   repo.ID,
 			Name: string(repo.Name),
@@ -165,11 +165,11 @@ func TestGitLabHandler(t *testing.T) {
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
 
 	db := database.NewMockDB()
-	repos := database.NewMockRepoStore()
-	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+	repositories := database.NewMockRepoStore()
+	repositories.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
 		return api.RepoName(repoName), nil
 	})
-	db.ReposFunc.SetDefaultReturn(repos)
+	db.ReposFunc.SetDefaultReturn(repositories)
 
 	handler := NewGitLabHandler()
 	data, err := os.ReadFile("testdata/gitlab-push.json")
@@ -201,11 +201,11 @@ func TestBitbucketServerHandler(t *testing.T) {
 	repoName := "bitbucket.sgdev.org/private/test-2020-06-01"
 
 	db := database.NewMockDB()
-	repos := database.NewMockRepoStore()
-	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+	repositories := database.NewMockRepoStore()
+	repositories.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
 		return "bitbucket.sgdev.org/private/test-2020-06-01", nil
 	})
-	db.ReposFunc.SetDefaultReturn(repos)
+	db.ReposFunc.SetDefaultReturn(repositories)
 
 	handler := NewBitbucketServerHandler()
 	data, err := os.ReadFile("testdata/bitbucket-server-push.json")
@@ -237,11 +237,11 @@ func TestBitbucketCloudHandler(t *testing.T) {
 	repoName := "bitbucket.org/sourcegraph-testing/sourcegraph"
 
 	db := database.NewMockDB()
-	repos := database.NewMockRepoStore()
-	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+	repositories := database.NewMockRepoStore()
+	repositories.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
 		return "bitbucket.org/sourcegraph-testing/sourcegraph", nil
 	})
-	db.ReposFunc.SetDefaultReturn(repos)
+	db.ReposFunc.SetDefaultReturn(repositories)
 
 	handler := NewBitbucketCloudHandler()
 	data, err := os.ReadFile("testdata/bitbucket-cloud-push.json")

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -221,7 +221,7 @@ func (r *batchSpecWorkspaceCreator) process(
 	usedCacheEntries := []int64{}
 	changesetsByWorkspace := make(map[*btypes.BatchSpecWorkspace][]*btypes.ChangesetSpec)
 
-	author, err := author.GetChangesetAuthorForUser(ctx, database.UsersWith(r.logger, r.store), spec.UserID)
+	changesetAuthor, err := author.GetChangesetAuthorForUser(ctx, database.UsersWith(r.logger, r.store), spec.UserID)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func (r *batchSpecWorkspaceCreator) process(
 
 		workspace.dbWorkspace.CachedResultFound = true
 
-		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, *res.Value, workspace.dbWorkspace.Path, true, author)
+		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, *res.Value, workspace.dbWorkspace.Path, true, changesetAuthor)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -429,16 +429,16 @@ func newMetricsForBitbucketProjectPermissionsQueries(logger log.Logger) bitbucke
 	})
 	observationCtx.Registerer.MustRegister(resets)
 
-	errors := prometheus.NewCounter(prometheus.CounterOpts{
+	errorCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_explicit_permissions_bitbucket_project_query_errors_total",
 		Help: "The number of errors that occur during job.",
 	})
-	observationCtx.Registerer.MustRegister(errors)
+	observationCtx.Registerer.MustRegister(errorCounter)
 
 	return bitbucketProjectPermissionsMetrics{
 		workerMetrics: workerutil.NewMetrics(observationCtx, "explicit_permissions_bitbucket_project_queries"),
 		resets:        resets,
 		resetFailures: resetFailures,
-		errors:        errors,
+		errors:        errorCounter,
 	}
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -896,18 +896,18 @@ func publishFinalDockerImage(c Config, app string) operations.Operation {
 		devImage := images.DevRegistryImage(app, "")
 		publishImage := images.PublishedRegistryImage(app, "")
 
-		var images []string
+		var imgs []string
 		for _, image := range []string{publishImage, devImage} {
 			if app != "server" || c.RunType.Is(runtype.TaggedRelease, runtype.ImagePatch, runtype.ImagePatchNoTest) {
-				images = append(images, fmt.Sprintf("%s:%s", image, c.Version))
+				imgs = append(imgs, fmt.Sprintf("%s:%s", image, c.Version))
 			}
 
 			if app == "server" && c.RunType.Is(runtype.ReleaseBranch) {
-				images = append(images, fmt.Sprintf("%s:%s-insiders", image, c.Branch))
+				imgs = append(imgs, fmt.Sprintf("%s:%s-insiders", image, c.Branch))
 			}
 
 			if c.RunType.Is(runtype.MainBranch) {
-				images = append(images, fmt.Sprintf("%s:insiders", image))
+				imgs = append(imgs, fmt.Sprintf("%s:insiders", image))
 			}
 		}
 
@@ -923,11 +923,11 @@ func publishFinalDockerImage(c Config, app string) operations.Operation {
 			strconv.Itoa(c.BuildNumber),
 		} {
 			internalImage := fmt.Sprintf("%s:%s", devImage, tag)
-			images = append(images, internalImage)
+			imgs = append(imgs, internalImage)
 		}
 
 		candidateImage := fmt.Sprintf("%s:%s", devImage, c.candidateImageTag())
-		cmd := fmt.Sprintf("./dev/ci/docker-publish.sh %s %s", candidateImage, strings.Join(images, " "))
+		cmd := fmt.Sprintf("./dev/ci/docker-publish.sh %s %s", candidateImage, strings.Join(imgs, " "))
 
 		pipeline.AddStep(fmt.Sprintf(":docker: :truck: %s", app),
 			// This step just pulls a prebuild image and pushes it to some registries. The

--- a/enterprise/dev/ci/scripts/app-token/main.go
+++ b/enterprise/dev/ci/scripts/app-token/main.go
@@ -29,14 +29,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	jwt, err := genJwtToken(*appID, *keyPath)
+	jwtToken, err := genJwtToken(*appID, *keyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: jwt},
+		&oauth2.Token{AccessToken: jwtToken},
 	)
 	tc := oauth2.NewClient(ctx, ts)
 	ghc := github.NewClient(tc)

--- a/enterprise/internal/authz/bitbucketcloud/authz_test.go
+++ b/enterprise/internal/authz/bitbucketcloud/authz_test.go
@@ -26,12 +26,12 @@ func TestNewAuthzProviders(t *testing.T) {
 			[]schema.AuthProviders{},
 		)
 
-		assert := assert.New(t)
+		assertion := assert.New(t)
 
-		assert.Len(initResults.Providers, 0, "unexpected a providers: %+v", initResults.Providers)
-		assert.Len(initResults.Problems, 0, "unexpected problems: %+v", initResults.Problems)
-		assert.Len(initResults.Warnings, 0, "unexpected warnings: %+v", initResults.Warnings)
-		assert.Len(initResults.InvalidConnections, 0, "unexpected invalidConnections: %+v", initResults.InvalidConnections)
+		assertion.Len(initResults.Providers, 0, "unexpected a providers: %+v", initResults.Providers)
+		assertion.Len(initResults.Problems, 0, "unexpected problems: %+v", initResults.Problems)
+		assertion.Len(initResults.Warnings, 0, "unexpected warnings: %+v", initResults.Warnings)
+		assertion.Len(initResults.InvalidConnections, 0, "unexpected invalidConnections: %+v", initResults.InvalidConnections)
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -37,12 +37,12 @@ func TestNewAuthzProviders(t *testing.T) {
 			false,
 		)
 
-		assert := assert.New(t)
+		assertion := assert.New(t)
 
-		assert.Len(initResults.Providers, 0, "unexpected a providers: %+v", initResults.Providers)
-		assert.Len(initResults.Problems, 0, "unexpected problems: %+v", initResults.Problems)
-		assert.Len(initResults.Warnings, 0, "unexpected warnings: %+v", initResults.Warnings)
-		assert.Len(initResults.InvalidConnections, 0, "unexpected invalidConnections: %+v", initResults.InvalidConnections)
+		assertion.Len(initResults.Providers, 0, "unexpected a providers: %+v", initResults.Providers)
+		assertion.Len(initResults.Problems, 0, "unexpected problems: %+v", initResults.Problems)
+		assertion.Len(initResults.Warnings, 0, "unexpected warnings: %+v", initResults.Warnings)
+		assertion.Len(initResults.InvalidConnections, 0, "unexpected invalidConnections: %+v", initResults.InvalidConnections)
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -1138,30 +1138,30 @@ func TestHandleArchivedRepo(t *testing.T) {
 		ch := &btypes.Changeset{ExternalState: btypes.ChangesetExternalStateDraft}
 		repo := &types.Repo{Archived: false}
 
-		store := repos.NewMockStore()
-		store.UpdateRepoFunc.SetDefaultReturn(repo, nil)
+		mockStore := repos.NewMockStore()
+		mockStore.UpdateRepoFunc.SetDefaultReturn(repo, nil)
 
-		err := handleArchivedRepo(ctx, store, repo, ch)
+		err := handleArchivedRepo(ctx, mockStore, repo, ch)
 		assert.NoError(t, err)
 		assert.True(t, repo.Archived)
 		assert.Equal(t, btypes.ChangesetExternalStateReadOnly, ch.ExternalState)
-		assert.NotEmpty(t, store.UpdateRepoFunc.History())
+		assert.NotEmpty(t, mockStore.UpdateRepoFunc.History())
 	})
 
 	t.Run("store error", func(t *testing.T) {
 		ch := &btypes.Changeset{ExternalState: btypes.ChangesetExternalStateDraft}
 		repo := &types.Repo{Archived: false}
 
-		store := repos.NewMockStore()
+		mockStore := repos.NewMockStore()
 		want := errors.New("")
-		store.UpdateRepoFunc.SetDefaultReturn(nil, want)
+		mockStore.UpdateRepoFunc.SetDefaultReturn(nil, want)
 
-		have := handleArchivedRepo(ctx, store, repo, ch)
+		have := handleArchivedRepo(ctx, mockStore, repo, ch)
 		assert.Error(t, have)
 		assert.ErrorIs(t, have, want)
 		assert.True(t, repo.Archived)
 		assert.Equal(t, btypes.ChangesetExternalStateDraft, ch.ExternalState)
-		assert.NotEmpty(t, store.UpdateRepoFunc.History())
+		assert.NotEmpty(t, mockStore.UpdateRepoFunc.History())
 	})
 }
 

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -391,8 +391,8 @@ func getCloneURL(repo *types.Repo) (*vcs.URL, error) {
 	}
 
 	parsedURLs := make([]*vcs.URL, 0, len(cloneURLs))
-	for _, url := range cloneURLs {
-		parsedURL, err := vcs.ParseURL(url)
+	for _, cloneURL := range cloneURLs {
+		parsedURL, err := vcs.ParseURL(cloneURL)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -212,7 +212,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 		}
 	}
 
-	author, err := author.GetChangesetAuthorForUser(ctx, database.UsersWith(s.logger, s), batchSpec.UserID)
+	changesetAuthor, err := author.GetChangesetAuthorForUser(ctx, database.UsersWith(s.logger, s), batchSpec.UserID)
 	if err != nil {
 		return false, errors.Wrap(err, "creating changeset author")
 	}
@@ -229,7 +229,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 		latestStepResult.Value,
 		workspace.Path,
 		true,
-		author,
+		changesetAuthor,
 	)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to build changeset specs from cache")

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -287,7 +287,7 @@ type syncerMetrics struct {
 }
 
 func makeMetrics(observationCtx *observation.Context) *syncerMetrics {
-	metrics := &syncerMetrics{
+	m := &syncerMetrics{
 		syncs: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "src_repoupdater_changeset_syncer_syncs",
 			Help: "Total number of changeset syncs",
@@ -315,14 +315,14 @@ func makeMetrics(observationCtx *observation.Context) *syncerMetrics {
 			Help: "The number of changesets behind schedule",
 		}, []string{"codehost"}),
 	}
-	observationCtx.Registerer.MustRegister(metrics.syncs)
-	observationCtx.Registerer.MustRegister(metrics.priorityQueued)
-	observationCtx.Registerer.MustRegister(metrics.syncDuration)
-	observationCtx.Registerer.MustRegister(metrics.computeScheduleDuration)
-	observationCtx.Registerer.MustRegister(metrics.scheduleSize)
-	observationCtx.Registerer.MustRegister(metrics.behindSchedule)
+	observationCtx.Registerer.MustRegister(m.syncs)
+	observationCtx.Registerer.MustRegister(m.priorityQueued)
+	observationCtx.Registerer.MustRegister(m.syncDuration)
+	observationCtx.Registerer.MustRegister(m.computeScheduleDuration)
+	observationCtx.Registerer.MustRegister(m.scheduleSize)
+	observationCtx.Registerer.MustRegister(m.behindSchedule)
 
-	return metrics
+	return m
 }
 
 // Run will start the process of changeset syncing. It is long running

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -51,7 +51,7 @@ func NewScheduler(
 		indexEnqueuer: indexEnqueuer,
 	}
 
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_autoindexing_background",
@@ -70,7 +70,7 @@ func NewScheduler(
 		observationCtx.Operation(observation.Op{
 			Name:              "codeintel.indexing.HandleIndexSchedule",
 			MetricLabelValues: []string{"HandleIndexSchedule"},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.As(err, &inference.LimitError{}) {
 					return observation.EmitForDefault.Without(observation.EmitForMetrics)

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
@@ -21,7 +21,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_autoindexing_inference",
@@ -34,7 +34,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.autoindexing.inference.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/store/store_sourced_commits_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store_sourced_commits_test.go
@@ -30,9 +30,9 @@ func newTest(db database.DB) *store {
 }
 
 func TestProcessStaleSourcedCommits(t *testing.T) {
-	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
-	db := database.NewDB(logger, sqlDB)
+	log := logtest.Scoped(t)
+	sqlDB := dbtest.NewDB(log, t)
+	db := database.NewDB(log, sqlDB)
 	store := newTest(db)
 
 	ctx := context.Background()

--- a/enterprise/internal/codeintel/autoindexing/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/service_test.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func TestQueueIndexesExplicit(t *testing.T) {
-	config := `{
+	conf := `{
 		"shared_steps": [
 			{
 				"root": "/",
@@ -74,7 +74,7 @@ func TestQueueIndexesExplicit(t *testing.T) {
 		mockGitserverClient,
 		nil, // symbolsClient
 	)
-	_, _ = service.QueueIndexes(context.Background(), 42, "HEAD", config, false, false)
+	_, _ = service.QueueIndexes(context.Background(), 42, "HEAD", conf, false, false)
 
 	if len(mockDBStore.IsQueuedFunc.History()) != 1 {
 		t.Errorf("unexpected number of calls to IsQueued. want=%d have=%d", 1, len(mockDBStore.IsQueuedFunc.History()))

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -27,7 +27,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_codenav_lsifstore",
@@ -40,7 +40,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.codenav.lsifstore.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/codenav/internal/store/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/store/observability.go
@@ -15,7 +15,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_codenav_store",
@@ -28,7 +28,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.codenav.store.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/codenav/observability.go
+++ b/enterprise/internal/codeintel/codenav/observability.go
@@ -26,7 +26,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_codenav",
@@ -39,7 +39,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.codenav.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/policies/enterprise/matcher.go
+++ b/enterprise/internal/codeintel/policies/enterprise/matcher.go
@@ -67,7 +67,7 @@ func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int
 	}
 
 	// mutable context
-	context := matcherContext{
+	mContext := matcherContext{
 		repositoryID:   repositoryID,
 		policies:       policies,
 		patterns:       patterns,
@@ -85,26 +85,26 @@ func (m *Matcher) CommitsDescribedByPolicy(ctx context.Context, repositoryID int
 			switch refDescription.Type {
 			case gitdomain.RefTypeTag:
 				// Match tagged commits
-				m.matchTaggedCommits(context, commit, refDescription, now)
+				m.matchTaggedCommits(mContext, commit, refDescription, now)
 
 			case gitdomain.RefTypeBranch:
 				// Match tips of branches
-				m.matchBranchHeads(context, commit, refDescription, now)
+				m.matchBranchHeads(mContext, commit, refDescription, now)
 			}
 		}
 	}
 
 	// Match commits on branches but not at tip
-	if err := m.matchCommitsOnBranch(ctx, context, now); err != nil {
+	if err := m.matchCommitsOnBranch(ctx, mContext, now); err != nil {
 		return nil, err
 	}
 
 	// Match comments via rev-parse
-	if err := m.matchCommitPolicies(ctx, context, now); err != nil {
+	if err := m.matchCommitPolicies(ctx, mContext, now); err != nil {
 		return nil, err
 	}
 
-	return context.commitMap, nil
+	return mContext.commitMap, nil
 }
 
 type matcherContext struct {

--- a/enterprise/internal/codeintel/policies/observability.go
+++ b/enterprise/internal/codeintel/policies/observability.go
@@ -28,7 +28,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_policies",
@@ -41,7 +41,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.policies.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/policies/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/root_resolver.go
@@ -93,12 +93,12 @@ func (r *rootResolver) CodeIntelligenceConfigurationPolicies(ctx context.Context
 		opts.ForIndexing = *args.ForIndexing
 	}
 
-	policies, totalCount, err := r.policySvc.GetConfigurationPolicies(ctx, opts)
+	configPolicies, totalCount, err := r.policySvc.GetConfigurationPolicies(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewCodeIntelligenceConfigurationPolicyConnectionResolver(r.policySvc, policies, totalCount, traceErrs), nil
+	return NewCodeIntelligenceConfigurationPolicyConnectionResolver(r.policySvc, configPolicies, totalCount, traceErrs), nil
 }
 
 // 🚨 SECURITY: Only site admins may modify code intelligence configuration policies

--- a/enterprise/internal/codeintel/shared/gitserver/observability.go
+++ b/enterprise/internal/codeintel/shared/gitserver/observability.go
@@ -29,7 +29,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_gitserver",
@@ -42,7 +42,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.gitserver.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					return observation.EmitForNone

--- a/enterprise/internal/codeintel/shared/resolvers/git_commit_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_commit_resolver.go
@@ -43,9 +43,9 @@ func (r *GitCommitResolver) AbbreviatedOID() string {
 }
 
 func (r *GitCommitResolver) URL() string {
-	url := r.repoResolver.url()
-	url.Path += "/-/commit/" + r.inputRevOrImmutableRev()
-	return url.String()
+	u := r.repoResolver.url()
+	u.Path += "/-/commit/" + r.inputRevOrImmutableRev()
+	return u.String()
 }
 
 // inputRevOrImmutableRev returns the input revspec, if it is provided and nonempty. Otherwise it returns the
@@ -59,9 +59,9 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 
 func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 	// Dereference to copy the URL to avoid mutation
-	url := *r.repoResolver.RepoMatch.URL()
-	url.Path += "@" + string(r.oid)
-	return &url
+	repoURL := *r.repoResolver.RepoMatch.URL()
+	repoURL.Path += "@" + string(r.oid)
+	return &repoURL
 }
 
 // repoRevURL returns the URL path prefix to use when constructing URLs to resources at this
@@ -71,7 +71,7 @@ func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 // "/REPO/-/commit/REVSPEC").
 func (r *GitCommitResolver) repoRevURL() *url.URL {
 	// Dereference to copy to avoid mutation
-	url := *r.repoResolver.RepoMatch.URL()
+	repoURL := *r.repoResolver.RepoMatch.URL()
 	var rev string
 	if r.inputRev != nil {
 		rev = *r.inputRev // use the original input rev from the user
@@ -79,7 +79,7 @@ func (r *GitCommitResolver) repoRevURL() *url.URL {
 		rev = string(r.oid)
 	}
 	if rev != "" {
-		url.Path += "@" + rev
+		repoURL.Path += "@" + rev
 	}
-	return &url
+	return &repoURL
 }

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -90,13 +90,13 @@ func (r *GitTreeEntryResolver) Repository() resolverstubs.RepositoryResolver {
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() string {
-	url := r.commit.canonicalRepoRevURL()
-	return r.urlPath(url).String()
+	canonicalURL := r.commit.canonicalRepoRevURL()
+	return r.urlPath(canonicalURL).String()
 }
 
 func (r *GitTreeEntryResolver) IsRoot() bool {
-	path := path.Clean(r.Path())
-	return path == "/" || path == "." || path == ""
+	cleanedPath := path.Clean(r.Path())
+	return cleanedPath == "/" || cleanedPath == "." || cleanedPath == ""
 }
 
 func (r *GitTreeEntryResolver) IsDirectory() bool { return r.stat.Mode().IsDir() }

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
@@ -173,8 +173,8 @@ func (r *UploadResolver) AuditLogs(ctx context.Context) (*[]resolverstubs.LSIFUp
 	}
 
 	resolvers := make([]resolverstubs.LSIFUploadsAuditLogsResolver, 0, len(logs))
-	for _, log := range logs {
-		resolvers = append(resolvers, NewLSIFUploadsAuditLogsResolver(log))
+	for _, uploadLog := range logs {
+		resolvers = append(resolvers, NewLSIFUploadsAuditLogsResolver(uploadLog))
 	}
 
 	return &resolvers, nil

--- a/enterprise/internal/codeintel/shared/types/scip_test.go
+++ b/enterprise/internal/codeintel/shared/types/scip_test.go
@@ -140,8 +140,8 @@ func TestComparePositionToRange(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if cmp := comparePositionToRange(5, 11, 5, 13, testCase.line, testCase.character); cmp != testCase.expected {
-			t.Errorf("unexpected ComparePositionSCIP result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmp)
+		if cmpRes := comparePositionToRange(5, 11, 5, 13, testCase.line, testCase.character); cmpRes != testCase.expected {
+			t.Errorf("unexpected ComparePositionSCIP result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmpRes)
 		}
 	}
 }

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -38,7 +38,7 @@ func NewService(
 	repoStore := backend.NewRepos(scopedContext("repos", observationCtx).Logger, db, gitserver.NewClient())
 	lsifStore := lsifstore.New(scopedContext("lsifstore", observationCtx), codeIntelDB)
 	policyMatcher := policiesEnterprise.NewMatcher(gsc, policiesEnterprise.RetentionExtractor, true, false)
-	locker := locker.NewWith(db, "codeintel")
+	ciLocker := locker.NewWith(db, "codeintel")
 
 	rankingBucket := func() *storage.BucketHandle {
 		if rankingBucketCredentialsFile == "" {
@@ -68,7 +68,7 @@ func NewService(
 		rankingBucket,
 		nil, // written in circular fashion
 		policyMatcher,
-		locker,
+		ciLocker,
 	)
 	svc.policySvc = policies.NewService(observationCtx, db, svc, gsc)
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -26,7 +26,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_uploads_lsifstore",
@@ -39,7 +39,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.uploads.lsifstore.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -81,7 +81,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_uploads_store",
@@ -94,7 +94,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.uploads.store.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -1074,12 +1074,12 @@ func (s *store) SourcedCommitsWithoutCommittedAt(ctx context.Context, batchSize 
 	}})
 	defer func() { endObservation(1, observation.Args{}) }()
 
-	batch, err := scanSourcedCommits(s.db.Query(ctx, sqlf.Sprintf(sourcedCommitsWithoutCommittedAtQuery, batchSize)))
+	batchOfCommits, err := scanSourcedCommits(s.db.Query(ctx, sqlf.Sprintf(sourcedCommitsWithoutCommittedAtQuery, batchSize)))
 	if err != nil {
 		return nil, err
 	}
 
-	return batch, nil
+	return batchOfCommits, nil
 }
 
 const sourcedCommitsWithoutCommittedAtQuery = `

--- a/enterprise/internal/codeintel/uploads/transport/http/auth/gitlab.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/auth/gitlab.go
@@ -42,9 +42,9 @@ func enforceAuthViaGitLab(ctx context.Context, query url.Values, repoName string
 	values.Set("sort", "asc")
 
 	// Build url of initial page of results
-	url := *gitlabURL
-	url.RawQuery = values.Encode()
-	nextURL := url.String()
+	urlCopy := *gitlabURL
+	urlCopy.RawQuery = values.Encode()
+	nextURL := urlCopy.String()
 
 	for nextURL != "" {
 		// Get current page of results, and prep the loop for the next iteration. If after

--- a/enterprise/internal/codeintel/uploads/transport/http/auth/gitlab_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/auth/gitlab_test.go
@@ -22,8 +22,8 @@ func TestEnforceAuthViaGitLab(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		makeLinkHeader := func(cursor string) string {
-			url := fmt.Sprintf("%s?cursor=%s", gitlabURL, cursor)
-			link := linkheader.Link{URL: url, Rel: "next"}
+			urlWithCursor := fmt.Sprintf("%s?cursor=%s", gitlabURL, cursor)
+			link := linkheader.Link{URL: urlWithCursor, Rel: "next"}
 			return link.String()
 		}
 

--- a/enterprise/internal/codeintel/uploads/transport/http/observability.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/observability.go
@@ -12,7 +12,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"codeintel_uploads_transport_http",
 		metrics.WithLabels("op"),
@@ -23,7 +23,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.uploads.transport.http.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -62,12 +62,12 @@ func Settings(ctx context.Context) (_ *schema.Settings, err error) {
 		return nil, errors.Wrap(err, "marshal request body")
 	}
 
-	url, err := gqlURL("CodeMonitorSettings")
+	urlStr, err := gqlURL("CodeMonitorSettings")
 	if err != nil {
 		return nil, errors.Wrap(err, "construct frontend URL")
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
+	req, err := http.NewRequest("POST", urlStr, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, errors.Wrap(err, "construct request")
 	}

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -91,9 +91,9 @@ func TestAddCodeMonitorHook(t *testing.T) {
 			"type:commit a or b repo:c context:global",
 		}
 
-		for _, query := range queries {
+		for _, q := range queries {
 			t.Run("", func(t *testing.T) {
-				test(t, query)
+				test(t, q)
 			})
 		}
 	})

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -52,8 +52,8 @@ func Test_matchOnly(t *testing.T) {
 
 	test := func(input string, serialize serializer) string {
 		r, _ := regexp.Compile(input)
-		result := matchOnly(data, r)
-		w := want{Input: input, Result: serialize(result)}
+		matchContext := matchOnly(data, r)
+		w := want{Input: input, Result: serialize(matchContext)}
 		v, _ := json.MarshalIndent(w, "", "  ")
 		return string(v)
 	}

--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -134,11 +134,11 @@ func (c *Output) Run(ctx context.Context, r result.Match) (Result, error) {
 			return nil, err
 		}
 
-		result, err := toTextResult(ctx, content, c.SearchPattern, outputPattern, c.Separator, c.Selector)
+		textResult, err := toTextResult(ctx, content, c.SearchPattern, outputPattern, c.Separator, c.Selector)
 		if err != nil {
 			return nil, err
 		}
-		sb.WriteString(result)
+		sb.WriteString(textResult)
 	}
 
 	switch c.Kind {

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -17,11 +17,11 @@ import (
 
 func Test_output(t *testing.T) {
 	test := func(input string, cmd *Output) string {
-		result, err := output(context.Background(), input, cmd.SearchPattern, cmd.OutputPattern, cmd.Separator)
+		content, err := output(context.Background(), input, cmd.SearchPattern, cmd.OutputPattern, cmd.Separator)
 		if err != nil {
 			return err.Error()
 		}
-		return result
+		return content
 	}
 
 	autogold.Want(
@@ -83,17 +83,17 @@ func commitMatch(content string) result.Match {
 func TestRun(t *testing.T) {
 	test := func(q string, m result.Match) string {
 		computeQuery, _ := Parse(q)
-		res, err := computeQuery.Command.Run(context.Background(), m)
+		commandResult, err := computeQuery.Command.Run(context.Background(), m)
 		if err != nil {
 			return err.Error()
 		}
 
-		switch r := res.(type) {
+		switch r := commandResult.(type) {
 		case *Text:
 			return r.Value
 		case *TextExtra:
-			result, _ := json.Marshal(r)
-			return string(result)
+			commandResult, _ := json.Marshal(r)
+			return string(commandResult)
 		}
 		return "Error, unrecognized result type returned"
 	}

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -183,8 +183,8 @@ func toJSONString(template *Template) string {
 	for _, atom := range *template {
 		jsons = append(jsons, toJSON(atom))
 	}
-	json, _ := json.Marshal(jsons)
-	return string(json)
+	j, _ := json.Marshal(jsons)
+	return string(j)
 }
 
 type MetaEnvironment struct {

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -90,7 +90,7 @@ func countCaptureGroupsFunc(querystring string) (AggregationCountFunc, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getCasedPattern")
 	}
-	regexp, err := regexp.Compile(pattern.String())
+	regex, err := regexp.Compile(pattern.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not compile regexp")
 	}
@@ -100,7 +100,7 @@ func countCaptureGroupsFunc(querystring string) (AggregationCountFunc, error) {
 		if len(content) != 0 {
 			matches := map[MatchKey]int{}
 			for _, contentPiece := range content {
-				for _, submatches := range regexp.FindAllStringSubmatchIndex(contentPiece, -1) {
+				for _, submatches := range regex.FindAllStringSubmatchIndex(contentPiece, -1) {
 					contentMatches := fromRegexpMatches(submatches, contentPiece)
 					for value, count := range contentMatches {
 						key := MatchKey{Repo: string(r.RepoName().Name), RepoID: int32(r.RepoName().ID), Group: value}

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -22,14 +22,14 @@ import (
 // and webhook insights across all user settings, and enqueue work for the query runner and webhook
 // runner workers to perform.
 func newInsightEnqueuer(ctx context.Context, observationCtx *observation.Context, workerBaseStore *basestore.Store, insightStore store.DataSeriesStore) goroutine.BackgroundRoutine {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"insights_enqueuer",
 		metrics.WithCountHelp("Total number of insights enqueuer executions"),
 	)
 	operation := observationCtx.Operation(observation.Op{
 		Name:    "Enqueuer.Run",
-		Metrics: metrics,
+		Metrics: redMetrics,
 	})
 
 	// Note: We run this goroutine once every hour, and StalledMaxAge in queryrunner/ is

--- a/enterprise/internal/insights/background/queryrunner/cleaner.go
+++ b/enterprise/internal/insights/background/queryrunner/cleaner.go
@@ -19,14 +19,14 @@ import (
 // num_series*num_repos*num_timeframes jobs (example: 20*40,000*6 in an average case) which
 // can quickly add up to be millions of jobs left in a "completed" state in the DB.
 func NewCleaner(ctx context.Context, observationCtx *observation.Context, workerBaseStore *basestore.Store) goroutine.BackgroundRoutine {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"insights_query_runner_cleaner",
 		metrics.WithCountHelp("Total number of insights queryrunner cleaner executions"),
 	)
 	operation := observationCtx.Operation(observation.Op{
 		Name:    "QueryRunner.Cleaner.Run",
-		Metrics: metrics,
+		Metrics: redMetrics,
 	})
 
 	// We look for jobs to clean up every hour.

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -45,7 +45,7 @@ func WithBase(insightsDB edb.InsightsDB, primaryDB database.DB, clock func() tim
 	insightStore := store.NewInsightStore(insightsDB)
 	timeSeriesStore := store.NewWithClock(insightsDB, store.NewInsightPermissionStore(primaryDB), clock)
 	dashboardStore := store.NewDashboardStore(insightsDB)
-	scheduler := scheduler.NewScheduler(insightsDB)
+	insightsScheduler := scheduler.NewScheduler(insightsDB)
 	workerBaseStore := basestore.NewWithHandle(primaryDB.Handle())
 
 	return &baseInsightResolver{
@@ -53,7 +53,7 @@ func WithBase(insightsDB edb.InsightsDB, primaryDB database.DB, clock func() tim
 		timeSeriesStore: timeSeriesStore,
 		dashboardStore:  dashboardStore,
 		workerBaseStore: workerBaseStore,
-		scheduler:       scheduler,
+		scheduler:       insightsScheduler,
 		insightsDB:      insightsDB,
 		postgresDB:      primaryDB,
 	}

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -171,11 +171,11 @@ func (h *newBackfillHandler) Handle(ctx context.Context, logger log.Logger, job 
 
 func parseQuery(series types.InsightSeries) (query.Plan, error) {
 	if series.GeneratedFromCaptureGroups {
-		query, err := compute.Parse(series.Query)
+		seriesQuery, err := compute.Parse(series.Query)
 		if err != nil {
 			return nil, errors.Wrap(err, "compute.Parse")
 		}
-		searchQuery, err := query.ToSearchQuery()
+		searchQuery, err := seriesQuery.ToSearchQuery()
 		if err != nil {
 			return nil, errors.Wrap(err, "ToSearchQuery")
 		}

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -66,7 +66,7 @@ SELECT time,
 		t.Fatal(err)
 	}
 
-	time := func(s string) *time.Time {
+	parseTime := func(s string) *time.Time {
 		v, err := time.Parse(time.RFC3339, s)
 		if err != nil {
 			t.Fatal(err)
@@ -87,8 +87,8 @@ SELECT time,
 	t.Run("subset of data", func(t *testing.T) {
 		// Confirm we can get a subset of data points.
 		points, err = store.SeriesPoints(ctx, SeriesPointsOpts{
-			From: time("2020-03-01T00:00:00Z"),
-			To:   time("2020-06-01T00:00:00Z"),
+			From: parseTime("2020-03-01T00:00:00Z"),
+			To:   parseTime("2020-06-01T00:00:00Z"),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCheckFeature(t *testing.T) {
-	license := func(tags ...string) *Info { return &Info{Info: license.Info{Tags: tags}} }
+	licenseInfo := func(tags ...string) *Info { return &Info{Info: license.Info{Tags: tags}} }
 
 	check := func(t *testing.T, feature Feature, info *Info, wantEnabled bool) {
 		t.Helper()
@@ -37,126 +37,126 @@ func TestCheckFeature(t *testing.T) {
 	t.Run(string(FeatureSSO), func(t *testing.T) {
 		check(t, FeatureSSO, nil, false)
 
-		check(t, FeatureSSO, license("starter"), false)
-		check(t, FeatureSSO, license("starter", string(FeatureSSO)), true)
-		check(t, FeatureSSO, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureSSO, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureSSO, license(), true)
+		check(t, FeatureSSO, licenseInfo("starter"), false)
+		check(t, FeatureSSO, licenseInfo("starter", string(FeatureSSO)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureSSO, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureSSO, licenseInfo(), true)
 
-		check(t, FeatureSSO, license(plan(PlanTeam0)), true)
-		check(t, FeatureSSO, license(plan(PlanEnterprise0)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanTeam0)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanEnterprise0)), true)
 
-		check(t, FeatureSSO, license(plan(PlanBusiness0)), true)
-		check(t, FeatureSSO, license(plan(PlanEnterprise1)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanBusiness0)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanEnterprise1)), true)
 
-		check(t, FeatureSSO, license(plan(PlanFree0)), true)
+		check(t, FeatureSSO, licenseInfo(plan(PlanFree0)), true)
 	})
 
 	t.Run(string(FeatureExplicitPermissionsAPI), func(t *testing.T) {
 		check(t, FeatureExplicitPermissionsAPI, nil, false)
 
-		check(t, FeatureExplicitPermissionsAPI, license("starter"), false)
-		check(t, FeatureExplicitPermissionsAPI, license("starter", string(FeatureExplicitPermissionsAPI)), true)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureExplicitPermissionsAPI, license(), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo("starter"), false)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo("starter", string(FeatureExplicitPermissionsAPI)), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(), true)
 
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanTeam0)), true)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanEnterprise0)), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanTeam0)), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanEnterprise0)), true)
 
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanBusiness0)), false)
-		check(t, FeatureExplicitPermissionsAPI, license(plan(PlanEnterprise1)), true)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanBusiness0)), false)
+		check(t, FeatureExplicitPermissionsAPI, licenseInfo(plan(PlanEnterprise1)), true)
 	})
 
 	t.Run(string(FeatureACLs), func(t *testing.T) {
 		check(t, FeatureACLs, nil, false)
 
-		check(t, FeatureACLs, license("starter"), false)
-		check(t, FeatureACLs, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureACLs, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureACLs, license(), true)
+		check(t, FeatureACLs, licenseInfo("starter"), false)
+		check(t, FeatureACLs, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureACLs, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureACLs, licenseInfo(), true)
 
-		check(t, FeatureACLs, license(plan(PlanTeam0)), true)
-		check(t, FeatureACLs, license(plan(PlanEnterprise0)), true)
-		check(t, FeatureACLs, license(plan(PlanEnterprise0), string(FeatureACLs)), true)
+		check(t, FeatureACLs, licenseInfo(plan(PlanTeam0)), true)
+		check(t, FeatureACLs, licenseInfo(plan(PlanEnterprise0)), true)
+		check(t, FeatureACLs, licenseInfo(plan(PlanEnterprise0), string(FeatureACLs)), true)
 
-		check(t, FeatureACLs, license(plan(PlanBusiness0)), true)
-		check(t, FeatureACLs, license(plan(PlanEnterprise1)), true)
+		check(t, FeatureACLs, licenseInfo(plan(PlanBusiness0)), true)
+		check(t, FeatureACLs, licenseInfo(plan(PlanEnterprise1)), true)
 	})
 
 	t.Run(string(FeatureExtensionRegistry), func(t *testing.T) {
 		check(t, FeatureExtensionRegistry, nil, false)
 
-		check(t, FeatureExtensionRegistry, license("starter"), false)
-		check(t, FeatureExtensionRegistry, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureExtensionRegistry, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureExtensionRegistry, license(), true)
+		check(t, FeatureExtensionRegistry, licenseInfo("starter"), false)
+		check(t, FeatureExtensionRegistry, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureExtensionRegistry, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureExtensionRegistry, licenseInfo(), true)
 
-		check(t, FeatureExtensionRegistry, license(plan(PlanTeam0)), false)
-		check(t, FeatureExtensionRegistry, license(plan(PlanEnterprise0)), false)
-		check(t, FeatureExtensionRegistry, license(plan(PlanEnterprise0), string(FeatureExtensionRegistry)), true)
+		check(t, FeatureExtensionRegistry, licenseInfo(plan(PlanTeam0)), false)
+		check(t, FeatureExtensionRegistry, licenseInfo(plan(PlanEnterprise0)), false)
+		check(t, FeatureExtensionRegistry, licenseInfo(plan(PlanEnterprise0), string(FeatureExtensionRegistry)), true)
 	})
 
 	t.Run(string(FeatureRemoteExtensionsAllowDisallow), func(t *testing.T) {
 		check(t, FeatureRemoteExtensionsAllowDisallow, nil, false)
 
-		check(t, FeatureRemoteExtensionsAllowDisallow, license("starter"), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(), true)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo("starter"), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(), true)
 
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanTeam0)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanEnterprise0)), false)
-		check(t, FeatureRemoteExtensionsAllowDisallow, license(plan(PlanEnterprise0), string(FeatureRemoteExtensionsAllowDisallow)), true)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(plan(PlanTeam0)), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(plan(PlanEnterprise0)), false)
+		check(t, FeatureRemoteExtensionsAllowDisallow, licenseInfo(plan(PlanEnterprise0), string(FeatureRemoteExtensionsAllowDisallow)), true)
 	})
 
 	t.Run(string(FeatureBranding), func(t *testing.T) {
 		check(t, FeatureBranding, nil, false)
 
-		check(t, FeatureBranding, license("starter"), false)
-		check(t, FeatureBranding, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureBranding, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureBranding, license(), true)
+		check(t, FeatureBranding, licenseInfo("starter"), false)
+		check(t, FeatureBranding, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureBranding, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureBranding, licenseInfo(), true)
 
-		check(t, FeatureBranding, license(plan(PlanTeam0)), false)
-		check(t, FeatureBranding, license(plan(PlanEnterprise0)), false)
-		check(t, FeatureBranding, license(plan(PlanEnterprise0), string(FeatureBranding)), true)
+		check(t, FeatureBranding, licenseInfo(plan(PlanTeam0)), false)
+		check(t, FeatureBranding, licenseInfo(plan(PlanEnterprise0)), false)
+		check(t, FeatureBranding, licenseInfo(plan(PlanEnterprise0), string(FeatureBranding)), true)
 	})
 
 	t.Run((&FeatureBatchChanges{}).FeatureName(), func(t *testing.T) {
 		check(t, &FeatureBatchChanges{}, nil, false)
 
-		checkAs(t, &FeatureBatchChanges{}, license("starter"), true, &FeatureBatchChanges{MaxNumChangesets: 10})
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanOldEnterpriseStarter)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanOldEnterprise)), true, &FeatureBatchChanges{Unrestricted: true})
-		checkAs(t, &FeatureBatchChanges{}, license(), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo("starter"), true, &FeatureBatchChanges{MaxNumChangesets: 10})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanOldEnterpriseStarter)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanOldEnterprise)), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(), true, &FeatureBatchChanges{Unrestricted: true})
 
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanTeam0)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanEnterprise0)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanEnterprise0), (&FeatureBatchChanges{}).FeatureName()), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanTeam0)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanEnterprise0)), true, &FeatureBatchChanges{MaxNumChangesets: 10})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanEnterprise0), (&FeatureBatchChanges{}).FeatureName()), true, &FeatureBatchChanges{Unrestricted: true})
 
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanBusiness0)), true, &FeatureBatchChanges{Unrestricted: true})
-		checkAs(t, &FeatureBatchChanges{}, license(plan(PlanEnterprise1)), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanBusiness0)), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo(plan(PlanEnterprise1)), true, &FeatureBatchChanges{Unrestricted: true})
 
 		// Batch changes should be unrestricted if Campaigns is set.
-		checkAs(t, &FeatureBatchChanges{}, license("starter", string(FeatureCampaigns)), true, &FeatureBatchChanges{Unrestricted: true})
+		checkAs(t, &FeatureBatchChanges{}, licenseInfo("starter", string(FeatureCampaigns)), true, &FeatureBatchChanges{Unrestricted: true})
 	})
 
 	testCodeInsights := func(feature Feature) func(*testing.T) {
 		return func(t *testing.T) {
 			check(t, feature, nil, false)
 
-			check(t, feature, license("starter"), false)
-			check(t, feature, license(plan(PlanOldEnterpriseStarter)), false)
-			check(t, feature, license(plan(PlanOldEnterprise)), true)
-			check(t, feature, license(), true)
+			check(t, feature, licenseInfo("starter"), false)
+			check(t, feature, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+			check(t, feature, licenseInfo(plan(PlanOldEnterprise)), true)
+			check(t, feature, licenseInfo(), true)
 
-			check(t, feature, license(plan(PlanTeam0)), false)
-			check(t, feature, license(plan(PlanEnterprise0)), false)
-			check(t, feature, license(plan(PlanEnterprise0), feature.FeatureName()), true)
+			check(t, feature, licenseInfo(plan(PlanTeam0)), false)
+			check(t, feature, licenseInfo(plan(PlanEnterprise0)), false)
+			check(t, feature, licenseInfo(plan(PlanEnterprise0), feature.FeatureName()), true)
 
-			check(t, feature, license(plan(PlanBusiness0)), true)
-			check(t, feature, license(plan(PlanEnterprise1)), true)
+			check(t, feature, licenseInfo(plan(PlanBusiness0)), true)
+			check(t, feature, licenseInfo(plan(PlanEnterprise1)), true)
 		}
 	}
 	// Code Insights
@@ -165,26 +165,26 @@ func TestCheckFeature(t *testing.T) {
 	t.Run(string(FeatureMonitoring), func(t *testing.T) {
 		check(t, FeatureMonitoring, nil, false)
 
-		check(t, FeatureMonitoring, license("starter"), false)
-		check(t, FeatureMonitoring, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureMonitoring, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureMonitoring, license(), true)
+		check(t, FeatureMonitoring, licenseInfo("starter"), false)
+		check(t, FeatureMonitoring, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureMonitoring, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureMonitoring, licenseInfo(), true)
 
-		check(t, FeatureMonitoring, license(plan(PlanTeam0)), false)
-		check(t, FeatureMonitoring, license(plan(PlanEnterprise0)), false)
-		check(t, FeatureMonitoring, license(plan(PlanEnterprise0), string(FeatureMonitoring)), true)
+		check(t, FeatureMonitoring, licenseInfo(plan(PlanTeam0)), false)
+		check(t, FeatureMonitoring, licenseInfo(plan(PlanEnterprise0)), false)
+		check(t, FeatureMonitoring, licenseInfo(plan(PlanEnterprise0), string(FeatureMonitoring)), true)
 	})
 
 	t.Run(string(FeatureBackupAndRestore), func(t *testing.T) {
 		check(t, FeatureBackupAndRestore, nil, false)
 
-		check(t, FeatureBackupAndRestore, license("starter"), false)
-		check(t, FeatureBackupAndRestore, license(plan(PlanOldEnterpriseStarter)), false)
-		check(t, FeatureBackupAndRestore, license(plan(PlanOldEnterprise)), true)
-		check(t, FeatureBackupAndRestore, license(), true)
+		check(t, FeatureBackupAndRestore, licenseInfo("starter"), false)
+		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanOldEnterpriseStarter)), false)
+		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanOldEnterprise)), true)
+		check(t, FeatureBackupAndRestore, licenseInfo(), true)
 
-		check(t, FeatureBackupAndRestore, license(plan(PlanTeam0)), false)
-		check(t, FeatureBackupAndRestore, license(plan(PlanEnterprise0)), false)
-		check(t, FeatureBackupAndRestore, license(plan(PlanEnterprise0), string(FeatureBackupAndRestore)), true)
+		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanTeam0)), false)
+		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanEnterprise0)), false)
+		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanEnterprise0), string(FeatureBackupAndRestore)), true)
 	})
 }

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -40,13 +40,13 @@ func RegisterEnterpriseMigrators(ctx context.Context, db database.DB, runner *oo
 		insightsStore = basestore.NewWithHandle(codeInsightsDB.Handle())
 	}
 
-	keyring := keyring.Default()
+	defaultKeyring := keyring.Default()
 
 	return registerEnterpriseMigrators(runner, false, dependencies{
 		store:          basestore.NewWithHandle(db.Handle()),
 		codeIntelStore: basestore.NewWithHandle(basestore.NewHandleWithDB(log.NoOp(), codeIntelDB, sql.TxOptions{})),
 		insightsStore:  insightsStore,
-		keyring:        &keyring,
+		keyring:        &defaultKeyring,
 	})
 }
 

--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -561,20 +561,20 @@ func regexMatch(conditions Conditions, regex string, isCaseSensitive bool) *sqlf
 // If so, this function returns true along with the literal search query. If not, this
 // function returns false.
 func isLiteralEquality(expr string) (string, bool, error) {
-	regexp, err := syntax.Parse(expr, syntax.Perl)
+	regex, err := syntax.Parse(expr, syntax.Perl)
 	if err != nil {
 		return "", false, errors.Wrap(err, "regexp/syntax.Parse")
 	}
 
 	// want a concat of size 3 which is [begin, literal, end]
-	if regexp.Op == syntax.OpConcat && len(regexp.Sub) == 3 {
+	if regex.Op == syntax.OpConcat && len(regex.Sub) == 3 {
 		// starts with ^
-		if regexp.Sub[0].Op == syntax.OpBeginLine || regexp.Sub[0].Op == syntax.OpBeginText {
+		if regex.Sub[0].Op == syntax.OpBeginLine || regex.Sub[0].Op == syntax.OpBeginText {
 			// is a literal
-			if regexp.Sub[1].Op == syntax.OpLiteral {
+			if regex.Sub[1].Op == syntax.OpLiteral {
 				// ends with $
-				if regexp.Sub[2].Op == syntax.OpEndLine || regexp.Sub[2].Op == syntax.OpEndText {
-					return string(regexp.Sub[1].Rune), true, nil
+				if regex.Sub[2].Op == syntax.OpEndLine || regex.Sub[2].Op == syntax.OpEndText {
+					return string(regex.Sub[1].Rune), true, nil
 				}
 			}
 		}
@@ -587,18 +587,18 @@ func isLiteralEquality(expr string) (string, bool, error) {
 // If so, this function returns true along with the literal search query. If not, this
 // function returns false.
 func isLiteralPrefix(expr string) (string, bool, error) {
-	regexp, err := syntax.Parse(expr, syntax.Perl)
+	regex, err := syntax.Parse(expr, syntax.Perl)
 	if err != nil {
 		return "", false, errors.Wrap(err, "regexp/syntax.Parse")
 	}
 
 	// want a concat of size 2 which is [begin, literal]
-	if regexp.Op == syntax.OpConcat && len(regexp.Sub) == 2 {
+	if regex.Op == syntax.OpConcat && len(regex.Sub) == 2 {
 		// starts with ^
-		if regexp.Sub[0].Op == syntax.OpBeginLine || regexp.Sub[0].Op == syntax.OpBeginText {
+		if regex.Sub[0].Op == syntax.OpBeginLine || regex.Sub[0].Op == syntax.OpBeginText {
 			// is a literal
-			if regexp.Sub[1].Op == syntax.OpLiteral {
-				return string(regexp.Sub[1].Rune), true, nil
+			if regex.Sub[1].Op == syntax.OpLiteral {
+				return string(regex.Sub[1].Rune), true, nil
 			}
 		}
 	}

--- a/enterprise/internal/rockskip/server_test.go
+++ b/enterprise/internal/rockskip/server_test.go
@@ -130,12 +130,12 @@ func TestIndex(t *testing.T) {
 			gotPathSet[blob.Path] = struct{}{}
 		}
 		gotPaths := []string{}
-		for path := range gotPathSet {
-			gotPaths = append(gotPaths, path)
+		for gotPath := range gotPathSet {
+			gotPaths = append(gotPaths, gotPath)
 		}
 		wantPaths := []string{}
-		for path := range state {
-			wantPaths = append(wantPaths, path)
+		for wantPath := range state {
+			wantPaths = append(wantPaths, wantPath)
 		}
 		sort.Strings(gotPaths)
 		sort.Strings(wantPaths)
@@ -153,8 +153,8 @@ func TestIndex(t *testing.T) {
 		}
 
 		// Make sure the symbols match.
-		for path, gotSymbols := range gotPathToSymbols {
-			wantSymbols := state[path]
+		for gotPath, gotSymbols := range gotPathToSymbols {
+			wantSymbols := state[gotPath]
 			sort.Strings(gotSymbols)
 			sort.Strings(wantSymbols)
 			if diff := cmp.Diff(gotSymbols, wantSymbols); diff != "" {
@@ -286,8 +286,8 @@ func (f *mockRepositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo
 	ch := make(chan fetcher.ParseRequestOrError)
 
 	go func() {
-		for _, path := range paths {
-			_, err := f.git.catFileStdin.Write([]byte(fmt.Sprintf("%s:%s\n", commit, path)))
+		for _, p := range paths {
+			_, err := f.git.catFileStdin.Write([]byte(fmt.Sprintf("%s:%s\n", commit, p)))
 			if err != nil {
 				ch <- fetcher.ParseRequestOrError{
 					Err: errors.Wrap(err, "writing to cat-file stdin"),
@@ -342,7 +342,7 @@ func (f *mockRepositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo
 
 			ch <- fetcher.ParseRequestOrError{
 				ParseRequest: fetcher.ParseRequest{
-					Path: path,
+					Path: p,
 					Data: fileContents,
 				},
 			}

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -60,7 +60,7 @@ func (o *Options) SetDefaults() {
 func Combine(path string, opt Options) error {
 	opt.SetDefaults()
 
-	log := opt.Logger
+	logger := opt.Logger
 
 	r, err := git.PlainOpen(path)
 	if err != nil {
@@ -81,7 +81,7 @@ func Combine(path string, opt Options) error {
 		}
 	}
 
-	log.Println("Determining the tree hashes of subdirectories...")
+	logger.Println("Determining the tree hashes of subdirectories...")
 	remoteToTree := map[string]plumbing.Hash{}
 	if head != nil {
 		tree, err := head.Tree()
@@ -93,7 +93,7 @@ func Combine(path string, opt Options) error {
 		}
 	}
 
-	log.Println("Collecting new commits...")
+	logger.Println("Collecting new commits...")
 	lastLog := time.Now()
 	remoteToCommits := map[string][]*object.Commit{}
 	for remote := range conf.Remotes {
@@ -112,7 +112,7 @@ func Combine(path string, opt Options) error {
 
 		for depth := 0; depth < opt.LimitRemote; depth++ {
 			if time.Since(lastLog) > time.Second {
-				log.Printf("Collecting new commits... (remotes %s, commit depth %d)", remote, depth)
+				logger.Printf("Collecting new commits... (remotes %s, commit depth %d)", remote, depth)
 				lastLog = time.Now()
 			}
 
@@ -202,7 +202,7 @@ func Combine(path string, opt Options) error {
 		return nil
 	}
 
-	log.Println("Applying new commits...")
+	logger.Println("Applying new commits...")
 	total := 0
 	for _, commits := range remoteToCommits {
 		total += len(commits)
@@ -234,7 +234,7 @@ func Combine(path string, opt Options) error {
 
 			if time.Since(lastLog) > time.Second {
 				progress := float64(height) / float64(total)
-				log.Printf("%.2f%% done (applied %d commits out of %d total)", progress*100, height+1, total)
+				logger.Printf("%.2f%% done (applied %d commits out of %d total)", progress*100, height+1, total)
 				lastLog = time.Now()
 			}
 		}

--- a/internal/cmd/progress-bot/main.go
+++ b/internal/cmd/progress-bot/main.go
@@ -132,8 +132,8 @@ func (cl Changelog) ToSlackMessage(cli *SlackClient, bucket *storage.BucketHandl
 	}
 
 	section := func(name string, cs []Change) ([]slack.Block, error) {
-		var text bytes.Buffer
-		fmt.Fprintf(&text, "*%s*\n\n", name)
+		var resultText bytes.Buffer
+		fmt.Fprintf(&resultText, "*%s*\n\n", name)
 
 		avatarURLs := map[string]struct{}{}
 		for _, c := range cs {
@@ -151,12 +151,12 @@ func (cl Changelog) ToSlackMessage(cli *SlackClient, bucket *storage.BucketHandl
 				avatarURLs[gravatarURL(c.GitCommit.Author.Email)] = struct{}{}
 			}
 
-			fmt.Fprintln(&text, c.SlackText(slackUserID))
+			fmt.Fprintln(&resultText, c.SlackText(slackUserID))
 		}
 
 		block := &slack.SectionBlock{
 			Type: slack.MBTSection,
-			Text: &slack.TextBlockObject{Type: "mrkdwn", Text: text.String()},
+			Text: &slack.TextBlockObject{Type: "mrkdwn", Text: resultText.String()},
 		}
 
 		if len(avatarURLs) > 0 {

--- a/internal/cmd/tracking-issue/context.go
+++ b/internal/cmd/tracking-issue/context.go
@@ -12,7 +12,7 @@ type IssueContext struct {
 	pullRequests   []*PullRequest
 }
 
-// NewIssueContext creates  anew issue context with the given visible issues, tracking
+// NewIssueContext creates a new issue context with the given visible issues, tracking
 // issues, and pull requests.
 func NewIssueContext(trackingIssue *Issue, trackingIssues []*Issue, issues []*Issue, pullRequests []*PullRequest) IssueContext {
 	return IssueContext{

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -92,9 +92,9 @@ func run(token, org string, dry bool) (err error) {
 
 	var updatedTrackingIssues []*Issue
 	for _, trackingIssue := range openTrackingIssues {
-		context := NewIssueContext(trackingIssue, trackingIssues, issues, pullRequests)
+		issueContext := NewIssueContext(trackingIssue, trackingIssues, issues, pullRequests)
 
-		updated, ok := trackingIssue.UpdateBody(RenderTrackingIssue(context))
+		updated, ok := trackingIssue.UpdateBody(RenderTrackingIssue(issueContext))
 		if !ok {
 			log.Printf("failed to patch work section in %q %s", trackingIssue.SafeTitle(), trackingIssue.URL)
 			continue

--- a/internal/cmd/tracking-issue/main_test.go
+++ b/internal/cmd/tracking-issue/main_test.go
@@ -73,8 +73,8 @@ func TestIntegration(t *testing.T) {
 					continue
 				}
 
-				context := NewIssueContext(trackingIssue, trackingIssues, issues, pullRequests)
-				if _, ok := trackingIssue.UpdateBody(RenderTrackingIssue(context)); !ok {
+				issueContext := NewIssueContext(trackingIssue, trackingIssues, issues, pullRequests)
+				if _, ok := trackingIssue.UpdateBody(RenderTrackingIssue(issueContext)); !ok {
 					t.Fatal("failed to patch issue")
 				}
 

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -25,7 +25,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"codeintel_dependencies_store",
@@ -38,7 +38,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.dependencies.store.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -138,7 +138,7 @@ func TestValidateSettings(t *testing.T) {
 }
 
 func TestDoValidate(t *testing.T) {
-	schema := schema.SiteSchemaJSON
+	siteSchemaJSON := schema.SiteSchemaJSON
 
 	tests := map[string]struct {
 		input        string
@@ -159,7 +159,7 @@ func TestDoValidate(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			problems := doValidate([]byte(test.input), schema)
+			problems := doValidate([]byte(test.input), siteSchemaJSON)
 			if !reflect.DeepEqual(problems, test.wantProblems) {
 				t.Errorf("got problems %v, want %v", problems, test.wantProblems)
 			}

--- a/internal/database/batch/observability.go
+++ b/internal/database/batch/observability.go
@@ -16,7 +16,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"database_batch",
 		metrics.WithLabels("op"),
@@ -27,7 +27,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("database.batch.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/internal/database/dbtest/dsn.go
+++ b/internal/database/dbtest/dsn.go
@@ -27,8 +27,8 @@ func GetDSN() (*url.URL, error) {
 	}
 
 	username := ""
-	if user, err := user.Current(); err == nil {
-		username = user.Username
+	if osUser, err := user.Current(); err == nil {
+		username = osUser.Username
 	}
 
 	dsn := postgresdsn.New("", username, getenv)

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -564,14 +564,14 @@ func (f *featureFlagStore) GetUserFlags(ctx context.Context, userID int32) (map[
 
 	res := make(map[string]bool)
 	for rows.Next() {
-		ff, override, err := scanFeatureFlagAndOverride(rows)
+		flag, override, err := scanFeatureFlagAndOverride(rows)
 		if err != nil {
 			return nil, err
 		}
 		if override != nil {
-			res[ff.Name] = *override
+			res[flag.Name] = *override
 		} else {
-			res[ff.Name] = ff.EvaluateForUser(userID)
+			res[flag.Name] = flag.EvaluateForUser(userID)
 		}
 	}
 	return res, rows.Err()
@@ -585,8 +585,8 @@ func (f *featureFlagStore) GetAnonymousUserFlags(ctx context.Context, anonymousU
 	}
 
 	res := make(map[string]bool, len(flags))
-	for _, ff := range flags {
-		res[ff.Name] = ff.EvaluateForAnonymousUser(anonymousUID)
+	for _, flag := range flags {
+		res[flag.Name] = flag.EvaluateForAnonymousUser(anonymousUID)
 	}
 
 	return res, nil
@@ -599,9 +599,9 @@ func (f *featureFlagStore) GetGlobalFeatureFlags(ctx context.Context) (map[strin
 	}
 
 	res := make(map[string]bool, len(flags))
-	for _, ff := range flags {
-		if val, ok := ff.EvaluateGlobal(); ok {
-			res[ff.Name] = val
+	for _, flag := range flags {
+		if val, ok := flag.EvaluateGlobal(); ok {
+			res[flag.Name] = val
 		}
 	}
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -642,19 +642,19 @@ func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, r
 	}
 	defer func() { err = tx.Done(err) }()
 
-	batch := make([]*sqlf.Query, batchSize)
+	queries := make([]*sqlf.Query, batchSize)
 
 	left := len(repos)
 	currentCount := 0
 	updatedRows := 0
 	for repo, size := range repos {
-		batch[currentCount] = sqlf.Sprintf("(%s::integer, %s::bigint)", repo, size)
+		queries[currentCount] = sqlf.Sprintf("(%s::integer, %s::bigint)", repo, size)
 
 		currentCount += 1
 
 		if currentCount == batchSize || currentCount == left {
 			// IMPORTANT: we only take the elements of batch up to currentCount
-			q := sqlf.Sprintf(updateRepoSizesQueryFmtstr, sqlf.Join(batch[:currentCount], ","))
+			q := sqlf.Sprintf(updateRepoSizesQueryFmtstr, sqlf.Join(queries[:currentCount], ","))
 			res, err := tx.ExecResult(ctx, q)
 			if err != nil {
 				return 0, err

--- a/internal/database/migration/cliutil/drift_util.go
+++ b/internal/database/migration/cliutil/drift_util.go
@@ -374,9 +374,9 @@ func makeSearchURL(schemaName, version string, searchTerms ...string) string {
 	qs.Add("patternType", "regexp")
 	qs.Add("q", strings.Join(queryParts, " "))
 
-	url, _ := url.Parse("https://sourcegraph.com/search")
-	url.RawQuery = qs.Encode()
-	return url.String()
+	searchUrl, _ := url.Parse("https://sourcegraph.com/search")
+	searchUrl.RawQuery = qs.Encode()
+	return searchUrl.String()
 }
 
 // quoteTerm converts the given literal search term into a regular expression.

--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -312,11 +312,11 @@ func checkDrift(ctx context.Context, r Runner, version string, out *output.Outpu
 		if err != nil {
 			return err
 		}
-		schemas, err := store.Describe(ctx)
+		schemaDescriptions, err := store.Describe(ctx)
 		if err != nil {
 			return err
 		}
-		schema := schemas["public"]
+		schema := schemaDescriptions["public"]
 
 		var buf bytes.Buffer
 		noopOutput := output.NewOutput(&buf, output.OutputOpts{})

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -43,22 +43,22 @@ func flagHelp(out *output.Output, message string, args ...any) error {
 
 // setupRunner initializes and returns the runner associated witht the given schema.
 func setupRunner(factory RunnerFactory, schemaNames ...string) (Runner, error) {
-	runner, err := factory(schemaNames)
+	r, err := factory(schemaNames)
 	if err != nil {
 		return nil, err
 	}
 
-	return runner, nil
+	return r, nil
 }
 
 // setupStore initializes and returns the store associated witht the given schema.
 func setupStore(ctx context.Context, factory RunnerFactory, schemaName string) (Store, error) {
-	runner, err := setupRunner(factory, schemaName)
+	r, err := setupRunner(factory, schemaName)
 	if err != nil {
 		return nil, err
 	}
 
-	store, err := runner.Store(ctx, schemaName)
+	store, err := r.Store(ctx, schemaName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/migration/definition/read_test.go
+++ b/internal/database/migration/definition/read_test.go
@@ -16,12 +16,12 @@ const relativeWorkingDirectory = "internal/database/migration/definition"
 
 func TestReadDefinitions(t *testing.T) {
 	t.Run("well-formed", func(t *testing.T) {
-		fs, err := fs.Sub(testdata.Content, "well-formed")
+		fsys, err := fs.Sub(testdata.Content, "well-formed")
 		if err != nil {
 			t.Fatalf("unexpected error fetching schema %q: %s", "well-formed", err)
 		}
 
-		definitions, err := ReadDefinitions(fs, relativeWorkingDirectory)
+		definitions, err := ReadDefinitions(fsys, relativeWorkingDirectory)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -40,12 +40,12 @@ func TestReadDefinitions(t *testing.T) {
 	})
 
 	t.Run("concurrent", func(t *testing.T) {
-		fs, err := fs.Sub(testdata.Content, "concurrent")
+		fsys, err := fs.Sub(testdata.Content, "concurrent")
 		if err != nil {
 			t.Fatalf("unexpected error fetching schema %q: %s", "concurrent", err)
 		}
 
-		definitions, err := ReadDefinitions(fs, relativeWorkingDirectory)
+		definitions, err := ReadDefinitions(fsys, relativeWorkingDirectory)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -76,12 +76,12 @@ func TestReadDefinitions(t *testing.T) {
 	})
 
 	t.Run("privileged", func(t *testing.T) {
-		fs, err := fs.Sub(testdata.Content, "privileged")
+		fsys, err := fs.Sub(testdata.Content, "privileged")
 		if err != nil {
 			t.Fatalf("unexpected error fetching schema %q: %s", "privileged", err)
 		}
 
-		definitions, err := ReadDefinitions(fs, relativeWorkingDirectory)
+		definitions, err := ReadDefinitions(fsys, relativeWorkingDirectory)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -124,12 +124,12 @@ func TestReadDefinitions(t *testing.T) {
 func testReadDefinitionsError(t *testing.T, name, expectedError string) {
 	t.Helper()
 
-	fs, err := fs.Sub(testdata.Content, name)
+	fsys, err := fs.Sub(testdata.Content, name)
 	if err != nil {
 		t.Fatalf("unexpected error fetching schema %q: %s", name, err)
 	}
 
-	if _, err := ReadDefinitions(fs, relativeWorkingDirectory); err == nil || !strings.Contains(err.Error(), expectedError) {
+	if _, err := ReadDefinitions(fsys, relativeWorkingDirectory); err == nil || !strings.Contains(err.Error(), expectedError) {
 		t.Fatalf("unexpected error. want=%q got=%q", expectedError, err)
 	}
 }

--- a/internal/database/migration/runner/helpers_test.go
+++ b/internal/database/migration/runner/helpers_test.go
@@ -22,12 +22,12 @@ func makeTestSchemas(t *testing.T) []*schemas.Schema {
 }
 
 func makeTestSchema(t *testing.T, name string) *schemas.Schema {
-	fs, err := fs.Sub(testdata.Content, name)
+	fsys, err := fs.Sub(testdata.Content, name)
 	if err != nil {
 		t.Fatalf("malformed migration definitions %q: %s", name, err)
 	}
 
-	definitions, err := definition.ReadDefinitions(fs, name)
+	definitions, err := definition.ReadDefinitions(fsys, name)
 	if err != nil {
 		t.Fatalf("malformed migration definitions %q: %s", name, err)
 	}

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -341,15 +341,15 @@ func groupByState(schemaVersion schemaVersion, definitions []definition.Definiti
 	pendingVersionsMap := intSet(schemaVersion.pendingVersions)
 
 	states := definitionsByState{}
-	for _, definition := range definitions {
-		if _, ok := appliedVersionsMap[definition.ID]; ok {
-			states.applied = append(states.applied, definition)
+	for _, def := range definitions {
+		if _, ok := appliedVersionsMap[def.ID]; ok {
+			states.applied = append(states.applied, def)
 		}
-		if _, ok := pendingVersionsMap[definition.ID]; ok {
-			states.pending = append(states.pending, definition)
+		if _, ok := pendingVersionsMap[def.ID]; ok {
+			states.pending = append(states.pending, def)
 		}
-		if _, ok := failedVersionsMap[definition.ID]; ok {
-			states.failed = append(states.failed, definition)
+		if _, ok := failedVersionsMap[def.ID]; ok {
+			states.failed = append(states.failed, def)
 		}
 	}
 
@@ -369,12 +369,12 @@ func validateSchemaState(
 ) (retry bool, _ error) {
 	if ignoreSingleDirtyLog && len(byState.failed) == 1 {
 		appliedVersionMap := intSet(extractIDs(byState.applied))
-		for _, definition := range definitions {
+		for _, def := range definitions {
 			if _, ok := appliedVersionMap[definitions[0].ID]; ok {
 				continue
 			}
 
-			if byState.failed[0].ID == definition.ID {
+			if byState.failed[0].ID == def.ID {
 				schemaContext.logger.Warn("Attempting to re-try migration that previously failed")
 				return false, nil
 			}
@@ -435,20 +435,20 @@ func partitionPendingMigrations(
 	schemaContext schemaContext,
 	definitions []definition.Definition,
 ) (pendingDefinitions []definitionWithStatus, failedDefinitions []definition.Definition, _ error) {
-	for _, definition := range definitions {
-		if definition.IsCreateIndexConcurrently {
-			tableName := definition.IndexMetadata.TableName
-			indexName := definition.IndexMetadata.IndexName
+	for _, def := range definitions {
+		if def.IsCreateIndexConcurrently {
+			tableName := def.IndexMetadata.TableName
+			indexName := def.IndexMetadata.IndexName
 
 			if indexStatus, ok, err := schemaContext.store.IndexStatus(ctx, tableName, indexName); err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to check creation status of index %q.%q", tableName, indexName)
 			} else if ok && indexStatus.Phase != nil {
-				pendingDefinitions = append(pendingDefinitions, definitionWithStatus{definition, indexStatus})
+				pendingDefinitions = append(pendingDefinitions, definitionWithStatus{def, indexStatus})
 				continue
 			}
 		}
 
-		failedDefinitions = append(failedDefinitions, definition)
+		failedDefinitions = append(failedDefinitions, def)
 	}
 
 	return pendingDefinitions, failedDefinitions, nil

--- a/internal/database/migration/runner/util.go
+++ b/internal/database/migration/runner/util.go
@@ -10,8 +10,8 @@ import (
 
 func extractIDs(definitions []definition.Definition) []int {
 	ids := make([]int, 0, len(definitions))
-	for _, definition := range definitions {
-		ids = append(ids, definition.ID)
+	for _, def := range definitions {
+		ids = append(ids, def.ID)
 	}
 
 	return ids

--- a/internal/database/migration/schemas/schemas.go
+++ b/internal/database/migration/schemas/schemas.go
@@ -25,12 +25,12 @@ var (
 )
 
 func mustResolveSchema(name string) *Schema {
-	fs, err := fs.Sub(migrations.QueryDefinitions, name)
+	fsys, err := fs.Sub(migrations.QueryDefinitions, name)
 	if err != nil {
 		panic(fmt.Sprintf("malformed migration definitions %q: %s", name, err))
 	}
 
-	schema, err := ResolveSchema(fs, name)
+	schema, err := ResolveSchema(fsys, name)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/internal/database/migration/stitch/rewriter.go
+++ b/internal/database/migration/stitch/rewriter.go
@@ -398,9 +398,9 @@ func replaceParents(contents string, parents ...int) string {
 
 // replaceParentsInDefinitionMap updates the `parents` field of the definition with the given identifier.
 func replaceParentsInDefinitionMap(definitionMap map[int]definition.Definition, id int, parents []int) {
-	definition := definitionMap[id]
-	definition.Parents = parents
-	definitionMap[id] = definition
+	def := definitionMap[id]
+	def.Parents = parents
+	definitionMap[id] = def
 }
 
 var alterExtensionPattern = lazyregexp.New(`(?:CREATE|COMMENT ON|DROP)\s+EXTENSION.*;`)

--- a/internal/database/migration/store/observability.go
+++ b/internal/database/migration/store/observability.go
@@ -26,7 +26,7 @@ var (
 
 func NewOperations(observationCtx *observation.Context) *Operations {
 	once.Do(func() {
-		metrics := metrics.NewREDMetrics(
+		redMetrics := metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"migrations",
 			metrics.WithLabels("op"),
@@ -37,7 +37,7 @@ func NewOperations(observationCtx *observation.Context) *Operations {
 			return observationCtx.Operation(observation.Op{
 				Name:              fmt.Sprintf("migrations.%s", name),
 				MetricLabelValues: []string{name},
-				Metrics:           metrics,
+				Metrics:           redMetrics,
 			})
 		}
 

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -491,18 +491,18 @@ func scanMigrationLogs(rows *sql.Rows, queryErr error) (_ []migrationLog, err er
 
 	var logs []migrationLog
 	for rows.Next() {
-		var log migrationLog
+		var mLog migrationLog
 
 		if err := rows.Scan(
-			&log.Schema,
-			&log.Version,
-			&log.Up,
-			&log.Success,
+			&mLog.Schema,
+			&mLog.Version,
+			&mLog.Up,
+			&mLog.Success,
 		); err != nil {
 			return nil, err
 		}
 
-		logs = append(logs, log)
+		logs = append(logs, mLog)
 	}
 
 	return logs, nil

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -316,14 +316,14 @@ func TestWrappedUp(t *testing.T) {
 
 	// Seed a few migrations
 	for _, id := range []int{13, 14, 15} {
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID:      id,
 			UpQuery: sqlf.Sprintf(`-- No-op`),
 		}
 		f := func() error {
-			return store.Up(ctx, definition)
+			return store.Up(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err != nil {
+		if err := store.WithMigrationLog(ctx, def, true, f); err != nil {
 			t.Fatalf("unexpected error running migration: %s", err)
 		}
 	}
@@ -350,7 +350,7 @@ func TestWrappedUp(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID: 16,
 			UpQuery: sqlf.Sprintf(`
 				CREATE TABLE test_trees (
@@ -366,9 +366,9 @@ func TestWrappedUp(t *testing.T) {
 			`),
 		}
 		f := func() error {
-			return store.Up(ctx, definition)
+			return store.Up(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err != nil {
+		if err := store.WithMigrationLog(ctx, def, true, f); err != nil {
 			t.Fatalf("unexpected error running migration: %s", err)
 		}
 
@@ -391,7 +391,7 @@ func TestWrappedUp(t *testing.T) {
 	t.Run("query failure", func(t *testing.T) {
 		expectedErrorMessage := "ERROR: relation"
 
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID: 17,
 			UpQuery: sqlf.Sprintf(`
 				-- Note: table already exists
@@ -404,9 +404,9 @@ func TestWrappedUp(t *testing.T) {
 			`),
 		}
 		f := func() error {
-			return store.Up(ctx, definition)
+			return store.Up(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
+		if err := store.WithMigrationLog(ctx, def, true, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
 			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
 		}
 
@@ -459,14 +459,14 @@ func TestWrappedDown(t *testing.T) {
 
 	// Seed a few migrations
 	for _, id := range []int{12, 13, 14} {
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID:      id,
 			UpQuery: sqlf.Sprintf(`-- No-op`),
 		}
 		f := func() error {
-			return store.Up(ctx, definition)
+			return store.Up(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, true, f); err != nil {
+		if err := store.WithMigrationLog(ctx, def, true, f); err != nil {
 			t.Fatalf("unexpected error running migration: %s", err)
 		}
 	}
@@ -493,16 +493,16 @@ func TestWrappedDown(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID: 14,
 			DownQuery: sqlf.Sprintf(`
 				DROP TABLE test_trees;
 			`),
 		}
 		f := func() error {
-			return store.Down(ctx, definition)
+			return store.Down(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, false, f); err != nil {
+		if err := store.WithMigrationLog(ctx, def, false, f); err != nil {
 			t.Fatalf("unexpected error running migration: %s", err)
 		}
 
@@ -524,7 +524,7 @@ func TestWrappedDown(t *testing.T) {
 	t.Run("query failure", func(t *testing.T) {
 		expectedErrorMessage := "ERROR: syntax error at or near"
 
-		definition := definition.Definition{
+		def := definition.Definition{
 			ID: 13,
 			DownQuery: sqlf.Sprintf(`
 				-- Note: table does not exist
@@ -532,9 +532,9 @@ func TestWrappedDown(t *testing.T) {
 			`),
 		}
 		f := func() error {
-			return store.Down(ctx, definition)
+			return store.Down(ctx, def)
 		}
-		if err := store.WithMigrationLog(ctx, definition, false, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
+		if err := store.WithMigrationLog(ctx, def, false, f); err == nil || !strings.Contains(err.Error(), expectedErrorMessage) {
 			t.Fatalf("unexpected error want=%q have=%q", expectedErrorMessage, err)
 		}
 

--- a/internal/database/outbound_webhook_logs_test.go
+++ b/internal/database/outbound_webhook_logs_test.go
@@ -40,9 +40,9 @@ func TestOutboundWebhookLogs(t *testing.T) {
 				want := errors.New("bad key")
 				key := &et.BadKey{Err: want}
 
-				log := newOutboundWebhookLogSuccess(t, job, webhook, 200, "req", "resp")
+				owLog := newOutboundWebhookLogSuccess(t, job, webhook, 200, "req", "resp")
 
-				have := OutboundWebhookLogsWith(store, key).Create(ctx, log)
+				have := OutboundWebhookLogsWith(store, key).Create(ctx, owLog)
 				assert.ErrorIs(t, have, want)
 			})
 

--- a/internal/database/postgresdsn/schema.go
+++ b/internal/database/postgresdsn/schema.go
@@ -28,8 +28,8 @@ func DSNsBySchema(schemaNames []string) (map[string]string, error) {
 
 func RawDSNsBySchema(schemaNames []string, getenv func(string) string) map[string]string {
 	username := ""
-	if user, err := user.Current(); err == nil {
-		username = user.Username
+	if currentUser, err := user.Current(); err == nil {
+		username = currentUser.Username
 	}
 
 	dsns := make(map[string]string, len(schemaNames))

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -216,12 +216,12 @@ func TestRepoStore_userCanSeeUnrestricedRepo(t *testing.T) {
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
 	}
-	extsvc := &types.ExternalService{
+	externalService := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "GITHUB #1",
 		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`),
 	}
-	err = db.ExternalServices().Create(ctx, confGet, extsvc)
+	err = db.ExternalServices().Create(ctx, confGet, externalService)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestRepoStore_userCanSeeUnrestricedRepo(t *testing.T) {
 	q := sqlf.Sprintf(`
 INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 VALUES (%s, %s, '')
-`, extsvc.ID, privateRepo1.ID)
+`, externalService.ID, privateRepo1.ID)
 
 	_, err = db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -186,15 +186,15 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 					ExternalServiceType: extsvc.TypeBitbucketCloud,
 					ExternalServiceID:   "https://bitbucket.org",
 				}
-				auth := &auth.BasicAuth{}
+				basicAuth := &auth.BasicAuth{}
 
 				// Attempt to create with the invalid context.
-				cred, err := fx.db.Create(tc.ctx, scope, auth)
+				cred, err := fx.db.Create(tc.ctx, scope, basicAuth)
 				assert.Error(t, err)
 				assert.Nil(t, cred)
 
 				// Now we'll create a credential so we can test update.
-				cred, err = fx.db.Create(fx.internalCtx, scope, auth)
+				cred, err = fx.db.Create(fx.internalCtx, scope, basicAuth)
 				require.NoError(t, err)
 				require.NotNil(t, cred)
 
@@ -207,7 +207,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 	// Instead of two of every animal, we want one of every authenticator. Same,
 	// same.
-	for name, auth := range createUserCredentialAuths(t) {
+	for name, authenticator := range createUserCredentialAuths(t) {
 		t.Run(name, func(t *testing.T) {
 			scope := UserCredentialScope{
 				Domain:              name,
@@ -216,7 +216,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 				ExternalServiceID:   "https://github.com",
 			}
 
-			cred, err := fx.db.Create(fx.userCtx, scope, auth)
+			cred, err := fx.db.Create(fx.userCtx, scope, authenticator)
 			assert.NoError(t, err)
 			assert.NotNil(t, cred)
 			assert.NotZero(t, cred.ID)
@@ -229,10 +229,10 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 			have, err := cred.Authenticator(fx.userCtx)
 			assert.NoError(t, err)
-			assert.Equal(t, auth, have)
+			assert.Equal(t, authenticator, have)
 
 			// Ensure that trying to insert again fails.
-			second, err := fx.db.Create(fx.userCtx, scope, auth)
+			second, err := fx.db.Create(fx.userCtx, scope, authenticator)
 			assert.Error(t, err)
 			assert.Nil(t, second)
 

--- a/internal/encryption/awskms/aws_kms.go
+++ b/internal/encryption/awskms/aws_kms.go
@@ -20,11 +20,11 @@ import (
 )
 
 func NewKey(ctx context.Context, keyConfig schema.AWSKMSEncryptionKey) (encryption.Key, error) {
-	config, err := config.LoadDefaultConfig(ctx, awsConfigOptsForKeyConfig(keyConfig)...)
+	defaultConfig, err := config.LoadDefaultConfig(ctx, awsConfigOptsForKeyConfig(keyConfig)...)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading config for aws KMS")
 	}
-	return newKey(ctx, keyConfig, config)
+	return newKey(ctx, keyConfig, defaultConfig)
 }
 
 func newKey(ctx context.Context, keyConfig schema.AWSKMSEncryptionKey, config aws.Config) (encryption.Key, error) {

--- a/internal/encryption/awskms/aws_kms_test.go
+++ b/internal/encryption/awskms/aws_kms_test.go
@@ -54,12 +54,12 @@ func TestRoundtrip(t *testing.T) {
 		readEnvFallback("AWS_SECRET_ACCESS_KEY", "test"),
 		"",
 	)))
-	config, err := config.LoadDefaultConfig(ctx, configOpts...)
+	defaultConfig, err := config.LoadDefaultConfig(ctx, configOpts...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	k, err := newKey(ctx, keyConfig, config)
+	k, err := newKey(ctx, keyConfig, defaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1486,12 +1486,12 @@ func getGithubProxyURL() (*url.URL, bool) {
 	if githubProxyRawURL == "" {
 		return nil, false
 	}
-	url, err := url.Parse(githubProxyRawURL)
+	parsedUrl, err := url.Parse(githubProxyRawURL)
 	if err != nil {
 		log.Scoped("extsvc.github", "github package").Fatal("Error parsing GITHUB_BASE_URL", log.Error(err))
 		return nil, false
 	}
-	return url, true
+	return parsedUrl, true
 }
 
 // APIRoot returns the root URL of the API using the base URL of the GitHub instance.

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -788,7 +788,7 @@ type Config struct {
 // Cloud API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/webhooks/repos#create-a-repository-webhook
 // Server API docs: https://docs.github.com/en/enterprise-server@3.3/rest/webhooks/repos#create-a-repository-webhook
 func (c *V3Client) CreateSyncWebhook(ctx context.Context, repoName, targetHost, secret string) (int, error) {
-	url, err := webhookURLBuilder(repoName)
+	hooksUrl, err := webhookURLBuilder(repoName)
 	if err != nil {
 		return 0, err
 	}
@@ -808,7 +808,7 @@ func (c *V3Client) CreateSyncWebhook(ctx context.Context, repoName, targetHost, 
 	}
 
 	var result WebhookPayload
-	resp, err := c.post(ctx, url, payload, &result)
+	resp, err := c.post(ctx, hooksUrl, payload, &result)
 	if err != nil {
 		return 0, err
 	}
@@ -825,13 +825,13 @@ func (c *V3Client) CreateSyncWebhook(ctx context.Context, repoName, targetHost, 
 // Cloud API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/webhooks/repos#list-repository-webhooks
 // Server API docs: https://docs.github.com/en/enterprise-server@3.3/rest/webhooks/repos#list-repository-webhooks
 func (c *V3Client) ListSyncWebhooks(ctx context.Context, repoName string) ([]WebhookPayload, error) {
-	url, err := webhookURLBuilder(repoName)
+	hooksUrl, err := webhookURLBuilder(repoName)
 	if err != nil {
 		return nil, err
 	}
 
 	var results []WebhookPayload
-	resp, err := c.get(ctx, url, &results)
+	resp, err := c.get(ctx, hooksUrl, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -866,12 +866,12 @@ func (c *V3Client) FindSyncWebhook(ctx context.Context, repoName string) (*Webho
 // Cloud API docs: https://docs.github.com/en/enterprise-cloud@latest/rest/webhooks/repos#delete-a-repository-webhook
 // Server API docs: https://docs.github.com/en/enterprise-server@3.3/rest/webhooks/repos#delete-a-repository-webhook
 func (c *V3Client) DeleteSyncWebhook(ctx context.Context, repoName string, hookID int) (bool, error) {
-	url, err := webhookURLBuilderWithID(repoName, hookID)
+	hookUrl, err := webhookURLBuilderWithID(repoName, hookID)
 	if err != nil {
 		return false, err
 	}
 
-	resp, err := c.delete(ctx, url)
+	resp, err := c.delete(ctx, hookUrl)
 	if err != nil && err != io.EOF {
 		return false, err
 	}

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -701,20 +701,20 @@ func TestV3Client_WithAuthenticator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	old := &V3Client{
+	oldClient := &V3Client{
 		log:    logtest.Scoped(t),
 		apiURL: uri,
 		auth:   &auth.OAuthBearerToken{Token: "old_token"},
 	}
 
 	newToken := &auth.OAuthBearerToken{Token: "new_token"}
-	new := old.WithAuthenticator(newToken)
-	if old == new {
+	newClient := oldClient.WithAuthenticator(newToken)
+	if oldClient == newClient {
 		t.Fatal("both clients have the same address")
 	}
 
-	if new.auth != newToken {
-		t.Fatalf("token: want %p but got %p", newToken, new.auth)
+	if newClient.auth != newToken {
+		t.Fatalf("token: want %p but got %p", newToken, newClient.auth)
 	}
 }
 

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -318,7 +318,7 @@ func unmarshal(data []byte, v any) error {
 // determineGitHubVersion returns a *semver.Version for the targetted GitHub instance by this client. When an
 // error occurs, we print a warning to the logs but don't fail and return the allMatchingSemver.
 func (c *V4Client) determineGitHubVersion(ctx context.Context) *semver.Version {
-	url := normalizeURL(c.apiURL.String())
+	urlStr := normalizeURL(c.apiURL.String())
 	globalVersionCache.mu.Lock()
 	defer globalVersionCache.mu.Unlock()
 
@@ -327,11 +327,11 @@ func (c *V4Client) determineGitHubVersion(ctx context.Context) *semver.Version {
 		globalVersionCache.lastReset = time.Now()
 		globalVersionCache.versions = make(map[string]*semver.Version)
 	}
-	if version, ok := globalVersionCache.versions[url]; ok {
+	if version, ok := globalVersionCache.versions[urlStr]; ok {
 		return version
 	}
 	version := c.fetchGitHubVersion(ctx)
-	globalVersionCache.versions[url] = version
+	globalVersionCache.versions[urlStr] = version
 	return version
 }
 

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -790,19 +790,19 @@ func TestV4Client_WithAuthenticator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	old := &V4Client{
+	oldClient := &V4Client{
 		apiURL: uri,
 		auth:   &auth.OAuthBearerToken{Token: "old_token"},
 	}
 
 	newToken := &auth.OAuthBearerToken{Token: "new_token"}
-	new := old.WithAuthenticator(newToken)
-	if old == new {
+	newClient := oldClient.WithAuthenticator(newToken)
+	if oldClient == newClient {
 		t.Fatal("both clients have the same address")
 	}
 
-	if new.auth != newToken {
-		t.Fatalf("token: want %p but got %p", newToken, new.auth)
+	if newClient.auth != newToken {
+		t.Fatalf("token: want %p but got %p", newToken, newClient.auth)
 	}
 }
 

--- a/internal/extsvc/gitlab/notes.go
+++ b/internal/extsvc/gitlab/notes.go
@@ -32,15 +32,15 @@ func (c *Client) GetMergeRequestNotes(ctx context.Context, project *Project, iid
 
 		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 
-		url, err := url.Parse(baseURL)
+		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
 		}
-		q := url.Query()
+		q := parsedUrl.Query()
 		q.Add("page", currentPage)
-		url.RawQuery = q.Encode()
+		parsedUrl.RawQuery = q.Encode()
 
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequest("GET", parsedUrl.String(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating notes request")
 		}

--- a/internal/extsvc/gitlab/pipelines.go
+++ b/internal/extsvc/gitlab/pipelines.go
@@ -32,15 +32,15 @@ func (c *Client) GetMergeRequestPipelines(ctx context.Context, project *Project,
 
 		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 
-		url, err := url.Parse(baseURL)
+		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
 		}
-		q := url.Query()
+		q := parsedUrl.Query()
 		q.Add("page", currentPage)
-		url.RawQuery = q.Encode()
+		parsedUrl.RawQuery = q.Encode()
 
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequest("GET", parsedUrl.String(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating pipeline request")
 		}

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -32,15 +32,15 @@ func (c *Client) GetMergeRequestResourceStateEvents(ctx context.Context, project
 
 		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
 
-		url, err := url.Parse(baseURL)
+		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
 		}
-		q := url.Query()
+		q := parsedUrl.Query()
 		q.Add("page", currentPage)
-		url.RawQuery = q.Encode()
+		parsedUrl.RawQuery = q.Encode()
 
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequest("GET", parsedUrl.String(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating rse request")
 		}

--- a/internal/extsvc/jvmpackages/coursier/observability.go
+++ b/internal/extsvc/jvmpackages/coursier/observability.go
@@ -21,7 +21,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"codeintel_coursier",
 		metrics.WithLabels("op"),
@@ -32,7 +32,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("codeintel.coursier.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if err != nil && strings.Contains(err.Error(), "not found") {
 					return observation.EmitForMetrics | observation.EmitForTraces

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -372,10 +372,10 @@ func TestClient_P4Exec(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			server := httptest.NewServer(test.handler)
-			defer server.Close()
+			testServer := httptest.NewServer(test.handler)
+			defer testServer.Close()
 
-			u, _ := url.Parse(server.URL)
+			u, _ := url.Parse(testServer.URL)
 			addrs := []string{u.Host}
 			cli := gitserver.NewTestClient(&http.Client{}, addrs)
 

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -178,10 +178,10 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 
 				fileNames = append(fileNames, file.NewName)
 
-				fs := file.Stat()
-				stat.Added += fs.Added
-				stat.Changed += fs.Changed
-				stat.Deleted += fs.Deleted
+				fileStat := file.Stat()
+				stat.Added += fileStat.Added
+				stat.Changed += fileStat.Changed
+				stat.Deleted += fileStat.Deleted
 			}
 			if diff := cmp.Diff(fileNames, tc.expectedDiffFiles); diff != "" {
 				t.Fatal(diff)

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -16,7 +16,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"gitserver_client",
 		metrics.WithLabels("op"),
@@ -27,7 +27,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("gitserver.client.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -123,8 +123,8 @@ func (cs *CommitSearcher) Search(ctx context.Context, onMatch func(*protocol.Com
 	// submitted to the job queue
 	g.Go(func() error {
 		for resultChan := range resultChans {
-			for result := range resultChan {
-				onMatch(result)
+			for res := range resultChan {
+				onMatch(res)
 			}
 		}
 

--- a/internal/instrumentation/http.go
+++ b/internal/instrumentation/http.go
@@ -40,17 +40,17 @@ func HTTPMiddleware(operation string, h http.Handler, opts ...otelhttp.Option) h
 		)...)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var trace bool
+		var shouldTrace bool
 		switch policy.GetTracePolicy() {
 		case policy.TraceSelective:
-			trace = policy.RequestWantsTracing(r)
+			shouldTrace = policy.RequestWantsTracing(r)
 		case policy.TraceAll:
-			trace = true
+			shouldTrace = true
 		default:
-			trace = false
+			shouldTrace = false
 		}
 		// Pass through to instrumented handler with trace policy in context
-		instrumentedHandler.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), trace)))
+		instrumentedHandler.ServeHTTP(w, r.WithContext(policy.WithShouldTrace(r.Context(), shouldTrace)))
 	})
 }
 

--- a/internal/luasandbox/observability.go
+++ b/internal/luasandbox/observability.go
@@ -19,7 +19,7 @@ type operations struct {
 var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := m.Get(func() *metrics.REDMetrics {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
 		return metrics.NewREDMetrics(
 			observationCtx.Registerer,
 			"luasandbox",
@@ -32,7 +32,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("luasandbox.%s", name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/internal/oobmigration/migrations/register.go
+++ b/internal/oobmigration/migrations/register.go
@@ -13,11 +13,11 @@ import (
 )
 
 func RegisterOSSMigrators(ctx context.Context, db database.DB, runner *oobmigration.Runner) error {
-	keyring := keyring.Default()
+	defaultKeyring := keyring.Default()
 
 	return registerOSSMigrators(runner, false, migratorDependencies{
 		store:   basestore.NewWithHandle(db.Handle()),
-		keyring: &keyring,
+		keyring: &defaultKeyring,
 	})
 }
 

--- a/internal/oobmigration/observability.go
+++ b/internal/oobmigration/observability.go
@@ -14,7 +14,7 @@ type operations struct {
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		"oobmigration",
 		metrics.WithLabels("op", "migration"),
@@ -26,7 +26,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 			return observationCtx.Operation(observation.Op{
 				Name:              fmt.Sprintf("oobmigration.%s", name),
 				MetricLabelValues: []string{name, strconv.Itoa(migrationID)},
-				Metrics:           metrics,
+				Metrics:           redMetrics,
 			})
 		}
 	}

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -203,8 +203,8 @@ func githubCloneURL(logger log.Logger, repo *github.Repository, cfg *schema.GitH
 		}
 		baseURL = extsvc.NormalizeBaseURL(baseURL)
 		originalHostname := baseURL.Hostname()
-		url := fmt.Sprintf("git@%s:%s.git", originalHostname, repo.NameWithOwner)
-		return url, nil
+		cloneUrl := fmt.Sprintf("git@%s:%s.git", originalHostname, repo.NameWithOwner)
+		return cloneUrl, nil
 	}
 
 	if repo.URL == "" {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -348,8 +348,8 @@ func (s *GitHubSource) makeRepo(r *github.Repository) *types.Repo {
 // if you need to get an authenticated clone url use repos.CloneURL
 func (s *GitHubSource) remoteURL(repo *github.Repository) string {
 	if s.config.GitURLType == "ssh" {
-		url := fmt.Sprintf("git@%s:%s.git", s.originalHostname, repo.NameWithOwner)
-		return url
+		assembledURL := fmt.Sprintf("git@%s:%s.git", s.originalHostname, repo.NameWithOwner)
+		return assembledURL
 	}
 
 	return repo.URL

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -310,7 +310,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 		go func(projectQuery string) {
 			defer wg.Done()
 
-			url, err := projectQueryToURL(projectQuery, perPage) // first page URL
+			urlStr, err := projectQueryToURL(projectQuery, perPage) // first page URL
 			if err != nil {
 				ch <- batch{err: errors.Wrapf(err, "invalid GitLab projectQuery=%q", projectQuery)}
 				return
@@ -321,16 +321,16 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 					ch <- batch{err: err}
 					return
 				}
-				projects, nextPageURL, err := s.client.ListProjects(ctx, url)
+				projects, nextPageURL, err := s.client.ListProjects(ctx, urlStr)
 				if err != nil {
-					ch <- batch{err: errors.Wrapf(err, "error listing GitLab projects: url=%q", url)}
+					ch <- batch{err: errors.Wrapf(err, "error listing GitLab projects: url=%q", urlStr)}
 					return
 				}
 				ch <- batch{projs: projects}
 				if nextPageURL == nil {
 					return
 				}
-				url = *nextPageURL
+				urlStr = *nextPageURL
 
 				// 0-duration sleep unless nearing rate limit exhaustion. If context has been canceled, next iteration of loop will return error.
 				timeutil.SleepWithContext(ctx, s.client.RateLimitMonitor().RecommendedWaitForBackgroundOp(1))

--- a/internal/search/job/jobutil/combinators_test.go
+++ b/internal/search/job/jobutil/combinators_test.go
@@ -101,8 +101,8 @@ func TestLimitJob(t *testing.T) {
 	})
 
 	t.Run("NewLimitJob propagates noop", func(t *testing.T) {
-		job := NewLimitJob(10, NewNoopJob())
-		require.Equal(t, NewNoopJob(), job)
+		j := NewLimitJob(10, NewNoopJob())
+		require.Equal(t, NewNoopJob(), j)
 	})
 }
 
@@ -119,8 +119,8 @@ func TestTimeoutJob(t *testing.T) {
 	})
 
 	t.Run("NewTimeoutJob propagates noop", func(t *testing.T) {
-		job := NewTimeoutJob(10*time.Second, NewNoopJob())
-		require.Equal(t, NewNoopJob(), job)
+		j := NewTimeoutJob(10*time.Second, NewNoopJob())
+		require.Equal(t, NewNoopJob(), j)
 	})
 }
 

--- a/internal/search/job/jobutil/filter_file_contains_test.go
+++ b/internal/search/job/jobutil/filter_file_contains_test.go
@@ -262,15 +262,15 @@ func TestFileContainsFilterJob(t *testing.T) {
 				}
 				return false, nil
 			}
-			var result streaming.SearchEvent
+			var resultEvent streaming.SearchEvent
 			streamCollector := streaming.StreamFunc(func(ev streaming.SearchEvent) {
-				result = ev
+				resultEvent = ev
 			})
 			j := NewFileContainsFilterJob(tc.includePatterns, tc.originalPattern, tc.caseSensitive, childJob)
 			alert, err := j.Run(context.Background(), job.RuntimeClients{}, streamCollector)
 			require.Nil(t, alert)
 			require.NoError(t, err)
-			require.Equal(t, tc.outputEvent, result)
+			require.Equal(t, tc.outputEvent, resultEvent)
 		})
 	}
 }

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1448,12 +1448,12 @@ func RunRepoSubsetTextSearch(
 			return nil, streaming.Stats{}, err
 		}
 
-		types, _ := q.StringValues(query.FieldType)
+		fieldTypes, _ := q.StringValues(query.FieldType)
 		var resultTypes result.Types
-		if len(types) == 0 {
+		if len(fieldTypes) == 0 {
 			resultTypes = result.TypeFile | result.TypePath | result.TypeRepo
 		} else {
-			for _, t := range types {
+			for _, t := range fieldTypes {
 				resultTypes = resultTypes.With(result.TypeFromString[t])
 			}
 		}

--- a/internal/search/job/jobutil/sanitize_job_test.go
+++ b/internal/search/job/jobutil/sanitize_job_test.go
@@ -157,16 +157,16 @@ func TestSanitizeJob(t *testing.T) {
 				return nil, nil
 			})
 
-			var result streaming.SearchEvent
+			var searchEvent streaming.SearchEvent
 			streamCollector := streaming.StreamFunc(func(event streaming.SearchEvent) {
-				result = event
+				searchEvent = event
 			})
 
 			j := NewSanitizeJob(omitPatterns, childJob)
 			alert, err := j.Run(context.Background(), job.RuntimeClients{}, streamCollector)
 			require.Nil(t, alert)
 			require.NoError(t, err)
-			require.Equal(t, tc.outputEvent, result)
+			require.Equal(t, tc.outputEvent, searchEvent)
 		})
 	}
 }

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -770,8 +770,8 @@ func TestParseStandard(t *testing.T) {
 		if err != nil {
 			return err.Error()
 		}
-		json, _ := PrettyJSON(result)
-		return json
+		jsonStr, _ := PrettyJSON(result)
+		return jsonStr
 	}
 
 	t.Run("patterns are literal and slash-delimited patterns /.../ are regexp", func(t *testing.T) {

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -207,17 +207,17 @@ func nodesToJSON(q Q) []any {
 }
 
 func ToJSON(q Q) (string, error) {
-	json, err := json.Marshal(nodesToJSON(q))
+	j, err := json.Marshal(nodesToJSON(q))
 	if err != nil {
 		return "", err
 	}
-	return string(json), nil
+	return string(j), nil
 }
 
 func PrettyJSON(q Q) (string, error) {
-	json, err := json.MarshalIndent(nodesToJSON(q), "", "  ")
+	j, err := json.MarshalIndent(nodesToJSON(q), "", "  ")
 	if err != nil {
 		return "", err
 	}
-	return string(json), nil
+	return string(j), nil
 }

--- a/internal/search/query/printer_test.go
+++ b/internal/search/query/printer_test.go
@@ -31,14 +31,14 @@ func TestStringHuman(t *testing.T) {
 
 	test := func(input string) string {
 		q, _ := ParseStandard(input)
-		json, _ := json.MarshalIndent(struct {
+		j, _ := json.MarshalIndent(struct {
 			Input  string
 			Result string
 		}{
 			Input:  input,
 			Result: StringHuman(q),
 		}, "", "  ")
-		return string(json)
+		return string(j)
 	}
 
 	for _, c := range cases {

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -23,17 +23,17 @@ type File struct {
 }
 
 func (f *File) URL() *url.URL {
-	var path strings.Builder
-	path.Grow(len("/@/-/blob/") + len(f.Repo.Name) + len(f.Path) + 20)
-	path.WriteRune('/')
-	path.WriteString(string(f.Repo.Name))
+	var urlPath strings.Builder
+	urlPath.Grow(len("/@/-/blob/") + len(f.Repo.Name) + len(f.Path) + 20)
+	urlPath.WriteRune('/')
+	urlPath.WriteString(string(f.Repo.Name))
 	if f.InputRev != nil && len(*f.InputRev) > 0 {
-		path.WriteRune('@')
-		path.WriteString(*f.InputRev)
+		urlPath.WriteRune('@')
+		urlPath.WriteString(*f.InputRev)
 	}
-	path.WriteString("/-/blob/")
-	path.WriteString(f.Path)
-	return &url.URL{Path: path.String()}
+	urlPath.WriteString("/-/blob/")
+	urlPath.WriteString(f.Path)
+	return &url.URL{Path: urlPath.String()}
 }
 
 // FileMatch represents either:

--- a/internal/search/smartsearch/rules_test.go
+++ b/internal/search/smartsearch/rules_test.go
@@ -23,8 +23,8 @@ func apply(input string, transform []transform) string {
 		queryStr = query.StringHuman(out.ToParseTree())
 	}
 	result := want{Input: input, Query: queryStr}
-	json, _ := json.MarshalIndent(result, "", "  ")
-	return string(json)
+	j, _ := json.MarshalIndent(result, "", "  ")
+	return string(j)
 }
 
 func Test_unquotePatterns(t *testing.T) {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -199,9 +199,9 @@ func PartitionRepos(
 	}()
 
 	// Only include indexes with symbol information if a symbol request.
-	var filter func(repo *zoekt.MinimalRepoListEntry) bool
+	var filterFunc func(repo *zoekt.MinimalRepoListEntry) bool
 	if typ == search.SymbolRequest {
-		filter = func(repo *zoekt.MinimalRepoListEntry) bool {
+		filterFunc = func(repo *zoekt.MinimalRepoListEntry) bool {
 			return repo.HasSymbols
 		}
 	}
@@ -229,7 +229,7 @@ func PartitionRepos(
 	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.Minimal))) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	// Split based on indexed vs unindexed
-	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filterFunc) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	tr.SetAttributes(
 		attribute.Int("indexed.size", len(indexed.RepoRevs)),

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -274,7 +274,7 @@ func TestIndexedSearch(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			zoekt := &searchbackend.FakeSearcher{
+			fakeZoekt := &searchbackend.FakeSearcher{
 				Result: &zoekt.SearchResult{Files: tt.args.results},
 				Repos:  zoektRepos,
 			}
@@ -294,7 +294,7 @@ func TestIndexedSearch(t *testing.T) {
 				context.Background(),
 				logtest.Scoped(t),
 				tt.args.repos,
-				zoekt,
+				fakeZoekt,
 				search.TextRequest,
 				query.Yes,
 				query.ContainsRefGlobs(q),
@@ -316,7 +316,7 @@ func TestIndexedSearch(t *testing.T) {
 				Since:          tt.args.since,
 			}
 
-			_, err = zoektJob.Run(tt.args.ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
+			_, err = zoektJob.Run(tt.args.ctx, job.RuntimeClients{Zoekt: fakeZoekt}, agg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -178,9 +178,9 @@ func toZoektPattern(
 }
 
 func mapSlice(values []string, f func(string) string) []string {
-	result := make([]string, len(values))
+	out := make([]string, len(values))
 	for i, v := range values {
-		result[i] = f(v)
+		out[i] = f(v)
 	}
-	return result
+	return out
 }

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -474,7 +474,7 @@ func (c *Client) httpPost(
 		span.Finish()
 	}()
 
-	url, err := c.url(repo)
+	repoUrl, err := c.url(repo)
 	if err != nil {
 		return nil, err
 	}
@@ -484,10 +484,10 @@ func (c *Client) httpPost(
 		return nil, err
 	}
 
-	if !strings.HasSuffix(url, "/") {
-		url += "/"
+	if !strings.HasSuffix(repoUrl, "/") {
+		repoUrl += "/"
 	}
-	req, err := http.NewRequest("POST", url+method, bytes.NewReader(reqBody))
+	req, err := http.NewRequest("POST", repoUrl+method, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -20,17 +20,17 @@ import (
 )
 
 func TestTgzFallback(t *testing.T) {
-	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
+	tarBytes := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
 
 	t.Run("with-io-read-seeker", func(t *testing.T) {
-		err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
+		err := Tgz(bytes.NewReader(tarBytes), t.TempDir(), Opts{})
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("without-io-read-seeker", func(t *testing.T) {
-		err := Tgz(bytes.NewBuffer(tar), t.TempDir(), Opts{})
+		err := Tgz(bytes.NewBuffer(tarBytes), t.TempDir(), Opts{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/uploadhandler/observability.go
+++ b/internal/uploadhandler/observability.go
@@ -18,7 +18,7 @@ type Operations struct {
 }
 
 func NewOperations(observationCtx *observation.Context, prefix string) *Operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		fmt.Sprintf("%s_uploadhandler", prefix),
 		metrics.WithLabels("op"),
@@ -29,7 +29,7 @@ func NewOperations(observationCtx *observation.Context, prefix string) *Operatio
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("%s.uploadhandler.%s", prefix, name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				var errno syscall.Errno
 				if errors.As(err, &errno) && errno == syscall.ECONNREFUSED {

--- a/internal/uploadstore/observability.go
+++ b/internal/uploadstore/observability.go
@@ -16,7 +16,7 @@ type Operations struct {
 }
 
 func NewOperations(observationCtx *observation.Context, domain, storeName string) *Operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		fmt.Sprintf("%s_%s", domain, storeName),
 		metrics.WithLabels("op"),
@@ -27,7 +27,7 @@ func NewOperations(observationCtx *observation.Context, domain, storeName string
 		return observationCtx.Operation(observation.Op{
 			Name:              fmt.Sprintf("%s.%s.%s", domain, storeName, name),
 			MetricLabelValues: []string{name},
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -177,7 +177,7 @@ func serializePublishSourcegraphDotComEvents(events []Event) ([]string, error) {
 			return nil, err
 		}
 
-		url, err := redactSensitiveInfoFromCloudURL(event.URL)
+		saferUrl, err := redactSensitiveInfoFromCloudURL(event.URL)
 		if err != nil {
 			return nil, err
 		}
@@ -186,7 +186,7 @@ func serializePublishSourcegraphDotComEvents(events []Event) ([]string, error) {
 			EventName:        event.EventName,
 			UserID:           int(event.UserID),
 			AnonymousUserID:  event.UserCookieID,
-			URL:              url,
+			URL:              saferUrl,
 			FirstSourceURL:   firstSourceURL,
 			LastSourceURL:    lastSourceURL,
 			Referrer:         referrer,

--- a/internal/workerutil/observability.go
+++ b/internal/workerutil/observability.go
@@ -114,7 +114,7 @@ func NewMetrics(observationCtx *observation.Context, prefix string, opts ...Obse
 }
 
 func newOperations(observationCtx *observation.Context, prefix string, keys, values []string, durationBuckets []float64) *operations {
-	metrics := metrics.NewREDMetrics(
+	redMetrics := metrics.NewREDMetrics(
 		observationCtx.Registerer,
 		prefix,
 		metrics.WithLabels(append(keys, "op")...),
@@ -126,7 +126,7 @@ func newOperations(observationCtx *observation.Context, prefix string, keys, val
 		return observationCtx.Operation(observation.Op{
 			Name:              name,
 			MetricLabelValues: append(append([]string{}, values...), name),
-			Metrics:           metrics,
+			Metrics:           redMetrics,
 		})
 	}
 

--- a/lib/codeintel/lsif/conversion/group_test.go
+++ b/lib/codeintel/lsif/conversion/group_test.go
@@ -702,8 +702,8 @@ func sortDiagnostics(s []precise.DiagnosticData) {
 
 func sortDocumentIDRangeIDs(s []precise.DocumentIDRangeID) {
 	sort.Slice(s, func(i, j int) bool {
-		if cmp := strings.Compare(string(s[i].DocumentID), string(s[j].DocumentID)); cmp != 0 {
-			return cmp < 0
+		if compareResult := strings.Compare(string(s[i].DocumentID), string(s[j].DocumentID)); compareResult != 0 {
+			return compareResult < 0
 		} else {
 			return strings.Compare(string(s[i].RangeID), string(s[j].RangeID)) < 0
 		}
@@ -712,10 +712,10 @@ func sortDocumentIDRangeIDs(s []precise.DocumentIDRangeID) {
 
 func sortMonikerLocations(monikerLocations []precise.MonikerLocations) {
 	sort.Slice(monikerLocations, func(i, j int) bool {
-		if cmp := strings.Compare(monikerLocations[i].Scheme, monikerLocations[j].Scheme); cmp != 0 {
-			return cmp < 0
-		} else if cmp := strings.Compare(monikerLocations[i].Identifier, monikerLocations[j].Identifier); cmp != 0 {
-			return cmp < 0
+		if compareResult := strings.Compare(monikerLocations[i].Scheme, monikerLocations[j].Scheme); compareResult != 0 {
+			return compareResult < 0
+		} else if compareResult := strings.Compare(monikerLocations[i].Identifier, monikerLocations[j].Identifier); compareResult != 0 {
+			return compareResult < 0
 		}
 		return false
 	})
@@ -727,8 +727,8 @@ func sortMonikerLocations(monikerLocations []precise.MonikerLocations) {
 
 func sortLocations(locations []precise.LocationData) {
 	sort.Slice(locations, func(i, j int) bool {
-		if cmp := strings.Compare(locations[i].URI, locations[j].URI); cmp != 0 {
-			return cmp < 0
+		if compareResult := strings.Compare(locations[i].URI, locations[j].URI); compareResult != 0 {
+			return compareResult < 0
 		}
 
 		return locations[i].StartLine < locations[j].StartLine

--- a/lib/codeintel/lsif/validation/validators_vertex.go
+++ b/lib/codeintel/lsif/validation/validators_vertex.go
@@ -21,17 +21,17 @@ func validateMetaDataVertex(ctx *ValidationContext, lineContext reader.LineConte
 		return false
 	}
 
-	url, err := url.Parse(metaData.ProjectRoot)
+	projectRootURL, err := url.Parse(metaData.ProjectRoot)
 	if err != nil {
 		ctx.AddError("project root is not a valid URL").AddContext(lineContext)
 		return false
 	}
-	if url.Scheme == "" {
+	if projectRootURL.Scheme == "" {
 		ctx.AddError("project root is not a valid URL").AddContext(lineContext)
 		return false
 	}
 
-	ctx.ProjectRoot = url
+	ctx.ProjectRoot = projectRootURL
 	return true
 }
 
@@ -44,17 +44,17 @@ func validateDocumentVertex(ctx *ValidationContext, lineContext reader.LineConte
 		return false
 	}
 
-	url, err := url.Parse(uri)
+	documentUrl, err := url.Parse(uri)
 	if err != nil {
 		ctx.AddError("document uri is not a valid URL").AddContext(lineContext)
 		return false
 	}
-	if url.Scheme == "" {
+	if documentUrl.Scheme == "" {
 		ctx.AddError("document uri is not a valid URL").AddContext(lineContext)
 		return false
 	}
 
-	if ctx.ProjectRoot != nil && !strings.HasPrefix(url.String(), ctx.ProjectRoot.String()) {
+	if ctx.ProjectRoot != nil && !strings.HasPrefix(documentUrl.String(), ctx.ProjectRoot.String()) {
 		ctx.AddError("document is not relative to project root").AddContext(lineContext)
 		return false
 	}

--- a/lib/codeintel/precise/util_test.go
+++ b/lib/codeintel/precise/util_test.go
@@ -160,8 +160,8 @@ func TestComparePosition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if cmp := ComparePosition(left, testCase.line, testCase.character); cmp != testCase.expected {
-			t.Errorf("unexpected comparisonPosition result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmp)
+		if cmpResult := ComparePosition(left, testCase.line, testCase.character); cmpResult != testCase.expected {
+			t.Errorf("unexpected comparisonPosition result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmpResult)
 		}
 	}
 }

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -261,13 +261,13 @@ func validateDump(directory string) (bundleResult, error) {
 	}
 
 	if len(ctx.Errors) > 0 {
-		errors := make([]string, len(ctx.Errors)+1)
-		errors[0] = fmt.Sprintf("Detected %d errors", len(ctx.Errors))
+		errs := make([]string, len(ctx.Errors)+1)
+		errs[0] = fmt.Sprintf("Detected %d errors", len(ctx.Errors))
 		for i, err := range ctx.Errors {
-			errors[i+1] = fmt.Sprintf("%d. %s", i, err)
+			errs[i+1] = fmt.Sprintf("%d. %s", i, err)
 		}
 
-		return bundleResult{Valid: false, Errors: errors}, nil
+		return bundleResult{Valid: false, Errors: errs}, nil
 	}
 
 	return bundleResult{Valid: true}, nil
@@ -480,11 +480,11 @@ func runOneReferencesRequest(projectRoot string, bundle *precise.GroupedBundleDa
 func runOneDefinitionRequest(logger log.Logger, projectRoot string, bundle *precise.GroupedBundleDataMaps, testCase DefinitionTest, fileResult *testFileResult) error {
 	request := testCase.Request
 
-	path := request.TextDocument
+	docPath := request.TextDocument
 	line := request.Position.Line
 	character := request.Position.Character
 
-	results, err := precise.Query(bundle, path, line, character)
+	results, err := precise.Query(bundle, docPath, line, character)
 	if err != nil {
 		return err
 	}

--- a/lib/codeintel/upload/request.go
+++ b/lib/codeintel/upload/request.go
@@ -51,12 +51,12 @@ func performUploadRequest(ctx context.Context, httpClient Client, opts uploadReq
 
 // makeUploadRequest creates an HTTP request to the upload endpoint described by the given arguments.
 func makeUploadRequest(opts uploadRequestOptions) (*http.Request, error) {
-	url, err := makeUploadURL(opts)
+	uploadURL, err := makeUploadURL(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url.String(), opts.Payload)
+	req, err := http.NewRequest("POST", uploadURL.String(), opts.Payload)
 	if err != nil {
 		return nil, err
 	}
@@ -190,13 +190,13 @@ func makeUploadURL(opts uploadRequestOptions) (*url.URL, error) {
 		path = "/.api/lsif/upload"
 	}
 
-	url, err := url.Parse(opts.SourcegraphInstanceOptions.SourcegraphURL + path)
+	parsedUrl, err := url.Parse(opts.SourcegraphInstanceOptions.SourcegraphURL + path)
 	if err != nil {
 		return nil, err
 	}
 
-	url.RawQuery = qs.Encode()
-	return url, nil
+	parsedUrl.RawQuery = qs.Encode()
+	return parsedUrl, nil
 }
 
 func formatInt(v int) string {

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -32,7 +32,7 @@ func ExampleIterator() {
 }
 
 func TestIterator_Err(t *testing.T) {
-	assert := assert.New(t)
+	assertion := assert.New(t)
 
 	sendErr := false
 	it := iterator.New(func() ([]int, error) {
@@ -46,33 +46,33 @@ func TestIterator_Err(t *testing.T) {
 	})
 
 	got, err := iterator.Collect(it)
-	assert.Equal([]int{1, 2, 3, 1, 2, 3}, got)
-	assert.ErrorContains(err, "boom")
+	assertion.Equal([]int{1, 2, 3, 1, 2, 3}, got)
+	assertion.ErrorContains(err, "boom")
 
 	// Double check it is safe to call Next and Err again.
-	assert.Falsef(it.Next(), "expected collected Next to return false")
-	assert.Errorf(it.Err(), "expected collected Err to be non-nil")
+	assertion.Falsef(it.Next(), "expected collected Next to return false")
+	assertion.Errorf(it.Err(), "expected collected Err to be non-nil")
 
 	// Ensure we panic on calling Current.
-	assert.Panics(func() { it.Current() })
+	assertion.Panics(func() { it.Current() })
 }
 
 func TestIterator_Current(t *testing.T) {
-	assert := assert.New(t)
+	assertion := assert.New(t)
 
 	it := iterator.From([]int{1})
-	assert.PanicsWithValue(
+	assertion.PanicsWithValue(
 		"*iterator.Iterator[int].Current() called before first call to Next()",
 		func() { it.Current() },
 		"Current before Next should panic",
 	)
 
-	assert.True(it.Next())
-	assert.Equal(1, it.Current())
-	assert.Equal(1, it.Current(), "Current should be idempotent")
+	assertion.True(it.Next())
+	assertion.Equal(1, it.Current())
+	assertion.Equal(1, it.Current(), "Current should be idempotent")
 
-	assert.False(it.Next())
-	assert.PanicsWithValue(
+	assertion.False(it.Next())
+	assertion.PanicsWithValue(
 		"*iterator.Iterator[int].Current() called after Next() returned false",
 		func() { it.Current() },
 		"Current after Next is false should panic",

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -367,7 +367,7 @@ func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher)
 							c.Name, o.Name, level, err)
 					}
 
-					labels := map[string]string{
+					labelMap := map[string]string{
 						"name":         o.Name,
 						"level":        level,
 						"service_name": c.Name,
@@ -380,9 +380,9 @@ func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher)
 					}
 					// Inject labels as fixed values for alert rules
 					for _, l := range injectLabelMatchers {
-						labels[l.Name] = l.Value
+						labelMap[l.Name] = l.Value
 					}
-					group.appendRow(alertQuery, labels, a.duration)
+					group.appendRow(alertQuery, labelMap, a.duration)
 				}
 			}
 		}

--- a/monitoring/monitoring/prometheus.go
+++ b/monitoring/monitoring/prometheus.go
@@ -109,9 +109,9 @@ func (g *PrometheusRuleGroup) appendRow(alertQuery string, labels map[string]str
 
 func CustomPrometheusRules(injectLabelMatchers []*labels.Matcher) (*PrometheusRules, error) {
 	// Hardcode the desired label matcher values as labels
-	labels := make(map[string]string)
+	labelsMap := make(map[string]string)
 	for _, matcher := range injectLabelMatchers {
-		labels[matcher.Name] = matcher.Value
+		labelsMap[matcher.Name] = matcher.Value
 	}
 
 	var injectErrors error
@@ -131,19 +131,19 @@ func CustomPrometheusRules(injectLabelMatchers []*labels.Matcher) (*PrometheusRu
 				// The number of CPUs allocated to the container according to the configured Docker / Kubernetes limits.
 				Record: "cadvisor_container_cpu_limit",
 				Expr:   injectExpr("avg by (name)(container_spec_cpu_quota) / avg by (name)(container_spec_cpu_period)"),
-				Labels: labels,
+				Labels: labelsMap,
 			}, {
 				// Percentage of CPU cores the container consumed on average over a 1m period.
 				// For example, if a container has a 4 CPU limit and this metric reports 50%,
 				// it means the container consumed 2 cores on average over that 1m period.
 				Record: "cadvisor_container_cpu_usage_percentage_total",
 				Expr:   injectExpr("(avg by (name)(rate(container_cpu_usage_seconds_total[1m])) / cadvisor_container_cpu_limit) * 100.0"),
-				Labels: labels,
+				Labels: labelsMap,
 			}, {
 				// Percentage of memory usage the container is consuming.
 				Record: "cadvisor_container_memory_usage_percentage_total",
 				Expr:   injectExpr("max by (name)(container_memory_working_set_bytes / container_spec_memory_limit_bytes) * 100.0"),
-				Labels: labels,
+				Labels: labelsMap,
 			}},
 		}},
 	}


### PR DESCRIPTION
This is a refactor PR; it shouldn't change behavior.

A bunch of variables in the codebase collided with package names.
This can cause confusion and unwanted behavior that increases debugging time during development.

I've renamed the colliding variables to make them unique.
I've tried to improve code quality with this change by making the variable names at least as descriptive as they were while embracing the conciseness that seems idiomatic in Go. It was, at times, difficult to strike a balance between these, but at this point, I'm satisfied with the result.
In some cases, I opted for not renaming the variable names at all but rather adding an alias for the package with the conflicting name. I've committed those changes in a separate PR: https://github.com/sourcegraph/sourcegraph/pull/47180.

**For reviewers:** The recommended way to review this is to just scroll through it, either in the unified or the split view, whichever you're more used to. That's what I did about twice. It is long, but it's extremely simple: 100% renames. It will take less than 10 minutes if you agree with all my changes, a bit more otherwise. It needs some concentration, though—naming is hard. Thanks for loaning me your brain on this! 🧠 

## Test plan

Refactor commit with only renames. Tests should pass.