### PR TITLE
Update release-config for 4.5.0

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,16 +11,16 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "thorsten",
-    "captainGitHubUsername": "mrnugget",
+    "captainSlackUsername": "keegan",
+    "captainGitHubUsername": "keegancsmith",
     // Release versions
-    "previousRelease": "4.4.1",
-    "upcomingRelease": "4.4.2",
-    "oneWorkingWeekBeforeRelease": "25 January 2023 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "27 January 2023 10:00 PST",
-    "releaseDate": "1 February 2023 10:00 PST",
-    "oneWorkingDayAfterRelease": "2 February 2023 10:00 PST",
-    "oneWorkingWeekAfterRelease": "8 February 2023 10:00 PST",
+    "previousRelease": "4.4.2",
+    "upcomingRelease": "4.5.0",
+    "oneWorkingWeekBeforeRelease": "15 February 2023 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "17 February 2023 10:00 PST",
+    "releaseDate": "22 February 2023 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 February 2023 10:00 PST",
+    "oneWorkingWeekAfterRelease": "1 March 2023 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "announce-engineering",
     // Email for preparing calendar events


### PR DESCRIPTION
This undoes the changes I made yesterday for 4.4.2, but keeps the updated `slackAnnounceChannel`.

## Test plan

- N/A