### PR TITLE
Bazel: build //cmd/...  (+ rules for buf and fix grpc proto compiler) 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,10 +34,24 @@ ts_config(
     ],
 )
 
-load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+
+gazelle_binary(
+    name = "gazelle-buf",
+    languages = [
+        # Loads the native proto extension
+        "@bazel_gazelle//language/proto:go_default_library",
+        # Loads the Buf extension
+        "@rules_buf//gazelle/buf:buf",
+        # NOTE: This needs to be loaded after the proto language
+    ],
+)
 
 # gazelle:prefix github.com/sourcegraph/sourcegraph
-gazelle(name = "gazelle")
+gazelle(
+    name = "gazelle",
+    gazelle = ":gazelle-buf",
+)
 
 go_library(
     name = "sourcegraph",
@@ -57,4 +71,22 @@ gazelle(
         "-build_file_proto_mode=disable_global",
     ],
     command = "update-repos",
+)
+
+load("@io_bazel_rules_go//proto/wkt:well_known_types.bzl", "WELL_KNOWN_TYPES_APIV2")
+load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
+
+# Because the current implementation of rules_go uses the old protoc grpc compiler, we have to declare our own, and declare it manually in the build files.
+# See https://github.com/bazelbuild/rules_go/issues/3022
+go_proto_compiler(
+    name = "gen-go-grpc",
+    plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
+    suffix = "_grpc.pb.go",
+    valid_archive = False,
+    visibility = ["//visibility:public"],
+    deps = WELL_KNOWN_TYPES_APIV2 + [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,22 @@ http_archive(
 )
 
 http_archive(
+    name = "rules_buf",
+    sha256 = "523a4e06f0746661e092d083757263a249fedca535bd6dd819a8c50de074731a",
+    strip_prefix = "rules_buf-0.1.1",
+    urls = [
+        "https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.1.1.zip",
+    ],
+)
+
+# http_archive(
+#     name = "rules_proto_grpc",
+#     sha256 = "fb7fc7a3c19a92b2f15ed7c4ffb2983e956625c1436f57a3430b897ba9864059",
+#     strip_prefix = "rules_proto_grpc-4.3.0",
+#     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.3.0.tar.gz"],
+# )
+
+http_archive(
     name = "bazel_gazelle",
     sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
     urls = [
@@ -113,6 +129,22 @@ load("@jest//:npm_repositories.bzl", jest_npm_repositories = "npm_repositories")
 jest_npm_repositories()
 
 # Go toolchain setup
+
+load("@rules_buf//buf:repositories.bzl", "rules_buf_dependencies", "rules_buf_toolchains")
+
+rules_buf_dependencies()
+
+rules_buf_toolchains(version = "v1.11.0")
+
+load("@rules_buf//gazelle/buf:repositories.bzl", "gazelle_buf_dependencies")
+
+gazelle_buf_dependencies()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/cmd/searcher/shared/BUILD.bazel
+++ b/cmd/searcher/shared/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "shared",
     srcs = [
+        "debug.go",
         "service.go",
         "shared.go",
     ],

--- a/cmd/symbols/shared/BUILD.bazel
+++ b/cmd/symbols/shared/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "shared",
     srcs = [
+        "debug.go",
         "main.go",
         "service.go",
         "sqlite.go",

--- a/deps.bzl
+++ b/deps.bzl
@@ -2239,11 +2239,19 @@ def go_dependencies():
         version = "v0.0.0-20190404230743-d7302db945fa",
     )
     go_repository(
+        name = "com_github_fullstorydev_grpcui",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/fullstorydev/grpcui",
+        sum = "h1:lVXozTNkJJouBL+wpmvxMnltiwYp8mgyd0TRs93i6Rw=",
+        version = "v1.3.1",
+    )
+
+    go_repository(
         name = "com_github_fullstorydev_grpcurl",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/fullstorydev/grpcurl",
-        sum = "h1:Pp648wlTTg3OKySeqxM5pzh8XF6vLqrm8wRq66+5Xo0=",
-        version = "v1.8.1",
+        sum = "h1:WylAwnPauJIofYSHqqMTC1eEfUIzqzevXyogBxnQquo=",
+        version = "v1.8.6",
     )
     go_repository(
         name = "com_github_fxamacker_cbor_v2",
@@ -3536,6 +3544,14 @@ def go_dependencies():
         sum = "h1:fA2uLoctU5+T3OhOn2vYP0DVT6pxc7xhTlBB1paATqQ=",
         version = "v1.1.0",
     )
+    go_repository(
+        name = "com_github_gordonklaus_ineffassign",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/gordonklaus/ineffassign",
+        sum = "h1:vc7Dmrk4JwS0ZPS6WZvWlwDflgDTA26jItmbSj83nug=",
+        version = "v0.0.0-20200309095847-7953dde2c7bf",
+    )
+
     go_repository(
         name = "com_github_goreleaser_goreleaser",
         build_file_proto_mode = "disable_global",
@@ -5498,6 +5514,14 @@ def go_dependencies():
         sum = "h1:5YAIqNTdl6lAOb7lD2AyQ1RuFGPVrAKvUexphk8PGbo=",
         version = "v1.6.5",
     )
+    go_repository(
+        name = "com_github_nishanths_predeclared",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/nishanths/predeclared",
+        sum = "h1:3f0nxAmdj/VoCGN/ijdMy7bj6SBagaqYg1B0hu8clMA=",
+        version = "v0.0.0-20200524104333-86fad755b4d3",
+    )
+
     go_repository(
         name = "com_github_npillmayer_nestext",
         build_file_proto_mode = "disable_global",

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -16,18 +16,7 @@ func BazelOperations() *operations.Set {
 		"//dev/sg",
 		"//lib/...",
 		"//internal/...",
-		"//cmd/blobstore",
-		"//cmd/frontend",
-		"//cmd/github-proxy",
-		"//cmd/gitserver",
-		"//cmd/loadtest",
-		"//cmd/migrator",
-		"//cmd/repo-updater",
-		"//cmd/server",
-		// "//cmd/sourcegraph-oss", // TODO broken
-		// "//cmd/searcher", // TODO broken
-		// "//cmd/symbols", // TODO broken
-		"//cmd/worker",
+		"//cmd/...",
 	))
 	ops.Append(bazelTest("//monitoring/..."))
 	return ops

--- a/internal/debugserver/BUILD.bazel
+++ b/internal/debugserver/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "debug.go",
         "expvar.go",
+        "grpcui.go",
         "metadata.go",
         "ready.go",
     ],
@@ -13,13 +14,18 @@ go_library(
     deps = [
         "//internal/env",
         "//internal/goroutine",
+        "//internal/grpc/defaults",
         "//internal/httpserver",
         "//internal/version",
+        "//lib/errors",
         "@com_github_felixge_fgprof//:fgprof",
+        "@com_github_fullstorydev_grpcui//standalone",
         "@com_github_gorilla_mux//:mux",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_x_net//trace",
     ],
 )

--- a/internal/own/codeowners/proto/BUILD.bazel
+++ b/internal/own/codeowners/proto/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_buf//buf:defs.bzl", "buf_lint_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -37,4 +38,9 @@ go_proto_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/own/codeowners/proto",
     proto = ":proto_proto",
     visibility = ["//:__subpackages__"],
+)
+
+buf_lint_test(
+    name = "proto_proto_lint",
+    targets = [":proto_proto"],
 )

--- a/internal/own/codeowners/proto/BUILD.bazel
+++ b/internal/own/codeowners/proto/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
+exports_files(["buf.gen.yaml"])
+
 proto_library(
     name = "proto_proto",
     srcs = ["codeowners.proto"],

--- a/internal/searcher/proto/BUILD.bazel
+++ b/internal/searcher/proto/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@rules_buf//buf:defs.bzl", "buf_lint_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+exports_files(["buf.gen.yaml"])
 
 proto_library(
     name = "proto_proto",
@@ -11,7 +14,7 @@ proto_library(
 
 go_proto_library(
     name = "proto_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_proto", "//:gen-go-grpc"], # keep
     importpath = "github.com/sourcegraph/sourcegraph/internal/searcher/proto",
     proto = ":proto_proto",
     visibility = ["//visibility:public"],
@@ -22,4 +25,9 @@ go_library(
     embed = [":proto_go_proto"],
     importpath = "github.com/sourcegraph/sourcegraph/internal/searcher/proto",
     visibility = ["//visibility:public"],
+)
+
+buf_lint_test(
+    name = "proto_proto_lint",
+    targets = [":proto_proto"],
 )

--- a/internal/symbols/proto/BUILD.bazel
+++ b/internal/symbols/proto/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@rules_buf//buf:defs.bzl", "buf_lint_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+exports_files(["buf.gen.yaml"])
 
 proto_library(
     name = "proto_proto",
@@ -14,7 +17,7 @@ proto_library(
 
 go_proto_library(
     name = "proto_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_proto", "//:gen-go-grpc"] # keep,
     importpath = "github.com/sourcegraph/sourcegraph/internal/symbols/proto",
     proto = ":proto_proto",
     visibility = ["//visibility:public"],
@@ -49,4 +52,9 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
     ],
+)
+
+buf_lint_test(
+    name = "proto_proto_lint",
+    targets = [":proto_proto"],
 )

--- a/internal/symbols/proto/BUILD.bazel
+++ b/internal/symbols/proto/BUILD.bazel
@@ -17,7 +17,7 @@ proto_library(
 
 go_proto_library(
     name = "proto_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_proto", "//:gen-go-grpc"] # keep,
+    compilers = ["@io_bazel_rules_go//proto:go_proto", "//:gen-go-grpc"], # keep,
     importpath = "github.com/sourcegraph/sourcegraph/internal/symbols/proto",
     proto = ":proto_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This PR fixes the issue we've seen with the proto compilation earlier and add some rules for buf. 

- Because of https://github.com/bazelbuild/rules_go/issues/3022 we had to declare our own variant of the compiler and add it onto the Build files that were requiring it. 
- This also add some rules for `buf`. 

This effectively builds all of `//cmd/...`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + main-dry-run 
