### PR TITLE
web: debugging urls with spaces

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -55,7 +55,7 @@ describe('Repository', () => {
     before(async () => {
         driver = await createDriverForTest()
     })
-    after(() => driver?.close())
+    // after(() => driver?.close())
     let testContext: WebIntegrationTestContext
     beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
@@ -64,8 +64,8 @@ describe('Repository', () => {
             directory: __dirname,
         })
     })
-    afterEachSaveScreenshotIfFailed(() => driver.page)
-    afterEach(() => testContext?.dispose())
+    // afterEachSaveScreenshotIfFailed(() => driver.page)
+    // afterEach(() => testContext?.dispose())
 
     async function assertSelectorHasText(selector: string, text: string) {
         assert.strictEqual(
@@ -589,7 +589,7 @@ describe('Repository', () => {
             await percySnapshotWithVariants(driver.page, 'Repository cloning in progress page')
         })
 
-        it('works with spaces in the repository name', async () => {
+        it.only('works with spaces in the repository name', async () => {
             const shortRepositoryName = 'my org/repo with spaces'
             const repositoryName = `github.com/${shortRepositoryName}`
             const repositorySourcegraphUrl = '/github.com/my%20org/repo%20with%20spaces'

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -267,7 +267,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
 
     const { useActionItemsBar, useActionItemsToggle } = useWebActionItems()
 
-    const repoMatchURL = '/' + encodeURIPathComponent(repoName)
+    const repoNameURL = '/' + encodeURIPathComponent(repoName)
 
     // render go to the code host action on all the repo container routes and on all compare spec routes
     const isGoToCodeHostActionVisible = useMemo(() => {
@@ -276,8 +276,8 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         }
         const paths = [...repoContainerRoutes.map(route => route.path), compareSpecPath, commitsPath]
 
-        return paths.some(path => matchPath(location.pathname, { path: repoMatchURL + path }))
-    }, [repoContainerRoutes, repoMatchURL, location.pathname])
+        return paths.some(path => matchPath(location.pathname, { path: repoNameURL + path }))
+    }, [repoContainerRoutes, repoNameURL, location.pathname])
 
     if (isErrorLike(repoOrError) || isErrorLike(resolvedRevisionOrError)) {
         const viewerCanAdminister = !!authenticatedUser && authenticatedUser.siteAdmin
@@ -309,11 +309,6 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         useActionItemsBar,
     }
 
-    const repoRevisionContainerPaths = [
-        ...(rawRevision ? [{ path: `@${rawRevision}` }] : []), // must exactly match how the revision was encoded in the URL
-        ...repoRevisionContainerRoutes,
-    ].map(({ path }) => `${repoMatchURL}${path}/*`)
-
     const perforceCodeHostUrlToSwarmUrlMap =
         (props.settingsCascade.final &&
             !isErrorLike(props.settingsCascade.final) &&
@@ -326,6 +321,11 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         resolvedRevisionOrError,
         onDidUpdateExternalLinks: setExternalLinks,
     }
+
+    const repoRevisionContainerSplats = [
+        ...(rawRevision ? [repoNameURL + `@${rawRevision}/*`] : []), // must exactly match how the revision was encoded in the URL
+        repoNameURL + '/*',
+    ]
 
     return (
         <div className={classNames('w-100 d-flex flex-column', styles.repoContainer)}>
@@ -394,10 +394,10 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
             <ErrorBoundary location={location}>
                 <Suspense fallback={null}>
                     <Routes>
-                        {repoRevisionContainerPaths.map(path => (
+                        {repoRevisionContainerSplats.map(splatPath => (
                             <Route
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                path={path}
+                                path={(console.log('RepoContainer splat path', splatPath), splatPath)}
                                 element={
                                     <RepoRevisionContainer
                                         {...repoRevisionContainerContext}
@@ -410,7 +410,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         {repoContainerRoutes.map(({ path, render, condition = () => true }) => (
                             <Route
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                path={repoMatchURL + path}
+                                path={repoNameURL + path}
                                 /**
                                  * `RepoContainerContextRoutes` depend on `repoOrError`. We render these routes only when
                                  * the `repoOrError` value is resolved.

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -323,8 +323,8 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     }
 
     const repoRevisionContainerSplats = [
-        ...(rawRevision ? [repoNameURL + `@${rawRevision}/*`] : []), // must exactly match how the revision was encoded in the URL
-        repoNameURL + '/*',
+        ...(rawRevision ? [`@${rawRevision}/*`] : []), // must exactly match how the revision was encoded in the URL
+        '*',
     ]
 
     return (

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -209,7 +209,11 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                 {routes.map(
                     ({ path, render, condition = () => true }) =>
                         condition(repoRevisionContainerContext) && (
-                            <Route key="hardcoded-key" path={path} element={render(repoRevisionContainerContext)} />
+                            <Route
+                                key="hardcoded-key"
+                                path={(console.log('RepoRevisionContainer path:', path), path)}
+                                element={render(repoRevisionContainerContext)}
+                            />
                         )
                 )}
             </Routes>

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -30,10 +30,13 @@ const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
 /** A page that shows a file or a directory (tree view) in a repository at the
  * current revision. */
 export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => {
+    console.log('RepositoryFileTreePage')
     const { repo, resolvedRevision, repoName, globbing, objectType: maybeObjectType, ...context } = props
 
     const location = useLocation()
     const { '*': filePath = '' } = useParams<{ '*': string }>()
+
+    console.log({ filePath, repo, maybeObjectType })
 
     // Redirect tree and blob routes pointing to the root to the repo page
     if (maybeObjectType && filePath.replace(/\/+$/g, '') === '') {
@@ -67,6 +70,8 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
         const url = appendLineRangeQueryParameter(location.pathname + location.search, range ? `L${range}` : undefined)
         return <Navigate to={url + formatHash(hashParameters)} />
     }
+
+    console.log(objectType, resolvedRevision)
 
     return (
         <>

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat'
+import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 
 import { appendLineRangeQueryParameter } from '@sourcegraph/common'
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
@@ -11,7 +11,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { NotebookProps } from '../notebooks'
 import { GettingStartedTour } from '../tour/GettingStartedTour'
-import { formatHash, formatLineOrPositionOrRange } from '../util/url'
+import { formatHash, formatLineOrPositionOrRange, parseBrowserRepoURL } from '../util/url'
 
 import { BlobPage } from './blob/BlobPage'
 import { RepoRevisionContainerContext } from './RepoRevisionContainer'
@@ -34,7 +34,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
     const { repo, resolvedRevision, repoName, globbing, objectType: maybeObjectType, ...context } = props
 
     const location = useLocation()
-    const { '*': filePath = '' } = useParams<{ '*': string }>()
+    const { filePath = '' } = parseBrowserRepoURL(location.pathname)
 
     console.log({ filePath, repo, maybeObjectType })
 

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -18,7 +18,7 @@ const ActionItemsBar = lazyComponent<ActionItemsBarProps, 'ActionItemsBar'>(
 const routeToObjectType = {
     '/-/blob/*': 'blob',
     '/-/tree/*': 'tree',
-    '': undefined,
+    '*': undefined,
 } as const
 
 export const commitsPath = '/-/commits/*'

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -15,13 +15,22 @@ const ActionItemsBar = lazyComponent<ActionItemsBarProps, 'ActionItemsBar'>(
     'ActionItemsBar'
 )
 
+// Work around the issue that react router can not match nested splats
+// by expanding the repo matcher to an optional path of up to 10
+// segments.
+//
+// We don't rely on the route param names anyway and use `parseBrowserRepoURL`
+// instead to parse the repo name.
+const repoSplat =
+    '/:repo_one/:repo_two?/:repo_three?/:repo_four?/:repo_five?/:repo_six?/:repo_seven?/:repo_eight?/:repo_nine?/:repo_ten?'
+
 const routeToObjectType = {
-    '/-/blob/*': 'blob',
-    '/-/tree/*': 'tree',
-    '*': undefined,
+    [repoSplat + '/-/blob/*']: 'blob',
+    [repoSplat + '/-/tree/*']: 'tree',
+    [repoSplat]: undefined,
 } as const
 
-export const commitsPath = '/-/commits/*'
+export const commitsPath = repoSplat + '/-/commits/*'
 
 export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] = [
     ...Object.entries(routeToObjectType).map<RepoRevisionContainerRoute>(([routePath, objectType]) => ({

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -288,6 +288,8 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
         </>
     )
 
+    console.log('tree page', treeOrError)
+
     return (
         <div className={classNames(styles.treePage, className)}>
             <Container className={styles.container}>

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -413,7 +413,7 @@ commands:
       pnpm generate
     env:
       WEBPACK_SERVE_INDEX: true
-      SOURCEGRAPH_API_URL: https://k8s.sgdev.org
+      SOURCEGRAPH_API_URL: https://sourcegraph.com
 
   web-standalone-http-prod:
     description: Standalone web frontend (production) with API proxy to a configurable URL
@@ -422,7 +422,7 @@ commands:
     env:
       NODE_ENV: production
       WEBPACK_SERVE_INDEX: true
-      SOURCEGRAPH_API_URL: https://k8s.sgdev.org
+      SOURCEGRAPH_API_URL: https://sourcegraph.com
 
   web-integration-build:
     description: Build development web application for integration tests


### PR DESCRIPTION
## Context

AFAIU react-router decodes routes before matching them here: 

https://github.com/remix-run/react-router/blob/13f4eed82e596e674ec7b79a2ad4f4aba7099281/packages/router/utils.ts#L347

## Test plan

1. `BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true DISABLE_APP_ASSETS_MOCKING=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 pnpm _test-integration --retries=0 --jobs=1 client/web/src/integration/repository.test.ts`
2. It should open `https://sourcegraph.test:3443/github.com/my%20org/repo%20with%20spaces` in Chromium.
3. See that the repository home page is not rendered because it's not matched by react-router. 

I suspect it happens because we rely on the `repoNameURL + '/*'` path to render `RepoRevisionContainer` routes. Internally react-router safely decodes the URL with spaces. But then, for matching inside the `RepoRevisionContainer` it uses a non-decoded pathname. It works fine for repos without spaces in the pathname. 
