### PR TITLE
Prioritise SSO sign-in if exists

### DIFF
--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -4,7 +4,7 @@ import { Route, Routes } from 'react-router-dom-v5-compat'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { AuthenticatedUser } from '../auth'
-import { SourcegraphContext } from '../jscontext'
+import { AuthProvider, SourcegraphContext } from '../jscontext'
 
 import { SignInPage } from './SignInPage'
 
@@ -26,44 +26,25 @@ describe('SignInPage', () => {
         },
     ]
 
-    it('renders sign in page (server)', () => {
-        expect(
-            renderWithBrandedContext(
-                <Routes>
-                    <Route
-                        path="/sign-in"
-                        element={
-                            <SignInPage
-                                authenticatedUser={null}
-                                context={{
-                                    allowSignup: true,
-                                    sourcegraphDotComMode: false,
-                                    authProviders,
-                                    resetPasswordEnabled: true,
-                                    xhrHeaders: {},
-                                }}
-                                isSourcegraphDotCom={false}
-                            />
-                        }
-                    />
-                </Routes>,
-                { route: '/sign-in' }
-            ).asFragment()
-        ).toMatchSnapshot()
-    })
-
-    const render = (route: string, authProviders: SourcegraphContext['authProviders']) =>
+    const render = (
+        route: string,
+        props: {
+            authProviders?: AuthProvider[]
+            authenticatedUser?: AuthenticatedUser
+            sourcegraphDotComMode?: boolean
+        }
+    ) =>
         renderWithBrandedContext(
             <Routes>
                 <Route
                     path="/sign-in"
                     element={
                         <SignInPage
-                            authenticatedUser={null}
+                            authenticatedUser={props.authenticatedUser ?? null}
                             context={{
                                 allowSignup: true,
-                                sourcegraphDotComMode: false,
-                                authProviders,
+                                sourcegraphDotComMode: props.sourcegraphDotComMode ?? false,
+                                authProviders: props.authProviders ?? authProviders,
                                 resetPasswordEnabled: true,
                                 xhrHeaders: {},
                             }}
@@ -74,6 +55,11 @@ describe('SignInPage', () => {
             </Routes>,
             { route }
         )
+
+    it('renders sign in page (server)', () => {
+        const rendered = render('/sign-in', {})
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
 
     describe('with Sourcegraph operator auth provider', () => {
         const withSourcegraphOperator: SourcegraphContext['authProviders'] = [
@@ -88,7 +74,7 @@ describe('SignInPage', () => {
         ]
 
         it('renders page with 2 providers', () => {
-            const rendered = render('/sign-in', withSourcegraphOperator)
+            const rendered = render('/sign-in', { authProviders: withSourcegraphOperator })
             expect(
                 within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Operators'))
             ).not.toBeInTheDocument()
@@ -96,7 +82,7 @@ describe('SignInPage', () => {
         })
 
         it('renders page with 3 providers (url-param present)', () => {
-            const rendered = render('/sign-in?sourcegraph-operator', withSourcegraphOperator)
+            const rendered = render('/sign-in?sourcegraph-operator', { authProviders: withSourcegraphOperator })
             expect(
                 within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Operators'))
             ).toBeInTheDocument()
@@ -116,36 +102,14 @@ describe('SignInPage', () => {
             },
         ]
         it('does not render the Gerrit provider', () => {
-            const rendered = render('/sign-in', withGerritProvider)
+            const rendered = render('/sign-in', { authProviders: withGerritProvider })
             expect(within(rendered.baseElement).queryByText(txt => txt.includes('Gerrit'))).not.toBeInTheDocument()
             expect(rendered.asFragment()).toMatchSnapshot()
         })
     })
 
     it('renders sign in page (cloud)', () => {
-        expect(
-            renderWithBrandedContext(
-                <Routes>
-                    <Route
-                        path="/sign-in"
-                        element={
-                            <SignInPage
-                                authenticatedUser={null}
-                                context={{
-                                    allowSignup: true,
-                                    sourcegraphDotComMode: true,
-                                    authProviders,
-                                    resetPasswordEnabled: true,
-                                    xhrHeaders: {},
-                                }}
-                                isSourcegraphDotCom={false}
-                            />
-                        }
-                    />
-                </Routes>,
-                { route: '/sign-in' }
-            ).asFragment()
-        ).toMatchSnapshot()
+        expect(render('/sign-in', { sourcegraphDotComMode: true }).asFragment()).toMatchSnapshot()
     })
 
     it('renders redirect when user is authenticated', () => {
@@ -157,28 +121,6 @@ describe('SignInPage', () => {
             siteAdmin: true,
         } as AuthenticatedUser
 
-        expect(
-            renderWithBrandedContext(
-                <Routes>
-                    <Route
-                        path="/sign-in"
-                        element={
-                            <SignInPage
-                                authenticatedUser={mockUser}
-                                context={{
-                                    allowSignup: true,
-                                    sourcegraphDotComMode: false,
-                                    authProviders,
-                                    xhrHeaders: {},
-                                    resetPasswordEnabled: true,
-                                }}
-                                isSourcegraphDotCom={false}
-                            />
-                        }
-                    />
-                </Routes>,
-                { route: '/sign-in' }
-            ).asFragment()
-        ).toMatchSnapshot()
+        expect(render('/sign-in', { authenticatedUser: mockUser }).asFragment()).toMatchSnapshot()
     })
 })

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -58,6 +58,31 @@ describe('SignInPage', () => {
 
     it('renders sign in page (server)', () => {
         const rendered = render('/sign-in', {})
+        expect(
+            within(rendered.baseElement)
+                .queryByText(txt => txt.includes('Continue with Email'))
+                ?.closest('a')
+        ).toHaveAttribute('href', '/sign-in?email=1')
+
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
+
+    it('renders sign in page (server) with email form expanded', () => {
+        const rendered = render('/sign-in?email=1', {})
+        expect(
+            within(rendered.baseElement).queryByText(txt => txt.includes('Continue with Email'))
+        ).not.toBeInTheDocument()
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
+
+    it('renders sign in page (server) with only builtin authProvider', () => {
+        const rendered = render('/sign-in', {
+            authProviders: authProviders.filter(authProvider => authProvider.serviceType === 'builtin'),
+        })
+        expect(
+            within(rendered.baseElement).queryByText(txt => txt.includes('Continue with Email'))
+        ).not.toBeInTheDocument()
+
         expect(rendered.asFragment()).toMatchSnapshot()
     })
 

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -62,7 +62,7 @@ describe('SignInPage', () => {
             within(rendered.baseElement)
                 .queryByText(txt => txt.includes('Continue with Email'))
                 ?.closest('a')
-        ).toHaveAttribute('href', '/sign-in?email=1')
+        ).toHaveAttribute('href', '/sign-in?email=1&')
 
         expect(rendered.asFragment()).toMatchSnapshot()
     })

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react'
 
-import { mdiBitbucket, mdiGithub, mdiGitlab } from '@mdi/js'
+import { mdiBitbucket, mdiGithub, mdiGitlab, mdiEmail } from '@mdi/js'
 import classNames from 'classnames'
 import { partition } from 'lodash'
 import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 
-import { Alert, Icon, Text, Link, AnchorLink, Button, ErrorAlert } from '@sourcegraph/wildcard'
+import { Alert, Icon, Text, Link, Button, ErrorAlert } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { HeroPage } from '../components/HeroPage'
@@ -59,6 +59,11 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
 
+    const searchParams = new URLSearchParams(location.search)
+    const showBuiltInAuthForm = searchParams.has('email') || thirdPartyAuthProviders.length === 0
+    searchParams.set('email', '1')
+    const builtInAuthProviderURL = `${location.pathname}?${searchParams.toString()}`
+
     const body =
         !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (
             <Alert className="mt-3" variant="info">
@@ -74,39 +79,39 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                         error ? 'mt-3' : 'mt-4'
                     )}
                 >
-                    {builtInAuthProvider && (
+                    {builtInAuthProvider && showBuiltInAuthForm && (
                         <UsernamePasswordSignInForm
                             {...props}
                             onAuthError={setError}
-                            noThirdPartyProviders={thirdPartyAuthProviders.length === 0}
+                            className={classNames(thirdPartyAuthProviders.length > 0 && 'mb-3')}
                         />
                     )}
-                    {builtInAuthProvider && thirdPartyAuthProviders.length > 0 && <OrDivider className="mb-3 py-1" />}
+                    {builtInAuthProvider && showBuiltInAuthForm && thirdPartyAuthProviders.length > 0 && (
+                        <OrDivider className="mb-3 py-1" />
+                    )}
                     {thirdPartyAuthProviders.map((provider, index) => (
                         // Use index as key because display name may not be unique. This is OK
                         // here because this list will not be updated during this component's lifetime.
                         /* eslint-disable react/no-array-index-key */
                         <div className="mb-2" key={index}>
-                            <Button to={provider.authenticationURL} display="block" variant="secondary" as={AnchorLink}>
-                                {provider.serviceType === 'github' && (
-                                    <>
-                                        <Icon aria-hidden={true} svgPath={mdiGithub} />{' '}
-                                    </>
-                                )}
-                                {provider.serviceType === 'gitlab' && (
-                                    <>
-                                        <Icon aria-hidden={true} svgPath={mdiGitlab} />{' '}
-                                    </>
-                                )}
+                            <Button to={provider.authenticationURL} display="block" variant="secondary" as={Link}>
+                                {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
+                                {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
                                 {provider.serviceType === 'bitbucketCloud' && (
-                                    <>
-                                        <Icon aria-hidden={true} svgPath={mdiBitbucket} />{' '}
-                                    </>
-                                )}
+                                    <Icon aria-hidden={true} svgPath={mdiBitbucket} />
+                                )}{' '}
                                 Continue with {provider.displayName}
                             </Button>
                         </div>
                     ))}
+                    {builtInAuthProvider && !showBuiltInAuthForm && (
+                        <div className="mb-2">
+                            <Button to={builtInAuthProviderURL} display="block" variant="secondary" as={Link}>
+                                <Icon aria-hidden={true} svgPath={mdiEmail} />
+                                Continue with Email
+                            </Button>
+                        </div>
+                    )}
                 </div>
                 {props.context.allowSignup ? (
                     <Text>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -94,7 +94,12 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                         // here because this list will not be updated during this component's lifetime.
                         /* eslint-disable react/no-array-index-key */
                         <div className="mb-2" key={index}>
-                            <Button to={provider.authenticationURL} display="block" variant="secondary" as={Link}>
+                            <Button
+                                to={provider.authenticationURL}
+                                display="block"
+                                variant={showBuiltInAuthForm ? 'secondary' : 'primary'}
+                                as={Link}
+                            >
                                 {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
                                 {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
                                 {provider.serviceType === 'bitbucketCloud' && (

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -107,8 +107,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                     {builtInAuthProvider && !showBuiltInAuthForm && (
                         <div className="mb-2">
                             <Button to={builtInAuthProviderURL} display="block" variant="secondary" as={Link}>
-                                <Icon aria-hidden={true} svgPath={mdiEmail} />
-                                Continue with Email
+                                <Icon aria-hidden={true} svgPath={mdiEmail} /> Continue with Email
                             </Button>
                         </div>
                     )}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { mdiBitbucket, mdiGithub, mdiGitlab, mdiEmail } from '@mdi/js'
 import classNames from 'classnames'
 import { partition } from 'lodash'
-import { Navigate, useLocation } from 'react-router-dom-v5-compat'
+import { Navigate, useLocation, useSearchParams } from 'react-router-dom-v5-compat'
 
 import { Alert, Icon, Text, Link, Button, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -34,6 +34,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)
+    const [searchParams] = useSearchParams()
 
     if (props.authenticatedUser) {
         const returnTo = getReturnTo(location)
@@ -49,7 +50,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
         // Hide the Sourcegraph Operator authentication provider by default because it is
         // not useful to customer users and may even cause confusion.
         if (provider.serviceType === 'sourcegraph-operator') {
-            return new URLSearchParams(location.search).has('sourcegraph-operator')
+            return searchParams.has('sourcegraph-operator')
         }
         if (provider.serviceType === 'gerrit') {
             return false
@@ -59,10 +60,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
 
-    const searchParams = new URLSearchParams(location.search)
     const showBuiltInAuthForm = searchParams.has('email') || thirdPartyAuthProviders.length === 0
-    searchParams.set('email', '1')
-    const builtInAuthProviderURL = `${location.pathname}?${searchParams.toString()}`
 
     const body =
         !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (
@@ -111,7 +109,12 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                     ))}
                     {builtInAuthProvider && !showBuiltInAuthForm && (
                         <div className="mb-2">
-                            <Button to={builtInAuthProviderURL} display="block" variant="secondary" as={Link}>
+                            <Button
+                                to={`?email=1&${searchParams.toString()}`}
+                                display="block"
+                                variant="secondary"
+                                as={Link}
+                            >
                                 <Icon aria-hidden={true} svgPath={mdiEmail} /> Continue with Email
                             </Button>
                         </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -83,7 +83,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                         <UsernamePasswordSignInForm
                             {...props}
                             onAuthError={setError}
-                            className={classNames(thirdPartyAuthProviders.length > 0 && 'mb-3')}
+                            className={classNames({ 'mb-3': thirdPartyAuthProviders.length > 0 })}
                         />
                     )}
                     {builtInAuthProvider && showBuiltInAuthForm && thirdPartyAuthProviders.length > 0 && (

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -110,7 +110,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                     {builtInAuthProvider && !showBuiltInAuthForm && (
                         <div className="mb-2">
                             <Button
-                                to={`?email=1&${searchParams.toString()}`}
+                                to={`${location.pathname}?email=1&${searchParams.toString()}`}
                                 display="block"
                                 variant="secondary"
                                 as={Link}

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -13,11 +13,11 @@ import { getReturnTo, PasswordInput } from './SignInSignUpCommon'
 
 interface Props {
     onAuthError: (error: Error | null) => void
-    noThirdPartyProviders?: boolean
     context: Pick<
         SourcegraphContext,
         'allowSignup' | 'authProviders' | 'sourcegraphDotComMode' | 'xhrHeaders' | 'resetPasswordEnabled'
     >
+    className?: string
 }
 
 /**
@@ -25,7 +25,7 @@ interface Props {
  */
 export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     onAuthError,
-    noThirdPartyProviders,
+    className,
     context,
 }) => {
     const location = useLocation()
@@ -90,7 +90,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
 
     return (
         <>
-            <Form onSubmit={handleSubmit}>
+            <Form onSubmit={handleSubmit} className={className}>
                 <Input
                     id="username-or-email"
                     label={<Text alignment="left">Username or email</Text>}
@@ -126,11 +126,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
                     )}
                 </div>
 
-                <div
-                    className={classNames('form-group', {
-                        'mb-0': noThirdPartyProviders,
-                    })}
-                >
+                <div className={classNames('form-group', 'mb-0')}>
                     <Button display="block" type="submit" disabled={loading} variant="primary">
                         {loading ? <LoadingSpinner /> : 'Sign in'}
                     </Button>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -54,96 +54,6 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
         <div
           class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
         >
-          <form
-            class=""
-          >
-            <label
-              class="label label form-group"
-            >
-              <div
-                class="mb-2"
-              >
-                <p
-                  class="alignLeft"
-                >
-                  Username or email
-                </p>
-              </div>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocapitalize="off"
-                  autocomplete="username"
-                  class="form-control with-invalid-icon"
-                  id="username-or-email"
-                  required=""
-                  type="text"
-                  value=""
-                />
-              </div>
-            </label>
-            <div
-              class="form-group d-flex flex-column align-content-start position-relative"
-            >
-              <label
-                class="label align-self-start"
-                for="password"
-              >
-                Password
-              </label>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocomplete="current-password"
-                  class="form-control with-invalid-icon"
-                  id="password"
-                  name="password"
-                  placeholder=" "
-                  required=""
-                  type="password"
-                  value=""
-                />
-              </div>
-              <small
-                class="form-text text-muted align-self-end position-absolute"
-              >
-                <a
-                  class="anchorLink"
-                  href="/password-reset"
-                >
-                  Forgot password?
-                </a>
-              </small>
-            </div>
-            <div
-              class="form-group"
-            >
-              <button
-                aria-disabled="false"
-                class="btn btnPrimary btnBlock"
-                type="submit"
-              >
-                Sign in
-              </button>
-            </div>
-          </form>
-          <div
-            class="mb-3 py-1 d-flex align-items-center"
-          >
-            <div
-              class="w-100 border"
-            />
-            <small
-              class="px-2 text-muted "
-            >
-              OR
-            </small>
-            <div
-              class="w-100 border"
-            />
-          </div>
           <div
             class="mb-2"
           >
@@ -165,6 +75,29 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                 />
               </svg>
                Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?email=1"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                />
+              </svg>
+              Continue with Email
             </a>
           </div>
         </div>
@@ -231,8 +164,118 @@ exports[`SignInPage renders sign in page (server) 1`] = `
         <div
           class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
         >
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?email=1"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                />
+              </svg>
+              Continue with Email
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SignInPage renders sign in page (server) with email form expanded 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
           <form
-            class=""
+            class="mb-3"
           >
             <label
               class="label label form-group"
@@ -295,7 +338,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
               </small>
             </div>
             <div
-              class="form-group"
+              class="form-group mb-0"
             >
               <button
                 aria-disabled="false"
@@ -362,7 +405,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SignInPage with Gerrit auth provider does not render the Gerrit provider 1`] = `
+exports[`SignInPage renders sign in page (server) with only builtin authProvider 1`] = `
 <DocumentFragment>
   <div
     class="signinSignupPage"
@@ -472,7 +515,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
               </small>
             </div>
             <div
-              class="form-group"
+              class="form-group mb-0"
             >
               <button
                 aria-disabled="false"
@@ -483,21 +526,70 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
               </button>
             </div>
           </form>
-          <div
-            class="mb-3 py-1 d-flex align-items-center"
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
           >
-            <div
-              class="w-100 border"
-            />
-            <small
-              class="px-2 text-muted "
-            >
-              OR
-            </small>
-            <div
-              class="w-100 border"
-            />
-          </div>
+            Sign up
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SignInPage with Gerrit auth provider does not render the Gerrit provider 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
           <div
             class="mb-2"
           >
@@ -519,6 +611,29 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                 />
               </svg>
                Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?email=1"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                />
+              </svg>
+              Continue with Email
             </a>
           </div>
         </div>
@@ -585,96 +700,6 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
         <div
           class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
         >
-          <form
-            class=""
-          >
-            <label
-              class="label label form-group"
-            >
-              <div
-                class="mb-2"
-              >
-                <p
-                  class="alignLeft"
-                >
-                  Username or email
-                </p>
-              </div>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocapitalize="off"
-                  autocomplete="username"
-                  class="form-control with-invalid-icon"
-                  id="username-or-email"
-                  required=""
-                  type="text"
-                  value=""
-                />
-              </div>
-            </label>
-            <div
-              class="form-group d-flex flex-column align-content-start position-relative"
-            >
-              <label
-                class="label align-self-start"
-                for="password"
-              >
-                Password
-              </label>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocomplete="current-password"
-                  class="form-control with-invalid-icon"
-                  id="password"
-                  name="password"
-                  placeholder=" "
-                  required=""
-                  type="password"
-                  value=""
-                />
-              </div>
-              <small
-                class="form-text text-muted align-self-end position-absolute"
-              >
-                <a
-                  class="anchorLink"
-                  href="/password-reset"
-                >
-                  Forgot password?
-                </a>
-              </small>
-            </div>
-            <div
-              class="form-group"
-            >
-              <button
-                aria-disabled="false"
-                class="btn btnPrimary btnBlock"
-                type="submit"
-              >
-                Sign in
-              </button>
-            </div>
-          </form>
-          <div
-            class="mb-3 py-1 d-flex align-items-center"
-          >
-            <div
-              class="w-100 border"
-            />
-            <small
-              class="px-2 text-muted "
-            >
-              OR
-            </small>
-            <div
-              class="w-100 border"
-            />
-          </div>
           <div
             class="mb-2"
           >
@@ -696,6 +721,29 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                 />
               </svg>
                Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?email=1"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                />
+              </svg>
+              Continue with Email
             </a>
           </div>
         </div>
@@ -762,96 +810,6 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
         <div
           class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
         >
-          <form
-            class=""
-          >
-            <label
-              class="label label form-group"
-            >
-              <div
-                class="mb-2"
-              >
-                <p
-                  class="alignLeft"
-                >
-                  Username or email
-                </p>
-              </div>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocapitalize="off"
-                  autocomplete="username"
-                  class="form-control with-invalid-icon"
-                  id="username-or-email"
-                  required=""
-                  type="text"
-                  value=""
-                />
-              </div>
-            </label>
-            <div
-              class="form-group d-flex flex-column align-content-start position-relative"
-            >
-              <label
-                class="label align-self-start"
-                for="password"
-              >
-                Password
-              </label>
-              <div
-                class="container loader-input loaderInput"
-              >
-                <input
-                  autocomplete="current-password"
-                  class="form-control with-invalid-icon"
-                  id="password"
-                  name="password"
-                  placeholder=" "
-                  required=""
-                  type="password"
-                  value=""
-                />
-              </div>
-              <small
-                class="form-text text-muted align-self-end position-absolute"
-              >
-                <a
-                  class="anchorLink"
-                  href="/password-reset"
-                >
-                  Forgot password?
-                </a>
-              </small>
-            </div>
-            <div
-              class="form-group"
-            >
-              <button
-                aria-disabled="false"
-                class="btn btnPrimary btnBlock"
-                type="submit"
-              >
-                Sign in
-              </button>
-            </div>
-          </form>
-          <div
-            class="mb-3 py-1 d-flex align-items-center"
-          >
-            <div
-              class="w-100 border"
-            />
-            <small
-              class="px-2 text-muted "
-            >
-              OR
-            </small>
-            <div
-              class="w-100 border"
-            />
-          </div>
           <div
             class="mb-2"
           >
@@ -882,7 +840,30 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
               class="anchorLink btn btnSecondary btnBlock"
               href=""
             >
-              Continue with Sourcegraph Operators
+               Continue with Sourcegraph Operators
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?sourcegraph-operator=&email=1"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                />
+              </svg>
+              Continue with Email
             </a>
           </div>
         </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href="/.auth/github/login?pc=f00bar"
             >
               <svg
@@ -97,7 +97,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                   d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
                 />
               </svg>
-              Continue with Email
+               Continue with Email
             </a>
           </div>
         </div>
@@ -168,7 +168,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href="/.auth/github/login?pc=f00bar"
             >
               <svg
@@ -207,7 +207,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                   d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
                 />
               </svg>
-              Continue with Email
+               Continue with Email
             </a>
           </div>
         </div>
@@ -594,7 +594,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href="/.auth/github/login?pc=f00bar"
             >
               <svg
@@ -633,7 +633,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                   d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
                 />
               </svg>
-              Continue with Email
+               Continue with Email
             </a>
           </div>
         </div>
@@ -704,7 +704,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href="/.auth/github/login?pc=f00bar"
             >
               <svg
@@ -743,7 +743,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                   d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
                 />
               </svg>
-              Continue with Email
+               Continue with Email
             </a>
           </div>
         </div>
@@ -814,7 +814,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href="/.auth/github/login?pc=f00bar"
             >
               <svg
@@ -837,7 +837,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
+              class="anchorLink btn btnPrimary btnBlock"
               href=""
             >
                Continue with Sourcegraph Operators
@@ -863,7 +863,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
                   d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
                 />
               </svg>
-              Continue with Email
+               Continue with Email
             </a>
           </div>
         </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
           >
             <a
               class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1"
+              href="/sign-in?email=1&"
             >
               <svg
                 aria-hidden="true"
@@ -192,7 +192,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
           >
             <a
               class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1"
+              href="/sign-in?email=1&"
             >
               <svg
                 aria-hidden="true"
@@ -618,7 +618,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
           >
             <a
               class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1"
+              href="/sign-in?email=1&"
             >
               <svg
                 aria-hidden="true"
@@ -728,7 +728,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
           >
             <a
               class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1"
+              href="/sign-in?email=1&"
             >
               <svg
                 aria-hidden="true"
@@ -848,7 +848,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
           >
             <a
               class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?sourcegraph-operator=&email=1"
+              href="/sign-in?email=1&sourcegraph-operator="
             >
               <svg
                 aria-hidden="true"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47444.

[Demo video](https://www.loom.com/share/1a27acf4bc924311a1ced0ae6772fee2)

## Screenshots
| Description/Scenario | Before | After |
| --: | :--: | :-- |
| When multiple SSO options exist | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216393098-f911448c-9392-43cc-821d-c29609796cfe.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216607670-df12e412-34ef-4bb0-8ead-ad96bfc0104c.png"> |
| When clicked on "Continue with Email" | None (scenario doesn't exist) | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216392355-2eb607ae-0044-4a4a-b4d0-b385f5924cab.png">|
| When only built-in auth option | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216393202-d60117cd-4028-4233-b8e1-49f0d9ddc638.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216392573-56d8f035-ba0e-48ad-9add-21951f9e9839.png"> |
| When built-in auth disabled | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216393286-ebe6e2a6-fd1d-4b65-93b7-b6de73f6e37c.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/216607782-24e15958-4b51-4f51-9602-da817eaed858.png"> |


## Test plan
- Run locally in different modes (enterprise, dotcom, oss)
- Update siteAdmin > `auth.providers` to different variations (multiple sso, only built-in, no built-in, but multiple sso) and check http://localhost:3080/sign-in page
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-prioritize-sso-signin-if.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

