### PR TITLE
Add Archive & Restore experimental functionality

### DIFF
--- a/client/web/src/site-admin/SiteAdminArchivePage.module.scss
+++ b/client/web/src/site-admin/SiteAdminArchivePage.module.scss
@@ -1,0 +1,3 @@
+.selectInput input {
+    padding-bottom: 2rem;
+}

--- a/client/web/src/site-admin/SiteAdminArchivePage.tsx
+++ b/client/web/src/site-admin/SiteAdminArchivePage.tsx
@@ -1,0 +1,147 @@
+import React, { ChangeEvent, useCallback, useMemo, useState } from 'react'
+
+import classNames from 'classnames'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import {
+    PageHeader,
+    Container,
+    AnchorLink,
+    Button,
+    Input,
+    Text,
+    Alert,
+    ProductStatusBadge,
+    Modal,
+    H3,
+} from '@sourcegraph/wildcard'
+
+import styles from './SiteAdminArchivePage.module.scss'
+
+import { PageTitle } from '../components/PageTitle'
+
+interface Props extends TelemetryProps {}
+
+/**
+ * A page for archiving and restoring a Sourcegraph instance
+ */
+export const SiteAdminArchivePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryService }) => {
+    useMemo(() => {
+        telemetryService.logPageView('SiteAdminArchive')
+    }, [telemetryService])
+
+    const [file, setFile] = useState<File | null>(null)
+    // TODO(jac): deduplicate
+    const [showSuccessModal, setShowSuccessModal] = useState<Boolean>(false)
+    const [showFailureModal, setShowFailureModal] = useState<Boolean>(false)
+
+    const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files[0]) {
+            setFile(e.target.files[0])
+        }
+    }
+
+    const upload = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            if (!file) {
+                return
+            }
+
+            event.preventDefault()
+
+            const data = new FormData()
+            data.append('archive', file, file.name)
+
+            fetch('/site-admin/archive/upload', {
+                method: 'POST',
+                body: data,
+            }).then(res => {
+                if (res.ok) {
+                    setShowSuccessModal(true)
+                } else {
+                    setShowFailureModal(true)
+                }
+            })
+        },
+        [file]
+    )
+
+    return (
+        <div>
+            <PageTitle title="Archive & Restore - Admin" />
+            <PageHeader
+                path={[{ text: 'Archive & Restore' }]}
+                headingElement="h2"
+                className="mb-3"
+                description="Archive & Restore Sourcegraph instance configuration."
+            />
+            <ProductStatusBadge status="experimental" className="mb-2" />
+            <Container className="mb-2">
+                <H3>Archive</H3>
+                <Text>
+                    The archive includes <strong>non-regenerable</strong> data e.g. <em>site configuration</em>,{' '}
+                    <em>code host configuration</em>. The archive <strong>does not</strong> include regenerable data
+                    e.g. <em>cloned repositories</em>, <em>search indexes</em>.
+                </Text>
+                <Button to="/site-admin/archive/download" download="true" variant="primary" as={AnchorLink}>
+                    Download Archive
+                </Button>
+            </Container>
+
+            <Container className="mb-2">
+                {/* TODO(jac): deduplicate */}
+                {showSuccessModal && (
+                    <Modal aria-labelledby="Restore - Success">
+                        <H3 className="mb-4">Restore - Success</H3>
+                        <div className="form-group mb-4">
+                            Please restart the Sourcegraph instance for the changes to take effect.
+                        </div>
+                        <div className="d-flex justify-content-end">
+                            <Button className="mr-2" onClick={() => setShowSuccessModal(false)} variant="primary">
+                                Close
+                            </Button>
+                        </div>
+                    </Modal>
+                )}
+                {showFailureModal && (
+                    <Modal aria-labelledby="Restore - Failure">
+                        <H3 className="mb-4">Restore - Failure</H3>
+                        <div className="form-group mb-4">
+                            Restore failed - the instance may be in a bad state. Please revert to a backup
+                        </div>
+                        <div className="d-flex justify-content-end">
+                            <Button className="mr-2" onClick={() => setShowFailureModal(false)} variant="primary">
+                                Close
+                            </Button>
+                        </div>
+                    </Modal>
+                )}
+                <H3>Restore</H3>
+                <Text>
+                    Restore Sourcegraph instance configuration from an archive. The archive <strong>must</strong> have
+                    been exported from a Sourcegraph instance running the same version as this instance.
+                </Text>
+                <Text>For the restore to take effect the instance must be restarted.</Text>
+                <Alert variant="warning">
+                    <h4>Restore is a destructive action</h4>
+                    The current instance configuration will be overwritten.
+                    <Text>
+                        This feature is currently experimental. As such it is advised that a backup has been created in
+                        the event of a restore failure.
+                    </Text>
+                </Alert>
+                <Input
+                    label="Select Archive File"
+                    type="file"
+                    name="archive"
+                    onChange={handleFileChange}
+                    className={classNames(styles.selectInput)}
+                />
+
+                <Button className="m2-4" type="submit" variant="danger" onClick={upload}>
+                    Restore
+                </Button>
+            </Container>
+        </div>
+    )
+}

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -170,4 +170,9 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
         render: lazyComponent(() => import('./SiteAdminWebhookUpdatePage'), 'SiteAdminWebhookUpdatePage'),
     },
