### PR TITLE
release-tool: release tool small fixes

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -573,9 +573,7 @@ cc @${config.captainGitHubUsername}
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
                         edits: [`tools/update-docker-tags.sh ${release.version}`],
-                        ...prBodyAndDraftState([
-                            'Follow the [release guide](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md#releasing-pure-docker) to complete this PR',
-                        ]),
+                        ...prBodyAndDraftState([]),
                     },
                     {
                         owner: 'sourcegraph',

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -698,6 +698,7 @@ Batch change: ${batchChangeURL}`,
                 'deploy-sourcegraph',
                 'deploy-sourcegraph-docker',
                 'deploy-sourcegraph-docker-customer-replica-1',
+                'deploy-sourcegraph-k8s'
             ]) {
                 try {
                     await createTag(

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -696,7 +696,7 @@ Batch change: ${batchChangeURL}`,
                 'deploy-sourcegraph',
                 'deploy-sourcegraph-docker',
                 'deploy-sourcegraph-docker-customer-replica-1',
-                'deploy-sourcegraph-k8s'
+                'deploy-sourcegraph-k8s',
             ]) {
                 try {
                     await createTag(

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -523,7 +523,7 @@ cc @${config.captainGitHubUsername}
                                 items.push(
                                     'Ensure all other pull requests in the batch change have been merged',
                                     'Run `pnpm run release release:finalize` to generate the tags required. CI will not pass until this command is run.',
-                                    'Re-run the build on this branch (using either `sg ci build --wait` or the Buildkite UI) and merge when the build passes.'
+                                    'Re-run the build on this branch (using either `sg ci build` or the Buildkite UI) and merge when the build passes.'
                                 )
                                 return items
                             })()

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -523,7 +523,7 @@ cc @${config.captainGitHubUsername}
                                 items.push(
                                     'Ensure all other pull requests in the batch change have been merged',
                                     'Run `pnpm run release release:finalize` to generate the tags required. CI will not pass until this command is run.',
-                                    'Re-run the build on this branch (using either `sg ci build` or the Buildkite UI) and merge when the build passes.'
+                                    'Re-run the build on this branch (using either the command `sg ci build` or the Buildkite UI) and merge when the build passes.'
                                 )
                                 return items
                             })()


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47278

Fixes up some lint in the release tool:
1. New k8s repo wasn't added to the auto-tag for release:finalize
2. The instruction for ci build --wait wasn't correct
3. Deploy-sourcegraph-docker PR template links to release guide which is no longer required and was confusing for captains

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-release-tool-lint.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

