### PR TITLE
Render link for "Go to definition" button

### DIFF
--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -95,8 +95,8 @@ export class CodeIntelTooltip implements Tooltip {
                     id: 'invokeFunction',
                     title: 'Go to definition',
                     disabledTitle: noDefinitionFound ? 'No definition found' : 'You are at the definition',
-                    command: 'invokeFunction-new',
-                    commandArguments: [() => definition.asyncHandler()],
+                    command: definition.url ? 'open' : 'invokeFunction-new',
+                    commandArguments: [definition.url ? definition.url : () => definition.asyncHandler()],
                 },
             },
             {


### PR DESCRIPTION
Addresses https://sourcegraph.slack.com/archives/C03CSAER9LK/p1675322888176849


## Test plan

Manually tested by starting the server locally and right-click on the "Go to definition" button to validate it's a link.

<img width="422" alt="CleanShot 2023-02-02 at 09 44 57@2x" src="https://user-images.githubusercontent.com/1408093/216274821-f3146f04-1197-41da-9916-428349d12ff5.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-definition-url.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
