### PR TITLE
web: migrate code-insights routes

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -1,9 +1,7 @@
 import { FC, useEffect, useState } from 'react'
 
 import { gql, useLazyQuery } from '@apollo/client'
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Route, RouteComponentProps, Switch, useRouteMatch } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { Route, Routes, Navigate } from 'react-router-dom-v5-compat'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -11,7 +9,8 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { HeroPage } from '../../components/HeroPage'
+import { NotFoundPage } from '../../components/HeroPage'
+import { RedirectRoute } from '../../components/RedirectRoute'
 import { GetFirstAvailableDashboardResult, GetFirstAvailableDashboardVariables } from '../../graphql-operations'
 
 import { CodeInsightsBackendContext } from './core'
@@ -33,6 +32,12 @@ export interface CodeInsightsAppRouter extends TelemetryProps {
     authenticatedUser: AuthenticatedUser
 }
 
+const rootPagePathsToTab = {
+    'dashboards/:dashboardId?': CodeInsightsRootPageTab.Dashboards,
+    all: CodeInsightsRootPageTab.AllInsights,
+    about: CodeInsightsRootPageTab.GettingStarted,
+} as const
+
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
     const { telemetryService } = props
 
@@ -45,69 +50,49 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
 
     return (
         <CodeInsightsBackendContext.Provider value={api}>
-            <Route path="*" component={GaConfirmationModal} />
+            <GaConfirmationModal />
 
-            <Switch>
-                <Route path="/insights" exact={true} component={CodeInsightsSmartRoutingRedirect} />
+            <Routes>
+                <Route index={true} element={<CodeInsightsSmartRoutingRedirect />} />
 
-                <Route path="/insights/create" render={() => <CreationRoutes telemetryService={telemetryService} />} />
+                <Route path="create/*" element={<CreationRoutes telemetryService={telemetryService} />} />
 
-                <Route
-                    path="/insights/dashboards/:dashboardId/edit"
-                    render={props => <EditDashboardPage dashboardId={props.match.params.dashboardId} />}
-                />
+                <Route path="dashboards/:dashboardId/edit" element={<EditDashboardPage />} />
 
                 <Route
-                    path="/insights/add-dashboard"
-                    render={() => <InsightsDashboardCreationPage telemetryService={telemetryService} />}
+                    path="add-dashboard"
+                    element={<InsightsDashboardCreationPage telemetryService={telemetryService} />}
                 />
 
-                <Route
-                    path={['/insights/dashboards/:dashboardId?', '/insights/all', '/insights/about']}
-                    render={(props: RouteComponentProps<{ dashboardId?: string }>) => (
-                        <CodeInsightsRootPage
-                            dashboardId={props.match.params.dashboardId}
-                            activeTab={getActiveTabByURL('/insights', props)}
-                            telemetryService={telemetryService}
-                        />
-                    )}
-                />
+                {Object.entries(rootPagePathsToTab).map(([path, activeTab]) => (
+                    <Route
+                        key="hardcoded-key"
+                        path={path}
+                        element={<CodeInsightsRootPage activeTab={activeTab} telemetryService={telemetryService} />}
+                    />
+                ))}
 
                 <Route
                     // Deprecated URL, delete this in the 4.10
-                    path="/insights/edit/:insightId"
-                    render={props => <Redirect to={`/insights/${props.match.params.insightId}/edit`} />}
+                    path="edit/:insightId"
+                    element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}/edit`} />}
                 />
-
-                <Route
-                    path="/insights/:insightId/edit"
-                    render={props => <EditInsightLazyPage insightID={props.match.params.insightId} />}
-                />
+                <Route path=":insightId/edit" element={<EditInsightLazyPage />} />
 
                 <Route
                     // Deprecated URL, delete this in the 4.10
-                    path="/insights/insight/:id"
-                    render={props => <Redirect to={`/insights/${props.match.params.id}`} />}
+                    path="insight/:id"
+                    element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}`} />}
                 />
+                <Route path=":id" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
 
