### PR TITLE
rbac: add comment for `GetNamespacePermissionOpts`

### DIFF
--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -136,6 +136,9 @@ const namespacePermissionGetQueryFmtStr = `
 SELECT %s FROM namespace_permissions WHERE %s
 `
 
+// When querying namespace permissions, you need to provide one of the following
+// 1. The ID belonging to the namespace to be retrieved.
+// 2. The Namespace, ResourceID, Action and UserID associated with the namespace permission.
 type GetNamespacePermissionOpts struct {
 	ID         int64
 	Namespace  string


### PR DESCRIPTION
#47130 introduced store methods for `namespace_permissions` - I accidentally merged before including a comment on the `GetNamespacePermissionOpts ` struct. This comment adds more details about what the `.Get` method expects when querying a namespace permission.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
N/A