### PR TITLE
web: migrate embedded web app to react-router 6 API

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,7 +1,7 @@
-import React, { Suspense, useEffect, useMemo } from 'react'
+import { FC, Suspense, useEffect, useMemo } from 'react'
 
-import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
+import { Router } from 'react-router'
+import { CompatRouter, Routes, Route } from 'react-router-dom-v5-compat'
 
 import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/createSyncLoadedController'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -16,6 +16,7 @@ import { useTheme, ThemePreference } from '../../theme'
 import { OpenNewTabAnchorLink } from './OpenNewTabAnchorLink'
 
 import styles from './EmbeddedWebApp.module.scss'
+import { globalHistory } from '../../util/globalHistory'
 
 // Since we intend to embed the EmbeddedWebApp component within an iframe,
 // we want to open all links in a new tab instead of the current iframe window.
@@ -33,7 +34,7 @@ const EmbeddedNotebookPage = lazyComponent(
 
 const EMPTY_SETTINGS_CASCADE = { final: {}, subjects: [] }
 
-export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+export const EmbeddedWebApp: FC = () => {
     const { enhancedThemePreference, setThemePreference } = useTheme()
     const isLightTheme = enhancedThemePreference === ThemePreference.Light
 
@@ -60,7 +61,7 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
     //
     // IMPORTANT: Please consult with the security team if you are unsure whether your changes could introduce security exploits.
     return (
-        <BrowserRouter>
+        <Router history={globalHistory}>
             <CompatRouter>
                 <WildcardThemeContext.Provider value={WILDCARD_THEME}>
                     <div className={styles.body}>
@@ -71,12 +72,11 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
                                 </div>
                             }
                         >
-                            <Switch>
+                            <Routes>
                                 <Route
                                     path="/embed/notebooks/:notebookId"
-                                    render={(props: RouteComponentProps<{ notebookId: string }>) => (
+                                    element={
                                         <EmbeddedNotebookPage
-                                            notebookId={props.match.params.notebookId}
                                             searchContextsEnabled={true}
                                             isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                                             authenticatedUser={null}
@@ -84,17 +84,17 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
                                             settingsCascade={EMPTY_SETTINGS_CASCADE}
                                             platformContext={platformContext}
                                         />
-                                    )}
+                                    }
                                 />
                                 <Route
                                     path="*"
-                                    render={() => (
+                                    element={
                                         <Alert variant="danger">
                                             Invalid embedding route, please check the embedding URL.
                                         </Alert>
-                                    )}
+                                    }
                                 />
-                            </Switch>
+                            </Routes>
                         </Suspense>
                         <GlobalContributions
                             extensionsController={extensionsController}
@@ -103,6 +103,6 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
                     </div>
                 </WildcardThemeContext.Provider>
             </CompatRouter>
-        </BrowserRouter>
+        </Router>
     )
 }

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -12,11 +12,11 @@ import '../../SourcegraphWebApp.scss'
 import { GlobalContributions } from '../../contributions'
 import { createPlatformContext } from '../../platform/context'
 import { useTheme, ThemePreference } from '../../theme'
+import { globalHistory } from '../../util/globalHistory'
 
 import { OpenNewTabAnchorLink } from './OpenNewTabAnchorLink'
 
 import styles from './EmbeddedWebApp.module.scss'
-import { globalHistory } from '../../util/globalHistory'
 
 // Since we intend to embed the EmbeddedWebApp component within an iframe,
 // we want to open all links in a new tab instead of the current iframe window.

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -1,9 +1,9 @@
 import { FC, useCallback, useEffect, useMemo } from 'react'
 
 import { noop } from 'lodash'
+import { useParams } from 'react-router-dom-v5-compat'
 import { NEVER } from 'rxjs'
 import { catchError, startWith } from 'rxjs/operators'
-import { useParams } from 'react-router-dom-v5-compat'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import {

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import { FC, useCallback, useEffect, useMemo } from 'react'
 
 import { noop } from 'lodash'
 import { NEVER } from 'rxjs'
 import { catchError, startWith } from 'rxjs/operators'
+import { useParams } from 'react-router-dom-v5-compat'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import {
@@ -24,23 +25,19 @@ interface EmbeddedNotebookPageProps
             NotebookContentProps,
             'isLightTheme' | 'searchContextsEnabled' | 'isSourcegraphDotCom' | 'authenticatedUser' | 'settingsCascade'
         >,
-        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'> {
-    notebookId: string
-}
+        PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'> {}
 
 const LOADING = 'loading' as const
 
-export const EmbeddedNotebookPage: React.FunctionComponent<React.PropsWithChildren<EmbeddedNotebookPageProps>> = ({
-    notebookId,
-    platformContext,
-    ...props
-}) => {
+export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformContext, ...props }) => {
+    const { notebookId } = useParams()
+
     useEffect(() => eventLogger.logPageView('EmbeddedNotebookPage'), [])
 
     const notebookOrError = useObservable(
         useMemo(
             () =>
-                fetchNotebook(notebookId).pipe(
+                fetchNotebook(notebookId!).pipe(
                     startWith(LOADING),
                     catchError(error => [asError(error)])
                 ),


### PR DESCRIPTION
# Context

- Part of #33834 
- Mirror the `SourcegraphWebApp` component setup.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-react-router-migration-1.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
