### PR TITLE
Adds Dynamic "Code Stats" Value

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -14,8 +14,8 @@ import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../../
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { getByteUnitLabel, getByteUnitValue } from '../utils'
 import { useChartFilters } from '../useChartFilters'
+import { getByteUnitLabel, getByteUnitValue } from '../utils'
 
 import { DevTimeSaved } from './DevTimeSaved'
 import { OVERVIEW_STATISTICS } from './queries'

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -14,6 +14,7 @@ import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../../
 import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { HorizontalSelect } from '../components/HorizontalSelect'
+import { getByteUnitLabel, getByteUnitValue } from '../utils'
 import { useChartFilters } from '../useChartFilters'
 
 import { DevTimeSaved } from './DevTimeSaved'
@@ -21,7 +22,6 @@ import { OVERVIEW_STATISTICS } from './queries'
 import { Sidebar } from './Sidebar'
 
 import styles from './index.module.scss'
-import { getByteUnitLabel, getByteUnitValue } from '../utils'
 
 interface IProps {
     history: H.History

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -21,6 +21,7 @@ import { OVERVIEW_STATISTICS } from './queries'
 import { Sidebar } from './Sidebar'
 
 import styles from './index.module.scss'
+import { getByteUnitLabel, getByteUnitValue } from '../utils'
 
 interface IProps {
     history: H.History
@@ -131,8 +132,8 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ history
                                             value: data.repositories.totalCount || 0,
                                         },
                                         {
-                                            label: 'Bytes stored',
-                                            value: Number(data.repositoryStats.gitDirBytes),
+                                            label: `${getByteUnitLabel(Number(data.repositoryStats.gitDirBytes))} stored`, 
+                                            value: getByteUnitValue(Number(data.repositoryStats.gitDirBytes)),
                                         },
                                         {
                                             label: 'Lines of code',

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -132,7 +132,9 @@ export const AnalyticsOverviewPage: React.FunctionComponent<IProps> = ({ history
                                             value: data.repositories.totalCount || 0,
                                         },
                                         {
-                                            label: `${getByteUnitLabel(Number(data.repositoryStats.gitDirBytes))} stored`, 
+                                            label: `${getByteUnitLabel(
+                                                Number(data.repositoryStats.gitDirBytes)
+                                            )} stored`,
                                             value: getByteUnitValue(Number(data.repositoryStats.gitDirBytes)),
                                         },
                                         {

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -36,16 +36,15 @@ export function buildFrequencyDatum(
     return result
 }
 
-export const formatNumber = (value: number): string =>
-    Intl.NumberFormat('en', { notation: 'compact' }).format(value)
+export const formatNumber = (value: number): string => Intl.NumberFormat('en', { notation: 'compact' }).format(value)
 
 export const getByteUnitValue = (value: number): number => {
     switch (true) {
-        case (value < 1000):
+        case value < 1000:
             return value
-        case (value >= 1000 && value < 1000000):
+        case value >= 1000 && value < 1000000:
             return value / 1000
-        case (value < 1000000000):
+        case value < 1000000000:
             return value / 1000000
         default:
             return value / 1000000000
@@ -54,13 +53,13 @@ export const getByteUnitValue = (value: number): number => {
 
 export const getByteUnitLabel = (value: number): string => {
     switch (true) {
-        case (value < 1000):
-            return "Bytes"
-        case (value < 1000000):
-            return "KB"
-        case (value < 1000000000):
-            return "MB"
+        case value < 1000:
+            return 'Bytes'
+        case value < 1000000:
+            return 'KB'
+        case value < 1000000000:
+            return 'MB'
         default:
-            return "GB"
+            return 'GB'
     }
 }

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -43,7 +43,7 @@ export const getByteUnitValue = (value: number): number => {
     switch (true) {
         case (value < 1000):
             return value
-        case (value > 999 && value < 1000000):
+        case (value >= 1000 && value < 1000000):
             return value / 1000
         case (value < 1000000000):
             return value / 1000000
@@ -54,11 +54,11 @@ export const getByteUnitValue = (value: number): number => {
 
 export const getByteUnitLabel = (value: number): string => {
     switch (true) {
-        case (value <= 999):
+        case (value < 1000):
             return "Bytes"
-        case (value <= 999999):
+        case (value < 1000000):
             return "KB"
-        case (value <= 999999999):
+        case (value < 1000000000):
             return "MB"
         default:
             return "GB"

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -41,14 +41,14 @@ export const formatNumber = (value: number): string =>
 
 export const getByteUnitValue = (value: number): number => {
     switch (true) {
+        case (value < 1000):
+            return value
         case (value > 999 && value < 1000000):
             return value / 1000
         case (value < 1000000000):
             return value / 1000000
-        case (value < 1000000000000):
-            return value / 1000000000
         default:
-            return value
+            return value / 1000000000
     }
 }
 

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -36,4 +36,33 @@ export function buildFrequencyDatum(
     return result
 }
 
-export const formatNumber = (value: number): string => Intl.NumberFormat('en', { notation: 'compact' }).format(value)
+export const formatNumber = (value: number): string =>
+    Intl.NumberFormat('en', { notation: 'compact' }).format(value)
+
+export const getByteUnitValue = (value: number): number => {
+    switch (true) {
+        case (value < 1000):
+            return value
+        case (value < 1000000):
+            return value / 1000
+        case (value < 1000000000):
+            return value / 1000000
+        case (value < 1000000000000):
+            return value / 1000000000
+        default:
+            return -1
+    }
+}
+
+export const getByteUnitLabel = (value: number): string => {
+    switch (true) {
+        case (value <= 999):
+            return "Bytes"
+        case (value <= 999999):
+            return "KB"
+        case (value <= 999999999):
+            return "MB"
+        default:
+            return "GB"
+    }
+}

--- a/client/web/src/site-admin/analytics/utils.ts
+++ b/client/web/src/site-admin/analytics/utils.ts
@@ -41,16 +41,14 @@ export const formatNumber = (value: number): string =>
 
 export const getByteUnitValue = (value: number): number => {
     switch (true) {
-        case (value < 1000):
-            return value
-        case (value < 1000000):
+        case (value > 999 && value < 1000000):
             return value / 1000
         case (value < 1000000000):
             return value / 1000000
         case (value < 1000000000000):
             return value / 1000000000
         default:
-            return -1
+            return value
     }
 }
 

--- a/client/web/src/util/codeStatsUtils.test.ts
+++ b/client/web/src/util/codeStatsUtils.test.ts
@@ -1,17 +1,17 @@
-import { getByteUnitLabel, getByteUnitValue } from "../site-admin/analytics/utils"
+import { getByteUnitLabel, getByteUnitValue } from '../site-admin/analytics/utils'
 
 describe('getByteUnitLabel', () => {
     it('should determine the correct label from the number of bytes', () => {
-        expect(getByteUnitLabel(886)).toEqual("Bytes")
-        expect(getByteUnitLabel(1234)).toEqual("KB")
-        expect(getByteUnitLabel(12343)).toEqual("KB")
-        expect(getByteUnitLabel(123432)).toEqual("KB")
-        expect(getByteUnitLabel(8234333)).toEqual("MB")
-        expect(getByteUnitLabel(82343253)).toEqual("MB")
-        expect(getByteUnitLabel(823433335)).toEqual("MB")
-        expect(getByteUnitLabel(6234325223)).toEqual("GB")
-        expect(getByteUnitLabel(62343252236)).toEqual("GB")
-        expect(getByteUnitLabel(623432522396)).toEqual("GB")
+        expect(getByteUnitLabel(886)).toEqual('Bytes')
+        expect(getByteUnitLabel(1234)).toEqual('KB')
+        expect(getByteUnitLabel(12343)).toEqual('KB')
+        expect(getByteUnitLabel(123432)).toEqual('KB')
+        expect(getByteUnitLabel(8234333)).toEqual('MB')
+        expect(getByteUnitLabel(82343253)).toEqual('MB')
+        expect(getByteUnitLabel(823433335)).toEqual('MB')
+        expect(getByteUnitLabel(6234325223)).toEqual('GB')
+        expect(getByteUnitLabel(62343252236)).toEqual('GB')
+        expect(getByteUnitLabel(623432522396)).toEqual('GB')
     })
 })
 

--- a/client/web/src/util/codeStatsUtils.test.ts
+++ b/client/web/src/util/codeStatsUtils.test.ts
@@ -1,0 +1,28 @@
+import { getByteUnitLabel, getByteUnitValue } from "../site-admin/analytics/utils"
+
+describe('getByteUnitLabel', () => {
+    it('should determine the correct label from the number of bytes', () => {
+        expect(getByteUnitLabel(886)).toEqual("Bytes")
+        expect(getByteUnitLabel(1234)).toEqual("KB")
+        expect(getByteUnitLabel(12343)).toEqual("KB")
+        expect(getByteUnitLabel(123432)).toEqual("KB")
+        expect(getByteUnitLabel(8234333)).toEqual("MB")
+        expect(getByteUnitLabel(82343253)).toEqual("MB")
+        expect(getByteUnitLabel(823433335)).toEqual("MB")
+        expect(getByteUnitLabel(6234325223)).toEqual("GB")
+        expect(getByteUnitLabel(62343252236)).toEqual("GB")
+        expect(getByteUnitLabel(623432522396)).toEqual("GB")
+    })
+})
+
+describe('getByteUnitValue', () => {
+    it('should change unit of measurement based on amount', () => {
+        expect(getByteUnitValue(886)).toEqual(886)
+        expect(getByteUnitValue(12000)).toEqual(12)
+        expect(getByteUnitValue(3400000)).toEqual(3.4)
+        expect(getByteUnitValue(5600700200)).toEqual(5.6007002)
+        expect(getByteUnitValue(1000)).toEqual(1)
+        expect(getByteUnitValue(1000000)).toEqual(1)
+        expect(getByteUnitValue(1000000000)).toEqual(1)
+    })
+})


### PR DESCRIPTION
## Explanation
In support we often refer customers to the Analytics Overview page to get their total size of all repos in GB, but the sidebar defaults to `bytes` as a unit of measurement. 

This commit dynamically changes the unit of measurement based on the number of bytes. 
i.e.

- lt 999 - bytes
- lt 1000000 - kb
- lt 1000000000 - mb
- 1000000000 or more - gb

![Screenshot 2023-01-31 at 4 39 01 PM](https://user-images.githubusercontent.com/62355966/215899852-61dd85e9-500c-4585-bfd7-b70a7f7316f4.png)

## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Shipped with unit tests for new functions.

## App preview:

- [Web](https://sg-web-jhh-dynamic-code-stats-value.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
