### PR TITLE
Teams/GraphQL: Add URL resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
@@ -125,15 +127,28 @@ type teamResolver struct {
 func (r *teamResolver) ID() graphql.ID {
 	return relay.MarshalID("Team", r.team.ID)
 }
-func (r *teamResolver) Name() string { return r.team.Name }
-func (r *teamResolver) URL() string  { return "" }
+
+func (r *teamResolver) Name() string {
+	return r.team.Name
+}
+
+func (r *teamResolver) URL() string {
+	absolutePath := fmt.Sprintf("/teams/%s", r.team.Name)
+	u := &url.URL{Path: absolutePath}
+	return u.String()
+}
+
 func (r *teamResolver) DisplayName() *string {
 	if r.team.DisplayName == "" {
 		return nil
 	}
 	return &r.team.DisplayName
 }
-func (r *teamResolver) Readonly() bool { return r.team.ReadOnly }
+
+func (r *teamResolver) Readonly() bool {
+	return r.team.ReadOnly
+}
+
 func (r *teamResolver) ParentTeam(ctx context.Context) (*teamResolver, error) {
 	if r.team.ParentTeamID == 0 {
 		return nil, nil
@@ -144,14 +159,17 @@ func (r *teamResolver) ParentTeam(ctx context.Context) (*teamResolver, error) {
 	}
 	return &teamResolver{team: parentTeam, db: r.db}, nil
 }
+
 func (r *teamResolver) ViewerCanAdminister(ctx context.Context) bool {
 	// 🚨 SECURITY: For now administration is only allowed for site admins.
 	err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db)
 	return err == nil
 }
+
 func (r *teamResolver) Members(args *ListTeamsArgs) *teamMemberConnection {
 	return &teamMemberConnection{}
 }
+
 func (r *teamResolver) ChildTeams(ctx context.Context, args *ListTeamsArgs) (*teamConnectionResolver, error) {
 	c := &teamConnectionResolver{
 		db:       r.db,

--- a/cmd/frontend/graphqlbackend/teams_test.go
+++ b/cmd/frontend/graphqlbackend/teams_test.go
@@ -167,6 +167,33 @@ func TestTeamNode(t *testing.T) {
 	})
 }
 
+func TestTeamNodeURL(t *testing.T) {
+	db, ts := setupDB()
+	ctx, _, _ := fakeUser(t, context.Background(), db, true)
+	team := &types.Team{
+		Name: "team-刺身", // team-sashimi
+	}
+	if err := ts.CreateTeam(ctx, team); err != nil {
+		t.Fatalf("failed to create fake team: %s", err)
+	}
+	RunTest(t, &Test{
+		Schema:  mustParseGraphQLSchema(t, db),
+		Context: ctx,
+		Query: `{
+			team(name: "team-刺身") {
+				... on Team {
+					url
+				}
+			}
+		}`,
+		ExpectedResult: `{
+			"team": {
+				"url": "/teams/team-%E5%88%BA%E8%BA%AB"
+			}
+		}`,
+	})
+}
+
 func TestTeamNodeSiteAdminCanAdminister(t *testing.T) {
 	for _, isAdmin := range []bool{true, false} {
 		t.Run(fmt.Sprintf("viewer is admin = %v", isAdmin), func(t *testing.T) {


### PR DESCRIPTION
Part of #47043 

- Using `url.URL.String()` rather than just `fmt.Sprintf` for path in order to correctly handle escaping.

## Test plan

Single test checking whether escaping works OK.
