### PR TITLE
remove unused missingUserID func

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1442,18 +1442,3 @@ func useFastPasswordMocks() {
 		return hash == strconv.FormatUint(h.Sum64(), 16)
 	}
 }
-
-func missingUserIds(id, affectedIds []int32) []string {
-	maffectedIds := make(map[int32]struct{}, len(affectedIds))
-	for _, x := range affectedIds {
-		maffectedIds[x] = struct{}{}
-	}
-	var diff []string
-	for _, x := range id {
-		if _, found := maffectedIds[x]; !found {
-			strId := strconv.Itoa(int(x))
-			diff = append(diff, strId)
-		}
-	}
-	return diff
-}


### PR DESCRIPTION
Removing because the function is unused. Functionality was moved to graphqlResolver and is not needed here.
## Test plan
sg start
checked if the recover user functionality is still working
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
