### PR TITLE
servicecatalog: add prometheus to protected services

### DIFF
--- a/lib/servicecatalog/service-catalog.yaml
+++ b/lib/servicecatalog/service-catalog.yaml
@@ -21,6 +21,8 @@ protected_services:
       # other stuff we just know about
       - search-indexer
       - indexed-searcher
+      # observability
+      - prometheus
 
   # $ go run ./dev/depgraph/ summary internal/redispool
   # $ go run ./dev/depgraph/ summary internal/rcache
@@ -36,7 +38,8 @@ protected_services:
       - searcher
       - symbols
       - worker
-      # other stuff we just know about
+      # observability
+      - prometheus
       - redis-exporter
 
   # $ go run ./dev/depgraph/ summary internal/database
@@ -51,3 +54,6 @@ protected_services:
       - symbols
       - worker
       - precise-code-intel-worker
+      # observability
+      - prometheus
+      - postgres-exporter


### PR DESCRIPTION
Oversight - prometheus needs to be able to pull metrics from these services. On https://bobheadxi.sourcegraph.com/-/debug/grafana/d/gitserver/git-server?orgId=1 all gitserver metrics are 0 and critical alerts are firing saying gitserver is down

Also added postgres-exporter to the list - like redis-exporter it's not a separate thing in our Helm deployments, but might be good to include just to be complete.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a