-                <Route
-                    path="/insights/:id"
-                    render={props => (
-                        <CodeInsightIndependentPage
-                            insightId={props.match.params.id}
-                            telemetryService={telemetryService}
-                        />
-                    )}
-                />
-
-                <Route render={() => <HeroPage icon={MapSearchIcon} title="404: Not Found" />} key="hardcoded-key" />
-            </Switch>
+                <Route element={<NotFoundPage pageType="code insights" />} />
+            </Routes>
         </CodeInsightsBackendContext.Provider>
     )
 })
 
 const CodeInsightsSmartRoutingRedirect: FC = () => {
-    const match = useRouteMatch()
     const state = useDashboardExistence()
 
     if (state.status === 'loading') {
@@ -117,18 +102,18 @@ const CodeInsightsSmartRoutingRedirect: FC = () => {
     // No dashboards status means that there are no insights either, so redirect
     // to the getting started page in this case
     if (state.status === 'noDashboards') {
-        return <Redirect from={match.url} exact={true} to="/insights/about" />
+        return <Navigate to="/insights/about" replace={true} />
     }
 
     // There are some dashboards, but we didn't find any particular dashboard in the user
     // temporal settings so redirect to the dashboard tab and select first private dashboard
     if (state.status === 'availableDashboard') {
-        return <Redirect from={match.url} exact={true} to="/insights/dashboards" />
+        return <Navigate to="/insights/dashboards" replace={true} />
     }
 
     // We found a recently viewed dashboard id in the temporal settings, so redirect to this
     // dashboard.
-    return <Redirect from={match.url} exact={true} to={`/insights/dashboards/${state.dashboardId}`} />
+    return <Navigate to={`/insights/dashboards/${state.dashboardId}`} replace={true} />
 }
 
 type DashboardExistence =
@@ -204,25 +189,4 @@ function useDashboardExistence(): DashboardExistence {
     }, [fetchFirstAvailableDashboard, lastVisitedDashboardId, temporalSettingStatus])
 
     return state
-}
-
-function getActiveTabByURL(
-    matchURL: string,
-    props: RouteComponentProps<{ dashboardId?: string }>
-): CodeInsightsRootPageTab {
-    const { match } = props
-
-    switch (match.path) {
-        case `${matchURL}/dashboards/:dashboardId?`:
-            return CodeInsightsRootPageTab.Dashboards
-
-        case `${matchURL}/all`:
-            return CodeInsightsRootPageTab.AllInsights
-
-        case `${matchURL}/about`:
-            return CodeInsightsRootPageTab.GettingStarted
-
-        default:
-            return CodeInsightsRootPageTab.Dashboards
-    }
 }

--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -36,7 +36,7 @@ const rootPagePathsToTab = {
     'dashboards/:dashboardId?': CodeInsightsRootPageTab.Dashboards,
     all: CodeInsightsRootPageTab.AllInsights,
     about: CodeInsightsRootPageTab.GettingStarted,
-} as const
+}
 
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
     const { telemetryService } = props
@@ -102,18 +102,18 @@ const CodeInsightsSmartRoutingRedirect: FC = () => {
     // No dashboards status means that there are no insights either, so redirect
     // to the getting started page in this case
     if (state.status === 'noDashboards') {
-        return <Navigate to="/insights/about" replace={true} />
+        return <Navigate to="about" replace={true} />
     }
 
     // There are some dashboards, but we didn't find any particular dashboard in the user
     // temporal settings so redirect to the dashboard tab and select first private dashboard
     if (state.status === 'availableDashboard') {
-        return <Navigate to="/insights/dashboards" replace={true} />
+        return <Navigate to="dashboards" replace={true} />
     }
 
     // We found a recently viewed dashboard id in the temporal settings, so redirect to this
     // dashboard.
-    return <Navigate to={`/insights/dashboards/${state.dashboardId}`} replace={true} />
+    return <Navigate to={`dashboards/${state.dashboardId}`} replace={true} />
 }
 
 type DashboardExistence =

--- a/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
+++ b/client/web/src/enterprise/insights/modals/GaConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { Button, Modal, Link, H1, Text } from '@sourcegraph/wildcard'
@@ -9,7 +9,7 @@ import { FourLineChart, LangStatsInsightChart, ThreeLineChart } from './componen
 
 import styles from './GaConfirmationModal.module.scss'
 
