### PR TITLE
Treeview: Tweak ".." UI

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { mdiFileDocumentOutline, mdiSourceRepository, mdiFolderOutline, mdiFolderOpenOutline } from '@mdi/js'
+import {
+    mdiFileDocumentOutline,
+    mdiSourceRepository,
+    mdiFolderOutline,
+    mdiFolderOpenOutline,
+    mdiFolderArrowUp,
+} from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom-v5-compat'
 
@@ -279,11 +285,11 @@ function renderNode({
                 }}
             >
                 <Icon
-                    svgPath={mdiFolderOutline}
+                    svgPath={mdiFolderArrowUp}
                     className={classNames('mr-1', styles.icon)}
                     aria-label="Load parent directory"
                 />
-                ..
+                {name}
             </Link>
         )
     }
@@ -537,9 +543,11 @@ function insertRootNode(tree: TreeData, rootTreeUrl: string, alwaysLoadAncestors
 
     if (!alwaysLoadAncestors && tree.rootPath !== '') {
         const id = tree.nodes.length
+        const parentPathName = getParentPath(tree.rootPath)
+        const parentDirName = parentPathName === '' ? 'Repository root' : parentPathName.split('/').pop()
         const path = tree.rootPath + '/..'
         const node: TreeNode = {
-            name: '..',
+            name: parentDirName,
             id,
             isBranch: false,
             parent: 0,

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -544,7 +544,7 @@ function insertRootNode(tree: TreeData, rootTreeUrl: string, alwaysLoadAncestors
     if (!alwaysLoadAncestors && tree.rootPath !== '') {
         const id = tree.nodes.length
         const parentPathName = getParentPath(tree.rootPath)
-        const parentDirName = parentPathName === '' ? 'Repository root' : parentPathName.split('/').pop()
+        const parentDirName = parentPathName === '' ? 'Repository root' : parentPathName.split('/').pop()!
         const path = tree.rootPath + '/..'
         const node: TreeNode = {
             name: parentDirName,

--- a/client/wildcard/src/components/Tree/Tree.module.scss
+++ b/client/wildcard/src/components/Tree/Tree.module.scss
@@ -50,7 +50,7 @@
 
     .collapse-icon {
         min-height: 1.75rem;
-        min-width: 1.5rem;
+        min-width: 1rem;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -133,15 +133,8 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
 }
 
 function getMarginLeft(level: number, isBranch: boolean): string {
-    // The level starts with 1 so the least margin by this logic is 0.75 * 1.
-    //
-    // Since folders render a chevron icon that is 1.25rem wide and we want to
-    // render it to the left of the item, we need to add 0.5rem so we don't have
-    // a negative margin
-    level += 0.5
-
     if (isBranch) {
-        return `${0.75 * level - 1.25}rem`
+        return `${0.75 * level - 0.75}rem`
     }
     return `${0.75 * level}rem`
 }


### PR DESCRIPTION
Part of #12916 

This PR implements some feedback shared in https://sourcegraph.slack.com/archives/C04931KQVRC/p1675437746606569?thread_ts=1675261251.770359&cid=C04931KQVRC

- This gets rid of the `..` item and instead renders a different icon + the parent folder name (`Repository root` if the parent is the root)
- Reduces the width of the collapse icon (I felt like there was too much padding before) 

## Open issues

- We currently re-render everything when we're navigating to the parent tree like this. I did this to keep the behavior the same with the existing implementation but also because it will require quite a bit of book keeping to get this fixed with the tree abstraction we use. Will look into it but I don't want to make promises. 

## Test plan

https://user-images.githubusercontent.com/458591/216651725-aebee3cd-8113-41b4-92d7-1d7d3dfef54e.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-tree-view-up-arrow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

