### PR TITLE
SCIM: User get all filters

### DIFF
--- a/enterprise/internal/scim/filter/filter.go
+++ b/enterprise/internal/scim/filter/filter.go
@@ -1,0 +1,335 @@
+package filter
+
+import (
+	"fmt"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+// This is almost unmodified copy-pasta from https://github.com/elimity-com/scim/
+// The only changes to the package are the package names and imports in the test files.
+// Non-test files are unchanged from the original.
+// Elimity's SCIM package has the following licensing information:
+// ----------------------------------------------------------------------------
+// MIT License
+//
+// Copyright (c) 2019 Elimity NV
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE  FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+// validateAttributePath checks whether the given attribute path is a valid path within the given reference schema.
+func validateAttributePath(ref schema.Schema, attrPath filter.AttributePath) (schema.CoreAttribute, error) {
+	if uri := attrPath.URI(); uri != "" && uri != ref.ID {
+		return schema.CoreAttribute{}, fmt.Errorf("the uri does not match the schema id: %s", uri)
+	}
+
+	attr, ok := ref.Attributes.ContainsAttribute(attrPath.AttributeName)
+	if !ok {
+		return schema.CoreAttribute{}, fmt.Errorf(
+			"the reference schema does not have an attribute with the name: %s",
+			attrPath.AttributeName,
+		)
+	}
+	// e.g. name.givenName
+	//           ^________
+	if subAttrName := attrPath.SubAttributeName(); subAttrName != "" {
+		if err := validateSubAttribute(attr, subAttrName); err != nil {
+			return schema.CoreAttribute{}, err
+		}
+	}
+	return attr, nil
+}
+
+// validateExpression checks whether the given expression is a valid expression within the given reference schema.
+func validateExpression(ref schema.Schema, e filter.Expression) error {
+	switch e := e.(type) {
+	case *filter.ValuePath:
+		attr, err := validateAttributePath(ref, e.AttributePath)
+		if err != nil {
+			return nil
+		}
+		if err := validateExpression(
+			schema.Schema{
+				ID:         ref.ID,
+				Attributes: attr.SubAttributes(),
+			},
+			e.ValueFilter,
+		); err != nil {
+			return err
+		}
+		return nil
+	case *filter.AttributeExpression:
+		if _, err := validateAttributePath(ref, e.AttributePath); err != nil {
+			return err
+		}
+		return nil
+	case *filter.LogicalExpression:
+		if err := validateExpression(ref, e.Left); err != nil {
+			return err
+		}
+		if err := validateExpression(ref, e.Right); err != nil {
+			return err
+		}
+		return nil
+	case *filter.NotExpression:
+		if err := validateExpression(ref, e.Expression); err != nil {
+			return err
+		}
+		return nil
+	default:
+		panic(fmt.Sprintf("unknown expression type: %s", e))
+	}
+}
+
+// validateSubAttribute checks whether the given attribute name is a attribute within the given reference attribute.
+func validateSubAttribute(attr schema.CoreAttribute, subAttrName string) error {
+	if !attr.HasSubAttributes() {
+		return fmt.Errorf("the attribute has no sub-attributes")
+	}
+
+	if _, ok := attr.SubAttributes().ContainsAttribute(subAttrName); !ok {
+		return fmt.Errorf("the attribute has no sub-attributes named: %s", subAttrName)
+	}
+	return nil
+}
+
+// Validator represents a filter validator.
+type Validator struct {
+	filter     filter.Expression
+	schema     schema.Schema
+	extensions []schema.Schema
+}
+
+// NewFilterValidator constructs a new filter validator.
+func NewFilterValidator(exp filter.Expression, s schema.Schema, exts ...schema.Schema) Validator {
+	return Validator{
+		filter:     exp,
+		schema:     s,
+		extensions: exts,
+	}
+}
+
+// NewValidator constructs a new filter validator.
+func NewValidator(exp string, s schema.Schema, exts ...schema.Schema) (Validator, error) {
+	e, err := filter.ParseFilter([]byte(exp))
+	if err != nil {
+		return Validator{}, err
+	}
+	return Validator{
+		filter:     e,
+		schema:     s,
+		extensions: exts,
+	}, nil
+}
+
+// GetFilter returns the filter contained within the validator.
+func (v Validator) GetFilter() filter.Expression {
+	return v.filter
+}
+
+// PassesFilter checks whether given resources passes the filter.
+func (v Validator) PassesFilter(resource map[string]interface{}) error {
+	switch e := v.filter.(type) {
+	case *filter.ValuePath:
+		ref, attr, ok := v.referenceContains(e.AttributePath)
+		if !ok {
+			return fmt.Errorf("could not find an attribute that matches the attribute path: %s", e.AttributePath)
+		}
+		if !attr.MultiValued() {
+			return fmt.Errorf("value path filters can only be applied to multi-valued attributes")
+		}
+
+		value, ok := resource[attr.Name()]
+		if !ok {
+			// Also try with the id as prefix.
+			value, ok = resource[fmt.Sprintf("%s:%s", ref.ID, attr.Name())]
+			if !ok {
+				return fmt.Errorf("the resource does contain the attribute specified in the filter")
+			}
+		}
+		valueFilter := Validator{
+			filter: e.ValueFilter,
+			schema: schema.Schema{
+				ID:         ref.ID,
+				Attributes: attr.SubAttributes(),
+			},
+		}
+		switch value := value.(type) {
+		case []interface{}:
+			for _, a := range value {
+				attr, ok := a.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("the target is not a complex attribute")
+				}
+				if err := valueFilter.PassesFilter(attr); err == nil {
+					// Found an attribute that passed the value filter.
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("the resource does not pass the filter")
+	case *filter.AttributeExpression:
+		ref, attr, ok := v.referenceContains(e.AttributePath)
+		if !ok {
+			return fmt.Errorf("could not find an attribute that matches the attribute path: %s", e.AttributePath)
+		}
+
+		value, ok := resource[attr.Name()]
+		if !ok {
+			// Also try with the id as prefix.
+			value, ok = resource[fmt.Sprintf("%s:%s", ref.ID, attr.Name())]
+			if !ok {
+				return fmt.Errorf("the resource does contain the attribute specified in the filter")
+			}
+		}
+
+		var (
+			// cmpAttr will be the attribute to validate the filter against.
+			cmpAttr = attr
+
+			subAttr     schema.CoreAttribute
+			subAttrName = e.AttributePath.SubAttributeName()
+		)
+
+		if subAttrName != "" {
+			if !attr.HasSubAttributes() {
+				// The attribute has no sub-attributes.
+				return fmt.Errorf("the specified attribute has no sub-attributes")
+			}
+			subAttr, ok = attr.SubAttributes().ContainsAttribute(subAttrName)
+			if !ok {
+				return fmt.Errorf("the resource has no sub-attribute named: %s", subAttrName)
+			}
+
+			attr, ok := value.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("the target is not a complex attribute")
+			}
+			value, ok = attr[subAttr.Name()]
+			if !ok {
+				return fmt.Errorf("the resource does contain the attribute specified in the filter")
+			}
+
+			cmpAttr = subAttr
+		}
+
+		// If the attribute has a non-empty or non-null value or if it contains a non-empty node for complex attributes, there is a match.
+		if e.Operator == filter.PR {
+			// We already found a value.
+			return nil
+		}
+
+		cmp, err := createCompareFunction(e, cmpAttr)
+		if err != nil {
+			return err
+		}
+
+		if !attr.MultiValued() {
+			if err := cmp(value); err != nil {
+				return fmt.Errorf("the resource does not pass the filter: %s", err)
+			}
+			return nil
+		}
+
+		switch value := value.(type) {
+		case []interface{}:
+			var err error
+			for _, v := range value {
+				if err = cmp(v); err == nil {
+					return nil
+				}
+			}
+			return fmt.Errorf("the resource does not pass the filter: %s", err)
+		default:
+			panic(fmt.Sprintf("given value is not a []interface{}: %v", value))
+		}
+	case *filter.LogicalExpression:
+		switch e.Operator {
+		case filter.AND:
+			leftValidator := Validator{
+				e.Left,
+				v.schema,
+				v.extensions,
+			}
+			if err := leftValidator.PassesFilter(resource); err != nil {
+				return err
+			}
+			rightValidator := Validator{
+				e.Right,
+				v.schema,
+				v.extensions,
+			}
+			return rightValidator.PassesFilter(resource)
+		case filter.OR:
+			leftValidator := Validator{
+				e.Left,
+				v.schema,
+				v.extensions,
+			}
+			if err := leftValidator.PassesFilter(resource); err == nil {
+				return nil
+			}
+			rightValidator := Validator{
+				e.Right,
+				v.schema,
+				v.extensions,
+			}
+			return rightValidator.PassesFilter(resource)
+		}
+		return fmt.Errorf("the resource does not pass the filter")
+	case *filter.NotExpression:
+		validator := Validator{
+			e.Expression,
+			v.schema,
+			v.extensions,
+		}
+		if err := validator.PassesFilter(resource); err != nil {
+			return nil
+		}
+		return fmt.Errorf("the resource does not pass the filter")
+	default:
+		panic(fmt.Sprintf("unknown expression type: %s", e))
+	}
+}
+
+// Validate checks whether the expression is a valid path within the given reference schemas.
+func (v Validator) Validate() error {
+	err := validateExpression(v.schema, v.filter)
+	if err == nil {
+		return nil
+	}
+	for _, e := range v.extensions {
+		if err := validateExpression(e, v.filter); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// referenceContains returns the schema and attribute to which the attribute path applies.
+func (v Validator) referenceContains(attrPath filter.AttributePath) (schema.Schema, schema.CoreAttribute, bool) {
+	for _, s := range append([]schema.Schema{v.schema}, v.extensions...) {
+		if uri := attrPath.URI(); uri != "" && s.ID != uri {
+			continue
+		}
+		if attr, ok := s.Attributes.ContainsAttribute(attrPath.AttributeName); ok {
+			return s, attr, true
+		}
+	}
+	return schema.Schema{}, schema.CoreAttribute{}, false
+}

--- a/enterprise/internal/scim/filter/filter_test.go
+++ b/enterprise/internal/scim/filter/filter_test.go
@@ -1,0 +1,281 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+)
+
+func TestPathValidator_Validate(t *testing.T) {
+	// More info: https://tools.ietf.org/html/rfc7644#section-3.5.2
+	t.Run("Valid", func(t *testing.T) {
+		for _, f := range []string{
+			`urn:ietf:params:scim:schemas:core:2.0:User:name`,
+			`urn:ietf:params:scim:schemas:core:2.0:User:name.familyName`,
+			`urn:ietf:params:scim:schemas:core:2.0:User:emails[type eq "work"]`,
+			`urn:ietf:params:scim:schemas:core:2.0:User:emails[type eq "work"].display`,
+
+			`name`,
+			`name.familyName`,
+			`emails`,
+			`emails.value`,
+			`emails[type eq "work"]`,
+			`emails[type eq "work"].display`,
+
+			`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber`,
+			`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName`,
+		} {
+			validator, err := NewPathValidator(f, schema.CoreUserSchema(), schema.ExtensionEnterpriseUser())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validator.Validate(); err != nil {
+				t.Errorf("(%s) %v", f, err)
+			}
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		for _, f := range []string{
+			`urn:ietf:params:scim:schemas:core:2.0:Invalid:name`,
+
+			`invalid`,
+			`name.invalid`,
+			`emails[invalid eq "work"]`,
+			`emails[type eq "work"].invalid`,
+
+			`urn:ietf:params:scim:schemas:core:2.0:User:employeeNumber`,
+			`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userName`,
+		} {
+			validator, err := NewPathValidator(f, schema.CoreUserSchema(), schema.ExtensionEnterpriseUser())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validator.Validate(); err == nil {
+				t.Errorf("(%s) should not be valid", f)
+			}
+		}
+	})
+}
+
+func TestValidator_PassesFilter(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		for _, test := range []struct {
+			filter  string
+			valid   map[string]interface{}
+			invalid map[string]interface{}
+		}{
+			{
+				filter: `userName eq "john"`,
+				valid: map[string]interface{}{
+					"userName": "john",
+				},
+				invalid: map[string]interface{}{
+					"userName": "doe",
+				},
+			},
+			{
+				filter: `emails[type eq "work"]`,
+				valid: map[string]interface{}{
+					"emails": []interface{}{
+						map[string]interface{}{
+							"type": "work",
+						},
+					},
+				},
+				invalid: map[string]interface{}{
+					"emails": []interface{}{
+						map[string]interface{}{
+							"type": "private",
+						},
+					},
+				},
+			},
+		} {
+			validator, err := NewValidator(test.filter, schema.CoreUserSchema())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resource := test.valid; resource != nil {
+				if err := validator.PassesFilter(resource); err != nil {
+					t.Errorf("(%v) should be valid: %v", resource, err)
+				}
+			}
+			if resource := test.invalid; resource != nil {
+				if err := validator.PassesFilter(resource); err == nil {
+					t.Errorf("(%v) should not be valid", resource)
+				}
+			}
+		}
+	})
+
+	for _, test := range []struct {
+		name   string
+		amount int
+		filter string
+	}{
+		{name: "eq", amount: 1, filter: `userName eq "di-wu"`},
+		{name: "ne", amount: 5, filter: `userName ne "di-wu"`},
+		{name: "co", amount: 3, filter: `userName co "u"`},
+		{name: "co", amount: 2, filter: `name.familyName co "d"`},
+		{name: "sw", amount: 2, filter: `userName sw "a"`},
+		{name: "sw", amount: 2, filter: `urn:ietf:params:scim:schemas:core:2.0:User:userName sw "a"`},
+		{name: "ew", amount: 2, filter: `userName ew "n"`},
+		{name: "pr", amount: 6, filter: `userName pr`},
+		{name: "gt", amount: 2, filter: `userName gt "guest"`},
+		{name: "ge", amount: 3, filter: `userName ge "guest"`},
+		{name: "lt", amount: 3, filter: `userName lt "guest"`},
+		{name: "le", amount: 4, filter: `userName le "guest"`},
+		{name: "value", amount: 2, filter: `emails[type eq "work"]`},
+		{name: "and", amount: 1, filter: `name.familyName eq "ad" and userType eq "admin"`},
+		{name: "or", amount: 2, filter: `name.familyName eq "ad" or userType eq "admin"`},
+		{name: "not", amount: 5, filter: `not (userName eq "di-wu")`},
+		{name: "meta", amount: 1, filter: `meta.lastModified gt "2011-05-13T04:42:34Z"`},
+		{name: "schemas", amount: 2, filter: `schemas eq "urn:ietf:params:scim:schemas:core:2.0:User"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			userSchema := schema.CoreUserSchema()
+			userSchema.Attributes = append(userSchema.Attributes, schema.SchemasAttributes())
+			userSchema.Attributes = append(userSchema.Attributes, schema.CommonAttributes()...)
+			validator, err := NewValidator(test.filter, userSchema)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var amount int
+			for _, resource := range testResources() {
+				if err := validator.PassesFilter(resource); err == nil {
+					amount++
+				}
+			}
+			if amount != test.amount {
+				t.Errorf("Expected %d resources to pass, got %d.", test.amount, amount)
+			}
+		})
+	}
+
+	t.Run("extensions", func(t *testing.T) {
+		for _, test := range []struct {
+			amount int
+			filter string
+		}{
+			{
+				amount: 1,
+				filter: `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName eq "di-wu"`,
+			},
+			{
+				amount: 1,
+				filter: `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization eq "Elimity"`,
+			},
+		} {
+			validator, err := NewValidator(test.filter, schema.ExtensionEnterpriseUser())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var amount int
+			for _, resource := range testResources() {
+				if err := validator.PassesFilter(resource); err == nil {
+					amount++
+				}
+			}
+			if amount != test.amount {
+				t.Errorf("Expected %d resources to pass, got %d.", test.amount, amount)
+			}
+		}
+	})
+}
+
+func TestValidator_Validate(t *testing.T) {
+	// More info: https://tools.ietf.org/html/rfc7644#section-3.4.2.2
+	userSchema := schema.CoreUserSchema()
+	userSchema.Attributes = append(userSchema.Attributes, schema.CommonAttributes()...)
+
+	for _, f := range []string{
+		`userName Eq "john"`,
+		`Username eq "john"`,
+
+		`userName eq "bjensen"`,
+		`name.familyName co "O'Malley"`,
+		`userName sw "J"`,
+		`urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"`,
+		`title pr`,
+		`meta.lastModified gt "2011-05-13T04:42:34Z"`,
+		`meta.lastModified ge "2011-05-13T04:42:34Z"`,
+		`meta.lastModified lt "2011-05-13T04:42:34Z"`,
+		`meta.lastModified le "2011-05-13T04:42:34Z"`,
+		`title pr and userType eq "Employee"`,
+		`title pr or userType eq "Intern"`,
+		`schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"`,
+		`userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")`,
+		`userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")`,
+		`userType eq "Employee" and (emails.type eq "work")`,
+		`userType eq "Employee" and emails[type eq "work" and value co "@example.com"]`,
+		`emails[type eq "work" and value co "@example.com"] or ims[type eq "xmpp" and value co "@foo.com"]`,
+	} {
+		validator, err := NewValidator(f, userSchema)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validator.Validate(); err != nil {
+			t.Errorf("(%s) %v", f, err)
+		}
+	}
+}
+
+func testResources() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"schemas": []interface{}{
+				"urn:ietf:params:scim:schemas:core:2.0:User",
+			},
+			"userName": "di-wu",
+			"userType": "admin",
+			"name": map[string]interface{}{
+				"familyName": "di",
+				"givenName":  "wu",
+			},
+			"emails": []interface{}{
+				map[string]interface{}{
+					"value": "quint@elimity.com",
+					"type":  "work",
+				},
+			},
+			"meta": map[string]interface{}{
+				"lastModified": "2020-07-26T20:02:34Z",
+			},
+			"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization": "Elimity",
+		},
+		{
+			"schemas": []interface{}{
+				"urn:ietf:params:scim:schemas:core:2.0:User",
+			},
+			"userName": "noreply",
+			"emails": []interface{}{
+				map[string]interface{}{
+					"value": "noreply@elimity.com",
+					"type":  "work",
+				},
+			},
+		},
+		{
+			"userName": "admin",
+			"userType": "admin",
+			"name": map[string]interface{}{
+				"familyName": "ad",
+				"givenName":  "min",
+			},
+			"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager": map[string]interface{}{
+				"displayName": "di-wu",
+			},
+		},
+		{"userName": "guest"},
+		{
+			"userName": "unknown",
+			"name": map[string]interface{}{
+				"familyName": "un",
+				"givenName":  "known",
+			},
+		},
+		{"userName": "another"},
+	}
+}

