### PR TITLE
insights: all repo iterator to pull multiple repos at a time

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -83,7 +83,7 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 			InsightStore:            insightsStore,
 			CommitClient:            gitserver.NewGitCommitClient(),
 			SearchPlanWorkerLimit:   1,
-			SearchRunnerWorkerLimit: 5, // TODO: move these to settings
+			SearchRunnerWorkerLimit: 1, // TODO: move these to settings
 			SearchRateLimiter:       searchRateLimiter,
 			HistoricRateLimiter:     historicRateLimiter,
 		}

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -83,7 +83,7 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 			InsightStore:            insightsStore,
 			CommitClient:            gitserver.NewGitCommitClient(),
 			SearchPlanWorkerLimit:   1,
-			SearchRunnerWorkerLimit: 1, // TODO: move these to settings
+			SearchRunnerWorkerLimit: 1, // TODO: this can scale with the number of searcher endpoints
 			SearchRateLimiter:       searchRateLimiter,
 			HistoricRateLimiter:     historicRateLimiter,
 		}

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -234,7 +234,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 				}
 				// The groups functions don't return errors so not checking for them
 				g.Wait()
-				execution.logger.Info("page complete", log.Duration("page duration", time.Since(startPage)), log.Int("page size", pageSize), log.Int("number repos", len(repoIds)))
+				execution.logger.Debug("page complete", log.Duration("page duration", time.Since(startPage)), log.Int("page size", pageSize), log.Int("number repos", len(repoIds)))
 				err = finish(ctx, h.backfillStore.Store, repoErrors)
 				if err != nil {
 					return false, err

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/group"
 )
 
 const (
@@ -91,7 +93,11 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		oldVal := task.config.interruptAfter
 		newVal := getInterruptAfter()
 		task.config.interruptAfter = newVal
+		oldPageSize := task.config.pageSize
+		newPageSize := getPageSize()
+		task.config.pageSize = newPageSize
 		configLogger.Info("insights backfiller interrupt time changed", log.Duration("old", oldVal), log.Duration("new", newVal))
+		configLogger.Info("insights backfiller repo page size changed", log.Int("old", oldPageSize), log.Int("new", newPageSize))
 	})
 
 	return worker, resetter, workerStore
@@ -112,10 +118,11 @@ type inProgressHandler struct {
 type handlerConfig struct {
 	interruptAfter      time.Duration
 	errorThresholdFloor int
+	pageSize            int
 }
 
 func newHandlerConfig() handlerConfig {
-	return handlerConfig{interruptAfter: getInterruptAfter(), errorThresholdFloor: getErrorThresholdFloor()}
+	return handlerConfig{interruptAfter: getInterruptAfter(), errorThresholdFloor: getErrorThresholdFloor(), pageSize: getPageSize()}
 }
 
 var _ workerutil.Handler[*BaseJob] = &inProgressHandler{}
@@ -150,6 +157,8 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 	return nil
 }
 
+type nextNFunc func(pageSize int, config iterator.IterationConfig) ([]api.RepoID, bool, iterator.FinishNFunc)
+
 func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfillExecution) (interrupt bool, err error) {
 	timeExpired := h.clock.After(h.config.interruptAfter)
 
@@ -178,10 +187,12 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 		},
 	}
 
-	type nextFunc func(config iterator.IterationConfig) (api.RepoID, bool, iterator.FinishFunc)
-	itrLoop := func(nextFunc nextFunc) (interrupted bool, _ error) {
+	itrLoop := func(pageSize int, nextFunc nextNFunc) (interrupted bool, _ error) {
+		// Unrelated to the page size this will limit to backfilling at most 3 repos concurrently
+		g := group.New().WithContext(ctx).WithMaxConcurrency(3)
+		mu := sync.Mutex{}
 		for {
-			repoId, more, finish := nextFunc(itrConfig)
+			repoIds, more, finish := nextFunc(pageSize, itrConfig)
 			if !more {
 				break
 			}
@@ -189,21 +200,35 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 			case <-timeExpired:
 				return true, nil
 			default:
-				repo, repoErr := h.repoStore.Get(ctx, repoId)
-				if repoErr != nil {
-					err = finish(ctx, h.backfillStore.Store, errors.Wrap(repoErr, "InProgressHandler.repoStore.Get"))
-					if err != nil {
-						return false, err
-					}
-					continue
-				}
+				repoErrors := map[int32]error{}
+				startPage := time.Now()
+				for i := 0; i < len(repoIds); i++ {
+					repoId := repoIds[i]
+					g.Go(func(ctx context.Context) error {
+						repo, repoErr := h.repoStore.Get(ctx, repoId)
+						if repoErr != nil {
+							mu.Lock()
+							repoErrors[int32(repoId)] = errors.Wrap(repoErr, "InProgressHandler.repoStore.Get")
+							mu.Unlock()
+							return nil
+						}
+						execution.logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
+						runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: execution.series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, SampleTimes: execution.sampleTimes})
+						if runErr != nil {
+							execution.logger.Error("error during backfill execution", execution.logFields(log.Error(runErr))...)
+							mu.Lock()
+							repoErrors[int32(repoId)] = runErr
+							mu.Unlock()
+							return nil
+						}
+						return nil
+					})
 
-				execution.logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
-				runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: execution.series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, SampleTimes: execution.sampleTimes})
-				if runErr != nil {
-					execution.logger.Error("error during backfill execution", execution.logFields(log.Error(runErr))...)
 				}
