### PR TITLE
rbac: add mutation for creating roles

### DIFF
--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -28,6 +28,7 @@ type PermissionResolver interface {
 type RBACResolver interface {
 	// MUTATIONS
 	DeleteRole(ctx context.Context, args *DeleteRoleArgs) (*EmptyResponse, error)
+	CreateRole(ctx context.Context, args *CreateRoleArgs) (RoleResolver, error)
 
 	// QUERIES
 	Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error)
@@ -38,6 +39,10 @@ type RBACResolver interface {
 
 type DeleteRoleArgs struct {
 	Role graphql.ID
+}
+
+type CreateRoleArgs struct {
+	Name string
 }
 
 type ListRoleArgs struct {

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -155,6 +155,11 @@ extend type Mutation {
     Any users who were assigned to the role will be unassigned and lose any permissions associated with it.
     """
     deleteRole(role: ID!): EmptyResponse!
+
+    """
+    Creates a role.
+    """
+    createRole(name: String!): Role!
 }
 
 extend type User {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
@@ -100,7 +100,7 @@ func (r *Resolver) DeleteRole(ctx context.Context, args *gql.DeleteRoleArgs) (_ 
 }
 
 func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gql.RoleResolver, error) {
-	// 🚨 SECURITY: Only site administrators can delete roles.
+	// 🚨 SECURITY: Only site administrators can create roles.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
@@ -98,3 +98,20 @@ func (r *Resolver) DeleteRole(ctx context.Context, args *gql.DeleteRoleArgs) (_ 
 
 	return &gql.EmptyResponse{}, nil
 }
+
+func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gql.RoleResolver, error) {
+	// 🚨 SECURITY: Only site administrators can delete roles.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	newRole, err := r.db.Roles().Create(ctx, args.Name, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &roleResolver{
+		db:   r.db,
+		role: newRole,
+	}, nil
+}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -295,3 +295,64 @@ mutation DeleteRole($role: ID!) {
 	}
 }
 `
+
+func TestCreateRole(t *testing.T) {
+	logger := logtest.Scoped(t)
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	userID := createTestUser(t, db, false).ID
+	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+	adminUserID := createTestUser(t, db, true).ID
+	adminActorCtx := actor.WithActor(ctx, actor.FromUser(adminUserID))
+
+	r := &Resolver{logger: logger, db: db}
+	s, err := newSchema(db, r)
+	assert.NoError(t, err)
+
+	t.Run("as non site-admin", func(t *testing.T) {
+		input := map[string]any{"name": "TEST-ROLE"}
+
+		var response struct{ CreateRole apitest.Role }
+		errs := apitest.Exec(actorCtx, t, s, input, &response, createRoleMutation)
+
+		if len(errs) != 1 {
+			t.Fatalf("expected single errors, but got %d", len(errs))
+		}
+		if have, want := errs[0].Message, "must be site admin"; have != want {
+			t.Fatalf("wrong error. want=%q, have=%q", want, have)
+		}
+	})
+
+	t.Run("as site-admin", func(t *testing.T) {
+		input := map[string]any{"name": "TEST-ROLE"}
+
+		var response struct{ CreateRole apitest.Role }
+		// First time it should work, because the role exists
+		apitest.MustExec(adminActorCtx, t, s, input, &response, createRoleMutation)
+
+		// Second time it should fail because role names are unique
+		errs := apitest.Exec(adminActorCtx, t, s, input, &response, createRoleMutation)
+		if len(errs) != 1 {
+			t.Fatalf("expected a single error, but got %d", len(errs))
+		}
+		if have, want := errs[0].Message, "cannot create role: err_name_exists"; have != want {
+			t.Fatalf("wrong error code. want=%q, have=%q", want, have)
+		}
+	})
+}
+
+const createRoleMutation = `
+mutation CreateRole($name: String!) {
+	createRole(name: $name) {
+		id
+		name
+		system
+	}
+}
+`

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -322,7 +322,7 @@ func TestCreateRole(t *testing.T) {
 		errs := apitest.Exec(actorCtx, t, s, input, &response, createRoleMutation)
 
 		if len(errs) != 1 {
-			t.Fatalf("expected single errors, but got %d", len(errs))
+			t.Fatalf("expected a single error, but got %d", len(errs))
 		}
 		if have, want := errs[0].Message, "must be site admin"; have != want {
 			t.Fatalf("wrong error. want=%q, have=%q", want, have)

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -336,7 +336,7 @@ func TestCreateRole(t *testing.T) {
 		// First time it should work, because the role exists
 		apitest.MustExec(adminActorCtx, t, s, input, &response, createRoleMutation)
 
-		// Second time it should fail because role names are unique
+		// Second time it should fail because role names must be unique
 		errs := apitest.Exec(adminActorCtx, t, s, input, &response, createRoleMutation)
 		if len(errs) != 1 {
 			t.Fatalf("expected a single error, but got %d", len(errs))

--- a/internal/database/roles.go
+++ b/internal/database/roles.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -12,6 +13,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+// errCannotCreateRole is the error returned when a role cannot be inserted
+// into the database due to a constraint.
+type errCannotCreateRole struct {
+	code string
+}
+
+const errorCodeRoleNameExists = "err_name_exists"
+
+func (err errCannotCreateRole) Error() string {
+	return fmt.Sprintf("cannot create role: %v", err.code)
+}
+
+func (err errCannotCreateRole) Code() string {
+	return err.code
+}
 
 var roleColumns = []*sqlf.Query{
 	sqlf.Sprintf("roles.id"),
@@ -230,6 +247,11 @@ func (r *roleStore) Create(ctx context.Context, name string, isSystemRole bool) 
 
 	role, err := scanRole(r.QueryRow(ctx, q))
 	if err != nil {
+		var e *pgconn.PgError
+		if errors.As(err, &e) && e.ConstraintName == "roles_name" {
+			return nil, errCannotCreateRole{errorCodeRoleNameExists}
+		}
+		fmt.Println("outside of the thing")
 		return nil, errors.Wrap(err, "scanning role")
 	}
 

--- a/internal/database/roles.go
+++ b/internal/database/roles.go
@@ -251,7 +251,6 @@ func (r *roleStore) Create(ctx context.Context, name string, isSystemRole bool) 
 		if errors.As(err, &e) && e.ConstraintName == "roles_name" {
 			return nil, errCannotCreateRole{errorCodeRoleNameExists}
 		}
-		fmt.Println("outside of the thing")
 		return nil, errors.Wrap(err, "scanning role")
 	}
 


### PR DESCRIPTION
This PR adds a mutation that will be used to create new roles.
Closes #45449

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* added unit tests
* manually tested