### PR TITLE
Treeview: Fix indentation and expansion behavior

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -250,12 +250,14 @@ function renderNode({
     isBranch,
     isExpanded,
     handleSelect,
+    handleExpand,
     props,
 }: {
     element: TreeNode
     isBranch: boolean
     isExpanded: boolean
     handleSelect: (event: React.MouseEvent) => {}
+    handleExpand: (event: React.MouseEvent) => {}
     props: { className: string }
 }): React.ReactNode {
     const { entry, error, dotdot, name } = element
@@ -333,6 +335,11 @@ function renderNode({
             onClick={event => {
                 event.preventDefault()
                 handleSelect(event)
+                // When clicking on a non-expanded folder, we want to navigate
+                // to it _and_ expand it.
+                if (isBranch && !isExpanded) {
+                    handleExpand(event)
+                }
             }}
         >
             <Icon

--- a/client/wildcard/src/components/Tree/Tree.module.scss
+++ b/client/wildcard/src/components/Tree/Tree.module.scss
@@ -59,7 +59,7 @@
     }
 
     .content {
-        padding: 0.25rem 0.5rem;
+        padding: 0.25rem;
         padding-right: 0;
         min-height: 1.75rem;
         align-items: center;

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -79,8 +79,8 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
                     {...props}
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{
-                        marginLeft: getMarginLeft(level),
-                        minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level)})`,
+                        marginLeft: getMarginLeft(level, isBranch),
+                        minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level, isBranch)})`,
                     }}
                     data-tree-node-id={element.id}
                     className={classNames(styles.node, isSelected && styles.selected)}
@@ -130,6 +130,15 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
     )
 }
 
-function getMarginLeft(level: number): string {
-    return `${0.75 * (level - 1)}rem`
+function getMarginLeft(level: number, isBranch: boolean): string {
+    // The level starts with 1 but we subtract 1.25 to make room for the folder
+    // chevron icon so to make sure we don't have a negative margin, we need to
+    // increase the level by the remaining 0.25.
+    level += 0.25
+
+    if (isBranch) {
+        return `${level - 1.25}rem`
+    } else {
+        return `${level}rem`
+    }
 }

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -142,7 +142,6 @@ function getMarginLeft(level: number, isBranch: boolean): string {
 
     if (isBranch) {
         return `${0.75 * level - 1.25}rem`
-    } else {
-        return `${0.75 * level}rem`
     }
+    return `${0.75 * level}rem`
 }

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -22,6 +22,7 @@ interface Props<N extends TreeNode> extends Omit<ITreeViewProps, 'nodes' | 'onSe
         isBranch: boolean
         isExpanded: boolean
         handleSelect: (event: React.MouseEvent) => {}
+        handleExpand: (event: React.MouseEvent) => {}
         props: { className: string; tabIndex: number }
     }) => React.ReactNode
 
@@ -66,12 +67,12 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
             isBranch: boolean
             isExpanded: boolean
             isSelected: boolean
-            getNodeProps: (props: { onClick: (event: Event) => {} }) => {
+            getNodeProps: (props: { onClick: (event: React.MouseEvent) => {} }) => {
                 onClick: (event: React.MouseEvent) => {}
             }
             level: number
             handleSelect: (event: React.MouseEvent) => {}
-            handleExpand: (event: Event) => {}
+            handleExpand: (event: React.MouseEvent) => {}
         }): React.ReactNode => {
             const { onClick, ...props } = getNodeProps({ onClick: handleExpand })
             return (
@@ -104,6 +105,7 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
                               isBranch,
                               isExpanded,
                               handleSelect,
+                              handleExpand,
                               props: {
                                   className: classNames(styles.content, { [styles.contentInBranch]: isBranch }),
                                   // We don't want links or any other item inside the Tree to be focusable, as focus
@@ -131,14 +133,16 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
 }
 
 function getMarginLeft(level: number, isBranch: boolean): string {
-    // The level starts with 1 but we subtract 1.25 to make room for the folder
-    // chevron icon so to make sure we don't have a negative margin, we need to
-    // increase the level by the remaining 0.25.
-    level += 0.25
+    // The level starts with 1 so the least margin by this logic is 0.75 * 1.
+    //
+    // Since folders render a chevron icon that is 1.25rem wide and we want to
+    // render it to the left of the item, we need to add 0.5rem so we don't have
+    // a negative margin
+    level += 0.5
 
     if (isBranch) {
-        return `${level - 1.25}rem`
+        return `${0.75 * level - 1.25}rem`
     } else {
-        return `${level}rem`
+        return `${0.75 * level}rem`
     }
 }


### PR DESCRIPTION
Part of #12916 

This fixes two issues:

## The chevron icon is now rendered on the left to the logical item so the visual order looks correct:

<img width="383" alt="Screenshot 2023-02-01 at 18 28 30" src="https://user-images.githubusercontent.com/458591/216117999-d7e2472b-04c2-4d16-b526-571db8159de3.png">

## Clicking on a folder will now expand it:

https://user-images.githubusercontent.com/458591/216118363-e113a74f-53bb-48f0-b19c-9f9d2ab053da.mov

Thank you @umpox for the feedback!

## Test plan

- Tested locally (see screenshots/videos above)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-tweaks-two.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
