### PR TITLE
blob: fix gutters style conflicts

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -151,6 +151,10 @@ const staticExtensions: Extension = [
             backgroundColor: 'var(--code-bg)',
             borderRight: 'initial',
         },
+        '.cm-content:focus-visible': {
+            outline: 'none',
+            boxShadow: 'none',
+        },
         '.cm-line': {
             paddingLeft: '0',
         },

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -152,7 +152,7 @@ const staticExtensions: Extension = [
             borderRight: 'initial',
         },
         '.cm-line': {
-            paddingLeft: '1rem',
+            paddingLeft: '0',
         },
         '.selected-line': {
             backgroundColor: 'var(--code-selection-bg)',

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -278,6 +278,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
                 enableSelectionDrivenCodeNavigation,
             }),
+            codeFoldingExtension(),
             enableSelectionDrivenCodeNavigation ? tokenSelectionExtension() : [],
             enableLinkDrivenCodeNavigation
                 ? tokensAsLinks({ navigate: navigateRef.current, blobInfo, preloadGoToDefinition })
@@ -304,7 +305,6 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 overrideBrowserFindInPageShortcut: useFileSearch,
                 onOverrideBrowserFindInPageToggle: setUseFileSearch,
             }),
-            codeFoldingExtension(),
         ],
         // A couple of values are not dependencies (blameDecorations, blobProps,
         // hasPin, position and settings) because those are updated in effects

--- a/client/web/src/repo/blob/LegacyBlob.module.scss
+++ b/client/web/src/repo/blob/LegacyBlob.module.scss
@@ -107,6 +107,6 @@
     background-color: var(--body-bg);
 }
 
