### PR TITLE
updatecheck: exclude old-fashion site admins from total user count

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -109,7 +109,12 @@ func hasFindRefsOccurred(ctx context.Context) (_ bool, err error) {
 
 func getTotalUsersCount(ctx context.Context, db database.DB) (_ int, err error) {
 	defer recordOperation("getTotalUsersCount")(&err)
-	return db.Users().Count(ctx, &database.UsersListOptions{ExcludeSourcegraphOperators: true})
+	return db.Users().Count(ctx,
+		&database.UsersListOptions{
+			ExcludeSourcegraphAdmins:    true,
+			ExcludeSourcegraphOperators: true,
+		},
+	)
 }
 
 func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {


### PR DESCRIPTION
As mentioned in https://github.com/sourcegraph/customer/issues/1531, we need to continue excluding old-fashion site admins from the total user account in Ping data because they may still exist (legitimately).

1. Default "admin" account in all MIs (used as a service account)
2. MIs do not allow UI access to us and are skipped for the cleanup cron job. 

## Test plan

CI
