### PR TITLE
permissions-center: add basic permission sync jobs API.

### DIFF
--- a/cmd/frontend/graphqlbackend/permission_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permission_sync_jobs.go
@@ -1,0 +1,29 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+)
+
+// PermissionSyncJobsResolver is a main interface for all GraphQL operations with
+// permission sync jobs.
+type PermissionSyncJobsResolver interface {
+	PermissionSyncJobs(ctx context.Context, args *ListPermissionSyncJobsArgs) (PermissionSyncJobConnectionResolver, error)
+}
+
+// PermissionSyncJobConnectionResolver is an interface for querying lists of
+// permission sync jobs.
+type PermissionSyncJobConnectionResolver interface {
+	Nodes(ctx context.Context) ([]PermissionSyncJobResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+type PermissionSyncJobResolver interface {
+	ID() graphql.ID
+}
+
+type ListPermissionSyncJobsArgs struct {
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs.go
@@ -1,0 +1,79 @@
+package resolvers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+var _ graphqlbackend.PermissionSyncJobsResolver = &permissionSyncJobsResolver{}
+
+type permissionSyncJobsResolver struct {
+	db database.DB
+}
+
+func NewPermissionSyncJobsResolver(db database.DB) graphqlbackend.PermissionSyncJobsResolver {
+	return &permissionSyncJobsResolver{db: db}
+}
+
+func (r *permissionSyncJobsResolver) PermissionSyncJobs(ctx context.Context, args *graphqlbackend.ListPermissionSyncJobsArgs) (graphqlbackend.PermissionSyncJobConnectionResolver, error) {
+	return &permissionSyncJobConnectionResolver{db: r.db}, nil
+}
+
+type permissionSyncJobConnectionResolver struct {
+	db   database.DB
+	once sync.Once
+	jobs []*database.PermissionSyncJob
+	err  error
+}
+
+func (p *permissionSyncJobConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.PermissionSyncJobResolver, error) {
+	jobs, err := p.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvers := make([]graphqlbackend.PermissionSyncJobResolver, 0, len(jobs))
+	for _, job := range jobs {
+		resolvers = append(resolvers, &permissionSyncJobResolver{
+			db:  p.db,
+			job: job,
+		})
+	}
+	return resolvers, nil
+}
+
+func (p *permissionSyncJobConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	if p.err != nil {
+		return 0, p.err
+	}
+	return int32(len(p.jobs)), nil
+}
+
+func (p *permissionSyncJobConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return nil, nil
+}
+
+func (p *permissionSyncJobConnectionResolver) compute(ctx context.Context) ([]*database.PermissionSyncJob, error) {
+	p.once.Do(func() {
+		p.jobs, p.err = p.db.PermissionSyncJobs().List(ctx, database.ListPermissionSyncJobOpts{})
+	})
+	return p.jobs, p.err
+}
+
+type permissionSyncJobResolver struct {
+	db  database.DB
+	job *database.PermissionSyncJob
+}
+
+func (p *permissionSyncJobResolver) ID() graphql.ID {
+	return marshalPermissionSyncJobID(p.job.ID)
+}
+
+func marshalPermissionSyncJobID(id int) graphql.ID {
+	return relay.MarshalID("PermissionSyncJob", id)
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs_test.go
@@ -1,0 +1,47 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionSyncJobsResolver(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("No jobs found", func(t *testing.T) {
+		db := database.NewMockDB()
+
+		jobsStore := database.NewMockPermissionSyncJobStore()
+		jobsStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{}, nil)
+
+		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
+
+		resolver := NewPermissionSyncJobsResolver(db)
+		jobsResolver, err := resolver.PermissionSyncJobs(ctx, &graphqlbackend.ListPermissionSyncJobsArgs{})
+		require.NoError(t, err)
+		jobs, err := jobsResolver.Nodes(ctx)
+		require.NoError(t, err)
+		require.Empty(t, jobs)
+	})
+
+	t.Run("One job found", func(t *testing.T) {
+		db := database.NewMockDB()
+
+		jobsStore := database.NewMockPermissionSyncJobStore()
+		jobsStore.ListFunc.SetDefaultReturn([]*database.PermissionSyncJob{{ID: 1}}, nil)
+
+		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
+
+		resolver := NewPermissionSyncJobsResolver(db)
+		jobsResolver, err := resolver.PermissionSyncJobs(ctx, &graphqlbackend.ListPermissionSyncJobsArgs{})
+		require.NoError(t, err)
+		jobs, err := jobsResolver.Nodes(ctx)
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+		require.Equal(t, marshalPermissionSyncJobID(1), jobs[0].ID())
+	})
+}


### PR DESCRIPTION
# WIP

## Just want to test will the build pass when there is an API (gql resolvers) added without extending the GraphQL schema itself.