### PR TITLE
permissions-center: add pagination support for permission sync jobs store.

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -282,10 +282,7 @@ func (s *BackfillStore) GetBackfillQueueInfo(ctx context.Context, args BackfillQ
 	if args.PaginationArgs != nil {
 		pagination = *args.PaginationArgs
 	}
-	p, err := pagination.SQL()
-	if err != nil {
-		return nil, err
-	}
+	p := pagination.SQL()
 	// Add in pagination where clause
 	if p.Where != nil {
 		where = append(where, p.Where)

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -158,10 +158,7 @@ func (s *confStore) ListSiteConfigs(ctx context.Context, paginationArgs *Paginat
 		return scanSiteConfigs(rows, err)
 	}
 
-	args, err := paginationArgs.SQL()
-	if err != nil {
-		return []*SiteConfig{}, nil
-	}
+	args := paginationArgs.SQL()
 
 	if args.Where != nil {
 		where = append(where, args.Where)

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -8,8 +8,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
-
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is typically embedded in other options
@@ -130,12 +128,12 @@ type PaginationArgs struct {
 	After  *string
 	Before *string
 
-	// TODDO(naman): explain default
+	// TODO(naman): explain default
 	OrderBy   OrderBy
 	Ascending bool
 }
 
-func (p *PaginationArgs) SQL() (*QueryArgs, error) {
+func (p *PaginationArgs) SQL() *QueryArgs {
 	queryArgs := &QueryArgs{}
 
 	var conditions []*sqlf.Query
@@ -177,10 +175,10 @@ func (p *PaginationArgs) SQL() (*QueryArgs, error) {
 		queryArgs.Order = orderBy.SQL(!p.Ascending)
 		queryArgs.Limit = sqlf.Sprintf("LIMIT %d", *p.Last)
 	} else {
-		return nil, errors.New("First or Last must be set")
+		queryArgs.Order = orderBy.SQL(p.Ascending)
 	}
 
-	return queryArgs, nil
+	return queryArgs
 }
 
 func copyPtr[T any](n *T) *T {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -939,10 +939,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	querySuffix := sqlf.Sprintf("%s %s", opt.OrderBy.SQL(), opt.LimitOffset.SQL())
 
 	if opt.PaginationArgs != nil {
-		p, err := opt.PaginationArgs.SQL()
-		if err != nil {
-			return nil, err
-		}
+		p := opt.PaginationArgs.SQL()
 
 		if p.Where != nil {
 			where = append(where, p.Where)

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -247,14 +247,11 @@ func (s *savedSearchStore) ListSavedSearchesByOrgID(ctx context.Context, orgID i
 // organization for the user.
 //
 // 🚨 SECURITY: This method does NOT verify the user's identity or that the
-// user is an admin. It is the callers responsibility to ensure only admins or
+// user is an admin. It is the caller's responsibility to ensure only admins or
 // members of the specified organization can access the returned saved
 // searches.
 func (s *savedSearchStore) ListSavedSearchesByOrgOrUser(ctx context.Context, userID, orgID *int32, paginationArgs *PaginationArgs) ([]*types.SavedSearch, error) {
-	p, err := paginationArgs.SQL()
-	if err != nil {
-		return nil, err
-	}
+	p := paginationArgs.SQL()
 
 	var where []*sqlf.Query
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -976,10 +976,7 @@ func (u *userStore) ListByOrg(ctx context.Context, orgID int32, paginationArgs *
 		where = append(where, cond)
 	}
 
-	p, err := paginationArgs.SQL()
-	if err != nil {
-		return nil, err
-	}
+	p := paginationArgs.SQL()
 
 	if p.Where != nil {
 		where = append(where, p.Where)


### PR DESCRIPTION
This commit also removes an error in `QueryArgs` when there is only `OrderBy` argument provided without `First` or `Last`.

Test plan:
Tests added.

Part of https://github.com/sourcegraph/sourcegraph/issues/47301