+    {
+        path: '/archive',
+        exact: true,
+        render: lazyComponent(() => import('./SiteAdminArchivePage'), 'SiteAdminArchivePage'),
+    },
 ]

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -168,6 +168,10 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/background-jobs',
             source: 'server',
         },
+        {
+            label: 'Archive & Restore',
+            to: '/site-admin/archive',
+        },
     ],
 }
 

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -75,6 +75,12 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 	// One-click export ZIP download
 	r.Get(router.OneClickExportArchive).Handler(trace.Route(oneClickExportHandler(db, logger)))
 
+	// Database Archive ZIP download
+	r.Get(router.ArchiveDownload).Handler(trace.Route(archiveDownloadHandler(logger, db)))
+
+	// Database Archive ZIP upload
+	r.Get(router.ArchiveUpload).Handler(trace.Route(archiveUploadHandler(logger, db)))
+
 	// Ping retrieval
 	r.Get(router.LatestPing).Handler(trace.Route(latestPingHandler(db)))
 

--- a/cmd/frontend/internal/app/archive.go
+++ b/cmd/frontend/internal/app/archive.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/archive"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+const (
+	MAX_SIZE = 10 << 20 // 10MB
+	FORM_KEY = "archive"
+)
+
+func archiveDownloadHandler(logger log.Logger, db database.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// 🚨SECURITY: Only site admins may get this archive.
+		if err := auth.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"SourcegraphArchive.zip\"")
+
+		archive, err := archive.CreateArchive(r.Context(), logger)
+		if err != nil {
+			logger.Error("archive.download", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		_, err = io.Copy(w, archive)
+		if err != nil {
+			logger.Error("Writing archive to HTTP response", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func archiveUploadHandler(logger log.Logger, db database.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// TODO(jac): also allow if the site hasn't been initialized yet
+		// 🚨SECURITY: Only site admins can restore
+		if err := auth.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		r.ParseMultipartForm(MAX_SIZE)
+		file, handler, err := r.FormFile(FORM_KEY)
+		if err != nil {
+			logger.Error("archive.upload", log.Error(err))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+
+		dir, err := os.MkdirTemp(os.TempDir(), "archive-*")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		f, err := os.Create(filepath.Join(dir, handler.Filename))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Copy uploaded file from memory to file on disk
+		if written, err := io.Copy(f, file); err != nil || written != handler.Size {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		f.Close()
+
+		err = archive.RestoreFromArchive(r.Context(), logger, f.Name())
+		if err != nil {
+			//TODO(jac):
+			// - type of errors e.g. bad archive (client), myriad errors (server)
+			// - return the error to the user
+			w.WriteHeader(http.StatusInternalServerError)
+			logger.Error("Restore Failed", log.Error(err))
+			return
+		}
+	}
+}

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -39,6 +39,9 @@ const (
 
 	OneClickExportArchive = "one-click-export.archive"
 
+	ArchiveDownload = "archive.download"
+	ArchiveUpload   = "archive.upload"
+
 	LatestPing = "pings.latest"
 
 	SetupGitHubAppCloud = "setup.github.app.cloud"
@@ -102,6 +105,9 @@ func newRouter() *mux.Router {
 	base.Path("/site-admin/usage-statistics/archive").Methods("GET").Name(UsageStatsDownload)
 
 	base.Path("/site-admin/data-export/archive").Methods("POST").Name(OneClickExportArchive)
+
+	base.Path("/site-admin/archive/download").Methods("GET").Name(ArchiveDownload)
+	base.Path("/site-admin/archive/upload").Methods("POST").Name(ArchiveUpload)
 
 	base.Path("/site-admin/pings/latest").Methods("GET").Name(LatestPing)
 

--- a/cmd/frontend/internal/archive/archive.go
+++ b/cmd/frontend/internal/archive/archive.go
@@ -1,0 +1,140 @@
+package archive
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const (
+	VERSION_FILE = ".sourcegraph-version"
+)
+
+// Archiver types implement the methods to archive and restore storage backends
+type Archiver interface {
+	archive(root string) error
+	restore(root string) error
+	root() string
+}
+
+// archiveSources - storage backends which should be included in the archive
+// TODO(jac): allow user to select which sources to archive?
+func archiveSources() []Archiver {
+	sources := make([]Archiver, 0, 3)
+	sources = append(sources, dbSources()...)
+	return sources
+}
+
+// archiveIdentify - identify storage backends included in the archive
+// TODO(jac): allow user to choose which identified sources to restore?
+func archiveIdentify(path string) []Archiver {
+	sources := make([]Archiver, 0, 3)
+	sources = append(sources, dbIdentify(path)...)
+	return sources
+}
+
+func CreateArchive(c context.Context, logger log.Logger) (io.Reader, error) {
+	dir, err := os.MkdirTemp(os.TempDir(), "archive-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	if err = writeSiteVersion(dir); err != nil {
+		return nil, err
+	}
+
+	sources := archiveSources()
+
+	for _, source := range sources {
+		root, err := createRoot(dir, source.root())
+		if err != nil {
+			return nil, err
+		}
+		err = source.archive(root)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	files, err := archiveFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	zip, err := createZip(dir, files)
+	if err != nil {
+		return nil, err
+	}
+
+	return zip, err
+}
+
+func writeSiteVersion(path string) error {
+	f, err := os.Create(filepath.Join(path, VERSION_FILE))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	f.Write([]byte(version.Version()))
+	return nil
+}
+
+func compareSiteVersion(path string) error {
+	f, err := os.Open(filepath.Join(path, VERSION_FILE))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	c, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	if string(c) != version.Version() {
+		return errors.New("archive version does not match running instance")
+	}
+
+	return nil
+}
+
+// create storage backend root folder inside archive root dir
+func createRoot(archiveRoot string, root string) (string, error) {
+	path := filepath.Join(archiveRoot, root)
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(path, os.ModePerm)
+		if err != nil {
+			return path, err
+		}
+	}
+
+	return path, nil
+}
+
+func RestoreFromArchive(c context.Context, logger log.Logger, archive string) error {
+	path, err := unZip(archive)
+	if err != nil {
+		return err
+	}
+
+	if err = compareSiteVersion(path); err != nil {
+		return err
+	}
+
+	sources := archiveIdentify(path)
+	for _, source := range sources {
+		if err := source.restore(filepath.Join(path, source.root())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/frontend/internal/archive/database.go
+++ b/cmd/frontend/internal/archive/database.go
@@ -1,0 +1,101 @@
+package archive
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
+)
+
+const (
+	ROOT     = "databases" // root folder within archive to hold all DBArchive outputs
+	PGSQL    = "pgsql.out"
+	INTEL    = "code-intel.out"
+	INSIGHTS = "code-insights.out"
+)
+
+type DBArchive struct {
+	name string
+	dsn  string
+}
+
+func (d *DBArchive) archive(root string) error {
+	path := filepath.Join(root, d.name)
+	dump, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer dump.Close()
+
+	// Fc - custom output format
+	// c  - include "drop if exists" sql for restore
+	// f  - output file
+	return exec.Command("pg_dump", "-Fc", "-c", "-f", path, "--dbname", d.dsn).Run()
+}
+
+func (d *DBArchive) restore(root string) error {
+	dump := filepath.Join(root, d.name)
+	fmt.Println(*d)
+	return exec.Command("pg_restore", "-c", "--dbname", d.dsn, dump).Run()
+}
+
+func (d *DBArchive) root() string {
+	return ROOT
+}
+
+func dbSources() []Archiver {
+	dsns := dsn()
+	dbs := make([]Archiver, 0, len(dsns))
+	for name, dsn := range dsns {
+		dbs = append(dbs, &DBArchive{
+			name: name,
+			dsn:  dsn,
+		})
+	}
+
+	return dbs
+}
+
+func dbIdentify(path string) []Archiver {
+	path = filepath.Join(path, ROOT)
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+
+	dsns := dsn()
+
+	dbs := make([]Archiver, 0, len(dsns))
+	for name, dsn := range dsns {
+		p := filepath.Join(path, name)
+		if _, err := os.Stat(p); err == nil {
+			dbs = append(dbs, &DBArchive{
+				name: name,
+				dsn:  dsn,
+			})
+		}
+	}
+
+	return dbs
+}
+
+func dsn() map[string]string {
+	// TODO(jac): does this need better validation?
+	m := make(map[string]string, 3)
+	m[PGSQL] = postgresdsn.New("frontend", "", os.Getenv)
+	m[INTEL] = postgresdsn.New("CODEINTEL", "", os.Getenv)
+	m[INSIGHTS] = postgresdsn.New("CODEINSIGHTS", "", os.Getenv)
+
+	// pg_dump errors if TimeZone is supplied
+	for name, dsn := range m {
+		dsn, _ := url.Parse(dsn)
+		q := dsn.Query()
+		q.Del("timezone")
+		dsn.RawQuery = q.Encode()
+		m[name] = dsn.String()
+	}
+
+	return m
+}

--- a/cmd/frontend/internal/archive/zip.go
+++ b/cmd/frontend/internal/archive/zip.go
@@ -1,0 +1,106 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fileInfo struct {
+	path  string
+	isDir bool
+}
+
+// walk archive root dir to discover all files to zip
+func archiveFiles(dir string) ([]fileInfo, error) {
+	var files []fileInfo
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		files = append(files, fileInfo{
+			path:  path,
+			isDir: info.IsDir(),
+		})
+		return nil
+	})
+	return files, err
+}
+
+func createZip(dir string, files []fileInfo) (io.Reader, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for _, file := range files {
+		path := file.path
+		if file.isDir {
+			path = fmt.Sprintf("%s%c", path, os.PathSeparator)
+		}
+
+		// path in zip must be relative to zip root
+		w, err := zw.Create(strings.TrimPrefix(path, dir))
+		if err != nil {
+			return nil, err
+		}
+
+		if !file.isDir {
+			file, err := os.Open(path)
+			if err != nil {
+				return nil, err
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(w, file); err != nil {
+				return nil, err
+			}
+		}
+
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}
+
+func unZip(path string) (string, error) {
+	z, err := zip.OpenReader(path)
+	if err != nil {
+		return "", err
+	}
+	defer z.Close()
+
+	parentDir := filepath.Dir(path)
+	for _, f := range z.File {
+		fp := filepath.Join(parentDir, f.Name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(fp, os.ModePerm)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(fp), os.ModePerm); err != nil {
+			return parentDir, err
+		}
+
+		src, err := f.Open()
+		if err != nil {
+			return parentDir, err
+		}
+		defer src.Close()
+
+		dst, err := os.Create(fp)
+		if err != nil {
+			return parentDir, err
+		}
+		defer dst.Close()
+
+		if _, err := io.Copy(dst, src); err != nil {
+			return parentDir, err
+		}
+
+	}
+
+	return parentDir, nil
+}


### PR DESCRIPTION
# Archive & Restore
Allows Site Admins to archive the current Sourcegraph instance state (currently database dumps) which can be restored to the same, or another, instance running the same Sourcegraph version.

The goal is to easily allow customers to migrate from an on-prem deployment to an AMI or potentially on-prem to cloud.

There are still some things which need to be done before this is production ready but it is working well enough to start gathering feedback.

## Outstanding Items
- [ ] Handle disabled code-intel db
- [ ] Handle multiple database URIs pointing to the same DB
- [ ] Verify batch changes restores correctly
- [ ] Verify code insights restores correctly (need to better handle code insights in general as we only need to archive an Insight config and not the associated data)
- [ ] Better convey result status/error to user
- [ ] Better error logging
- [ ] Exclude DB tables for which it doesn't make sense to include in an archive (e.g. data computed from state such as cloned/indexed repos)
- [ ] Tests

## Considerations
- If a Restore fails it could leave the instance in a bad state
- This allows Site Admins to essentially upload SQL (in the form of a Postgres custom archive) to the databases. 
- Future state may not be stored exclusively in the DBs
  - I've tried to remedy this somewhat by making it easy to add a new data source to be archived/restored
- Will require `pg_dump` and `pg_restore` to be added to the frontend containers 

## Test plan

For anyone who would like to try this out: (not a perfect method but demonstrates the principle)
1. `sg db reset-pg -db=all`
2. `sg start enterprise-e2e`
3. Initialise & Add a code host
4. Navigate to Site Admin > Maintenance > Archive & Restore; Click `Download Archive`
5. Stop instance; run `sg db reset-pg -db=all`
6. `sg start enterprise-e2e`
7. Initialise the instance and then attempt to restore from the previous backup
8. On success restart the instance - the previous code host config should have been restored
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
