### PR TITLE
sg: propagate errors when running individual generate commands

### DIFF
--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -86,6 +86,10 @@ func (gt generateTargets) Commands() (cmds []*cli.Command) {
 				return err
 			}
 			report := c.Runner(cmd.Context, cmd.Args().Slice())
+			if report.Err != nil {
+				return report.Err
+			}
+
 			fmt.Printf(report.Output)
 			std.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "(%ds)", report.Duration/time.Second))
 			return nil


### PR DESCRIPTION
Before, error codes wouldn't not be properly propagated back to the main process if you ran an individual `sg generate` target (ex: `sg generate buf`) This small change fixes that. 

Example output:

```shell
~/dev/go/src/github.com/sourcegraph/sourcegraph fix-error-reporting* ≡ 7s
base ❯ go run ./dev/sg  generate buf                                                                                                                                                                 (base) 16:17:08
❌ running "buf generate": exit status 100: searcher.proto:12:45:method searcher.v1.SearcherService.Search: unknown response type SearchResponsefff
exit status 1
```


## Test plan

Manual testing. 