### PR TITLE
Housekeeping: Add package name aliases to avoid collisions with variables

### DIFF
--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -6,7 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -170,7 +170,7 @@ func (r *schemaResolver) OrganizationFeatureFlagValue(ctx context.Context, args 
 }
 
 func (r *schemaResolver) OrganizationFeatureFlagOverrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 
 	if !actor.IsAuthenticated() {
 		return nil, errors.New("no current user")

--- a/cmd/frontend/graphqlbackend/highlight.go
+++ b/cmd/frontend/graphqlbackend/highlight.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 type highlightedRangeResolver struct {
-	inner result.HighlightedRange
+	inner searchresult.HighlightedRange
 }
 
 func (h highlightedRangeResolver) Line() int32      { return h.inner.Line }
@@ -20,7 +20,7 @@ func (h highlightedRangeResolver) Character() int32 { return h.inner.Character }
 func (h highlightedRangeResolver) Length() int32    { return h.inner.Length }
 
 type highlightedStringResolver struct {
-	inner result.HighlightedString
+	inner searchresult.HighlightedString
 }
 
 func (s *highlightedStringResolver) Value() string { return s.inner.Value }

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -116,7 +116,7 @@ func checkEmail(ctx context.Context, db database.DB, inviteEmail string) (bool, 
 func (r *schemaResolver) PendingInvitations(ctx context.Context, args *struct {
 	Organization graphql.ID
 }) ([]*organizationInvitationResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}
@@ -160,7 +160,7 @@ func newExpiryTime() time.Time {
 func (r *schemaResolver) InvitationByToken(ctx context.Context, args *struct {
 	Token string
 }) (*organizationInvitationResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}
@@ -291,7 +291,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 	OrganizationInvitation graphql.ID
 	ResponseType           string
 }) (*EmptyResponse, error) {
-	a := actor.FromContext(ctx)
+	a := sgactor.FromContext(ctx)
 	if !a.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -6,7 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
@@ -35,7 +35,7 @@ func (r *schemaResolver) AutocompleteMembersSearch(ctx context.Context, args *st
 	Organization graphql.ID
 	Query        string
 }) ([]*OrgMemberAutocompleteSearchItemResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}
@@ -62,7 +62,7 @@ func (r *schemaResolver) AutocompleteMembersSearch(ctx context.Context, args *st
 func (r *schemaResolver) OrgMembersSummary(ctx context.Context, args *struct {
 	Organization graphql.ID
 }) (*OrgMembersSummaryResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, errors.New("no current user")
 	}

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -556,7 +556,7 @@ index 373ae20..89ad131 100644
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fileDiff, err := diff.ParseFileDiff([]byte(tc.patch))
+			fileDiff, err := godiff.ParseFileDiff([]byte(tc.patch))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
@@ -454,7 +454,7 @@ func TestRepositoryComparison(t *testing.T) {
 func TestDiffHunk(t *testing.T) {
 	ctx := context.Background()
 
-	dr := diff.NewMultiFileDiffReader(strings.NewReader(testDiff))
+	dr := godiff.NewMultiFileDiffReader(strings.NewReader(testDiff))
 	// We only read the first file diff from testDiff
 	fileDiff, err := dr.ReadFile()
 	if err != nil && err != io.EOF {
@@ -564,7 +564,7 @@ index 4d14577..10ef458 100644
 +(c) Copyright Sourcegraph 2013-2021.
 \ No newline at end of file
 `
-	dr := diff.NewMultiFileDiffReader(strings.NewReader(filediff))
+	dr := godiff.NewMultiFileDiffReader(strings.NewReader(filediff))
 	// We only read the first file diff from testDiff
 	fileDiff, err := dr.ReadFile()
 	if err != nil && err != io.EOF {
@@ -650,7 +650,7 @@ index 4d14577..9fe9a4f 100644
 ` + "-" + `
  See [the main README](https://github.com/dominikh/go-tools#installation) for installation instructions.`
 
-	dr := diff.NewMultiFileDiffReader(strings.NewReader(filediff))
+	dr := godiff.NewMultiFileDiffReader(strings.NewReader(filediff))
 	// We only read the first file diff from testDiff
 	fileDiff, err := dr.ReadFile()
 	if err != nil && err != io.EOF {
@@ -750,7 +750,7 @@ index d206c4c..bb06461 100644
 -}
 `
 
-	dr := diff.NewMultiFileDiffReader(strings.NewReader(filediff))
+	dr := godiff.NewMultiFileDiffReader(strings.NewReader(filediff))
 	// We only read the first file diff from testDiff
 	fileDiff, err := dr.ReadFile()
 	if err != nil && err != io.EOF {

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/users"
+	sgusers "github.com/sourcegraph/sourcegraph/internal/users"
 )
 
 func (s *siteResolver) Users(ctx context.Context, args *struct {
@@ -17,10 +17,10 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	SiteAdmin    *bool
 	Username     *string
 	Email        *string
-	CreatedAt    *users.UsersStatsDateTimeRange
-	LastActiveAt *users.UsersStatsDateTimeRange
-	DeletedAt    *users.UsersStatsDateTimeRange
-	EventsCount  *users.UsersStatsNumberRange
+	CreatedAt    *sgusers.UsersStatsDateTimeRange
+	LastActiveAt *sgusers.UsersStatsDateTimeRange
+	DeletedAt    *sgusers.UsersStatsDateTimeRange
+	EventsCount  *sgusers.UsersStatsNumberRange
 },
 ) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
@@ -29,7 +29,7 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	}
 
 	return &siteUsersResolver{
-		&users.UsersStats{DB: s.db, Filters: users.UsersStatsFilters{
+		&sgusers.UsersStats{DB: s.db, Filters: sgusers.UsersStatsFilters{
 			Query:        args.Query,
 			SiteAdmin:    args.SiteAdmin,
 			Username:     args.Username,
@@ -43,7 +43,7 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 }
 
 type siteUsersResolver struct {
-	userStats *users.UsersStats
+	userStats *sgusers.UsersStats
 }
 
 func (s *siteUsersResolver) TotalCount(ctx context.Context) (float64, error) {
@@ -57,7 +57,7 @@ func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 	Offset     *int32
 },
 ) ([]*siteUserResolver, error) {
-	users, err := s.userStats.ListUsers(ctx, &users.UsersStatsListUsersFilters{OrderBy: args.OrderBy, Descending: args.Descending, Limit: args.Limit, Offset: args.Offset})
+	users, err := s.userStats.ListUsers(ctx, &sgusers.UsersStatsListUsersFilters{OrderBy: args.OrderBy, Descending: args.Descending, Limit: args.Limit, Offset: args.Offset})
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 }
 
 type siteUserResolver struct {
-	user         *users.UserStatItem
+	user         *sgusers.UserStatItem
 	lockoutStore userpasswd.LockoutStore
 }
 

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot/hubspotutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -99,7 +99,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 	}
 
 	// If user is authenticated, use their uid and overwrite the optional email field.
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if actor.IsAuthenticated() {
 		uid = &actor.UID
 		e, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, actor.UID)
@@ -164,7 +164,7 @@ func (r *schemaResolver) SubmitHappinessFeedback(ctx context.Context, args *stru
 
 	// We include the username and email address of the user (if signed in). For signed-in users,
 	// the UI indicates that the username and email address will be sent to Sourcegraph.
-	if actor := actor.FromContext(ctx); actor.IsAuthenticated() {
+	if actor := sgactor.FromContext(ctx); actor.IsAuthenticated() {
 		currentUser, err := r.db.Users().GetByID(ctx, actor.UID)
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/graphqlbackend/user_session.go
+++ b/cmd/frontend/graphqlbackend/user_session.go
@@ -3,7 +3,7 @@ package graphqlbackend
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -11,7 +11,7 @@ import (
 func (r *UserResolver) Session(ctx context.Context) (*sessionResolver, error) {
 	// 🚨 SECURITY: Only the user can view their session information, because it is retrieved from
 	// the context of this request (and not persisted in a way that is queryable).
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() || actor.UID != r.user.ID {
 		return nil, errors.New("unable to view session for a user other than the currently authenticated user")
 	}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -127,7 +127,7 @@ type JSContext struct {
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
 // request.
 func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
-	actor := actor.FromContext(req.Context())
+	actor := sgactor.FromContext(req.Context())
 
 	headers := make(map[string]string)
 	headers["x-sourcegraph-client"] = globals.ExternalURL().String()

--- a/cmd/frontend/internal/handlerutil/error_reporting.go
+++ b/cmd/frontend/internal/handlerutil/error_reporting.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getsentry/raven-go"
 	"github.com/gorilla/mux"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -83,7 +83,7 @@ func reportError(r *http.Request, status int, err error, panicked bool) {
 	}
 
 	// Add request context tags.
-	if actor := actor.FromContext(r.Context()); actor.IsAuthenticated() {
+	if actor := sgactor.FromContext(r.Context()); actor.IsAuthenticated() {
 		addTag("Authed", "yes")
 		addTag("Authed UID", actor.UIDString())
 	} else {

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -15,7 +15,7 @@ import (
 	sqlite "github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/janitor"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/writer"
-	"github.com/sourcegraph/sourcegraph/cmd/symbols/parser"
+	symbolparser "github.com/sourcegraph/sourcegraph/cmd/symbols/parser"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
@@ -43,9 +43,9 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	sqlite.Init()
 
 	parserFactory := func() (ctags.Parser, error) {
-		return parser.SpawnCtags(logger, config.Ctags)
+		return symbolparser.SpawnCtags(logger, config.Ctags)
 	}
-	parserPool, err := parser.NewParserPool(parserFactory, config.NumCtagsProcesses)
+	parserPool, err := symbolparser.NewParserPool(parserFactory, config.NumCtagsProcesses)
 	if err != nil {
 		logger.Fatal("failed to create parser pool", log.Error(err))
 	}
@@ -55,7 +55,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 		diskcache.WithobservationCtx(observationCtx),
 	)
 
-	parser := parser.NewParser(observationCtx, parserPool, repositoryFetcher, config.RequestBufferSize, config.NumCtagsProcesses)
+	parser := symbolparser.NewParser(observationCtx, parserPool, repositoryFetcher, config.RequestBufferSize, config.NumCtagsProcesses)
 	databaseWriter := writer.NewDatabaseWriter(observationCtx, config.CacheDir, gitserverClient, parser, semaphore.NewWeighted(int64(config.MaxConcurrentlyIndexing)))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	searchFunc := api.MakeSqliteSearchFunc(observationCtx, cachedDatabaseWriter, db)

--- a/dev/depgraph/lint.go
+++ b/dev/depgraph/lint.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
-	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	depgraph "github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/lints"
 )
 
@@ -29,7 +29,7 @@ func lint(ctx context.Context, args []string) error {
 		return err
 	}
 
-	graph, err := graph.Load(root)
+	graph, err := depgraph.Load(root)
 	if err != nil {
 		return err
 	}

--- a/dev/depgraph/summary.go
+++ b/dev/depgraph/summary.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/run"
 
-	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	depgraph "github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -40,7 +40,7 @@ func summary(ctx context.Context, args []string) error {
 		return err
 	}
 
-	graph, err := graph.Load(root)
+	graph, err := depgraph.Load(root)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ outer:
 }
 
 // isMain returns true if the given package declares "main" in the given package name map.
-func isMain(graph *graph.DependencyGraph, pkg string) bool {
+func isMain(graph *depgraph.DependencyGraph, pkg string) bool {
 	for _, name := range graph.PackageNames[pkg] {
 		if name == "main" {
 			return true

--- a/dev/depgraph/trace.go
+++ b/dev/depgraph/trace.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
-	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	depgraph "github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/visualization"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -36,7 +36,7 @@ func trace(ctx context.Context, args []string) error {
 		return err
 	}
 
-	graph, err := graph.Load(root)
+	graph, err := depgraph.Load(root)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func trace(ctx context.Context, args []string) error {
 // traceWalkGraph traverses the given dependency graph in both directions and returns a
 // set of packages and edges (separated by traversal direction) forming the dependency
 // graph around the given blessed package.
-func traceWalkGraph(graph *graph.DependencyGraph, pkg string, dependencyMaxDepth, dependentMaxDepth int) (packages []string, dependencyEdges, dependentEdges map[string][]string) {
+func traceWalkGraph(graph *depgraph.DependencyGraph, pkg string, dependencyMaxDepth, dependentMaxDepth int) (packages []string, dependencyEdges, dependentEdges map[string][]string) {
 	dependencyPackages, dependencyEdges := traceTraverse(pkg, graph.Dependencies, dependencyMaxDepth)
 	dependentPackages, dependentEdges := traceTraverse(pkg, graph.Dependents, dependentMaxDepth)
 	return append(dependencyPackages, dependentPackages...), dependencyEdges, dependentEdges

--- a/dev/depgraph/trace_internal.go
+++ b/dev/depgraph/trace_internal.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
-	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
+	depgraph "github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/visualization"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -34,7 +34,7 @@ func traceInternal(ctx context.Context, args []string) error {
 		return err
 	}
 
-	graph, err := graph.Load(root)
+	graph, err := depgraph.Load(root)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func traceInternal(ctx context.Context, args []string) error {
 	return nil
 }
 
-func filterExternalReferences(graph *graph.DependencyGraph, prefix string) ([]string, map[string][]string) {
+func filterExternalReferences(graph *depgraph.DependencyGraph, prefix string) ([]string, map[string][]string) {
 	packages := make([]string, 0, len(graph.Packages))
 	for _, pkg := range graph.Packages {
 		if strings.HasPrefix(pkg, prefix) {

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	a "github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -90,7 +90,7 @@ func TestNewGitHubAppSetupHandler(t *testing.T) {
 		assert.Equal(t, `Invalid setup action "incorrect"`, resp.Body.String())
 	})
 
-	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
+	ctx := sgactor.WithActor(req.Context(), &sgactor.Actor{UID: 1})
 	req = req.WithContext(ctx)
 
 	t.Run("create new", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -87,7 +87,7 @@ func handleOpenIDConnectAuth(db database.DB, w http.ResponseWriter, r *http.Requ
 
 	// If the actor is authenticated and not performing an OpenID Connect flow, then proceed to
 	// next.
-	if actor.FromContext(r.Context()).IsAuthenticated() {
+	if sgactor.FromContext(r.Context()).IsAuthenticated() {
 		next.ServeHTTP(w, r)
 		return
 	}
@@ -172,7 +172,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// if !idToken.Expiry.IsZero() {
 			// 	exp = time.Until(idToken.Expiry)
 			// }
-			if err = session.SetActor(w, r, actor.FromUser(result.User.ID), exp, result.User.CreatedAt); err != nil {
+			if err = session.SetActor(w, r, sgactor.FromUser(result.User.ID), exp, result.User.CreatedAt); err != nil {
 				log15.Error("Failed to authenticate with OpenID connect: could not initiate session.", "error", err)
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)
 				return

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -52,7 +52,7 @@ func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next ht
 	}
 
 	// If the actor is authenticated and not performing a SAML operation, then proceed to next.
-	if actor.FromContext(r.Context()).IsAuthenticated() {
+	if sgactor.FromContext(r.Context()).IsAuthenticated() {
 		next.ServeHTTP(w, r)
 		return
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches/resolvers/apitest"
 	bgql "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/graphql"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -33,7 +33,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 
 	userID := bt.CreateTestUser(t, db, true).ID
 
-	bstore := store.New(db, &observation.TestContext, nil)
+	bstore := bstore.New(db, &observation.TestContext, nil)
 	repoStore := database.ReposWith(logger, bstore)
 	esStore := database.ExternalServicesWith(logger, bstore)
 
@@ -189,7 +189,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 	orgID := bt.CreateTestOrg(t, db, "org").ID
 
-	store := store.New(db, &observation.TestContext, nil)
+	store := bstore.New(db, &observation.TestContext, nil)
 
 	r := &Resolver{store: store}
 	s, err := newSchema(db, r)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -249,13 +249,13 @@ func (r *batchSpecResolver) SupersedingBatchSpec(ctx context.Context) (graphqlba
 		return nil, err
 	}
 
-	a := actor.FromContext(ctx)
-	if !a.IsAuthenticated() {
+	actor := sgactor.FromContext(ctx)
+	if !actor.IsAuthenticated() {
 		return nil, errors.New("user is not authenticated")
 	}
 
 	svc := service.New(r.store)
-	newest, err := svc.GetNewestBatchSpec(ctx, r.store, r.batchSpec, a.UID)
+	newest, err := svc.GetNewestBatchSpec(ctx, r.store, r.batchSpec, actor.UID)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (r *batchSpecResolver) SupersedingBatchSpec(ctx context.Context) (graphqlba
 }
 
 func (r *batchSpecResolver) ViewerBatchChangesCodeHosts(ctx context.Context, args *graphqlbackend.ListViewerBatchChangesCodeHostsArgs) (graphqlbackend.BatchChangesCodeHostConnectionResolver, error) {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, auth.ErrNotAuthenticated
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/config"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -184,7 +184,7 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 	isSiteAdmin := authErr != auth.ErrMustBeSiteAdmin
 	if !isSiteAdmin {
 		if args.ViewerCanAdminister != nil && *args.ViewerCanAdminister {
-			actor := actor.FromContext(ctx)
+			actor := sgactor.FromContext(ctx)
 			opts.OnlyAdministeredByUserID = actor.UID
 		}
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -52,7 +52,7 @@ func batchChangesCreateAccess(ctx context.Context, db database.DB) error {
 		return err
 	}
 
-	act := actor.FromContext(ctx)
+	act := sgactor.FromContext(ctx)
 	if !act.IsAuthenticated() {
 		return auth.ErrNotAuthenticated
 	}
@@ -80,7 +80,7 @@ type batchChangeEventArg struct {
 }
 
 func logBackendEvent(ctx context.Context, db database.DB, name string, args any, publicArgs any) error {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	jsonArg, err := json.Marshal(args)
 	if err != nil {
 		return err
@@ -214,7 +214,7 @@ func (r *Resolver) ResolveWorkspacesForBatchSpec(ctx context.Context, args *grap
 	}
 
 	// Verify the user is authenticated.
-	act := actor.FromContext(ctx)
+	act := sgactor.FromContext(ctx)
 	if !act.IsAuthenticated() {
 		return nil, auth.ErrNotAuthenticated
 	}
@@ -609,7 +609,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 		return nil, err
 	}
 
-	act := actor.FromContext(ctx)
+	act := sgactor.FromContext(ctx)
 	// Actor MUST be logged in at this stage, because batchChangesCreateAccess checks that already.
 	// To be extra safe, we'll just do the cheap check again here so if anyone ever modifies
 	// batchChangesCreateAccess, we still enforce it here.
@@ -638,7 +638,7 @@ func (r *Resolver) CreateChangesetSpecs(ctx context.Context, args *graphqlbacken
 		return nil, err
 	}
 
-	act := actor.FromContext(ctx)
+	act := sgactor.FromContext(ctx)
 	// Actor MUST be logged in at this stage, because batchChangesCreateAccess checks that already.
 	// To be extra safe, we'll just do the cheap check again here so if anyone ever modifies
 	// batchChangesCreateAccess, we still enforce it here.
@@ -786,7 +786,7 @@ func (r *Resolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBa
 	}
 	isSiteAdmin := authErr != auth.ErrMustBeSiteAdmin
 	if !isSiteAdmin {
-		actor := actor.FromContext(ctx)
+		actor := sgactor.FromContext(ctx)
 		if args.ViewerCanAdminister != nil && *args.ViewerCanAdminister {
 			opts.OnlyAdministeredByUserID = actor.UID
 		}
@@ -1543,7 +1543,7 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 	// BatchSpecs that were created with CreateBatchSpecFromRaw and not owned
 	// by the user
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
-		opts.ExcludeCreatedFromRawNotOwnedByUser = actor.FromContext(ctx).UID
+		opts.ExcludeCreatedFromRawNotOwnedByUser = sgactor.FromContext(ctx).UID
 	}
 
 	if args.After != nil {

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/executor"
 	metricsstore "github.com/sourcegraph/sourcegraph/internal/metrics/store"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
-	workerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
-	workerstoremocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	dbworkerstoremocks "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store/mocks"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -28,7 +27,7 @@ func TestDequeue(t *testing.T) {
 		},
 	}
 
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42, Payload: "secret"}, true, nil)
 	recordTransformer := func(ctx context.Context, _ string, tr testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		if tr.Payload != "secret" {
@@ -62,7 +61,7 @@ func TestDequeueNoRecord(t *testing.T) {
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
 
-	handler := NewHandler(executorStore, metricsStore, QueueOptions[testRecord]{Store: workerstoremocks.NewMockStore[testRecord]()})
+	handler := NewHandler(executorStore, metricsStore, QueueOptions[testRecord]{Store: dbworkerstoremocks.NewMockStore[testRecord]()})
 
 	_, dequeued, err := handler.dequeue(context.Background(), executorMetadata{Name: "deadbeef"})
 	if err != nil {
@@ -74,7 +73,7 @@ func TestDequeueNoRecord(t *testing.T) {
 }
 
 func TestAddExecutionLogEntry(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
@@ -120,8 +119,8 @@ func TestAddExecutionLogEntry(t *testing.T) {
 }
 
 func TestAddExecutionLogEntryUnknownJob(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
-	store.AddExecutionLogEntryFunc.SetDefaultReturn(0, workerstore.ErrExecutionLogEntryNotUpdated)
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
+	store.AddExecutionLogEntryFunc.SetDefaultReturn(0, dbworkerstore.ErrExecutionLogEntryNotUpdated)
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
 	handler := NewHandler(executorStore, metricsStore, QueueOptions[testRecord]{Store: store})
@@ -136,7 +135,7 @@ func TestAddExecutionLogEntryUnknownJob(t *testing.T) {
 }
 
 func TestUpdateExecutionLogEntry(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
@@ -180,8 +179,8 @@ func TestUpdateExecutionLogEntry(t *testing.T) {
 }
 
 func TestUpdateExecutionLogEntryUnknownJob(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
-	store.UpdateExecutionLogEntryFunc.SetDefaultReturn(workerstore.ErrExecutionLogEntryNotUpdated)
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
+	store.UpdateExecutionLogEntryFunc.SetDefaultReturn(dbworkerstore.ErrExecutionLogEntryNotUpdated)
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
 	handler := NewHandler(executorStore, metricsStore, QueueOptions[testRecord]{Store: store})
@@ -196,7 +195,7 @@ func TestUpdateExecutionLogEntryUnknownJob(t *testing.T) {
 }
 
 func TestMarkComplete(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkCompleteFunc.SetDefaultReturn(true, nil)
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
@@ -230,7 +229,7 @@ func TestMarkComplete(t *testing.T) {
 }
 
 func TestMarkCompleteUnknownJob(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.MarkCompleteFunc.SetDefaultReturn(false, nil)
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
@@ -242,7 +241,7 @@ func TestMarkCompleteUnknownJob(t *testing.T) {
 }
 
 func TestMarkCompleteStoreError(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	internalErr := errors.New("something went wrong")
 	store.MarkCompleteFunc.SetDefaultReturn(false, internalErr)
 	executorStore := database.NewMockExecutorStore()
@@ -255,7 +254,7 @@ func TestMarkCompleteStoreError(t *testing.T) {
 }
 
 func TestMarkErrored(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkErroredFunc.SetDefaultReturn(true, nil)
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
@@ -292,7 +291,7 @@ func TestMarkErrored(t *testing.T) {
 }
 
 func TestMarkErroredUnknownJob(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.MarkErroredFunc.SetDefaultReturn(false, nil)
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
@@ -304,7 +303,7 @@ func TestMarkErroredUnknownJob(t *testing.T) {
 }
 
 func TestMarkErroredStoreError(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	storeErr := errors.New("something went wrong")
 	store.MarkErroredFunc.SetDefaultReturn(false, storeErr)
 	executorStore := database.NewMockExecutorStore()
@@ -317,7 +316,7 @@ func TestMarkErroredStoreError(t *testing.T) {
 }
 
 func TestMarkFailed(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkFailedFunc.SetDefaultReturn(true, nil)
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
@@ -354,7 +353,7 @@ func TestMarkFailed(t *testing.T) {
 }
 
 func TestMarkFailedUnknownJob(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	store.MarkFailedFunc.SetDefaultReturn(false, nil)
 	executorStore := database.NewMockExecutorStore()
 	metricsStore := metricsstore.NewMockDistributedStore()
@@ -366,7 +365,7 @@ func TestMarkFailedUnknownJob(t *testing.T) {
 }
 
 func TestMarkFailedStoreError(t *testing.T) {
-	store := workerstoremocks.NewMockStore[testRecord]()
+	store := dbworkerstoremocks.NewMockStore[testRecord]()
 	storeErr := errors.New("something went wrong")
 	store.MarkFailedFunc.SetDefaultReturn(false, storeErr)
 	executorStore := database.NewMockExecutorStore()
@@ -379,12 +378,12 @@ func TestMarkFailedStoreError(t *testing.T) {
 }
 
 func TestHeartbeat(t *testing.T) {
-	s := workerstoremocks.NewMockStore[testRecord]()
+	s := dbworkerstoremocks.NewMockStore[testRecord]()
 	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: record.RecordID()}, nil
 	}
 	testKnownID := 10
-	s.HeartbeatFunc.SetDefaultHook(func(ctx context.Context, ids []int, options store.HeartbeatOptions) ([]int, []int, error) {
+	s.HeartbeatFunc.SetDefaultHook(func(ctx context.Context, ids []int, options dbworkerstore.HeartbeatOptions) ([]int, []int, error) {
 		return []int{testKnownID}, []int{testKnownID}, nil
 	})
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -16,11 +16,11 @@ import (
 func QueueOptions(observationCtx *observation.Context, db database.DB, _ func() string) handler.QueueOptions[*btypes.BatchSpecWorkspaceExecutionJob] {
 	logger := log.Scoped("executor-queue.batches", "The executor queue handlers for the batches queue")
 	recordTransformer := func(ctx context.Context, version string, record *btypes.BatchSpecWorkspaceExecutionJob, _ handler.ResourceMetadata) (apiclient.Job, error) {
-		batchesStore := store.New(db, observationCtx, nil)
+		batchesStore := bstore.New(db, observationCtx, nil)
 		return transformRecord(ctx, logger, batchesStore, record, version)
 	}
 
-	store := store.NewBatchSpecWorkspaceExecutionWorkerStore(observationCtx, db.Handle())
+	store := bstore.NewBatchSpecWorkspaceExecutionWorkerStore(observationCtx, db.Handle())
 	return handler.QueueOptions[*btypes.BatchSpecWorkspaceExecutionJob]{
 		Name:              "batches",
 		Store:             store,

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
@@ -9,7 +9,7 @@ import (
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
 func QueueOptions(observationCtx *observation.Context, db database.DB, accessToken func() string) handler.QueueOptions[types.Index] {
@@ -17,7 +17,7 @@ func QueueOptions(observationCtx *observation.Context, db database.DB, accessTok
 		return transformRecord(ctx, db, record, resourceMetadata, accessToken())
 	}
 
-	store := store.New(observationCtx, db.Handle(), autoindexing.IndexWorkerStoreOptions)
+	store := dbworkerstore.New(observationCtx, db.Handle(), autoindexing.IndexWorkerStoreOptions)
 
 	return handler.QueueOptions[types.Index]{
 		Name:              "codeintel",

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	stesting "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/testing"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -30,7 +30,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	store := store.New(db, &observation.TestContext, nil)
+	store := bstore.New(db, &observation.TestContext, nil)
 
 	admin := bt.CreateTestUser(t, db, true)
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -185,7 +185,7 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		return nil, err
 	}
 
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
 
 	batchSpec := &btypes.BatchSpec{
@@ -269,7 +269,7 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		return nil, err
 	}
 
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
 
 	batchSpec := &btypes.BatchSpec{
@@ -338,7 +338,7 @@ func (s *Service) CreateBatchSpec(ctx context.Context, opts CreateBatchSpecOpts)
 	}
 	spec.NamespaceOrgID = opts.NamespaceOrgID
 	spec.NamespaceUserID = opts.NamespaceUserID
-	a := actor.FromContext(ctx)
+	a := sgactor.FromContext(ctx)
 	spec.UserID = a.UID
 
 	if len(opts.ChangesetSpecRandIDs) == 0 {
@@ -431,7 +431,7 @@ func (s *Service) CreateBatchSpecFromRaw(ctx context.Context, opts CreateBatchSp
 	spec.NamespaceOrgID = opts.NamespaceOrgID
 	spec.NamespaceUserID = opts.NamespaceUserID
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
-	a := actor.FromContext(ctx)
+	a := sgactor.FromContext(ctx)
 	spec.UserID = a.UID
 
 	spec.BatchChangeID = opts.BatchChange
@@ -726,7 +726,7 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 	spec.NamespaceOrgID = opts.NamespaceOrgID
 	spec.NamespaceUserID = opts.NamespaceUserID
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
-	a := actor.FromContext(ctx)
+	a := sgactor.FromContext(ctx)
 	spec.UserID = a.UID
 
 	// Start transaction.
@@ -1298,7 +1298,7 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 	}
 	defer func() { err = tx.Done(err) }()
 
-	userID := actor.FromContext(ctx).UID
+	userID := sgactor.FromContext(ctx).UID
 	changesetJobs := make([]*btypes.ChangesetJob, 0, len(cs))
 	for _, changeset := range cs {
 		changesetJobs = append(changesetJobs, &btypes.ChangesetJob{

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/reconciler"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -41,7 +41,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	store := store.NewWithClock(db, &observation.TestContext, nil, clock)
+	store := bstore.NewWithClock(db, &observation.TestContext, nil, clock)
 	svc := New(store)
 
 	t.Run("BatchSpec without changesetSpecs", func(t *testing.T) {
@@ -1215,7 +1215,7 @@ func applyAndListChangesets(ctx context.Context, t *testing.T, svc *Service, bat
 		t.Fatalf("batch change ID is zero")
 	}
 
-	changesets, _, err := svc.store.ListChangesets(ctx, store.ListChangesetsOpts{
+	changesets, _, err := svc.store.ListChangesets(ctx, bstore.ListChangesetsOpts{
 		BatchChangeID:   batchChange.ID,
 		IncludeArchived: true,
 	})

--- a/enterprise/internal/batches/store/batch_changes_test.go
+++ b/enterprise/internal/batches/store/batch_changes_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/log/logtest"
 
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -807,7 +807,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock bt
 		})
 
 		{
-			want := &diff.Stat{
+			want := &godiff.Stat{
 				Added:   testDiffStatCount,
 				Deleted: testDiffStatCount,
 			}
@@ -825,7 +825,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock bt
 		// Now revoke repo access, and check that we don't see it in the diff stat anymore.
 		bt.MockRepoPermissions(t, s.DatabaseDB(), 0, repo.ID)
 		{
-			want := &diff.Stat{
+			want := &godiff.Stat{
 				Added:   0,
 				Changed: 0,
 				Deleted: 0,
@@ -885,25 +885,25 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock bt
 		{
 			tcs := []struct {
 				repoID api.RepoID
-				want   *diff.Stat
+				want   *godiff.Stat
 			}{
 				{
 					repoID: repo1.ID,
-					want: &diff.Stat{
+					want: &godiff.Stat{
 						Added:   testDiffStatCount1 + testDiffStatCount2,
 						Deleted: testDiffStatCount1 + testDiffStatCount2,
 					},
 				},
 				{
 					repoID: repo2.ID,
-					want: &diff.Stat{
+					want: &godiff.Stat{
 						Added:   testDiffStatCount2,
 						Deleted: testDiffStatCount2,
 					},
 				},
 				{
 					repoID: repo3.ID,
-					want: &diff.Stat{
+					want: &godiff.Stat{
 						Added:   0,
 						Deleted: 0,
 					},
@@ -928,7 +928,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock bt
 		// Now revoke repo1 access, and check that we don't get a diff stat for it anymore.
 		bt.MockRepoPermissions(t, s.DatabaseDB(), 0, repo1.ID)
 		{
-			want := &diff.Stat{
+			want := &godiff.Stat{
 				Added:   0,
 				Changed: 0,
 				Deleted: 0,

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -145,7 +145,7 @@ type ChangesetAssertions struct {
 	ExternalID            string
 	ExternalBranch        string
 	ExternalForkNamespace string
-	DiffStat              *diff.Stat
+	DiffStat              *godiff.Stat
 	Closing               bool
 
 	Title string

--- a/enterprise/internal/batches/types/changeset_spec.go
+++ b/enterprise/internal/batches/types/changeset_spec.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -130,8 +130,8 @@ func (cs *ChangesetSpec) computeDiffStat() error {
 		return nil
 	}
 
-	stats := diff.Stat{}
-	reader := diff.NewMultiFileDiffReader(bytes.NewReader(cs.Diff))
+	stats := godiff.Stat{}
+	reader := godiff.NewMultiFileDiffReader(bytes.NewReader(cs.Diff))
 	for {
 		fileDiff, err := reader.ReadFile()
 		if err == io.EOF {
@@ -164,8 +164,8 @@ func (cs *ChangesetSpec) computeForkNamespace() {
 }
 
 // DiffStat returns a *diff.Stat.
-func (cs *ChangesetSpec) DiffStat() diff.Stat {
-	return diff.Stat{
+func (cs *ChangesetSpec) DiffStat() godiff.Stat {
+	return godiff.Stat{
 		Added:   cs.DiffStatAdded,
 		Deleted: cs.DiffStatDeleted,
 	}

--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store"
+	autoindexingstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -29,7 +29,7 @@ func NewService(
 	policiesSvc PoliciesService,
 	gitserver GitserverClient,
 ) *Service {
-	store := store.New(scopedContext("store", observationCtx), db)
+	store := autoindexingstore.New(scopedContext("store", observationCtx), db)
 	symbolsClient := symbols.DefaultClient
 	repoUpdater := repoupdater.DefaultClient
 	inferenceSvc := inference.NewService()

--- a/enterprise/internal/codeintel/codenav/gittree_translator_test.go
+++ b/enterprise/internal/codeintel/codenav/gittree_translator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
@@ -389,7 +389,7 @@ func TestRawGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 		name := fmt.Sprintf("%s : %s", testCase.diffName, testCase.description)
 
 		t.Run(name, func(t *testing.T) {
-			diff, err := diff.NewFileDiffReader(bytes.NewReader([]byte(testCase.diff))).Read()
+			diff, err := godiff.NewFileDiffReader(bytes.NewReader([]byte(testCase.diff))).Read()
 			if err != nil {
 				t.Fatalf("unexpected error reading file diff: %s", err)
 			}

--- a/enterprise/internal/codeintel/codenav/init.go
+++ b/enterprise/internal/codeintel/codenav/init.go
@@ -2,7 +2,7 @@ package codenav
 
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/lsifstore"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/store"
+	codenavstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/store"
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -15,7 +15,7 @@ func NewService(
 	uploadSvc UploadService,
 	gitserver GitserverClient,
 ) *Service {
-	store := store.New(scopedContext("store", observationCtx), db)
+	store := codenavstore.New(scopedContext("store", observationCtx), db)
 	lsifStore := lsifstore.New(scopedContext("lsifstore", observationCtx), codeIntelDB)
 
 	return newService(

--- a/enterprise/internal/codeintel/codenav/service_ranges_test.go
+++ b/enterprise/internal/codeintel/codenav/service_ranges_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -39,9 +39,9 @@ func TestRanges(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := NewMockGitserverClient()
-	mockGitServer.DiffPathFunc.SetDefaultHook(func(ctx context.Context, srpc authz.SubRepoPermissionChecker, rn api.RepoName, sourceCommit, targetCommit, path string) ([]*diff.Hunk, error) {
+	mockGitServer.DiffPathFunc.SetDefaultHook(func(ctx context.Context, srpc authz.SubRepoPermissionChecker, rn api.RepoName, sourceCommit, targetCommit, path string) ([]*godiff.Hunk, error) {
 		if path == "sub3/changed.go" {
-			fileDiff, err := diff.ParseFileDiff([]byte(rangesDiff))
+			fileDiff, err := godiff.ParseFileDiff([]byte(rangesDiff))
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/internal/codeintel/policies/init.go
+++ b/enterprise/internal/codeintel/policies/init.go
@@ -2,7 +2,7 @@ package policies
 
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/background"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store"
+	policiesstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -14,7 +14,7 @@ func NewService(
 	uploadSvc UploadService,
 	gitserver GitserverClient,
 ) *Service {
-	store := store.New(scopedContext("store", observationCtx), db)
+	store := policiesstore.New(scopedContext("store", observationCtx), db)
 
 	return newService(
 		observationCtx,

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -16,7 +16,7 @@ import (
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
+	uploadsstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -34,7 +34,7 @@ func NewService(
 	codeIntelDB codeintelshared.CodeIntelDB,
 	gsc GitserverClient,
 ) *Service {
-	store := store.New(scopedContext("store", observationCtx), db)
+	store := uploadsstore.New(scopedContext("uploadsstore", observationCtx), db)
 	repoStore := backend.NewRepos(scopedContext("repos", observationCtx).Logger, db, gitserver.NewClient())
 	lsifStore := lsifstore.New(scopedContext("lsifstore", observationCtx), codeIntelDB)
 	policyMatcher := policiesEnterprise.NewMatcher(gsc, policiesEnterprise.RetentionExtractor, true, false)
@@ -97,7 +97,7 @@ func NewUploadProcessorJob(
 	workerPollInterval time.Duration,
 	maximumRuntimePerJob time.Duration,
 ) goroutine.BackgroundRoutine {
-	uploadsProcessorStore := dbworkerstore.New(observationCtx, db.Handle(), store.UploadWorkerStoreOptions)
+	uploadsProcessorStore := dbworkerstore.New(observationCtx, db.Handle(), uploadsstore.UploadWorkerStoreOptions)
 
 	dbworker.InitPrometheusMetric(observationCtx, uploadsProcessorStore, "codeintel", "upload", nil)
 
@@ -158,7 +158,7 @@ func NewReconciler(observationCtx *observation.Context, uploadSvc *Service) []go
 
 func NewResetters(observationCtx *observation.Context, db database.DB) []goroutine.BackgroundRoutine {
 	metrics := background.NewResetterMetrics(observationCtx)
-	uploadsResetterStore := dbworkerstore.New(observationCtx, db.Handle(), store.UploadWorkerStoreOptions)
+	uploadsResetterStore := dbworkerstore.New(observationCtx, db.Handle(), uploadsstore.UploadWorkerStoreOptions)
 
 	return []goroutine.BackgroundRoutine{
 		background.NewUploadResetter(observationCtx.Logger, uploadsResetterStore, ConfigJanitorInst.Interval, metrics),

--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -205,7 +205,7 @@ type DisplayResult struct {
 	Content    string
 }
 
-func toDisplayResult(result *result.CommitMatch, externalURL *url.URL) *DisplayResult {
+func toDisplayResult(result *searchresult.CommitMatch, externalURL *url.URL) *DisplayResult {
 	resultType := "Message"
 	if result.DiffPreview != nil {
 		resultType = "Diff"

--- a/enterprise/internal/codemonitors/background/slack.go
+++ b/enterprise/internal/codemonitors/background/slack.go
@@ -12,7 +12,7 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -97,9 +97,9 @@ func truncateString(input string) string {
 	return strings.Join(splitLines, "")
 }
 
-func truncateResults(results []*result.CommitMatch, maxResults int) (_ []*result.CommitMatch, totalCount, truncatedCount int) {
+func truncateResults(results []*searchresult.CommitMatch, maxResults int) (_ []*searchresult.CommitMatch, totalCount, truncatedCount int) {
 	// Convert to type result.Matches
-	matches := make(result.Matches, len(results))
+	matches := make(searchresult.Matches, len(results))
 	for i, res := range results {
 		matches[i] = res
 	}
@@ -109,9 +109,9 @@ func truncateResults(results []*result.CommitMatch, maxResults int) (_ []*result
 	outputCount := matches.ResultCount()
 
 	// Convert back type []*result.CommitMatch
-	output := make([]*result.CommitMatch, len(matches))
+	output := make([]*searchresult.CommitMatch, len(matches))
 	for i, match := range matches {
-		output[i] = match.(*result.CommitMatch)
+		output[i] = match.(*searchresult.CommitMatch)
 	}
 
 	return output, totalCount, totalCount - outputCount

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // Template is just a list of Atom, where an Atom is either a Variable or a Constant string.
@@ -264,14 +264,14 @@ func substituteMetaVariables(pattern string, env *MetaEnvironment) (string, erro
 
 // NewMetaEnvironment maps results to a metavariable:value environment where
 // metavariables can be referenced and substituted for in an output template.
-func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
+func NewMetaEnvironment(r searchresult.Match, content string) *MetaEnvironment {
 	switch m := r.(type) {
-	case *result.RepoMatch:
+	case *searchresult.RepoMatch:
 		return &MetaEnvironment{
 			Repo:    string(m.Name),
 			Content: string(m.Name),
 		}
-	case *result.FileMatch:
+	case *searchresult.FileMatch:
 		lang, _ := enry.GetLanguageByExtension(m.Path)
 		return &MetaEnvironment{
 			Repo:    string(m.Repo.Name),
@@ -280,7 +280,7 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Content: content,
 			Lang:    lang,
 		}
-	case *result.CommitMatch:
+	case *searchresult.CommitMatch:
 		return &MetaEnvironment{
 			Repo:    string(m.Repo.Name),
 			Commit:  string(m.Commit.ID),
@@ -289,7 +289,7 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Email:   m.Commit.Author.Email,
 			Content: content,
 		}
-	case *result.CommitDiffMatch:
+	case *searchresult.CommitDiffMatch:
 		path := m.Path()
 		lang, _ := enry.GetLanguageByExtension(path)
 		return &MetaEnvironment{

--- a/enterprise/internal/insights/resolvers/admin_resolver.go
+++ b/enterprise/internal/insights/resolvers/admin_resolver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	insightsstore "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -43,7 +43,7 @@ func (r *Resolver) UpdateInsightSeries(ctx context.Context, args *graphqlbackend
 		}
 	}
 
-	series, err := r.dataSeriesStore.GetDataSeries(ctx, store.GetDataSeriesArgs{IncludeDeleted: true, SeriesID: args.Input.SeriesId})
+	series, err := r.dataSeriesStore.GetDataSeries(ctx, insightsstore.GetDataSeriesArgs{IncludeDeleted: true, SeriesID: args.Input.SeriesId})
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (r *Resolver) InsightSeriesQueryStatus(ctx context.Context) ([]graphqlbacke
 	}
 
 	// need to do a manual join with metadata since this lives in a separate database.
-	seriesMetadata, err := r.dataSeriesStore.GetDataSeries(ctx, store.GetDataSeriesArgs{IncludeDeleted: true})
+	seriesMetadata, err := r.dataSeriesStore.GetDataSeries(ctx, insightsstore.GetDataSeriesArgs{IncludeDeleted: true})
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (r *Resolver) InsightViewDebug(ctx context.Context, args graphqlbackend.Ins
 	}
 
 	// 🚨 SECURITY: This debug resolver is restricted to admins only so looking up the series does not check for the users authorization
-	viewSeries, err := r.insightStore.Get(ctx, store.InsightQueryArgs{UniqueID: viewId, WithoutAuthorization: true})
+	viewSeries, err := r.insightStore.Get(ctx, insightsstore.InsightQueryArgs{UniqueID: viewId, WithoutAuthorization: true})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/insights/scheduler/backfill_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	insightsstore "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
@@ -22,7 +22,7 @@ func Test_NewBackfill(t *testing.T) {
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
 	ctx := context.Background()
-	insightStore := store.NewInsightStore(insightsDB)
+	insightStore := insightsstore.NewInsightStore(insightsDB)
 	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 	clock := glock.NewMockClockAt(now)
 	store := newBackfillStoreWithClock(insightsDB, clock)

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -2,19 +2,19 @@ package dependencies
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/background"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
+	dependenciesstore "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func NewService(observationCtx *observation.Context, db database.DB) *Service {
-	return newService(scopedContext("service", observationCtx), store.New(scopedContext("store", observationCtx), db))
+	return newService(scopedContext("service", observationCtx), dependenciesstore.New(scopedContext("store", observationCtx), db))
 }
 
 // TestService creates a new dependencies service with noop observation contexts.
 func TestService(db database.DB, _ GitserverClient) *Service {
-	store := store.New(&observation.TestContext, db)
+	store := dependenciesstore.New(&observation.TestContext, db)
 
 	return newService(&observation.TestContext, store)
 }

--- a/internal/database/connections/live/store.go
+++ b/internal/database/connections/live/store.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
-	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
+	migrationstore "github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -21,7 +21,7 @@ type StoreFactory func(db *sql.DB, migrationsTable string) Store
 
 func newStoreFactory(observationCtx *observation.Context) func(db *sql.DB, migrationsTable string) Store {
 	return func(db *sql.DB, migrationsTable string) Store {
-		return NewStoreShim(store.NewWithDB(observationCtx, db, migrationsTable))
+		return NewStoreShim(migrationstore.NewWithDB(observationCtx, db, migrationsTable))
 	}
 }
 
@@ -48,10 +48,10 @@ func initStore(ctx context.Context, newStore StoreFactory, db *sql.DB, schema *s
 }
 
 type storeShim struct {
-	*store.Store
+	*migrationstore.Store
 }
 
-func NewStoreShim(s *store.Store) Store {
+func NewStoreShim(s *migrationstore.Store) Store {
 	return &storeShim{s}
 }
 

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
@@ -219,7 +219,7 @@ func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 		return *in
 	}
 
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	rowValues := make(chan []any, len(events))
 	for _, event := range events {
 		featureFlags, err := json.Marshal(event.EvaluatedFlagSet)

--- a/internal/database/migration/cliutil/run_oobmigrations.go
+++ b/internal/database/migration/cliutil/run_oobmigrations.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
-	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
+	oobmigrations "github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -25,7 +25,7 @@ func RunOutOfBandMigrations(
 	commandName string,
 	runnerFactory RunnerFactory,
 	outFactory OutputFactory,
-	registerMigratorsWithStore func(storeFactory migrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
+	registerMigratorsWithStore func(storeFactory oobmigrations.StoreFactory) oobmigration.RegisterMigratorsFunc,
 ) *cli.Command {
 	idsFlag := &cli.IntSliceFlag{
 		Name:     "id",

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -115,7 +115,7 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, event *SecurityEven
 }
 
 func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*SecurityEvent) error {
-	actor := actor.FromContext(ctx)
+	actor := sgactor.FromContext(ctx)
 	vals := make([]*sqlf.Query, len(events))
 	for index, event := range events {
 		// Add an attribution for Sourcegraph operator to be distinguished in our analytics pipelines

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -104,13 +104,13 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 		label               string
 		extraGitCommands    []string
 		expectedDiffFiles   []string
-		expectedFileStat    *diff.Stat
+		expectedFileStat    *godiff.Stat
 		rangeOverAllCommits bool
 	}{
 		{
 			label:               "adding files",
 			expectedDiffFiles:   []string{"file1", "file3", "file3.3"},
-			expectedFileStat:    &diff.Stat{Added: 3},
+			expectedFileStat:    &godiff.Stat{Added: 3},
 			rangeOverAllCommits: true,
 		},
 		{
@@ -121,7 +121,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 				makeGitCommit("rename", 7),
 			},
 			expectedDiffFiles: []string{"file_can_access"},
-			expectedFileStat:  &diff.Stat{Added: 1},
+			expectedFileStat:  &godiff.Stat{Added: 1},
 		},
 		{
 			label: "file modified",
@@ -133,7 +133,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 				makeGitCommit("edit_files", 7),
 			},
 			expectedDiffFiles: []string{"file1"}, // file2 is updated but user doesn't have access
-			expectedFileStat:  &diff.Stat{Changed: 1},
+			expectedFileStat:  &godiff.Stat{Changed: 1},
 		},
 		{
 			label: "diff for commit w/ no access returns empty result",
@@ -143,7 +143,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 				makeGitCommit("no_access", 7),
 			},
 			expectedDiffFiles: []string{},
-			expectedFileStat:  &diff.Stat{},
+			expectedFileStat:  &godiff.Stat{},
 		},
 	}
 	for _, tc := range testCases {
@@ -166,7 +166,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 			}
 			defer iter.Close()
 
-			stat := &diff.Stat{}
+			stat := &godiff.Stat{}
 			fileNames := make([]string, 0, 3)
 			for {
 				file, err := iter.Next()

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
@@ -18,7 +18,7 @@ type LazyCommit struct {
 	*RawCommit
 
 	// diff is the parsed output from the diff fetcher, cached here for performance
-	diff        []*diff.FileDiff
+	diff        []*godiff.FileDiff
 	diffFetcher *DiffFetcher
 
 	// LowerBuf is a re-usable buffer for doing case-transformations on the fields of LazyCommit
@@ -49,7 +49,7 @@ func (l *LazyCommit) RawDiff() ([]byte, error) {
 }
 
 // Diff fetches the diff, then parses it with go-diff, caching the result
-func (l *LazyCommit) Diff() ([]*diff.FileDiff, error) {
+func (l *LazyCommit) Diff() ([]*godiff.FileDiff, error) {
 	if l.diff != nil {
 		return l.diff, nil
 	}
@@ -59,7 +59,7 @@ func (l *LazyCommit) Diff() ([]*diff.FileDiff, error) {
 		return nil, err
 	}
 
-	r := diff.NewMultiFileDiffReader(bytes.NewReader(rawDiff))
+	r := godiff.NewMultiFileDiffReader(bytes.NewReader(rawDiff))
 	diff, err := r.ReadAllFiles()
 	if err != nil {
 		return nil, err

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
 
@@ -437,12 +437,12 @@ func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool, filte
 	}, nil
 }
 
-func filterRawDiff(rawDiff []*diff.FileDiff, filterFunc func(string) (bool, error)) []*diff.FileDiff {
+func filterRawDiff(rawDiff []*godiff.FileDiff, filterFunc func(string) (bool, error)) []*godiff.FileDiff {
 	logger := log.Scoped("filterRawDiff", "sub-repo filtering for raw diffs")
 	if filterFunc == nil {
 		return rawDiff
 	}
-	filtered := make([]*diff.FileDiff, 0, len(rawDiff))
+	filtered := make([]*godiff.FileDiff, 0, len(rawDiff))
 	for _, fileDiff := range rawDiff {
 		if filterFunc != nil {
 			if isAllowed, err := filterFunc(fileDiff.NewName); err != nil {

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
-	workerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
 type SyncWorkerOptions struct {
@@ -53,11 +53,11 @@ func NewSyncWorker(ctx context.Context, observationCtx *observation.Context, dbH
 
 	observationCtx = observation.ContextWithLogger(observationCtx.Logger.Scoped("repo.sync.workerstore.Store", ""), observationCtx)
 
-	store := workerstore.New(observationCtx, dbHandle, workerstore.Options[*SyncJob]{
+	store := dbworkerstore.New(observationCtx, dbHandle, dbworkerstore.Options[*SyncJob]{
 		Name:              "repo_sync_worker_store",
 		TableName:         "external_service_sync_jobs",
 		ViewName:          "external_service_sync_jobs_with_next_sync_at",
-		Scan:              workerstore.BuildWorkerScan(scanJob),
+		Scan:              dbworkerstore.BuildWorkerScan(scanJob),
 		OrderByExpression: sqlf.Sprintf("next_sync_at"),
 		ColumnExpressions: syncJobColumns,
 		StalledMaxAge:     30 * time.Second,

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
-	"github.com/sourcegraph/sourcegraph/internal/service"
+	sgservice "github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/singleprogram"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 // Main is called from the `main` function of the `sourcegraph-oss` and `sourcegraph` commands.
-func Main(services []service.Service, config Config) {
+func Main(services []sgservice.Service, config Config) {
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
@@ -49,7 +49,7 @@ func Main(services []service.Service, config Config) {
 //
 // DEPRECATED: Building per-service commands (i.e., a separate binary for frontend, gitserver, etc.)
 // is deprecated.
-func DeprecatedSingleServiceMain(svc service.Service, config Config, validateConfig, useConfPackage bool) {
+func DeprecatedSingleServiceMain(svc sgservice.Service, config Config, validateConfig, useConfPackage bool) {
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
@@ -63,13 +63,13 @@ func DeprecatedSingleServiceMain(svc service.Service, config Config, validateCon
 		),
 	)
 	logger := log.Scoped("sourcegraph", "Sourcegraph")
-	run(liblog, logger, []service.Service{svc}, config, validateConfig, useConfPackage)
+	run(liblog, logger, []sgservice.Service{svc}, config, validateConfig, useConfPackage)
 }
 
 func run(
 	liblog *log.PostInitCallbacks,
 	logger log.Logger,
-	services []service.Service,
+	services []sgservice.Service,
 	config Config,
 	validateConfig bool,
 	useConfPackage bool,

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/sourcegraph/go-diff/diff"
+	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
@@ -240,7 +240,7 @@ func validateGroups(repoName, defaultBranch string, groups []Group) error {
 }
 
 func groupFileDiffs(completeDiff []byte, defaultBranch string, groups []Group) (map[string][]byte, error) {
-	fileDiffs, err := diff.ParseMultiFileDiff(completeDiff)
+	fileDiffs, err := godiff.ParseMultiFileDiff(completeDiff)
 	if err != nil {
 		return nil, err
 	}
@@ -255,8 +255,8 @@ func groupFileDiffs(completeDiff []byte, defaultBranch string, groups []Group) (
 		dirs = append(dirs, g.Directory)
 	}
 
-	byBranch := make(map[string][]*diff.FileDiff, len(groups))
-	byBranch[defaultBranch] = []*diff.FileDiff{}
+	byBranch := make(map[string][]*godiff.FileDiff, len(groups))
+	byBranch[defaultBranch] = []*godiff.FileDiff{}
 
 	// For each file diff...
 	for _, f := range fileDiffs {
@@ -292,7 +292,7 @@ func groupFileDiffs(completeDiff []byte, defaultBranch string, groups []Group) (
 
 	finalDiffsByBranch := make(map[string][]byte, len(byBranch))
 	for branch, diffs := range byBranch {
-		printed, err := diff.PrintMultiFileDiff(diffs)
+		printed, err := godiff.PrintMultiFileDiff(diffs)
 		if err != nil {
 			return nil, errors.Wrap(err, "printing multi file diff failed")
 		}


### PR DESCRIPTION
This is a refactor PR; it shouldn't change behavior.

A bunch of variables in the codebase collided with package names.
This can cause confusion and unwanted behavior that increases debugging time during development.

I've added package name aliases to make names unique.
I've used the same aliases, and only for a small set of packages, to make it as clear as possible.
In some cases, I opted for renaming variables rather than adding an alias for the package. I've committed those changes in a separate PR: https://github.com/sourcegraph/sourcegraph/pull/47179

**For reviewers:** The recommended way to review this is to just scroll through it, either in the unified or the split view. That's what I did about three times. It is long, but it's extremely simple. Nice recreational scrolling. It will take about 3 minutes if you agree with my changes.

## Test plan

Refactor commit with only renames. Tests should pass.