### PR TITLE
packages: fix package ref listing query with limit

### DIFF
--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
@@ -104,6 +105,11 @@ func TestListPackageRepoRefs(t *testing.T) {
 	}
 
 	if _, _, err := store.InsertPackageRepoRefs(ctx, batches); err != nil {
+		t.Fatal(err)
+	}
+
+	// want to mimic data that might exist because of the 2-step migration
+	if err := store.db.Exec(ctx, sqlf.Sprintf(`INSERT INTO lsif_dependency_repos (scheme, name, version) VALUES ('npm','foo','4.2.0')`)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -118,13 +118,17 @@ func TestListPackageRepoRefs(t *testing.T) {
 		{{Scheme: "npm", Name: "banana"}, {Scheme: "npm", Name: "bar"}, {Scheme: "npm", Name: "foo"}},
 		{{Scheme: "npm", Name: "turtle"}},
 	} {
-		depRepos, _, err := store.ListPackageRepoRefs(ctx, ListDependencyReposOpts{
+		depRepos, total, err := store.ListPackageRepoRefs(ctx, ListDependencyReposOpts{
 			Scheme: "npm",
 			After:  lastID,
 			Limit:  3,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if total != 4 {
+			t.Errorf("unexpected total count of package repos: want=%d got=%d", 4, total)
 		}
 
 		lastID = depRepos[len(depRepos)-1].ID


### PR DESCRIPTION
The list package repo refs query accidentally worked under the assumption of what the data should ideally look like (unique `(scheme,name)` tuples). This is not true in stage 1 of the migration, where there is still one `(scheme,name)` tuple for every version of that tuple. 
Continuing: in step 1 of the migration, we copy for every row in lsif_dependency_repos into package_repo_versions, using the smallest ID for every `(scheme,name)` as the "canonical" package repo entry ID (this is so when we collapse n into 1, every entry in package_repo_versions still points to an existing package repo reference).
Thus when joining the two tables, every entry besides the first for every `(scheme,name)` would not have an accompanying entry in the latter table, thus not being in the final result set. This happens after the limit factor, so we would end up with <= limit.

There was also a bug with the count section that was fixed here, because the reduce happens in-application instead of in SQL :^)

## Test plan

Added extra part in existing unit test and tested the extra part with before and after
