### PR TITLE
permissions-center: make `perms_syncer_cleaner` delete oldest _processed_ jobs first.

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner.go
@@ -113,7 +113,7 @@ const cleanJobsFmtStr = `
 WITH job_history AS (
 	SELECT id, repository_id, user_id, ROW_NUMBER() OVER (
 		PARTITION BY repository_id, user_id
-		ORDER BY id DESC
+		ORDER BY finished_at DESC NULLS LAST
 	) FROM permission_sync_jobs
 	WHERE state NOT IN ('queued', 'processing')
 )


### PR DESCRIPTION
Previously it was removing oldest _queued_ jobs first which is wrong and breaks in such situation: job1 created 10 minutes ago and finished 10 seconds ago vs. job2 created 1 min ago and finished 30 secs ago. Job1 finished more recently and should be kept, but it would have been cleared with previous behaviour.

Test plan:
Unit test updated.