### PR TITLE
Remove rate limiter waiting in perms syncer

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -36,11 +36,6 @@ var (
 		Name: "src_repoupdater_perms_syncer_queue_size",
 		Help: "The size of the sync request queue",
 	})
-	metricsRateLimiterWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_repoupdater_perms_syncer_sync_wait_duration_seconds",
-		Help:    "Time spent waiting on rate-limiter to sync permissions",
-		Buckets: []float64{0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120},
-	}, []string{"type", "success"})
 	metricsConcurrentSyncs = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_repoupdater_perms_syncer_concurrent_syncs",
 		Help: "The number of concurrent permissions syncs",

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -13,5 +12,3 @@ func scanDependencyRepo(s dbutil.Scanner) (shared.PackageRepoReference, error) {
 	ref.Versions = []shared.PackageRepoRefVersion{version}
 	return ref, err
 }
-
-var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1520,6 +1520,7 @@ func newHttpResponseState(statusCode int, headers http.Header) *httpResponseStat
 }
 
 func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result any) (responseState *httpResponseState, err error) {
+	fmt.Println("Doing github request")
 	req.URL.Path = path.Join(apiURL.Path, req.URL.Path)
 	req.URL = apiURL.ResolveReference(req.URL)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1520,7 +1520,6 @@ func newHttpResponseState(statusCode int, headers http.Header) *httpResponseStat
 }
 
 func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result any) (responseState *httpResponseState, err error) {
-	fmt.Println("Doing github request")
 	req.URL.Path = path.Join(apiURL.Path, req.URL.Path)
 	req.URL = apiURL.ResolveReference(req.URL)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
Closes #47186 

We already wait for rate limits inside the clients that make requests to the code hosts. Waiting for rate limits in the perms syncer causes double consumption of tokens:

Here you can see the rate limit tokens being reduced twice for a single GitHub request
<img width="828" alt="image" src="https://user-images.githubusercontent.com/6427795/216612944-6f466b4b-bce7-4d07-98d8-2a576345b015.png">

And here it is after removing the wait in the perms syncer:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/6427795/216613078-9d776a80-9205-45c7-a89f-3677b25f639d.png">

## Test plan
Removed unit tests that are no longer necessary. The rest remains the same.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
