### PR TITLE
searcher: use the same gitserver fetch timeout as symbols

### DIFF
--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -78,6 +78,11 @@ type Store struct {
 	// MaxCacheSizeBytes.
 	MaxCacheSizeBytes int64
 
+	// BackgroundTimeout is the maximum time spent fetching a working copy
+	// from gitserver. If zero then we will respect the passed in context of a
+	// request.
+	BackgroundTimeout time.Duration
+
 	// Log is the Logger to use.
 	Log log.Logger
 
@@ -109,7 +114,7 @@ func (s *Store) Start() {
 	s.once.Do(func() {
 		s.fetchLimiter = mutablelimiter.New(15)
 		s.cache = diskcache.NewStore(s.Path, "store",
-			diskcache.WithBackgroundTimeout(10*time.Minute),
+			diskcache.WithBackgroundTimeout(s.BackgroundTimeout),
 			diskcache.WithBeforeEvict(s.zipCache.delete),
 			diskcache.WithobservationCtx(s.ObservationCtx),
 		)

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -43,6 +43,9 @@ var (
 	cacheDir    = env.Get("CACHE_DIR", "/tmp", "directory to store cached archives.")
 	cacheSizeMB = env.Get("SEARCHER_CACHE_SIZE_MB", "100000", "maximum size of the on disk cache in megabytes")
 
+	// Same environment variable name (and default value) used by symbols.
+	backgroundTimeout = env.MustGetDuration("PROCESSING_TIMEOUT", 2*time.Hour, "maximum time to spend processing a repository")
+
 	maxTotalPathsLengthRaw = env.Get("MAX_TOTAL_PATHS_LENGTH", "100000", "maximum sum of lengths of all paths in a single call to git archive")
 )
 
@@ -153,6 +156,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),
 			MaxCacheSizeBytes: cacheSizeBytes,
+			BackgroundTimeout: backgroundTimeout,
 			Log:               storeObservationCtx.Logger,
 			ObservationCtx:    storeObservationCtx,
 		},


### PR DESCRIPTION
Searcher has a hardcoded timeout of 10 minutes. Interestingly symbols has a hardcoded timeout of 2 hours. Now this is likely due to fetching more history for a repository for rockskip. However, I suspect 10 minutes is too aggressive for large monorepos. As such we use a much more conservative timeout of 2h.

The downside of this approach is we have a relatively naive semaphore controlling concurrent fetches. So if we have a large burst of activity that never gets retried it will take a lot longer for us to cancel out the backlog. However, in practice this feels like the better tradeoff as well as this being consistent with symbols.

Test Plan: go test