### PR TITLE
Add expired license restrictions and new plan

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -146,7 +146,7 @@ func Init(
 		}
 		if info != nil && info.IsExpiringSoon() {
 			return []*graphqlbackend.Alert{{
-				TypeValue:    graphqlbackend.AlertTypeError,
+				TypeValue:    graphqlbackend.AlertTypeWarning,
 				MessageValue: fmt.Sprintf("Sourcegraph license will expire soon! Expires on: %s. Update the license key in the [**site configuration**](/site-admin/configuration) or downgrade to only using Sourcegraph Free features.", info.ExpiresAt.UTC().Truncate(time.Hour).Format(time.UnixDate)),
 			}}
 		}

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -138,10 +138,16 @@ func Init(
 				MessageValue: "Error reading Sourcegraph license key. Check the logs for more information, or update the license key in the [**site configuration**](/site-admin/configuration).",
 			}}
 		}
-		if info != nil && info.IsExpiredWithGracePeriod() {
+		if info != nil && info.IsExpired() {
 			return []*graphqlbackend.Alert{{
 				TypeValue:    graphqlbackend.AlertTypeError,
 				MessageValue: "Sourcegraph license expired! All non-admin users are locked out of Sourcegraph. Update the license key in the [**site configuration**](/site-admin/configuration) or downgrade to only using Sourcegraph Free features.",
+			}}
+		}
+		if info != nil && info.IsExpiringSoon() {
+			return []*graphqlbackend.Alert{{
+				TypeValue:    graphqlbackend.AlertTypeError,
+				MessageValue: fmt.Sprintf("Sourcegraph license will expire soon! Expires on: %s. Update the license key in the [**site configuration**](/site-admin/configuration) or downgrade to only using Sourcegraph Free features.", info.ExpiresAt.UTC().Truncate(time.Hour).Format(time.UnixDate)),
 			}}
 		}
 		return nil
@@ -187,7 +193,7 @@ func Init(
 				})
 				return
 			}
