### PR TITLE
search: send stats for retry of structural search

### DIFF
--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -120,9 +120,16 @@ func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *
 	event := agg.SearchEvent
 	if len(event.Results) == 0 && err == nil {
 		// retry structural search with a higher limit.
-		agg := streaming.NewAggregatingStream()
-		err := retryStructuralSearch(ctx, clients, args, repos, agg)
+		aggRetry := streaming.NewAggregatingStream()
+		err := retryStructuralSearch(ctx, clients, args, repos, aggRetry)
 		if err != nil {
+			// It is possible that the retry couldn't search any repos before the context
+			// expired, in which case we send the stats from the first try.
+			stats := aggRetry.Stats
+			if stats.Zero() {
+				stats = agg.Stats
+			}
+			stream.Send(streaming.SearchEvent{Stats: stats})
 			return err
 		}
 


### PR DESCRIPTION
fixes #47317 

[Our code assumes that timeouts are communicated via stats and not via errors](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6d607386d3a8934d7fa3633ac9eaf1c49038218f/-/blob/internal/search/alert/observer.go?L167:20-167:25). However, for structural search, if the retry fails, we don't send any stats. This can lead to a "success" status even if the search timed out.

This triggered our alarms over the last couple of days because our sentinel query for structural seems to suddenly take the retry code path.

## Test plan
- Manual testing
