### PR TITLE
release-tool: remove client CI checks from release-config file

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -15,7 +15,7 @@
     "captainGitHubUsername": "keegancsmith",
     // Release versions
     "previousRelease": "4.4.1",
-    "upcomingRelease": "4.5.0",
+    "upcomingRelease": "4.6.0",
     "oneWorkingWeekBeforeRelease": "15 February 2023 10:00 PST",
     "threeWorkingDaysBeforeRelease": "17 February 2023 10:00 PST",
     "releaseDate": "22 February 2023 10:00 PST",

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -15,7 +15,7 @@
     "captainGitHubUsername": "keegancsmith",
     // Release versions
     "previousRelease": "4.4.1",
-    "upcomingRelease": "4.6.0",
+    "upcomingRelease": "4.5.0",
     "oneWorkingWeekBeforeRelease": "15 February 2023 10:00 PST",
     "threeWorkingDaysBeforeRelease": "17 February 2023 10:00 PST",
     "releaseDate": "22 February 2023 10:00 PST",

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -98,8 +98,8 @@ func ParseDiff(files []string) (diff Diff, changedFiles ChangedFiles) {
 			diff |= Client
 		}
 		// dev/release contains a nodejs script that doesn't have tests but needs to be
-		// linted with Client linters
-		if strings.HasPrefix(p, "dev/release/") {
+		// linted with Client linters. We skip the release config file to reduce friction editing during releases.
+		if strings.HasPrefix(p, "dev/release/") && !strings.Contains(p, "release-config") {
 			diff |= Client
 		}
 


### PR DESCRIPTION
Closes [46944](https://github.com/sourcegraph/sourcegraph/issues/46944)

All of the client checks get executed on the release-config.jsonc file, which adds a lot of waiting time to patch releases where we have to edit this file ad hoc. 

Probably a better approach is to separate the linter command from the Client diff type, but this is a pretty straightforward change.

## Test plan

Here is the output of `sg ci preview` after this change (with a release-config diff):

``` Detected run type: Pull request                                                             
  • Detected diffs: Docs                                                                        
  • Computed build steps:                                                                       
    • Metadata                                                                                  
      • 📝:pipeline: Pipeline metadata                                                          
    • Linters and static analysis                                                               
      • 🍍:lint-roller: Run sg lint                                                             
    • ⤴️ Upload build trace
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-ci-release-config.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

