### PR TITLE
release-protector: update for 4.5 release

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -13,11 +13,15 @@ jobs:
     outputs:
       releaseBranchExists: ${{ steps.checkout.outputs.exists }}
     steps:
-      - name: Checkout new release branch
+      - name: Check if latest release branch exists
         id: checkout
-        uses: actions/checkout@v2
-        with:
-          ref: 4.5 # update this before releasing or something - find a way to automate
+        run: |
+          branch="4.5"
+          if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
 
   protect-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -17,7 +17,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v2
         with:
-          ref: 4.4 # update this before releasing or something - find a way to automate
+          ref: 4.5 # update this before releasing or something - find a way to automate
 
   protect-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of the requirements for the release protector, we are meant to be updating the release protector to include the new release version.

There's still the question of if we are having another code freeze this month.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
N/A