### PR TITLE
monitoring: disable executors rate critial error

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -7669,7 +7669,7 @@ Custom query for critical alert: `min(((sum(src_executor_processor_handlers{sg_j
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> executor: 100%+ executor operation error rate over 5m for 1h0m0s
+- <span class="badge badge-warning">warning</span> executor: 100%+ executor operation error rate over 5m for 1h0m0s
 
 **Next steps**
 
@@ -7682,7 +7682,7 @@ problem is not know to be resolved until jobs start succeeding again.
 
 ```json
 "observability.silenceAlerts": [
-  "critical_executor_executor_processor_error_rate"
+  "warning_executor_executor_processor_error_rate"
 ]
 ```
 
@@ -7691,7 +7691,7 @@ problem is not know to be resolved until jobs start succeeding again.
 <details>
 <summary>Technical details</summary>
 
-Custom query for critical alert: `max((last_over_time(sum(increase(src_executor_processor_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100) >= 100)`
+Custom query for warning alert: `max((last_over_time(sum(increase(src_executor_processor_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) / (last_over_time(sum(increase(src_executor_processor_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:]) + last_over_time(sum(increase(src_executor_processor_errors_total{sg_job=~"^sourcegraph-executors.*"}[5m]))[5h:])) * 100) >= 100)`
 
 </details>
 

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -321,7 +321,7 @@ func (codeIntelligence) NewExecutorProcessorGroup(containerName string) monitori
 			Total:    NoAlertsOption("none"),
 			Duration: NoAlertsOption("none"),
 			Errors:   NoAlertsOption("none"),
-			ErrorRate: CriticalOption(
+			ErrorRate: WarningOption(
 				monitoring.Alert().
 					CustomQuery(Workerutil.LastOverTimeErrorRate(containerName, model.Duration(time.Hour*5), constructorOptions)).
 					For(time.Hour).


### PR DESCRIPTION
This error is firing a lot in Cloud when customer misconfigure auto index config or inferences doesn't work..

I think this is more so an user-error and does not quality for a critical alert that worth paging customer admin up in the middle of the night.

https://sourcegraph.slack.com/archives/C017SLJGA2Z/p1675704354773989

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI