### PR TITLE
Example batch spec: target only workspaces in subdirectory

### DIFF
--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -903,7 +903,7 @@ changesetTemplate:
   branch: my-batch-change-${{ outputs.projectName }}
 ```
 
-Create changesets only on workspaces defined within subdirectories `if:`:
+Create changesets only on workspaces defined within subdirectories using `if:`:
 
 ```yaml
 name: test-in

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -921,7 +921,7 @@ steps:
   - run: |
       echo Path is: ${{ steps.path }} | tee path.txt
     container: alpine:3
-    # Only creates changesets for package.json instances found within client subdirectories
+    # Only creates changesets in subdirectories of client containing package.json files
     if: ${{ matches steps.path "client*" }}
 
 changesetTemplate:

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -903,6 +903,35 @@ changesetTemplate:
   branch: my-batch-change-${{ outputs.projectName }}
 ```
 
+Create changesets only on workspaces defined within subdirectories `if:`:
+
+```yaml
+name: test-in
+description: what happens in `in`?
+
+on:
+  - repository: github.com/sourcegraph/sourcegraph
+
+workspaces:
+  - rootAtLocationOf: package.json
+    in: github.com/sourcegraph/sourcegraph
+    onlyFetchWorkspace: true
+
+steps:
+  - run: |
+      echo Path is: ${{ steps.path }} | tee path.txt
+    container: alpine:3
+    # Only creates changesets for package.json instances found within client subdirectories
+    if: ${{ matches steps.path "client*" }}
+
+changesetTemplate:
+  title: Test `in` 
+  body: what happens in `in`?
+  branch: test-in-${{ replace "/" "-" steps.path }}
+  commit:
+    message: Test in
+```
+
 ## [`workspaces.rootAtLocationOf`](#workspaces-rootatlocationof)
 
 The full name of the file that sits at the root of one or more workspaces in a given repository.


### PR DESCRIPTION
Brings in an example from a customer usecase. Target subdirectories with nested repos to create changesets only in certain directories 

## Test plan

sg run docsite

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
