### PR TITLE
Allow users signed up with SSO to create password

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -262,8 +262,7 @@ type Mutation {
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     """
-    Creates a password for the current user. It is only permitted if the user does not have a password and
-    they don't have any login connections.
+    Creates a password for the current user. It is only permitted if the user does not have a password.
     """
     createPassword(newPassword: String!): EmptyResponse
     """

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1307,8 +1307,7 @@ func (u *userStore) UpdatePassword(ctx context.Context, id int32, oldPassword, n
 	return nil
 }
 
-// CreatePassword creates a user's password iff don't have a password and they
-// don't have any valid login connections.
+// CreatePassword creates a user's password if don't have a password
 func (u *userStore) CreatePassword(ctx context.Context, id int32, password string) error {
 	// 🚨 SECURITY: Check min and max password length
 	if err := CheckPassword(password); err != nil {
@@ -1329,15 +1328,7 @@ WHERE id=%s
   AND passwd IS NULL
   AND passwd_reset_code IS NULL
   AND passwd_reset_time IS NULL
-  AND NOT EXISTS (
-    SELECT 1
-    FROM user_external_accounts
-    WHERE
-          user_id = %s
-      AND deleted_at IS NULL
-      AND expired_at IS NULL
-    )
-`, passwd, id, id))
+`, passwd, id))
 	if err != nil {
 		return errors.Wrap(err, "creating password")
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1307,7 +1307,7 @@ func (u *userStore) UpdatePassword(ctx context.Context, id int32, oldPassword, n
 	return nil
 }
 
-// CreatePassword creates a user's password if don't have a password
+// CreatePassword creates a user's password if they don't have a password.
 func (u *userStore) CreatePassword(ctx context.Context, id int32, password string) error {
 	// 🚨 SECURITY: Check min and max password length
 	if err := CheckPassword(password); err != nil {

--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -270,7 +270,7 @@ func TestUsers_CreatePassword(t *testing.T) {
 		t.Fatal("Should fail, password already exists")
 	}
 
-	// A new user with an external account can't create a password
+	// A new user with an external account should be able to create a password
 	newUser, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{
 		Email:                 "usr3@bar.com",
 		Username:              "usr3",
@@ -292,8 +292,8 @@ func TestUsers_CreatePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.Users().CreatePassword(ctx, newUser.ID, "the-new-password"); err == nil {
-		t.Fatal("Should fail, user has external account")
+	if err := db.Users().CreatePassword(ctx, newUser.ID, "the-new-password"); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47443.

This PR:
- Allows users signed up with SSO to create a password

## Test plan
- Open https://sourcegraph.test:3443/site-admin/configuration as site admin and add for any of the SSOs `allowSignup=true`
- Sign out and open https://sourcegraph.test:3443/sign-in and continue via a fresh SSO (which does not have any shared emails with any of the existing users on your local instance)
  - This will automatically create a new account and sign in
- Go to `Settings > Account Security` and to create a password. You should be able to create and use both email/password as well as SSO for signing in to the instance



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
