### PR TITLE
own: add test CODEOWNERS file for dogfooding

### DIFF
--- a/.github/test.CODEOWNERS
+++ b/.github/test.CODEOWNERS
@@ -1,0 +1,261 @@
+# Sourcegraph uses CODENOTIFY to make individuals or groups aware of changes that are happening in code they care about,
+# without explicitly requiring those engineers to "own" the code.
+# This is a test CODEOWNERS file generated from all the CODENOTIFY files in this repository. It is not intended as a
+# move to use CODEOWNERS again, but rather to dogfood our Own product within Sourcegraph (hence the `.test` naming)
+
+.github/workflows/codenotify.yml @unknwon
+.github/workflows/licenses-check.yml          @bobheadxi
+.github/workflows/licenses-update.yml         @bobheadxi
+.github/workflows/renovate-downstream.yml     @bobheadxi
+.github/workflows/renovate-downstream.json    @bobheadxi
+
+client/branded/src/search-ui/components/** @limitedmage @fkling
+
+client/jetbrains/** @vdavid @philipp-spiess
+
+client/shared/src/search/**/* @fkling
+
+client/shared/src/search/query/**/* @fkling
+
+client/web/src/enterprise/batches/**/* @eseliger
+client/web/src/enterprise/batches/**/* @courier-new
+client/web/src/enterprise/batches/**/* @BolajiOlajide
+
+client/web/src/enterprise/code-monitoring/**/* @limitedmage
+
+client/web/src/enterprise/codeintel/**/* @efritz
+
+client/web/src/enterprise/executors/**/* @efritz
+client/web/src/enterprise/executors/**/* @eseliger
+
+client/web/src/integration/batches* @eseliger
+client/web/src/integration/batches* @courier-new
+client/web/src/integration/batches* @BolajiOlajide
+client/web/src/integration/search* @limitedmage
+client/web/src/integration/code-monitoring* @limitedmage
+
+client/web/src/search/**/* @limitedmage @fkling
+
+cmd/blobstore/**/* @slimsag
+
+cmd/frontend/graphqlbackend/observability.go @bobheadxi
+cmd/frontend/graphqlbackend/site_monitoring.go @bobheadxi
+cmd/frontend/graphqlbackend/*search*.go @keegancsmith
+cmd/frontend/graphqlbackend/*zoekt*.go @keegancsmith
+cmd/frontend/graphqlbackend/batches.go @eseliger
+cmd/frontend/graphqlbackend/batches.go @courier-new
+cmd/frontend/graphqlbackend/insights.go @sourcegraph/code-insights-backend
+cmd/frontend/graphqlbackend/codeintel.go @efritz
+cmd/frontend/graphqlbackend/oobmigrations.go @efritz
+
+cmd/frontend/internal/search/** @keegancsmith
+cmd/frontend/internal/search/**/* @camdencheek
+
+cmd/gitserver/server/* @indradhanush
+cmd/gitserver/server/* @sashaostrikov
+
+cmd/repo-updater/* @indradhanush
+cmd/repo-updater/* @sashaostrikov
+
+cmd/searcher/**/* @keegancsmith
+
+cmd/server/internal/goreman/** @keegancsmith
+
+cmd/server/internal/goremancmd/** @keegancsmith
+
+cmd/symbols/** @keegancsmith
+
+cmd/worker/**/* @efritz
+
+dev/authtest/**/* @unknwon
+
+dev/codeintel-qa/**/* @efritz
+
+dev/depgraph/**/* @efritz
+
+dev/gqltest/**/* @unknwon
+
+doc/**/admin/** @sourcegraph/delivery
+doc/dev/background-information/adding_ping_data.md @ebrodymoore @dadlerj
+
+doc/batch_changes/**/* @eseliger
+doc/batch_changes/**/* @courier-new
+
+doc/code_navigation/**/* @efritz
+
+doc/code_search/**/* @rvantonder
+
+doc/dev/adr/**/* @unknwon
+
+doc/dev/background-information/codeintel/**/* @efritz
+
+docker-images/cadvisor/**/* @bobheadxi
+
+docker-images/grafana/**/* @bobheadxi
+
+docker-images/postgres-12-alpine/**/* @sourcegraph/delivery
+
+docker-images/prometheus/**/* @bobheadxi
+
+enterprise/cmd/executor/**/* @efritz
+
+enterprise/cmd/frontend/internal/auth/**/* @unknwon
+
+enterprise/cmd/frontend/internal/authz/**/* @unknwon
+
+enterprise/cmd/frontend/internal/codeintel/**/* @efritz
+
+enterprise/cmd/frontend/internal/executorqueue/**/* @efritz
+enterprise/cmd/frontend/internal/executorqueue/**/* @eseliger
+
+enterprise/cmd/frontend/internal/licensing/**/* @unknwon
+
+enterprise/cmd/migrator/**/* @efritz
+
+enterprise/cmd/precise-code-intel-worker/**/* @efritz
+
+enterprise/cmd/repo-updater/**/* @indradhanush
+
+enterprise/cmd/repo-updater/internal/authz/**/* @unknwon
+
+enterprise/cmd/worker/**/* @efritz
+
+enterprise/cmd/worker/internal/batches/**/* @eseliger
+
+enterprise/cmd/worker/internal/executorqueue/**/* @efritz
+enterprise/cmd/worker/internal/executorqueue/**/* @eseliger
+
+enterprise/cmd/worker/internal/executors/**/* @efritz
+
+enterprise/dev/ci/**/* @bobheadxi
+
+enterprise/internal/authz/**/* @unknwon
+
+enterprise/internal/batches/**/* @eseliger
+
+enterprise/internal/cloud/**/* @unknwon @michaellzc
+
+enterprise/internal/codeintel/**/* @efritz
+enterprise/internal/codeintel/**/* @Strum355
+
+enterprise/internal/database/external_services* @unknwon
+enterprise/internal/database/perms_store* @unknwon
+
+enterprise/internal/executor/**/* @efritz
+
+enterprise/internal/insights/**/* @sourcegraph/code-insights-backend
+
+enterprise/internal/license/**/* @unknwon
+
+enterprise/internal/licensing/**/* @unknwon
+
+internal/authz/**/* @unknwon
+
+internal/codeintel/**/* @efritz
+
+internal/codeintel/dependencies/**/* @mrnugget
+
+internal/database/external* @eseliger
+internal/database/namespaces* @eseliger
+internal/database/repos* @eseliger
+internal/database/permissions* @BolajiOlajide
+internal/database/user_roles* @BolajiOlajide
+internal/database/roles* @BolajiOlajide
+internal/database/role_permissions* @BolajiOlajide
+
+internal/database/basestore/**/* @efritz
+
+internal/database/batch/**/* @efritz
+
+internal/database/connections/**/* @efritz
+
+internal/database/dbconn/**/* @efritz
+
+internal/database/dbtest/**/* @efritz
+
+internal/database/dbutil/**/* @efritz
+
+internal/database/locker/**/* @efritz
+
+internal/database/migration/**/* @efritz
+
+internal/database/postgresdsn/**/* @efritz
+
+internal/debugserver/** @keegancsmith
+
+internal/diskcache/** @keegancsmith
+
+internal/endpoint/** @keegancsmith
+
+internal/env/baseconfig.go @efritz
+
+internal/extsvc/**/* @eseliger
+
+internal/extsvc/auth/**/* @unknwon
+
+internal/gitserver/* @indradhanush
+internal/gitserver/* @sashaostrikov
+
+internal/goroutine/**/* @efritz
+
+internal/gqltestutil/**/* @unknwon
+
+internal/honey/** @keegancsmith
+
+internal/httpcli/** @keegancsmith
+
+internal/lazyregexp/** @keegancsmith
+
+internal/luasandbox/**/* @efritz
+
+internal/mutablelimiter/** @keegancsmith
+
+internal/observation/**/* @sourcegraph/dev-experience
+
+internal/oobmigration/**/* @efritz
+
+internal/rcache/** @keegancsmith
+
+internal/redispool/** @keegancsmith
+
+internal/repos/* @indradhanush
+internal/repos/* @sashaostrikov
+
+internal/search/**/* @keegancsmith
+internal/search/**/* @camdencheek
+
+internal/src-cli/**/* @eseliger
+internal/src-cli/**/* @BolajiOlajide
+internal/src-cli/**/* @courier-new
+
+internal/symbols/** @keegancsmith
+
+internal/sysreq/** @keegancsmith
+
+internal/trace/** @keegancsmith
+internal/trace/**/* @sourcegraph/dev-experience
+
+internal/tracer/** @keegancsmith
+internal/tracer/**/* @sourcegraph/dev-experience
+
+internal/usagestats/batches.go @eseliger
+internal/usagestats/batches_test.go @eseliger
+internal/usagestats/*codeintel*.go @efritz
+
+internal/vcs/** @keegancsmith
+
+internal/workerutil/**/* @efritz
+
+lib/codeintel/**/* @efritz
+
+lib/errors/**/* @sourcegraph/dev-experience
+
+lib/servicecatalog/**/* @sourcegraph/cloud
+lib/servicecatalog/**/* @sourcegraph/security
+
+monitoring/**/* @bobheadxi
+monitoring/**/* @slimsag
+monitoring/**/* @sourcegraph/delivery
+monitoring/frontend.go @efritz
+monitoring/precise_code_intel_* @efritz
+monitoring/precise_code_intel_* @sourcegraph/code-intelligence

