### PR TITLE
include paginated output lines in e2e tests

### DIFF
--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -309,10 +309,13 @@ var expectedState = gqltestutil.BatchSpecDeep{
 							Number:    1,
 							Run:       "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
 							Container: "ubuntu:18.04",
-							OutputLines: []string{
-								"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
-								"stderr: Hello World",
-								"",
+							OutputLines: gqltestutil.WorkspaceOutputLines{
+								Nodes: []string{
+									"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
+									"stderr: Hello World",
+									"",
+								},
+								TotalCount: 3,
 							},
 							ExitCode:        0,
 							Environment:     []gqltestutil.WorkspaceEnvironmentVariable{},

--- a/internal/gqltestutil/batch_specs.go
+++ b/internal/gqltestutil/batch_specs.go
@@ -263,7 +263,10 @@ query GetBatchSpecDeep($id: ID!) {
 				  ifCondition
 				  cachedResultFound
 				  skipped
-				  outputLines
+				  outputLines {
+					nodes
+					totalCount
+				  }
 				  startedAt
 				  finishedAt
 				  exitCode
@@ -374,6 +377,11 @@ type BatchSpecWorkspace struct {
 	Executor             Executor
 }
 
+type WorkspaceOutputLines struct {
+	Nodes      []string
+	TotalCount int
+}
+
 type BatchSpecWorkspaceStep struct {
 	Number            int
 	Run               string
@@ -381,7 +389,7 @@ type BatchSpecWorkspaceStep struct {
 	IfCondition       string
 	CachedResultFound bool
 	Skipped           bool
-	OutputLines       []string
+	OutputLines       WorkspaceOutputLines
 	StartedAt         string
 	FinishedAt        string
 	ExitCode          int


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
The change to the `steps.outputLines` caused a failure in the e2e tests, this PR ensures the graphql schema for the e2e test complies with the change made in #46335.