### PR TITLE
rbac: assign roles when a user is created

### DIFF
--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -263,6 +264,10 @@ func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 	}
 
 	if err = r.db.Users().SetIsSiteAdmin(ctx, affectedUserID, args.SiteAdmin); err != nil {
+		return nil, err
+	}
+
+	if _, err = r.db.UserRoles().AssignSystemRoleToUser(ctx, affectedUserID, types.SiteAdministratorSystemRole); err != nil {
 		return nil, err
 	}
 

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -192,6 +192,10 @@ func dbAddUserAction(cmd *cli.Context) error {
 		return err
 	}
 
+	if _, err = db.UserRoles().AssignSystemRoleToUser(ctx, user.ID, types.SiteAdministratorSystemRole); err != nil {
+		return err
+	}
+
 	// Report back the new user information.
 	std.Out.WriteSuccessf(
 		// the space after the last %s is so the user can select the password easily in the shell to copy it.

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	internalauth "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -198,6 +199,18 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not set as site admin.", http.StatusInternalServerError)
 					return
 				}
+
+				if _, err = db.UserRoles().AssignSystemRoleToUser(ctx, result.User.ID, types.SiteAdministratorSystemRole); err != nil {
+					logger.Error("failed to assign SITE_ADMINISTRATOR role to Sourcegraph Operator")
+					http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not set as site admin.", http.StatusInternalServerError)
+					return
+				}
+			}
+
+			if _, err = db.UserRoles().AssignSystemRoleToUser(ctx, result.User.ID, types.UserSystemRole); err != nil {
+				logger.Error("failed to assign USER role to Sourcegraph Operator")
+				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not set as site admin.", http.StatusInternalServerError)
+				return
 			}
 
 			// 🚨 SECURITY: Call auth.SafeRedirectURL to avoid the open-redirect vulnerability.

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -93,6 +93,11 @@ func NewAfterCreateUserHook() func(context.Context, database.DB, *types.User) er
 			if err := store.SetIsSiteAdmin(ctx, user.ID, user.SiteAdmin); err != nil {
 				return err
 			}
+
+			// Assign site administrator role to this user
+			if _, err := tx.UserRoles().AssignSystemRoleToUser(ctx, user.ID, types.SiteAdministratorSystemRole); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/internal/database/user_roles.go
+++ b/internal/database/user_roles.go
@@ -43,6 +43,8 @@ type BulkCreateForUserOpts struct {
 type UserRoleStore interface {
 	basestore.ShareableStore
 
+	// AssignSystemRoleToUser assigns a system role to a user
+	AssignSystemRoleToUser(ctx context.Context, userID int32, role types.SystemRole) (*types.UserRole, error)
 	// Create inserts the given user and role relationship into the database.
 	Create(ctx context.Context, opts CreateUserRoleOpts) (*types.UserRole, error)
 	// BulkCreateForUser assigns multiple roles to a single user. This is useful
@@ -87,6 +89,31 @@ INSERT INTO
 VALUES %s
 RETURNING %s;
 `
+
+func (r *userRoleStore) AssignSystemRoleToUser(ctx context.Context, userID int32, role types.SystemRole) (*types.UserRole, error) {
+	if userID == 0 {
+		return nil, errors.New("missing user id")
+	}
+
+	if role == "" {
+		return nil, errors.New("missing role")
+	}
+
+	roleQuery := sqlf.Sprintf("SELECT id FROM roles WHERE name = %s", role)
+
+	q := sqlf.Sprintf(
+		userRoleCreateQueryFmtStr,
+		sqlf.Join(userRoleInsertColumns, ", "),
+		sqlf.Sprintf("( %s, %s )", userID, roleQuery),
+		sqlf.Join(userRoleColumns, ", "),
+	)
+
+	rm, err := scanUserRole(r.QueryRow(ctx, q))
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning user role")
+	}
+	return rm, nil
+}
 
 func (r *userRoleStore) Create(ctx context.Context, opts CreateUserRoleOpts) (*types.UserRole, error) {
 	if opts.UserID == 0 {


### PR DESCRIPTION
Closes #47131

This PR handles the assignment of roles when a user is created (either using the `sg` cli or via the UI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Added unit tests