### PR TITLE
experimental search input: Add support for history mode

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/placeholder.ts
+++ b/client/branded/src/search-ui/input/codemirror/placeholder.ts
@@ -30,13 +30,13 @@ function showWhenEmpty(state: EditorState): boolean {
 
 interface PlaceholderConfig {
     content: string
-    show: (state: EditorState) => boolean
+    show?: (state: EditorState) => boolean
 }
 
-const placeholderConfigFacet = Facet.define<PlaceholderConfig, PlaceholderConfig>({
+export const placeholderConfig = Facet.define<PlaceholderConfig, Required<PlaceholderConfig>>({
     combine(configs) {
         // Keep highest priority config
-        return configs.length > 0 ? configs[0] : { content: '', show: showWhenEmpty }
+        return configs.length > 0 ? { show: showWhenEmpty, ...configs[0] } : { content: '', show: showWhenEmpty }
     },
     enables: facet =>
         ViewPlugin.fromClass(
@@ -67,7 +67,7 @@ const placeholderConfigFacet = Facet.define<PlaceholderConfig, PlaceholderConfig
                     return Decoration.widget({ widget: new Placeholder(content), side: 1 })
                 }
 
-                private createDecorationSet(state: EditorState, config: PlaceholderConfig): DecorationSet {
+                private createDecorationSet(state: EditorState, config: Required<PlaceholderConfig>): DecorationSet {
                     return config.show(state)
                         ? Decoration.set([this.placeholderDecoration.range(state.doc.length)])
                         : Decoration.none
@@ -82,5 +82,5 @@ const placeholderConfigFacet = Facet.define<PlaceholderConfig, PlaceholderConfig
  * default it will show the placeholder when the document is empty.
  */
 export function placeholder(content: string, show: (state: EditorState) => boolean = showWhenEmpty): Extension {
-    return placeholderConfigFacet.of({ content, show })
+    return placeholderConfig.of({ content, show })
 }

--- a/client/branded/src/search-ui/input/codemirror/placeholder.ts
+++ b/client/branded/src/search-ui/input/codemirror/placeholder.ts
@@ -2,7 +2,7 @@
  * This is an adaption of the built-in CodeMirror placeholder to make it
  * configurable when the placeholder should be shown or not.
  */
-import { EditorState, Extension } from '@codemirror/state'
+import { EditorState, Extension, Facet } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetType } from '@codemirror/view'
 
 class Placeholder extends WidgetType {
@@ -28,33 +28,59 @@ function showWhenEmpty(state: EditorState): boolean {
     return state.doc.length === 0
 }
 
+interface PlaceholderConfig {
+    content: string
+    show: (state: EditorState) => boolean
+}
+
+const placeholderConfigFacet = Facet.define<PlaceholderConfig, PlaceholderConfig>({
+    combine(configs) {
+        // Keep highest priority config
+        return configs.length > 0 ? configs[0] : { content: '', show: showWhenEmpty }
+    },
+    enables: facet =>
+        ViewPlugin.fromClass(
+            class {
+                private placeholderDecoration: Decoration
+                public decorations: DecorationSet
+
+                constructor(view: EditorView) {
+                    const config = view.state.facet(facet)
+                    this.placeholderDecoration = this.createWidget(config.content)
+                    this.decorations = this.createDecorationSet(view.state, config)
+                }
+
+                public update(update: ViewUpdate): void {
+                    let updateDecorations = update.docChanged || update.selectionSet
+
+                    const config = update.view.state.facet(facet)
+                    if (config !== update.startState.facet(facet)) {
+                        this.placeholderDecoration = this.createWidget(config.content)
+                        updateDecorations = true
+                    }
+                    if (updateDecorations) {
+                        this.decorations = this.createDecorationSet(update.view.state, config)
+                    }
+                }
+
+                private createWidget(content: string): Decoration {
+                    return Decoration.widget({ widget: new Placeholder(content), side: 1 })
+                }
+
+                private createDecorationSet(state: EditorState, config: PlaceholderConfig): DecorationSet {
+                    return config.show(state)
+                        ? Decoration.set([this.placeholderDecoration.range(state.doc.length)])
+                        : Decoration.none
+                }
+            },
+            { decorations: plugin => plugin.decorations }
+        ),
+})
+
 /**
  * Extension that shows a placeholder when the provided condition is met. By
  * default it will show the placeholder when the document is empty.
  */
 export function placeholder(content: string, show: (state: EditorState) => boolean = showWhenEmpty): Extension {
-    return ViewPlugin.fromClass(
-        class {
-            private placeholderDecoration: Decoration
-            public decorations: DecorationSet
-
-            constructor(view: EditorView) {
-                this.placeholderDecoration = Decoration.widget({ widget: new Placeholder(content), side: 1 })
-                this.decorations = this.createDecorationSet(view.state)
-            }
-
-            public update(update: ViewUpdate): void {
-                if (update.docChanged || update.selectionSet) {
-                    this.decorations = this.createDecorationSet(update.view.state)
-                }
-            }
-
-            private createDecorationSet(state: EditorState): DecorationSet {
-                return show(state)
-                    ? Decoration.set([this.placeholderDecoration.range(state.doc.length)])
-                    : Decoration.none
-            }
-        },
-        { decorations: plugin => plugin.decorations }
-    )
+    return placeholderConfigFacet.of({ content, show })
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -22,6 +22,7 @@ import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
 import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 
 import { filterHighlight } from './codemirror/syntax-highlighting'
+import { modeScope } from './modes'
 import { editorConfigFacet, Source, suggestions } from './suggestionsExtension'
 
 import styles from './CodeMirrorQueryInputWrapper.module.scss'
@@ -179,7 +180,7 @@ function createEditor(
                 keymap.of(historyKeymap),
                 keymap.of(defaultKeymap),
                 codemirrorHistory(),
-                Prec.low([querySyntaxHighlighting, filterHighlight]),
+                Prec.low([querySyntaxHighlighting, modeScope(filterHighlight, [null])]),
                 EditorView.theme({
                     '&': {
                         flex: 1,
@@ -195,6 +196,9 @@ function createEditor(
                         fontFamily: 'var(--code-font-family)',
                         fontSize: 'var(--code-font-size)',
                         color: 'var(--search-query-text-color)',
+                    },
+                    '.cm-line': {
+                        paddingLeft: '0.25rem',
                     },
                 }),
                 querySettingsCompartment.of(queryExtensions),

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -60,12 +60,15 @@
                     cursor: pointer;
                 }
 
+                .label {
+                    margin-right: 0.5rem;
+                }
+
                 .match {
                     font-weight: bold;
                 }
 
                 .description {
-                    margin-left: 0.5rem;
                     color: var(--input-placeholder-color);
                 }
 
@@ -75,6 +78,7 @@
                     color: var(--text-muted);
                     font-family: var(--font-family-base);
                     display: flex;
+                    white-space: nowrap;
 
                     > [role='gridcell'] {
                         padding: 0 0.5rem;
@@ -91,7 +95,6 @@
 }
 
 .filter-option {
-    display: flex;
     font-family: var(--code-font-family);
     font-size: 0.75rem;
 

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -104,7 +104,7 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
                                             <Icon className={styles.icon} svgPath={option.icon} aria-hidden="true" />
                                         </div>
                                     )}
-                                    <div className={classnames(!option.multiline && 'd-flex', 'flex-wrap')}>
+                                    <div className="d-flex flex-wrap">
                                         <div role="gridcell" className={styles.label}>
                                             {option.render ? (
                                                 option.render(option)

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -7,9 +7,11 @@ import { isSafari } from '@sourcegraph/common'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { Icon, useWindowSize } from '@sourcegraph/wildcard'
 
-import { Action, Group, Option } from './suggestionsExtension'
+import { Action, CustomRenderer, Group, Option } from './suggestionsExtension'
 
 import styles from './Suggestions.module.scss'
+
+type Renderable = React.ReactElement | string | null
 
 function getActionName(action: Action): string {
     switch (action.type) {
@@ -100,14 +102,14 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
                                     aria-selected={focusedItem === option}
                                 >
                                     {option.icon && (
-                                        <div className="pr-1">
+                                        <div className="pr-1 align-self-start">
                                             <Icon className={styles.icon} svgPath={option.icon} aria-hidden="true" />
                                         </div>
                                     )}
                                     <div className="d-flex flex-wrap">
                                         <div role="gridcell" className={styles.label}>
                                             {option.render ? (
-                                                option.render(option)
+                                                renderStringOrRenderer(option.render, option)
                                             ) : option.matches ? (
                                                 <HighlightedLabel label={option.label} matches={option.matches} />
                                             ) : (
@@ -140,7 +142,7 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
 const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
     <div className={classnames(styles.footer, 'd-flex align-items-center justify-content-between')}>
         <span>
-            {option.info?.(option)}
+            {option.info && renderStringOrRenderer(option.info, option)}
             {!option.info && (
                 <>
                     <ActionInfo action={option.action} shortcut="Return" />{' '}
@@ -155,27 +157,45 @@ const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
 )
 
 const ActionInfo: React.FunctionComponent<{ action: Action; shortcut: string }> = ({ action, shortcut }) => {
-    const displayName = shortcutDisplayName(shortcut)
-    switch (action.type) {
-        case 'completion':
-            return (
-                <>
-                    Press <kbd>{displayName}</kbd> to <strong>add</strong> to your query.
-                </>
-            )
-        case 'goto':
-            return (
-                <>
-                    Press <kbd>{displayName}</kbd> to <strong>go to</strong> the suggestion.
-                </>
-            )
-        case 'command':
-            return (
-                <>
-                    Press <kbd>{displayName}</kbd> to <strong>execute</strong> the command.
-                </>
-            )
+    let info: Renderable = action.info ? renderStringOrRenderer(action.info, action) : null
+    if (!info) {
+        switch (action.type) {
+            case 'completion':
+                info = (
+                    <>
+                        <strong>add</strong> to your query
+                    </>
+                )
+                break
+            case 'goto':
+                info = (
+                    <>
+                        <strong>go to</strong> the suggestion
+                    </>
+                )
+                break
+            case 'command':
+                info = (
+                    <>
+                        <strong>execute</strong> the command
+                    </>
+                )
+                break
+        }
     }
+
+    return (
+        <>
+            Press <kbd>{shortcutDisplayName(shortcut)}</kbd> to {info}.
+        </>
+    )
+}
+
+function renderStringOrRenderer<T>(renderer: CustomRenderer<T>, obj: T): Renderable {
+    if (typeof renderer === 'string') {
+        return renderer
+    }
+    return renderer(obj)
 }
 
 export const HighlightedLabel: React.FunctionComponent<{ label: string; matches: Set<number>; offset?: number }> = ({

--- a/client/branded/src/search-ui/input/experimental/SyntaxHighlightedSearchQuery.tsx
+++ b/client/branded/src/search-ui/input/experimental/SyntaxHighlightedSearchQuery.tsx
@@ -1,0 +1,46 @@
+import React, { Fragment, useMemo } from 'react'
+
+import classNames from 'classnames'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { decorate, toDecoration } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+
+import { HighlightedLabel } from './Suggestions'
+
+interface SyntaxHighlightedSearchQueryProps extends React.HTMLAttributes<HTMLSpanElement> {
+    query: string
+    matches?: Set<number>
+    searchPatternType?: SearchPatternType
+}
+
+// A read-only syntax highlighted search query
+export const SyntaxHighlightedSearchQuery: React.FunctionComponent<
+    React.PropsWithChildren<SyntaxHighlightedSearchQueryProps>
+> = ({ query, searchPatternType, matches, ...otherProps }) => {
+    const tokens = useMemo(() => {
+        const tokens = searchPatternType ? scanSearchQuery(query, false, searchPatternType) : scanSearchQuery(query)
+        return tokens.type === 'success'
+            ? tokens.term.flatMap(token =>
+                  decorate(token).map(token => {
+                      const { value, key, className } = toDecoration(query, token)
+                      return (
+                          <span className={className} key={key}>
+                              {matches ? (
+                                  <HighlightedLabel label={value} matches={matches} offset={token.range.start} />
+                              ) : (
+                                  value
+                              )}
+                          </span>
+                      )
+                  })
+              )
+            : [<Fragment key="0">{query}</Fragment>]
+    }, [query, matches, searchPatternType])
+
+    return (
+        <span {...otherProps} className={classNames('text-monospace search-query-link', otherProps.className)}>
+            {tokens}
+        </span>
+    )
+}

--- a/client/branded/src/search-ui/input/experimental/codemirror/history.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/history.ts
@@ -1,0 +1,166 @@
+import { Extension, Prec } from '@codemirror/state'
+import { Decoration, EditorView, ViewPlugin, WidgetType } from '@codemirror/view'
+import { mdiClockOutline } from '@mdi/js'
+import { formatDistanceToNow, parseISO } from 'date-fns'
+import { Fzf, FzfOptions } from 'fzf'
+
+import { pluralize } from '@sourcegraph/common'
+import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
+import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
+
+import { queryRenderer } from '../optionRenderer'
+import {
+    clearMode,
+    getSelectedMode,
+    setMode,
+    Source,
+    suggestionSources,
+    Option,
+    ModeDefinition,
+    suggestionModes,
+} from '../suggestionsExtension'
+
+const theme = EditorView.theme({
+    '.sg-history-button': {
+        border: 'none',
+        backgroundColor: 'transparent',
+        padding: 0,
+        marginRight: '0.5rem',
+        width: 'var(--icon-inline-size)',
+        height: 'var(--icon-inline-size)',
+        color: 'var(--icon-color)',
+        verticalAlign: 'text-top',
+    },
+    '.sg-history-button > svg': {
+        // Setting this simplifies event handling for the history button widget
+        pointerEvents: 'none',
+        // This is overwritten to 'middle' which doesn't look right
+        verticalAlign: 'initial',
+    },
+    '.sg-mode-History .sg-history-button': {
+        marginRight: '0.125rem',
+        color: 'var(--logo-purple)',
+    },
+})
+
+function toggleHistoryMode(event: MouseEvent | KeyboardEvent, view: EditorView): void {
+    if ((event.target as HTMLElement).classList.contains('sg-history-button')) {
+        event.preventDefault()
+        const selectedMode = getSelectedMode(view.state)
+        if (selectedMode?.name === 'History') {
+            clearMode(view)
+        } else {
+            setMode(view, 'History')
+        }
+        view.focus()
+    }
+}
+
+/**
+ * This ViewPlugin renders the history button at the beginning of the search
+ * input.
+ */
+const historyButton = ViewPlugin.define(
+    () => ({
+        decorations: Decoration.set(
+            Decoration.widget({
+                side: -1,
+                widget: new (class extends WidgetType {
+                    public toDOM(_view: EditorView): HTMLElement {
+                        const button = document.createElement('button')
+                        button.className = 'sg-history-button'
+                        button.type = 'button'
+                        const icon = createSVGIcon(mdiClockOutline)
+                        button.append(icon)
+                        return button
+                    }
+                    public ignoreEvent(): boolean {
+                        return false
+                    }
+                })(),
+            }).range(0)
+        ),
+    }),
+    {
+        decorations: plugin => plugin.decorations,
+        eventHandlers: {
+            // Click doesn't work because it moves the cursor to the beginning
+            // of the input.
+            mousedown: toggleHistoryMode,
+            keydown: (event, view) => {
+                if (event.key === ' ') {
+                    toggleHistoryMode(event, view)
+                }
+            },
+        },
+    }
+)
+
+const fzfOptions: FzfOptions<RecentSearch> = {
+    selector: search => search.query,
+    // match: extendedMatch,
+    // fuzzy: false,
+}
+
+const formatTimeOptions = {
+    addSuffix: true,
+}
+
+function createHistorySuggestionSource(
+    source: () => RecentSearch[],
+    submitQuery: (query: string) => void
+): Source['query'] {
+    const applySuggestion = (option: Option): void => {
+        submitQuery(option.label)
+    }
+
+    return state => {
+        const query = state.sliceDoc()
+        const fzf = new Fzf(source(), fzfOptions)
+        const results = fzf.find(query)
+        return {
+            result: [
+                {
+                    title: 'History',
+                    options: results.map(({ item, positions }) => ({
+                        label: item.query,
+                        icon: mdiClockOutline,
+                        matches: positions,
+                        description: `• ${item.resultCount}${item.limitHit ? '+' : ''} ${pluralize(
+                            'result',
+                            item.resultCount
+                        )} • ${formatDistanceToNow(parseISO(item.timestamp), formatTimeOptions)}`,
+                        action: {
+                            type: 'command',
+                            name: 'Run',
+                            apply: applySuggestion,
+                        },
+                        alternativeAction: {
+                            type: 'completion',
+                            name: 'Edit query',
+                            insertValue: item.query + ' ',
+                            from: 0,
+                        },
+                        render: queryRenderer,
+                    })),
+                },
+            ],
+        }
+    }
+}
+
+export function searchHistoryExtension(config: {
+    mode: ModeDefinition
+    source: () => RecentSearch[]
+    submitQuery: (query: string) => void
+}): Extension {
+    return [
+        suggestionModes.of([config.mode]),
+        theme,
+        Prec.highest(historyButton),
+        suggestionSources.of({
+            query: createHistorySuggestionSource(config.source, config.submitQuery),
+            mode: config.mode.name,
+        }),
+    ]
+}

--- a/client/branded/src/search-ui/input/experimental/codemirror/history.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/history.ts
@@ -8,28 +8,23 @@ import { pluralize } from '@sourcegraph/common'
 import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
 
+import { clearMode, getSelectedMode, ModeDefinition, modesFacet, setMode } from '../modes'
 import { queryRenderer } from '../optionRenderer'
-import {
-    clearMode,
-    getSelectedMode,
-    setMode,
-    Source,
-    suggestionSources,
-    Option,
-    ModeDefinition,
-    suggestionModes,
-} from '../suggestionsExtension'
+import { Source, suggestionSources, Option } from '../suggestionsExtension'
 
 const theme = EditorView.theme({
     '.sg-history-button': {
-        border: 'none',
+        boxSizing: 'content-box',
+        border: '0',
         backgroundColor: 'transparent',
         padding: 0,
-        marginRight: '0.5rem',
+        marginRight: '0.25rem',
+        paddingRight: '0.25rem',
         width: 'var(--icon-inline-size)',
         height: 'var(--icon-inline-size)',
         color: 'var(--icon-color)',
         verticalAlign: 'text-top',
+        borderRight: '1px solid var(--border-color-2)',
     },
     '.sg-history-button > svg': {
         // Setting this simplifies event handling for the history button widget
@@ -38,8 +33,9 @@ const theme = EditorView.theme({
         verticalAlign: 'initial',
     },
     '.sg-mode-History .sg-history-button': {
-        marginRight: '0.125rem',
         color: 'var(--logo-purple)',
+        marginRight: '0',
+        border: '0',
     },
 })
 
@@ -155,7 +151,7 @@ export function searchHistoryExtension(config: {
     submitQuery: (query: string) => void
 }): Extension {
     return [
-        suggestionModes.of([config.mode]),
+        modesFacet.of([config.mode]),
         theme,
         Prec.highest(historyButton),
         suggestionSources.of({

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -16,9 +16,9 @@ import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
 
 import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
 
-const validFilter = Decoration.mark({ class: 'sg-filter', inclusive: false })
-const invalidFilter = Decoration.mark({ class: 'sg-filter sg-invalid-filter', inclusive: false })
-const contextFilter = Decoration.mark({ class: 'sg-context-filter', inclusive: true })
+const validFilter = Decoration.mark({ class: 'sg-filter' })
+const invalidFilter = Decoration.mark({ class: 'sg-filter sg-invalid-filter' })
+const contextFilter = Decoration.mark({ class: 'sg-context-filter', inclusiveEnd: true })
 const replaceContext = Decoration.replace({})
 class ClearTokenWidget extends WidgetType {
     constructor(private token: Token) {
@@ -121,15 +121,17 @@ export const filterHighlight = [
                             token.range.start,
                             token.range.end + 1
                         ) // or cursor is within field
-                        builder.add(token.range.start, token.range.end, contextFilter)
                         if (token.value?.value && (!withinRange || !view.hasFocus)) {
                             // hide context: field name and show remove button
                             builder.add(token.range.start, token.field.range.end + 1, replaceContext)
+                            builder.add(token.range.start, token.range.end, contextFilter)
                             builder.add(
                                 token.range.end,
                                 token.range.end,
-                                Decoration.widget({ widget: new ClearTokenWidget(token) })
+                                Decoration.widget({ widget: new ClearTokenWidget(token), side: -1 })
                             )
+                        } else {
+                            builder.add(token.range.start, token.range.end, contextFilter)
                         }
                     }
                 }

--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -8,6 +8,7 @@ export type {
     Source,
     SuggestionResult,
 } from './suggestionsExtension'
-export { getEditorConfig } from './suggestionsExtension'
+export { getEditorConfig, combineResults } from './suggestionsExtension'
 export * from './optionRenderer'
 export * from './utils'
+export * from './codemirror/history'

--- a/client/branded/src/search-ui/input/experimental/modes.ts
+++ b/client/branded/src/search-ui/input/experimental/modes.ts
@@ -1,0 +1,199 @@
+import {
+    Compartment,
+    EditorState,
+    Extension,
+    Facet,
+    Prec,
+    StateEffect,
+    StateField,
+    Transaction,
+} from '@codemirror/state'
+import { Decoration, EditorView, KeyBinding, keymap, WidgetType } from '@codemirror/view'
+
+import { placeholderConfig } from '../codemirror/placeholder'
+
+export interface ModeDefinition {
+    name: string
+    keybinding?: Omit<KeyBinding, 'run' | 'scope' | 'any' | 'shift'>
+    placeholder?: string
+}
+
+class SelectedModeState {
+    constructor(
+        public readonly selectedMode: ModeDefinition | null = null,
+        public readonly previousInput: string | null = null
+    ) {}
+
+    public update(transaction: Transaction): SelectedModeState {
+        // Aliasing makes it easier to update the state
+        // eslint-disable-next-line @typescript-eslint/no-this-alias,unicorn/no-this-assignment
+        let state: SelectedModeState = this
+        const modes = transaction.state.facet(modesFacet)
+
+        for (const effect of transaction.effects) {
+            if (effect.is(setModeEffect)) {
+                if (!effect.value) {
+                    state = new SelectedModeState()
+                } else if (state.selectedMode?.name !== effect.value) {
+                    const mode = modes.find(mode => mode.name === effect.value)
+                    state = mode
+                        ? new SelectedModeState(mode, transaction.startState.sliceDoc())
+                        : new SelectedModeState()
+                }
+            }
+        }
+
+        if (state.selectedMode && !modes.includes(state.selectedMode)) {
+            // Availabel modes might have been changed, in which case we need to
+            // update the state.
+            const mode = modes.find(mode => mode.name === state.selectedMode?.name)
+            if (mode) {
+                state = new SelectedModeState(mode, state.previousInput)
+            }
+        }
+
+        return state
+    }
+}
+
+export const setModeEffect = StateEffect.define<string | null>()
+const selectedModeField = StateField.define<SelectedModeState>({
+    create() {
+        return new SelectedModeState()
+    },
+    update(selectedMode, transaction) {
+        return selectedMode.update(transaction)
+    },
+    provide(field) {
+        return [
+            Prec.highest(
+                placeholderConfig.computeN([field], state => {
+                    const selectedMode = state.field(field).selectedMode
+                    if (!selectedMode?.placeholder) {
+                        return []
+                    }
+                    return [{ content: selectedMode.placeholder }]
+                })
+            ),
+            EditorView.contentAttributes.compute([field], state => {
+                const selectedMode = state.field(field).selectedMode
+                return {
+                    class: selectedMode ? `sg-mode-${selectedMode.name}` : '',
+                }
+            }),
+            EditorView.theme({
+                '.sg-mode-marker': {
+                    color: 'var(--logo-purple)',
+                    paddingRight: '0.125rem',
+                },
+            }),
+            EditorView.decorations.compute([field], state => {
+                const selectedMode = state.field(field).selectedMode
+                if (!selectedMode) {
+                    return Decoration.none
+                }
+                return Decoration.set(
+                    Decoration.widget({
+                        widget: new (class extends WidgetType {
+                            public toDOM(): HTMLElement {
+                                const marker = document.createElement('span')
+                                marker.className = 'sg-mode-marker'
+                                marker.textContent = selectedMode.name + ':'
+                                return marker
+                            }
+                        })(),
+                        side: -1,
+                    }).range(0)
+                )
+            }),
+        ]
+    },
+})
+
+export const modesFacet = Facet.define<ModeDefinition[], ModeDefinition[]>({
+    combine(modes) {
+        return modes.flat()
+    },
+    enables(facet) {
+        return [
+            selectedModeField,
+            Prec.highest([
+                keymap.compute([facet], state => {
+                    const modes = state.facet(facet)
+                    return [
+                        {
+                            key: 'Escape',
+                            run: clearMode,
+                        },
+                        ...modes
+                            .filter(mode => mode.keybinding)
+                            .map(
+                                (mode): KeyBinding => ({
+                                    ...mode.keybinding,
+                                    run: view => setMode(view, mode.name),
+                                })
+                            ),
+                    ]
+                }),
+            ]),
+        ]
+    },
+})
+
+export function modeChanged({ startState, state }: Transaction): boolean {
+    return getSelectedMode(startState) !== getSelectedMode(state)
+}
+
+export function getSelectedMode(state: EditorState): ModeDefinition | null {
+    return state.field(selectedModeField, false)?.selectedMode ?? null
+}
+
+export function setMode(view: EditorView, name: string): boolean {
+    view.dispatch({
+        effects: setModeEffect.of(name),
+        // Clear input
+        changes: { from: 0, to: view.state.doc.length, insert: '' },
+        // It seems that setting the selection explicitly
+        // ensures that the cursor is rendered correctly after the widget decoration.
+        selection: { anchor: 0 },
+    })
+    return true
+}
+
+export function clearMode(view: EditorView, restoreInput = true): boolean {
+    const state = view.state.field(selectedModeField, false)
+    if (state?.selectedMode) {
+        const changes = restoreInput
+            ? { from: 0, to: view.state.doc.length, insert: state.previousInput ?? '' }
+            : undefined
+        view.dispatch({
+            effects: setModeEffect.of(null),
+            changes,
+            selection: changes ? { anchor: changes.insert.length } : undefined,
+        })
+        return true
+    }
+    return false
+}
+
+const isSetModeEffect = (effect: StateEffect<unknown>): effect is StateEffect<string | null> => effect.is(setModeEffect)
+
+/**
+ * The provided extensions are only enabled when the specified modes are active
+ * or, when `null` is passed, when no mode is active.
+ */
+export function modeScope(extension: Extension, modes: (string | null)[]): Extension {
+    const compartment = new Compartment()
+    return [
+        compartment.of(extension),
+        EditorState.transactionExtender.of(transaction => {
+            const effect = transaction.effects.find(isSetModeEffect)
+            if (!effect) {
+                return null
+            }
+            return {
+                effects: compartment.reconfigure(modes.includes(effect.value) ? extension : []),
+            }
+        }),
+    ]
+}

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -22,7 +22,7 @@ const FilterValueOption: React.FunctionComponent<{ option: Option }> = ({ option
     return (
         <span className={styles.filterOption}>
             <span className={styles.filterField}>
-                {option.matches ? <HighlightedLabel label={field} matches={option.matches} /> : option.label}
+                {field}
                 <span className={styles.separator}>:</span>
             </span>
             {option.matches ? <HighlightedLabel label={value} matches={option.matches} /> : option.label}

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -1,9 +1,8 @@
 import classnames from 'classnames'
 
-import { SyntaxHighlightedSearchQuery } from '../../components'
-
 import { HighlightedLabel } from './Suggestions'
 import { Option } from './suggestionsExtension'
+import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
 
 import styles from './Suggestions.module.scss'
 
@@ -32,7 +31,7 @@ const FilterValueOption: React.FunctionComponent<{ option: Option }> = ({ option
 }
 
 const QueryOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <SyntaxHighlightedSearchQuery query={option.label} />
+    <SyntaxHighlightedSearchQuery query={option.label} matches={option.matches} />
 )
 
 // Custom renderer for filter suggestions

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -54,7 +54,7 @@ export interface SuggestionResult {
     valid?: (state: EditorState, position: number) => boolean
 }
 
-export type CustomRenderer = (option: Option) => React.ReactElement
+export type CustomRenderer<T> = ((value: T) => React.ReactElement) | string
 
 export interface Option {
     /**
@@ -82,11 +82,11 @@ export interface Option {
      * If present the provided component will be used to render the label of the
      * option.
      */
-    render?: CustomRenderer
+    render?: CustomRenderer<Option>
     /**
      * If present this component is rendered as footer.
      */
-    info?: CustomRenderer
+    info?: CustomRenderer<Option>
     /**
      * A set of character indexes. If provided the characters of at these
      * positions in the label will be highlighted as matches.
@@ -98,11 +98,19 @@ export interface CommandAction {
     type: 'command'
     apply: (option: Option, view: EditorView) => void
     name?: string
+    /**
+     * If present this component is rendered as part of the footer.
+     */
+    info?: CustomRenderer<Action>
 }
 export interface GoToAction {
     type: 'goto'
     url: string
     name?: string
+    /**
+     * If present this component is rendered as part of the footer.
+     */
+    info?: CustomRenderer<Action>
 }
 export interface CompletionAction {
     type: 'completion'
@@ -110,6 +118,10 @@ export interface CompletionAction {
     name?: string
     to?: number
     insertValue?: string
+    /**
+     * If present this component is rendered as part of the footer.
+     */
+    info?: CustomRenderer<Action>
 }
 export type Action = CommandAction | GoToAction | CompletionAction
 

--- a/client/shared/src/search/query/utils.ts
+++ b/client/shared/src/search/query/utils.ts
@@ -1,0 +1,8 @@
+import type { Token } from './token'
+
+/**
+ * Returns the (string) length of the provided token.
+ */
+export function getTokenLength(token: Token): number {
+    return token.range.end - token.range.start
+}


### PR DESCRIPTION
This PR adds support "history mode" to the experimental search input. Two major changes make this happen:

- Suggestions can be switched into a specific "mode". Modes are indicated by prefixing the input with the mode name (in this case 'History:'). Modes can be activated buy calling the `setMode` function.
- Suggestions can now come from multiple sources (i.e. sources can be defined independently, which means all the history-related logic is independent from other suggestion sources) and sources can be associated with a mode. If a mode is active only sources associated with a mode are used for suggestions.

See the demo video: 

https://user-images.githubusercontent.com/179026/215798119-40076a30-80a7-4de8-a67c-859790ffaa09.mp4


You'll also notice a `keybinding` property. I tested keybindings successfully but eventually decided to not add one for history mode right now because *which* binding to use requires some more thought.

Other supporting changes:

- improve multline rendering of suggestions with long labels or descriptions
- make our custom placeholder extension configurable via a facet so that the placeholder text can be changed more easily by other extensions. This is used to show a different text when the history mode is active.
- added a custom query syntax highlighting component that supports "matches" rendering

## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-experimental-history-mode.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
