### PR TITLE
build-tracker: cache teammates and add a fixed a section

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -53,10 +53,10 @@ func (b *Build) hasFailed() bool {
 	return b.state() == "failed"
 }
 
-// isFixed determines whether the job is considered fixed. A job is fixed when:
+// isFinalized determines whether the job is considered fixed. A job is fixed when:
 // * It has previously failed which means we have sent a notification for it
 // * It is not failed anymore
-func (b *Build) isFixed() bool {
+func (b *Build) isFinalized() bool {
 	// if we have sent a notification previously for this build ie. the build failed previously
 	// and the build is not failed currently = the build must be fixed
 	return !b.hasFailed() && b.hasNotification()

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -229,29 +229,31 @@ func (s *Server) notifyIfFailed(build *Build) error {
 	return nil
 }
 
-func (s *Server) startOldBuildCleaner(every, window time.Duration) func() {
+func (s *Server) deleteOldBuilds(window time.Duration) {
+	oldBuilds := make([]int, 0)
+	now := nowFunc()
+	for _, b := range s.store.FinishedBuilds() {
+		finishedAt := *b.FinishedAt
+		delta := now.Sub(finishedAt.Time)
+		if delta >= window {
+			s.logger.Debug("build past age window", log.Int("buildNumber", *b.Number), log.Time("FinishedAt", finishedAt.Time), log.Duration("window", window))
+			oldBuilds = append(oldBuilds, *b.Number)
+		}
+	}
+	s.logger.Info("deleting old builds", log.Int("oldBuildCount", len(oldBuilds)))
+	s.store.DelByBuildNumber(oldBuilds...)
+}
+
+func (s *Server) startCleaner(every, window time.Duration) func() {
 	ticker := time.NewTicker(every)
 	done := make(chan interface{})
 
-	// We could technically remove  the builds immediately after we've sent a notification for or it, or the build has passed.
-	// But we keep builds a little longer and prediodically clean them out so that we can in future allow possibly querying
-	// of builds and other use cases, like retrying a build etc.
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
-				oldBuilds := make([]int, 0)
-				now := nowFunc()
-				for _, b := range s.store.FinishedBuilds() {
-					finishedAt := *b.FinishedAt
-					delta := now.Sub(finishedAt.Time)
-					if delta >= window {
-						s.logger.Debug("build past age window", log.Int("buildNumber", *b.Number), log.Time("FinishedAt", finishedAt.Time), log.Duration("window", window))
-						oldBuilds = append(oldBuilds, *b.Number)
-					}
-				}
-				s.logger.Info("deleting old builds", log.Int("oldBuildCount", len(oldBuilds)))
-				s.store.DelByBuildNumber(oldBuilds...)
+				s.deleteOldBuilds(window)
+				s.notifyClient.cacheCleanup(int(BuildExpiryWindow.Hours()))
 			case <-done:
 				ticker.Stop()
 				return
@@ -303,7 +305,7 @@ func main() {
 	logger.Info("config loaded from environment", log.Object("config", log.String("SlackChannel", serverConf.SlackChannel), log.Bool("Production", serverConf.Production)))
 	server := NewServer(logger, *serverConf)
 
-	stopFn := server.startOldBuildCleaner(CleanUpInterval, BuildExpiryWindow)
+	stopFn := server.startCleaner(CleanUpInterval, BuildExpiryWindow)
 	defer stopFn()
 
 	if server.config.Production {

--- a/dev/build-tracker/server_test.go
+++ b/dev/build-tracker/server_test.go
@@ -128,7 +128,7 @@ func TestOldBuildsGetDeleted(t *testing.T) {
 		server.store.builds[*b.Number] = b
 		builds := server.store.FinishedBuilds()
 
-		stopFunc := server.startOldBuildCleaner(10*time.Millisecond, 24*time.Hour)
+		stopFunc := server.startCleaner(10*time.Millisecond, 24*time.Hour)
 		time.Sleep(20 * time.Millisecond)
 		stopFunc()
 
@@ -149,7 +149,7 @@ func TestOldBuildsGetDeleted(t *testing.T) {
 		b = finishedBuild(3, "failed", time.Now())
 		server.store.builds[*b.Number] = b
 
-		stopFunc := server.startOldBuildCleaner(10*time.Millisecond, 24*time.Hour)
+		stopFunc := server.startCleaner(10*time.Millisecond, 24*time.Hour)
 		time.Sleep(20 * time.Millisecond)
 		stopFunc()
 

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -86,7 +86,7 @@ func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel s
 
 func (c *NotificationClient) getTeammateForBuild(build *Build) (*team.Teammate, error) {
 	// first check if we already have the details for this teammate
-	c.logger.Debug("determining teammate", log.String("author", stringp(build.authorName)), log.String("commit", build.commit()))
+	c.logger.Debug("determining teammate", log.String("author", build.authorName()), log.String("commit", build.commit()))
 	cached, ok := c.commitTeammateCache[build.commit()]
 
 	// we have the details for this member already!

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -78,7 +78,7 @@ func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel s
 		logger:              logger.Scoped("notificationClient", "client which interacts with Slack and Github to send notifications"),
 		slack:               *slackClient,
 		team:                teamResolver,
-		commitTeammateCache: map[string]cacheItem[*team.Teammate]{},
+		commitTeammateCache: map[string]*cacheItem[*team.Teammate]{},
 		channel:             channel,
 	}
 

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -15,13 +15,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/team"
 )
 
-const JobShowLimit = 10
+const JobShowLimit = 5
 
 type NotificationClient struct {
-	slack   slack.Client
-	team    team.TeammateResolver
-	logger  log.Logger
-	channel string
+	slack               slack.Client
+	team                team.TeammateResolver
+	commitTeammateCache map[string]*team.Teammate
+	logger              log.Logger
+	channel             string
 }
 type SlackNotification struct {
 	// SentAt is the time the notification got sent.
@@ -62,15 +63,32 @@ func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel s
 	teamResolver := team.NewTeammateResolver(githubClient, slackClient)
 
 	return &NotificationClient{
-		logger:  logger.Scoped("notificationClient", "client which interacts with Slack and Github to send notifications"),
-		slack:   *slackClient,
-		team:    teamResolver,
-		channel: channel,
+		logger:              logger.Scoped("notificationClient", "client which interacts with Slack and Github to send notifications"),
+		slack:               *slackClient,
+		team:                teamResolver,
+		commitTeammateCache: map[string]*team.Teammate{},
+		channel:             channel,
 	}
 }
 
 func (c *NotificationClient) getTeammateForBuild(build *Build) (*team.Teammate, error) {
-	return c.team.ResolveByCommitAuthor(context.Background(), "sourcegraph", "sourcegraph", build.commit())
+	// first check if we already have the details for this teammate
+	member, ok := c.commitTeammateCache[build.commit()]
+
+	// we have the details for this member already!
+	if ok {
+		return member, nil
+	}
+
+	result, err := c.team.ResolveByCommitAuthor(context.Background(), "sourcegraph", "sourcegraph", build.commit())
+	if err != nil {
+		return nil, err
+	}
+	// remember this teammate! for this commit
+	// we're not using the author email from the build since might not map 1:1 to the commit author
+	c.commitTeammateCache[build.commit()] = result
+	return result, nil
+
 }
 
 func (c *NotificationClient) sendUpdatedMessage(build *Build, previous *SlackNotification) (*SlackNotification, error) {
@@ -143,24 +161,28 @@ func (c *NotificationClient) createMessageBlocks(logger log.Logger, build *Build
 
 	// create a bulleted list of all the failed jobs
 	//
-	// if there are more than JobShowLimit of failed jobs, we cannot print all of it
-	// since the message will to big and slack will reject the message with "invalid_blocks"
-	failedJobs := build.failedJobs()
-	jobSection := "*Failed jobs:*\n\n"
-	if len(failedJobs) > JobShowLimit {
-		jobSection = fmt.Sprintf("* %d Failed jobs (showing %d):*\n\n", len(failedJobs), JobShowLimit)
-	}
-	logger.Info("failed job count on build", log.Int("failedJobs", len(failedJobs)))
-	for i := 0; i < JobShowLimit && i < len(failedJobs); i++ {
-		j := failedJobs[i]
-		jobSection += fmt.Sprintf("• %s", *j.Name)
-		if j.hasTimedOut() {
-			jobSection += "(Timed out)"
+	filteredJobs := build.Filter(FailedJobFilter, FixedJobFilter)
+
+	jobSection := ""
+	for group, groupJobs := range filteredJobs {
+		jobSection := fmt.Sprintf("*%s jobs:*\n\n", group)
+		// if there are more than JobShowLimit of failed jobs, we cannot print all of it
+		// since the message will to big and slack will reject the message with "invalid_blocks"
+		if len(groupJobs) > JobShowLimit {
+			jobSection = fmt.Sprintf("* %d %s jobs (showing %d):*\n\n", len(groupJobs), group, JobShowLimit)
 		}
-		if j.WebURL != "" {
-			jobSection += fmt.Sprintf(" - <%s|logs>", j.WebURL)
+		logger.Info("group job count on build", log.String("group", group), log.Int("jobs", len(groupJobs)))
+		for i := 0; i < JobShowLimit && i < len(groupJobs); i++ {
+			j := groupJobs[i]
+			jobSection += fmt.Sprintf("• %s", *j.Name)
+			if j.hasTimedOut() {
+				jobSection += " (Timed out)"
+			}
+			if j.WebURL != "" {
+				jobSection += fmt.Sprintf(" - <%s|logs>", j.WebURL)
+			}
+			jobSection += "\n"
 		}
-		jobSection += "\n"
 	}
 
 	failedSection += jobSection
@@ -236,6 +258,9 @@ _Disable flakes on sight and save your fellow teammate some time!_`,
 }
 
 func generateSlackHeader(build *Build) string {
+	if !build.isFixed() {
+		return fmt.Sprintf(":green_circle: Build %d fixed", build.number())
+	}
 	header := fmt.Sprintf(":red_circle: Build %d failed", build.number())
 	switch build.ConsecutiveFailure {
 	case 0, 1: // no suffix

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -86,6 +86,7 @@ func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel s
 
 func (c *NotificationClient) getTeammateForBuild(build *Build) (*team.Teammate, error) {
 	// first check if we already have the details for this teammate
+	c.logger.Debug("determining teammate", log.String("author", stringp(build.authorName)), log.String("commit", build.commit()))
 	cached, ok := c.commitTeammateCache[build.commit()]
 
 	// we have the details for this member already!

--- a/dev/build-tracker/slack_test.go
+++ b/dev/build-tracker/slack_test.go
@@ -216,12 +216,12 @@ func TestCacheClean(t *testing.T) {
 		item := newCacheItem(&team.Teammate{})
 		// subtract 1 year
 		item.Timestamp = time.Now().AddDate(-1, 0, 0)
-		client.commitTeammateCache[fmt.Sprintf("%d", i)] = *item
+		client.commitTeammateCache[fmt.Sprintf("%d", i)] = item
 	}
 	// Add some recent builds
-	client.commitTeammateCache["4"] = *newCacheItem(&team.Teammate{})
-	client.commitTeammateCache["5"] = *newCacheItem(&team.Teammate{})
-	client.commitTeammateCache["6"] = *newCacheItem(&team.Teammate{})
+	client.commitTeammateCache["4"] = newCacheItem(&team.Teammate{})
+	client.commitTeammateCache["5"] = newCacheItem(&team.Teammate{})
+	client.commitTeammateCache["6"] = newCacheItem(&team.Teammate{})
 
 	// Clean up! 3 items should be left
 	// we can put any hours, since our 3 builds are years old

--- a/dev/build-tracker/slack_test.go
+++ b/dev/build-tracker/slack_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/hexops/autogold"
@@ -17,10 +18,13 @@ var RunSlackIntegrationTest = flag.Bool("RunSlackIntegrationTest", false, "Run S
 var RunGitHubIntegrationTest = flag.Bool("RunGitHubIntegrationTest", false, "Run Github integration tests")
 
 func newJob(name string, exit int) *Job {
-	return &Job{buildkite.Job{
-		Name:       &name,
-		ExitStatus: &exit,
-	}}
+	return &Job{
+		Job: buildkite.Job{
+			Name:       &name,
+			ExitStatus: &exit,
+		},
+		fixed: true,
+	}
 
 }
 
@@ -167,6 +171,63 @@ func TestGetTeammateFromBuild(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, teammate.Name, "Ryan Slade")
 	})
+	t.Run("retrieving teammate for build populates cache", func(t *testing.T) {
+		client := NewNotificationClient(logger, config.SlackToken, config.GithubToken, DefaultChannel)
+
+		num := 160000
+		commit := "78926a5b3b836a8a104a5d5adf891e5626b1e405"
+		pipelineID := "sourcegraph"
+		build := &Build{
+			Build: buildkite.Build{
+				Pipeline: &buildkite.Pipeline{
+					ID:   &pipelineID,
+					Name: &pipelineID,
+				},
+				Number: &num,
+				Commit: &commit,
+				Author: &buildkite.Author{
+					Name:  "William Bezuidenhout",
+					Email: "william.bezuidenhout@sourcegraph.com",
+				},
+			},
+			Pipeline: &Pipeline{buildkite.Pipeline{
+				Name: &pipelineID,
+			}},
+			Jobs: map[string]Job{},
+		}
+
+		teammate, err := client.getTeammateForBuild(build)
+		require.NoError(t, err)
+		require.NotNil(t, teammate)
+
+		if _, ok := client.commitTeammateCache[build.commit()]; !ok {
+			t.Fatalf("teammate should exist in cache after first resolve")
+		}
+	})
+}
+
+func TestCacheClean(t *testing.T) {
+	// Populate the cache with items
+	logger := logtest.NoOp(t)
+	client := NewNotificationClient(logger, "testing", "testing", DefaultChannel)
+
+	// Add some old items
+	for i := 0; i < 3; i++ {
+		item := newCacheItem(&team.Teammate{})
+		// subtract 1 year
+		item.Timestamp = time.Now().AddDate(-1, 0, 0)
+		client.commitTeammateCache[fmt.Sprintf("%d", i)] = *item
+	}
+	// Add some recent builds
+	client.commitTeammateCache["4"] = *newCacheItem(&team.Teammate{})
+	client.commitTeammateCache["5"] = *newCacheItem(&team.Teammate{})
+	client.commitTeammateCache["6"] = *newCacheItem(&team.Teammate{})
+
+	// Clean up! 3 items should be left
+	// we can put any hours, since our 3 builds are years old
+	client.cacheCleanup(5)
+
+	require.Equal(t, 3, len(client.commitTeammateCache))
 }
 
 func TestSlackNotification(t *testing.T) {
@@ -354,27 +415,49 @@ func TestServerNotify(t *testing.T) {
 }
 
 func TestGenerateHeader(t *testing.T) {
+	intp := func(v int) *int {
+		return &v
+	}
 	for _, tc := range []struct {
 		build *Build
 		want  autogold.Value // use 'go test -update' to update
 	}{
 		{
 			build: &Build{
+				Build: buildkite.Build{
+					Number: intp(100),
+				},
 				ConsecutiveFailure: 0,
 			},
-			want: autogold.Want("first failure", ":red_circle: Build 0 failed"),
+			want: autogold.Want("first failure", ":red_circle: Build 100 failed"),
 		},
 		{
 			build: &Build{
+				Build: buildkite.Build{
+					Number: intp(100),
+				},
 				ConsecutiveFailure: 1,
 			},
-			want: autogold.Want("second failure", ":red_circle: Build 0 failed"),
+			want: autogold.Want("second failure", ":red_circle: Build 100 failed"),
 		},
 		{
 			build: &Build{
+				Build: buildkite.Build{
+					Number: intp(100),
+				},
 				ConsecutiveFailure: 4,
 			},
-			want: autogold.Want("fifth failure", ":red_circle: Build 0 failed (:bangbang: 4th failure)"),
+			want: autogold.Want("fifth failure", ":red_circle: Build 100 failed (:bangbang: 4th failure)"),
+		},
+		{
+			build: &Build{
+				Build: buildkite.Build{
+					Number: intp(100),
+				},
+				ConsecutiveFailure: 4,
+				Notification:       &SlackNotification{},
+			},
+			want: autogold.Want("fifth failure", ":green_circle: Build 100 fixed"),
 		},
 	} {
 		t.Run(tc.want.Name(), func(t *testing.T) {


### PR DESCRIPTION
We recently started hitting a rate limit for determining teammates from commits because we update slack notifications when a build is retried. This causes increased queries. **THE CACHE IS NOT IDEAL**, future work would be to cache the commit author ... so we log the build author now so that we can in future rather use it. We don't use it now, since I think it is unreliable and returns an empty string sometimes.

We also add a fixed section now. Previously the build would be fixed and hence no "Failed Jobs" but the notification would have a "Failed Jobs" section
## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
