### PR TITLE
graphqlbackend: expose schema drift information

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6848,6 +6848,21 @@ type Site implements SettingsSubject {
     Reflects the site configuration `enableLegacyExtensions` experimental feature value.
     """
     enableLegacyExtensions: Boolean!
+
+    """
+    FOR INTERNAL USE ONLY: todo
+    """
+    upgradeReadiness: UpgradeReadiness!
+}
+
+"""
+todo
+"""
+type UpgradeReadiness {
+    """
+    todo
+    """
+    schemaDrift: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6850,17 +6850,17 @@ type Site implements SettingsSubject {
     enableLegacyExtensions: Boolean!
 
     """
-    FOR INTERNAL USE ONLY: todo
+    FOR INTERNAL USE ONLY: Returns information about instance upgrade readiness.
     """
     upgradeReadiness: UpgradeReadiness!
 }
 
 """
-todo
+Instance upgrade readiness information includes schema drifts and deprecated-but-unfinished out-of-band migrations.
 """
 type UpgradeReadiness {
     """
-    todo
+    The schema drift details.
     """
     schemaDrift: String!
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -254,11 +254,7 @@ func (r *upgradeReadinessResolver) SchemaDrift(ctx context.Context) (string, err
 		"2939fb1300d431075994ebb7d50ab2352b8983a9", // todo: get the current service version
 		out,
 		true, // verbose
-		[]cliutil.ExpectedSchemaFactory{
-			cliutil.GitHubExpectedSchemaFactory,
-			cliutil.GCSExpectedSchemaFactory,
-			cliutil.LocalExpectedSchemaFactory,
-		},
+		migratorshared.DefaultSchemaFactories,
 	)
 	if err == cliutil.ErrDatabaseDriftDetected {
 		return drift.String(), nil

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -232,7 +232,10 @@ func (r *siteResolver) EnableLegacyExtensions() bool {
 }
 
 func (r *siteResolver) UpgradeReadiness() (*upgradeReadinessResolver, error) {
-	return &upgradeReadinessResolver{logger: r.logger, db: r.db}, nil
+	return &upgradeReadinessResolver{
+		logger: r.logger.Scoped("upgradeReadiness", ""),
+		db:     r.db,
+	}, nil
 }
 
 type upgradeReadinessResolver struct {
@@ -265,6 +268,7 @@ func (r *upgradeReadinessResolver) SchemaDrift(ctx context.Context) (string, err
 	} else {
 		version = v.GitTagWithPatch(patch)
 	}
+	r.logger.Debug("schema drift", log.String("version", version))
 
 	var drift bytes.Buffer
 	out := output.NewOutput(&drift, output.OutputOpts{Verbose: true})

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -231,7 +231,12 @@ func (r *siteResolver) EnableLegacyExtensions() bool {
 	return conf.ExperimentalFeatures().EnableLegacyExtensions
 }
 
-func (r *siteResolver) UpgradeReadiness() (*upgradeReadinessResolver, error) {
+func (r *siteResolver) UpgradeReadiness(ctx context.Context) (*upgradeReadinessResolver, error) {
+	// 🚨 SECURITY: Only site admins may view upgrade readiness information.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
 	return &upgradeReadinessResolver{
 		logger: r.logger.Scoped("upgradeReadiness", ""),
 		db:     r.db,

--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -44,6 +44,14 @@ func NewRunnerWithSchemas(observationCtx *observation.Context, logger log.Logger
 	return cliutil.NewShim(r), nil
 }
 
+// DefaultSchemaFactories is a list of schema factories to be used in
+// non-exceptional cases.
+var DefaultSchemaFactories = []cliutil.ExpectedSchemaFactory{
+	cliutil.GitHubExpectedSchemaFactory,
+	cliutil.GCSExpectedSchemaFactory,
+	cliutil.LocalExpectedSchemaFactory,
+}
+
 func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsingConfAndStoreFactoryFunc) error {
 	observationCtx := observation.NewContext(logger)
 
@@ -61,12 +69,6 @@ func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsing
 		registerEnterpriseMigrators,
 	)
 
-	schemaFactories := []cliutil.ExpectedSchemaFactory{
-		cliutil.GitHubExpectedSchemaFactory,
-		cliutil.GCSExpectedSchemaFactory,
-		cliutil.LocalExpectedSchemaFactory,
-	}
-
 	command := &cli.App{
 		Name:   appName,
 		Usage:  "Validates and runs schema migrations",
@@ -77,10 +79,10 @@ func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsing
 			cliutil.DownTo(appName, newRunner, outputFactory, false),
 			cliutil.Validate(appName, newRunner, outputFactory),
 			cliutil.Describe(appName, newRunner, outputFactory),
-			cliutil.Drift(appName, newRunner, outputFactory, schemaFactories...),
+			cliutil.Drift(appName, newRunner, outputFactory, DefaultSchemaFactories...),
 			cliutil.AddLog(appName, newRunner, outputFactory),
-			cliutil.Upgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, schemaFactories...),
-			cliutil.Downgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, schemaFactories...),
+			cliutil.Upgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, DefaultSchemaFactories...),
+			cliutil.Downgrade(appName, newRunnerWithSchemas, outputFactory, registerMigrators, DefaultSchemaFactories...),
 			cliutil.RunOutOfBandMigrations(appName, newRunner, outputFactory, registerMigrators),
 		},
 	}

--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -27,7 +27,8 @@ var out = output.NewOutput(os.Stdout, output.OutputOpts{
 	ForceTTY:   true,
 })
 
-// todo
+// NewRunnerWithSchemas returns new migrator runner with given scheme names and
+// definitions.
 func NewRunnerWithSchemas(observationCtx *observation.Context, logger log.Logger, schemaNames []string, schemas []*schemas.Schema) (cliutil.Runner, error) {
 	dsns, err := postgresdsn.DSNsBySchema(schemaNames)
 	if err != nil {

--- a/internal/database/dbconn/connect.go
+++ b/internal/database/dbconn/connect.go
@@ -41,7 +41,9 @@ func ConnectInternal(logger log.Logger, dsn, appName, dbName string) (_ *sql.DB,
 
 	if dbName != "" {
 		if err := prometheus.Register(newMetricsCollector(db, dbName, appName)); err != nil {
-			return nil, err
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -215,7 +215,7 @@ func fetchExpectedSchema(
 		))
 	}
 
-	return descriptions.SchemaDescription{}, errors.Newf("failed to locate target schema description")
+	return descriptions.SchemaDescription{}, errors.New("failed to locate target schema description")
 }
 
 func canonicalize(schemaDescription descriptions.SchemaDescription) descriptions.SchemaDescription {

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -60,7 +60,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		// the user to skip erroring here if they are explicitly skipping this
 		// version check.
 		inferredVersion, ok, err := func() (string, bool, error) {
-			v, patch, ok, err := getServiceVersion(ctx, r)
+			v, patch, ok, err := GetServiceVersion(ctx, r)
 			if err != nil || !ok {
 				return "", false, err
 			}

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -60,7 +60,7 @@ func gcsExpectedSchemaPath(filename, version string) string {
 }
 
 // LocalExpectedSchemaFactory reads schema definitions from a local directory baked into the migrator image.
-var LocalExpectedSchemaFactory = NewExpectedSchemaFactory("Local file", []NamedRegexp{tagPattern}, localSchemaPath, readSchemaFromFile)
+var LocalExpectedSchemaFactory = NewExpectedSchemaFactory("Local file", []NamedRegexp{tagPattern}, localSchemaPath, ReadSchemaFromFile)
 
 const migratorImageDescriptionPrefix = "/schema-descriptions"
 
@@ -71,7 +71,7 @@ func localSchemaPath(filename, version string) string {
 // NewExplicitFileSchemaFactory creates a schema factory that reads a schema description from the given filename.
 // The parameters of the returned function are ignored on invocation.
 func NewExplicitFileSchemaFactory(filename string) ExpectedSchemaFactory {
-	return NewExpectedSchemaFactory("Local file", nil, func(_, _ string) string { return filename }, readSchemaFromFile)
+	return NewExpectedSchemaFactory("Local file", nil, func(_, _ string) string { return filename }, ReadSchemaFromFile)
 }
 
 // fetchSchema makes an HTTP GET request to the given URL and reads the schema description from the response.
@@ -97,8 +97,8 @@ func fetchSchema(ctx context.Context, url string) (descriptions.SchemaDescriptio
 	return schemaDescription, err
 }
 
-// readSchemaFromFile reads a schema description from the given filename.
-func readSchemaFromFile(ctx context.Context, filename string) (descriptions.SchemaDescription, error) {
+// ReadSchemaFromFile reads a schema description from the given filename.
+func ReadSchemaFromFile(ctx context.Context, filename string) (descriptions.SchemaDescription, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return descriptions.SchemaDescription{}, err

--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -142,7 +142,7 @@ func runMigration(
 	// `patch` below but only if we can best-effort fetch it. We want to allow
 	// the user to skip erroring here if they are explicitly skipping this
 	// version check.
-	version, patch, ok, err := getServiceVersion(ctx, r)
+	version, patch, ok, err := GetServiceVersion(ctx, r)
 	if !skipVersionCheck {
 		if err != nil {
 			return err
@@ -270,7 +270,8 @@ func filterStitchedMigrationsForTags(tags []string) (map[string]shared.StitchedM
 	return filteredStitchedMigrationBySchemaName, nil
 }
 
-func getServiceVersion(ctx context.Context, r Runner) (_ oobmigration.Version, patch int, ok bool, _ error) {
+// todo
+func GetServiceVersion(ctx context.Context, r Runner) (_ oobmigration.Version, patch int, ok bool, _ error) {
 	db, err := extractDatabase(ctx, r)
 	if err != nil {
 		return oobmigration.Version{}, 0, false, err

--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -270,7 +270,9 @@ func filterStitchedMigrationsForTags(tags []string) (map[string]shared.StitchedM
 	return filteredStitchedMigrationBySchemaName, nil
 }
 
-// todo
+// GetServiceVersion returns the frontend service version information for the
+// given runner. Both of the return values `ok` and `error` should be checked to
+// ensure a valid version is returned.
 func GetServiceVersion(ctx context.Context, r Runner) (_ oobmigration.Version, patch int, ok bool, _ error) {
 	db, err := extractDatabase(ctx, r)
 	if err != nil {
@@ -308,7 +310,13 @@ func setServiceVersion(ctx context.Context, r Runner, version oobmigration.Versi
 
 var ErrDatabaseDriftDetected = errors.New("database drift detected")
 
-// todo
+// CheckDrift uses given runner to check whether schema drift exists for any
+// non-empty database. It returns ErrDatabaseDriftDetected when the schema drift
+// exists, and nil error when not.
+//
+//   - The `verbose` indicates whether to collect drift details in the output.
+//   - The `expectedSchemaFactories` is the means to retrieve the schema
+//     definitions at the target version.
 func CheckDrift(ctx context.Context, r Runner, version string, out *output.Output, verbose bool, expectedSchemaFactories []ExpectedSchemaFactory) error {
 	type schemaWithDrift struct {
 		name  string

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -29,10 +29,10 @@ func NewVersionFromString(v string) (Version, bool) {
 	return version, ok
 }
 
-// NewVersionFromString parses the major and minor version from the given string. If
-// the string does not look like a parseable version, a false-valued flag is returned.
-// If the input string also supplies a patch version, it is returned. If a patch is
-// not supplied this value is zero.
+// NewVersionAndPatchFromString parses the major and minor version from the given
+// string. If the string does not look like a parseable version, a false-valued
+// flag is returned. If the input string also supplies a patch version, it is
+// returned. If a patch is not supplied this value is zero.
 func NewVersionAndPatchFromString(v string) (Version, int, bool) {
 	matches := versionPattern.FindStringSubmatch(v)
 	if len(matches) < 3 {


### PR DESCRIPTION
This PR adds a new GraphQL endpoint under `site > upgradeReadiness` for querying instance upgrade readiness.

Currently, only schema drift is checked and returned, but a later PR will also make it report unfinished-but-deprecated OOB migrations.

## Test plan

#### 1. Local dev

1. Run the following query in the **API console** and no drift:

	```graphql
	{
	  site {
	    upgradeReadiness {
	      schemaDrift
	    }
	  }
	}
	```
	<img width="245" alt="CleanShot 2023-02-15 at 20 33 46@2x" src="https://user-images.githubusercontent.com/2946214/219028644-bce652cd-b4f1-4017-a0b3-31b31ef337ed.png">


1. Add a random column to a random table (e.g. `versions`):
1. Re-run the query in step 1:

	![CleanShot 2023-02-15 at 20 46 51@2x](https://user-images.githubusercontent.com/2946214/219031199-c61f4b4a-1d35-40ec-b7a2-a67ae6176ddb.png)

#### 2. Released version

1. Run the following query to set a fake version:

	```sql
	UPDATE versions SET version = '4.4.1';
	```
1. Run the following query in the **API console**:

	```graphql
	{
	  site {
	    upgradeReadiness {
	      schemaDrift
	    }
	  }
	}
	```
	![CleanShot 2023-02-15 at 20 44 55@2x](https://user-images.githubusercontent.com/2946214/219030849-82fdc6dd-2a17-49bf-8a8a-1cc09958d713.png)

---

Part of https://github.com/sourcegraph/sourcegraph/issues/47258