### PR TITLE
Fix layout shifts on the new tree pages

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -543,11 +543,7 @@ export const BlobPage: FC<BlobPageProps> = ({ className, ...props }) => {
                 </React.Suspense>
             )}
             {!isSearchNotebook && blobInfoOrError.richHTML && renderMode === 'rendered' && (
-                <RenderedFile
-                    dangerousInnerHTML={blobInfoOrError.richHTML}
-                    location={location}
-                    className={styles.border}
-                />
+                <RenderedFile dangerousInnerHTML={blobInfoOrError.richHTML} className={styles.border} />
             )}
             {!blobInfoOrError.richHTML && blobInfoOrError.aborted && (
                 <div>

--- a/client/web/src/repo/blob/RenderedFile.tsx
+++ b/client/web/src/repo/blob/RenderedFile.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react'
 
 import classNames from 'classnames'
-import * as H from 'history'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Markdown } from '@sourcegraph/wildcard'
 
@@ -10,18 +10,17 @@ import { useScrollToLocationHash } from '../../components/useScrollToLocationHas
 import styles from './RenderedFile.module.scss'
 
 interface Props {
-    /** The rendered HTML contents of the file. */
     dangerousInnerHTML: string
-    location: H.Location
     className?: string
 }
 
 /**
  * Displays a file whose contents are rendered to HTML, such as a Markdown file.
  */
-export const RenderedFile = forwardRef<HTMLDivElement, Props>((props, reference) => {
-    const { dangerousInnerHTML, location, className } = props
+export const RenderedFile = forwardRef<HTMLDivElement, Props>(function RenderedFile(props, reference) {
+    const { dangerousInnerHTML, className } = props
 
+    const location = useLocation()
     useScrollToLocationHash(location)
 
     return (

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -22,6 +22,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    // 30rem for the readme height + 1.5rem for the link that will be rendered
+    // below it and additional margin.
     height: 31.5rem;
 }
 

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -22,7 +22,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 30rem;
+    height: 31.5rem;
 }
 
 .card-col-header-wrapper {

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -18,6 +18,13 @@
     }
 }
 
+.readme-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 30rem;
+}
+
 .card-col-header-wrapper {
     background-color: var(--color-bg-2);
 

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useCallback, useRef, useState, useMemo } from 'react'
+import React, { FC, useCallback, useRef, useState, useMemo, useEffect } from 'react'
 
 import { mdiFileDocumentOutline, mdiFolderOutline, mdiMenuDown, mdiMenuUp } from '@mdi/js'
 import classNames from 'classnames'
-import * as H from 'history'
 
 import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import {
@@ -11,48 +10,76 @@ import {
     Icon,
     Link,
     LinkOrSpan,
+    LoadingSpinner,
     ParentSize,
     StackedMeter,
     Tooltip,
     useElementObscuredArea,
 } from '@sourcegraph/wildcard'
 
+import { BlobFileFields } from '../../graphql-operations'
 import { dirname } from '../../util/path'
+import { fetchBlob } from '../blob/backend'
 import { RenderedFile } from '../blob/RenderedFile'
 
 import styles from './TreePagePanels.module.scss'
 
 interface ReadmePreviewCardProps {
-    readmeHTML: string
-    readmeURL: string
-    location: H.Location
-    className?: string
+    entry: TreeFields['entries'][number]
+    repoName: string
+    revision: string
 }
+export const ReadmePreviewCard: React.FunctionComponent<ReadmePreviewCardProps> = ({ entry, repoName, revision }) => {
+    const [readmeInfo, setReadmeInfo] = useState<null | BlobFileFields>(null)
 
-export const ReadmePreviewCard: React.FunctionComponent<ReadmePreviewCardProps> = props => {
-    const { readmeHTML, readmeURL, location, className } = props
-
-    const renderedFileRef = useRef<HTMLDivElement>(null)
-    const { bottom } = useElementObscuredArea(renderedFileRef)
+    useEffect(() => {
+        const subscription = fetchBlob({
+            repoName,
+            revision,
+            filePath: entry.path,
+            disableTimeout: true,
+        }).subscribe(blob => {
+            if (blob) {
+                setReadmeInfo(blob)
+            } else {
+                setReadmeInfo(null)
+            }
+        })
+        return () => subscription.unsubscribe()
+    }, [repoName, revision, entry.path])
 
     return (
-        <section className={className}>
-            <RenderedFile
-                key={readmeHTML}
-                ref={renderedFileRef}
-                location={location}
-                dangerousInnerHTML={readmeHTML}
-                className={styles.readme}
-            />
+        <section className="mb-4">
+            {readmeInfo ? (
+                <RenderedReadmeFile blob={readmeInfo} entryUrl={entry.url} />
+            ) : (
+                <div className={classNames('text-muted', styles.readmeLoading)}>
+                    <LoadingSpinner />
+                </div>
+            )}
+        </section>
+    )
+}
+
+interface RenderedReadmeFileProps {
+    blob: BlobFileFields
+    entryUrl: string
+}
+const RenderedReadmeFile: React.FC<RenderedReadmeFileProps> = ({ blob, entryUrl }) => {
+    const renderedFileRef = useRef<HTMLDivElement>(null)
+    const { bottom } = useElementObscuredArea(renderedFileRef)
+    return (
+        <>
+            <RenderedFile ref={renderedFileRef} dangerousInnerHTML={blob.richHTML} className={styles.readme} />
             {bottom > 0 && (
                 <>
                     <div className={styles.readmeFader} />
-                    <Link to={readmeURL} className={styles.readmeMoreLink}>
+                    <Link to={entryUrl} className={styles.readmeMoreLink}>
                         View full README
                     </Link>
                 </>
             )}
-        </section>
+        </>
     )
 }
 


### PR DESCRIPTION
Part of #44627

The readme was finishing the rendering after we've already rendered the file content, which caused an annoying layout shift whenever we navigate between tree pages:

https://user-images.githubusercontent.com/458591/216358584-4f1af589-a620-47ca-ad1c-5ae2fb376bf4.mov

This fix shows a loading indicator now that uses the max-width of `40rem`. There will still be a layout shift for readme that are shorter than 40rem but that's fine since it feels less annoying and in my limited test, most readmes are definitely longer. 

## Test plan


https://user-images.githubusercontent.com/458591/216359875-8a0a940a-fa79-4993-853e-5e428b2ec2bd.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-layout-shifts-on-repo-route.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
