### PR TITLE
Add default width and height to Gerrit SVG icon

### DIFF
--- a/client/web/src/components/externalServices/GerritIcon.tsx
+++ b/client/web/src/components/externalServices/GerritIcon.tsx
@@ -3,9 +3,9 @@ import { MdiReactIconComponentType } from 'mdi-react'
 export const GerritIcon: MdiReactIconComponentType = props => (
     <svg
         className={'mdi-icon ' + (props.className || '')}
-        width={props.size}
-        height={props.size}
-        fill={props.color}
+        width={props.size ?? 24}
+        height={props.size ?? 24}
+        fill={props.color ?? 'currentColor'}
         viewBox="0 0 52 52"
     >
         <path


### PR DESCRIPTION
Not all places in the code specify an icon size, making the icon disappear

## Test plan

Visually confirmed myself.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-gerrit-icon-account.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