-:global(.cm-editor:not(:focus-within) .focus-visible) {
+:global(.cm-editor:not(:focus-within) :focus-visible) {
     box-shadow: none;
 }

--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -220,9 +220,7 @@ const showGitBlameDecorations = Facet.define<BlameDecorationsFacetProps, BlameDe
                 // Move the start of the line to after the blame decoration.
                 // This is necessary because the start of the line is used for
                 // aligning tab characters.
-                //
-                // 1rem is the default padding-left so we have to add it here
-                paddingLeft: 'calc(var(--blame-decoration-width) + 1rem) !important',
+                paddingLeft: 'var(--blame-decoration-width) !important',
             },
             '.blame-decoration': {
                 // Remove the blame decoration from the content flow so that

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -143,14 +143,15 @@ export const selectedLines = StateField.define<SelectedLineRange>({
              */
             '.selected-lines-layer .selected-line': {
                 marginTop: '-1px',
+
+                // Ensure selection marker height matches line height.
+                minHeight: '1rem',
             },
             '.selected-lines-layer .selected-line.blame-visible': {
                 marginTop: '-6px',
-            },
 
-            // Ensure selection marker height matches the increased line height
-            '.selected-lines-layer .selected-line.blame-visible:first-child:nth-last-child(2)': {
-                height: 'calc(1.5rem + 1px) !important',
+                // Ensure selection marker height matches the increased line height.
+                minHeight: 'calc(1.5rem + 1px)',
             },
 
             // Selected line background is set by adding 'selected-line' class to the layer markers.

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -24,6 +24,7 @@ import {
 import classNames from 'classnames'
 
 import { isValidLineRange, MOUSE_MAIN_BUTTON, preciseOffsetAtCoords } from './utils'
+
 import { blobPropsFacet } from './index'
 
 /**

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -148,6 +148,11 @@ export const selectedLines = StateField.define<SelectedLineRange>({
                 marginTop: '-6px',
             },
 
+            // Ensure selection marker height matches the increased line height
+            '.selected-lines-layer .selected-line.blame-visible:first-child:nth-last-child(2)': {
+                height: 'calc(1.5rem + 1px) !important',
+            },
+
             // Selected line background is set by adding 'selected-line' class to the layer markers.
             '.cm-line.selected-line': {
                 background: 'transparent',

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -21,8 +21,10 @@ import {
     ViewPlugin,
     ViewUpdate,
 } from '@codemirror/view'
+import classNames from 'classnames'
 
 import { isValidLineRange, MOUSE_MAIN_BUTTON, preciseOffsetAtCoords } from './utils'
+import { blobPropsFacet } from './index'
 
 /**
  * Represents the currently selected line range. null means no lines are
@@ -32,6 +34,7 @@ import { isValidLineRange, MOUSE_MAIN_BUTTON, preciseOffsetAtCoords } from './ut
 export type SelectedLineRange = { line: number; character?: number; endLine?: number } | null
 
 const selectedLineDecoration = Decoration.line({
+    class: 'selected-line',
     attributes: {
         tabIndex: '-1',
         'data-line-focusable': '',
@@ -115,7 +118,7 @@ export const selectedLines = StateField.define<SelectedLineRange>({
 
                 return RectangleMarker.forRange(
                     view,
-                    'selected-line',
+                    classNames('selected-line', { ['blame-visible']: view.state.facet(blobPropsFacet).isBlameVisible }),
                     EditorSelection.range(startLine.from, Math.min(endLine.to + 1, view.state.doc.length))
                 )
             },
@@ -132,13 +135,22 @@ export const selectedLines = StateField.define<SelectedLineRange>({
             class: 'selected-lines-layer',
         }),
         EditorView.theme({
+            /**
+             * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
+             * returns absolutely positioned markers. Markers top position has extra 1px (6px in case blame decorations
+             * are visible) more in its `top` value breaking alignment wih the line.
+             * We compensate this spacing by setting negative margin-top.
+             */
             '.selected-lines-layer .selected-line': {
-                /**
-                 * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
-                 * returns absolutely positioned markers. Markers top position has extra 1px more in its `top` value breaking alignment wih the line.
-                 * We compensate this spacing by setting negative margin-top.
-                 */
                 marginTop: '-1px',
+            },
+            '.selected-lines-layer .selected-line.blame-visible': {
+                marginTop: '-6px',
+            },
+
+            // Selected line background is set by adding 'selected-line' class to the layer markers.
+            '.cm-line.selected-line': {
+                background: 'transparent',
             },
 
             /**
@@ -148,9 +160,6 @@ export const selectedLines = StateField.define<SelectedLineRange>({
              * highlight (background color) between the selected line gutters (decorated with {@link selectedLineGutterMarker}) and layer.
              * To remove this gap we move padding from `.cm-line` to the last gutter.
              */
-            '.cm-line': {
-                paddingLeft: '0 !important',
-            },
             '.cm-gutter:last-child .cm-gutterElement': {
                 paddingRight: '1rem',
             },

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -277,16 +277,6 @@ function textSelectionExtension(): Extension {
             },
             '.cm-selectionLayer .cm-selectionBackground': {
                 background: 'var(--code-selection-bg-2)',
-
-                /**
-                 * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
-                 * returns absolutely positioned markers. Markers top position has extra 1px more in its `top` value breaking alignment wih the line.
-                 * We compensate this spacing by setting negative margin-top.
-                 */
-                marginTop: '-1px',
-
-                // Ensure selection marker height matches line height.
-                minHeight: '1rem',
             },
         }),
     ]

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -275,7 +275,6 @@ function textSelectionExtension(): Extension {
                     backgroundColor: 'transparent !important',
                 },
             },
