### PR TITLE
SCIM: Optimize user querying

### DIFF
--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -11,10 +11,8 @@ import (
 	"github.com/elimity-com/scim/schema"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // UserResourceHandler implements the scim.ResourceHandler interface for users.
@@ -71,7 +69,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 	}
 
 	// Get users
-	users, err := h.db.Users().List(r.Context(), &database.UsersListOptions{
+	users, err := h.db.Users().ListForSCIM(r.Context(), &database.UsersListOptions{
 		LimitOffset: &database.LimitOffset{
 			Limit:  params.Count,
 			Offset: offset,
@@ -83,7 +81,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 
 	resources := make([]scim.Resource, 0, len(users))
 	for _, user := range users {
-		resource, err := h.convertUserToSCIMResource(r.Context(), user)
+		resource, err := h.convertUserToSCIMResource(user)
 		if err != nil {
 			// Log error and skip user
 			h.observationCtx.Logger.Error("Error converting user to SCIM resource", log.String("username", user.Username), log.Error(err))
@@ -99,44 +97,20 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 }
 
 // convertUserToSCIMResource converts a Sourcegraph user to a SCIM resource.
-func (h *UserResourceHandler) convertUserToSCIMResource(ctx context.Context, user *types.User) (*scim.Resource, error) {
-	// Get names
+func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM) (*scim.Resource, error) {
+	// Convert names
 	firstName, middleName, lastName := displayNameToPieces(user.DisplayName)
 
-	// Get SCIM external account ID if available
-	var scimAccount *extsvc.Account
-	extAccounts, err := h.db.UserExternalAccounts().List(h.ctx, database.ExternalAccountsListOptions{UserID: user.ID})
-	if err != nil {
-		return nil, errors.Wrap(err, "list external accounts")
-	}
-	for _, acct := range extAccounts {
-		if acct.ServiceType == "scim" { // TODO: Also filter by service ID that we should be getting from the request
-			scimAccount = acct
-			break
-		}
-	}
-	var externalID string
-	if scimAccount != nil {
-		externalID = scimAccount.AccountID
-	}
+	// Convert external ID
 	externalIDOptional := optional.String{}
-	if scimAccount != nil {
-		externalIDOptional = optional.NewString(scimAccount.AccountID)
+	if user.SCIMExternalID != "" {
+		externalIDOptional = optional.NewString(user.SCIMExternalID)
 	}
 
-	// Get verified email addresses
-	verifiedEmails, err := h.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
-		UserID:       user.ID,
-		OnlyVerified: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-	emailStrings := make([]interface{}, len(verifiedEmails))
-	for i := range verifiedEmails {
-		emailStrings[i] = map[string]interface{}{
-			"value": verifiedEmails[i].Email,
-		}
+	// Convert emails
+	emailMap := make([]interface{}, 0, len(user.Emails))
+	for _, email := range user.Emails {
+		emailMap = append(emailMap, map[string]interface{}{"value": email})
 	}
 
 	return &scim.Resource{
@@ -144,7 +118,7 @@ func (h *UserResourceHandler) convertUserToSCIMResource(ctx context.Context, use
 		ExternalID: externalIDOptional,
 		Attributes: scim.ResourceAttributes{
 			"userName":   user.Username,
-			"externalId": externalID,
+			"externalId": user.SCIMExternalID,
 			"name": map[string]interface{}{
 				"givenName":  firstName,
 				"middleName": middleName,
@@ -152,7 +126,7 @@ func (h *UserResourceHandler) convertUserToSCIMResource(ctx context.Context, use
 				"formatted":  user.DisplayName,
 			},
 			"displayName": user.DisplayName,
-			"emails":      emailStrings,
+			"emails":      emailMap,
 			"active":      true,
 		},
 	}, nil

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -81,13 +81,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 
 	resources := make([]scim.Resource, 0, len(users))
 	for _, user := range users {
-		resource, err := h.convertUserToSCIMResource(user)
-		if err != nil {
-			// Log error and skip user
-			h.observationCtx.Logger.Error("Error converting user to SCIM resource", log.String("username", user.Username), log.Error(err))
-			continue
-		}
-		resources = append(resources, *resource)
+		resources = append(resources, *h.convertUserToSCIMResource(user))
 	}
 
 	return scim.Page{
@@ -97,7 +91,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 }
 
 // convertUserToSCIMResource converts a Sourcegraph user to a SCIM resource.
-func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM) (*scim.Resource, error) {
+func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM) *scim.Resource {
 	// Convert names
 	firstName, middleName, lastName := displayNameToPieces(user.DisplayName)
 
@@ -129,7 +123,7 @@ func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM)
 			"emails":      emailMap,
 			"active":      true,
 		},
-	}, nil
+	}
 }
 
 // displayNameToPieces splits a display name into first, middle, and last name.

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -52960,6 +52960,9 @@ type MockUserStore struct {
 	// ListDatesFunc is an instance of a mock function object controlling
 	// the behavior of the method ListDates.
 	ListDatesFunc *UserStoreListDatesFunc
+	// ListForSCIMFunc is an instance of a mock function object controlling
+	// the behavior of the method ListForSCIM.
+	ListForSCIMFunc *UserStoreListForSCIMFunc
 	// RandomizePasswordAndClearPasswordResetRateLimitFunc is an instance of
 	// a mock function object controlling the behavior of the method
 	// RandomizePasswordAndClearPasswordResetRateLimit.
@@ -53127,6 +53130,11 @@ func NewMockUserStore() *MockUserStore {
 		},
 		ListDatesFunc: &UserStoreListDatesFunc{
 			defaultHook: func(context.Context) (r0 []types.UserDates, r1 error) {
+				return
+			},
+		},
+		ListForSCIMFunc: &UserStoreListForSCIMFunc{
+			defaultHook: func(context.Context, *UsersListOptions) (r0 []*types.UserForSCIM, r1 error) {
 				return
 			},
 		},
@@ -53322,6 +53330,11 @@ func NewStrictMockUserStore() *MockUserStore {
 				panic("unexpected invocation of MockUserStore.ListDates")
 			},
 		},
+		ListForSCIMFunc: &UserStoreListForSCIMFunc{
+			defaultHook: func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error) {
+				panic("unexpected invocation of MockUserStore.ListForSCIM")
+			},
+		},
 		RandomizePasswordAndClearPasswordResetRateLimitFunc: &UserStoreRandomizePasswordAndClearPasswordResetRateLimitFunc{
 			defaultHook: func(context.Context, int32) error {
 				panic("unexpected invocation of MockUserStore.RandomizePasswordAndClearPasswordResetRateLimit")
@@ -53461,6 +53474,9 @@ func NewMockUserStoreFrom(i UserStore) *MockUserStore {
 		},
 		ListDatesFunc: &UserStoreListDatesFunc{
 			defaultHook: i.ListDates,
+		},
+		ListForSCIMFunc: &UserStoreListForSCIMFunc{
+			defaultHook: i.ListForSCIM,
 		},
 		RandomizePasswordAndClearPasswordResetRateLimitFunc: &UserStoreRandomizePasswordAndClearPasswordResetRateLimitFunc{
 			defaultHook: i.RandomizePasswordAndClearPasswordResetRateLimit,
@@ -56282,6 +56298,114 @@ func (c UserStoreListDatesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserStoreListDatesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// UserStoreListForSCIMFunc describes the behavior when the ListForSCIM
+// method of the parent MockUserStore instance is invoked.
+type UserStoreListForSCIMFunc struct {
+	defaultHook func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error)
+	hooks       []func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error)
+	history     []UserStoreListForSCIMFuncCall
+	mutex       sync.Mutex
+}
+
+// ListForSCIM delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockUserStore) ListForSCIM(v0 context.Context, v1 *UsersListOptions) ([]*types.UserForSCIM, error) {
+	r0, r1 := m.ListForSCIMFunc.nextHook()(v0, v1)
+	m.ListForSCIMFunc.appendCall(UserStoreListForSCIMFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListForSCIM method
+// of the parent MockUserStore instance is invoked and the hook queue is
+// empty.
+func (f *UserStoreListForSCIMFunc) SetDefaultHook(hook func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListForSCIM method of the parent MockUserStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *UserStoreListForSCIMFunc) PushHook(hook func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserStoreListForSCIMFunc) SetDefaultReturn(r0 []*types.UserForSCIM, r1 error) {
+	f.SetDefaultHook(func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserStoreListForSCIMFunc) PushReturn(r0 []*types.UserForSCIM, r1 error) {
+	f.PushHook(func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error) {
+		return r0, r1
+	})
+}
+
+func (f *UserStoreListForSCIMFunc) nextHook() func(context.Context, *UsersListOptions) ([]*types.UserForSCIM, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserStoreListForSCIMFunc) appendCall(r0 UserStoreListForSCIMFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserStoreListForSCIMFuncCall objects
+// describing the invocations of this function.
+func (f *UserStoreListForSCIMFunc) History() []UserStoreListForSCIMFuncCall {
+	f.mutex.Lock()
+	history := make([]UserStoreListForSCIMFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserStoreListForSCIMFuncCall is an object that describes an invocation of
+// method ListForSCIM on an instance of MockUserStore.
+type UserStoreListForSCIMFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *UsersListOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.UserForSCIM
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserStoreListForSCIMFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserStoreListForSCIMFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -77,6 +77,7 @@ type UserStore interface {
 	InvalidateSessionsByIDs(context.Context, []int32) (err error)
 	IsPassword(ctx context.Context, id int32, password string) (bool, error)
 	List(context.Context, *UsersListOptions) (_ []*types.User, err error)
+	ListForSCIM(context.Context, *UsersListOptions) (_ []*types.UserForSCIM, err error)
 	ListDates(context.Context) ([]types.UserDates, error)
 	ListByOrg(ctx context.Context, orgID int32, paginationArgs *PaginationArgs, query *string) ([]*types.User, error)
 	RandomizePasswordAndClearPasswordResetRateLimit(context.Context, int32) error
@@ -916,6 +917,23 @@ func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types
 	return u.getBySQL(ctx, q)
 }
 
+// ListForSCIM lists users along with their email addresses and SCIM ExternalID.
+func (u *userStore) ListForSCIM(ctx context.Context, opt *UsersListOptions) (_ []*types.UserForSCIM, err error) {
+	tr, ctx := trace.New(ctx, "database.Users.ListForSCIM", fmt.Sprintf("%+v", opt))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
+	if opt == nil {
+		opt = &UsersListOptions{}
+	}
+	conditions := u.listSQL(*opt)
+
+	q := sqlf.Sprintf("WHERE %s ORDER BY id ASC %s", sqlf.Join(conditions, "AND"), opt.LimitOffset.SQL())
+	return u.getBySQLWithEmailsAndSCIMExternalID(ctx, q)
+}
+
 // ListDates lists all user's created and deleted dates, used by usage stats.
 func (u *userStore) ListDates(ctx context.Context) (dates []types.UserDates, _ error) {
 	rows, err := u.Query(ctx, sqlf.Sprintf(listDatesQuery))
@@ -1120,6 +1138,40 @@ func (u *userStore) getBySQL(ctx context.Context, query *sqlf.Query) ([]*types.U
 		}
 		u.DisplayName = displayName.String
 		u.AvatarURL = avatarURL.String
+		users = append(users, &u)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}
+
+// getBySQLWithEmailsAndSCIMExternalID returns users matching the SQL query, along with their email addresses and SCIM ExternalID.
+func (u *userStore) getBySQLWithEmailsAndSCIMExternalID(ctx context.Context, query *sqlf.Query) ([]*types.UserForSCIM, error) {
+	// NOTE: We use a separate query here because we want to fetch the emails and SCIM ExternalID in a single query.
+	q := sqlf.Sprintf(`SELECT u.id, u.username, u.display_name, u.avatar_url, u.created_at, u.updated_at, u.site_admin, u.passwd IS NOT NULL, u.tags, u.invalidated_sessions_at, u.tos_accepted, u.searchable,
+       	ARRAY(SELECT email FROM user_emails WHERE user_id = u.id) AS emails,
+       	(SELECT account_id FROM user_external_accounts WHERE user_id=u.id AND service_type = 'scim') AS scim_external_id
+  FROM users u %s`, query)
+	rows, err := u.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Convert results to users
+	users := []*types.UserForSCIM{}
+	for rows.Next() {
+		var u types.UserForSCIM
+		var displayName, avatarURL, scimExternalID sql.NullString
+		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.BuiltinAuth, pq.Array(&u.Tags), &u.InvalidatedSessionsAt, &u.TosAccepted, &u.Searchable, &u.Emails, &scimExternalID)
+		if err != nil {
+			return nil, err
+		}
+		u.DisplayName = displayName.String
+		u.AvatarURL = avatarURL.String
+		u.SCIMExternalID = scimExternalID.String
 		users = append(users, &u)
 	}
 	if err = rows.Err(); err != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -805,6 +805,13 @@ type User struct {
 	Searchable            bool
 }
 
+// UserForSCIM extends user with email addresses and SCIM external ID.
+type UserForSCIM struct {
+	User
+	Emails         []string
+	SCIMExternalID string
+}
+
 type SystemRole string
 
 var (


### PR DESCRIPTION
- A follow-up to https://github.com/sourcegraph/sourcegraph/pull/47041

As @mrnugget pointed out in a [comment](https://github.com/sourcegraph/sourcegraph/pull/47041#discussion_r1091782098), the existing solution used N*2+1 DB queries to get N users.
This PR adds a custom DB query to query users + their SCIM external IDs + email addresses.

This is almost only a refactor PR.
The only expected behavior change is that the previous query only returned _verified_ email addresses, while the new one doesn't do that filtering. It'd be an easy add, but I'm hesitant about the spec, so will fine-tune this later.

## Test plan

I've updated the integration test, it passes, I'm happy with it. This is still not a production feature.