### PR TITLE
docs: update resource estimator version

### DIFF
--- a/doc/admin/install/resource_estimator.md
+++ b/doc/admin/install/resource_estimator.md
@@ -39,6 +39,6 @@
 </style>
 
 <script src="https://storage.googleapis.com/sourcegraph-resource-estimator/go_1_14_wasm_exec.js"></script>
-<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="94ad774"></script>
+<script src="https://storage.googleapis.com/sourcegraph-resource-estimator/launch_script.js?v2" version="5dd901d"></script>
 
 <form id="root"></form>


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/43069

Update resource estimator version that includes changes in [this PR](https://github.com/sourcegraph/resource-estimator/pull/22):
- Replace `minio` with `blobstore`
- Replace `Docker Compose` with `AMIs` in `Recommend Deployment Type`
- Add `Instance Size` to the output
- Remove override file export for `Docker Compose` --we should create override files and link them in the docs for each instance size instead

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally:

![image](https://user-images.githubusercontent.com/68532117/216374051-c00a6192-7495-4079-ab7a-4a4cf663818f.png)
