### PR TITLE
Add "Connect external accounts" global alert

### DIFF
--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -41,6 +41,12 @@ export const currentAuthStateQuery = gql`
                 id
                 contents
             }
+            externalAccounts {
+                nodes {
+                    serviceID
+                    serviceType
+                }
+            }
         }
     }
 `


### PR DESCRIPTION
TODO: create an issue and link here

This PR:
- Adds a global alert to show the "connect external accounts" suggestion global alert
  - The `Connect` link redirects to the `Settings / Account Security` page
  - The `multiple code host permissions` redirects to [docs](http://localhost:3080/help/admin/repo/permissions#permissions-for-multiple-code-hosts)
  - Alert is dismissable so that user can close it, and it won't be shown again
  - Alert is not shown if the user is already on the `Settings / Account Security` page
  - Alert is not shown if the user has already connected all external auth providers configured on the code host

## Screenshot
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/6717049/217274802-ad72cec3-9317-4e47-8e57-e0645f1c0b26.png">

## Test plan
- `sg start`
- Open https://sourcegraph.test:3443/ and sign-in
- Remove/disconnect any of the external accounts if you've configured all of them `Settings / Account Security`
   - Check that alert is shown on top 
   - Connect all external accounts (`Settings / Account Security`) and check that alert is not shown after that
- Remove/disconnect any of the external accounts  if you've configured all of them  `Settings / Account Security`
  - Check that alert is shown
  - Dismiss it and check that it doesn't appear anymore
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-add-connect-external.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

