### PR TITLE
Treeview: Fix history bug and 404 handling

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -122,12 +122,8 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             ancestors: alwaysLoadAncestors,
         },
         onCompleted(data) {
-            let rootTreeUrl = data?.repository?.commit?.tree?.url
-            let entries = data?.repository?.commit?.tree?.entries
-            if (!entries || !rootTreeUrl) {
-                rootTreeUrl = location.pathname
-                entries = []
-            }
+            const rootTreeUrl = data?.repository?.commit?.tree?.url ?? location.pathname
+            const entries = data?.repository?.commit?.tree?.entries ?? []
             if (treeData === null) {
                 setTreeData(
                     appendTreeData(
@@ -138,7 +134,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
                     )
                 )
             } else {
-                setTreeData(treeData => appendTreeData(treeData!, entries!, rootTreeUrl!, alwaysLoadAncestors))
+                setTreeData(treeData => appendTreeData(treeData!, entries, rootTreeUrl, alwaysLoadAncestors))
             }
         },
     })

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -170,6 +170,11 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
                 return
             }
 
+            // Bail out if we controlled the selection update.
+            if (selectedIds.length > 0 && selectedIds[0] === element.id) {
+                return
+            }
+
             // On the initial rendering, an onSelect event is fired for the
             // default node. We don't want to navigate to that node though.
             if (defaultSelectFiredRef.current === false && element.id === defaultNodeId) {
@@ -197,7 +202,15 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             }
             setSelectedIds([element.id])
         },
-        [defaultNodeId, telemetryService, navigate, props.initialFilePathIsDirectory, initialFilePath, onExpandParent]
+        [
+            selectedIds,
+            defaultNodeId,
+            telemetryService,
+            navigate,
+            props.initialFilePathIsDirectory,
+            initialFilePath,
+            onExpandParent,
+        ]
     )
 
     // We need a mutable reference to the tree data since we don't want the

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { mdiFileDocumentOutline, mdiSourceRepository, mdiFolderOutline, mdiFolderOpenOutline } from '@mdi/js'
 import classNames from 'classnames'
-import { useNavigate } from 'react-router-dom-v5-compat'
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -106,6 +106,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
     const [selectedIds, setSelectedIds] = useState<number[]>(defaultSelectedIds)
 
     const navigate = useNavigate()
+    const location = useLocation()
 
     const [defaultVariables] = useState({
         repoName: props.repoName,
@@ -121,10 +122,11 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             ancestors: alwaysLoadAncestors,
         },
         onCompleted(data) {
-            const rootTreeUrl = data?.repository?.commit?.tree?.url
-            const entries = data?.repository?.commit?.tree?.entries
+            let rootTreeUrl = data?.repository?.commit?.tree?.url
+            let entries = data?.repository?.commit?.tree?.entries
             if (!entries || !rootTreeUrl) {
-                throw new Error('No entries or root data')
+                rootTreeUrl = location.pathname
+                entries = []
             }
             if (treeData === null) {
                 setTreeData(
@@ -136,7 +138,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
                     )
                 )
             } else {
-                setTreeData(treeData => appendTreeData(treeData!, entries, rootTreeUrl, alwaysLoadAncestors))
+                setTreeData(treeData => appendTreeData(treeData!, entries!, rootTreeUrl!, alwaysLoadAncestors))
             }
         },
     })


### PR DESCRIPTION
Part of #12916 

Thank you @valerybugakov for reporting this. This PR fixes two bugs:

- When loading a 404 page, the sidebar was stuck in an endless loading state. We now instead always render the `..` icon to allow the user to recover.
- When navigating between files, elements were pushed to the history multiple times resulting in invalid back button behavior.

## Test plan

Tested locally:

https://user-images.githubusercontent.com/458591/216605131-e4830321-1ce0-466c-bd43-dc913d051d1c.mov

https://user-images.githubusercontent.com/458591/216605152-19f4dc95-799f-4d77-9f49-dc5126e90535.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-fix-404.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
