### PR TITLE
Fix URL in global-settings page

### DIFF
--- a/client/web/src/site-admin/SiteAdminSettingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSettingsPage.tsx
@@ -21,6 +21,7 @@ export const SiteAdminSettingsPage: React.FunctionComponent<React.PropsWithChild
         <PageTitle title="Global settings" />
         <SettingsArea
             {...props}
+            url="/site-admin/global-settings"
             subject={props.site}
             authenticatedUser={props.authenticatedUser}
             extraHeader={


### PR DESCRIPTION
An URL was set to the wrong value when I migrated the admin panel. 

## Test plan

<img width="1090" alt="Screenshot 2023-02-09 at 10 09 34" src="https://user-images.githubusercontent.com/458591/217767763-0590b546-2d90-4f50-8767-fb23344ce2a9.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
