### PR TITLE
vscode settings: fix jest extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,7 @@
     "build.allowImplicitNetworkAccess": true,
     "local": "github.com/sourcegraph/sourcegraph"
   },
-  "jest.jestCommandLine": "pnpm test",
+  "jest.jestCommandLine": "pnpm run test",
   "jest.showCoverageOnLoad": false,
   "gulp.autoDetect": "off",
   "npm.packageManager": "pnpm",


### PR DESCRIPTION
I was getting errors running the Jest extension; [this change fixed it for some reason](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1675184121744639?thread_ts=1675183135.119089&cid=C01C3NCGD40).

## Test plan

Jest extension in VSCode should work