### PR TITLE
blob: fix highlight occurrence decorations and tooltips

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
@@ -67,7 +67,21 @@ export const codeIntelTooltipsState = StateField.define<Record<CodeIntelTooltipT
     },
     provide(field) {
         return [
-            showTooltip.computeN([field], state => Object.values(state.field(field)).map(val => val?.tooltip ?? null)),
+            showTooltip.computeN([field], state => {
+                const { hover, focus, pin } = state.field(field)
+
+                // Only show one tooltip for the occurrence at a time
+                const uniqueTooltips = [pin, focus, hover]
+                    .reduce((acc, current) => {
+                        if (current?.tooltip && acc.every(({ occurrence }) => occurrence !== current.occurrence)) {
+                            acc.push(current)
+                        }
+                        return acc
+                    }, [] as NonNullable<CodeIntelTooltipState>[])
+                    .map(({ tooltip }) => tooltip)
+
+                return uniqueTooltips
+            }),
 
             /**
              * If there is a focused occurrence set editor's tabindex to -1, so that pressing Shift+Tab moves the focus

--- a/client/web/src/repo/blob/codemirror/token-selection/decorations.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/decorations.ts
@@ -1,6 +1,8 @@
-import { Extension, Range } from '@codemirror/state'
+import { Extension, Range as CodeMirrorRange } from '@codemirror/state'
 import { Decoration, EditorView } from '@codemirror/view'
 import classNames from 'classnames'
+
+import { Range } from '@sourcegraph/extension-api-types'
 
 import { positionToOffset, sortRangeValuesByStart } from '../utils'
 
@@ -9,8 +11,33 @@ import { definitionUrlField } from './definition'
 import { documentHighlightsField, findByOccurrence } from './document-highlights'
 import { isModifierKeyHeld } from './modifier-click'
 
-function sortByFromPosition(ranges: Range<Decoration>[]): Range<Decoration>[] {
+interface DecorationItem {
+    decoration: Decoration
+    range: Range
+}
+
+function sortByFromPosition(ranges: CodeMirrorRange<Decoration>[]): CodeMirrorRange<Decoration>[] {
     return ranges.sort((a, b) => a.from - b.from)
+}
+
+function findByRange(decorations: DecorationItem[], range: Range): DecorationItem | undefined {
+    return decorations.find(
+        ({ range: decorationRange }) =>
+            decorationRange.start.line === range.start.line &&
+            decorationRange.start.character === range.start.character &&
+            decorationRange.end.line === range.end.line &&
+            decorationRange.end.character === range.end.character
+    )
+}
+
+function addOrReplace(decorations: DecorationItem[], item: DecorationItem): DecorationItem[] {
+    const existing = findByRange(decorations, item.range)
+    if (existing) {
+        existing.decoration = item.decoration
+    } else {
+        decorations.push(item)
+    }
+    return decorations
 }
 
 /**
@@ -23,7 +50,7 @@ export function interactiveOccurrencesExtension(): Extension {
             [codeIntelTooltipsState, documentHighlightsField, definitionUrlField, isModifierKeyHeld],
             state => {
                 const { focus, hover, pin } = state.field(codeIntelTooltipsState)
-                const decorations = []
+                let decorations: DecorationItem[] = []
 
                 if (focus) {
                     decorations.push({
@@ -31,7 +58,7 @@ export function interactiveOccurrencesExtension(): Extension {
                             class: classNames(
                                 'interactive-occurrence', // used as interactive occurrence selector
                                 'focus-visible', // prevents code editor from blur when focused element inside it changes
-                                'sourcegraph-document-highlight' // highlights the selected (focused) occurrence
+                                'selection-highlight' // highlights the selected (focused) occurrence
                             ),
                             attributes: {
                                 // Selected (focused) occurrence is the only focusable element in the editor.
@@ -62,15 +89,19 @@ export function interactiveOccurrencesExtension(): Extension {
                     }
                 }
 
-                if (pin) {
-                    decorations.push({
+                // focused occurrence is already highlighted
+                if (pin && pin.occurrence !== focus?.occurrence) {
+                    // pinned decoration styles have higher precedence over the document highlights decoration
+                    decorations = addOrReplace(decorations, {
                         decoration: Decoration.mark({ class: 'selection-highlight' }),
                         range: pin.occurrence.range,
                     })
                 }
 
-                if (hover) {
-                    decorations.push({
+                // focused and pinned occurrences are already highlighted
+                if (hover && hover.occurrence !== focus?.occurrence && hover.occurrence !== pin?.occurrence) {
+                    // pinned decoration styles have higher precedence over the document highlights decoration
+                    decorations = addOrReplace(decorations, {
                         decoration: Decoration.mark({
                             class: classNames('selection-highlight', {
                                 // If the user is hovering over a selected (focused) occurrence with a definition holding the modifier key,
@@ -93,7 +124,7 @@ export function interactiveOccurrencesExtension(): Extension {
                     }
 
                     return acc
-                }, [] as Range<Decoration>[])
+                }, [] as CodeMirrorRange<Decoration>[])
 
                 return Decoration.set(sortByFromPosition(ranges))
             }


### PR DESCRIPTION
1. Changes focused occurrence styles to match pinned and hover ones.
2. Adds an extra check to code-intel tooltips to ensure that only one tooltip is rendered for an occurrence at a time.  


https://user-images.githubusercontent.com/25318659/217316741-b8e62810-94c1-4734-b030-d58a05f45e5e.mov



## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-cm-blob-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

