### PR TITLE
graphqlbackend: only allow SOAP users to delete other SOAP users

### DIFF
--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -126,11 +126,7 @@ func (r *schemaResolver) DeleteUsers(ctx context.Context, args *struct {
 			// If the delete target is a SOAP user, make sure the actor is also a SOAP
 			// user - regular users should not be able to delete SOAP users.
 			if acct.ServiceType == auth.SourcegraphOperatorProviderType {
-				actorSoapAccts, err := r.db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
-					UserID:      a.UID,
-					ServiceType: auth.SourcegraphOperatorProviderType,
-				})
-				if err != nil || len(actorSoapAccts) == 0 {
+				if !a.SourcegraphOperator {
 					return nil, errors.Newf("%[1]q users cannot be deleted by non-%[1]q users",
 						auth.SourcegraphOperatorProviderType)
 				}

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -157,11 +157,13 @@ func TestDeleteUser(t *testing.T) {
 					}
 				}
 			`,
-					ExpectedResult: `{ "deleteUser": null }`,
-					ExpectedErrors: []*gqlerrors.QueryError{{
-						Path:    []any{"deleteUser"},
-						Message: fmt.Sprintf("no users found with IDs: [%d]", notFoundUID),
-					}},
+					ExpectedResult: `
+				{
+					"deleteUser": {
+						"alwaysNil": null
+					}
+				}
+			`,
 				},
 			},
 		},
@@ -242,8 +244,8 @@ func TestDeleteUser(t *testing.T) {
 					ExpectedErrors: []*gqlerrors.QueryError{
 						{
 							Path: []any{"deleteUser"},
-							Message: fmt.Sprintf("%[1]q users cannot be deleted by non-%[1]q users",
-								auth.SourcegraphOperatorProviderType),
+							Message: fmt.Sprintf("%[1]q user %d cannot be deleted by a non-%[1]q user",
+								auth.SourcegraphOperatorProviderType, aliceUID),
 						},
 					},
 				},

--- a/internal/auth/const.go
+++ b/internal/auth/const.go
@@ -1,5 +1,11 @@
 package auth
 
 // SourcegraphOperatorProviderType is the unique identifier of the Sourcegraph
-// Operator authentication provider.
+// Operator authentication provider, also referred to as "SOAP".  There can only
+// ever be one provider of this type, and it can only be provisioned through
+// Cloud site configuration (see github.com/sourcegraph/sourcegraph/enterprise/internal/cloud)
+//
+// SOAP is used to provision accounts for Sourcegraph teammates in Sourcegraph
+// Cloud - for more details, refer to
+// https://handbook.sourcegraph.com/departments/cloud/technical-docs/oidc_site_admin/#faq
 const SourcegraphOperatorProviderType = "sourcegraph-operator"


### PR DESCRIPTION
This change prevents non-SOAP users from deleting SOAP users.

This is not much of an issue yet because SOAP users are shortlived and unlikely to be deleted by a Cloud customer admin, but is relevant for https://github.com/sourcegraph/sourcegraph/pull/47059 and https://github.com/sourcegraph/sourcegraph/pull/47235 where we want to introduce the concept of a SOAP service account.

Stack fixes https://github.com/sourcegraph/customer/issues/1929

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

New and existing automated tests