### PR TITLE
svc: fix incorrect use of logger

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -137,7 +137,7 @@ func run(
 			// TODO(sqs): TODO(single-binary): Consider using the goroutine package and/or the errgroup package to report
 			// errors and listen to signals to initiate cleanup in a consistent way across all
 			// services.
-			obctx := observation.ScopedContext("", service.Name(), "", obctx)
+			obctx := observation.ContextWithLogger(log.Scoped(service.Name(), service.Name()), obctx)
 			err := service.Start(ctx, obctx, allReadyWG.Done, serviceConfig)
 			if err != nil {
 				logger.Fatal("failed to start service", log.String("service", service.Name()), log.Error(err))


### PR DESCRIPTION
The previous code was reusing a helper to inject in the scope a bunch of metadata that we don't have at this stage. This lead to the inclusion of a bunch of `...` in the scope.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally observed the problem being fixed. 

```
[   repo-updater] INFO repo-updater.PermsSyncer.runSchedule authz/perms_syncer.go:1192 scheduling permission syncs {"users": 0, "repos": 0, "database-backed perm syncer": false}
```