-
             '.cm-selectionLayer .cm-selectionBackground': {
                 background: 'var(--code-selection-bg-2)',
 

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -8,7 +8,6 @@ import {
 } from '@codemirror/commands'
 import { Extension, Prec } from '@codemirror/state'
 import { EditorView, KeyBinding, keymap, layer, RectangleMarker } from '@codemirror/view'
-import classNames from 'classnames'
 
 import { blobPropsFacet } from '..'
 import { syntaxHighlight } from '../highlight'
@@ -250,17 +249,7 @@ const selectionLayer = Prec.high(
         above: false,
         markers(view) {
             return view.state.selection.ranges
-                .map(range =>
-                    range.empty
-                        ? []
-                        : RectangleMarker.forRange(
-                              view,
-                              classNames('cm-selectionBackground', {
-                                  ['blame-visible']: view.state.facet(blobPropsFacet).isBlameVisible,
-                              }),
-                              range
-                          )
-                )
+                .map(range => (range.empty ? [] : RectangleMarker.forRange(view, 'cm-selectionBackground', range)))
                 .reduce((a, b) => a.concat(b))
         },
         update(update) {
@@ -289,8 +278,7 @@ function textSelectionExtension(): Extension {
 
             /**
              * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
-             * returns absolutely positioned markers. Markers top position has extra 1px (6px in case blame decorations
-             * are visible) more in its `top` value breaking alignment wih the line.
+             * returns absolutely positioned markers. Markers top position has extra 1px more in its `top` value breaking alignment wih the line.
              * We compensate this spacing by setting negative margin-top.
              */
             '.cm-selectionLayer .cm-selectionBackground': {
@@ -299,12 +287,6 @@ function textSelectionExtension(): Extension {
 
                 // Ensure selection marker height matches line height.
                 minHeight: '1rem',
-            },
-            '.cm-selectionLayer .cm-selectionBackground.blame-visible': {
-                marginTop: '-6px',
-
-                // Ensure selection marker height matches the increased line height.
-                minHeight: 'calc(1.5rem + 1px)',
             },
         }),
     ]

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -276,13 +276,14 @@ function textSelectionExtension(): Extension {
                 },
             },
 
-            /**
-             * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
-             * returns absolutely positioned markers. Markers top position has extra 1px more in its `top` value breaking alignment wih the line.
-             * We compensate this spacing by setting negative margin-top.
-             */
             '.cm-selectionLayer .cm-selectionBackground': {
                 background: 'var(--code-selection-bg-2)',
+
+                /**
+                 * [RectangleMarker.forRange](https://sourcegraph.com/github.com/codemirror/view@a0a0b9ef5a4deaf58842422ac080030042d83065/-/blob/src/layer.ts?L60-75)
+                 * returns absolutely positioned markers. Markers top position has extra 1px more in its `top` value breaking alignment wih the line.
+                 * We compensate this spacing by setting negative margin-top.
+                 */
                 marginTop: '-1px',
 
                 // Ensure selection marker height matches line height.

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -300,6 +300,11 @@ function textSelectionExtension(): Extension {
             '.cm-selectionLayer .cm-selectionBackground.blame-visible': {
                 marginTop: '-6px',
             },
+
+            // Ensure selection marker height matches the increased line height
+            '.cm-selectionLayer .cm-selectionBackground.blame-visible:last-child': {
+                height: 'calc(1.5rem + 1px) !important',
+            },
         }),
     ]
 }

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -296,14 +296,15 @@ function textSelectionExtension(): Extension {
             '.cm-selectionLayer .cm-selectionBackground': {
                 background: 'var(--code-selection-bg-2)',
                 marginTop: '-1px',
+
+                // Ensure selection marker height matches line height.
+                minHeight: '1rem',
             },
             '.cm-selectionLayer .cm-selectionBackground.blame-visible': {
                 marginTop: '-6px',
-            },
 
-            // Ensure selection marker height matches the increased line height
-            '.cm-selectionLayer .cm-selectionBackground.blame-visible:last-child': {
-                height: 'calc(1.5rem + 1px) !important',
+                // Ensure selection marker height matches the increased line height.
+                minHeight: 'calc(1.5rem + 1px)',
             },
         }),
     ]


### PR DESCRIPTION
1. Places code folding gutters before the blame decorations gutter. 
_Note:_ Blame decorations can't go before the code folding gutters because of the way the former is implemented (TL;DR: blame decorations are not in the gutter, but inside the line, see https://github.com/sourcegraph/sourcegraph/pull/44148#issue-1442079069).
2. Sets minimum height for selected lines layer markers to match the increased line height when the blame decorations are visible.
3. Removes focus styles from `.cm-content` (redundant blue line below the content [reported in Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1675865805755409?thread_ts=1675755916.910739&cid=C03CSAER9LK)).
4. Removes selection layer overflow [reported in Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1675755916910739).

Though some of these changes seem unrelated I put them in a single PR because all of them originate from selected text and lines layers configuration.
 
https://user-images.githubusercontent.com/25318659/217593509-7872cd08-84f6-40cd-99f8-429f020fbf2c.mov





## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-cm-blob-fix-gutters.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

