### PR TITLE
ci: build azure images for docker registry

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script builds the executor image as a GCP boot disk image and as an AWS AMI.
+# This script builds the executor image as a GCP boot disk image, AWS AMI, and Azure Disk image.
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -7,6 +7,10 @@ packer {
         googlecompute = {
             version = ">= 1.0.0"
             source  = "github.com/hashicorp/googlecompute"
+       }
+        azure = {
+            version = ">= 1.4.0"
+            source  = "github.com/hashicorp/azure"
         }
     }
 }
@@ -92,10 +96,29 @@ source "amazon-ebs" "aws" {
       }
 }
 
+source "azure-arm" "azure" {
+    # sourcegraph/infrastructure/org/azure
+    client_id = "5caef3ae-85d7-4ee1-bf98-ddc1c3dd7329"
+    resource_group_name = "sourcegraph-ci"
+    storage_account = "virtualmachines"
+
+    capture_container_name = "images"
+    capture_name_prefix = "packer"
+
+    os_type = "Linux"
+    image_publisher = "Canonical"
+    image_offer = "UbuntuServer"
+    image_sku = "20_04"
+
+    location = "East US"
+    vm_size = "Standard_A2"
+}
+
 build {
     sources = [
         "source.googlecompute.gcp",
-        "source.amazon-ebs.aws"
+        "source.amazon-ebs.aws",
+        "source.azure-arm.azure"
     ]
 
     provisioner "shell" {
@@ -107,6 +130,9 @@ build {
             },
             "aws" = {
                 environment_vars = ["PLATFORM_TYPE=aws"]
+            },
+            "azure" = {
+                environment_vars = ["PLATFORM_TYPE=azure"]
             }
         }
     }


### PR DESCRIPTION
Part of: https://github.com/sourcegraph/sourcegraph/issues/47485

Do not merge as is. Reliant on the application registration created [here](https://github.com/sourcegraph/infrastructure/pull/4578) that's reliant on some click-ops created resources.

Build the registry image and push it to Azure

## Test plan
Run it off this branch and give it a whirl.