### PR TITLE
Fix requested env vars for index configurations

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
@@ -222,15 +222,16 @@ func convertIndexConfiguration(repositoryID int, commit string, indexConfigurati
 		}
 
 		indexes = append(indexes, types.Index{
-			Commit:       commit,
-			RepositoryID: repositoryID,
-			State:        "queued",
-			DockerSteps:  dockerSteps,
-			LocalSteps:   indexJob.LocalSteps,
-			Root:         indexJob.Root,
-			Indexer:      indexJob.Indexer,
-			IndexerArgs:  indexJob.IndexerArgs,
-			Outfile:      indexJob.Outfile,
+			Commit:           commit,
+			RepositoryID:     repositoryID,
+			State:            "queued",
+			DockerSteps:      dockerSteps,
+			LocalSteps:       indexJob.LocalSteps,
+			Root:             indexJob.Root,
+			Indexer:          indexJob.Indexer,
+			IndexerArgs:      indexJob.IndexerArgs,
+			Outfile:          indexJob.Outfile,
+			RequestedEnvVars: indexJob.RequestedEnvVars,
 		})
 	}
 


### PR DESCRIPTION
This already worked for inferred indexes, but not for hard-coded ones. This fixes it.



## Test plan

Verified locally that env vars work after this change.