-			if info != nil && info.IsExpiredWithGracePeriod() {
+			if info != nil && info.IsExpired() {
 				siteadminOrHandler(func() {
 					enforcement.WriteSubscriptionErrorResponse(w, http.StatusForbidden, "Sourcegraph license expired", "To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration).")
 				})

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -130,7 +130,9 @@ func TestCreateBatchSpec(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	licensingInfo := func(tags ...string) *licensing.Info { return &licensing.Info{Info: license.Info{Tags: tags}} }
+	licensingInfo := func(tags ...string) *licensing.Info {
+		return &licensing.Info{Info: license.Info{Tags: tags, ExpiresAt: time.Now().Add(1 * time.Hour)}}
+	}
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewBeforeCreateUserHook returns a BeforeCreateUserHook closure with the given UsersStore
@@ -100,20 +101,26 @@ func NewAfterCreateUserHook() func(context.Context, database.DB, *types.User) er
 }
 
 // NewBeforeSetUserIsSiteAdmin returns a BeforeSetUserIsSiteAdmin closure that determines whether
-// non-site admin roles are allowed (i.e. revoke site admins) based on the product license.
+// the creation or removal of site admins are allowed.
 func NewBeforeSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
 	return func(isSiteAdmin bool) error {
-		if isSiteAdmin {
-			return nil
-		}
-
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
 			return err
 		}
 
-		if info != nil && info.Plan() != licensing.PlanFree0 {
-			return nil
+		if info != nil {
+			if info.IsExpired() {
+				return errors.New("The sourcegraph license has expired. No site admins can be created until the license is updated.")
+			}
+			if info.Plan() != licensing.PlanFree0 {
+				return nil
+			}
+
+			// Allow users to be promoted to site admins on the Free plan.
+			if info.Plan() == licensing.PlanFree0 && isSiteAdmin {
+				return nil
+			}
 		}
 
 		return licensing.NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", "non-site admin roles"))

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -111,7 +111,7 @@ func NewBeforeSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
 
 		if info != nil {
 			if info.IsExpired() {
-				return errors.New("The sourcegraph license has expired. No site admins can be created until the license is updated.")
+				return errors.New("The Sourcegraph license has expired. No site-admins can be created until the license is updated.")
 			}
 			if info.Plan() != licensing.PlanFree0 {
 				return nil

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -218,19 +218,26 @@ func TestEnforcement_PreSetUserIsSiteAdmin(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "promote to site admin is OK",
+			name:        "promote to site admin with a valid license is OK",
+			license:     &license.Info{ExpiresAt: time.Now().Add(1 * time.Hour)},
 			isSiteAdmin: true,
 			wantErr:     false,
 		},
 		{
 			name:        "revoke site admin with a valid license is OK",
-			license:     &license.Info{UserCount: 10},
+			license:     &license.Info{UserCount: 10, ExpiresAt: time.Now().Add(1 * time.Hour)},
 			isSiteAdmin: false,
 			wantErr:     false,
 		},
 		{
 			name:        "revoke site admin without a license is not OK",
 			isSiteAdmin: false,
+			wantErr:     true,
+		},
+		{
+			name:        "promote to site admin with expired license is not OK",
+			license:     &license.Info{UserCount: 10, ExpiresAt: time.Now().Add(-1 * time.Hour)},
+			isSiteAdmin: true,
 			wantErr:     true,
 		},
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -40,9 +40,9 @@ func Init(
 
 	// Enforce non-site admin roles in Free tier.
 	database.AfterCreateUser = enforcement.NewAfterCreateUserHook()
-	// Uncomment this when the licensing for this feature should be enforced.
-	// See https://github.com/sourcegraph/sourcegraph/issues/42527 for more context.
-	// database.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
+
+	// Enforce site admin creation rules.
+	database.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
 
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.

--- a/enterprise/internal/license/license.go
+++ b/enterprise/internal/license/license.go
@@ -40,10 +40,10 @@ func (l Info) IsExpired() bool {
 	return l.ExpiresAt.Before(time.Now())
 }
 
-// IsExpiredWithGracePeriod reports whether the license has expired, adding a grace period of 3 days
+// IsExpiringSoon reports whether the license has expired, adding a grace period of 3 days
 // after the license's expiration.
-func (l Info) IsExpiredWithGracePeriod() bool {
-	return l.ExpiresAt.Add(3 * 24 * time.Hour).Before(time.Now())
+func (l Info) IsExpiringSoon() bool {
+	return l.ExpiresAt.Add(-7 * 24 * time.Hour).Before(time.Now())
 }
 
 // HasTag reports whether tag is in l's list of tags.

--- a/enterprise/internal/license/license.go
+++ b/enterprise/internal/license/license.go
@@ -40,8 +40,7 @@ func (l Info) IsExpired() bool {
 	return l.ExpiresAt.Before(time.Now())
 }
 
-// IsExpiringSoon reports whether the license has expired, adding a grace period of 3 days
-// after the license's expiration.
+// IsExpiringSoon reports whether the license will expire within the next 7 days.
 func (l Info) IsExpiringSoon() bool {
 	return l.ExpiresAt.Add(-7 * 24 * time.Hour).Before(time.Now())
 }

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -121,6 +121,7 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 
 type PlanDetails struct {
 	Features        []Feature
+	// ExpiredFeatures are the features that still work after the plan is expired.
 	ExpiredFeatures []Feature
 }
 

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -120,7 +120,7 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 }
 
 type PlanDetails struct {
-	Features        []Feature
+	Features []Feature
 	// ExpiredFeatures are the features that still work after the plan is expired.
 	ExpiredFeatures []Feature
 }

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -100,13 +100,13 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 	}
 
 	// If the deprecated campaigns are enabled, use unrestricted batch changes
-	if FeatureCampaigns.Check(info) == nil {
+	if FeatureCampaigns.Check(info) == nil && !info.IsExpired() {
 		f.Unrestricted = true
 		return nil
 	}
 
 	// If the batch changes tag exists on the license, use unrestricted batch changes
-	if info.HasTag(f.FeatureName()) {
+	if info.HasTag(f.FeatureName()) && !info.IsExpired() {
 		f.Unrestricted = true
 		return nil
 	}

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -130,6 +130,10 @@ var planDetails = map[Plan]PlanDetails{
 		Features: []Feature{
 			&FeatureBatchChanges{MaxNumChangesets: 10},
 		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
+		},
 	},
 	PlanOldEnterprise: {
 		Features: []Feature{
@@ -145,6 +149,10 @@ var planDetails = map[Plan]PlanDetails{
 			FeatureBackupAndRestore,
 			FeatureCodeInsights,
 		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
+		},
 	},
 	PlanTeam0: {
 		Features: []Feature{
@@ -153,6 +161,10 @@ var planDetails = map[Plan]PlanDetails{
 			FeatureSSO,
 			&FeatureBatchChanges{MaxNumChangesets: 10},
 		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
+		},
 	},
 	PlanEnterprise0: {
 		Features: []Feature{
@@ -160,6 +172,10 @@ var planDetails = map[Plan]PlanDetails{
 			FeatureExplicitPermissionsAPI,
 			FeatureSSO,
 			&FeatureBatchChanges{MaxNumChangesets: 10},
+		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
 		},
 	},
 
@@ -171,6 +187,10 @@ var planDetails = map[Plan]PlanDetails{
 			FeatureCodeInsights,
 			FeatureSSO,
 		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
+		},
 	},
 	PlanEnterprise1: {
 		Features: []Feature{
@@ -179,6 +199,10 @@ var planDetails = map[Plan]PlanDetails{
 			FeatureCodeInsights,
 			&FeatureBatchChanges{Unrestricted: true},
 			FeatureExplicitPermissionsAPI,
+			FeatureSSO,
+		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
 			FeatureSSO,
 		},
 	},

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -90,10 +90,6 @@ type FeatureBatchChanges struct {
 	MaxNumChangesets int
 }
 
-type FeatureExpiredFeatures struct {
-	ExpiredFeatures []Feature
-}
-
 func (*FeatureBatchChanges) FeatureName() string {
 	return "batch-changes"
 }

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -19,6 +19,9 @@ const (
 	// PlanEnterprise1 is the "Enterprise" plan for 4.0.
 	PlanEnterprise1 Plan = "enterprise-1"
 
+	// PlanEnterpriseExtension is for customers who require an extended trial on a new Sourcegraph 4.4.2 instance.
+	PlanEnterpriseExtension Plan = "enterprise-extension"
+
 	// PlanFree0 is the default plan if no license key is set.
 	PlanFree0 Plan = "free-0"
 )
@@ -31,6 +34,7 @@ var allPlans = []Plan{
 
 	PlanBusiness0,
 	PlanEnterprise1,
+	PlanEnterpriseExtension,
 	PlanFree0,
 }
 
@@ -86,6 +90,10 @@ type FeatureBatchChanges struct {
 	MaxNumChangesets int
 }
 
+type FeatureExpiredFeatures struct {
+	ExpiredFeatures []Feature
+}
+
 func (*FeatureBatchChanges) FeatureName() string {
 	return "batch-changes"
 }
@@ -108,62 +116,93 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 	}
 
 	// Otherwise, check the default batch changes feature
-	if info.Plan().HasFeature(f) {
+	if info.Plan().HasFeature(f, info.IsExpired()) {
 		return nil
 	}
 
 	return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", f.FeatureName()))
 }
 
-// planFeatures defines the features that are enabled for each plan.
-var planFeatures = map[Plan][]Feature{
+type PlanDetails struct {
+	Features        []Feature
+	ExpiredFeatures []Feature
+}
+
+// planDetails defines the features that are enabled for each plan.
+var planDetails = map[Plan]PlanDetails{
 	PlanOldEnterpriseStarter: {
-		&FeatureBatchChanges{MaxNumChangesets: 10},
+		Features: []Feature{
+			&FeatureBatchChanges{MaxNumChangesets: 10},
+		},
 	},
 	PlanOldEnterprise: {
-		FeatureSSO,
-		FeatureACLs,
-		FeatureExplicitPermissionsAPI,
-		FeatureExtensionRegistry,
-		FeatureRemoteExtensionsAllowDisallow,
-		FeatureBranding,
-		FeatureCampaigns,
-		&FeatureBatchChanges{Unrestricted: true},
-		FeatureMonitoring,
-		FeatureBackupAndRestore,
-		FeatureCodeInsights,
+		Features: []Feature{
+			FeatureSSO,
+			FeatureACLs,
+			FeatureExplicitPermissionsAPI,
+			FeatureExtensionRegistry,
+			FeatureRemoteExtensionsAllowDisallow,
+			FeatureBranding,
+			FeatureCampaigns,
+			&FeatureBatchChanges{Unrestricted: true},
+			FeatureMonitoring,
+			FeatureBackupAndRestore,
+			FeatureCodeInsights,
+		},
 	},
 	PlanTeam0: {
-		FeatureACLs,
-		FeatureExplicitPermissionsAPI,
-		FeatureSSO,
-		&FeatureBatchChanges{MaxNumChangesets: 10},
+		Features: []Feature{
+			FeatureACLs,
+			FeatureExplicitPermissionsAPI,
+			FeatureSSO,
+			&FeatureBatchChanges{MaxNumChangesets: 10},
+		},
 	},
 	PlanEnterprise0: {
-		FeatureACLs,
-		FeatureExplicitPermissionsAPI,
-		FeatureSSO,
-		&FeatureBatchChanges{MaxNumChangesets: 10},
+		Features: []Feature{
+			FeatureACLs,
+			FeatureExplicitPermissionsAPI,
+			FeatureSSO,
+			&FeatureBatchChanges{MaxNumChangesets: 10},
+		},
 	},
 
 	PlanBusiness0: {
-		FeatureACLs,
-		FeatureCampaigns,
-		&FeatureBatchChanges{Unrestricted: true},
-		FeatureCodeInsights,
-		FeatureSSO,
+		Features: []Feature{
+			FeatureACLs,
+			FeatureCampaigns,
+			&FeatureBatchChanges{Unrestricted: true},
+			FeatureCodeInsights,
+			FeatureSSO,
+		},
 	},
 	PlanEnterprise1: {
-		FeatureACLs,
-		FeatureCampaigns,
-		FeatureCodeInsights,
-		&FeatureBatchChanges{Unrestricted: true},
-		FeatureExplicitPermissionsAPI,
-		FeatureSSO,
+		Features: []Feature{
+			FeatureACLs,
+			FeatureCampaigns,
+			FeatureCodeInsights,
+			&FeatureBatchChanges{Unrestricted: true},
+			FeatureExplicitPermissionsAPI,
+			FeatureSSO,
+		},
 	},
-	PlanFree0: {
+	PlanEnterpriseExtension: {
+		Features: []Feature{
+			FeatureACLs,
+			FeatureCampaigns,
+			FeatureCodeInsights,
+			&FeatureBatchChanges{Unrestricted: true},
+			FeatureExplicitPermissionsAPI,
+			FeatureSSO,
+		},
+		ExpiredFeatures: []Feature{
+			FeatureACLs,
+			FeatureSSO,
+		},
+	},
+	PlanFree0: {Features: []Feature{
 		FeatureSSO,
 		FeatureMonitoring,
 		&FeatureBatchChanges{MaxNumChangesets: 10},
-	},
+	}},
 }

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -43,7 +43,7 @@ func (f BasicFeature) Check(info *Info) error {
 		}
 		return false
 	}
-	if !info.Plan().HasFeature(featureTrimmed) && !hasFeature(featureTrimmed) {
+	if !info.Plan().HasFeature(featureTrimmed, info.IsExpired()) && !(!info.IsExpired() && hasFeature(featureTrimmed)) {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", f))
 	}
 	return nil

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -32,6 +32,10 @@ func (f BasicFeature) Check(info *Info) error {
 
 	// Check if the feature is explicitly allowed via license tag.
 	hasFeature := func(want Feature) bool {
+		// if license is expired, do not look at tags anymore
+		if info.IsExpired() {
+			return false
+		}
 		for _, t := range info.Tags {
 			// We have been issuing licenses with trailing spaces in the tags for a while.
 			// Eventually we should be able to remove these `TrimSpace` calls again,
@@ -43,7 +47,7 @@ func (f BasicFeature) Check(info *Info) error {
 		}
 		return false
 	}
-	if !info.Plan().HasFeature(featureTrimmed, info.IsExpired()) && !(!info.IsExpired() && hasFeature(featureTrimmed)) {
+	if !(info.Plan().HasFeature(featureTrimmed, info.IsExpired()) || hasFeature(featureTrimmed)) {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", f))
 	}
 	return nil

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -2,13 +2,16 @@ package licensing
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 )
 
 func TestCheckFeature(t *testing.T) {
-	licenseInfo := func(tags ...string) *Info { return &Info{Info: license.Info{Tags: tags}} }
+	licenseInfo := func(tags ...string) *Info {
+		return &Info{Info: license.Info{Tags: tags, ExpiresAt: time.Now().Add(1 * time.Hour)}}
+	}
 
 	check := func(t *testing.T, feature Feature, info *Info, wantEnabled bool) {
 		t.Helper()

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -131,7 +131,6 @@ func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {
 			lastInfo = info
 			lastSignature = signature
 		}
-
 		return info, signature, nil
 	} else {
 		// If no license key, default to free tier

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -46,7 +46,6 @@ func toInfo(origInfo *license.Info, origSignature string, origErr error) (info *
 	if origInfo != nil {
 		info = &Info{Info: *origInfo}
 	}
-	info.Tags = []string{"plan:enterprise-extension"}
 	return info, origSignature, origErr
 }
 

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -46,6 +46,7 @@ func toInfo(origInfo *license.Info, origSignature string, origErr error) (info *
 	if origInfo != nil {
 		info = &Info{Info: *origInfo}
 	}
+	info.Tags = []string{"plan:enterprise-extension"}
 	return info, origSignature, origErr
 }
 
@@ -131,6 +132,7 @@ func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {
 			lastInfo = info
 			lastSignature = signature
 		}
+
 		return info, signature, nil
 	} else {
 		// If no license key, default to free tier

--- a/enterprise/internal/licensing/plans.go
+++ b/enterprise/internal/licensing/plans.go
@@ -13,7 +13,7 @@ type Plan string
 // HasFeature returns whether the plan has the given feature.
 // If the target is a pointer, the plan's feature configuration will be
 // set to the target.
-func (p Plan) HasFeature(target Feature) bool {
+func (p Plan) HasFeature(target Feature, isExpired bool) bool {
 	if target == nil {
 		panic("licensing: target cannot be nil")
 	}
@@ -23,12 +23,23 @@ func (p Plan) HasFeature(target Feature) bool {
 		panic("licensing: target cannot be a nil pointer")
 	}
 
-	for _, f := range planFeatures[p] {
-		if target.FeatureName() == f.FeatureName() {
-			if val.Kind() == reflect.Ptr {
-				val.Elem().Set(reflect.ValueOf(f).Elem())
+	if isExpired {
+		for _, f := range planDetails[p].ExpiredFeatures {
+			if target.FeatureName() == f.FeatureName() {
+				if val.Kind() == reflect.Ptr {
+					val.Elem().Set(reflect.ValueOf(f).Elem())
+				}
+				return true
 			}
-			return true
+		}
+	} else {
+		for _, f := range planDetails[p].Features {
+			if target.FeatureName() == f.FeatureName() {
+				if val.Kind() == reflect.Ptr {
+					val.Elem().Set(reflect.ValueOf(f).Elem())
+				}
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Plans now have an `ExpiredFeatures` as well as a `Features` field, which allows us to specific features to remain active when a plan expires.

The 3 day grace period after a license has expired has been removed. Instead, a site-wide warning will be displayed one week before a license expires. After the expiry date is reached, Sourcegraph usage will be restricted.

Users' admin level cannot be modified when a license is expired.

See Loom: https://www.loom.com/share/9730f92598534c26932b8b07f683f502

Possible TODOs:
- [x] Add `ExpiredFeatures` to all the other licenses. Possibly the same two (`SSO` + `ACLs`) where applicable
- [ ] Do a `main-dry-run` to test the integration tests. I don't know if they don't bother using unexpired licenses.
- [ ] ... ?

## Test plan

Update failing tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
