### PR TITLE
fix off by 1 and add tests

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -329,7 +329,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db database.DB, timeseriesS
 		return nil, errors.Wrap(err, "GetOffsetNRecordingTime")
 	}
 	if !oldest.IsZero() {
-		opts.From = &oldest
+		opts.After = &oldest
 	}
 
 	includeRepo := func(regex ...string) {
@@ -359,7 +359,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db database.DB, timeseriesS
 var loadingStrategyRED = metrics.NewREDMetrics(prometheus.DefaultRegisterer, "src_insights_loading_strategy", metrics.WithLabels("in_mem", "capture"))
 
 func fetchSeries(ctx context.Context, definition types.InsightViewSeries, filters types.InsightViewFilters, options types.SeriesDisplayOptions, r *baseInsightResolver) (points []store.SeriesPoint, err error) {
-	opts, err := getRecordedSeriesPointOpts(ctx, database.NewDBWith(log.Scoped("recordedSeries", ""), r.workerBaseStore), r.timeSeriesStore, definition, filters, options)
+	opts, err := getRecordedSeriesPointOpts(ctx, database.NewDBWith(log.Scoped("recordedSeries", ""), r.postgresDB), r.timeSeriesStore, definition, filters, options)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
 	}


### PR DESCRIPTION
Previously "fixed" in https://github.com/sourcegraph/sourcegraph/pull/47121. It turns out there was never an off by 1, the problem is it's decptive if you are just looking at the chart as snapshots can overlap points on the same day, making it appear as though fewer points are on the chart than are actually resolving. This reverts the previous PR, and wraps the functionality in a test.

## Test plan

Unit tests and locally running

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