--- a/cmd/frontend/backend/own.go
+++ b/cmd/frontend/backend/own.go
@@ -34,12 +34,13 @@ type ownService struct {
 // is expected to be found relative to the repository root directory.
 // These are in line with GitHub and GitLab documentation.
 // https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-// https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 var codeownersLocations = []string{
 	"CODEOWNERS",
 	".github/CODEOWNERS",
 	".gitlab/CODEOWNERS",
 	"docs/CODEOWNERS",
+
+	".github/test.CODEOWNERS", // hardcoded test file for internal dogfooding
 }
 
 // OwnersFile makes a best effort attempt to return a CODEOWNERS file from one of

--- a/cmd/frontend/backend/own.go
+++ b/cmd/frontend/backend/own.go
@@ -35,12 +35,12 @@ type ownService struct {
 // These are in line with GitHub and GitLab documentation.
 // https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 var codeownersLocations = []string{
+	".github/test.CODEOWNERS", // hardcoded test file for internal dogfooding, first for priority.
+
 	"CODEOWNERS",
 	".github/CODEOWNERS",
 	".gitlab/CODEOWNERS",
 	"docs/CODEOWNERS",
-
-	".github/test.CODEOWNERS", // hardcoded test file for internal dogfooding
 }
 
 // OwnersFile makes a best effort attempt to return a CODEOWNERS file from one of

