### PR TITLE
SCIM: Add service provider config and docs

### DIFF
--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -1,6 +1,6 @@
 # SCIM
 
-**⚠️ DISCLAIMER: SCIM SUPPORT IS UNDER DEVELOPMENT. THE ENDPOINT DOES NOT COMPLY WITH THE SCIM STANDARD YET AND IT ISN’T READY FOR PRODUCTION USE.**
+**⚠️ DISCLAIMER: SCIM SUPPORT IS UNDER DEVELOPMENT. THE ENDPOINT DOES NOT COMPLY WITH THE SCIM STANDARD YET AND IT IS NOT READY FOR PRODUCTION USE.**
 
 SCIM (System for Cross-domain Identity Management) is a standard for provisioning users and groups in an organization. It is supported by many IdP (identity providers) such as Okta, OneLogin, and Azure Active Directory.
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -10,7 +10,7 @@ You can use any IdP that supports SCIM, but we’ve only tested the endpoint wit
 
 ## How to use
 
-To use SCIM, you must have an existing identity provider (IdP) configured with your Sourcegraph instance.
+To use SCIM, you must have an existing IdP configured with your Sourcegraph instance.
 To configure it, add the following line to your [site configuration](config/site_config.md):
 
 ```

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -2,7 +2,7 @@
 
 **⚠️ DISCLAIMER: SCIM SUPPORT IS UNDER DEVELOPMENT. THE ENDPOINT DOES NOT COMPLY WITH THE SCIM STANDARD YET AND IT ISN’T READY FOR PRODUCTION USE.**
 
-SCIM is a standard for provisioning users and groups in an organization. It is supported by many IdP (identity providers) such as Okta, OneLogin, and Azure Active Directory.
+SCIM (System for Cross-domain Identity Management) is a standard for provisioning users and groups in an organization. It is supported by many IdP (identity providers) such as Okta, OneLogin, and Azure Active Directory.
 
 Sourcegraph supports SCIM for provisioning and de-provisioning _users_, but not groups at this time.
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -6,7 +6,7 @@ SCIM (System for Cross-domain Identity Management) is a standard for provisionin
 
 Sourcegraph supports SCIM for provisioning and de-provisioning _users_, but not groups at this time.
 
-You can use any identity provider that supports SCIM, but we’ve only tested the endpoint with Okta and Azure Active Directory.
+You can use any IdP that supports SCIM, but we’ve only tested the endpoint with Okta and Azure Active Directory.
 
 ## How to use
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -1,0 +1,23 @@
+# SCIM
+
+**⚠️ DISCLAIMER: SCIM SUPPORT IS UNDER DEVELOPMENT. THE ENDPOINT DOES NOT COMPLY WITH THE SCIM STANDARD YET AND IT ISN’T READY FOR PRODUCTION USE.**
+
+SCIM is a standard for provisioning users and groups in an organization. It is supported by many IdP (identity providers) such as Okta, OneLogin, and Azure Active Directory.
+
+Sourcegraph supports SCIM for provisioning and de-provisioning _users_, but not groups at this time.
+
+You can use any identity provider that supports SCIM, but we’ve only tested the endpoint with Okta and Azure Active Directory.
+
+## How to use
+
+To use SCIM, you must have an existing identity provider (IdP) configured with your Sourcegraph instance.
+To configure it, add the following line to your [site configuration](config/site_config.md):
+
+```
+"scim.authToken": "{your token}"
+```
+
+Currently, we only support Bearer token authentication.
+
+Then you can set up your IdP to to use the SCIM endpoint. The API is at `https://sourcegraph.company.com/.api/scim/v2`, so the “Users” endpoint is at `https://sourcegraph.company.com/.api/scim/v2/Users`.
+

--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -31,10 +31,12 @@ func NewHandler(ctx context.Context, db database.DB, observationCtx *observation
 		SupportFiltering: true,
 		AuthenticationSchemes: []scim.AuthenticationScheme{
 			{
-				Name:    "OAuth Bearer Token",
-				SpecURI: optional.NewString("https://tools.ietf.org/html/rfc6750"),
-				Type:    scim.AuthenticationTypeOauthBearerToken,
-				Primary: true,
+				Type:             scim.AuthenticationTypeOauthBearerToken,
+				Name:             "OAuth Bearer Token",
+				Description:      "Authentication scheme using the Bearer Token standard – use the key 'scim.authToken' in the site config to set the token.",
+				SpecURI:          optional.NewString("https://tools.ietf.org/html/rfc6750"),
+				DocumentationURI: optional.NewString("docs.sourcegraph.com/admin/scim"),
+				Primary:          true,
 			},
 		},
 	}

--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -26,7 +26,9 @@ func Init(ctx context.Context, observationCtx *observation.Context, db database.
 // NewHandler creates and returns a new SCIM 2.0 handler.
 func NewHandler(ctx context.Context, db database.DB, observationCtx *observation.Context) http.Handler {
 	config := scim.ServiceProviderConfig{
-		DocumentationURI: optional.NewString("www.example.com/scim"),
+		DocumentationURI: optional.NewString("docs.sourcegraph.com/admin/scim"),
+		MaxResults:       100,
+		SupportFiltering: true,
 	}
 
 	var userResourceHandler = NewUserResourceHandler(ctx, observationCtx, db)

--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -29,6 +29,14 @@ func NewHandler(ctx context.Context, db database.DB, observationCtx *observation
 		DocumentationURI: optional.NewString("docs.sourcegraph.com/admin/scim"),
 		MaxResults:       100,
 		SupportFiltering: true,
+		AuthenticationSchemes: []scim.AuthenticationScheme{
+			{
+				Name:    "OAuth Bearer Token",
+				SpecURI: optional.NewString("https://tools.ietf.org/html/rfc6750"),
+				Type:    scim.AuthenticationTypeOauthBearerToken,
+				Primary: true,
+			},
+		},
 	}
 
 	var userResourceHandler = NewUserResourceHandler(ctx, observationCtx, db)


### PR DESCRIPTION
SCIM has a mandatory endpoint at `/ServiceProviderConfig`
The PR adds this at `/.api/scim/v2/ServiceProviderConfig`.
It was an easy win because the elimity Go package provides it out of the box, so I only had to configure it. I had to reference docs at two places, and I didn't want to reference a non-existing URL, so I've also added some basic docs with a big disclaimer that this is not production-ready.

## Test plan

Tested it with Postman, it works as expected. To make sure, I will test it with Okta's and Microsoft's test packages later.