### PR TITLE
permissions-center: fill `no_perms` column of `permission_sync_jobs`.

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -112,7 +112,7 @@ func scheduleJobs(ctx context.Context, db database.DB, logger log.Logger) (int, 
 	logger.Info("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
 
 	for _, u := range schedule.Users {
-		opts := database.PermissionSyncJobOpts{Reason: u.reason, Priority: u.priority}
+		opts := database.PermissionSyncJobOpts{Reason: u.reason, Priority: u.priority, NoPerms: u.noPerms}
 		if err := store.CreateUserSyncJob(ctx, u.userID, opts); err != nil {
 			logger.Error(fmt.Sprintf("failed to create sync job for user (%d)", u.userID), log.Error(err))
 			continue
@@ -120,7 +120,7 @@ func scheduleJobs(ctx context.Context, db database.DB, logger log.Logger) (int, 
 	}
 
 	for _, r := range schedule.Repos {
-		opts := database.PermissionSyncJobOpts{Reason: r.reason, Priority: r.priority}
+		opts := database.PermissionSyncJobOpts{Reason: r.reason, Priority: r.priority, NoPerms: r.noPerms}
 		if err := store.CreateRepoSyncJob(ctx, r.repoID, opts); err != nil {
 			logger.Error(fmt.Sprintf("failed to create sync job for repo (%d)", r.repoID), log.Error(err))
 			continue

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -63,12 +63,14 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 			RepositoryID: 0,
 			Reason:       database.ReasonUserNoPermissions,
 			Priority:     database.MediumPriorityPermissionSync,
+			NoPerms:      true,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo1.ID),
 			Reason:       database.ReasonRepoNoPermissions,
 			Priority:     database.MediumPriorityPermissionSync,
+			NoPerms:      true,
 		},
 	}
 	runJobsTest(t, ctx, logger, db, store, wantJobs)
@@ -100,12 +102,14 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 			RepositoryID: 0,
 			Reason:       database.ReasonUserNoPermissions,
 			Priority:     database.MediumPriorityPermissionSync,
+			NoPerms:      true,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo1.ID),
 			Reason:       database.ReasonRepoNoPermissions,
 			Priority:     database.MediumPriorityPermissionSync,
+			NoPerms:      true,
 		},
 		{
 			UserID:       int(user2.ID),
@@ -162,6 +166,7 @@ type testJob struct {
 	RepositoryID int
 	UserID       int
 	Priority     database.PermissionSyncJobPriority
+	NoPerms      bool
 }
 
 func runJobsTest(t *testing.T, ctx context.Context, logger log.Logger, db database.DB, store database.PermissionSyncJobStore, wantJobs []testJob) {
@@ -181,6 +186,7 @@ func runJobsTest(t *testing.T, ctx context.Context, logger log.Logger, db databa
 			RepositoryID: job.RepositoryID,
 			Reason:       job.Reason,
 			Priority:     job.Priority,
+			NoPerms:      job.NoPerms,
 		}
 		actualJobs = append(actualJobs, actualJob)
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
@@ -83,20 +83,20 @@ func (h *permsSyncerWorker) Handle(ctx context.Context, _ log.Logger, record *da
 	// is not used anywhere in `syncer.syncPerms()`, therefore it is okay for now
 	// to pass old priority enum values.
 	// `requestQueue` can also be removed as it is only used by the old perms syncer.
-	return h.handlePermsSync(ctx, reqType, reqID, record.InvalidateCaches)
+	return h.handlePermsSync(ctx, reqType, reqID, record.NoPerms, record.InvalidateCaches)
 }
 
 // handlePermsSync is effectively a sync version of `perms_syncer.syncPerms`
 // which calls `perms_syncer.syncUserPerms` or `perms_syncer.syncRepoPerms`
 // depending on a request type and logs/adds metrics of sync statistics
 // afterwards.
-func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType requestType, reqID int32, invalidateCaches bool) error {
+func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType requestType, reqID int32, noPerms, invalidateCaches bool) error {
 	switch reqType {
 	case requestTypeUser:
-		providerStatuses, err := h.syncer.syncUserPerms(ctx, reqID, false, authz.FetchPermsOptions{InvalidateCaches: invalidateCaches})
+		providerStatuses, err := h.syncer.syncUserPerms(ctx, reqID, noPerms, authz.FetchPermsOptions{InvalidateCaches: invalidateCaches})
 		return h.handleSyncResults(reqType, reqID, providerStatuses, err)
 	case requestTypeRepo:
-		providerStatuses, err := h.syncer.syncRepoPerms(ctx, api.RepoID(reqID), false, authz.FetchPermsOptions{InvalidateCaches: invalidateCaches})
+		providerStatuses, err := h.syncer.syncRepoPerms(ctx, api.RepoID(reqID), noPerms, authz.FetchPermsOptions{InvalidateCaches: invalidateCaches})
 		return h.handleSyncResults(reqType, reqID, providerStatuses, err)
 	default:
 		return errors.Newf("unexpected request type: %q", reqType)

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -48,7 +48,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 0, "jobs returned even though database is empty")
 
-	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
+	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonUserNoPermissions, NoPerms: true, TriggeredByUserID: user.ID}
 	err = store.CreateRepoSyncJob(ctx, repo1.ID, opts)
 	require.NoError(t, err)
 
@@ -74,7 +74,8 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			RepositoryID:      int(repo1.ID),
 			Priority:          HighPriorityPermissionSync,
 			InvalidateCaches:  true,
-			Reason:            ReasonManualRepoSync,
+			Reason:            ReasonUserNoPermissions,
+			NoPerms:           true,
 			TriggeredByUserID: user.ID,
 		},
 		{


### PR DESCRIPTION
Test plan:
Tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/47151