--- a/internal/search/codeownership/job_test.go
+++ b/internal/search/codeownership/job_test.go
@@ -2,6 +2,7 @@ package codeownership
 
 import (
 	"context"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestApplyCodeOwnershipFiltering(t *testing.T) {
@@ -272,7 +272,7 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 			gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
 				content, ok := tt.args.repoContent[file]
 				if !ok {
-					return nil, errors.New("file does not exist")
+					return nil, fs.ErrNotExist
 				}
 				return []byte(content), nil
 			})


### PR DESCRIPTION
As Own grows we will want to have more internal dogfooding. However we don't use CODEOWNERS at Sourcegraph, for [a range of reasons](https://about.sourcegraph.com/blog/a-different-way-to-think-about-code-ownership), but mainly because of the automatic review assignment process it entails. So this adds a CODEOWNERS file in a format that won't get picked up by Github for automatic reviewer selection.

In the future we might want to allow custom CODEOWNERS path for customers such that they can have that same benefit (benefiting from Own features but not the automatic Github review assignment)

The file was generated with https://github.com/leonore/codenotify-codeowners.
```
go build . && ./codenotify-codeowners --path ../sourcegraph
```

## Test plan

Tested locally with the branch:
```
repo:^github\.com/sourcegraph/sourcegraph$ rev:own/add-test-codeowners apache file:has.owner(@vdavid)
```