### PR TITLE
insights: batch backfilling in groups of repos 

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/group"
 )
 
 const (
@@ -91,7 +93,11 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		oldVal := task.config.interruptAfter
 		newVal := getInterruptAfter()
 		task.config.interruptAfter = newVal
+		oldPageSize := task.config.pageSize
+		newPageSize := getPageSize()
+		task.config.pageSize = newPageSize
 		configLogger.Info("insights backfiller interrupt time changed", log.Duration("old", oldVal), log.Duration("new", newVal))
+		configLogger.Info("insights backfiller repo page size changed", log.Int("old", oldPageSize), log.Int("new", newPageSize))
 	})
 
 	return worker, resetter, workerStore
@@ -112,10 +118,11 @@ type inProgressHandler struct {
 type handlerConfig struct {
 	interruptAfter      time.Duration
 	errorThresholdFloor int
+	pageSize            int
 }
 
 func newHandlerConfig() handlerConfig {
-	return handlerConfig{interruptAfter: getInterruptAfter(), errorThresholdFloor: getErrorThresholdFloor()}
+	return handlerConfig{interruptAfter: getInterruptAfter(), errorThresholdFloor: getErrorThresholdFloor(), pageSize: getPageSize()}
 }
 
 var _ workerutil.Handler[*BaseJob] = &inProgressHandler{}
@@ -150,6 +157,8 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 	return nil
 }
 
+type nextNFunc func(pageSize int, config iterator.IterationConfig) ([]api.RepoID, bool, iterator.FinishNFunc)
+
 func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfillExecution) (interrupt bool, err error) {
 	timeExpired := h.clock.After(h.config.interruptAfter)
 
@@ -178,10 +187,12 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 		},
 	}
 
-	type nextFunc func(config iterator.IterationConfig) (api.RepoID, bool, iterator.FinishFunc)
-	itrLoop := func(nextFunc nextFunc) (interrupted bool, _ error) {
+	itrLoop := func(pageSize int, nextFunc nextNFunc) (interrupted bool, _ error) {
+		// Unrelated to the page size this will limit to backfilling at most 3 repos concurrently
+		g := group.New().WithContext(ctx).WithMaxConcurrency(3)
+		mu := sync.Mutex{}
 		for {
-			repoId, more, finish := nextFunc(itrConfig)
+			repoIds, more, finish := nextFunc(pageSize, itrConfig)
 			if !more {
 				break
 			}
@@ -189,21 +200,35 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 			case <-timeExpired:
 				return true, nil
 			default:
-				repo, repoErr := h.repoStore.Get(ctx, repoId)
-				if repoErr != nil {
-					err = finish(ctx, h.backfillStore.Store, errors.Wrap(repoErr, "InProgressHandler.repoStore.Get"))
-					if err != nil {
-						return false, err
-					}
-					continue
-				}
+				repoErrors := map[int32]error{}
+				startPage := time.Now()
+				for i := 0; i < len(repoIds); i++ {
+					repoId := repoIds[i]
+					g.Go(func(ctx context.Context) error {
+						repo, repoErr := h.repoStore.Get(ctx, repoId)
+						if repoErr != nil {
+							mu.Lock()
+							repoErrors[int32(repoId)] = errors.Wrap(repoErr, "InProgressHandler.repoStore.Get")
+							mu.Unlock()
+							return nil
+						}
+						execution.logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
+						runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: execution.series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, SampleTimes: execution.sampleTimes})
+						if runErr != nil {
+							execution.logger.Error("error during backfill execution", execution.logFields(log.Error(runErr))...)
+							mu.Lock()
+							repoErrors[int32(repoId)] = runErr
+							mu.Unlock()
+							return nil
+						}
+						return nil
+					})
 
-				execution.logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
-				runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: execution.series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, SampleTimes: execution.sampleTimes})
-				if runErr != nil {
-					execution.logger.Error("error during backfill execution", execution.logFields(log.Error(runErr))...)
 				}
-				err = finish(ctx, h.backfillStore.Store, runErr)
+				// The groups functions don't return errors so not checking for them
+				g.Wait()
+				execution.logger.Info("page complete", log.Duration("page duration", time.Since(startPage)), log.Int("page size", pageSize), log.Int("number repos", len(repoIds)))
+				err = finish(ctx, h.backfillStore.Store, repoErrors)
 				if err != nil {
 					return false, err
 				}
