### PR TITLE
database helpers: remove `fmt.Sprintf` and use only `sqlf.Sprintf`

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -26,7 +26,7 @@ type ConnectionResolverStore[N any] interface {
 	// MarshalCursor returns cursor for a node and is called for generating start and end cursors.
 	MarshalCursor(*N, database.OrderBy) (*string, error)
 	// UnmarshalCursor returns node id from after/before cursor string.
-	UnmarshalCursor(string, database.OrderBy) (*string, error)
+	UnmarshalCursor(string, database.OrderBy) (*string, []any, error)
 }
 
 type ConnectionResolverArgs struct {
@@ -123,21 +123,23 @@ func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, erro
 	}
 
 	if r.args.After != nil {
-		after, err := r.store.UnmarshalCursor(*r.args.After, r.options.OrderBy)
+		after, afterCols, err := r.store.UnmarshalCursor(*r.args.After, r.options.OrderBy)
 		if err != nil {
 			return nil, err
 		}
 
 		paginationArgs.After = after
+		paginationArgs.AfterColumns = afterCols
 	}
 
 	if r.args.Before != nil {
-		before, err := r.store.UnmarshalCursor(*r.args.Before, r.options.OrderBy)
+		before, beforeCols, err := r.store.UnmarshalCursor(*r.args.Before, r.options.OrderBy)
 		if err != nil {
 			return nil, err
 		}
 
 		paginationArgs.Before = before
+		paginationArgs.BeforeColumns = beforeCols
 	}
 
 	return &paginationArgs, nil

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -60,8 +60,8 @@ func (*testConnectionStore) MarshalCursor(n *testConnectionNode, _ database.Orde
 	return &cursor, nil
 }
 
-func (*testConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
-	return &cursor, nil
+func (*testConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, []any, error) {
+	return &cursor, []any{}, nil
 }
 
 func newInt(n int) *int {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -205,15 +205,15 @@ func (s *membersConnectionStore) MarshalCursor(node *UserResolver, _ database.Or
 	return &cursor, nil
 }
 
-func (s *membersConnectionStore) UnmarshalCursor(cusror string, _ database.OrderBy) (*string, error) {
+func (s *membersConnectionStore) UnmarshalCursor(cusror string, _ database.OrderBy) (*string, []any, error) {
 	nodeID, err := UnmarshalUserID(graphql.ID(cusror))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	id := string(nodeID)
 
-	return &id, nil
+	return &id, []any{}, nil
 }
 
 func (o *OrgResolver) settingsSubject() api.SettingsSubject {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -161,39 +161,27 @@ func (s *repositoriesConnectionStore) MarshalCursor(node *RepositoryResolver, or
 	return &cursor, nil
 }
 
-func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy database.OrderBy) (*string, error) {
+func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy database.OrderBy) (*string, []any, error) {
 	repoCursor, err := UnmarshalRepositoryCursor(&cursor)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(orderBy) == 0 {
-		return nil, errors.New("no orderBy provided")
+		return nil, nil, errors.New("no orderBy provided")
 	}
 
 	column := orderBy[0].Field
 	if repoCursor.Column != column {
-		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected: %s Actual: %s", column, repoCursor.Column))
+		return nil, nil, errors.New(fmt.Sprintf("Invalid cursor. Expected: %s Actual: %s", column, repoCursor.Column))
 	}
 
-	csv := ""
 	values := strings.Split(repoCursor.Value, "@")
 	if len(values) != 2 {
-		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value))
+		return nil, nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value))
 	}
 
-	switch database.RepoListColumn(column) {
-	case database.RepoListName:
-		csv = fmt.Sprintf("'%v', %v", values[0], values[1])
-	case database.RepoListCreatedAt:
-		csv = fmt.Sprintf("%v, %v", values[0], values[1])
-	case database.RepoListSize:
-		csv = fmt.Sprintf("%v, %v", values[0], values[1])
-	default:
-		return nil, errors.New("Invalid OrderBy Field.")
-	}
-
-	return &csv, err
+	return nil, []any{values[0], values[1]}, nil
 }
 
 func i32ptr(v int32) *int32 { return &v }

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -54,8 +54,8 @@ func (s *repositoryContributorConnectionStore) MarshalCursor(node *repositoryCon
 	return &position, nil
 }
 
-func (s *repositoryContributorConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
-	return &cursor, nil
+func (s *repositoryContributorConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, []any, error) {
+	return &cursor, nil, nil
 }
 
 func (s *repositoryContributorConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -157,15 +157,15 @@ func (s *savedSearchesConnectionStore) MarshalCursor(node *savedSearchResolver, 
 	return &cursor, nil
 }
 
-func (s *savedSearchesConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+func (s *savedSearchesConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, []any, error) {
 	nodeID, err := unmarshalSavedSearchID(graphql.ID(cursor))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	id := strconv.Itoa(int(nodeID))
 
-	return &id, nil
+	return &id, nil, nil
 }
 
 func (s *savedSearchesConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {

--- a/cmd/frontend/graphqlbackend/site_config_change_connection.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -67,15 +68,15 @@ func (s *SiteConfigurationChangeConnectionStore) MarshalCursor(node *SiteConfigu
 	return &cursor, nil
 }
 
-func (s *SiteConfigurationChangeConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+func (s *SiteConfigurationChangeConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, []any, error) {
 	var id int
 	err := relay.UnmarshalSpec(graphql.ID(cursor), &id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	idStr := strconv.Itoa(id)
-	return &idStr, err
+	return &idStr, nil, err
 }
 
 // modifyArgs will fetch one more than the originally requested number of items because we need one

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -154,7 +154,7 @@ func (p *PaginationArgs) SQL() (*QueryArgs, error) {
 			condition = fmt.Sprintf("(%s) <", columnsStr)
 		}
 
-		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%s)", *p.After)))
+		conditions = append(conditions, sqlf.Sprintf(condition+" (%s)", *p.After))
 	}
 	if p.Before != nil {
 		columnsStr := strings.Join(orderByColumns, ", ")
@@ -163,7 +163,7 @@ func (p *PaginationArgs) SQL() (*QueryArgs, error) {
 			condition = fmt.Sprintf("(%s) >", columnsStr)
 		}
 
-		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%s)", *p.Before)))
+		conditions = append(conditions, sqlf.Sprintf(condition+" (%s)", *p.Before))
 	}
 
 	if len(conditions) > 0 {


### PR DESCRIPTION
In response to this comment: https://github.com/sourcegraph/sourcegraph/pull/47105/files#r1094695781

## Test plan

- Existing tests