### PR TITLE
insights: [bug] unable to generate insights diff queries

### DIFF
--- a/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
@@ -49,6 +49,7 @@ func (i insightsDataPointResolver) DiffQuery() (*string, error) {
 	}
 	query, err := querybuilder.PointDiffQuery(*i.diffInfo)
 	if err != nil {
+        // we don't want to error the whole process if diff query building errored.
 		return nil, nil
 	}
 	q := query.String()

--- a/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
@@ -49,7 +49,7 @@ func (i insightsDataPointResolver) DiffQuery() (*string, error) {
 	}
 	query, err := querybuilder.PointDiffQuery(*i.diffInfo)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 	q := query.String()
 	return &q, nil

--- a/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
@@ -49,7 +49,7 @@ func (i insightsDataPointResolver) DiffQuery() (*string, error) {
 	}
 	query, err := querybuilder.PointDiffQuery(*i.diffInfo)
 	if err != nil {
-        // we don't want to error the whole process if diff query building errored.
+		// we don't want to error the whole process if diff query building errored.
 		return nil, nil
 	}
 	q := query.String()


### PR DESCRIPTION
Occasionally attempting to create a diff query for a point on an insight chart is unable to create a valid search.  This field is nullable so in this case just return null so that the preview is covered in errors.
## Test plan
Created know bad capture group insight with `file:data/team\.yml location: (.*)\n` 
Validated that the preview still renders and is not covered in errors.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
