### PR TITLE
experimental search input: Add back toggle buttons

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -35,6 +35,14 @@
     min-height: 32px;
     align-items: center;
 
+    .show-when-focused {
+        display: none;
+    }
+
+    .hide-when-focused {
+        display: block;
+    }
+
     &:focus-within {
         outline: 2px solid rgba(163, 208, 255, 1);
         outline-offset: 0;
@@ -75,4 +83,12 @@
 .suggestions {
     position: relative;
     display: none;
+}
+
+.separator {
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    width: 1px;
+    height: 1.125rem;
+    margin-right: 0.5rem;
+    background-color: var(--border-color-2);
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -27,8 +27,6 @@ import styles from './CodeMirrorQueryInputWrapper.module.scss'
 
 interface ExtensionConfig {
     popoverID: string
-    patternType: SearchPatternType
-    interpretComments: boolean
     isLightTheme: boolean
     placeholder: string
     onChange: (querySate: QueryState) => void
@@ -78,8 +76,6 @@ const extensionsCompartment = new Compartment()
 // creating the editor and to update it when the props change.
 function configureExtensions({
     popoverID,
-    patternType,
-    interpretComments,
     isLightTheme,
     placeholder,
     onChange,
@@ -91,7 +87,6 @@ function configureExtensions({
     const extensions = [
         singleLine,
         EditorView.darkTheme.of(isLightTheme === false),
-        parseInputAsQuery({ patternType, interpretComments }),
         EditorView.updateListener.of(update => {
             if (update.docChanged) {
                 onChange({
@@ -137,11 +132,28 @@ function configureExtensions({
     return extensions
 }
 
+// Holds extensions that somehow depend on the query or query parameters. They
+// are stored in a separate compartment to avoid re-creating other extensions.
+// (if we didn't do this the suggestions list would flicker because it gets
+// recreated)
+const querySettingsCompartment = new Compartment()
+
+function configureQueryExtensions({
+    patternType,
+    interpretComments,
+}: {
+    patternType: SearchPatternType
+    interpretComments: boolean
+}): Extension {
+    return parseInputAsQuery({ patternType, interpretComments })
+}
+
 function createEditor(
     parent: HTMLDivElement,
     popoverID: string,
     queryState: QueryState,
-    extensions: Extension
+    extensions: Extension,
+    queryExtensions: Extension
 ): EditorView {
     return new EditorView({
         state: EditorState.create({
@@ -176,6 +188,7 @@ function createEditor(
                         color: 'var(--search-query-text-color)',
                     },
                 }),
+                querySettingsCompartment.of(queryExtensions),
                 extensionsCompartment.of(extensions),
             ],
         }),
@@ -183,9 +196,15 @@ function createEditor(
     })
 }
 
-function updateEditor(editor: EditorView | null, extensions: Extension): void {
+function updateExtensions(editor: EditorView | null, extensions: Extension): void {
     if (editor) {
         editor.dispatch({ effects: extensionsCompartment.reconfigure(extensions) })
+    }
+}
+
+function updateQueryExtensions(editor: EditorView | null, extensions: Extension): void {
+    if (editor) {
+        editor.dispatch({ effects: querySettingsCompartment.reconfigure(extensions) })
     }
 }
 
@@ -209,7 +228,9 @@ export interface CodeMirrorQueryInputWrapperProps {
     suggestionSource: Source
 }
 
-export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQueryInputWrapperProps> = ({
+export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
+    React.PropsWithChildren<CodeMirrorQueryInputWrapperProps>
+> = ({
     queryState,
     onChange,
     onSubmit,
@@ -218,6 +239,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
     patternType,
     placeholder,
     suggestionSource,
+    children,
 }) => {
     const navigate = useNavigate()
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
@@ -236,8 +258,6 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
         () =>
             configureExtensions({
                 popoverID,
-                patternType,
-                interpretComments,
                 isLightTheme,
                 placeholder,
                 onChange,
@@ -248,8 +268,6 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
             }),
         [
             popoverID,
-            patternType,
-            interpretComments,
             isLightTheme,
             placeholder,
             onChange,
@@ -261,8 +279,14 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
         ]
     )
 
+    // Update query extensions whenever any of these props change
+    const queryExtensions = useMemo(
+        () => configureQueryExtensions({ patternType, interpretComments }),
+        [patternType, interpretComments]
+    )
+
     const editor = useMemo(
-        () => (container ? createEditor(container, popoverID, queryState, extensions) : null),
+        () => (container ? createEditor(container, popoverID, queryState, extensions, queryExtensions) : null),
         // Should only run once when the component is created, not when
         // extensions for state update (this is handled in separate hooks)
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -276,7 +300,8 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
     useEffect(() => updateValueIfNecessary(editorRef.current, queryState), [queryState])
 
     // Update editor configuration whenever extensions change
-    useEffect(() => updateEditor(editorRef.current, extensions), [extensions])
+    useEffect(() => updateExtensions(editorRef.current, extensions), [extensions])
+    useEffect(() => updateQueryExtensions(editorRef.current, queryExtensions), [queryExtensions])
 
     const focus = useCallback(() => {
         editorRef.current?.contentDOM.focus()
@@ -306,6 +331,8 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<CodeMirrorQuer
                     >
                         <Icon svgPath={mdiClose} aria-label="Clear" />
                     </button>
+                    {children && hasValue && <span className={classNames(styles.showWhenFocused, styles.separator)} />}
+                    <span className={styles.showWhenFocused}>{children}</span>
                     <button
                         type="button"
                         className={classNames(styles.inputButton, styles.globalShortcut, styles.hideWhenFocused)}

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -326,20 +326,25 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
                     <div ref={setContainer} className="d-contents" />
                     <button
                         type="button"
-                        className={classNames(styles.inputButton, { [styles.showWhenFocused]: hasValue })}
+                        className={classNames(styles.inputButton, hasValue && styles.showWhenFocused)}
                         onClick={clear}
                     >
                         <Icon svgPath={mdiClose} aria-label="Clear" />
                     </button>
-                    {children && hasValue && <span className={classNames(styles.showWhenFocused, styles.separator)} />}
-                    <span className={styles.showWhenFocused}>{children}</span>
                     <button
                         type="button"
-                        className={classNames(styles.inputButton, styles.globalShortcut, styles.hideWhenFocused)}
+                        className={classNames(
+                            styles.inputButton,
+                            styles.globalShortcut,
+                            styles.hideWhenFocused,
+                            'mr-2'
+                        )}
                         onClick={focus}
                     >
                         /
                     </button>
+                    {children && <span className={classNames(styles.separator, !hasValue && styles.hideWhenFocused)} />}
+                    {children}
                 </div>
                 <div ref={setSuggestionsContainer} className={styles.suggestions} />
             </div>

--- a/client/branded/src/search-ui/input/experimental/LazyCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/experimental/LazyCodeMirrorQueryInput.tsx
@@ -6,6 +6,6 @@ import type { CodeMirrorQueryInputWrapperProps } from './CodeMirrorQueryInputWra
 
 const CodeMirrorQueryInput = lazyComponent(() => import('./CodeMirrorQueryInputWrapper'), 'CodeMirrorQueryInputWrapper')
 
-export const LazyCodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputWrapperProps> = props => (
-    <CodeMirrorQueryInput {...props} />
-)
+export const LazyCodeMirrorQueryInput: React.FunctionComponent<
+    React.PropsWithChildren<CodeMirrorQueryInputWrapperProps>
+> = props => <CodeMirrorQueryInput {...props} />

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import { NavbarQueryState } from 'src/stores/navbarSearchQueryState'
 import shallow from 'zustand/shallow'
 
-import { SearchBox } from '@sourcegraph/branded'
+import { SearchBox, Toggles } from '@sourcegraph/branded'
 // The experimental search input should be shown on the search home page
 // eslint-disable-next-line no-restricted-imports
 import { LazyCodeMirrorQueryInput } from '@sourcegraph/branded/src/search-ui/experimental'
@@ -154,7 +154,18 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             isLightTheme={props.isLightTheme}
             placeholder="Search for code or files..."
             suggestionSource={suggestionSource}
-        />
+        >
+            <Toggles
+                patternType={patternType}
+                caseSensitive={caseSensitive}
+                setPatternType={setSearchPatternType}
+                setCaseSensitivity={setSearchCaseSensitivity}
+                searchMode={searchMode}
+                setSearchMode={setSearchMode}
+                settingsCascade={props.settingsCascade}
+                navbarSearchQuery={props.queryState.query}
+            />
+        </LazyCodeMirrorQueryInput>
     ) : (
         <SearchBox
             {...props}


### PR DESCRIPTION
This PR adds back the toggle buttons to the search input. This is an intermediate solution until we've explored whether we can provide the same functionality in a different way.

Most notable difference is that the toggles are only shown when the input is focused. Unfortunately this doesn't work well with the smart search toggle button popover. Opening the popover will hide the buttons. A couple of ways to address this:
- Don't show the smart search toggle button on the homepage.
- Always show toggle buttons (not only on focus)
- Find a way to render the popover inside the the search input container

I had to refactor the input component and create a separate compartment for the extension that depends on `patternType`. Without it clicking the toggles would cause the suggestions to "flicker" because the suggestions extension gets re-created.

<img width="835" alt="2023-02-01_14-20" src="https://user-images.githubusercontent.com/179026/216077341-7992ce4b-c260-4b9f-9d13-5d5461526851.png">


https://user-images.githubusercontent.com/179026/216078555-40914d56-0f4d-4877-9bb4-9638e99e9d63.mp4




## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-experimental-toggle-buttons.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
