### PR TITLE
chore: clean up pagination related code

### DIFF
--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -258,9 +258,9 @@ func (r *UserResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecrets
 	}, nil
 }
 
-func (r *OrgResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
+func (o *OrgResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
 	// 🚨 SECURITY: Only allow access to list secrets if the user has access to the namespace.
-	if err := checkNamespaceAccess(ctx, r.db, 0, r.org.ID); err != nil {
+	if err := checkNamespaceAccess(ctx, o.db, 0, o.org.ID); err != nil {
 		return nil, err
 	}
 
@@ -270,12 +270,12 @@ func (r *OrgResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsL
 	}
 
 	return &executorSecretConnectionResolver{
-		db:    r.db,
+		db:    o.db,
 		scope: args.Scope,
 		opts: database.ExecutorSecretsListOpts{
 			LimitOffset:     limit,
 			NamespaceUserID: 0,
-			NamespaceOrgID:  r.org.ID,
+			NamespaceOrgID:  o.org.ID,
 		},
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const DEFAULT_MAX_PAGE_SIZE = 100
+const DefaultMaxPageSize = 100
 
 type ConnectionResolver[N any] struct {
 	store   ConnectionResolverStore[N]
@@ -36,7 +36,7 @@ type ConnectionResolverArgs struct {
 	Before *string
 }
 
-// Limit returns max nodes limit based on resolver arguments
+// Limit returns max nodes limit based on resolver arguments.
 func (a *ConnectionResolverArgs) Limit(options *ConnectionResolverOptions) int {
 	var limit *int32
 
@@ -60,22 +60,22 @@ type ConnectionResolverOptions struct {
 	//
 	// Defaults to `true` when not set.
 	Reverse *bool
-	// Columns to order by
+	// Columns to order by.
 	OrderBy database.OrderBy
-	// Order direction
+	// Order direction.
 	Ascending bool
 }
 
-// MaxPageSize returns the configured max page limit for the connection
+// MaxPageSizeOrDefault returns the configured max page limit for the connection.
 func (o *ConnectionResolverOptions) MaxPageSizeOrDefault() int {
 	if o.MaxPageSize != nil {
 		return *o.MaxPageSize
 	}
 
-	return DEFAULT_MAX_PAGE_SIZE
+	return DefaultMaxPageSize
 }
 
-// ApplyMaxPageSize return max page size by applying the configured max limit to the first, last arguments
+// ApplyMaxPageSize return max page size by applying the configured max limit to the first, last arguments.
 func (o *ConnectionResolverOptions) ApplyMaxPageSize(limit *int32) int {
 	maxPageSize := o.MaxPageSizeOrDefault()
 

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -109,8 +109,6 @@ type OrgResolver struct {
 	org *types.Org
 }
 
-func NewOrg(db database.DB, org *types.Org) *OrgResolver { return &OrgResolver{db: db, org: org} }
-
 func (o *OrgResolver) ID() graphql.ID { return MarshalOrgID(o.org.ID) }
 
 func MarshalOrgID(id int32) graphql.ID { return relay.MarshalID("Org", id) }
@@ -205,8 +203,8 @@ func (s *membersConnectionStore) MarshalCursor(node *UserResolver, _ database.Or
 	return &cursor, nil
 }
 
-func (s *membersConnectionStore) UnmarshalCursor(cusror string, _ database.OrderBy) (*string, error) {
-	nodeID, err := UnmarshalUserID(graphql.ID(cusror))
+func (s *membersConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+	nodeID, err := UnmarshalUserID(graphql.ID(cursor))
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +314,7 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 		// we do not throw errors here as this is best effort
 		err = r.db.Orgs().UpdateOrgsOpenBetaStats(ctx, *args.StatsID, newOrg.ID)
 		if err != nil {
-			log15.Warn("Cannot update orgs open beta stats", "id", *args.StatsID, "orgID", newOrg.ID, "error", err)
+			r.logger.Warn("Cannot update orgs open beta stats", log.String("id", *args.StatsID), log.Int32("orgID", newOrg.ID), log.Error(err))
 		}
 	}
 
@@ -377,7 +375,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	if memberCount == 1 && !r.siteAdminSelfRemoving(ctx, userID) {
 		return nil, errors.New("you can’t remove the only member of an organization")
 	}
-	log15.Info("removing user from org", "user", userID, "org", orgID)
+	r.logger.Info("removing user from org", log.Int32("userID", userID), log.Int32("orgID", orgID))
 	if err := r.db.OrgMembers().Remove(ctx, orgID, userID); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -198,10 +198,10 @@ func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy dat
 
 func i32ptr(v int32) *int32 { return &v }
 
-func (r *repositoriesConnectionStore) ComputeTotal(ctx context.Context) (countptr *int32, err error) {
+func (s *repositoriesConnectionStore) ComputeTotal(ctx context.Context) (countptr *int32, err error) {
 	// 🚨 SECURITY: Only site admins can list all repos, because a total repository
 	// count does not respect repository permissions.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
 		return i32ptr(int32(0)), nil
 	}
 
@@ -210,23 +210,23 @@ func (r *repositoriesConnectionStore) ComputeTotal(ctx context.Context) (countpt
 		return i32ptr(int32(0)), nil
 	}
 
-	count, err := r.db.Repos().Count(ctx, r.opt)
+	count, err := s.db.Repos().Count(ctx, s.opt)
 	return i32ptr(int32(count)), err
 }
 
-func (r *repositoriesConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]*RepositoryResolver, error) {
-	opt := r.opt
+func (s *repositoriesConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]*RepositoryResolver, error) {
+	opt := s.opt
 	opt.PaginationArgs = args
 
 	client := gitserver.NewClient()
-	repos, err := backend.NewRepos(r.logger, r.db, client).List(ctx, opt)
+	repos, err := backend.NewRepos(s.logger, s.db, client).List(ctx, opt)
 	if err != nil {
 		return nil, err
 	}
 
 	resolvers := make([]*RepositoryResolver, 0, len(repos))
 	for _, repo := range repos {
-		resolvers = append(resolvers, NewRepositoryResolver(r.db, client, repo))
+		resolvers = append(resolvers, NewRepositoryResolver(s.db, client, repo))
 	}
 
 	return resolvers, nil

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -24,10 +24,9 @@ func (r *RepositoryResolver) Contributors(args *struct {
 	graphqlutil.ConnectionResolverArgs
 }) (*graphqlutil.ConnectionResolver[*repositoryContributorResolver], error) {
 	connectionStore := &repositoryContributorConnectionStore{
-		db:             r.db,
-		args:           &args.repositoryContributorsArgs,
-		connectionArgs: &args.ConnectionResolverArgs,
-		repo:           r,
+		db:   r.db,
+		args: &args.repositoryContributorsArgs,
+		repo: r,
 	}
 	reverse := false
 	connectionOptions := graphqlutil.ConnectionResolverOptions{
@@ -37,9 +36,8 @@ func (r *RepositoryResolver) Contributors(args *struct {
 }
 
 type repositoryContributorConnectionStore struct {
-	db             database.DB
-	args           *repositoryContributorsArgs
-	connectionArgs *graphqlutil.ConnectionResolverArgs
+	db   database.DB
+	args *repositoryContributorsArgs
 
 	repo *RepositoryResolver
 

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -12,7 +12,7 @@ import (
 	sgusers "github.com/sourcegraph/sourcegraph/internal/users"
 )
 
-func (s *siteResolver) Users(ctx context.Context, args *struct {
+func (r *siteResolver) Users(ctx context.Context, args *struct {
 	Query        *string
 	SiteAdmin    *bool
 	Username     *string
@@ -24,12 +24,12 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 },
 ) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
 	return &siteUsersResolver{
-		&sgusers.UsersStats{DB: s.db, Filters: sgusers.UsersStatsFilters{
+		&sgusers.UsersStats{DB: r.db, Filters: sgusers.UsersStatsFilters{
 			Query:        args.Query,
 			SiteAdmin:    args.SiteAdmin,
 			Username:     args.Username,

--- a/enterprise/cmd/frontend/internal/insights/resolvers/admin_resolver.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/admin_resolver.go
@@ -119,7 +119,7 @@ type insightSeriesMetadataPayloadResolver struct {
 	series *types.InsightSeries
 }
 
-func (i *insightSeriesMetadataPayloadResolver) Series(ctx context.Context) graphqlbackend.InsightSeriesMetadataResolver {
+func (i *insightSeriesMetadataPayloadResolver) Series(_ context.Context) graphqlbackend.InsightSeriesMetadataResolver {
 	return &insightSeriesMetadataResolver{series: i.series}
 }
 
@@ -127,15 +127,15 @@ type insightSeriesMetadataResolver struct {
 	series *types.InsightSeries
 }
 
-func (i *insightSeriesMetadataResolver) SeriesId(ctx context.Context) (string, error) {
+func (i *insightSeriesMetadataResolver) SeriesId(_ context.Context) (string, error) {
 	return i.series.SeriesID, nil
 }
 
-func (i *insightSeriesMetadataResolver) Query(ctx context.Context) (string, error) {
+func (i *insightSeriesMetadataResolver) Query(_ context.Context) (string, error) {
 	return i.series.Query, nil
 }
 
-func (i *insightSeriesMetadataResolver) Enabled(ctx context.Context) (bool, error) {
+func (i *insightSeriesMetadataResolver) Enabled(_ context.Context) (bool, error) {
 	return i.series.Enabled, nil
 }
 
@@ -143,35 +143,35 @@ type insightSeriesQueryStatusResolver struct {
 	status types.InsightSeriesStatus
 }
 
-func (i *insightSeriesQueryStatusResolver) SeriesId(ctx context.Context) (string, error) {
+func (i *insightSeriesQueryStatusResolver) SeriesId(_ context.Context) (string, error) {
 	return i.status.SeriesId, nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Query(ctx context.Context) (string, error) {
+func (i *insightSeriesQueryStatusResolver) Query(_ context.Context) (string, error) {
 	return i.status.Query, nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Enabled(ctx context.Context) (bool, error) {
+func (i *insightSeriesQueryStatusResolver) Enabled(_ context.Context) (bool, error) {
 	return i.status.Enabled, nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Errored(ctx context.Context) (int32, error) {
+func (i *insightSeriesQueryStatusResolver) Errored(_ context.Context) (int32, error) {
 	return int32(i.status.Errored), nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Completed(ctx context.Context) (int32, error) {
+func (i *insightSeriesQueryStatusResolver) Completed(_ context.Context) (int32, error) {
 	return int32(i.status.Completed), nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Processing(ctx context.Context) (int32, error) {
+func (i *insightSeriesQueryStatusResolver) Processing(_ context.Context) (int32, error) {
 	return int32(i.status.Processing), nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Failed(ctx context.Context) (int32, error) {
+func (i *insightSeriesQueryStatusResolver) Failed(_ context.Context) (int32, error) {
 	return int32(i.status.Failed), nil
 }
 
-func (i *insightSeriesQueryStatusResolver) Queued(ctx context.Context) (int32, error) {
+func (i *insightSeriesQueryStatusResolver) Queued(_ context.Context) (int32, error) {
 	return int32(i.status.Queued), nil
 }
 

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -10,14 +10,16 @@ import (
 	"github.com/keegancsmith/sqlf"
 )
 
-// LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is typically embedded in other options
-// structs that need to perform SQL queries with LIMIT and OFFSET.
+// LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is
+// typically embedded in other options structs that need to perform SQL queries
+// with LIMIT and OFFSET.
 type LimitOffset struct {
 	Limit  int // SQL LIMIT count
 	Offset int // SQL OFFSET count
 }
 
-// SQL returns the SQL query fragment ("LIMIT %d OFFSET %d") for use in SQL queries.
+// SQL returns the SQL query fragment ("LIMIT %d OFFSET %d") for use in SQL
+// queries.
 func (o *LimitOffset) SQL() *sqlf.Query {
 	if o == nil {
 		return &sqlf.Query{}
@@ -190,7 +192,8 @@ func copyPtr[T any](n *T) *T {
 	return &c
 }
 
-// Clone (aka deepcopy) returns a new PaginationArgs object with the same values as "p".
+// Clone (aka deepcopy) returns a new PaginationArgs object with the same values
+// as "p".
 func (p *PaginationArgs) Clone() *PaginationArgs {
 	return &PaginationArgs{
 		First:  copyPtr(p.First),


### PR DESCRIPTION
Previously, passing more than one OrderBy parameters and using After/Before constructed invalid SQL queries such as: `WHERE (user_id, repository_id) < (1)`.

The fix won't let this situation happen and keep only the first column for WHERE clause.

Test plan:
Test added + CI.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
