### PR TITLE
SCIM: Add single User GET endpoint

### DIFF
--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -81,7 +81,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 
 	resources := make([]scim.Resource, 0, len(users))
 	for _, user := range users {
-		resources = append(resources, *h.convertUserToSCIMResource(user))
+		resources = append(resources, h.convertUserToSCIMResource(user))
 	}
 
 	return scim.Page{
@@ -91,7 +91,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 }
 
 // convertUserToSCIMResource converts a Sourcegraph user to a SCIM resource.
-func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM) *scim.Resource {
+func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM) scim.Resource {
 	// Convert names
 	firstName, middleName, lastName := displayNameToPieces(user.DisplayName)
 
@@ -107,7 +107,7 @@ func (h *UserResourceHandler) convertUserToSCIMResource(user *types.UserForSCIM)
 		emailMap = append(emailMap, map[string]interface{}{"value": email})
 	}
 
-	return &scim.Resource{
+	return scim.Resource{
 		ID:         strconv.FormatInt(int64(user.ID), 10),
 		ExternalID: externalIDOptional,
 		Attributes: scim.ResourceAttributes{

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // UserResourceHandler implements the scim.ResourceHandler interface for users.
@@ -43,13 +44,26 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 }
 
 // Get returns the resource corresponding with the given identifier.
-func (h *UserResourceHandler) Get(r *http.Request, id string) (scim.Resource, error) {
-	// TODO: Add real logic
-	h.observationCtx.Logger.Error("XXXXX Get", log.String("method", r.Method), log.String("id", id))
+func (h *UserResourceHandler) Get(r *http.Request, idStr string) (scim.Resource, error) {
+	id, err := strconv.ParseInt(idStr, 10, 32)
+	if err != nil {
+		return scim.Resource{}, errors.New("invalid id")
+	}
 
-	return scim.Resource{
-		ID: "123",
-	}, nil
+	// Get users
+	users, err := h.db.Users().ListForSCIM(r.Context(), &database.UsersListOptions{
+		UserIDs: []int32{int32(id)},
+	})
+	if err != nil {
+		return scim.Resource{}, errors.Wrap(err, "Error loading user")
+	}
+	if len(users) == 0 {
+		return scim.Resource{}, errors.New("User not found")
+	}
+
+	resource := h.convertUserToSCIMResource(users[0])
+
+	return resource, nil
 }
 
 // GetAll returns a paginated list of resources.

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1174,26 +1174,8 @@ SELECT u.id,
 func (u *userStore) getBySQLForSCIM(ctx context.Context, query *sqlf.Query) ([]*types.UserForSCIM, error) {
 	// NOTE: We use a separate query here because we want to fetch the emails and SCIM ExternalID in a single query.
 	q := sqlf.Sprintf(userForSCIMQueryFmtStr, query)
-	rows, err := u.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	// Convert results to users
-	users := []*types.UserForSCIM{}
-	for rows.Next() {
-		u, err := scanUserForSCIM(rows)
-		if err != nil {
-			return nil, err
-		}
-		users = append(users, u)
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return users, nil
+	scanUsersForSCIM := basestore.NewSliceScanner(scanUserForSCIM)
+	return scanUsersForSCIM(u.Query(ctx, q))
 }
 
 // scanUserForSCIM scans a UserForSCIM from the return of a *sql.Rows.


### PR DESCRIPTION
Three changes, actually:
1. Refactor: remove pointer based on @mrnugget's [suggestion](https://github.com/sourcegraph/sourcegraph/pull/47253#discussion_r1093290608)
2. Refactor: simplify user scanning based on another [suggestion](https://github.com/sourcegraph/sourcegraph/pull/47253#discussion_r1093296097)
3. Implement the new endpoint. It reuses the previous logic, so it's very simple.

They are in three small commits, probably quickest to review them in three separate tabs.

## Test plan

The refactors are covered by tests, and they work. I tested the new endpoint with Postman; it works, too!

(FYI, the URL to call is `https://sourcegraph.test:3443/.api/scim/v2/Users/1` with `GET` and an Authorization token that matches the `scim.authToken` setting in the site config in `dev-private`.)