### PR TITLE
insights: use escaped view title in data export filename

### DIFF
--- a/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { escapeRegExp } from 'lodash'
 
-import { Modal, Text, H2 } from '@sourcegraph/wildcard'
+import {Modal, Text, H2, Link} from '@sourcegraph/wildcard'
 
 import { DownloadFileButton } from '../DownloadFileButton'
 
@@ -22,7 +22,8 @@ export const ExportInsightDataModal: FC<ExportInsightDataModalProps> = props => 
             <H2 className="font-weight-normal">Export data for '{insightTitle}' insight?</H2>
 
             <Text className="mt-4 mb-2">
-                This will create a CVS archive of all data for this Code Insight, including data that has been archived.
+                This will create a CSV archive of all data for this Code Insight, including
+                <Link to="/help/code_insights/explanations/data_retention" target="_blank" rel="noopener"> data that has been archived</Link>.
             </Text>
             <Text>This will only include data that you are permitted to see.</Text>
             <div className="d-flex justify-content-end mt-5">

--- a/enterprise/internal/insights/httpapi/export.go
+++ b/enterprise/internal/insights/httpapi/export.go
@@ -7,6 +7,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -61,7 +62,7 @@ func (h *ExportHandler) ExportFunc() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/zip")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"CodeInsightsDataExport-%s.zip\"", archive.name))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", archive.name))
 
 		_, err = w.Write(archive.data)
 		if err != nil {
@@ -133,7 +134,8 @@ func (h *ExportHandler) exportCodeInsightData(ctx context.Context, id string) (*
 	zw := zip.NewWriter(&buf)
 
 	timestamp := time.Now().Format(time.RFC3339)
-	name := fmt.Sprintf("%s-%s", insightViewId, timestamp)
+	escapedInsightViewTitle := regexp.MustCompile(`\W+`).ReplaceAllString(visibleViewSeries[0].Title, "-")
+	name := fmt.Sprintf("%s-%s", escapedInsightViewTitle, timestamp)
 
 	dataFile, err := zw.Create(fmt.Sprintf("%s.csv", name))
 	if err != nil {


### PR DESCRIPTION
closes #46876 

also add a link to data retention docs

<img width="561" alt="Screenshot 2023-02-02 at 13 46 08" src="https://user-images.githubusercontent.com/29406849/216342237-88c4bd35-ee1c-4491-99fc-110ee9026a5f.png">

## Test plan

Tested through curl and UI export with a file with special characters (specifically `\` which created folders prior)

| before | after |
| -- | -- |
| <img width="392" alt="Screenshot 2023-02-02 at 13 49 33" src="https://user-images.githubusercontent.com/29406849/216342547-e78d2ab4-feab-41bc-9625-c89906f00d0a.png">  | 
<img width="509" alt="image" src="https://user-images.githubusercontent.com/29406849/216342711-33b7faf1-ad2c-4eda-b89c-59e105ffa353.png"> | 