--- a/enterprise/internal/scim/filter/op_binary.go
+++ b/enterprise/internal/scim/filter/op_binary.go
@@ -1,0 +1,56 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+)
+
+// cmpBinary returns a compare function that compares a given value to the reference string based on the given attribute
+// expression and binary attribute. The filter operators gt, lt, ge and le are not supported on binary attributes.
+//
+// Expects a binary attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpBinary(e *filter.AttributeExpression, ref string) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpStr(ref, true, func(v, ref string) error {
+			if v != ref {
+				return fmt.Errorf("%s is not equal to %s", v, ref)
+			}
+			return nil
+		})
+	case filter.NE:
+		return cmpStr(ref, true, func(v, ref string) error {
+			if v == ref {
+				return fmt.Errorf("%s is equal to %s", v, ref)
+			}
+			return nil
+		})
+	case filter.CO:
+		return cmpStr(ref, true, func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpStr(ref, true, func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpStr(ref, true, func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT, filter.LT, filter.GE, filter.LE:
+		return nil, fmt.Errorf("can not use op %q on binary values", op)
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}

--- a/enterprise/internal/scim/filter/op_binary.go
+++ b/enterprise/internal/scim/filter/op_binary.go
@@ -2,8 +2,10 @@ package filter
 
 import (
 	"fmt"
-	"github.com/scim2/filter-parser/v2"
 	"strings"
+
+	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // cmpBinary returns a compare function that compares a given value to the reference string based on the given attribute
@@ -16,40 +18,40 @@ func cmpBinary(e *filter.AttributeExpression, ref string) (func(interface{}) err
 	case filter.EQ:
 		return cmpStr(ref, true, func(v, ref string) error {
 			if v != ref {
-				return fmt.Errorf("%s is not equal to %s", v, ref)
+				return errors.Newf("%s is not equal to %s", v, ref)
 			}
 			return nil
 		})
 	case filter.NE:
 		return cmpStr(ref, true, func(v, ref string) error {
 			if v == ref {
-				return fmt.Errorf("%s is equal to %s", v, ref)
+				return errors.Newf("%s is equal to %s", v, ref)
 			}
 			return nil
 		})
 	case filter.CO:
 		return cmpStr(ref, true, func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpStr(ref, true, func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpStr(ref, true, func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT, filter.LT, filter.GE, filter.LE:
-		return nil, fmt.Errorf("can not use op %q on binary values", op)
+		return nil, errors.Newf("can not use op %q on binary values", op)
 	default:
 		panic(fmt.Sprintf("unknown operator in expression: %s", e))
 	}

--- a/enterprise/internal/scim/filter/op_boolean.go
+++ b/enterprise/internal/scim/filter/op_boolean.go
@@ -1,0 +1,77 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+)
+
+func cmpBool(ref bool, cmp func(v, ref bool) error) func(interface{}) error {
+	return func(i interface{}) error {
+		value, ok := i.(bool)
+		if !ok {
+			panic(fmt.Sprintf("given value is not a boolean: %v", i))
+		}
+		return cmp(value, ref)
+	}
+}
+
+func cmpBoolStr(ref bool, cmp func(v, ref string) error) (func(interface{}) error, error) {
+	return func(i interface{}) error {
+		if _, ok := i.(bool); !ok {
+			panic(fmt.Sprintf("given value is not a boolean: %v", i))
+		}
+		return cmp(fmt.Sprintf("%t", i), fmt.Sprintf("%t", ref))
+	}, nil
+}
+
+// cmpBoolean returns a compare function that compares a given value to the reference boolean based on the given
+// attribute expression and string/reference attribute. The filter operators gt, lt, ge and le are not supported on
+// boolean attributes.
+//
+// Expects a boolean attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpBoolean(e *filter.AttributeExpression, attr schema.CoreAttribute, ref bool) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpBool(ref, func(v, ref bool) error {
+			if v != ref {
+				return fmt.Errorf("%t is not equal to %t", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.NE:
+		return cmpBool(ref, func(v, ref bool) error {
+			if v == ref {
+				return fmt.Errorf("%t is equal to %t", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.CO:
+		return cmpBoolStr(ref, func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpBoolStr(ref, func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpBoolStr(ref, func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT, filter.LT, filter.GE, filter.LE:
+		return nil, fmt.Errorf("can not use op %q on boolean values", op)
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}

--- a/enterprise/internal/scim/filter/op_boolean.go
+++ b/enterprise/internal/scim/filter/op_boolean.go
@@ -2,9 +2,10 @@ package filter
 
 import (
 	"fmt"
-	"github.com/elimity-com/scim/schema"
-	"github.com/scim2/filter-parser/v2"
 	"strings"
+
+	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func cmpBool(ref bool, cmp func(v, ref bool) error) func(interface{}) error {
@@ -32,45 +33,45 @@ func cmpBoolStr(ref bool, cmp func(v, ref string) error) (func(interface{}) erro
 //
 // Expects a boolean attribute. Will panic on unknown filter operator.
 // Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
-func cmpBoolean(e *filter.AttributeExpression, attr schema.CoreAttribute, ref bool) (func(interface{}) error, error) {
+func cmpBoolean(e *filter.AttributeExpression, ref bool) (func(interface{}) error, error) {
 	switch op := e.Operator; op {
 	case filter.EQ:
 		return cmpBool(ref, func(v, ref bool) error {
 			if v != ref {
-				return fmt.Errorf("%t is not equal to %t", v, ref)
+				return errors.Newf("%t is not equal to %t", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.NE:
 		return cmpBool(ref, func(v, ref bool) error {
 			if v == ref {
-				return fmt.Errorf("%t is equal to %t", v, ref)
+				return errors.Newf("%t is equal to %t", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.CO:
 		return cmpBoolStr(ref, func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpBoolStr(ref, func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpBoolStr(ref, func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT, filter.LT, filter.GE, filter.LE:
-		return nil, fmt.Errorf("can not use op %q on boolean values", op)
+		return nil, errors.Newf("can not use op %q on boolean values", op)
 	default:
 		panic(fmt.Sprintf("unknown operator in expression: %s", e))
 	}

--- a/enterprise/internal/scim/filter/op_boolean_test.go
+++ b/enterprise/internal/scim/filter/op_boolean_test.go
@@ -1,0 +1,53 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+func TestValidatorBoolean(t *testing.T) {
+	var (
+		exp = func(op filter.CompareOperator) string {
+			return fmt.Sprintf("bool %s true", op)
+		}
+		ref = schema.Schema{
+			Attributes: []schema.CoreAttribute{
+				schema.SimpleCoreAttribute(schema.SimpleBooleanParams(schema.BooleanParams{
+					Name: "bool",
+				})),
+			},
+		}
+		attr = map[string]interface{}{
+			"bool": true,
+		}
+	)
+
+	for _, test := range []struct {
+		op    filter.CompareOperator
+		valid bool // Whether the filter is valid.
+	}{
+		{filter.EQ, true},
+		{filter.NE, false},
+		{filter.CO, true},
+		{filter.SW, true},
+		{filter.EW, true},
+		{filter.GT, false},
+		{filter.LT, false},
+		{filter.GE, false},
+		{filter.LE, false},
+	} {
+		t.Run(string(test.op), func(t *testing.T) {
+			f := exp(test.op)
+			validator, err := NewValidator(f, ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validator.PassesFilter(attr); (err == nil) != test.valid {
+				t.Errorf("%s %v | actual %v, expected %v", f, attr, err, test.valid)
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/op_datetime.go
+++ b/enterprise/internal/scim/filter/op_datetime.go
@@ -1,0 +1,98 @@
+package filter
+
+import (
+	"fmt"
+	datetime "github.com/di-wu/xsd-datetime"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+	"time"
+)
+
+// cmpDateTime returns a compare function that compares a given value to the reference string/time based on the given
+// attribute expression and dateTime attribute.
+//
+// Expects a dateTime attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpDateTime(e *filter.AttributeExpression, date string, ref time.Time) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if !v.Equal(ref) {
+				return fmt.Errorf("%s is not equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	case filter.NE:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if v.Equal(ref) {
+				return fmt.Errorf("%s is equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	case filter.CO:
+		return cmpStr(date, false, func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpStr(date, false, func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpStr(date, false, func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if !v.After(ref) {
+				return fmt.Errorf("%s is not greater than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	case filter.LT:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if !v.Before(ref) {
+				return fmt.Errorf("%s is not less than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	case filter.GE:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if !v.After(ref) && !v.Equal(ref) {
+				return fmt.Errorf("%s is not greater or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	case filter.LE:
+		return cmpTime(ref, func(v, ref time.Time) error {
+			if !v.Before(ref) && !v.Equal(ref) {
+				return fmt.Errorf("%s is not less or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+			}
+			return nil
+		}), nil
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}
+
+func cmpTime(ref time.Time, cmp func(v, ref time.Time) error) func(interface{}) error {
+	return func(i interface{}) error {
+		date, ok := i.(string)
+		if !ok {
+			panic(fmt.Sprintf("given value is not a string: %v", i))
+		}
+		value, err := datetime.Parse(date)
+		if err != nil {
+			panic(fmt.Sprintf("given value is not a date time (%v): %s", i, err))
+		}
+		return cmp(value, ref)
+	}
+}

--- a/enterprise/internal/scim/filter/op_datetime.go
+++ b/enterprise/internal/scim/filter/op_datetime.go
@@ -2,10 +2,12 @@ package filter
 
 import (
 	"fmt"
-	datetime "github.com/di-wu/xsd-datetime"
-	"github.com/scim2/filter-parser/v2"
 	"strings"
 	"time"
+
+	datetime "github.com/di-wu/xsd-datetime"
+	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // cmpDateTime returns a compare function that compares a given value to the reference string/time based on the given
@@ -18,63 +20,63 @@ func cmpDateTime(e *filter.AttributeExpression, date string, ref time.Time) (fun
 	case filter.EQ:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if !v.Equal(ref) {
-				return fmt.Errorf("%s is not equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is not equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil
 	case filter.NE:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if v.Equal(ref) {
-				return fmt.Errorf("%s is equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil
 	case filter.CO:
 		return cmpStr(date, false, func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpStr(date, false, func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpStr(date, false, func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if !v.After(ref) {
-				return fmt.Errorf("%s is not greater than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is not greater than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil
 	case filter.LT:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if !v.Before(ref) {
-				return fmt.Errorf("%s is not less than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is not less than %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil
 	case filter.GE:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if !v.After(ref) && !v.Equal(ref) {
-				return fmt.Errorf("%s is not greater or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is not greater or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil
 	case filter.LE:
 		return cmpTime(ref, func(v, ref time.Time) error {
 			if !v.Before(ref) && !v.Equal(ref) {
-				return fmt.Errorf("%s is not less or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
+				return errors.Newf("%s is not less or equal to %s", v.Format(time.RFC3339), ref.Format(time.RFC3339))
 			}
 			return nil
 		}), nil

--- a/enterprise/internal/scim/filter/op_datetime_test.go
+++ b/enterprise/internal/scim/filter/op_datetime_test.go
@@ -1,0 +1,57 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+func TestValidatorDateTime(t *testing.T) {
+	var (
+		exp = func(op filter.CompareOperator) string {
+			return fmt.Sprintf("time %s \"2021-01-01T12:00:00Z\"", op)
+		}
+		ref = schema.Schema{
+			Attributes: []schema.CoreAttribute{
+				schema.SimpleCoreAttribute(schema.SimpleDateTimeParams(schema.DateTimeParams{
+					Name: "time",
+				})),
+			},
+		}
+		attrs = [3]map[string]interface{}{
+			{"time": "2021-01-01T08:00:00Z"}, // before
+			{"time": "2021-01-01T12:00:00Z"}, // equal
+			{"time": "2021-01-01T16:00:00Z"}, // after
+		}
+	)
+
+	for _, test := range []struct {
+		op    filter.CompareOperator
+		valid [3]bool
+	}{
+		{filter.EQ, [3]bool{false, true, false}},
+		{filter.NE, [3]bool{true, false, true}},
+		{filter.CO, [3]bool{false, true, false}},
+		{filter.SW, [3]bool{false, true, false}},
+		{filter.EW, [3]bool{false, true, false}},
+		{filter.GT, [3]bool{false, false, true}},
+		{filter.LT, [3]bool{true, false, false}},
+		{filter.GE, [3]bool{false, true, true}},
+		{filter.LE, [3]bool{true, true, false}},
+	} {
+		t.Run(string(test.op), func(t *testing.T) {
+			f := exp(test.op)
+			validator, err := NewValidator(f, ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i, attr := range attrs {
+				if err := validator.PassesFilter(attr); (err == nil) != test.valid[i] {
+					t.Errorf("(%d) %s %v | actual %v, expected %v", i, f, attr, err, test.valid[i])
+				}
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/op_decimal.go
+++ b/enterprise/internal/scim/filter/op_decimal.go
@@ -1,0 +1,102 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+)
+
+// cmpDecimal returns a compare function that compares a given value to the reference float based on the given attribute
+// expression and decimal attribute.
+//
+// Expects a decimal attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpDecimal(e *filter.AttributeExpression, ref float64) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v != ref {
+				return fmt.Errorf("%f is not equal to %f", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.NE:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v == ref {
+				return fmt.Errorf("%f is equal to %f", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.CO:
+		return cmpFloatStr(ref, func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpFloatStr(ref, func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpFloatStr(ref, func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v <= ref {
+				return fmt.Errorf("%f is not greater than %f", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.LT:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v >= ref {
+				return fmt.Errorf("%f is not less than %f", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.GE:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v < ref {
+				return fmt.Errorf("%f is not greater or equal to %f", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.LE:
+		return cmpFloat(ref, func(v, ref float64) error {
+			if v > ref {
+				return fmt.Errorf("%f is not less or equal to %f", v, ref)
+			}
+			return nil
+		}), nil
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}
+
+func cmpFloat(ref float64, cmp func(v, ref float64) error) func(interface{}) error {
+	return func(i interface{}) error {
+		f, ok := i.(float64)
+		if !ok {
+			panic(fmt.Sprintf("given value is not a float: %v", i))
+		}
+		return cmp(f, ref)
+	}
+}
+
+func cmpFloatStr(ref float64, cmp func(v, ref string) error) (func(interface{}) error, error) {
+	return func(i interface{}) error {
+		if _, ok := i.(float64); !ok {
+			panic(fmt.Sprintf("given value is not a float: %v", i))
+		}
+		// fmt.Sprintf("%f") would give them both the same precision.
+		return cmp(fmt.Sprint(i), fmt.Sprint(ref))
+	}, nil
+}

--- a/enterprise/internal/scim/filter/op_decimal.go
+++ b/enterprise/internal/scim/filter/op_decimal.go
@@ -2,8 +2,10 @@ package filter
 
 import (
 	"fmt"
-	"github.com/scim2/filter-parser/v2"
 	"strings"
+
+	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // cmpDecimal returns a compare function that compares a given value to the reference float based on the given attribute
@@ -16,63 +18,63 @@ func cmpDecimal(e *filter.AttributeExpression, ref float64) (func(interface{}) e
 	case filter.EQ:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v != ref {
-				return fmt.Errorf("%f is not equal to %f", v, ref)
+				return errors.Newf("%f is not equal to %f", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.NE:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v == ref {
-				return fmt.Errorf("%f is equal to %f", v, ref)
+				return errors.Newf("%f is equal to %f", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.CO:
 		return cmpFloatStr(ref, func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpFloatStr(ref, func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpFloatStr(ref, func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v <= ref {
-				return fmt.Errorf("%f is not greater than %f", v, ref)
+				return errors.Newf("%f is not greater than %f", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.LT:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v >= ref {
-				return fmt.Errorf("%f is not less than %f", v, ref)
+				return errors.Newf("%f is not less than %f", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.GE:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v < ref {
-				return fmt.Errorf("%f is not greater or equal to %f", v, ref)
+				return errors.Newf("%f is not greater or equal to %f", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.LE:
 		return cmpFloat(ref, func(v, ref float64) error {
 			if v > ref {
-				return fmt.Errorf("%f is not less or equal to %f", v, ref)
+				return errors.Newf("%f is not less or equal to %f", v, ref)
 			}
 			return nil
 		}), nil

--- a/enterprise/internal/scim/filter/op_decimal_test.go
+++ b/enterprise/internal/scim/filter/op_decimal_test.go
@@ -1,0 +1,58 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+func TestValidatorDecimal(t *testing.T) {
+	var (
+		exp = func(op filter.CompareOperator) string {
+			return fmt.Sprintf("dec %s 1.0", op)
+		}
+		ref = schema.Schema{
+			Attributes: []schema.CoreAttribute{
+				schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+					Name: "dec",
+					Type: schema.AttributeTypeDecimal(),
+				})),
+			},
+		}
+		attrs = [3]map[string]interface{}{
+			{"dec": -0.1},       // less
+			{"dec": float64(1)}, // equal
+			{"dec": 1.1},        // greater
+		}
+	)
+
+	for _, test := range []struct {
+		op    filter.CompareOperator
+		valid [3]bool
+	}{
+		{filter.EQ, [3]bool{false, true, false}},
+		{filter.NE, [3]bool{true, false, true}},
+		{filter.CO, [3]bool{true, true, true}},
+		{filter.SW, [3]bool{false, true, true}},
+		{filter.EW, [3]bool{true, true, true}},
+		{filter.GT, [3]bool{false, false, true}},
+		{filter.LT, [3]bool{true, false, false}},
+		{filter.GE, [3]bool{false, true, true}},
+		{filter.LE, [3]bool{true, true, false}},
+	} {
+		t.Run(string(test.op), func(t *testing.T) {
+			f := exp(test.op)
+			validator, err := NewValidator(f, ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i, attr := range attrs {
+				if err := validator.PassesFilter(attr); (err == nil) != test.valid[i] {
+					t.Errorf("(%d) %s %v | actual %v, expected %v", i, f, attr, err, test.valid[i])
+				}
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/op_integer.go
+++ b/enterprise/internal/scim/filter/op_integer.go
@@ -1,0 +1,101 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+)
+
+func cmpInt(ref int, cmp func(v, ref int) error) func(interface{}) error {
+	return func(i interface{}) error {
+		v, ok := i.(int)
+		if !ok {
+			panic(fmt.Sprintf("given value is not an integer: %v", i))
+		}
+		return cmp(v, ref)
+	}
+}
+
+func cmpIntStr(ref int, cmp func(v, ref string) error) (func(interface{}) error, error) {
+	return func(i interface{}) error {
+		if _, ok := i.(int); !ok {
+			panic(fmt.Sprintf("given value is not an integer: %v", i))
+		}
+		return cmp(fmt.Sprintf("%d", i), fmt.Sprintf("%d", ref))
+	}, nil
+}
+
+// cmpInteger returns a compare function that compares a given value to the reference int based on the given attribute
+// expression and integer attribute.
+//
+// Expects a integer attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpInteger(e *filter.AttributeExpression, ref int) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpInt(ref, func(v, ref int) error {
+			if v != ref {
+				return fmt.Errorf("%d is not equal to %d", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.NE:
+		return cmpInt(ref, func(v, ref int) error {
+			if v == ref {
+				return fmt.Errorf("%d is equal to %d", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.CO:
+		return cmpIntStr(ref, func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpIntStr(ref, func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpIntStr(ref, func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT:
+		return cmpInt(ref, func(v, ref int) error {
+			if v <= ref {
+				return fmt.Errorf("%d is not greater than %d", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.LT:
+		return cmpInt(ref, func(v, ref int) error {
+			if v >= ref {
+				return fmt.Errorf("%d is not less than %d", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.GE:
+		return cmpInt(ref, func(v, ref int) error {
+			if v < ref {
+				return fmt.Errorf("%d is not greater or equal to %d", v, ref)
+			}
+			return nil
+		}), nil
+	case filter.LE:
+		return cmpInt(ref, func(v, ref int) error {
+			if v > ref {
+				return fmt.Errorf("%d is not less or equal to %d", v, ref)
+			}
+			return nil
+		}), nil
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}

--- a/enterprise/internal/scim/filter/op_integer.go
+++ b/enterprise/internal/scim/filter/op_integer.go
@@ -2,8 +2,10 @@ package filter
 
 import (
 	"fmt"
-	"github.com/scim2/filter-parser/v2"
 	"strings"
+
+	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func cmpInt(ref int, cmp func(v, ref int) error) func(interface{}) error {
@@ -35,63 +37,63 @@ func cmpInteger(e *filter.AttributeExpression, ref int) (func(interface{}) error
 	case filter.EQ:
 		return cmpInt(ref, func(v, ref int) error {
 			if v != ref {
-				return fmt.Errorf("%d is not equal to %d", v, ref)
+				return errors.Newf("%d is not equal to %d", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.NE:
 		return cmpInt(ref, func(v, ref int) error {
 			if v == ref {
-				return fmt.Errorf("%d is equal to %d", v, ref)
+				return errors.Newf("%d is equal to %d", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.CO:
 		return cmpIntStr(ref, func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpIntStr(ref, func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpIntStr(ref, func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT:
 		return cmpInt(ref, func(v, ref int) error {
 			if v <= ref {
-				return fmt.Errorf("%d is not greater than %d", v, ref)
+				return errors.Newf("%d is not greater than %d", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.LT:
 		return cmpInt(ref, func(v, ref int) error {
 			if v >= ref {
-				return fmt.Errorf("%d is not less than %d", v, ref)
+				return errors.Newf("%d is not less than %d", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.GE:
 		return cmpInt(ref, func(v, ref int) error {
 			if v < ref {
-				return fmt.Errorf("%d is not greater or equal to %d", v, ref)
+				return errors.Newf("%d is not greater or equal to %d", v, ref)
 			}
 			return nil
 		}), nil
 	case filter.LE:
 		return cmpInt(ref, func(v, ref int) error {
 			if v > ref {
-				return fmt.Errorf("%d is not less or equal to %d", v, ref)
+				return errors.Newf("%d is not less or equal to %d", v, ref)
 			}
 			return nil
 		}), nil

--- a/enterprise/internal/scim/filter/op_integer_test.go
+++ b/enterprise/internal/scim/filter/op_integer_test.go
@@ -1,0 +1,58 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+func TestValidatorInteger(t *testing.T) {
+	var (
+		exp = func(op filter.CompareOperator) string {
+			return fmt.Sprintf("int %s 0", op)
+		}
+		ref = schema.Schema{
+			Attributes: []schema.CoreAttribute{
+				schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+					Name: "int",
+					Type: schema.AttributeTypeInteger(),
+				})),
+			},
+		}
+		attrs = [3]map[string]interface{}{
+			{"int": -1}, // less
+			{"int": 0},  // equal
+			{"int": 10}, // greater
+		}
+	)
+
+	for _, test := range []struct {
+		op    filter.CompareOperator
+		valid [3]bool
+	}{
+		{filter.EQ, [3]bool{false, true, false}},
+		{filter.NE, [3]bool{true, false, true}},
+		{filter.CO, [3]bool{false, true, true}},
+		{filter.SW, [3]bool{false, true, false}},
+		{filter.EW, [3]bool{false, true, true}},
+		{filter.GT, [3]bool{false, false, true}},
+		{filter.LT, [3]bool{true, false, false}},
+		{filter.GE, [3]bool{false, true, true}},
+		{filter.LE, [3]bool{true, true, false}},
+	} {
+		t.Run(string(test.op), func(t *testing.T) {
+			f := exp(test.op)
+			validator, err := NewValidator(f, ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i, attr := range attrs {
+				if err := validator.PassesFilter(attr); (err == nil) != test.valid[i] {
+					t.Errorf("(%d) %s %v | actual %v, expected %v", i, f, attr, err, test.valid[i])
+				}
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/op_string.go
+++ b/enterprise/internal/scim/filter/op_string.go
@@ -1,0 +1,102 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+	"strings"
+)
+
+func cmpStr(ref string, caseExact bool, cmp func(v, ref string) error) (func(interface{}) error, error) {
+	if caseExact {
+		return func(i interface{}) error {
+			value, ok := i.(string)
+			if !ok {
+				panic(fmt.Sprintf("given value is not a string: %v", i))
+			}
+			return cmp(value, ref)
+		}, nil
+	}
+	return func(i interface{}) error {
+		value, ok := i.(string)
+		if !ok {
+			panic(fmt.Sprintf("given value is not a string: %v", i))
+		}
+		return cmp(strings.ToLower(value), strings.ToLower(ref))
+	}, nil
+}
+
+// cmpString returns a compare function that compares a given value to the reference string based on the given attribute
+// expression and string/reference attribute.
+//
+// Expects a string/reference attribute. Will panic on unknown filter operator.
+// Known operators: eq, ne, co, sw, ew, gt, lt, ge and le.
+func cmpString(e *filter.AttributeExpression, attr schema.CoreAttribute, ref string) (func(interface{}) error, error) {
+	switch op := e.Operator; op {
+	case filter.EQ:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if v != ref {
+				return fmt.Errorf("%s is not equal to %s", v, ref)
+			}
+			return nil
+		})
+	case filter.NE:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if v == ref {
+				return fmt.Errorf("%s is equal to %s", v, ref)
+			}
+			return nil
+		})
+	case filter.CO:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if !strings.Contains(v, ref) {
+				return fmt.Errorf("%s does not contain %s", v, ref)
+			}
+			return nil
+		})
+	case filter.SW:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if !strings.HasPrefix(v, ref) {
+				return fmt.Errorf("%s does not start with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.EW:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if !strings.HasSuffix(v, ref) {
+				return fmt.Errorf("%s does not end with %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GT:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if strings.Compare(v, ref) <= 0 {
+				return fmt.Errorf("%s is not lexicographically greater than %s", v, ref)
+			}
+			return nil
+		})
+	case filter.LT:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if strings.Compare(v, ref) >= 0 {
+				return fmt.Errorf("%s is not lexicographically less than %s", v, ref)
+			}
+			return nil
+		})
+	case filter.GE:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if strings.Compare(v, ref) < 0 {
+				return fmt.Errorf("%s is not lexicographically greater or equal to %s", v, ref)
+			}
+			return nil
+		})
+	case filter.LE:
+		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
+			if strings.Compare(v, ref) > 0 {
+				return fmt.Errorf("%s is not lexicographically less or equal to %s", v, ref)
+			}
+			return nil
+		})
+	default:
+		panic(fmt.Sprintf("unknown operator in expression: %s", e))
+	}
+}

--- a/enterprise/internal/scim/filter/op_string.go
+++ b/enterprise/internal/scim/filter/op_string.go
@@ -2,9 +2,11 @@ package filter
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
-	"strings"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func cmpStr(ref string, caseExact bool, cmp func(v, ref string) error) (func(interface{}) error, error) {
@@ -36,63 +38,63 @@ func cmpString(e *filter.AttributeExpression, attr schema.CoreAttribute, ref str
 	case filter.EQ:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if v != ref {
-				return fmt.Errorf("%s is not equal to %s", v, ref)
+				return errors.Newf("%s is not equal to %s", v, ref)
 			}
 			return nil
 		})
 	case filter.NE:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if v == ref {
-				return fmt.Errorf("%s is equal to %s", v, ref)
+				return errors.Newf("%s is equal to %s", v, ref)
 			}
 			return nil
 		})
 	case filter.CO:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if !strings.Contains(v, ref) {
-				return fmt.Errorf("%s does not contain %s", v, ref)
+				return errors.Newf("%s does not contain %s", v, ref)
 			}
 			return nil
 		})
 	case filter.SW:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if !strings.HasPrefix(v, ref) {
-				return fmt.Errorf("%s does not start with %s", v, ref)
+				return errors.Newf("%s does not start with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.EW:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if !strings.HasSuffix(v, ref) {
-				return fmt.Errorf("%s does not end with %s", v, ref)
+				return errors.Newf("%s does not end with %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GT:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if strings.Compare(v, ref) <= 0 {
-				return fmt.Errorf("%s is not lexicographically greater than %s", v, ref)
+				return errors.Newf("%s is not lexicographically greater than %s", v, ref)
 			}
 			return nil
 		})
 	case filter.LT:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if strings.Compare(v, ref) >= 0 {
-				return fmt.Errorf("%s is not lexicographically less than %s", v, ref)
+				return errors.Newf("%s is not lexicographically less than %s", v, ref)
 			}
 			return nil
 		})
 	case filter.GE:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if strings.Compare(v, ref) < 0 {
-				return fmt.Errorf("%s is not lexicographically greater or equal to %s", v, ref)
+				return errors.Newf("%s is not lexicographically greater or equal to %s", v, ref)
 			}
 			return nil
 		})
 	case filter.LE:
 		return cmpStr(ref, attr.CaseExact(), func(v, ref string) error {
 			if strings.Compare(v, ref) > 0 {
-				return fmt.Errorf("%s is not lexicographically less or equal to %s", v, ref)
+				return errors.Newf("%s is not lexicographically less or equal to %s", v, ref)
 			}
 			return nil
 		})

--- a/enterprise/internal/scim/filter/op_string_test.go
+++ b/enterprise/internal/scim/filter/op_string_test.go
@@ -1,0 +1,70 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+func TestValidatorString(t *testing.T) {
+	var (
+		exp = func(op filter.CompareOperator) string {
+			return fmt.Sprintf("str %s \"x\"", op)
+		}
+		attrs = [3]map[string]interface{}{
+			{"str": "x"},
+			{"str": "X"},
+			{"str": "y"},
+		}
+	)
+
+	for _, test := range []struct {
+		op      filter.CompareOperator
+		valid   [3]bool
+		validCE [3]bool
+	}{
+		{filter.EQ, [3]bool{true, true, false}, [3]bool{true, false, false}},
+		{filter.NE, [3]bool{false, false, true}, [3]bool{false, true, true}},
+		{filter.CO, [3]bool{true, true, false}, [3]bool{true, false, false}},
+		{filter.SW, [3]bool{true, true, false}, [3]bool{true, false, false}},
+		{filter.EW, [3]bool{true, true, false}, [3]bool{true, false, false}},
+		{filter.GT, [3]bool{false, false, true}, [3]bool{false, false, true}},
+		{filter.LT, [3]bool{false, false, false}, [3]bool{false, true, false}},
+		{filter.GE, [3]bool{true, true, true}, [3]bool{true, false, true}},
+		{filter.LE, [3]bool{true, true, false}, [3]bool{true, true, false}},
+	} {
+		t.Run(string(test.op), func(t *testing.T) {
+			f := exp(test.op)
+			for i, attr := range attrs {
+				validator, err := NewValidator(f, schema.Schema{
+					Attributes: []schema.CoreAttribute{
+						schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+							Name: "str",
+						})),
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := validator.PassesFilter(attr); (err == nil) != test.valid[i] {
+					t.Errorf("(0.%d) %s %s | actual %v, expected %v", i, f, attr, err, test.valid[i])
+				}
+				validatorCE, err := NewValidator(f, schema.Schema{
+					Attributes: []schema.CoreAttribute{
+						schema.SimpleCoreAttribute(schema.SimpleReferenceParams(schema.ReferenceParams{
+							Name: "str",
+						})),
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := validatorCE.PassesFilter(attr); (err == nil) != test.validCE[i] {
+					t.Errorf("(1.%d) %s %s | actual %v, expected %v", i, f, attr, err, test.validCE[i])
+				}
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/operators.go
+++ b/enterprise/internal/scim/filter/operators.go
@@ -1,0 +1,57 @@
+package filter
+
+import (
+	"fmt"
+	datetime "github.com/di-wu/xsd-datetime"
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+// createCompareFunction returns a compare function based on the attribute expression and attribute.
+// e.g. `userName eq "john"` will return a string comparator that checks whether the passed value is equal to "john".
+func createCompareFunction(e *filter.AttributeExpression, attr schema.CoreAttribute) (func(interface{}) error, error) {
+	switch typ := attr.AttributeType(); typ {
+	case "binary":
+		ref, ok := e.CompareValue.(string)
+		if !ok {
+			return nil, fmt.Errorf("a binary attribute needs to be compared to a string")
+		}
+		return cmpBinary(e, ref)
+	case "dateTime":
+		date, ok := e.CompareValue.(string)
+		if !ok {
+			return nil, fmt.Errorf("a dateTime attribute needs to be compared to a string")
+		}
+		ref, err := datetime.Parse(date)
+		if err != nil {
+			return nil, fmt.Errorf("a dateTime attribute needs to be compared to a dateTime")
+		}
+		return cmpDateTime(e, date, ref)
+	case "reference", "string":
+		ref, ok := e.CompareValue.(string)
+		if !ok {
+			return nil, fmt.Errorf("a %s attribute needs to be compared to a string", typ)
+		}
+		return cmpString(e, attr, ref)
+	case "boolean":
+		ref, ok := e.CompareValue.(bool)
+		if !ok {
+			return nil, fmt.Errorf("a boolean attribute needs to be compared to a boolean")
+		}
+		return cmpBoolean(e, attr, ref)
+	case "decimal":
+		ref, ok := e.CompareValue.(float64)
+		if !ok {
+			return nil, fmt.Errorf("a decimal attribute needs to be compared to a float/int")
+		}
+		return cmpDecimal(e, ref)
+	case "integer":
+		ref, ok := e.CompareValue.(int)
+		if !ok {
+			return nil, fmt.Errorf("a integer attribute needs to be compared to a int")
+		}
+		return cmpInteger(e, ref)
+	default:
+		panic(fmt.Sprintf("unknown attribute type: %s", typ))
+	}
+}

--- a/enterprise/internal/scim/filter/operators.go
+++ b/enterprise/internal/scim/filter/operators.go
@@ -2,9 +2,11 @@ package filter
 
 import (
 	"fmt"
+
 	datetime "github.com/di-wu/xsd-datetime"
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // createCompareFunction returns a compare function based on the attribute expression and attribute.
@@ -14,41 +16,41 @@ func createCompareFunction(e *filter.AttributeExpression, attr schema.CoreAttrib
 	case "binary":
 		ref, ok := e.CompareValue.(string)
 		if !ok {
-			return nil, fmt.Errorf("a binary attribute needs to be compared to a string")
+			return nil, errors.Newf("a binary attribute needs to be compared to a string")
 		}
 		return cmpBinary(e, ref)
 	case "dateTime":
 		date, ok := e.CompareValue.(string)
 		if !ok {
-			return nil, fmt.Errorf("a dateTime attribute needs to be compared to a string")
+			return nil, errors.Newf("a dateTime attribute needs to be compared to a string")
 		}
 		ref, err := datetime.Parse(date)
 		if err != nil {
-			return nil, fmt.Errorf("a dateTime attribute needs to be compared to a dateTime")
+			return nil, errors.Newf("a dateTime attribute needs to be compared to a dateTime")
 		}
 		return cmpDateTime(e, date, ref)
 	case "reference", "string":
 		ref, ok := e.CompareValue.(string)
 		if !ok {
-			return nil, fmt.Errorf("a %s attribute needs to be compared to a string", typ)
+			return nil, errors.Newf("a %s attribute needs to be compared to a string", typ)
 		}
 		return cmpString(e, attr, ref)
 	case "boolean":
 		ref, ok := e.CompareValue.(bool)
 		if !ok {
-			return nil, fmt.Errorf("a boolean attribute needs to be compared to a boolean")
+			return nil, errors.Newf("a boolean attribute needs to be compared to a boolean")
 		}
-		return cmpBoolean(e, attr, ref)
+		return cmpBoolean(e, ref)
 	case "decimal":
 		ref, ok := e.CompareValue.(float64)
 		if !ok {
-			return nil, fmt.Errorf("a decimal attribute needs to be compared to a float/int")
+			return nil, errors.Newf("a decimal attribute needs to be compared to a float/int")
 		}
 		return cmpDecimal(e, ref)
 	case "integer":
 		ref, ok := e.CompareValue.(int)
 		if !ok {
-			return nil, fmt.Errorf("a integer attribute needs to be compared to a int")
+			return nil, errors.Newf("a integer attribute needs to be compared to a int")
 		}
 		return cmpInteger(e, ref)
 	default:

--- a/enterprise/internal/scim/filter/operators_test.go
+++ b/enterprise/internal/scim/filter/operators_test.go
@@ -1,0 +1,112 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/elimity-com/scim/schema"
+)
+
+// TestValidatorInvalidResourceTypes contains all the cases where an *errors.ScimError gets returned.
+func TestValidatorInvalidResourceTypes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		filter   string
+		attr     schema.CoreAttribute
+		resource map[string]interface{}
+	}{
+		{
+			"string", `attr eq "value"`,
+			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+				Name: "attr",
+			})),
+			map[string]interface{}{
+				"attr": 1, // expects a string
+			},
+		},
+		{
+			"stringMv", `attr eq "value"`,
+			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+				Name:        "attr",
+				MultiValued: true,
+			})),
+			map[string]interface{}{
+				"attr": []interface{}{1}, // expects a []interface{string}
+			},
+		},
+		{
+			"stringMv",
+			`attr eq "value"`,
+			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
+				Name:        "attr",
+				MultiValued: true,
+			})),
+			map[string]interface{}{
+				"attr": []string{"value"}, // expects a []interface{}
+			},
+		},
+		{
+			"dateTime", `attr eq "2006-01-02T15:04:05"`,
+			schema.SimpleCoreAttribute(schema.SimpleDateTimeParams(schema.DateTimeParams{
+				Name: "attr",
+			})),
+			map[string]interface{}{
+				"attr": 1, // expects a string
+			},
+		},
+		{
+			"dateTime", `attr eq "2006-01-02T15:04:05"`,
+			schema.SimpleCoreAttribute(schema.SimpleDateTimeParams(schema.DateTimeParams{
+				Name: "attr",
+			})),
+			map[string]interface{}{
+				"attr": "2006-01-02T", // expects a valid dateTime
+			},
+		},
+		{
+			"boolean", `attr eq true`,
+			schema.SimpleCoreAttribute(schema.SimpleBooleanParams(schema.BooleanParams{
+				Name: "attr",
+			})),
+			map[string]interface{}{
+				"attr": 1, // expects a boolean
+			},
+		},
+		{
+			"decimal", `attr eq 0.0`,
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr",
+				Type: schema.AttributeTypeDecimal(),
+			})),
+			map[string]interface{}{
+				"attr": "0", // expects a decimal value
+			},
+		},
+		{
+			"integer", `attr eq 0`,
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr",
+				Type: schema.AttributeTypeInteger(),
+			})),
+			map[string]interface{}{
+				"attr": 0.0, // expects an integer
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			validator, err := NewValidator(test.filter, schema.Schema{
+				Attributes: []schema.CoreAttribute{test.attr},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := recover(); err == nil {
+					t.Fatal(test)
+				}
+			}()
+			if err := validator.PassesFilter(test.resource); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/enterprise/internal/scim/filter/path.go
+++ b/enterprise/internal/scim/filter/path.go
@@ -1,0 +1,116 @@
+package filter
+
+import (
+	"github.com/elimity-com/scim/schema"
+	"github.com/scim2/filter-parser/v2"
+)
+
+// MultiValuedFilterAttributes returns the attributes of the given attribute on which can be filtered. In the case of a
+// complex attribute, the sub-attributes get returned. Otherwise if the given attribute is not complex, a "value" sub-
+// attribute gets created to filter against.
+func MultiValuedFilterAttributes(attr schema.CoreAttribute) schema.Attributes {
+	switch attr.AttributeType() {
+	case "complex":
+		return attr.SubAttributes()
+	default:
+		return schema.Attributes{schema.SimpleCoreAttribute(getSimpleParams(attr))}
+	}
+}
+
+// getSimpleParams returns simple params based on the type of the attribute. The simple params only have their name
+// assigned to "value", everything else is left out (i.e. default values). Can not be used for complex attributes.
+func getSimpleParams(attr schema.CoreAttribute) schema.SimpleParams {
+	switch attr.AttributeType() {
+	case "decimal":
+		return schema.SimpleNumberParams(schema.NumberParams{
+			Name: "value",
+			Type: schema.AttributeTypeDecimal(),
+		})
+	case "integer":
+		return schema.SimpleNumberParams(schema.NumberParams{
+			Name: "value",
+			Type: schema.AttributeTypeInteger(),
+		})
+	case "binary":
+		return schema.SimpleBinaryParams(schema.BinaryParams{Name: "value"})
+	case "boolean":
+		return schema.SimpleBooleanParams(schema.BooleanParams{Name: "value"})
+	case "dateTime":
+		return schema.SimpleDateTimeParams(schema.DateTimeParams{Name: "value"})
+	case "reference":
+		return schema.SimpleReferenceParams(schema.ReferenceParams{Name: "value"})
+	default:
+		return schema.SimpleStringParams(schema.StringParams{Name: "value"})
+	}
+}
+
+// PathValidator represents a path validator.
+type PathValidator struct {
+	path       filter.Path
+	schema     schema.Schema
+	extensions []schema.Schema
+}
+
+// NewPathValidator constructs a new path validator.
+func NewPathValidator(pathFilter string, s schema.Schema, exts ...schema.Schema) (PathValidator, error) {
+	f, err := filter.ParsePath([]byte(pathFilter))
+	if err != nil {
+		return PathValidator{}, err
+	}
+	return PathValidator{
+		path:       f,
+		schema:     s,
+		extensions: exts,
+	}, nil
+}
+
+func (v PathValidator) Path() filter.Path {
+	return v.path
+}
+
+// Validate checks whether the path is a valid path within the given reference schemas.
+func (v PathValidator) Validate() error {
+	err := v.validatePath(v.schema)
+	if err == nil {
+		return nil
+	}
+	for _, e := range v.extensions {
+		if err := v.validatePath(e); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// validatePath tries to validate the path against the given schema.
+func (v PathValidator) validatePath(ref schema.Schema) error {
+	// e.g. members
+	//      ^______
+	attr, err := validateAttributePath(ref, v.path.AttributePath)
+	if err != nil {
+		return err
+	}
+
+	// e.g. members[value eq "0"]
+	//             ^_____________
+	if v.path.ValueExpression != nil {
+		if err := validateExpression(
+			schema.Schema{
+				ID:         ref.ID,
+				Attributes: MultiValuedFilterAttributes(attr),
+			},
+			v.path.ValueExpression,
+		); err != nil {
+			return err
+		}
+	}
+
+	// e.g. members[value eq "0"].displayName
+	//                            ^__________
+	if subAttrName := v.path.SubAttributeName(); subAttrName != "" {
+		if err := validateSubAttribute(attr, subAttrName); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/elimity-com/scim"
+	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
 	"github.com/sourcegraph/log"
@@ -55,10 +56,10 @@ func (h *UserResourceHandler) Get(r *http.Request, idStr string) (scim.Resource,
 		UserIDs: []int32{int32(id)},
 	})
 	if err != nil {
-		return scim.Resource{}, errors.Wrap(err, "Error loading user")
+		return scim.Resource{}, scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 	}
 	if len(users) == 0 {
-		return scim.Resource{}, errors.New("User not found")
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(idStr)
 	}
 
 	resource := h.convertUserToSCIMResource(users[0])

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -83,7 +83,7 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 	if params.Filter == nil {
 		totalCount, resources, err = h.getAllFromDB(r, params.StartIndex, &params.Count)
 	} else {
-		// Fetch all resources from the GB and then filter them here.
+		// Fetch all resources from the DB and then filter them here.
 		// This doesn't feel efficient, but it wasn't reasonable to implement this in SQL in the time available.
 		var allResources []scim.Resource
 		_, allResources, err = h.getAllFromDB(r, 0, nil)

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -74,7 +74,7 @@ func (h *UserResourceHandler) Get(r *http.Request, idStr string) (scim.Resource,
 
 // GetAll returns a paginated list of resources.
 // An empty list of resources will be represented as `null` in the JSON response if `nil` is assigned to the
-// Page.Resources. Otherwise, is an empty slice is assigned, an empty list will be represented as `[]`.
+// Page.Resources. Otherwise, if an empty slice is assigned, an empty list will be represented as `[]`.
 func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestParams) (scim.Page, error) {
 	var totalCount int
 	var resources []scim.Resource

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -198,7 +198,23 @@ func (h *UserResourceHandler) Patch(r *http.Request, id string, operations []sci
 
 // createUserResourceType creates a SCIM resource type for users.
 func createUserResourceType(userResourceHandler *UserResourceHandler) scim.ResourceType {
-	coreUserSchema := schema.Schema{
+	coreUserSchema := createCoreSchema()
+	schemaExtensions := createSchemaExtensions()
+
+	return scim.ResourceType{
+		ID:               optional.NewString("User"),
+		Name:             "User",
+		Endpoint:         "/Users",
+		Description:      optional.NewString("User Account"),
+		Schema:           coreUserSchema,
+		SchemaExtensions: schemaExtensions,
+		Handler:          userResourceHandler,
+	}
+}
+
+// createCoreSchema creates a SCIM core schema for users.
+func createCoreSchema() schema.Schema {
+	return schema.Schema{
 		ID:          "urn:ietf:params:scim:schemas:core:2.0:User",
 		Name:        optional.NewString("User"),
 		Description: optional.NewString("User Account"),
@@ -210,7 +226,10 @@ func createUserResourceType(userResourceHandler *UserResourceHandler) scim.Resou
 			})),
 		},
 	}
+}
 
+// createSchemaExtensions creates a SCIM schema extension for users.
+func createSchemaExtensions() []scim.SchemaExtension {
 	extensionUserSchema := schema.Schema{
 		ID:          "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 		Name:        optional.NewString("EnterpriseUser"),
@@ -225,17 +244,10 @@ func createUserResourceType(userResourceHandler *UserResourceHandler) scim.Resou
 		},
 	}
 
-	return scim.ResourceType{
-		ID:          optional.NewString("User"),
-		Name:        "User",
-		Endpoint:    "/Users",
-		Description: optional.NewString("User Account"),
-		Schema:      coreUserSchema,
-		SchemaExtensions: []scim.SchemaExtension{
-			{Schema: extensionUserSchema},
-		},
-		Handler: userResourceHandler,
+	schemaExtensions := []scim.SchemaExtension{
+		{Schema: extensionUserSchema},
 	}
+	return schemaExtensions
 }
 
 // TODO: Temporary function to log attributes

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -104,10 +104,6 @@ func (h *UserResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 				resources = append(resources, resource)
 			}
 		}
-		return scim.Page{
-			TotalResults: totalCount,
-			Resources:    resources,
-		}, nil
 	}
 	if err != nil {
 		return scim.Page{}, scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}

--- a/enterprise/internal/scim/user_test.go
+++ b/enterprise/internal/scim/user_test.go
@@ -18,8 +18,10 @@ func TestUserResourceHandler_Get(t *testing.T) {
 	db := getMockDB()
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
 	user1, err := userResourceHandler.Get(&http.Request{}, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	user2, err := userResourceHandler.Get(&http.Request{}, "2")
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/scim/user_test.go
+++ b/enterprise/internal/scim/user_test.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/elimity-com/scim"
@@ -10,105 +11,166 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestUserResourceHandler_GetAll(t *testing.T) {
+func TestUserResourceHandler_Get(t *testing.T) {
 	db := getMockDB()
-
-	// Create handler, request, and params, then call GetAll()
-	request := &http.Request{}
-	params := scim.ListRequestParams{
-		Count:      0,
-		StartIndex: 1,
-		Filter:     &filter.AttributeExpression{},
-	}
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
-	page, err := userResourceHandler.GetAll(request, params)
+	user1, err := userResourceHandler.Get(&http.Request{}, "1")
+	user2, err := userResourceHandler.Get(&http.Request{}, "2")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Assert that the correct number of users are returned
-	if page.TotalResults != 4 {
-		t.Errorf("expected 4 users, got %d", page.TotalResults)
-	}
-	if len(page.Resources) != 2 {
-		t.Errorf("expected 2 users, got %d", len(page.Resources))
-	}
-
 	// Assert that IDs are correct
-	if page.Resources[0].ID != "1" {
-		t.Errorf("expected ID = 1, got %s", page.Resources[0].ID)
+	if user1.ID != "1" {
+		t.Errorf("expected ID = 1, got %s", user1.ID)
 	}
-	if page.Resources[1].ID != "2" {
-		t.Errorf("expected ID = 2, got %s", page.Resources[1].ID)
+	if user2.ID != "2" {
+		t.Errorf("expected ID = 2, got %s", user2.ID)
 	}
-	if page.Resources[0].ExternalID.Value() != "external1" {
-		t.Errorf("expected ExternalID = 'external1', got %s", page.Resources[0].ExternalID.Value())
+	if user1.ExternalID.Value() != "external1" {
+		t.Errorf("expected ExternalID = 'external1', got %s", user1.ExternalID.Value())
 	}
-	if page.Resources[1].ExternalID.Value() != "" {
-		t.Errorf("expected no ExternalID, got %s", page.Resources[0].ExternalID.Value())
+	if user2.ExternalID.Value() != "" {
+		t.Errorf("expected no ExternalID, got %s", user1.ExternalID.Value())
 	}
 
 	// Assert that usernames are correct
-	if page.Resources[0].Attributes["userName"] != "user1" {
-		t.Errorf("expected username = 'user1', got %s", page.Resources[0].Attributes["UserName"])
+	if user1.Attributes["userName"] != "user1" {
+		t.Errorf("expected username = 'user1', got %s", user1.Attributes["UserName"])
 	}
-	if page.Resources[1].Attributes["userName"] != "user2" {
-		t.Errorf("expected username = 'user2', got %s", page.Resources[1].Attributes["UserName"])
+	if user2.Attributes["userName"] != "user2" {
+		t.Errorf("expected username = 'user2', got %s", user2.Attributes["UserName"])
 	}
 
 	// Assert that names are correct
-	if page.Resources[0].Attributes["displayName"] != "First Last" {
-		t.Errorf("expected First Last, got %s", page.Resources[0].Attributes["displayName"])
+	if user1.Attributes["displayName"] != "First Last" {
+		t.Errorf("expected First Last, got %s", user1.Attributes["displayName"])
 	}
-	if page.Resources[1].Attributes["displayName"] != "First Middle Last" {
-		t.Errorf("expected First Middle Last, got %s", page.Resources[1].Attributes["displayName"])
+	if user2.Attributes["displayName"] != "First Middle Last" {
+		t.Errorf("expected First Middle Last, got %s", user2.Attributes["displayName"])
 	}
-	if page.Resources[0].Attributes["name"].(map[string]interface{})["givenName"] != "First" {
-		t.Errorf("expected First, got %s", page.Resources[0].Attributes["name"].(map[string]interface{})["givenName"])
+	if user1.Attributes["name"].(map[string]interface{})["givenName"] != "First" {
+		t.Errorf("expected First, got %s", user1.Attributes["name"].(map[string]interface{})["givenName"])
 	}
-	if page.Resources[0].Attributes["name"].(map[string]interface{})["middleName"] != "" {
-		t.Errorf("expected empty string, got %s", page.Resources[0].Attributes["name"].(map[string]interface{})["middleName"])
+	if user1.Attributes["name"].(map[string]interface{})["middleName"] != "" {
+		t.Errorf("expected empty string, got %s", user1.Attributes["name"].(map[string]interface{})["middleName"])
 	}
-	if page.Resources[0].Attributes["name"].(map[string]interface{})["familyName"] != "Last" {
-		t.Errorf("expected Last, got %s", page.Resources[0].Attributes["name"].(map[string]interface{})["familyName"])
+	if user1.Attributes["name"].(map[string]interface{})["familyName"] != "Last" {
+		t.Errorf("expected Last, got %s", user1.Attributes["name"].(map[string]interface{})["familyName"])
 	}
-	if page.Resources[1].Attributes["name"].(map[string]interface{})["givenName"] != "First" {
-		t.Errorf("expected First, got %s", page.Resources[1].Attributes["name"].(map[string]interface{})["givenName"])
+	if user2.Attributes["name"].(map[string]interface{})["givenName"] != "First" {
+		t.Errorf("expected First, got %s", user2.Attributes["name"].(map[string]interface{})["givenName"])
 	}
-	if page.Resources[1].Attributes["name"].(map[string]interface{})["middleName"] != "Middle" {
-		t.Errorf("expected Middle, got %s", page.Resources[1].Attributes["name"].(map[string]interface{})["middleName"])
+	if user2.Attributes["name"].(map[string]interface{})["middleName"] != "Middle" {
+		t.Errorf("expected Middle, got %s", user2.Attributes["name"].(map[string]interface{})["middleName"])
 	}
-	if page.Resources[1].Attributes["name"].(map[string]interface{})["familyName"] != "Last" {
-		t.Errorf("expected Last, got %s", page.Resources[1].Attributes["name"].(map[string]interface{})["familyName"])
+	if user2.Attributes["name"].(map[string]interface{})["familyName"] != "Last" {
+		t.Errorf("expected Last, got %s", user2.Attributes["name"].(map[string]interface{})["familyName"])
 	}
 
 	// Assert that emails are correct
-	if page.Resources[0].Attributes["emails"].([]interface{})[0].(map[string]interface{})["value"] != "a@example.com" {
-		t.Errorf("expected empty email, got %s", page.Resources[0].Attributes["emails"].([]interface{})[0].(map[string]interface{})["value"])
+	if user1.Attributes["emails"].([]interface{})[0].(map[string]interface{})["value"] != "a@example.com" {
+		t.Errorf("expected empty email, got %s", user1.Attributes["emails"].([]interface{})[0].(map[string]interface{})["value"])
+	}
+}
+
+func TestUserResourceHandler_GetAll(t *testing.T) {
+	db := getMockDB()
+
+	cases := []struct {
+		name             string
+		count            int
+		startIndex       int
+		filter           string
+		wantTotalResults int
+		wantResults      int
+		wantFirstID      int
+	}{
+		{name: "count=0", count: 0, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 0, wantFirstID: 0},
+		{name: "count=2", count: 2, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 1},
+		{name: "count=2, offset=1", count: 2, startIndex: 2, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 2},
+		{name: "count=999", count: 999, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 4, wantFirstID: 1},
+		{name: "count=0 with filter", count: 0, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 0, wantFirstID: 0},
+		{name: "userName filter", count: 999, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
+		{name: "OR filter", count: 999, startIndex: 1, filter: "(userName eq \"user3\") OR (displayName eq \"First Middle Last\")", wantTotalResults: 2, wantResults: 2, wantFirstID: 2},
+		{name: "OR filter", count: 999, startIndex: 1, filter: "(userName eq \"user3\") AND (displayName eq \"First Last\")", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
+	}
+
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	for _, c := range cases {
+		t.Run("TestUserResourceHandler_GetAll "+c.name, func(t *testing.T) {
+			var params scim.ListRequestParams
+			if c.filter != "" {
+				filterExpr, err := filter.ParseFilter([]byte(c.filter))
+				if err != nil {
+					t.Fatal(err)
+				}
+				params = scim.ListRequestParams{Count: c.count, StartIndex: c.startIndex, Filter: filterExpr}
+			} else {
+				params = scim.ListRequestParams{Count: c.count, StartIndex: c.startIndex, Filter: nil}
+			}
+			page, err := userResourceHandler.GetAll(&http.Request{}, params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, c.wantTotalResults, page.TotalResults)
+			assert.Equal(t, c.wantResults, len(page.Resources))
+			if c.wantResults > 0 {
+				assert.Equal(t, strconv.Itoa(c.wantFirstID), page.Resources[0].ID)
+			}
+		})
 	}
 }
 
 func getMockDB() *database.MockDB {
-	users := database.NewMockUserStore()
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
-	users.ListForSCIMFunc.SetDefaultHook(func(ctx context.Context, opt *database.UsersListOptions) ([]*types.UserForSCIM, error) {
-		if opt.LimitOffset.Offset == 2 {
-			return []*types.UserForSCIM{
-				{User: types.User{ID: 3, Username: "user3"}},
-				{User: types.User{ID: 4, Username: "user4"}},
-			}, nil
+	users := []*types.UserForSCIM{
+		{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "external1"},
+		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Middle Last"}, Emails: []string{"b@example.com"}, SCIMExternalID: ""},
+		{User: types.User{ID: 3, Username: "user3", DisplayName: "First Last"}},
+		{User: types.User{ID: 4, Username: "user4"}},
+	}
+
+	userStore := database.NewMockUserStore()
+	userStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	userStore.ListForSCIMFunc.SetDefaultHook(func(ctx context.Context, opt *database.UsersListOptions) ([]*types.UserForSCIM, error) {
+		// Return the users with the given IDs
+		if opt.UserIDs != nil {
+			var filteredUsers []*types.UserForSCIM
+			for _, id := range opt.UserIDs {
+				for _, user := range users {
+					if user.ID == id {
+						filteredUsers = append(filteredUsers, user)
+					}
+				}
+			}
+			return applyLimitOffset(filteredUsers, opt.LimitOffset)
 		}
-		return []*types.UserForSCIM{
-			{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "external1"},
-			{User: types.User{ID: 2, Username: "user2", DisplayName: "First Middle Last"}, Emails: []string{"b@example.com"}, SCIMExternalID: ""}}, nil
+
+		return applyLimitOffset(users, opt.LimitOffset)
 	})
-	users.CountFunc.SetDefaultReturn(4, nil)
+	userStore.CountFunc.SetDefaultReturn(4, nil)
 
 	// Create DB
 	db := database.NewMockDB()
-	db.UsersFunc.SetDefaultReturn(users)
+	db.UsersFunc.SetDefaultReturn(userStore)
 	return db
+}
+
+func applyLimitOffset(users []*types.UserForSCIM, limitOffset *database.LimitOffset) ([]*types.UserForSCIM, error) {
+	// Return all users
+	if limitOffset == nil {
+		return users, nil
+	}
+
+	// Return a slice of users based on the limit and offset
+	start := limitOffset.Offset
+	end := start + limitOffset.Limit
+	if end > len(users) {
+		end = len(users)
+	}
+	return users[start:end], nil
 }

--- a/enterprise/internal/scim/user_test.go
+++ b/enterprise/internal/scim/user_test.go
@@ -92,14 +92,15 @@ func TestUserResourceHandler_GetAll(t *testing.T) {
 		wantResults      int
 		wantFirstID      int
 	}{
-		{name: "count=0", count: 0, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 0, wantFirstID: 0},
-		{name: "count=2", count: 2, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 1},
-		{name: "count=2, offset=1", count: 2, startIndex: 2, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 2},
-		{name: "count=999", count: 999, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 4, wantFirstID: 1},
-		{name: "count=0 with filter", count: 0, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 0, wantFirstID: 0},
-		{name: "userName filter", count: 999, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
-		{name: "OR filter", count: 999, startIndex: 1, filter: "(userName eq \"user3\") OR (displayName eq \"First Middle Last\")", wantTotalResults: 2, wantResults: 2, wantFirstID: 2},
-		{name: "OR filter", count: 999, startIndex: 1, filter: "(userName eq \"user3\") AND (displayName eq \"First Last\")", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
+		{name: "no filter, count=0", count: 0, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 0, wantFirstID: 0},
+		{name: "no filter, count=2", count: 2, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 1},
+		{name: "no filter, offset=3", count: 999, startIndex: 4, filter: "", wantTotalResults: 4, wantResults: 1, wantFirstID: 4},
+		{name: "no filter, count=2, offset=1", count: 2, startIndex: 2, filter: "", wantTotalResults: 4, wantResults: 2, wantFirstID: 2},
+		{name: "no filter, count=999", count: 999, startIndex: 1, filter: "", wantTotalResults: 4, wantResults: 4, wantFirstID: 1},
+		{name: "filter, count=0", count: 0, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 0, wantFirstID: 0},
+		{name: "filter: userName", count: 999, startIndex: 1, filter: "userName eq \"user3\"", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
+		{name: "filter: OR", count: 999, startIndex: 1, filter: "(userName eq \"user3\") OR (displayName eq \"First Middle Last\")", wantTotalResults: 2, wantResults: 2, wantFirstID: 2},
+		{name: "filter: AND", count: 999, startIndex: 1, filter: "(userName eq \"user3\") AND (displayName eq \"First Last\")", wantTotalResults: 1, wantResults: 1, wantFirstID: 3},
 	}
 
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,6 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dghubble/sling v1.4.1 // indirect
 	github.com/di-wu/parser v0.2.2 // indirect
-	github.com/di-wu/xsd-datetime v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.6 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
@@ -228,6 +227,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/crewjam/saml/samlidp v0.0.0-20221211125903-d951aa2d145a
 	github.com/dcadenas/pagerank v0.0.0-20171013173705-af922e3ceea8
+	github.com/di-wu/xsd-datetime v1.0.0
 	github.com/elimity-com/scim v0.0.0-20220121082953-15165b1a61c8
 	github.com/fergusstrange/embedded-postgres v1.19.0
 	github.com/frankban/quicktest v1.14.3


### PR DESCRIPTION
⚠️ **Tip for reviewers**: skip the `/filter` folder! Only check our two files!

**Whoa**, now, this was some hardcore coding.

This PR adds **complete** filter support for User `GET`.

By “complete”, I mean it handles _insane_ queries like
`filter=emails[type eq "work" and value co "@example.com"] or ims[type eq "xmpp" and value co "@foo.com"]`.
It's meant to be 100% compatible with the RFC: https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.2, plus it's thoroughly tested.

Did I code it all by myself? Nope. I found the logic in the Elimity Go package ([here](https://sourcegraph.com/github.com/elimity-com/scim@15165b1a61c853d4e5e9ccfa54cfb2efc92eb733/-/blob/internal/filter/filter.go?L120) – found it using Sourcegraph search!), which is btw the same package that we use for our endpoint. But the filtering code is in the `/internal` folder of the package, and the only public part that uses it is the `/Schemas` REST endpoint handler and their test.
So, as it's very well-written logic, plus it's under the MIT license, I copy&pasted it to our code, and I use it for the filtering.
This should be legally fine, and as for elegance, I found no better way.

**Caveat:** as the filtering is done with **Go code**, _all_ resources (means: _all_ users) are fetched from the DB, then filtered in the backend. This is a limitation, as it will use more than a reasonable about of memory and processing power for customers with hundreds of thousands of users. Thoughts about this:
 - I've added a shortcut of “If there's no filter, just use and SQL with an OFFSET and LIMIT”. So the handler will only take the slow path if there's a filter.
 - We can add more shortcuts like this, like “If there is only a simple `userName` filter, just use SQL”. This is what the devs of another project did [here](https://sourcegraph.com/github.com/finleap-connect/monoskope@66c89aa22ad6903973591d2b58891e4872aa0c59/-/blob/internal/scimserver/user_handler.go?L162).
 - We can add a limitation that “under 1,000 users, we support complex filters; over that, we only support very basic ones”, and the limit could be configurable in the site config if customers really need this.
 - And then there's **the hard way**: we can rewrite the same logic with `sqlf` calls and transform the filters to an SQL query. I've tried to find an implementation for this but found none with Sourcegraph. I don't think it's needed at this point, though.
 - Btw, filter support is an _optional_ feature in SCIM (like most things in SCIM, tbh), so this is not a hard requirement. But it's quite close to the core requirements, and the current solution was worth a half day of fun engineering work, I'd say.

Another goodie for the end: this implementation is not specific to the resource type, so we'll get filtering for Groups for free once we add Group support later.

## Test plan

The new code is well tested (both the library I imported and my own part); I'm confident about it. Plus, customers won't use it yet.