### PR TITLE
Support repo query in insight data series query preview

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.module.scss
+++ b/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.module.scss
@@ -37,7 +37,6 @@
 
         &__live-preview {
             position: static;
-            min-height: 24rem;
 
             grid-column: 1/3;
             grid-row: 1/2;

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
@@ -17,6 +17,7 @@ import styles from './FormSeries.module.scss'
 export interface FormSeriesProps {
     seriesField: useFieldAPI<EditableDataSeries[]>
     repositories: string[]
+    repoQuery: string | null
     showValidationErrorsOnMount: boolean
 
     /**
@@ -39,6 +40,7 @@ export const FormSeries: FC<FormSeriesProps> = props => {
     const {
         seriesField,
         showValidationErrorsOnMount,
+        repoQuery,
         repositories,
         queryFieldDescription,
         hasAddNewSeriesButton = true,
@@ -58,6 +60,7 @@ export const FormSeries: FC<FormSeriesProps> = props => {
                         index={index + 1}
                         cancel={series.length > 1}
                         autofocus={line.autofocus}
+                        repoQuery={repoQuery}
                         repositories={repositories}
                         queryFieldDescription={queryFieldDescription}
                         className={classNames('p-3', styles.formSeriesItem)}

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
@@ -29,6 +29,12 @@ interface FormSeriesInputProps {
     repositories: string[]
 
     /**
+     * Code Insight repoQuery field string value - repo:github.com/sourcegraph/*
+     * This prop is used in order to generate a proper link for the query preview button.
+     */
+    repoQuery: string | null
+
+    /**
      * This field is only needed for specifying a special compute-specific
      * query field description when this component is used on the compute-powered insight.
      * This prop should be removed when we will have a better form series management
@@ -63,6 +69,7 @@ export const FormSeriesInput: FC<FormSeriesInputProps> = props => {
         className,
         cancel = false,
         autofocus = true,
+        repoQuery,
         repositories,
         queryFieldDescription,
         onCancel = noop,
@@ -133,6 +140,7 @@ export const FormSeriesInput: FC<FormSeriesInputProps> = props => {
                 label="Search query"
                 required={true}
                 as={InsightQueryInput}
+                repoQuery={repoQuery}
                 repositories={repositories}
                 patternType={getQueryPatternTypeFilter(queryField.input.value)}
                 placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"

--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
@@ -27,6 +27,7 @@ import {
     getDefaultInputProps,
     getDefaultInputStatus,
     getDefaultInputError,
+    getRepoQueryPreview,
     RepositoriesField,
     useFieldAPI,
     MonacoField,
@@ -228,7 +229,7 @@ function SmartSearchQueryRepoField(props: SmartSearchQueryRepoFieldProps): React
     }
 
     const queryState = disabled ? EMPTY_QUERY_STATA : value
-    const previewQuery = value.query ? `(${value.query}) archived:yes fork:yes count:all` : value.query
+    const previewQuery = value.query ? getRepoQueryPreview(value.query) : value.query
     const fieldStatus = getDefaultInputStatus(repoQuery, value => value.query)
     const LabelComponent = label ? Label : 'div'
 

--- a/client/web/src/enterprise/insights/components/form/index.ts
+++ b/client/web/src/enterprise/insights/components/form/index.ts
@@ -1,5 +1,6 @@
 // helpers for form-field's setup
 export { getDefaultInputProps, getDefaultInputError, getDefaultInputStatus } from './getDefaultInputProps'
+export { getRepoQueryPreview } from './query-input/utils/generate-repo-filters-query'
 
 // form components
 export { RepositoryField } from './repositories-field/RepositoryField'

--- a/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
@@ -9,7 +9,7 @@ import { QueryChangeSource, QueryState } from '@sourcegraph/shared/src/search'
 import type { MonacoFieldProps } from '../monaco-field'
 import * as Monaco from '../monaco-field'
 
-import { generateRepoFiltersQuery } from './utils/generate-repo-filters-query'
+import { generateRepoFiltersQuery, getRepoQueryPreview } from './utils/generate-repo-filters-query'
 
 import styles from './InsightQueryInput.module.scss'
 
@@ -18,8 +18,9 @@ type MonacoPublicProps = Omit<MonacoFieldProps, 'queryState' | 'onChange' | 'ari
 
 export interface InsightQueryInputProps extends MonacoPublicProps, NativeInputProps {
     value: string
+    repoQuery: string | null
+    repositories: string[]
     patternType: SearchPatternType
-    repositories?: string[]
     onChange: (value: string) => void
 }
 
@@ -28,13 +29,17 @@ export const InsightQueryInput = forwardRef<HTMLInputElement, PropsWithChildren<
         const {
             value,
             patternType,
+            repoQuery,
             repositories = [],
             'aria-invalid': ariaInvalid,
             onChange,
             children,
             ...otherProps
         } = props
-        const previewQuery = `${generateRepoFiltersQuery(repositories)} ${props.value}`.trim()
+
+        const repoQueryPreview =
+            repoQuery !== null ? getRepoQueryPreview(repoQuery) : generateRepoFiltersQuery(repositories)
+        const previewQuery = `${repoQueryPreview} ${props.value}`.trim()
 
         const handleOnChange = (queryState: QueryState): void => {
             if (queryState.query !== value) {

--- a/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
+++ b/client/web/src/enterprise/insights/components/form/query-input/utils/generate-repo-filters-query.ts
@@ -7,3 +7,12 @@ export const generateRepoFiltersQuery = (repositories: string[]): string => {
 
     return ''
 }
+
+/**
+ * Generates extended repositories query that Code Insights backend uses
+ * to gather repositories by query, (we omit archived and fork filters in
+ * user query but use them internally on the backend), there are cases when
+ * we need to use extended query on the client for example in query preview
+ * button
+ */
+export const getRepoQueryPreview = (repoQuery: string): string => `(${repoQuery}) archived:yes fork:yes count:all`

--- a/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
@@ -79,7 +79,7 @@ export const LineChartLivePreview: FC<LineChartLivePreviewProps> = props => {
                 {state.status === LivePreviewStatus.Loading ? (
                     <LivePreviewLoading>Loading code insight</LivePreviewLoading>
                 ) : state.status === LivePreviewStatus.Error ? (
-                    <ErrorAlert error={state.error} />
+                    <ErrorAlert error={state.error} className="m-0" />
                 ) : (
                     <LivePreviewChart>
                         {parent =>

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -112,6 +112,8 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
                         <Input
                             as={CaptureGroupQueryInput}
                             required={true}
+                            // Set repo query to preview only when search query mode is activated
+                            repoQuery={repoMode.input.value === 'search-query' ? repoQuery.input.value.query : null}
                             repositories={repositories.input.value}
                             placeholder="Example: file:\.pom$ <java\.version>(.*)</java\.version>"
                             aria-labelledby="capture-group-query-label"

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -146,6 +146,8 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                 >
                     <FormSeries
                         seriesField={series}
+                        // Compute doesn't support repo query selection
+                        repoQuery={null}
                         repositories={repositories.input.value}
                         showValidationErrorsOnMount={formAPI.submitted}
                         hasAddNewSeriesButton={false}

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
@@ -63,7 +63,7 @@ export const ComputeLivePreview: FC<ComputeLivePreviewProps> = props => {
                 {state.status === LivePreviewStatus.Loading ? (
                     <LivePreviewLoading>Loading code insight</LivePreviewLoading>
                 ) : state.status === LivePreviewStatus.Error ? (
-                    <ErrorAlert error={state.error} />
+                    <ErrorAlert error={state.error} className="m-0" />
                 ) : (
                     <LivePreviewChart>
                         {parent =>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -52,7 +52,7 @@ export const LangStatsInsightLivePreview: FC<LangStatsInsightLivePreviewProps> =
                 {state.status === LivePreviewStatus.Loading ? (
                     <LivePreviewLoading>Loading code insight</LivePreviewLoading>
                 ) : state.status === LivePreviewStatus.Error ? (
-                    <ErrorAlert error={state.error} />
+                    <ErrorAlert error={state.error} className="m-0" />
                 ) : (
                     <LivePreviewChart>
                         {parent =>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
@@ -86,6 +86,8 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
             >
                 <FormSeries
                     seriesField={series}
+                    // Set repo query to preview only when search query mode is activated
+                    repoQuery={repoMode.input.value === 'search-query' ? repoQuery.input.value.query : null}
                     repositories={repositories.input.value}
                     showValidationErrorsOnMount={submitted}
                 />

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -107,6 +107,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
                     label="Data series search query"
                     required={true}
                     as={InsightQueryInput}
+                    repoQuery={null}
                     repositories={repositories.input.value}
                     patternType={getQueryPatternTypeFilter(query.input.value)}
                     placeholder="Example: patternType:regexp const\s\w+:\s(React\.)?FunctionComponent"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/47490

## Test plan
- Fill out repo query and data series query 
- Check that data series query preview contains repo query part
- Check that data series query preview contains repositories from repo picker when Explicit list of repositories is enabled

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-query-preview.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