-				err = finish(ctx, h.backfillStore.Store, runErr)
+				// The groups functions don't return errors so not checking for them
+				g.Wait()
+				execution.logger.Info("page complete", log.Duration("page duration", time.Since(startPage)), log.Int("page size", pageSize), log.Int("number repos", len(repoIds)))
+				err = finish(ctx, h.backfillStore.Store, repoErrors)
 				if err != nil {
 					return false, err
 				}
@@ -219,7 +244,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	}
 
 	execution.logger.Debug("starting primary loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
-	if interrupted, err := itrLoop(execution.itr.NextWithFinish); err != nil {
+	if interrupted, err := itrLoop(h.config.pageSize, execution.itr.NextPageWithFinish); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.PrimaryLoop")
 	} else if interrupted {
 		execution.logger.Info("interrupted insight series backfill", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
@@ -227,7 +252,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	}
 
 	execution.logger.Debug("starting retry loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
-	if interrupted, err := itrLoop(execution.itr.NextRetryWithFinish); err != nil {
+	if interrupted, err := itrLoop(1, retryAdapter(execution.itr.NextRetryWithFinish)); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.RetryLoop")
 	} else if interrupted {
 		execution.logger.Info("interrupted insight series backfill retry", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
@@ -240,6 +265,17 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 		// in this state we have some errors that will need reprocessing, we will place this job back in queue
 		return true, nil
 	}
+}
+
+func retryAdapter(next func(config iterator.IterationConfig) (api.RepoID, bool, iterator.FinishFunc)) nextNFunc {
+	return func(pageSize int, config iterator.IterationConfig) ([]api.RepoID, bool, iterator.FinishNFunc) {
+		repoId, more, finish := next(config)
+		return []api.RepoID{repoId}, more, func(ctx context.Context, store *basestore.Store, maybeErr map[int32]error) error {
+			repoErr := maybeErr[int32(repoId)]
+			return finish(ctx, store, repoErr)
+		}
+	}
+
 }
 
 func (h *inProgressHandler) finish(ctx context.Context, ex *backfillExecution) (err error) {
@@ -358,6 +394,14 @@ func getInterruptAfter() time.Duration {
 		return time.Duration(val) * time.Second
 	}
 	return time.Duration(defaultInterruptSeconds) * time.Second
+}
+
+func getPageSize() int {
+	val := conf.Get().InsightsBackfillRepositoryGroupSize
+	if val > 0 {
+		return int(math.Min(float64(val), 100))
+	}
+	return 10
 }
 
 func getErrorThresholdFloor() int {

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -2,6 +2,7 @@ package iterator
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/derision-test/glock"
@@ -15,6 +16,7 @@ import (
 )
 
 type FinishFunc func(ctx context.Context, store *basestore.Store, maybeErr error) error
+type FinishNFunc func(ctx context.Context, store *basestore.Store, maybeErr map[int32]error) error
 
 // PersistentRepoIterator represents a durable (persisted) iterator over a set of repositories. This iteration is not
 // concurrency safe and only one consumer should have access to this resource at a time.
@@ -34,9 +36,6 @@ type PersistentRepoIterator struct {
 	terminalErrors errorMap
 	retryRepos     []int32
 	retryCursor    int
-
-	itrStart time.Time // time the current iteration started
-	itrEnd   time.Time // time the current iteration ended
 
 	glock glock.Clock
 }
@@ -165,10 +164,36 @@ func (p *PersistentRepoIterator) NextWithFinish(config IterationConfig) (api.Rep
 			return nil
 		}
 	}
-	p.itrStart = p.glock.Now()
+	itrStart := p.glock.Now()
 	return api.RepoID(current), true, func(ctx context.Context, store *basestore.Store, maybeErr error) error {
-		p.itrEnd = p.glock.Now()
-		if err := p.doFinish(ctx, store, maybeErr, current, false, config); err != nil {
+		itrEnd := p.glock.Now()
+		maybeErrs := map[int32]error{}
+		if maybeErr != nil {
+			maybeErrs[current] = maybeErr
+		}
+		if err := p.doFinishN(ctx, store, maybeErrs, []int32{current}, false, config, itrStart, itrEnd); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// NextPageWithFinish is like NextWithFinish but grabs the next pageSize number of repos.
+func (p *PersistentRepoIterator) NextPageWithFinish(pageSize int, config IterationConfig) ([]api.RepoID, bool, FinishNFunc) {
+	currentRepos, got := peekN(p.Cursor, pageSize, p.repos)
+	if !p.CompletedAt.IsZero() || !got {
+		return []api.RepoID{}, false, func(ctx context.Context, store *basestore.Store, maybeErrors map[int32]error) error {
+			return nil
+		}
+	}
+	itrStart := p.glock.Now()
+	repoIds := make([]api.RepoID, 0, len(currentRepos))
+	for i := 0; i < len(currentRepos); i++ {
+		repoIds = append(repoIds, api.RepoID(currentRepos[i]))
+	}
+	return repoIds, true, func(ctx context.Context, store *basestore.Store, maybeErrs map[int32]error) error {
+		itrEnd := p.glock.Now()
+		if err := p.doFinishN(ctx, store, maybeErrs, currentRepos, false, config, itrStart, itrEnd); err != nil {
 			return err
 		}
 		return nil
@@ -196,11 +221,15 @@ func (p *PersistentRepoIterator) NextRetryWithFinish(config IterationConfig) (ap
 		break
 	}
 
-	p.itrStart = p.glock.Now()
+	itrStart := p.glock.Now()
 	return api.RepoID(current), true, func(ctx context.Context, store *basestore.Store, maybeErr error) error {
-		p.itrEnd = p.glock.Now()
+		itrEnd := p.glock.Now()
 		p.advanceRetry()
-		if err := p.doFinish(ctx, store, maybeErr, current, true, config); err != nil {
+		maybeErrs := map[int32]error{}
+		if maybeErr != nil {
+			maybeErrs[current] = maybeErr
+		}
+		if err := p.doFinishN(ctx, store, maybeErrs, []int32{current}, true, config, itrStart, itrEnd); err != nil {
 			return err
 		}
 		return nil
@@ -267,6 +296,14 @@ func peek(offset int, repos []int32) (int32, bool) {
 	return repos[offset], true
 }
 
+func peekN(offset, num int, repos []int32) ([]int32, bool) {
+	if offset >= len(repos) {
+		return []int32{}, false
+	}
+	end := int32(math.Min(float64(offset+num), float64(len(repos))))
+	return repos[offset:end], true
+}
+
 func (p *PersistentRepoIterator) advanceRetry() {
 	p.retryCursor += 1
 }
@@ -301,21 +338,19 @@ func (p *PersistentRepoIterator) insertIterationError(ctx context.Context, store
 	return nil
 }
 
-func (p *PersistentRepoIterator) doFinish(ctx context.Context, store *basestore.Store, maybeErr error, currentRepo int32, isRetry bool, config IterationConfig) (err error) {
-	didSucceed := 0
-	cursorOffset := 1
-	totalFailures := p.errors.FailureCount(currentRepo)
-
-	if maybeErr == nil {
-		// if this was for a success then we will want to update
-		didSucceed = 1
-	} else {
-		totalFailures += 1
+func (p *PersistentRepoIterator) doFinishN(ctx context.Context, store *basestore.Store, maybeErrs map[int32]error, repos []int32, isRetry bool, config IterationConfig, start, end time.Time) (err error) {
+	cursorOffset := len(repos)
+	errorsCount := 0
+	for _, repoErr := range maybeErrs {
+		if repoErr != nil {
+			errorsCount++
+		}
 	}
+	successfulRepoCount := int(math.Max(float64(len(repos)-errorsCount), 0))
 	if isRetry {
 		cursorOffset = 0
 	}
-	itrDuration := p.itrEnd.Sub(p.itrStart)
+	itrDuration := end.Sub(start)
 
 	tx, err := store.Transact(ctx)
 	if err != nil {
@@ -324,33 +359,40 @@ func (p *PersistentRepoIterator) doFinish(ctx context.Context, store *basestore.
 	defer func() { err = tx.Done(err) }()
 
 	if p.StartedAt.IsZero() {
-		if err = stampStartedAt(ctx, tx, p.Id, p.itrStart); err != nil {
+		if err = stampStartedAt(ctx, tx, p.Id, start); err != nil {
 			return errors.Wrap(err, "stampStartedAt")
 		}
-		p.StartedAt = p.itrStart
+		p.StartedAt = start
 	}
-	err = p.updateRepoIterator(ctx, tx, didSucceed, cursorOffset, itrDuration)
-	if maybeErr != nil {
-		if err = p.insertIterationError(ctx, tx, currentRepo, maybeErr.Error()); err != nil {
-			return errors.Wrapf(err, "unable to upsert error for repo iterator id: %d", p.Id)
-		}
-		if config.MaxFailures != 0 && totalFailures >= config.MaxFailures {
-			// the condition is if there was an error, and we have configured both a max attempts, and the total attempts exceeds the config
-			if config.OnTerminal != nil {
-				err = config.OnTerminal(ctx, tx, currentRepo, maybeErr)
-				if err != nil {
-					return errors.Wrap(err, "iterator.OnTerminal")
-				}
-				p.setRepoTerminal(currentRepo)
+	// This updates the iterator moving it ahead by the current offset (number of repos being "finished")
+	err = p.updateRepoIterator(ctx, tx, successfulRepoCount, cursorOffset, itrDuration)
+
+	// For each repo that is being finished check if it errored
+	//    If errored - record the error
+	//    No error - clear any previous errors since it it now successful
+	for _, repoID := range repos {
+		if maybeErr, ok := maybeErrs[repoID]; ok && maybeErr != nil {
+			if err = p.insertIterationError(ctx, tx, repoID, maybeErr.Error()); err != nil {
+				return errors.Wrapf(err, "unable to upsert error for repo iterator id: %d", p.Id)
 			}
+			if config.MaxFailures != 0 && p.errors.FailureCount(repoID)+1 >= config.MaxFailures {
+				// the condition is if there was an error, and we have configured both a max attempts, and the total attempts exceeds the config
+				if config.OnTerminal != nil {
+					err = config.OnTerminal(ctx, tx, repoID, maybeErr)
+					if err != nil {
+						return errors.Wrap(err, "iterator.OnTerminal")
+					}
+					p.setRepoTerminal(repoID)
+				}
+			}
+		} else if isRetry {
+			// delete the error for this repo
+			err = tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM repo_iterator_errors WHERE id = %s`, p.errors[repoID].id))
+			if err != nil {
+				return errors.Wrap(err, "deleteIteratorError")
+			}
+			delete(p.errors, repoID)
 		}
-	} else if isRetry {
-		// delete the error for this repo
-		err = tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM repo_iterator_errors WHERE id = %s`, p.errors[currentRepo].id))
-		if err != nil {
-			return errors.Wrap(err, "deleteIteratorError")
-		}
-		delete(p.errors, currentRepo)
 	}
 
 	return nil
@@ -392,8 +434,6 @@ func (p *PersistentRepoIterator) updateRepoIterator(ctx context.Context, store *
 	p.SuccessCount = successCnt
 	p.PercentComplete = pct
 	p.RuntimeDuration = runtime
-	p.itrStart = time.Time{}
-	p.itrEnd = time.Time{}
 
 	return nil
 }

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -24,11 +24,11 @@ import (
 type testFunc func(context.Context, api.RepoID, FinishFunc) bool
 type testPageFunc func(context.Context, []api.RepoID, FinishNFunc) bool
 
-func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, seen []api.RepoID, do testFunc) (*PersistentRepoIterator, []api.RepoID) {
+func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, config IterationConfig, seen []api.RepoID, do testFunc) (*PersistentRepoIterator, []api.RepoID) {
 	ctx := context.Background()
 
 	for true {
-		repoId, more, finish := itr.NextWithFinish(IterationConfig{})
+		repoId, more, finish := itr.NextWithFinish(config)
 		if !more {
 			break
 		}
@@ -48,11 +48,11 @@ func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentR
 	return itr, seen
 }
 
-func testForNextNAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, pageSize int, seen []api.RepoID, do testPageFunc) (*PersistentRepoIterator, []api.RepoID) {
+func testForNextNAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, config IterationConfig, pageSize int, seen []api.RepoID, do testPageFunc) (*PersistentRepoIterator, []api.RepoID) {
 	ctx := context.Background()
 
 	for true {
-		repoIds, more, finish := itr.NextPageWithFinish(pageSize, IterationConfig{})
+		repoIds, more, finish := itr.NextPageWithFinish(pageSize, config)
 		if !more {
 			break
 		}
@@ -86,7 +86,7 @@ func TestForNextAndFinish(t *testing.T) {
 		itr, _ := NewWithClock(ctx, store, clock, repos)
 		var seen []api.RepoID
 
-		got, _ := testForNextAndFinish(t, store, itr, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
+		got, _ := testForNextAndFinish(t, store, itr, IterationConfig{}, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
 			clock.Advance(time.Second * 1)
 			err := fn(ctx, store, nil)
 			if err != nil {
@@ -105,7 +105,7 @@ func TestForNextAndFinish(t *testing.T) {
 		itr, _ := NewWithClock(ctx, store, clock, repos)
 		var seen []api.RepoID
 
-		got, _ := testForNextAndFinish(t, store, itr, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
+		got, _ := testForNextAndFinish(t, store, itr, IterationConfig{}, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
 			clock.Advance(time.Second * 1)
 			var executionErr error
 			if id == 6 {
@@ -125,6 +125,71 @@ func TestForNextAndFinish(t *testing.T) {
 			FailureCount:  1,
 			ErrorMessages: []string{"this repo errored"},
 		}}).Equal(t, got.errors)
+
+		autogold.Want("iterate with 1 error and no interruptions no config has no more", false).Equal(t, got.HasMore())
+		autogold.Want("iterate with 1 error and no interruptions no config has errors to retry", true).Equal(t, got.HasErrors())
+	})
+
+	t.Run("iterate with one error no interruptions and MaxFailures configured", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextAndFinish(t, store, itr, IterationConfig{MaxFailures: 3}, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
+			clock.Advance(time.Second * 1)
+			var executionErr error
+			if id == 6 {
+				executionErr = errors.New("this repo errored")
+			}
+			err := fn(ctx, store, executionErr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate with one error no interruptions and MaxFailures configured", `{"Id":3,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with one error no interruptions and MaxFailures configured error check", errorMap{6: &IterationError{
+			id:            2,
+			RepoId:        6,
+			FailureCount:  1,
+			ErrorMessages: []string{"this repo errored"},
+		}}).Equal(t, got.errors)
+		autogold.Want("iterate with one error no interruptions and MaxFailures configured has no more", false).Equal(t, got.HasMore())
+		autogold.Want("iterate with one error no interruptions and MaxFailures configured has errors to retry", true).Equal(t, got.HasErrors())
+	})
+
+	t.Run("iterate with one error no interruptions finished if MaxFailures reached", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextAndFinish(t, store, itr, IterationConfig{MaxFailures: 1}, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
+			clock.Advance(time.Second * 1)
+			var executionErr error
+			if id == 6 {
+				executionErr = errors.New("this repo errored")
+			}
+			err := fn(ctx, store, executionErr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate with one error no interruptions finished if MaxFailures reached", `{"Id":4,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with one error no interruptions finished if MaxFailures reached error check", errorMap{6: &IterationError{
+			id:            3,
+			RepoId:        6,
+			FailureCount:  1,
+			ErrorMessages: []string{"this repo errored"},
+		}}).Equal(t, got.errors)
+		autogold.Want("iterate with one error no interruptions finished if MaxFailures reached has no more", false).Equal(t, got.HasMore())
+		autogold.Want("iterate with one error no interruptions finished if MaxFailures reached has no errors to retry", true).Equal(t, got.HasErrors())
 	})
 
 	t.Run("iterate with no errors and one interruption", func(t *testing.T) {
@@ -149,16 +214,16 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		}
 
-		got, seen := testForNextAndFinish(t, store, itr, seen, do)
+		got, seen := testForNextAndFinish(t, store, itr, IterationConfig{}, seen, do)
 
 		require.Equal(t, got.Cursor, 2)
 		reloaded, _ := LoadWithClock(ctx, store, got.Id, clock)
 		require.Equal(t, reloaded.Cursor, got.Cursor)
 
 		// now iterate from the starting position _after_ reloading from the db
-		secondItr, _ := testForNextAndFinish(t, store, reloaded, seen, do)
+		secondItr, _ := testForNextAndFinish(t, store, reloaded, IterationConfig{}, seen, do)
 		jsonify, _ := json.Marshal(secondItr)
-		autogold.Want("iterate with no error and 1 interruptions", `{"Id":3,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:06Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with no error and 1 interruptions", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:06Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
 	})
 
 	t.Run("iterate twice and verify progress updates", func(t *testing.T) {
@@ -189,7 +254,7 @@ func TestForNextAndFinish(t *testing.T) {
 			t.Fatal(err)
 		}
 		jsonify, _ := json.Marshal(reloaded)
-		autogold.Want("iterate twice and verify progress", `{"Id":4,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.4,"TotalCount":5,"SuccessCount":2,"Cursor":2}`).Equal(t, string(jsonify))
+		autogold.Want("iterate twice and verify progress", `{"Id":6,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.4,"TotalCount":5,"SuccessCount":2,"Cursor":2}`).Equal(t, string(jsonify))
 	})
 
 	//test paging
@@ -200,7 +265,7 @@ func TestForNextAndFinish(t *testing.T) {
 		itr, _ := NewWithClock(ctx, store, clock, repos)
 		var seen []api.RepoID
 
-		got, _ := testForNextNAndFinish(t, store, itr, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+		got, _ := testForNextNAndFinish(t, store, itr, IterationConfig{}, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
 			clock.Advance(time.Second * 1)
 			err := fn(ctx, store, nil)
 			if err != nil {
@@ -209,7 +274,7 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		})
 		jsonify, _ := json.Marshal(got)
-		autogold.Want("iterate with no errors and no interruptions", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate page with no errors and no interruptions", `{"Id":7,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
 	})
 
 	t.Run("iterate page with one error and no interruptions", func(t *testing.T) {
@@ -219,7 +284,7 @@ func TestForNextAndFinish(t *testing.T) {
 		itr, _ := NewWithClock(ctx, store, clock, repos)
 		var seen []api.RepoID
 
-		got, _ := testForNextNAndFinish(t, store, itr, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+		got, _ := testForNextNAndFinish(t, store, itr, IterationConfig{}, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
 			clock.Advance(time.Second * 1)
 			executionErrs := map[int32]error{}
 			for _, id := range ids {
@@ -235,13 +300,15 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		})
 		jsonify, _ := json.Marshal(got)
-		autogold.Want("iterate with 1 error and no interruptions", `{"Id":6,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
-		autogold.Want("iterate with 1 error and no interruptions error check", errorMap{6: &IterationError{
-			id:            6,
+		autogold.Want("iterate page with 1 error and no interruptions", `{"Id":8,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate page with 1 error and no interruptions error check", errorMap{6: &IterationError{
+			id:            4,
 			RepoId:        6,
 			FailureCount:  1,
 			ErrorMessages: []string{"this repo errored"},
 		}}).Equal(t, got.errors)
+		autogold.Want("iterate page with 1 error and no interruptions HasMore", false).Equal(t, got.HasMore())
+		autogold.Want("iterate page with 1 error and no interruptions HasErrors", true).Equal(t, got.HasErrors())
 	})
 
 	t.Run("iterate page with no errors and one interruption", func(t *testing.T) {
@@ -269,19 +336,19 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		}
 
-		got, seen := testForNextNAndFinish(t, store, itr, 2, seen, do)
+		got, seen := testForNextNAndFinish(t, store, itr, IterationConfig{}, 2, seen, do)
 
 		require.Equal(t, got.Cursor, 2)
 		reloaded, _ := LoadWithClock(ctx, store, got.Id, clock)
 		require.Equal(t, reloaded.Cursor, got.Cursor)
 
 		// now iterate from the starting position _after_ reloading from the db
-		secondItr, _ := testForNextNAndFinish(t, store, reloaded, 2, seen, do)
+		secondItr, _ := testForNextNAndFinish(t, store, reloaded, IterationConfig{}, 2, seen, do)
 		jsonify, _ := json.Marshal(secondItr)
-		autogold.Want("iterate with no error and 1 interruptions", `{"Id":7,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:04Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate page with no error and 1 interruptions", `{"Id":9,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:04Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
 	})
 
-	t.Run("iterate twice and verify progress updates", func(t *testing.T) {
+	t.Run("iterate two pages and verify progress updates", func(t *testing.T) {
 		clock := glock.NewMockClock()
 		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
 		repos := []int32{1, 5, 6, 14, 17}
@@ -309,7 +376,75 @@ func TestForNextAndFinish(t *testing.T) {
 			t.Fatal(err)
 		}
 		jsonify, _ := json.Marshal(reloaded)
-		autogold.Want("iterate twice and verify progress", `{"Id":8,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.8,"TotalCount":5,"SuccessCount":4,"Cursor":4}`).Equal(t, string(jsonify))
+		autogold.Want("iterate two pages and verify progress", `{"Id":10,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.8,"TotalCount":5,"SuccessCount":4,"Cursor":4}`).Equal(t, string(jsonify))
+	})
+
+	t.Run("iterate pages with one error no interruptions and MaxFailures configured", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextNAndFinish(t, store, itr, IterationConfig{MaxFailures: 3}, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+			clock.Advance(time.Second * 1)
+			executionErr := map[int32]error{}
+			for _, id := range ids {
+				if id == 6 {
+					executionErr[int32(id)] = errors.New("this repo errored")
+				}
+			}
+
+			err := fn(ctx, store, executionErr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate pages with one error no interruptions and MaxFailures configured", `{"Id":11,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate pages with one error no interruptions and MaxFailures configured error check", errorMap{6: &IterationError{
+			id:            5,
+			RepoId:        6,
+			FailureCount:  1,
+			ErrorMessages: []string{"this repo errored"},
+		}}).Equal(t, got.errors)
+		autogold.Want("iterate pages with one error no interruptions and MaxFailures configured has no more", false).Equal(t, got.HasMore())
+		autogold.Want("iterate pages with one error no interruptions and MaxFailures configured has errors to retry", true).Equal(t, got.HasErrors())
+	})
+
+	t.Run("iterate page with one error no interruptions finished if MaxFailures reached", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextNAndFinish(t, store, itr, IterationConfig{MaxFailures: 1}, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+			clock.Advance(time.Second * 1)
+			executionErrs := map[int32]error{}
+			for _, id := range ids {
+				if id == 6 {
+					executionErrs[int32(id)] = errors.New("this repo errored")
+				}
+			}
+
+			err := fn(ctx, store, executionErrs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate page with one error no interruptions finished if MaxFailures reached", `{"Id":12,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate page with one error no interruptions finished if MaxFailures reached error check", errorMap{6: &IterationError{
+			id:            6,
+			RepoId:        6,
+			FailureCount:  1,
+			ErrorMessages: []string{"this repo errored"},
+		}}).Equal(t, got.errors)
+		autogold.Want("iterate page with one error no interruptions finished if MaxFailures reached has no more", false).Equal(t, got.HasMore())
+		autogold.Want("iterate page with one error no interruptions finished if MaxFailures reached has no errors to retry", true).Equal(t, got.HasErrors())
 	})
 }
 

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 type testFunc func(context.Context, api.RepoID, FinishFunc) bool
+type testPageFunc func(context.Context, []api.RepoID, FinishNFunc) bool
 
 func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, seen []api.RepoID, do testFunc) (*PersistentRepoIterator, []api.RepoID) {
 	ctx := context.Background()
@@ -36,6 +37,30 @@ func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentR
 			return itr, seen
 		}
 		seen = append(seen, repoId)
+	}
+
+	err := itr.MarkComplete(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, fmt.Sprintf("%v", itr.repos), fmt.Sprintf("%v", seen))
+	return itr, seen
+}
+
+func testForNextNAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, pageSize int, seen []api.RepoID, do testPageFunc) (*PersistentRepoIterator, []api.RepoID) {
+	ctx := context.Background()
+
+	for true {
+		repoIds, more, finish := itr.NextPageWithFinish(pageSize, IterationConfig{})
+		if !more {
+			break
+		}
+		shouldNext := do(ctx, repoIds, finish)
+		if !shouldNext {
+			return itr, seen
+		}
+		seen = append(seen, repoIds...)
 	}
 
 	err := itr.MarkComplete(ctx, store)
@@ -165,6 +190,126 @@ func TestForNextAndFinish(t *testing.T) {
 		}
 		jsonify, _ := json.Marshal(reloaded)
 		autogold.Want("iterate twice and verify progress", `{"Id":4,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.4,"TotalCount":5,"SuccessCount":2,"Cursor":2}`).Equal(t, string(jsonify))
+	})
+
+	//test paging
+	t.Run("iterate page with no errors and no interruptions", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextNAndFinish(t, store, itr, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+			clock.Advance(time.Second * 1)
+			err := fn(ctx, store, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate with no errors and no interruptions", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+	})
+
+	t.Run("iterate page with one error and no interruptions", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		got, _ := testForNextNAndFinish(t, store, itr, 2, seen, func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+			clock.Advance(time.Second * 1)
+			executionErrs := map[int32]error{}
+			for _, id := range ids {
+				if id == 6 {
+					executionErrs[int32(id)] = errors.New("this repo errored")
+				}
+			}
+
+			err := fn(ctx, store, executionErrs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		})
+		jsonify, _ := json.Marshal(got)
+		autogold.Want("iterate with 1 error and no interruptions", `{"Id":6,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:03Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with 1 error and no interruptions error check", errorMap{6: &IterationError{
+			id:            6,
+			RepoId:        6,
+			FailureCount:  1,
+			ErrorMessages: []string{"this repo errored"},
+		}}).Equal(t, got.errors)
+	})
+
+	t.Run("iterate page with no errors and one interruption", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		hasStopped := false
+		do := func(ctx context.Context, ids []api.RepoID, fn FinishNFunc) bool {
+			clock.Advance(time.Second * 1)
+			executionErrs := map[int32]error{}
+			for _, id := range ids {
+				if id == 6 && !hasStopped {
+					hasStopped = true
+					return false
+				}
+			}
+
+			err := fn(ctx, store, executionErrs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		}
+
+		got, seen := testForNextNAndFinish(t, store, itr, 2, seen, do)
+
+		require.Equal(t, got.Cursor, 2)
+		reloaded, _ := LoadWithClock(ctx, store, got.Id, clock)
+		require.Equal(t, reloaded.Cursor, got.Cursor)
+
+		// now iterate from the starting position _after_ reloading from the db
+		secondItr, _ := testForNextNAndFinish(t, store, reloaded, 2, seen, do)
+		jsonify, _ := json.Marshal(secondItr)
+		autogold.Want("iterate with no error and 1 interruptions", `{"Id":7,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:04Z","RuntimeDuration":3000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+	})
+
+	t.Run("iterate twice and verify progress updates", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5, 6, 14, 17}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+
+		var finishFunc FinishNFunc
+
+		// iterate once
+		_, _, finishFunc = itr.NextPageWithFinish(2, IterationConfig{})
+		err := finishFunc(ctx, store, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// then twice
+		_, _, finishFunc = itr.NextPageWithFinish(2, IterationConfig{})
+		err = finishFunc(ctx, store, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// we should see 80% progress
+		reloaded, err := Load(ctx, store, itr.Id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jsonify, _ := json.Marshal(reloaded)
+		autogold.Want("iterate twice and verify progress", `{"Id":8,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0.8,"TotalCount":5,"SuccessCount":4,"Cursor":4}`).Equal(t, string(jsonify))
 	})
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2450,6 +2450,8 @@ type SiteConfiguration struct {
 	InsightsAggregationsProactiveResultLimit int `json:"insights.aggregations.proactiveResultLimit,omitempty"`
 	// InsightsBackfillInterruptAfter description: Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.
 	InsightsBackfillInterruptAfter int `json:"insights.backfill.interruptAfter,omitempty"`
+	// InsightsBackfillRepositoryGroupSize description: Set the number of repositories to batch in a group during backfilling.
+	InsightsBackfillRepositoryGroupSize int `json:"insights.backfill.repositoryGroupSize,omitempty"`
 	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
 	InsightsHistoricalWorkerRateLimit *float64 `json:"insights.historical.worker.rateLimit,omitempty"`
 	// InsightsHistoricalWorkerRateLimitBurst description: The allowed burst rate for the Code Insights historical worker rate limiter.
@@ -2632,6 +2634,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "insights.aggregations.bufferSize")
 	delete(m, "insights.aggregations.proactiveResultLimit")
 	delete(m, "insights.backfill.interruptAfter")
+	delete(m, "insights.backfill.repositoryGroupSize")
 	delete(m, "insights.historical.worker.rateLimit")
 	delete(m, "insights.historical.worker.rateLimitBurst")
 	delete(m, "insights.maximumSampleSize")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2450,6 +2450,8 @@ type SiteConfiguration struct {
 	InsightsAggregationsProactiveResultLimit int `json:"insights.aggregations.proactiveResultLimit,omitempty"`
 	// InsightsBackfillInterruptAfter description: Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.
 	InsightsBackfillInterruptAfter int `json:"insights.backfill.interruptAfter,omitempty"`
+	// InsightsBackfillRepositoryConcurrency description: Number of repositories within the batch to backfill concurrently.
+	InsightsBackfillRepositoryConcurrency int `json:"insights.backfill.repositoryConcurrency,omitempty"`
 	// InsightsBackfillRepositoryGroupSize description: Set the number of repositories to batch in a group during backfilling.
 	InsightsBackfillRepositoryGroupSize int `json:"insights.backfill.repositoryGroupSize,omitempty"`
 	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
@@ -2634,6 +2636,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "insights.aggregations.bufferSize")
 	delete(m, "insights.aggregations.proactiveResultLimit")
 	delete(m, "insights.backfill.interruptAfter")
+	delete(m, "insights.backfill.repositoryConcurrency")
 	delete(m, "insights.backfill.repositoryGroupSize")
 	delete(m, "insights.historical.worker.rateLimit")
 	delete(m, "insights.historical.worker.rateLimitBurst")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1407,6 +1407,14 @@
       "group": "CodeInsights",
       "default": 10
     },
+    "insights.backfill.repositoryConcurrency": {
+      "description": "Number of repositories within the batch to backfill concurrently.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 3,
+      "maximum": 10,
+      "minimum": 1
+    },
     "insights.query.worker.concurrency": {
       "description": "Number of concurrent executions of a code insight query on a worker node",
       "type": "integer",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1401,6 +1401,12 @@
       "group": "CodeInsights",
       "default": 60
     },
+    "insights.backfill.repositoryGroupSize": {
+      "description": "Set the number of repositories to batch in a group during backfilling.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 10
+    },
     "insights.query.worker.concurrency": {
       "description": "Number of concurrent executions of a code insight query on a worker node",
       "type": "integer",


### PR DESCRIPTION
Adds new capability to the repo iterator to allow a consumer to pull multiple repos at a time and then call Finish once to complete them all.

Uses this new iterator capability because some repos take longer than other to backfill, the throughput is not always maximized.  By grabbing a batch of repos at a time we can run can continue to run additional repos though the backfill process while the larger/slower repo is running.  

This sets a conservative default page size of 10 and limits the concurrency to 3 repos backfilling at once.  Previous rate limits for searches per second still apply. A batch or repos will complete as a group, this means that the runtime of an iteration could exceeded the configured time, by an extended period of a batch contained multiple large repos.  This should not be problematic because if this insight is backfilling it is was the highest priority.

closes https://github.com/sourcegraph/sourcegraph/issues/46678

## Test plan
Existing test coverage for handler
Existing test tests coverage for iterator, plus added new tests to verify pages
Created an insight and backfilled it.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
