### PR TITLE
migration: make `--skip-version-check` work with `--file`

### DIFF
--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -83,7 +83,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 				err := errors.Newf("version assertion failed: %q != %q", inferredVersion, version)
 				return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
 			}
-		} else if version == "" {
+		} else if version == "" && file == "" {
 			return errors.New("-skip-version-check was supplied without -version or -file")
 		}
 


### PR DESCRIPTION
Previously, `--skip-version-check` won't be happy even if `--file` is given because of the missing `if` condition.

```
→ sg migration drift --db frontend --skip-version-check --file internal/database/schema.json
❌ -skip-version-check was supplied without -version or -file
```

## Test plan

```
→ sg start # to run any necessary migrations
→ sg migration drift --db frontend --skip-version-check --file internal/database/schema.json
ℹ️ Locating schema description
✅ Schema found in Local file (internal/database/schema.json).
✅ No drift detected
```
