### PR TITLE
Fixup casing and add requested_env_vars to indexer config

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -80,6 +80,14 @@
           "outfile": {
             "description": "The path to the LSIF index relative to the index root.",
             "type": "string"
+          },
+          "requested_env_vars": {
+            "description": "Env vars to load from executor secrets.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "additionalItems": false
           }
         },
         "additionalProperties": false,

--- a/enterprise/internal/codeintel/shared/types/index.go
+++ b/enterprise/internal/codeintel/shared/types/index.go
@@ -27,16 +27,57 @@ type Index struct {
 	Root               string                       `json:"root"`
 	Indexer            string                       `json:"indexer"`
 	IndexerArgs        []string                     `json:"indexer_args"` // TODO - convert this to `IndexCommand string`
+	RequestedEnvVars   []string                     `json:"requested_env_vars"`
 	Outfile            string                       `json:"outfile"`
 	ExecutionLogs      []executor.ExecutionLogEntry `json:"execution_logs"`
 	Rank               *int                         `json:"placeInQueue"`
 	AssociatedUploadID *int                         `json:"associatedUpload"`
 	ShouldReindex      bool                         `json:"shouldReindex"`
-	RequestedEnvVars   []string                     `json:"requestedEnvVars"`
 }
 
 func (i Index) RecordID() int {
 	return i.ID
+}
+
+func (i *Index) UnmarshalJSON(data []byte) error {
+	var old wrongCasingIndex
+	if err := json.Unmarshal(data, &old); err != nil {
+		return err
+	}
+	*i = Index{
+		ID:                 old.ID,
+		Commit:             old.Commit,
+		QueuedAt:           old.QueuedAt,
+		State:              old.State,
+		FailureMessage:     old.FailureMessage,
+		StartedAt:          old.StartedAt,
+		FinishedAt:         old.FinishedAt,
+		ProcessAfter:       old.ProcessAfter,
+		NumResets:          old.NumResets,
+		NumFailures:        old.NumFailures,
+		RepositoryID:       old.RepositoryID,
+		LocalSteps:         old.LocalSteps,
+		RepositoryName:     old.RepositoryName,
+		DockerSteps:        old.DockerSteps,
+		Root:               old.Root,
+		Indexer:            old.Indexer,
+		IndexerArgs:        old.IndexerArgs,
+		RequestedEnvVars:   old.RequestedEnvVars,
+		Outfile:            old.Outfile,
+		ExecutionLogs:      old.ExecutionLogs,
+		Rank:               old.Rank,
+		AssociatedUploadID: old.AssociatedUploadID,
+		ShouldReindex:      old.ShouldReindex,
+	}
+	var rcpi rightCasingPartialIndex
+	if err := json.Unmarshal(data, &rcpi); err != nil {
+		return err
+	}
+	if len(rcpi.RequestedEnvVars) > 0 {
+		i.RequestedEnvVars = rcpi.RequestedEnvVars
+	}
+
+	return nil
 }
 
 type DockerStep struct {
@@ -56,4 +97,36 @@ func (s *DockerStep) Scan(value any) error {
 
 func (s DockerStep) Value() (driver.Value, error) {
 	return json.Marshal(s)
+}
+
+// wrongCasingIndex is a type that was not having consistent casing. Don't use it!
+// This is just here so we can unmarshal with a fallback.
+type wrongCasingIndex struct {
+	ID                 int                          `json:"id"`
+	Commit             string                       `json:"commit"`
+	QueuedAt           time.Time                    `json:"queuedAt"`
+	State              string                       `json:"state"`
+	FailureMessage     *string                      `json:"failureMessage"`
+	StartedAt          *time.Time                   `json:"startedAt"`
+	FinishedAt         *time.Time                   `json:"finishedAt"`
+	ProcessAfter       *time.Time                   `json:"processAfter"`
+	NumResets          int                          `json:"numResets"`
+	NumFailures        int                          `json:"numFailures"`
+	RepositoryID       int                          `json:"repositoryId"`
+	LocalSteps         []string                     `json:"local_steps"`
+	RepositoryName     string                       `json:"repositoryName"`
+	DockerSteps        []DockerStep                 `json:"docker_steps"`
+	Root               string                       `json:"root"`
+	Indexer            string                       `json:"indexer"`
+	IndexerArgs        []string                     `json:"indexer_args"` // TODO - convert this to `IndexCommand string`
+	Outfile            string                       `json:"outfile"`
+	ExecutionLogs      []executor.ExecutionLogEntry `json:"execution_logs"`
+	Rank               *int                         `json:"placeInQueue"`
+	AssociatedUploadID *int                         `json:"associatedUpload"`
+	ShouldReindex      bool                         `json:"shouldReindex"`
+	RequestedEnvVars   []string                     `json:"requestedEnvVars"`
+}
+
+type rightCasingPartialIndex struct {
+	RequestedEnvVars []string `json:"requested_env_vars"`
 }

--- a/enterprise/internal/codeintel/shared/types/index_test.go
+++ b/enterprise/internal/codeintel/shared/types/index_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIndex_UnmarshalJSON(t *testing.T) {
+	tts := []struct {
+		input string
+		want  Index
+	}{
+		{
+			input: `{"requestedEnvVars": ["foobar"]}`,
+			want:  Index{RequestedEnvVars: []string{"foobar"}},
+		},
+		{
+			input: `{"requested_env_vars": ["foobar"]}`,
+			want:  Index{RequestedEnvVars: []string{"foobar"}},
+		},
+		{
+			input: `{"requestedEnvVars": ["foobar"],"requested_env_vars": ["barfoo"]}`,
+			want:  Index{RequestedEnvVars: []string{"barfoo"}},
+		},
+	}
+
+	for _, tt := range tts {
+		var have Index
+		if err := json.Unmarshal([]byte(tt.input), &have); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(tt.want, have); diff != "" {
+			t.Fatalf("unexpected index from json %s", diff)
+		}
+	}
+}


### PR DESCRIPTION
Adds a missing property to the schema, and fixes it's casing, making sure that existing config will continue to work.

## Test plan

Added a test for unmarshalling.