### PR TITLE
Fix references panel issues

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -143,8 +143,6 @@ function createStateFromLocation(location: H.Location): null | State {
 }
 
 export const ReferencesPanel: React.FunctionComponent<React.PropsWithChildren<ReferencesPanelProps>> = props => {
-    // We store the state in a React state so that we do not update it when the
-    // URL changes.
     const location = useLocation()
     const state = useMemo(() => createStateFromLocation(location), [location])
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -146,7 +146,7 @@ export const ReferencesPanel: React.FunctionComponent<React.PropsWithChildren<Re
     // We store the state in a React state so that we do not update it when the
     // URL changes.
     const location = useLocation()
-    const [state] = useState(createStateFromLocation(location))
+    const state = useMemo(() => createStateFromLocation(location), [location])
 
     if (state === null) {
         return null

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import { isEqual } from 'lodash'
-import { Location, createPath, NavigateFunction, useLocation, useNavigate } from 'react-router-dom-v5-compat'
+import { Location, createPath, NavigateFunction } from 'react-router-dom-v5-compat'
 import {
     BehaviorSubject,
     combineLatest,

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -220,10 +220,11 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         ariaLabel,
         history,
         'data-testid': dataTestId,
+
+        location,
+        navigate,
     } = props
 
-    const location = useLocation()
-    const navigate = useNavigate()
     const settingsChanges = useMemo(() => new BehaviorSubject<Settings | null>(null), [])
     useEffect(() => {
         if (

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -113,10 +113,11 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
 
         overrideBrowserSearchKeybinding,
         'data-testid': dataTestId,
+
+        location,
+        navigate,
     } = props
 
-    const location = useLocation()
-    const navigate = useNavigate()
     const [useFileSearch, setUseFileSearch] = useLocalStorage('blob.overrideBrowserFindOnPage', true)
 
     const [container, setContainer] = useState<HTMLDivElement | null>(null)

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -8,7 +8,7 @@ import { openSearchPanel } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { isEqual } from 'lodash'
-import { createPath, useLocation, useNavigate } from 'react-router-dom-v5-compat'
+import { createPath } from 'react-router-dom-v5-compat'
 
 import {
     addLineRangeQueryParameter,


### PR DESCRIPTION
Part of #33834 

Fixes issues introduced in #47014 and #46718

The references panel currently has two bugs:

- When clicking "find references" on another symbol, the references panel does not updated (added in #46718)
- When clicking on a different suggestion in the references list, the blob view does not update (added in #47014)

The cause is best described by looking at the code but TL;DR: We were snapshotting the outside URL state for the references panel instead of updating it when the location changes and we were using the outside URL state for the inside blob view instead of the location and history we pass into it.

Something to consider when we clean this up @valerybugakov 😬  Maybe the Blob view should just get a `location` and a `setLocation` callback?

Super special thanks to @mrnugget for feedback. 

## Test plan

Both features work now:

https://user-images.githubusercontent.com/458591/216644782-07e7d41c-50de-413a-af1c-3e9304978f69.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-code-intel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
