### PR TITLE
refactor ConnectionResolver to work with interfaces and concrete types

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -22,9 +22,9 @@ type ConnectionResolverStore[N any] interface {
 	// ComputeTotal returns the total count of all the items in the connection, independent of pagination arguments.
 	ComputeTotal(context.Context) (*int32, error)
 	// ComputeNodes returns the list of nodes based on the pagination args.
-	ComputeNodes(context.Context, *database.PaginationArgs) ([]*N, error)
+	ComputeNodes(context.Context, *database.PaginationArgs) ([]N, error)
 	// MarshalCursor returns cursor for a node and is called for generating start and end cursors.
-	MarshalCursor(*N, database.OrderBy) (*string, error)
+	MarshalCursor(N, database.OrderBy) (*string, error)
 	// UnmarshalCursor returns node id from after/before cursor string.
 	UnmarshalCursor(string, database.OrderBy) (*string, error)
 }
@@ -94,7 +94,7 @@ type connectionData[N any] struct {
 	total      *int32
 	totalError error
 
-	nodes      []*N
+	nodes      []N
 	nodesError error
 }
 
@@ -161,7 +161,7 @@ func (r *ConnectionResolver[N]) TotalCount(ctx context.Context) (int32, error) {
 }
 
 // Nodes returns value for connection.Nodes and is called by the graphql api.