@@ -219,7 +244,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	}
 
 	execution.logger.Debug("starting primary loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
-	if interrupted, err := itrLoop(execution.itr.NextWithFinish); err != nil {
+	if interrupted, err := itrLoop(h.config.pageSize, execution.itr.NextPageWithFinish); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.PrimaryLoop")
 	} else if interrupted {
 		execution.logger.Info("interrupted insight series backfill", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
@@ -227,7 +252,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	}
 
 	execution.logger.Debug("starting retry loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
-	if interrupted, err := itrLoop(execution.itr.NextRetryWithFinish); err != nil {
+	if interrupted, err := itrLoop(1, retryAdapter(execution.itr.NextRetryWithFinish)); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.RetryLoop")
 	} else if interrupted {
 		execution.logger.Info("interrupted insight series backfill retry", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
@@ -240,6 +265,17 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 		// in this state we have some errors that will need reprocessing, we will place this job back in queue
 		return true, nil
 	}
+}
+
+func retryAdapter(next func(config iterator.IterationConfig) (api.RepoID, bool, iterator.FinishFunc)) nextNFunc {
+	return func(pageSize int, config iterator.IterationConfig) ([]api.RepoID, bool, iterator.FinishNFunc) {
+		repoId, more, finish := next(config)
+		return []api.RepoID{repoId}, more, func(ctx context.Context, store *basestore.Store, maybeErr map[int32]error) error {
+			repoErr := maybeErr[int32(repoId)]
+			return finish(ctx, store, repoErr)
+		}
+	}
+
 }
 
 func (h *inProgressHandler) finish(ctx context.Context, ex *backfillExecution) (err error) {
@@ -358,6 +394,14 @@ func getInterruptAfter() time.Duration {
 		return time.Duration(val) * time.Second
 	}
 	return time.Duration(defaultInterruptSeconds) * time.Second
+}
+
+func getPageSize() int {
+	val := conf.Get().InsightsBackfillRepositoryGroupSize
+	if val > 0 {
+		return int(math.Min(float64(val), 100))
+	}
+	return 10
 }
 
 func getErrorThresholdFloor() int {

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -404,6 +404,7 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 		clock:              clock,
 	}
 	handler.config.interruptAfter = time.Second * 5
+	handler.config.pageSize = 2 // setting the page size to only complete 1/2 repos in 1 iteration
 
 	err = handler.Handle(ctx, logger, dequeue)
 	require.NoError(t, err)

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -371,7 +371,7 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 		SeriesID:            "series1",
 		Query:               "asdf",
 		SampleIntervalUnit:  string(types.Month),
-		Repositories:        []string{"repo1", "repo2"},
+		Repositories:        []string{"repo1", "repo2", "repo3", "repo4"},
 		SampleIntervalValue: 1,
 		GenerationMethod:    types.Search,
 	})
@@ -379,7 +379,7 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 
 	backfill, err := bfs.NewBackfill(ctx, series)
 	require.NoError(t, err)
-	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2}, 0)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2, 3, 4}, 0)
 	require.NoError(t, err)
 	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
 	require.NoError(t, err)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2450,6 +2450,8 @@ type SiteConfiguration struct {
 	InsightsAggregationsProactiveResultLimit int `json:"insights.aggregations.proactiveResultLimit,omitempty"`
 	// InsightsBackfillInterruptAfter description: Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.
 	InsightsBackfillInterruptAfter int `json:"insights.backfill.interruptAfter,omitempty"`
+	// InsightsBackfillRepositoryGroupSize description: Set the number of repositories to batch in a group during backfilling.
+	InsightsBackfillRepositoryGroupSize int `json:"insights.backfill.repositoryGroupSize,omitempty"`
 	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
 	InsightsHistoricalWorkerRateLimit *float64 `json:"insights.historical.worker.rateLimit,omitempty"`
 	// InsightsHistoricalWorkerRateLimitBurst description: The allowed burst rate for the Code Insights historical worker rate limiter.
@@ -2632,6 +2634,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "insights.aggregations.bufferSize")
 	delete(m, "insights.aggregations.proactiveResultLimit")
 	delete(m, "insights.backfill.interruptAfter")
+	delete(m, "insights.backfill.repositoryGroupSize")
 	delete(m, "insights.historical.worker.rateLimit")
 	delete(m, "insights.historical.worker.rateLimitBurst")
 	delete(m, "insights.maximumSampleSize")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1401,6 +1401,12 @@
       "group": "CodeInsights",
       "default": 60
     },
+    "insights.backfill.repositoryGroupSize": {
+      "description": "Set the number of repositories to batch in a group during backfilling.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 10
+    },
     "insights.query.worker.concurrency": {
       "description": "Number of concurrent executions of a code insight query on a worker node",
       "type": "integer",


### PR DESCRIPTION
Because some repos take longer than other to backfill, the throughput is not always maximized, by grabbing a batch of repos at a time we can run can continue to run additional repos though the backfill while larger/slower repos are running.  

This sets a conservative default page size of 10 and limits the concurrency to 3.   

## Test plan
unit tests
Backfilled insight
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
