### PR TITLE
sg: do not set repo-updater to gitserver's hostname

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -323,7 +323,6 @@ commands:
       go build -gcflags="$GCFLAGS" -o .bin/repo-updater github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
     checkBinary: .bin/repo-updater
     env:
-      HOSTNAME: $SRC_GIT_SERVER_1
       ENTERPRISE: 1
     watch:
       - lib


### PR DESCRIPTION
Looking at git blame I think this was just some copy-pasta mistakes.

Test Plan: sg start and the logs don't scream at me.
