### PR TITLE
web: remove remaining Switch usages

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import { FC, useEffect, useCallback, useState } from 'react'
 
-import * as H from 'history'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { asError, isErrorLike, logger, renderMarkdown } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Alert, Container, H2, H3, H4, Markdown } from '@sourcegraph/wildcard'
 
-import { ExternalServiceFields, Scalars, AddExternalServiceInput } from '../../graphql-operations'
+import { ExternalServiceFields, AddExternalServiceInput } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 import { PageTitle } from '../PageTitle'
 
@@ -17,10 +17,7 @@ import { ExternalServiceForm } from './ExternalServiceForm'
 import { AddExternalServiceOptions } from './externalServices'
 
 interface Props extends ThemeProps, TelemetryProps {
-    history: H.History
     externalService: AddExternalServiceOptions
-    routingPrefix: string
-    userID?: Scalars['ID']
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
 
@@ -31,19 +28,17 @@ interface Props extends ThemeProps, TelemetryProps {
 /**
  * Page for adding a single external service.
  */
-export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+export const AddExternalServicePage: FC<Props> = ({
     externalService,
-    history,
     isLightTheme,
-    routingPrefix,
     telemetryService,
-    userID,
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
 }) => {
     const [config, setConfig] = useState(externalService.defaultConfig)
     const [displayName, setDisplayName] = useState(externalService.defaultDisplayName)
+    const navigate = useNavigate()
 
     useEffect(() => {
         telemetryService.logPageView('AddExternalService')
@@ -91,9 +86,9 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
             // reflect the latest configuration.
             // eslint-disable-next-line rxjs/no-ignored-subscription
             refreshSiteFlags().subscribe({ error: error => logger.error(error) })
-            history.push(`${routingPrefix}/external-services/${createdExternalService.id}`)
+            navigate(`/site-admin/external-services/${createdExternalService.id}`)
         }
-    }, [createdExternalService, routingPrefix, history])
+    }, [createdExternalService, navigate])
 
     return (
         <>
@@ -107,7 +102,7 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
                                 {...externalService}
                                 title={createdExternalService.displayName}
                                 shortDescription="Update this external service configuration to manage repository mirroring."
-                                to={`${routingPrefix}/external-services/${createdExternalService.id}/edit`}
+                                to={`/site-admin/external-services/${createdExternalService.id}/edit`}
                             />
                         </div>
                         <Alert variant="warning">
@@ -123,7 +118,6 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
                         <H3>Instructions:</H3>
                         <div className="mb-4">{externalService.instructions}</div>
                         <ExternalServiceForm
-                            history={history}
                             isLightTheme={isLightTheme}
                             telemetryService={telemetryService}
                             error={isErrorLike(isCreating) ? isCreating : undefined}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -27,7 +27,6 @@ export const Overview: Story = () => (
         {webProps => (
             <AddExternalServicesPage
                 {...webProps}
-                routingPrefix="/site-admin"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}
@@ -44,7 +43,6 @@ export const AddConnectionBykind: Story = () => (
         {webProps => (
             <AddExternalServicesPage
                 {...webProps}
-                routingPrefix="/site-admin"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -1,13 +1,12 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { mdiInformation } from '@mdi/js'
-import * as H from 'history'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useLocalStorage, Button, Link, Alert, H2, H3, Icon, Text, Container } from '@sourcegraph/wildcard'
 
-import { Scalars } from '../../graphql-operations'
 import { PageTitle } from '../PageTitle'
 
 import { AddExternalServicePage } from './AddExternalServicePage'
@@ -17,10 +16,6 @@ import { allExternalServices, AddExternalServiceOptions } from './externalServic
 import styles from './AddExternalServicesPage.module.scss'
 
 export interface AddExternalServicesPageProps extends ThemeProps, TelemetryProps {
-    history: H.History
-    routingPrefix: string
-    userID?: Scalars['ID']
-
     /**
      * The list of code host external services to be displayed.
      * Pick items from externalServices.codeHostExternalServices.
@@ -42,20 +37,16 @@ export interface AddExternalServicesPageProps extends ThemeProps, TelemetryProps
 /**
  * Page for choosing a service kind and variant to add, among the available options.
  */
-export const AddExternalServicesPage: React.FunctionComponent<
-    React.PropsWithChildren<AddExternalServicesPageProps>
-> = ({
+export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
     codeHostExternalServices,
-    history,
     isLightTheme,
     nonCodeHostExternalServices,
-    routingPrefix,
     telemetryService,
-    userID,
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
 }) => {
+    const { search } = useLocation()
     const [hasDismissedPrivacyWarning, setHasDismissedPrivacyWarning] = useLocalStorage(
         'hasDismissedCodeHostPrivacyWarning',
         false
@@ -63,17 +54,15 @@ export const AddExternalServicesPage: React.FunctionComponent<
     const dismissPrivacyWarning = (): void => {
         setHasDismissedPrivacyWarning(true)
     }
-    const id = new URLSearchParams(history.location.search).get('id')
+
+    const id = new URLSearchParams(search).get('id')
     if (id) {
         const externalService = allExternalServices[id]
         if (externalService) {
             return (
                 <AddExternalServicePage
-                    history={history}
                     isLightTheme={isLightTheme}
-                    routingPrefix={routingPrefix}
                     telemetryService={telemetryService}
-                    userID={userID}
                     externalService={externalService}
                     autoFocusForm={autoFocusForm}
                     externalServicesFromFile={externalServicesFromFile}
@@ -101,13 +90,11 @@ export const AddExternalServicesPage: React.FunctionComponent<
                 <Text>Add repositories from one of these code hosts.</Text>
                 {hasDismissedPrivacyWarning && (
                     <Alert variant="info">
-                        {!userID && (
-                            <Text>
-                                This Sourcegraph installation will never send your code, repository names, file names,
-                                or any other specific code data to Sourcegraph.com or any other destination. Your code
-                                is kept private on this installation.
-                            </Text>
-                        )}
+                        <Text>
+                            This Sourcegraph installation will never send your code, repository names, file names, or
+                            any other specific code data to Sourcegraph.com or any other destination. Your code is kept
+                            private on this installation.
+                        </Text>
                         <H3>This Sourcegraph installation will access your code host by:</H3>
                         <ul>
                             <li>

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -6,12 +6,18 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
-import { WebStory } from '../WebStory'
+import { WebStory, WebStoryChildrenProps } from '../WebStory'
 
 import { FETCH_EXTERNAL_SERVICE } from './backend'
 import { ExternalServiceEditPage } from './ExternalServiceEditPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: DecoratorFn = story => (
+    <div className="p-3 container">
+        <WebStory path="/:externalServiceID" initialEntries={['service123']}>
+            {story}
+        </WebStory>
+    </div>
+)
 
 const config: Meta = {
     title: 'web/External services/ExternalServiceEditPage',
@@ -61,86 +67,58 @@ function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceF
     ])
 }
 
-export const ViewConfig: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider link={newFetchMock(externalService)}>
-                <ExternalServiceEditPage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    externalServiceID="service123"
-                    autoFocusForm={false}
-                    externalServicesFromFile={false}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+export const ViewConfig: Story<WebStoryChildrenProps> = props => (
+    <MockedTestProvider link={newFetchMock(externalService)}>
+        <ExternalServiceEditPage
+            isLightTheme={props.isLightTheme}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            autoFocusForm={false}
+            externalServicesFromFile={false}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 ViewConfig.storyName = 'View external service config'
 
-export const ConfigWithInvalidUrl: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
-                <ExternalServiceEditPage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    externalServiceID="service123"
-                    autoFocusForm={false}
-                    externalServicesFromFile={false}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+export const ConfigWithInvalidUrl: Story<WebStoryChildrenProps> = props => (
+    <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
+        <ExternalServiceEditPage
+            isLightTheme={props.isLightTheme}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            autoFocusForm={false}
+            externalServicesFromFile={false}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 ConfigWithInvalidUrl.storyName = 'External service config with invalid url'
 
-export const ConfigWithWarning: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider
-                link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}
-            >
-                <ExternalServiceEditPage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    externalServiceID="service123"
-                    autoFocusForm={false}
-                    externalServicesFromFile={false}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+export const ConfigWithWarning: Story<WebStoryChildrenProps> = props => (
+    <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
+        <ExternalServiceEditPage
+            isLightTheme={props.isLightTheme}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            autoFocusForm={false}
+            externalServicesFromFile={false}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 ConfigWithWarning.storyName = 'External service config with warning after update'
 
-export const EditingDisabled: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider
-                link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}
-            >
-                <ExternalServiceEditPage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    externalServiceID="service123"
-                    autoFocusForm={false}
-                    externalServicesFromFile={true}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+export const EditingDisabled: Story<WebStoryChildrenProps> = props => (
+    <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
+        <ExternalServiceEditPage
+            isLightTheme={props.isLightTheme}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            autoFocusForm={false}
+            externalServicesFromFile={true}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 EditingDisabled.storyName = 'External service config EXTSVC_CONFIG_FIlE set'

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { FC, useEffect, useState, useCallback } from 'react'
 
 import { mdiCog } from '@mdi/js'
-import * as H from 'history'
-import { Redirect } from 'react-router'
+import { Navigate, useParams } from 'react-router-dom-v5-compat'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -10,7 +9,6 @@ import { Container, ErrorAlert, PageHeader, Icon, ButtonLink } from '@sourcegrap
 
 import {
     ExternalServiceFields,
-    Scalars,
     AddExternalServiceInput,
     ExternalServiceResult,
     ExternalServiceVariables,
@@ -24,10 +22,7 @@ import { resolveExternalServiceCategory } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
 interface Props extends TelemetryProps {
-    externalServiceID: Scalars['ID']
     isLightTheme: boolean
-    history: H.History
-    routingPrefix: string
 
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
@@ -39,16 +34,15 @@ interface Props extends TelemetryProps {
 const getExternalService = (queryResult?: ExternalServiceResult): ExternalServiceFields | null =>
     queryResult?.node?.__typename === 'ExternalService' ? queryResult.node : null
 
-export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    externalServiceID,
-    history,
-    routingPrefix,
+export const ExternalServiceEditPage: FC<Props> = ({
     isLightTheme,
     telemetryService,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
     autoFocusForm,
 }) => {
+    const { externalServiceID } = useParams()
+
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
     }, [telemetryService])
@@ -58,7 +52,7 @@ export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChi
     const { error: fetchError, loading: fetchLoading } = useQuery<ExternalServiceResult, ExternalServiceVariables>(
         FETCH_EXTERNAL_SERVICE,
         {
-            variables: { id: externalServiceID },
+            variables: { id: externalServiceID! },
             notifyOnNetworkStatusChange: false,
             fetchPolicy: 'no-cache',
             onCompleted: result => {
@@ -114,7 +108,7 @@ export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChi
     const combinedLoading = fetchLoading || updateExternalServiceLoading
 
     if (updated && !combinedLoading && externalService?.warning === null) {
-        return <Redirect to={`${routingPrefix}/external-services/${externalService.id}`} />
+        return <Navigate to={`/site-admin/external-services/${externalService.id}`} replace={true} />
     }
 
     return (
@@ -175,7 +169,6 @@ export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChi
                             loading={combinedLoading}
                             onSubmit={onSubmit}
                             onChange={onChange}
-                            history={history}
                             isLightTheme={isLightTheme}
                             telemetryService={telemetryService}
                             autoFocus={autoFocusForm}

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback } from 'react'
 
-import * as H from 'history'
-
 import { ErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -26,7 +24,6 @@ import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTe
 import { AddExternalServiceOptions } from './externalServices'
 
 interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>, ThemeProps, TelemetryProps {
-    history: H.History
     input: AddExternalServiceInput
     externalServiceID?: string
     error?: ErrorLike
@@ -46,7 +43,6 @@ interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorAc
  * Form for submitting a new or updated external service.
  */
 export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    history,
     isLightTheme,
     telemetryService,
     jsonSchema,

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
 
 import { mdiCircle, mdiCog, mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
@@ -17,15 +17,10 @@ import styles from './ExternalServiceNode.module.scss'
 
 export interface ExternalServiceNodeProps {
     node: ListExternalServiceFields
-    routingPrefix: string
     editingDisabled: boolean
 }
 
-export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildren<ExternalServiceNodeProps>> = ({
-    node,
-    routingPrefix,
-    editingDisabled,
-}) => {
+export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editingDisabled }) => {
     const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
     const onDelete = useCallback<React.MouseEventHandler>(async () => {
         if (!window.confirm(`Delete the external service ${node.displayName}?`)) {
@@ -110,7 +105,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>
                         <Button
                             className="test-edit-external-service-button"
-                            to={`${routingPrefix}/external-services/${node.id}/edit`}
+                            to={`/site-admin/external-services/${node.id}/edit`}
                             variant="secondary"
                             size="sm"
                             as={Link}

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -8,12 +8,18 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { ExternalServiceFields, ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
-import { WebStory } from '../WebStory'
+import { WebStory, WebStoryChildrenProps } from '../WebStory'
 
 import { FETCH_EXTERNAL_SERVICE, queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
 import { ExternalServicePage } from './ExternalServicePage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: DecoratorFn = story => (
+    <div className="p-3 container">
+        <WebStory path="/:externalServiceID" initialEntries={['service123']}>
+            {story}
+        </WebStory>
+    </div>
+)
 
 const config: Meta = {
     title: 'web/External services/ExternalServicePage',
@@ -121,23 +127,17 @@ function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceF
     ])
 }
 
-export const ExternalServiceWithRepos: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider link={newFetchMock(externalService)}>
-                <ExternalServicePage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                    afterDeleteRoute="/site-admin/after-delete"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    externalServiceID="service123"
-                    externalServicesFromFile={false}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+export const ExternalServiceWithRepos: Story<WebStoryChildrenProps> = props => (
+    <MockedTestProvider link={newFetchMock(externalService)}>
+        <ExternalServicePage
+            isLightTheme={props.isLightTheme}
+            queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+            afterDeleteRoute="/site-admin/after-delete"
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            externalServicesFromFile={false}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 ExternalServiceWithRepos.storyName = 'External service with synced repos'

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState, useCallback, useMemo, FC } from 'react'
 
 import { mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Subject } from 'rxjs'
 import { useNavigate, useParams } from 'react-router-dom-v5-compat'
+import { Subject } from 'rxjs'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState, useCallback, useMemo, FC } from 'react'
 
 import { mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
-import * as H from 'history'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Subject } from 'rxjs'
+import { useNavigate, useParams } from 'react-router-dom-v5-compat'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, Container, ErrorAlert, H2, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
-import { Scalars, ExternalServiceResult, ExternalServiceVariables } from '../../graphql-operations'
+import { ExternalServiceResult, ExternalServiceVariables } from '../../graphql-operations'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
 import { refreshSiteFlags } from '../../site/backend'
 import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
@@ -31,10 +31,7 @@ import { ExternalServiceSyncJobsList } from './ExternalServiceSyncJobsList'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
 interface Props extends TelemetryProps {
-    externalServiceID: Scalars['ID']
     isLightTheme: boolean
-    history: H.History
-    routingPrefix: string
     afterDeleteRoute: string
 
     externalServicesFromFile: boolean
@@ -44,22 +41,22 @@ interface Props extends TelemetryProps {
     queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
 }
 
-const NotFoundPage: FC<React.PropsWithChildren<unknown>> = () => (
+const NotFoundPage: FC = () => (
     <HeroPage icon={MapSearchIcon} title="404: Not Found" subtitle="Sorry, the requested code host was not found." />
 )
 
-export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => {
+export const ExternalServicePage: FC<Props> = props => {
     const {
-        externalServiceID,
         isLightTheme,
-        history,
-        routingPrefix,
         telemetryService,
         afterDeleteRoute,
         externalServicesFromFile,
         allowEditExternalServicesWithFile,
         queryExternalServiceSyncJobs = _queryExternalServiceSyncJobs,
     } = props
+
+    const { externalServiceID } = useParams()
+    const navigate = useNavigate()
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
@@ -76,7 +73,7 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
         error: fetchError,
         loading: fetchLoading,
     } = useQuery<ExternalServiceResult, ExternalServiceVariables>(FETCH_EXTERNAL_SERVICE, {
-        variables: { id: externalServiceID },
+        variables: { id: externalServiceID! },
         notifyOnNetworkStatusChange: false,
         fetchPolicy: 'no-cache',
     })
@@ -121,11 +118,11 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
             setIsDeleting(false)
             // eslint-disable-next-line rxjs/no-ignored-subscription
             refreshSiteFlags().subscribe()
-            history.push(afterDeleteRoute)
+            navigate(afterDeleteRoute)
         } catch (error) {
             setIsDeleting(asError(error))
         }
-    }, [afterDeleteRoute, history, externalService])
+    }, [afterDeleteRoute, navigate, externalService])
 
     // If external service is undefined, we won't use doCheckConnection anyway,
     // that's why it's safe to pass an empty ID to useExternalServiceCheckConnectionByIdLazyQuery
@@ -206,7 +203,7 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
                                         <Tooltip content="Edit code host connection settings">
                                             <Button
                                                 className="test-edit-external-service-button"
-                                                to={`${routingPrefix}/external-services/${externalService.id}/edit`}
+                                                to={`/site-admin/external-services/${externalService.id}/edit`}
                                                 variant="primary"
                                                 size="sm"
                                                 as={Link}

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -12,7 +12,11 @@ import { WebStory } from '../WebStory'
 import { EXTERNAL_SERVICES } from './backend'
 import { ExternalServicesPage } from './ExternalServicesPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: DecoratorFn = story => (
+    <div className="p-3 container">
+        <WebStory>{story}</WebStory>
+    </div>
+)
 
 const config: Meta = {
     title: 'web/External services/ExternalServicesPage',
@@ -22,125 +26,120 @@ const config: Meta = {
 export default config
 
 export const ListOfExternalServices: Story = () => (
-    <WebStory>
-        {webProps => (
-            <MockedTestProvider
-                link={
-                    new WildcardMockLink([
-                        {
-                            request: {
-                                query: getDocumentNode(EXTERNAL_SERVICES),
-                                variables: MATCH_ANY_PARAMETERS,
-                            },
-                            nMatches: Number.POSITIVE_INFINITY,
-                            result: {
-                                data: {
-                                    externalServices: {
-                                        totalCount: 2,
-                                        pageInfo: {
-                                            endCursor: null,
-                                            hasNextPage: false,
-                                        },
-                                        nodes: [
-                                            {
-                                                __typename: 'ExternalService',
-                                                id: 'service1',
-                                                kind: ExternalServiceKind.GITHUB,
-                                                displayName: 'GitHub #1',
-                                                config: '{"githubconfig":true}',
-                                                warning: null,
-                                                lastSyncError: null,
-                                                repoCount: 0,
-                                                lastSyncAt: null,
-                                                nextSyncAt: null,
-                                                updatedAt: '2021-03-15T19:39:11Z',
-                                                createdAt: '2021-03-15T19:39:11Z',
-                                                namespace: null,
-                                                webhookURL: null,
-                                                hasConnectionCheck: true,
-                                                syncJobs: {
-                                                    __typename: 'ExternalServiceSyncJobConnection',
-                                                    totalCount: 1,
-                                                    pageInfo: { endCursor: null, hasNextPage: false },
-                                                    nodes: [
-                                                        {
-                                                            __typename: 'ExternalServiceSyncJob',
-                                                            failureMessage: null,
-                                                            startedAt: subMinutes(new Date(), 25).toISOString(),
-                                                            finishedAt: null,
-                                                            id: 'SYNCJOB1',
-                                                            state: ExternalServiceSyncJobState.PROCESSING,
-                                                            reposSynced: 5,
-                                                            repoSyncErrors: 0,
-                                                            reposAdded: 5,
-                                                            reposDeleted: 0,
-                                                            reposModified: 0,
-                                                            reposUnmodified: 0,
-                                                        },
-                                                    ],
-                                                },
-                                            },
-                                            {
-                                                __typename: 'ExternalService',
-                                                id: 'service2',
-                                                kind: ExternalServiceKind.GITHUB,
-                                                displayName: 'GitHub #2',
-                                                config: '{"githubconfig":true}',
-                                                warning: null,
-                                                lastSyncError: null,
-                                                repoCount: 0,
-                                                lastSyncAt: null,
-                                                nextSyncAt: null,
-                                                updatedAt: '2021-03-15T19:39:11Z',
-                                                createdAt: '2021-03-15T19:39:11Z',
-                                                namespace: {
-                                                    id: 'someuser-id',
-                                                    namespaceName: 'johndoe',
-                                                    url: '/users/johndoe',
-                                                },
-                                                webhookURL: null,
-                                                hasConnectionCheck: false,
-                                                syncJobs: {
-                                                    __typename: 'ExternalServiceSyncJobConnection',
-                                                    totalCount: 1,
-                                                    pageInfo: { endCursor: null, hasNextPage: false },
-                                                    nodes: [
-                                                        {
-                                                            __typename: 'ExternalServiceSyncJob',
-                                                            failureMessage: null,
-                                                            startedAt: subMinutes(new Date(), 25).toISOString(),
-                                                            finishedAt: null,
-                                                            id: 'SYNCJOB2',
-                                                            state: ExternalServiceSyncJobState.COMPLETED,
-                                                            reposSynced: 5,
-                                                            repoSyncErrors: 0,
-                                                            reposAdded: 5,
-                                                            reposDeleted: 0,
-                                                            reposModified: 0,
-                                                            reposUnmodified: 0,
-                                                        },
-                                                    ],
-                                                },
-                                            },
-                                        ],
-                                    },
-                                },
-                            },
-                        },
-                    ])
-                }
-            >
-                <ExternalServicesPage
-                    {...webProps}
-                    routingPrefix="/site-admin"
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                    authenticatedUser={{ id: '123' }}
-                    externalServicesFromFile={false}
-                    allowEditExternalServicesWithFile={false}
-                />
-            </MockedTestProvider>
-        )}
-    </WebStory>
+    <MockedTestProvider
+        link={
+            new WildcardMockLink([
+                {
+                    request: {
+                        query: getDocumentNode(EXTERNAL_SERVICES),
+                        variables: MATCH_ANY_PARAMETERS,
+                    },
+                    nMatches: Number.POSITIVE_INFINITY,
+                    result: {
+                        data: EXTERNAL_SERVICES_DATA_MOCK,
+                    },
+                },
+            ])
+        }
+    >
+        <ExternalServicesPage
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            externalServicesFromFile={false}
+            allowEditExternalServicesWithFile={false}
+        />
+    </MockedTestProvider>
 )
 
 ListOfExternalServices.storyName = 'List of external services'
+
+const EXTERNAL_SERVICES_DATA_MOCK = {
+    externalServices: {
+        totalCount: 2,
+        pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+        },
+        nodes: [
+            {
+                __typename: 'ExternalService',
+                id: 'service1',
+                kind: ExternalServiceKind.GITHUB,
+                displayName: 'GitHub #1',
+                config: '{"githubconfig":true}',
+                warning: null,
+                lastSyncError: null,
+                repoCount: 0,
+                lastSyncAt: null,
+                nextSyncAt: null,
+                updatedAt: '2021-03-15T19:39:11Z',
+                createdAt: '2021-03-15T19:39:11Z',
+                namespace: null,
+                webhookURL: null,
+                hasConnectionCheck: true,
+                syncJobs: {
+                    __typename: 'ExternalServiceSyncJobConnection',
+                    totalCount: 1,
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                    nodes: [
+                        {
+                            __typename: 'ExternalServiceSyncJob',
+                            failureMessage: null,
+                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                            finishedAt: null,
+                            id: 'SYNCJOB1',
+                            state: ExternalServiceSyncJobState.PROCESSING,
+                            reposSynced: 5,
+                            repoSyncErrors: 0,
+                            reposAdded: 5,
+                            reposDeleted: 0,
+                            reposModified: 0,
+                            reposUnmodified: 0,
+                        },
+                    ],
+                },
+            },
+            {
+                __typename: 'ExternalService',
+                id: 'service2',
+                kind: ExternalServiceKind.GITHUB,
+                displayName: 'GitHub #2',
+                config: '{"githubconfig":true}',
+                warning: null,
+                lastSyncError: null,
+                repoCount: 0,
+                lastSyncAt: null,
+                nextSyncAt: null,
+                updatedAt: '2021-03-15T19:39:11Z',
+                createdAt: '2021-03-15T19:39:11Z',
+                namespace: {
+                    id: 'someuser-id',
+                    namespaceName: 'johndoe',
+                    url: '/users/johndoe',
+                },
+                webhookURL: null,
+                hasConnectionCheck: false,
+                syncJobs: {
+                    __typename: 'ExternalServiceSyncJobConnection',
+                    totalCount: 1,
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                    nodes: [
+                        {
+                            __typename: 'ExternalServiceSyncJob',
+                            failureMessage: null,
+                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                            finishedAt: null,
+                            id: 'SYNCJOB2',
+                            state: ExternalServiceSyncJobState.COMPLETED,
+                            reposSynced: 5,
+                            repoSyncErrors: 0,
+                            reposAdded: 5,
+                            reposDeleted: 0,
+                            reposModified: 0,
+                            reposUnmodified: 0,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+}

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect } from 'react'
+import { FC, useEffect } from 'react'
 
 import { mdiPlus } from '@mdi/js'
-import { Redirect } from 'react-router'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ButtonLink, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../../auth'
-import { Scalars } from '../../graphql-operations'
 import {
     ConnectionContainer,
     ConnectionError,
@@ -25,10 +23,6 @@ import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTe
 import { ExternalServiceNode } from './ExternalServiceNode'
 
 interface Props extends TelemetryProps {
-    routingPrefix: string
-    userID?: Scalars['ID']
-    authenticatedUser: Pick<AuthenticatedUser, 'id'>
-
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
 }
@@ -36,11 +30,8 @@ interface Props extends TelemetryProps {
 /**
  * A page displaying the external services on this site.
  */
-export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    routingPrefix,
-    userID,
+export const ExternalServicesPage: FC<Props> = ({
     telemetryService,
-    authenticatedUser,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
 }) => {
@@ -54,10 +45,9 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
     })
 
     const editingDisabled = externalServicesFromFile && !allowEditExternalServicesWithFile
-    const isManagingOtherUser = !!userID && userID !== authenticatedUser.id
 
-    return !isManagingOtherUser && !loading && (connection?.nodes?.length ?? 0) === 0 ? (
-        <Redirect to={`${routingPrefix}/external-services/new`} />
+    return !loading && (connection?.nodes?.length ?? 0) === 0 ? (
+        <Navigate to="/site-admin/external-services/new" replace={true} />
     ) : (
         <div className="site-admin-external-services-page">
             <PageTitle title="Manage code hosts" />
@@ -66,19 +56,15 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
                 description="Manage code host connections to sync repositories."
                 headingElement="h2"
                 actions={
-                    <>
-                        {!isManagingOtherUser && (
-                            <ButtonLink
-                                className="test-goto-add-external-service-page"
-                                to={`${routingPrefix}/external-services/new`}
-                                variant="primary"
-                                as={Link}
-                                disabled={editingDisabled}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Add code host
-                            </ButtonLink>
-                        )}
-                    </>
+                    <ButtonLink
+                        className="test-goto-add-external-service-page"
+                        to="/site-admin/external-services/new"
+                        variant="primary"
+                        as={Link}
+                        disabled={editingDisabled}
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Add code host
+                    </ButtonLink>
                 }
                 className="mb-3"
             />
@@ -92,12 +78,7 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
                     {loading && !connection && <ConnectionLoading />}
                     <ConnectionList as="ul" className="list-group" aria-label="CodeHosts">
                         {connection?.nodes?.map(node => (
-                            <ExternalServiceNode
-                                key={node.id}
-                                node={node}
-                                routingPrefix={routingPrefix}
-                                editingDisabled={editingDisabled}
-                            />
+                            <ExternalServiceNode key={node.id} node={node} editingDisabled={editingDisabled} />
                         ))}
                     </ConnectionList>
                     {connection && (

--- a/client/web/src/enterprise/executors/ExecutorsSiteAdminArea.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsSiteAdminArea.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import { FC } from 'react'
 
-import { Route, Switch } from 'react-router'
+import { Route, Routes } from 'react-router-dom-v5-compat'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -19,19 +19,11 @@ const GlobalExecutorSecretsListPage = lazyComponent<
     'GlobalExecutorSecretsListPage'
 >(() => import('./secrets/ExecutorSecretsListPage'), 'GlobalExecutorSecretsListPage')
 
-const URL = '/site-admin/executors'
-
 /** The page area for all executors settings in site-admin. */
-export const ExecutorsSiteAdminArea: React.FC<{}> = () => (
-    <>
-        <Switch>
-            <Route render={() => <ExecutorsListPage />} path={URL} exact={true} />
-            <Route
-                path={`${URL}/secrets`}
-                render={props => <GlobalExecutorSecretsListPage {...props} />}
-                exact={true}
-            />
-            <Route render={() => <NotFoundPage pageType="settings" />} key="hardcoded-key" />
-        </Switch>
-    </>
+export const ExecutorsSiteAdminArea: FC = () => (
+    <Routes>
+        <Route index={true} element={<ExecutorsListPage />} />
+        <Route path="secrets" element={<GlobalExecutorSecretsListPage />} />
+        <Route element={<NotFoundPage pageType="settings" />} />
+    </Routes>
 )

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { FC, useCallback, useState } from 'react'
 
 import { Button, Container, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -25,9 +25,7 @@ import { ExecutorSecretScopeSelector } from './ExecutorSecretScopeSelector'
 
 export interface GlobalExecutorSecretsListPageProps {}
 
-export const GlobalExecutorSecretsListPage: React.FunctionComponent<
-    React.PropsWithChildren<GlobalExecutorSecretsListPageProps>
-> = props => {
+export const GlobalExecutorSecretsListPage: FC<GlobalExecutorSecretsListPageProps> = props => {
     const connectionLoader = useCallback(
         (scope: ExecutorSecretScope) => globalExecutorSecretsConnectionFactory(scope),
         []
@@ -46,9 +44,7 @@ export interface UserExecutorSecretsListPageProps extends GlobalExecutorSecretsL
     userID: Scalars['ID']
 }
 
-export const UserExecutorSecretsListPage: React.FunctionComponent<
-    React.PropsWithChildren<UserExecutorSecretsListPageProps>
-> = props => {
+export const UserExecutorSecretsListPage: FC<UserExecutorSecretsListPageProps> = props => {
     const connectionLoader = useCallback(
         (scope: ExecutorSecretScope) => userExecutorSecretsConnectionFactory(props.userID, scope),
         [props.userID]
@@ -75,9 +71,7 @@ export interface OrgExecutorSecretsListPageProps extends GlobalExecutorSecretsLi
     orgID: Scalars['ID']
 }
 
-export const OrgExecutorSecretsListPage: React.FunctionComponent<
-    React.PropsWithChildren<OrgExecutorSecretsListPageProps>
-> = props => {
+export const OrgExecutorSecretsListPage: FC<OrgExecutorSecretsListPageProps> = props => {
     const connectionLoader = useCallback(
         (scope: ExecutorSecretScope) => orgExecutorSecretsConnectionFactory(props.orgID, scope),
         [props.orgID]
@@ -106,11 +100,7 @@ export interface ExecutorSecretsListPageProps extends GlobalExecutorSecretsListP
     connectionLoader: (scope: ExecutorSecretScope) => UseShowMorePaginationResult<ExecutorSecretFields>
 }
 
-const ExecutorSecretsListPage: React.FunctionComponent<React.PropsWithChildren<ExecutorSecretsListPageProps>> = ({
-    namespaceID,
-    headerLine,
-    connectionLoader,
-}) => {
+const ExecutorSecretsListPage: FC<ExecutorSecretsListPageProps> = ({ namespaceID, headerLine, connectionLoader }) => {
     const [selectedScope, setSelectedScope] = useState<ExecutorSecretScope>(ExecutorSecretScope.BATCHES)
     const { loading, hasNextPage, fetchMore, connection, error, refetchAll } = connectionLoader(selectedScope)
 

--- a/client/web/src/enterprise/site-admin/routes.tsx
+++ b/client/web/src/enterprise/site-admin/routes.tsx
@@ -134,10 +134,6 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = (
 
         // Code intelligence redirect
         {
-            path: '/code-intelligence',
-            render: () => <NavigateToCodeGraph />,
-        },
-        {
             path: '/code-intelligence/*',
             render: () => <NavigateToCodeGraph />,
         },
@@ -177,11 +173,6 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = (
         },
 
         // Executor routes
-        {
-            path: '/executors',
-            render: () => <ExecutorsSiteAdminArea />,
-            condition: () => Boolean(window.context?.executorsEnabled),
-        },
         {
             path: '/executors/*',
             render: () => <ExecutorsSiteAdminArea />,

--- a/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
+++ b/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
@@ -1,11 +1,10 @@
-import React from 'react'
+import { FC } from 'react'
 
-import { RouteComponentProps, Switch, Route, Redirect } from 'react-router'
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat'
 import { SiteExternalServiceConfigResult, SiteExternalServiceConfigVariables } from 'src/graphql-operations'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -38,11 +37,7 @@ interface Props extends ThemeProps, TelemetryProps, PlatformContextProps, Settin
     authenticatedUser: AuthenticatedUser
 }
 
-const URL = '/site-admin/external-services'
-
-export const SiteAdminExternalServicesArea: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    ...outerProps
-}) => {
+export const SiteAdminExternalServicesArea: FC<Props> = props => {
     const { data, error, loading } = useQuery<SiteExternalServiceConfigResult, SiteExternalServiceConfigVariables>(
         SITE_EXTERNAL_SERVICE_CONFIG,
         {}
@@ -61,65 +56,52 @@ export const SiteAdminExternalServicesArea: React.FunctionComponent<React.PropsW
     }
 
     return (
-        <Switch>
+        <Routes>
             <Route
-                path={URL}
-                render={props => (
+                index={true}
+                element={
                     <ExternalServicesPage
-                        {...outerProps}
                         {...props}
-                        routingPrefix="/site-admin"
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />
-                )}
-                exact={true}
+                }
             />
-            <Route path={URL + '/add'} render={() => <Redirect to="new" />} exact={true} />
+
+            <Route path="/add" element={<Navigate to="new" replace={true} />} />
             <Route
-                path={`${URL}/new`}
-                render={props => (
+                path="new"
+                element={
                     <AddExternalServicesPage
-                        {...outerProps}
                         {...props}
-                        routingPrefix="/site-admin"
                         codeHostExternalServices={codeHostExternalServices}
                         nonCodeHostExternalServices={nonCodeHostExternalServices}
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />
-                )}
-                exact={true}
+                }
             />
             <Route
-                path={`${URL}/:id`}
-                render={({ match, ...props }: RouteComponentProps<{ id: Scalars['ID'] }>) => (
+                path=":externalServiceID"
+                element={
                     <ExternalServicePage
-                        {...outerProps}
                         {...props}
-                        routingPrefix="/site-admin"
                         afterDeleteRoute="/site-admin/external-services"
-                        externalServiceID={match.params.id}
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />
-                )}
-                exact={true}
+                }
             />
             <Route
-                path={`${URL}/:id/edit`}
-                render={({ match, ...props }: RouteComponentProps<{ id: Scalars['ID'] }>) => (
+                path=":externalServiceID/edit"
+                element={
                     <ExternalServiceEditPage
-                        {...outerProps}
                         {...props}
-                        routingPrefix="/site-admin"
-                        externalServiceID={match.params.id}
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />
-                )}
-                exact={true}
+                }
             />
-        </Switch>
+        </Routes>
     )
 }


### PR DESCRIPTION
## Context

- Migrate remaining `<Switch />` instances to `<Routes />`
- Part of #33834 

## Test plan

1. CI
2. visit affected routes manually

## App preview:

- [Web](https://sg-web-vb-react-router-migration-3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