-func (r *ConnectionResolver[N]) Nodes(ctx context.Context) ([]*N, error) {
+func (r *ConnectionResolver[N]) Nodes(ctx context.Context) ([]N, error) {
 	r.once.nodes.Do(func() {
 		paginationArgs, err := r.paginationArgs()
 		if err != nil {
@@ -222,7 +222,7 @@ func (r *ConnectionResolver[N]) PageInfo(ctx context.Context) (*ConnectionPageIn
 type ConnectionPageInfo[N any] struct {
 	pageSize          int
 	fetchedNodesCount int
-	nodes             []*N
+	nodes             []N
 	store             ConnectionResolverStore[N]
 	args              *ConnectionResolverArgs
 	orderBy           database.OrderBy

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -125,7 +125,7 @@ func withBeforePA(before string, a *database.PaginationArgs) *database.Paginatio
 func TestConnectionTotalCount(t *testing.T) {
 	ctx := context.Background()
 	store := &testConnectionStore{t: t}
-	resolver, err := NewConnectionResolver[testConnectionNode](store, withFirstCA(1, &ConnectionResolverArgs{}), nil)
+	resolver, err := NewConnectionResolver[*testConnectionNode](store, withFirstCA(1, &ConnectionResolverArgs{}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestConnectionTotalCount(t *testing.T) {
 	}
 }
 
-func testResolverNodesResponse(t *testing.T, resolver *ConnectionResolver[testConnectionNode], store *testConnectionStore, count int) {
+func testResolverNodesResponse(t *testing.T, resolver *ConnectionResolver[*testConnectionNode], store *testConnectionStore, count int) {
 	ctx := context.Background()
 	nodes, err := resolver.Nodes(ctx)
 	if err != nil {
@@ -209,7 +209,7 @@ func TestConnectionNodes(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			store := &testConnectionStore{t: t, expectedPaginationArgs: test.wantPaginationArgs}
-			resolver, err := NewConnectionResolver[testConnectionNode](store, test.connectionArgs, nil)
+			resolver, err := NewConnectionResolver[*testConnectionNode](store, test.connectionArgs, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -226,7 +226,7 @@ type pageInfoResponse struct {
 	hasPreviousPage bool
 }
 
-func testResolverPageInfoResponse(t *testing.T, resolver *ConnectionResolver[testConnectionNode], store *testConnectionStore, expectedResponse *pageInfoResponse) {
+func testResolverPageInfoResponse(t *testing.T, resolver *ConnectionResolver[*testConnectionNode], store *testConnectionStore, expectedResponse *pageInfoResponse) {
 	ctx := context.Background()
 	pageInfo, err := resolver.PageInfo(ctx)
 	if err != nil {
@@ -301,7 +301,7 @@ func TestConnectionPageInfo(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			store := &testConnectionStore{t: t}
-			resolver, err := NewConnectionResolver[testConnectionNode](store, test.args, nil)
+			resolver, err := NewConnectionResolver[*testConnectionNode](store, test.args, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -45,7 +45,7 @@ type InsightsResolver interface {
 	// Admin Management
 	InsightSeriesQueryStatus(ctx context.Context) ([]InsightSeriesQueryStatusResolver, error)
 	InsightViewDebug(ctx context.Context, args InsightViewDebugArgs) (InsightViewDebugResolver, error)
-	InsightAdminBackfillQueue(ctx context.Context, args *AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[BackfillQueueItemResolver], error)
+	InsightAdminBackfillQueue(ctx context.Context, args *AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[*BackfillQueueItemResolver], error)
 	// Admin Mutations
 	UpdateInsightSeries(ctx context.Context, args *UpdateInsightSeriesArgs) (InsightSeriesMetadataPayloadResolver, error)
 	// RetryInsightSeriesBackfill(ctx context.Context, args *BackfillArgs) (InsightBackfillQueueItemResolver, error)

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -144,7 +144,7 @@ func (o *OrgResolver) CreatedAt() gqlutil.DateTime { return gqlutil.DateTime{Tim
 func (o *OrgResolver) Members(ctx context.Context, args struct {
 	graphqlutil.ConnectionResolverArgs
 	Query *string
-}) (*graphqlutil.ConnectionResolver[UserResolver], error) {
+}) (*graphqlutil.ConnectionResolver[*UserResolver], error) {
 	// 🚨 SECURITY: Only org members can list other org members.
 	if err := checkMembersAccess(ctx, o.db, o.org.ID); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (o *OrgResolver) Members(ctx context.Context, args struct {
 		query: args.Query,
 	}
 
-	return graphqlutil.NewConnectionResolver[UserResolver](connectionStore, &args.ConnectionResolverArgs, nil)
+	return graphqlutil.NewConnectionResolver[*UserResolver](connectionStore, &args.ConnectionResolverArgs, nil)
 }
 
 type membersConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -91,7 +91,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	return opt, nil
 }
 
-func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs) (*graphqlutil.ConnectionResolver[RepositoryResolver], error) {
+func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs) (*graphqlutil.ConnectionResolver[*RepositoryResolver], error) {
 	opt, err := args.toReposListOptions()
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs)
 		Ascending:   !args.Descending,
 	}
 
-	return graphqlutil.NewConnectionResolver[RepositoryResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
+	return graphqlutil.NewConnectionResolver[*RepositoryResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }
 
 type repositoriesConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -22,7 +22,7 @@ type repositoryContributorsArgs struct {
 func (r *RepositoryResolver) Contributors(args *struct {
 	repositoryContributorsArgs
 	graphqlutil.ConnectionResolverArgs
-}) (*graphqlutil.ConnectionResolver[repositoryContributorResolver], error) {
+}) (*graphqlutil.ConnectionResolver[*repositoryContributorResolver], error) {
 	connectionStore := &repositoryContributorConnectionStore{
 		db:             r.db,
 		args:           &args.repositoryContributorsArgs,
@@ -33,7 +33,7 @@ func (r *RepositoryResolver) Contributors(args *struct {
 	connectionOptions := graphqlutil.ConnectionResolverOptions{
 		Reverse: &reverse,
 	}
-	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
+	return graphqlutil.NewConnectionResolver[*repositoryContributorResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }
 
 type repositoryContributorConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -118,7 +118,7 @@ type savedSearchesArgs struct {
 	Namespace graphql.ID
 }
 
-func (r *schemaResolver) SavedSearches(ctx context.Context, args savedSearchesArgs) (*graphqlutil.ConnectionResolver[savedSearchResolver], error) {
+func (r *schemaResolver) SavedSearches(ctx context.Context, args savedSearchesArgs) (*graphqlutil.ConnectionResolver[*savedSearchResolver], error) {
 	var userID, orgID int32
 	if err := UnmarshalNamespaceID(args.Namespace, &userID, &orgID); err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (r *schemaResolver) SavedSearches(ctx context.Context, args savedSearchesAr
 		orgID:  &orgID,
 	}
 
-	return graphqlutil.NewConnectionResolver[savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, nil)
+	return graphqlutil.NewConnectionResolver[*savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, nil)
 }
 
 type savedSearchesConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -158,7 +158,7 @@ func (r *siteConfigurationResolver) ValidationMessages(ctx context.Context) ([]s
 	return conf.ValidateSite(string(contents))
 }
 
-func (r *siteConfigurationResolver) History(ctx context.Context, args *graphqlutil.ConnectionResolverArgs) (*graphqlutil.ConnectionResolver[SiteConfigurationChangeResolver], error) {
+func (r *siteConfigurationResolver) History(ctx context.Context, args *graphqlutil.ConnectionResolverArgs) (*graphqlutil.ConnectionResolver[*SiteConfigurationChangeResolver], error) {
 	// 🚨 SECURITY: The site configuration contains secret tokens and credentials,
 	// so only admins may view the history.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
@@ -167,7 +167,7 @@ func (r *siteConfigurationResolver) History(ctx context.Context, args *graphqlut
 
 	connectionStore := SiteConfigurationChangeConnectionStore{db: r.db}
 
-	return graphqlutil.NewConnectionResolver[SiteConfigurationChangeResolver](
+	return graphqlutil.NewConnectionResolver[*SiteConfigurationChangeResolver](
 		&connectionStore,
 		args,
 		nil,

--- a/enterprise/internal/insights/resolvers/admin_resolver.go
+++ b/enterprise/internal/insights/resolvers/admin_resolver.go
@@ -256,7 +256,7 @@ func (r *insightViewDebugResolver) Raw(ctx context.Context) ([]string, error) {
 	return viewDebug, nil
 }
 
-func (r *Resolver) InsightAdminBackfillQueue(ctx context.Context, args *graphqlbackend.AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.BackfillQueueItemResolver], error) {
+func (r *Resolver) InsightAdminBackfillQueue(ctx context.Context, args *graphqlbackend.AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[*graphqlbackend.BackfillQueueItemResolver], error) {
 	// 🚨 SECURITY
 	// only admin users can access this resolver
 	actr := actor.FromContext(ctx)
@@ -275,7 +275,7 @@ func (r *Resolver) InsightAdminBackfillQueue(ctx context.Context, args *graphqlb
 		orderBy = args.OrderBy
 	}
 
-	resolver, err := graphqlutil.NewConnectionResolver[graphqlbackend.BackfillQueueItemResolver](
+	resolver, err := graphqlutil.NewConnectionResolver[*graphqlbackend.BackfillQueueItemResolver](
 		store,
 		&args.ConnectionResolverArgs,
 		&graphqlutil.ConnectionResolverOptions{

--- a/enterprise/internal/insights/resolvers/disabled_resolver.go
+++ b/enterprise/internal/insights/resolvers/disabled_resolver.go
@@ -100,6 +100,6 @@ func (r *disabledResolver) PreviewRepositoriesFromQuery(ctx context.Context, arg
 	return nil, errors.New(r.reason)
 }
 
-func (r *disabledResolver) InsightAdminBackfillQueue(ctx context.Context, args *graphqlbackend.AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.BackfillQueueItemResolver], error) {
+func (r *disabledResolver) InsightAdminBackfillQueue(ctx context.Context, args *graphqlbackend.AdminBackfillQueueArgs) (*graphqlutil.ConnectionResolver[*graphqlbackend.BackfillQueueItemResolver], error) {
 	return nil, errors.New(r.reason)
 }


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Confirm it works with both interfaces and concrete types.