### PR TITLE
release-tool: fix versions for patch upgrade guides

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -473,11 +473,6 @@ cc @${config.captainGitHubUsername}
                 }
             }
 
-            const [previousVersion, nextVersion] = [
-                `${previous.major}.${previous.minor}`,
-                `${release.major}.${release.minor}`,
-            ]
-
             // Render changes
             const createdChanges = await createChangesets({
                 requiredCommands: ['comby', sed, 'find', 'go', 'src', 'sg'],
@@ -515,7 +510,7 @@ cc @${config.captainGitHubUsername}
                             notPatchRelease
                                 ? `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version}"' enterprise/dev/ci/internal/ci/*.go`
                                 : 'echo "Skipping minimumUpgradeableVersion bump on patch release"',
-                            updateUpgradeGuides(previousVersion, nextVersion),
+                            updateUpgradeGuides(previous.version, release.version),
                         ],
                         ...prBodyAndDraftState(
                             ((): string[] => {
@@ -821,7 +816,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
         id: '_test:release-guide-update',
         description: 'Test update the upgrade guides',
         argNames: ['previous', 'next', 'dir'],
-        run: (config, previous, next, dir) => {
+        run: async (config, previous, next, dir) => {
             updateUpgradeGuides(previous, next)(dir)
         },
     },

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -816,7 +816,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
         id: '_test:release-guide-update',
         description: 'Test update the upgrade guides',
         argNames: ['previous', 'next', 'dir'],
-        run: async (config, previous, next, dir) => {
+        run: (config, previous, next, dir) => {
             updateUpgradeGuides(previous, next)(dir)
         },
     },


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47278

Fixes an issue where patch release guides were only generating with major / minor and not patch. 
## Test plan
Verified the correct version output with console.log()

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-fix-release-versions-for.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

