### PR TITLE
singleprogram: use localhost for gitserver

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -22,7 +22,11 @@ func Init(logger log.Logger) {
 	// INDEXED_SEARCH_SERVERS is empty (but defined) so that indexed search is disabled.
 	setDefaultEnv(logger, "INDEXED_SEARCH_SERVERS", "")
 
+	// GITSERVER_ADDR is used by gitserver to identify itself in the list in
+	// SRC_GIT_SERVERS.
+	setDefaultEnv(logger, "GITSERVER_ADDR", "127.0.0.1:3178")
 	setDefaultEnv(logger, "SRC_GIT_SERVERS", "127.0.0.1:3178")
+
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")
 	setDefaultEnv(logger, "SEARCHER_URL", "http://127.0.0.1:3181")
 	setDefaultEnv(logger, "REPO_UPDATER_URL", "http://127.0.0.1:3182")

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -22,9 +22,10 @@ func Init(logger log.Logger) {
 	// INDEXED_SEARCH_SERVERS is empty (but defined) so that indexed search is disabled.
 	setDefaultEnv(logger, "INDEXED_SEARCH_SERVERS", "")
 
-	// GITSERVER_ADDR is used by gitserver to identify itself in the list in
-	// SRC_GIT_SERVERS.
+	// GITSERVER_EXTERNAL_ADDR is used by gitserver to identify itself in the
+	// list in SRC_GIT_SERVERS.
 	setDefaultEnv(logger, "GITSERVER_ADDR", "127.0.0.1:3178")
+	setDefaultEnv(logger, "GITSERVER_EXTERNAL_ADDR", "127.0.0.1:3178")
 	setDefaultEnv(logger, "SRC_GIT_SERVERS", "127.0.0.1:3178")
 
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -22,15 +22,7 @@ func Init(logger log.Logger) {
 	// INDEXED_SEARCH_SERVERS is empty (but defined) so that indexed search is disabled.
 	setDefaultEnv(logger, "INDEXED_SEARCH_SERVERS", "")
 
-	// Need to set this to avoid trying to look up gitservers via k8s service discovery.
-	// TODO(sqs) TODO(single-binary): Make this not require the hostname.
-	hostname, err := os.Hostname()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "unable to determine hostname:", err)
-		os.Exit(1)
-	}
-	setDefaultEnv(logger, "SRC_GIT_SERVERS", hostname+":3178")
-
+	setDefaultEnv(logger, "SRC_GIT_SERVERS", "127.0.0.1:3178")
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")
 	setDefaultEnv(logger, "SEARCHER_URL", "http://127.0.0.1:3181")
 	setDefaultEnv(logger, "REPO_UPDATER_URL", "http://127.0.0.1:3182")

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -221,7 +221,7 @@ commands:
     <<: *oss_gitserver_template
     env:
       <<: *gitserverenv
-      HOSTNAME: 127.0.0.1:3501
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3501
       GITSERVER_ADDR: 127.0.0.1:3501
       SRC_REPOS_DIR: $HOME/.sourcegraph/repos_1
       SRC_PROF_HTTP: 127.0.0.1:3551
@@ -230,7 +230,7 @@ commands:
     <<: *oss_gitserver_template
     env:
       <<: *oss_gitserverenv
-      HOSTNAME: 127.0.0.1:3502
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3502
       GITSERVER_ADDR: 127.0.0.1:3502
       SRC_REPOS_DIR: $HOME/.sourcegraph/repos_2
       SRC_PROF_HTTP: 127.0.0.1:3552
@@ -244,7 +244,7 @@ commands:
     <<: *gitserver_template
     env:
       <<: *gitserverenv
-      HOSTNAME: 127.0.0.1:3501
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3501
       GITSERVER_ADDR: 127.0.0.1:3501
       SRC_REPOS_DIR: $HOME/.sourcegraph/repos_1
       SRC_PROF_HTTP: 127.0.0.1:3551
@@ -253,7 +253,7 @@ commands:
     <<: *gitserver_template
     env:
       <<: *gitserverenv
-      HOSTNAME: 127.0.0.1:3502
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3502
       GITSERVER_ADDR: 127.0.0.1:3502
       SRC_REPOS_DIR: $HOME/.sourcegraph/repos_2
       SRC_PROF_HTTP: 127.0.0.1:3552


### PR DESCRIPTION
Using the hostname isn't gaurenteed to work, it depends on how the machine is configured. For example on my linux desktop this fails. We only start the services on localhost and we use ipv4 localhost address for all other services.

Test Plan: sg start app doesn't spam my logs with failing to connect to gitserver.
