### PR TITLE
graphqlbackend: Implement diff and reproducedDiff

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6843,7 +6843,7 @@ type SiteConfigurationChange implements Node {
     reproducedDiff: Boolean!
 
     """
-    The diff string when diffed against the previous site config.
+    The diff string when diffed against the previous site config. When this is null there was no diff to the previous change.
     """
     diff: String
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6833,10 +6833,19 @@ type SiteConfigurationChange implements Node {
     via an internal process (example: site startup or SITE_CONFIG_FILE being reloaded).
     """
     author: User
+
     """
-    The diff string when diffed against the site config at previousID.
+    A flag to indicate if the diff of changes to the previous site configuration
+    was reproduced or not. Sometimes it may not be possible to generate a diff
+    (for example the redacted contents are not available) in which case the
+    value of the flag will be false.
     """
-    diff: String!
+    reproducedDiff: Boolean!
+
+    """
+    The diff string when diffed against the previous site config.
+    """
+    diff: String
     """
     The timestamp when this change in the site config was applied.
     """

--- a/cmd/frontend/graphqlbackend/site_config_change.go
+++ b/cmd/frontend/graphqlbackend/site_config_change.go
@@ -2,11 +2,15 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
 )
 
 const siteConfigurationChangeKind = "SiteConfigurationChange"
@@ -19,11 +23,6 @@ type SiteConfigurationChangeResolver struct {
 
 func (r SiteConfigurationChangeResolver) ID() graphql.ID {
 	return marshalSiteConfigurationChangeID(r.siteConfig.ID)
-}
-
-// One line wrapper to be able to use in tests as well.
-func marshalSiteConfigurationChangeID(id int32) graphql.ID {
-	return relay.MarshalID(siteConfigurationChangeKind, &id)
 }
 
 func (r SiteConfigurationChangeResolver) Author(ctx context.Context) (*UserResolver, error) {
@@ -39,17 +38,51 @@ func (r SiteConfigurationChangeResolver) Author(ctx context.Context) (*UserResol
 	return user, nil
 }
 
-// TODO: Implement this.
-func (r SiteConfigurationChangeResolver) Diff() string {
-	// TODO: We will do something like this, but for now return an empty string to not leak secrets
-	// until we have implemented redaction.
-	//
-	// if r.previousSiteConfig == nil {
-	// 	return ""
-	// }
+func (r SiteConfigurationChangeResolver) ReproducedDiff() bool {
+	// If we were able to redact contents for both siteConfig and previousSiteConfig and store it in
+	// the DB, then we can generate a diff.
+	if r.siteConfig != nil {
+		// As a special case, if previousSiteConfig is nil (first entry in the DB) and we also have
+		// redactedContents available for this siteConfig, we can generate a diff (it will be all
+		// lines added).
+		if r.previousSiteConfig == nil && r.siteConfig.RedactedContents != "" {
+			return true
+		}
 
-	// return cmp.Diff(r.siteConfig.Contents, r.previousSiteConfig.Contents)
-	return ""
+		if r.siteConfig.RedactedContents != "" && r.previousSiteConfig.RedactedContents != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r SiteConfigurationChangeResolver) Diff() *string {
+	if !r.ReproducedDiff() {
+		return nil
+	}
+
+	var prevID int32
+	var prevRedactedContents string
+	if r.previousSiteConfig != nil {
+		prevID = r.previousSiteConfig.ID
+
+		// 🚨 SECURITY: This should always use "siteConfig.RedactedContents" and never
+		// "siteConfig.Contents" to generate the diff because we do not want to leak secrets in the
+		// diff.
+		prevRedactedContents = r.previousSiteConfig.RedactedContents
+	} else {
+		prevID = 0
+		prevRedactedContents = ""
+	}
+
+	prettyID := func(id int32) string { return fmt.Sprintf("ID: %d", id) }
+
+	// We're not diffing a file, so set an empty string for the URI argument.
+	edits := myers.ComputeEdits("", prevRedactedContents, r.siteConfig.RedactedContents)
+	diff := fmt.Sprint(gotextdiff.ToUnified(prettyID(prevID), prettyID(r.siteConfig.ID), prevRedactedContents, edits))
+
+	return &diff
 }
 
 func (r SiteConfigurationChangeResolver) CreatedAt() gqlutil.DateTime {
@@ -58,4 +91,9 @@ func (r SiteConfigurationChangeResolver) CreatedAt() gqlutil.DateTime {
 
 func (r SiteConfigurationChangeResolver) UpdatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.siteConfig.UpdatedAt}
+}
+
+// One line wrapper to be able to use in tests as well.
+func marshalSiteConfigurationChangeID(id int32) graphql.ID {
+	return relay.MarshalID(siteConfigurationChangeKind, &id)
 }

--- a/cmd/frontend/graphqlbackend/site_config_change.go
+++ b/cmd/frontend/graphqlbackend/site_config_change.go
@@ -71,9 +71,6 @@ func (r SiteConfigurationChangeResolver) Diff() *string {
 		// "siteConfig.Contents" to generate the diff because we do not want to leak secrets in the
 		// diff.
 		prevRedactedContents = r.previousSiteConfig.RedactedContents
-	} else {
-		prevID = 0
-		prevRedactedContents = ""
 	}
 
 	prettyID := func(id int32) string { return fmt.Sprintf("ID: %d", id) }

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -465,12 +465,12 @@ func TestSiteConfigConnection(t *testing.T) {
 							"totalCount": 5,
 							"nodes": [
 								 {
-									 "id": %[1]q,
-									 "author": {
-										 "id": "VXNlcjoy",
-										 "username": "bar",
-										 "displayName": "bar user"
-									 },
+									"id": %[1]q,
+									"author": {
+										"id": "VXNlcjoy",
+										"username": "bar",
+										"displayName": "bar user"
+									},
 									"reproducedDiff": true,
 									"diff": %[3]q
 								 },

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -52,35 +52,35 @@ func setupSiteConfigStubs(t *testing.T) *siteConfigStubs {
 
 	conf := db.Conf()
 	siteConfigsToCreate := []*database.SiteConfig{
+		// ID: 2 (because first time we create a config an initial config will be created first)
 		{
-			Contents: `
-{
+			Contents: `{
   "auth.Providers": []
 }`,
 		},
+		// ID: 3
 		{
 			AuthorUserID: 2,
 			// A new line is added.
-			Contents: `
-{
+			Contents: `{
   "disableAutoGitUpdates": true,
   "auth.Providers": []
 }`,
 		},
+		// ID: 4
 		{
 			AuthorUserID: 1,
 			// Existing line is changed.
-			Contents: `
-{
+			Contents: `{
   "disableAutoGitUpdates": false,
   "auth.Providers": []
 }`,
 		},
+		// ID: 5
 		{
 			AuthorUserID: 1,
 			// Existing line is removed.
-			Contents: `
-{
+			Contents: `{
   "auth.Providers": []
 }`,
 		},

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -212,8 +212,8 @@ func TestSiteConfigConnection(t *testing.T) {
 								  username,
 								  displayName
 							  }
-                              reproducedDiff
-                              diff
+							  reproducedDiff
+							  diff
 						  }
 						  pageInfo {
 							hasNextPage
@@ -242,8 +242,8 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-                                    "reproducedDiff": true,
-                                    "diff": %[3]q
+									"reproducedDiff": true,
+									"diff": %[3]q
 								},
 								{
 									"id": %[2]q,
@@ -252,8 +252,8 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-                                    "reproducedDiff": true,
-                                    "diff": %[4]q
+									"reproducedDiff": true,
+									"diff": %[4]q
 								}
 							],
 							"pageInfo": {
@@ -266,8 +266,7 @@ func TestSiteConfigConnection(t *testing.T) {
 					}
 				}
 			}
-		`, marshalSiteConfigurationChangeID(5), marshalSiteConfigurationChangeID(4), expectedDiffs[5], expectedDiffs[4],
-			),
+		`, marshalSiteConfigurationChangeID(5), marshalSiteConfigurationChangeID(4), expectedDiffs[5], expectedDiffs[4]),
 		},
 		{
 			Schema:  mustParseGraphQLSchema(t, stubs.db),
@@ -288,8 +287,8 @@ func TestSiteConfigConnection(t *testing.T) {
 											username,
 											displayName
 										}
-                                        reproducedDiff
-                                        diff
+										reproducedDiff
+										diff
 									}
 									pageInfo {
 									  hasNextPage
@@ -318,20 +317,20 @@ func TestSiteConfigConnection(t *testing.T) {
 												"username": "bar",
 												"displayName": "bar user"
 											},
-                                            "reproducedDiff": true,
-                                            "diff": %[4]q
+											"reproducedDiff": true,
+											"diff": %[4]q
 										},
 										{
 											"id": %[2]q,
 											"author": null,
-                                            "reproducedDiff": true,
-                                            "diff": %[5]q
+											"reproducedDiff": true,
+											"diff": %[5]q
 										},
 										{
 											"id": %[3]q,
 											"author": null,
-                                            "reproducedDiff": true,
-                                            "diff": %[6]q
+											"reproducedDiff": true,
+											"diff": %[6]q
 										}
 									],
 									"pageInfo": {

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -366,8 +366,8 @@ func TestSiteConfigConnection(t *testing.T) {
 									username,
 									displayName
 								}
-                                reproducedDiff
-                                diff
+								reproducedDiff
+								diff
 							}
 							pageInfo {
 							  hasNextPage
@@ -396,8 +396,8 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-                                    "reproducedDiff": true,
-                                    "diff": %[3]q
+									"reproducedDiff": true,
+									"diff": %[3]q
 								},
 								{
 									"id": %[2]q,
@@ -406,8 +406,8 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "bar",
 										"displayName": "bar user"
 									},
-                                    "reproducedDiff": true,
-                                    "diff": %[4]q
+									"reproducedDiff": true,
+									"diff": %[4]q
 								}
 							],
 							"pageInfo": {
@@ -441,8 +441,8 @@ func TestSiteConfigConnection(t *testing.T) {
 									username,
 									displayName
 								}
-                                reproducedDiff
-                                diff
+								reproducedDiff
+								diff
 							}
 							pageInfo {
 							  hasNextPage
@@ -471,14 +471,14 @@ func TestSiteConfigConnection(t *testing.T) {
 										 "username": "bar",
 										 "displayName": "bar user"
 									 },
-                                    "reproducedDiff": true,
-                                    "diff": %[3]q
+									"reproducedDiff": true,
+									"diff": %[3]q
 								 },
 								 {
-									 "id": %[2]q,
-									 "author": null,
-                                     "reproducedDiff": true,
-                                     "diff": %[4]q
+									"id": %[2]q,
+									"author": null,
+									"reproducedDiff": true,
+									"diff": %[4]q
 								 }
 							],
 							"pageInfo": {

--- a/cmd/frontend/graphqlbackend/site_config_change_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_test.go
@@ -1,0 +1,259 @@
+package graphqlbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+func TestSiteConfigurationChangeResolverReproducedDiff(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resolver SiteConfigurationChangeResolver
+		expected bool
+	}{
+		{
+			name:     "both siteConfig and previousSiteConfig are nil",
+			resolver: SiteConfigurationChangeResolver{},
+			expected: false,
+		},
+		{
+			name: "siteConfig is nil",
+			resolver: SiteConfigurationChangeResolver{
+				previousSiteConfig: &database.SiteConfig{},
+			},
+			expected: false,
+		},
+		{
+			name: "previousSiteConfig is nil",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig: &database.SiteConfig{},
+			},
+			expected: false,
+		},
+
+		{
+			name: "siteConfig.RedactedContents is non-empty but previousSiteConfig is nil",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig: &database.SiteConfig{
+					RedactedContents: "foo",
+				},
+			},
+			expected: true,
+		},
+
+		{
+			name: "both siteConfig.RedactedContents and previousSiteConfig.RedactedContents are empty",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig:         &database.SiteConfig{},
+				previousSiteConfig: &database.SiteConfig{},
+			},
+			expected: false,
+		},
+
+		{
+			name: "siteConfig.RedactedContents is empty",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig:         &database.SiteConfig{},
+				previousSiteConfig: &database.SiteConfig{RedactedContents: "foo"},
+			},
+			expected: false,
+		},
+		{
+			name: "previousSiteConfig.RedactedContents is empty",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig:         &database.SiteConfig{RedactedContents: "foo"},
+				previousSiteConfig: &database.SiteConfig{},
+			},
+			expected: false,
+		},
+
+		{
+			name: "both siteConfig.RedactedContents and previousSiteConfig.RedactedContents is non-empty",
+			resolver: SiteConfigurationChangeResolver{
+				siteConfig:         &database.SiteConfig{RedactedContents: "foo"},
+				previousSiteConfig: &database.SiteConfig{RedactedContents: "foo"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.resolver.ReproducedDiff() != tc.expected {
+				t.Errorf("mismatched value for ReproducedDiff, expected %v, but got %v", tc.expected, tc.resolver.ReproducedDiff())
+			}
+		})
+	}
+
+}
+
+func TestSiteConfigurationDiff(t *testing.T) {
+	stubs := setupSiteConfigStubs(t)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: stubs.users[0].ID})
+	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClient()).Site().Configuration(ctx)
+	if err != nil {
+		t.Fatalf("failed to create schemaResolver: %v", err)
+	}
+
+	expectedNodes := []struct {
+		ID           int32
+		AuthorUserID int32
+		Diff         *string
+	}{
+		{
+			ID:           5,
+			AuthorUserID: 1,
+			Diff: stringPtr(`--- ID: 4
++++ ID: 5
+@@ -1,4 +1,3 @@
+ {
+-  "disableAutoGitUpdates": false,
+   "auth.Providers": []
+ }
+\ No newline at end of file
+`),
+		},
+		{
+			ID:           4,
+			AuthorUserID: 1,
+			Diff: stringPtr(`--- ID: 3
++++ ID: 4
+@@ -1,4 +1,4 @@
+ {
+-  "disableAutoGitUpdates": true,
++  "disableAutoGitUpdates": false,
+   "auth.Providers": []
+ }
+\ No newline at end of file
+`),
+		},
+		{
+			ID:           3,
+			AuthorUserID: 2,
+			Diff: stringPtr(`--- ID: 2
++++ ID: 3
+@@ -1,3 +1,4 @@
+ {
++  "disableAutoGitUpdates": true,
+   "auth.Providers": []
+ }
+\ No newline at end of file
+`),
+		},
+		{
+			ID:           2,
+			AuthorUserID: 0,
+			Diff: stringPtr(`--- ID: 1
++++ ID: 2
+@@ -1,17 +1,3 @@
+ {
+-  // The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
+-  // This is required to be configured for Sourcegraph to work correctly.
+-  // "externalURL": "https://sourcegraph.example.com",
+-  // The authentication provider to use for identifying and signing in users.
+-  // Only one entry is supported.
+-  //
+-  // The builtin auth provider with signup disallowed (shown below) means that
+-  // after the initial site admin signs in, all other users must be invited.
+-  //
+-  // Other providers are documented at https://docs.sourcegraph.com/admin/auth.
+-  "auth.providers": [
+-    {
+-      "type": "builtin"
+-    }
+-  ],
++  "auth.Providers": []
+ }
+\ No newline at end of file
+`),
+		},
+		{
+			ID:           1,
+			AuthorUserID: 0,
+			Diff: stringPtr(`--- ID: 0
++++ ID: 1
+@@ -1 +1,17 @@
++{
++  // The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
++  // This is required to be configured for Sourcegraph to work correctly.
++  // "externalURL": "https://sourcegraph.example.com",
++  // The authentication provider to use for identifying and signing in users.
++  // Only one entry is supported.
++  //
++  // The builtin auth provider with signup disallowed (shown below) means that
++  // after the initial site admin signs in, all other users must be invited.
++  //
++  // Other providers are documented at https://docs.sourcegraph.com/admin/auth.
++  "auth.providers": [
++    {
++      "type": "builtin"
++    }
++  ],
++}
+\ No newline at end of file
+`),
+		},
+	}
+
+	testCases := []struct {
+		name string
+		args *graphqlutil.ConnectionResolverArgs
+	}{
+		// We have tests for pagination so we can skip that here and just check for the diff for all
+		// the nodes in both the directions.
+		{
+			name: "first: 10",
+			args: &graphqlutil.ConnectionResolverArgs{First: int32Ptr(10)},
+		},
+		{
+			name: "last: 10",
+			args: &graphqlutil.ConnectionResolverArgs{Last: int32Ptr(10)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			connectionResolver, err := schemaResolver.History(ctx, tc.args)
+			if err != nil {
+				t.Fatalf("failed to get history: %v", err)
+			}
+
+			nodes, err := connectionResolver.Nodes(ctx)
+			if err != nil {
+				t.Fatalf("failed to get nodes: %v", err)
+			}
+
+			totalNodes, totalExpectedNodes := len(nodes), len(expectedNodes)
+			if totalNodes != totalExpectedNodes {
+				t.Fatalf("mismatched number of nodes, expected %d, got: %d", totalExpectedNodes, totalNodes)
+			}
+
+			for i := 0; i < totalNodes; i++ {
+				siteConfig, expectedNode := nodes[i].siteConfig, expectedNodes[i]
+
+				if siteConfig.ID != expectedNode.ID {
+					t.Errorf("mismatched node ID, expected: %d, but got: %d", siteConfig.ID, expectedNode.ID)
+				}
+
+				if siteConfig.AuthorUserID != expectedNode.AuthorUserID {
+					t.Errorf("mismatched node AuthorUserID, expected: %d, but got: %d", siteConfig.ID, expectedNode.ID)
+				}
+
+				if !nodes[i].ReproducedDiff() {
+					t.Fatal("expected reproducedDiff to be true but got false")
+				}
+
+				if diff := cmp.Diff(*expectedNode.Diff, *nodes[i].Diff()); diff != "" {
+					t.Errorf("mismatched node diff (-want, +got):\n%s ", diff)
+				}
+			}
+		})
+	}
+}

--- a/cmd/frontend/graphqlbackend/site_config_change_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_test.go
@@ -102,6 +102,8 @@ func TestSiteConfigurationDiff(t *testing.T) {
 		t.Fatalf("failed to create schemaResolver: %v", err)
 	}
 
+	expectedDiffs := stubs.expectedDiffs
+
 	expectedNodes := []struct {
 		ID           int32
 		AuthorUserID int32
@@ -110,95 +112,27 @@ func TestSiteConfigurationDiff(t *testing.T) {
 		{
 			ID:           5,
 			AuthorUserID: 1,
-			Diff: stringPtr(`--- ID: 4
-+++ ID: 5
-@@ -1,4 +1,3 @@
- {
--  "disableAutoGitUpdates": false,
-   "auth.Providers": []
- }
-\ No newline at end of file
-`),
+			Diff:         stringPtr(expectedDiffs[5]),
 		},
 		{
 			ID:           4,
 			AuthorUserID: 1,
-			Diff: stringPtr(`--- ID: 3
-+++ ID: 4
-@@ -1,4 +1,4 @@
- {
--  "disableAutoGitUpdates": true,
-+  "disableAutoGitUpdates": false,
-   "auth.Providers": []
- }
-\ No newline at end of file
-`),
+			Diff:         stringPtr(expectedDiffs[4]),
 		},
 		{
 			ID:           3,
 			AuthorUserID: 2,
-			Diff: stringPtr(`--- ID: 2
-+++ ID: 3
-@@ -1,3 +1,4 @@
- {
-+  "disableAutoGitUpdates": true,
-   "auth.Providers": []
- }
-\ No newline at end of file
-`),
+			Diff:         stringPtr(expectedDiffs[3]),
 		},
 		{
 			ID:           2,
 			AuthorUserID: 0,
-			Diff: stringPtr(`--- ID: 1
-+++ ID: 2
-@@ -1,17 +1,3 @@
- {
--  // The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
--  // This is required to be configured for Sourcegraph to work correctly.
--  // "externalURL": "https://sourcegraph.example.com",
--  // The authentication provider to use for identifying and signing in users.
--  // Only one entry is supported.
--  //
--  // The builtin auth provider with signup disallowed (shown below) means that
--  // after the initial site admin signs in, all other users must be invited.
--  //
--  // Other providers are documented at https://docs.sourcegraph.com/admin/auth.
--  "auth.providers": [
--    {
--      "type": "builtin"
--    }
--  ],
-+  "auth.Providers": []
- }
-\ No newline at end of file
-`),
+			Diff:         stringPtr(expectedDiffs[2]),
 		},
 		{
 			ID:           1,
 			AuthorUserID: 0,
-			Diff: stringPtr(`--- ID: 0
-+++ ID: 1
-@@ -1 +1,17 @@
-+{
-+  // The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
-+  // This is required to be configured for Sourcegraph to work correctly.
-+  // "externalURL": "https://sourcegraph.example.com",
-+  // The authentication provider to use for identifying and signing in users.
-+  // Only one entry is supported.
-+  //
-+  // The builtin auth provider with signup disallowed (shown below) means that
-+  // after the initial site admin signs in, all other users must be invited.
-+  //
-+  // Other providers are documented at https://docs.sourcegraph.com/admin/auth.
-+  "auth.providers": [
-+    {
-+      "type": "builtin"
-+    }
-+  ],
-+}
-\ No newline at end of file
-`),
+			Diff:         stringPtr(expectedDiffs[1]),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect


### PR DESCRIPTION
Fixes #46031.

In this commit we make the following changes to the
SiteConfigurationChange API:

- Add a new field reproducedDiff to indicate if Sourcegraph was able to
generate the diff or not
- Make the Diff field nullable
- Implement the Diff field which was previously hardcoded to return an
empty strings

Example API output:

<img width="1922" alt="image" src="https://user-images.githubusercontent.com/2682729/216308196-647a3e0b-a8d6-4f0f-8c87-d16c108ff5b1.png">

**👉🏽 Try it out yourself:** 

1. `git fetch && git checkout ig/pretty-diff-api`
1. `sg start`
1. Make a change to the site configuration from the UI
1. Run the query by clicking [here](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22query%20Site%20%7B%5Cn%20%20site%20%7B%5Cn%20%20%20%20__typename%5Cn%20%20%20%20id%5Cn%20%20%20%20configuration%20%7B%5Cn%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20history(first%3A%2010)%20%7B%5Cn%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%20%20totalCount%5Cn%20%20%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20%20%20%20%20author%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20%20%20%20%20%20%20username%5Cn%20%20%20%20%20%20%20%20%20%20%20%20displayName%5Cn%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20reproducedDiff%5Cn%20%20%20%20%20%20%20%20%20%20diff%5Cn%20%20%20%20%20%20%20%20%20%20createdAt%5Cn%20%20%20%20%20%20%20%20%20%20updatedAt%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20pageInfo%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20hasNextPage%5Cn%20%20%20%20%20%20%20%20%20%20hasPreviousPage%5Cn%20%20%20%20%20%20%20%20%20%20endCursor%5Cn%20%20%20%20%20%20%20%20%20%20startCursor%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22operationName%22%3A%22Site%22%7D).

## Test plan

- Tested locally
- Added tests
- Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