-export const GaConfirmationModal: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+export const GaConfirmationModal: FC = () => {
     const [isGaAccepted, setGaAccepted] = useTemporarySetting('insights.freeGaExpiredAccepted', false)
     const { licensed } = useUiFeatures()
 
@@ -39,9 +39,7 @@ interface GaConfirmationModalContentProps {
  * Exported especially for storybook story component cause chromatic has a problem of rendering modals
  * on CI.
  */
-export const GaConfirmationModalContent: React.FunctionComponent<
-    React.PropsWithChildren<GaConfirmationModalContentProps>
-> = props => {
+export const GaConfirmationModalContent: FC<GaConfirmationModalContentProps> = props => {
     const { onAccept } = props
 
     return (

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -1,13 +1,11 @@
 /* eslint-disable ban/ban */
-import React from 'react'
+import { ReactElement } from 'react'
 
 import { MockedResponse } from '@apollo/client/testing'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import * as H from 'history'
-import { MemoryRouter } from 'react-router'
-import { Route } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
+import { MemoryRouter } from 'react-router-dom'
+import { Routes, Route, CompatRouter } from 'react-router-dom-v5-compat'
 import sinon from 'sinon'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -21,19 +19,13 @@ import { GET_INSIGHT_DASHBOARDS_GQL } from '../core/hooks/use-insight-dashboards
 import { CodeInsightsRootPage, CodeInsightsRootPageTab } from './CodeInsightsRootPage'
 
 interface ReactRouterMock {
-    useHistory: () => unknown
-    useRouteMatch: () => unknown
+    useNavigate: () => unknown
 }
 
-const url = '/insights'
-
 jest.mock('react-router', () => ({
-    ...jest.requireActual<ReactRouterMock>('react-router'),
-    useHistory: () => ({
+    ...jest.requireActual<ReactRouterMock>('react-router-dom-v5-compat'),
+    useNavigate: () => ({
         push: jest.fn(),
-    }),
-    useRouteMatch: () => ({
-        url,
     }),
 }))
 
@@ -90,34 +82,21 @@ const mockedGQL: MockedResponse[] = [
     } as MockedResponse<InsightsDashboardsResult>,
 ]
 
-const renderWithBrandedContext = (component: React.ReactElement, { route = '/', api = {} } = {}) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const routerSettings: { testHistory: H.History; testLocation: H.Location } = {}
-
-    return {
+const renderWithBrandedContext = (component: ReactElement, { route = '/', path = '*', api = {} } = {}) => ({
         ...render(
             <MockedTestProvider mocks={mockedGQL}>
                 <Wrapper api={api}>
                     <MemoryRouter initialEntries={[route]}>
                         <CompatRouter>
-                            {component}
-                            <Route
-                                path="*"
-                                render={({ history, location }) => {
-                                    routerSettings.testHistory = history
-                                    routerSettings.testLocation = location
-                                    return null
-                                }}
-                            />
+                            <Routes>
+                                <Route path={path} element={component} />
+                            </Routes>
                         </CompatRouter>
                     </MemoryRouter>
                 </Wrapper>
             </MockedTestProvider>
         ),
-        ...routerSettings,
-    }
-}
+    })
 
 describe('CodeInsightsRootPage', () => {
     beforeAll(() => {
@@ -132,6 +111,7 @@ describe('CodeInsightsRootPage', () => {
             />,
             {
                 route: '/insights/dashboards/foo',
+                path: '/insights/dashboards/:dashboardId',
             }
         )
 
@@ -146,6 +126,7 @@ describe('CodeInsightsRootPage', () => {
             />,
             {
                 route: '/insights/dashboards/foo',
+                path: '/insights/dashboards/:dashboardId',
             }
         )
 

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -83,20 +83,20 @@ const mockedGQL: MockedResponse[] = [
 ]
 
 const renderWithBrandedContext = (component: ReactElement, { route = '/', path = '*', api = {} } = {}) => ({
-        ...render(
-            <MockedTestProvider mocks={mockedGQL}>
-                <Wrapper api={api}>
-                    <MemoryRouter initialEntries={[route]}>
-                        <CompatRouter>
-                            <Routes>
-                                <Route path={path} element={component} />
-                            </Routes>
-                        </CompatRouter>
-                    </MemoryRouter>
-                </Wrapper>
-            </MockedTestProvider>
-        ),
-    })
+    ...render(
+        <MockedTestProvider mocks={mockedGQL}>
+            <Wrapper api={api}>
+                <MemoryRouter initialEntries={[route]}>
+                    <CompatRouter>
+                        <Routes>
+                            <Route path={path} element={component} />
+                        </Routes>
+                    </CompatRouter>
+                </MemoryRouter>
+            </Wrapper>
+        </MockedTestProvider>
+    ),
+})
 
 describe('CodeInsightsRootPage', () => {
     beforeAll(() => {

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,7 +1,7 @@
 import { Suspense, FC, memo } from 'react'
 
 import { mdiPlus } from '@mdi/js'
-import { useHistory } from 'react-router'
+import { useParams, useNavigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -45,9 +45,10 @@ interface CodeInsightsRootPageProps extends TelemetryProps {
 }
 
 export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props => {
-    const { dashboardId, activeTab, telemetryService } = props
+    const { activeTab, telemetryService } = props
 
-    const history = useHistory()
+    const navigate = useNavigate()
+    const { dashboardId } = useParams()
     const { dashboardId: queryParameterDashboardId } = useQueryParameters(['dashboardId'])
 
     // Set either active dashboard from the dashboard tab param (dashboard)
@@ -59,15 +60,15 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
         switch (selectedTab) {
             case CodeInsightsRootPageTab.Dashboards: {
                 if (queryParameterDashboardId) {
-                    return history.push(`/insights/dashboards/${queryParameterDashboardId}`)
+                    return navigate(`/insights/dashboards/${queryParameterDashboardId}`)
                 }
 
-                return history.push('/insights/dashboards')
+                return navigate('/insights/dashboards')
             }
             case CodeInsightsRootPageTab.AllInsights:
-                return history.push(encodeDashboardIdQueryParam('/insights/all', absoluteDashboardId))
+                return navigate(encodeDashboardIdQueryParam('/insights/all', absoluteDashboardId))
             case CodeInsightsRootPageTab.GettingStarted:
-                return history.push(encodeDashboardIdQueryParam('/insights/about', absoluteDashboardId))
+                return navigate(encodeDashboardIdQueryParam('/insights/about', absoluteDashboardId))
         }
     }
 

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 
 import classNames from 'classnames'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Container, Button, LoadingSpinner, useObservable, Link, Tooltip } from '@sourcegraph/wildcard'
@@ -26,7 +26,8 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<
     React.PropsWithChildren<InsightsDashboardCreationPageProps>
 > = props => {
     const { telemetryService } = props
-    const history = useHistory()
+
+    const navigate = useNavigate()
     const { dashboard } = useUiFeatures()
 
     const { createDashboard, getDashboardOwners } = useContext(CodeInsightsBackendContext)
@@ -45,10 +46,10 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<
         telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
 
         // Navigate user to the dashboard page with new created dashboard
-        history.push(`/insights/dashboards/${createdDashboard.id}`)
+        navigate(`/insights/dashboards/${createdDashboard.id}`)
     }
 
-    const handleCancel = (): void => history.goBack()
+    const handleCancel = (): void => navigate(-1)
 
     // Loading state
     if (owners === undefined) {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react'
 
-import { useRouteMatch } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
@@ -24,7 +23,6 @@ export interface DashboardsViewProps extends TelemetryProps {
 export const DashboardsView: FC<DashboardsViewProps> = props => {
     const { dashboardId, telemetryService } = props
 
-    const { url } = useRouteMatch()
     const { dashboards } = useInsightDashboards()
 
     if (!dashboards) {
@@ -38,7 +36,7 @@ export const DashboardsView: FC<DashboardsViewProps> = props => {
     if (!dashboardId && dashboards.length > 0) {
         const currentDashboard = dashboards.find(isPersonalDashboard) ?? dashboards[0]
 
-        return <Redirect push={false} to={`${url}/${currentDashboard.id}`} />
+        return <Navigate replace={true} to={`./${currentDashboard.id}`} />
     }
 
     // We have dashboards and dashboard id in URL, try to find a current dashboard

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import ViewDashboardOutlineIcon from 'mdi-react/ViewDashboardOutlineIcon'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -31,7 +31,7 @@ export interface DashboardsContentProps extends TelemetryProps {
 export const DashboardsContent: FC<DashboardsContentProps> = props => {
     const { currentDashboard, dashboards, telemetryService } = props
 
-    const history = useHistory()
+    const navigate = useNavigate()
     const [, setLasVisitedDashboard] = useTemporarySetting('insights.lastVisitedDashboardId', null)
     const { dashboard: dashboardPermission, licensed } = useUiFeatures()
 
@@ -43,13 +43,13 @@ export const DashboardsContent: FC<DashboardsContentProps> = props => {
     useEffect(() => setLasVisitedDashboard(currentDashboard?.id ?? null), [currentDashboard, setLasVisitedDashboard])
 
     const handleDashboardSelect = (dashboard: CustomInsightDashboard): void =>
-        history.push(`/insights/dashboards/${dashboard.id}`)
+        navigate(`/insights/dashboards/${dashboard.id}`)
 
     const handleSelect = (action: DashboardMenuAction): void => {
         switch (action) {
             case DashboardMenuAction.Configure: {
                 if (currentDashboard) {
-                    history.push(`/insights/dashboards/${currentDashboard.id}/edit`)
+                    navigate(`/insights/dashboards/${currentDashboard.id}/edit`)
                 }
                 return
             }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/delete-dashboard-modal/DeleteDashboardModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/delete-dashboard-modal/DeleteDashboardModal.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiClose } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { isErrorLike } from '@sourcegraph/common'
 import { Button, Modal, H2, Icon, ErrorAlert } from '@sourcegraph/wildcard'
@@ -23,10 +23,10 @@ export const DeleteDashboardModal: React.FunctionComponent<
     React.PropsWithChildren<DeleteDashboardModalProps>
 > = props => {
     const { dashboard, onClose } = props
-    const history = useHistory()
+    const navigate = useNavigate()
 
     const handleDeleteSuccess = (): void => {
-        history.push('/insights/dashboards')
+        navigate('/insights/dashboards')
         onClose()
     }
 

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useMemo } from 'react'
+import { FC, useContext, useMemo } from 'react'
 
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { useHistory } from 'react-router'
+import { useParams, useNavigate } from 'react-router-dom-v5-compat'
 
 import { Button, Container, LoadingSpinner, PageHeader, useObservable, Link } from '@sourcegraph/wildcard'
 
@@ -27,16 +27,12 @@ import {
 
 import styles from './EditDashboardPage.module.scss'
 
-interface EditDashboardPageProps {
-    dashboardId: string
-}
-
 /**
  * Displays the edit (configure) dashboard page.
  */
-export const EditDashboardPage: React.FunctionComponent<React.PropsWithChildren<EditDashboardPageProps>> = props => {
-    const { dashboardId } = props
-    const history = useHistory()
+export const EditDashboardPage: FC = () => {
+    const navigate = useNavigate()
+    const { dashboardId } = useParams()
 
     const { getDashboardOwners, updateDashboard } = useContext(CodeInsightsBackendContext)
 
@@ -74,10 +70,10 @@ export const EditDashboardPage: React.FunctionComponent<React.PropsWithChildren<
             },
         }).toPromise()
 
-        history.push(`/insights/dashboards/${updatedDashboard.id}`)
+        navigate(`/insights/dashboards/${updatedDashboard.id}`)
     }
 
-    const handleCancel = (): void => history.goBack()
+    const handleCancel = (): void => navigate(-1)
 
     return (
         <CodeInsightsPage className={classNames('col-8', styles.page)}>

--- a/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import { FC } from 'react'
 
-import { Switch, Route, useRouteMatch } from 'react-router'
+import { Routes, Route } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -18,62 +18,56 @@ interface CreationRoutesProps extends TelemetryProps {}
  * Code insight sub-router for the creation area/routes.
  * Renders code insights creation routes (insight creation UI pages, creation intro page)
  */
-export const CreationRoutes: React.FunctionComponent<React.PropsWithChildren<CreationRoutesProps>> = props => {
+export const CreationRoutes: FC<CreationRoutesProps> = props => {
     const { telemetryService } = props
 
-    const match = useRouteMatch()
     const { codeInsightsCompute } = useExperimentalFeatures()
 
     return (
-        <Switch>
-            <Route
-                exact={true}
-                path={`${match.url}`}
-                render={() => <IntroCreationLazyPage telemetryService={telemetryService} />}
-            />
+        <Routes>
+            <Route index={true} element={<IntroCreationLazyPage telemetryService={telemetryService} />} />
 
             <Route
-                path={`${match.url}/search`}
-                render={() => (
+                path="search"
+                element={
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.Search}
                         telemetryService={telemetryService}
                     />
-                )}
+                }
             />
 
             <Route
-                path={`${match.url}/capture-group`}
-                render={() => (
+                path="capture-group"
+                element={
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.CaptureGroup}
                         telemetryService={telemetryService}
                     />
-                )}
+                }
             />
 
             <Route
-                path={`${match.url}/lang-stats`}
-                exact={true}
-                render={() => (
+                path="lang-stats"
+                element={
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.LangStats}
                         telemetryService={telemetryService}
                     />
-                )}
+                }
             />
 
             {codeInsightsCompute && (
                 <Route
-                    path={`${match.url}/group-results`}
-                    render={() => (
+                    path="group-results"
+                    element={
                         <InsightCreationLazyPage
                             mode={InsightCreationPageType.Compute}
                             telemetryService={telemetryService}
                         />
-                    )}
+                    }
                 />
             )}
-        </Switch>
+        </Routes>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from 'react'
 
-import { useHistory } from 'react-router'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -32,7 +32,7 @@ interface InsightCreationPageProps extends TelemetryProps {
 export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
     const { mode, telemetryService } = props
 
-    const history = useHistory()
+    const navigate = useNavigate()
     const { createInsight } = useContext(CodeInsightsBackendContext)
     const { dashboardId } = useQueryParameters(['dashboardId'])
 
@@ -47,22 +47,22 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
     const handleInsightSuccessfulCreation = (): void => {
         if (!dashboardId) {
             // Navigate to the dashboard page with new created dashboard
-            history.push('/insights/all')
+            navigate('/insights/all')
 
             return
         }
 
-        history.push(`/insights/dashboards/${dashboardId}`)
+        navigate(`/insights/dashboards/${dashboardId}`)
     }
 
     const handleCancel = (): void => {
         if (!dashboardId) {
-            history.push('/insights/all')
+            navigate('/insights/all')
 
             return
         }
 
-        history.push(`/insights/dashboards/${dashboardId}`)
+        navigate(`/insights/dashboards/${dashboardId}`)
     }
 
     const backCreateUrl = encodeDashboardIdQueryParam('/insights/create', dashboardId)

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 
-import { useHistory } from 'react-router'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
@@ -26,28 +25,28 @@ interface IntroCreationPageProps extends TelemetryProps {}
 export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<IntroCreationPageProps>> = props => {
     const { telemetryService } = props
 
-    const history = useHistory()
+    const navigate = useNavigate()
     const { search } = useLocation()
     const { codeInsightsCompute } = useExperimentalFeatures()
 
     const handleCreateSearchBasedInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateSearchBasedInsightClick')
-        history.push(`/insights/create/search${search}`)
+        navigate(`/insights/create/search${search}`)
     }
 
     const handleCaptureGroupInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCaptureGroupInsightClick')
-        history.push(`/insights/create/capture-group${search}`)
+        navigate(`/insights/create/capture-group${search}`)
     }
 
     const handleCreateComputeInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateComputeInsightClick')
-        history.push(`/insights/create/group-results${search}`)
+        navigate(`/insights/create/group-results${search}`)
     }
 
     const handleCreateCodeStatsInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCodeStatsInsightClick')
-        history.push(`/insights/create/lang-stats${search}`)
+        navigate(`/insights/create/lang-stats${search}`)
     }
 
     useEffect(() => {

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -1,6 +1,7 @@
-import React, { useContext, useMemo } from 'react'
+import { FC, useContext, useMemo } from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import { useParams } from 'react-router-dom-v5-compat'
 
 import { LoadingSpinner, useObservable, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -23,18 +24,16 @@ import { EditLangStatsInsight } from './components/EditLangStatsInsight'
 import { EditSearchBasedInsight } from './components/EditSearchInsight'
 import { useEditPageHandlers } from './hooks/use-edit-page-handlers'
 
-export interface EditInsightPageProps {
-    /** Normalized insight id <type insight>.insight.<name of insight> */
-    insightID: string
-}
+export interface EditInsightPageProps {}
 
-export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<EditInsightPageProps>> = props => {
-    const { insightID } = props
+export const EditInsightPage: FC<EditInsightPageProps> = props => {
+    /** Normalized insight id <type insight>.insight.<name of insight> */
+    const { insightID } = useParams()
 
     const { getInsightById } = useContext(CodeInsightsBackendContext)
     const { licensed, insight: insightFeatures } = useUiFeatures()
 
-    const insight = useObservable(useMemo(() => getInsightById(insightID), [getInsightById, insightID]))
+    const insight = useObservable(useMemo(() => getInsightById(insightID!), [getInsightById, insightID]))
     const { handleSubmit, handleCancel } = useEditPageHandlers({ id: insight?.id })
 
     const editPermission = useObservable(

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { eventLogger } from '../../../../../../tracking/eventLogger'
 import { SubmissionErrors } from '../../../../components'
@@ -19,7 +19,7 @@ export interface useHandleSubmitOutput {
 export function useEditPageHandlers(props: { id: string | undefined }): useHandleSubmitOutput {
     const { id } = props
     const { updateInsight } = useContext(CodeInsightsBackendContext)
-    const history = useHistory()
+    const navigate = useNavigate()
 
     const { dashboardId, insight } = useQueryParameters(['dashboardId', 'insight'])
     const redirectUrl = getReturnToLink(insight, dashboardId)
@@ -36,11 +36,11 @@ export function useEditPageHandlers(props: { id: string | undefined }): useHandl
 
         const insightType = getTrackingTypeByInsightType(newInsight.type)
         eventLogger.log('InsightEdit', { insightType }, { insightType })
-        history.push(redirectUrl)
+        navigate(redirectUrl)
     }
 
     const handleCancel = (): void => {
-        history.push(redirectUrl)
+        navigate(redirectUrl)
     }
 
     return { handleSubmit, handleCancel }

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -1,5 +1,7 @@
 import { FunctionComponent, useContext, useEffect, useMemo } from 'react'
 
+import { useParams } from 'react-router-dom-v5-compat'
+
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -15,15 +17,15 @@ import { Standalone404Insight } from './components/standalone-404-insight/Standa
 
 import styles from './CodeInsightIndependentPage.module.scss'
 
-interface CodeInsightIndependentPage extends TelemetryProps {
-    insightId: string
-}
+interface CodeInsightIndependentPage extends TelemetryProps {}
 
 export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependentPage> = props => {
-    const { insightId, telemetryService } = props
+    const { telemetryService } = props
+
+    const { insightId } = useParams()
     const { getInsightById } = useContext(CodeInsightsBackendContext)
 
-    const insight = useObservable(useMemo(() => getInsightById(insightId), [getInsightById, insightId]))
+    const insight = useObservable(useMemo(() => getInsightById(insightId!), [getInsightById, insightId]))
 
     useEffect(() => {
         telemetryService.logPageView('StandaloneInsightPage')

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useRef, useState } from 'react'
 
 import { mdiLinkVariant } from '@mdi/js'
 import { escapeRegExp } from 'lodash'
-import { useHistory } from 'react-router'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
@@ -21,7 +21,7 @@ interface Props extends TelemetryProps {
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
     const { insight, telemetryService } = props
 
-    const history = useHistory()
+    const navigate = useNavigate()
 
     const copyLinkButtonReference = useRef<HTMLButtonElement | null>(null)
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -80,7 +80,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
             <ConfirmDeleteModal
                 insight={insight}
                 showModal={showDeleteConfirm}
-                onConfirm={() => history.push('/insights/all')}
+                onConfirm={() => navigate('/insights/all')}
                 onCancel={() => setShowDeleteConfirm(false)}
             />
         </div>

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react'
 
 import classNames from 'classnames'
-import { useHistory } from 'react-router'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -49,7 +49,7 @@ interface StandaloneBackendInsight extends TelemetryProps {
 
 export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackendInsight> = props => {
     const { telemetryService, insight, className } = props
-    const history = useHistory()
+    const navigate = useNavigate()
     const { updateInsight } = useContext(CodeInsightsBackendContext)
     const [saveAsNewView] = useSaveInsightAsNewView({ dashboard: null })
 
@@ -133,7 +133,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         })
 
         setOriginalInsightFilters(filters)
-        history.push('/insights/all')
+        navigate('/insights/all')
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
     }
 


### PR DESCRIPTION
## Context

- Part of #33834 

## Test plan

1. CI
2. Manually visit all affected routes.

## App preview:

- [Web](https://sg-web-vb-react-router-migration-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
