### PR TITLE
rbac: remove action field from namespace_permissions

### DIFF
--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -17,7 +17,6 @@ var namespacePermissionColumns = []*sqlf.Query{
 	sqlf.Sprintf("namespace_permissions.id"),
 	sqlf.Sprintf("namespace_permissions.namespace"),
 	sqlf.Sprintf("namespace_permissions.resource_id"),
-	sqlf.Sprintf("namespace_permissions.action"),
 	sqlf.Sprintf("namespace_permissions.user_id"),
 	sqlf.Sprintf("namespace_permissions.created_at"),
 }
@@ -25,7 +24,6 @@ var namespacePermissionColumns = []*sqlf.Query{
 var namespacePermissionInsertColums = []*sqlf.Query{
 	sqlf.Sprintf("namespace"),
 	sqlf.Sprintf("resource_id"),
-	sqlf.Sprintf("action"),
 	sqlf.Sprintf("user_id"),
 }
 
@@ -65,7 +63,6 @@ INSERT INTO
 type CreateNamespacePermissionOpts struct {
 	Namespace  types.PermissionNamespace
 	ResourceID int64
-	Action     string
 	UserID     int32
 }
 
@@ -78,10 +75,6 @@ func (n *namespacePermissionStore) Create(ctx context.Context, opts CreateNamesp
 		return nil, errors.New("user id is required")
 	}
 
-	if opts.Action == "" {
-		return nil, errors.New("action is required")
-	}
-
 	if !opts.Namespace.Valid() {
 		return nil, errors.New("valid namespace is required")
 	}
@@ -91,7 +84,6 @@ func (n *namespacePermissionStore) Create(ctx context.Context, opts CreateNamesp
 		sqlf.Join(namespacePermissionInsertColums, ", "),
 		opts.Namespace,
 		opts.ResourceID,
-		opts.Action,
 		opts.UserID,
 		sqlf.Join(namespacePermissionColumns, ", "),
 	)
@@ -151,7 +143,6 @@ type GetNamespacePermissionOpts struct {
 	ID         int64
 	Namespace  types.PermissionNamespace
 	ResourceID int64
-	Action     string
 	UserID     int32
 }
 
@@ -165,7 +156,6 @@ func (n *namespacePermissionStore) Get(ctx context.Context, opts GetNamespacePer
 		conds = append(conds, sqlf.Sprintf("id = %s", opts.ID))
 	} else {
 		conds = append(conds, sqlf.Sprintf("namespace = %s", opts.Namespace))
-		conds = append(conds, sqlf.Sprintf("action = %s", opts.Action))
 		conds = append(conds, sqlf.Sprintf("user_id = %s", opts.UserID))
 		conds = append(conds, sqlf.Sprintf("resource_id = %s", opts.ResourceID))
 	}
@@ -190,9 +180,9 @@ func (n *namespacePermissionStore) Get(ctx context.Context, opts GetNamespacePer
 // isGetNamsepaceOptsValid is used to validate the options passed into the `namespacePermissionStore.Get` method are valid.
 // One of the conditions below need to be valid to execute a Get query.
 // 1. ID is provided
-// 2. Namespace, Actions, UserID and ResourceID is provided.
+// 2. Namespace, UserID and ResourceID is provided.
 func isGetNamsepaceOptsValid(opts GetNamespacePermissionOpts) bool {
-	areNonIDOptsValid := opts.Namespace.Valid() && opts.Action != "" && opts.UserID != 0 && opts.ResourceID != 0
+	areNonIDOptsValid := opts.Namespace.Valid() && opts.UserID != 0 && opts.ResourceID != 0
 	if areNonIDOptsValid || opts.ID != 0 {
 		return true
 	}
@@ -205,7 +195,6 @@ func scanNamespacePermission(sc dbutil.Scanner) (*types.NamespacePermission, err
 		&np.ID,
 		&np.Namespace,
 		&np.ResourceID,
-		&np.Action,
 		&np.UserID,
 		&np.CreatedAt,
 	); err != nil {

--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -138,7 +138,7 @@ SELECT %s FROM namespace_permissions WHERE %s
 
 // When querying namespace permissions, you need to provide one of the following
 // 1. The ID belonging to the namespace to be retrieved.
-// 2. The Namespace, ResourceID, Action and UserID associated with the namespace permission.
+// 2. The Namespace, ResourceID and UserID associated with the namespace permission.
 type GetNamespacePermissionOpts struct {
 	ID         int64
 	Namespace  types.PermissionNamespace

--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -54,7 +54,6 @@ INSERT INTO
 	VALUES (
 		%s,
 		%s,
-		%s,
 		%s
 	)
 	RETURNING %s

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -187,18 +187,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		require.Equal(t, err.Error(), "missing namespace permission query")
 	})
 
-	t.Run("missing action", func(t *testing.T) {
-		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Namespace:  types.BatchChangesNamespace,
-			UserID:     user.ID,
-			ResourceID: 1,
-		})
-
-		require.Nil(t, n)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "missing namespace permission query")
-	})
-
 	t.Run("missing resource id", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
 			Namespace: types.BatchChangesNamespace,

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -41,17 +41,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 		require.ErrorContains(t, err, "user id is required")
 	})
 
-	t.Run("missing action", func(t *testing.T) {
-		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-			ResourceID: 1,
-			UserID:     user.ID,
-		})
-
-		require.Nil(t, np)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "action is required")
-	})
-
 	t.Run("missing namespace", func(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
 			ResourceID: 1,

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -25,7 +25,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
 			Namespace: types.BatchChangesNamespace,
 			UserID:    user.ID,
-			Action:    "READ",
 		})
 		require.Nil(t, np)
 		require.Error(t, err)
@@ -36,7 +35,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
 			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
-			Action:     "READ",
 		})
 		require.Nil(t, np)
 		require.Error(t, err)
@@ -58,7 +56,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
 			ResourceID: 1,
 			UserID:     user.ID,
-			Action:     "READ",
 		})
 
 		require.Nil(t, np)
@@ -70,7 +67,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
 			Namespace:  types.PermissionNamespace("TEST_NAMESPACE"),
 			ResourceID: 1,
-			Action:     "READ",
 			UserID:     user.ID,
 		})
 
@@ -84,7 +80,6 @@ func TestCreateNamespacePermission(t *testing.T) {
 			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			UserID:     user.ID,
-			Action:     "READ",
 		})
 		require.NoError(t, err)
 		require.Equal(t, np.UserID, user.ID)
@@ -120,7 +115,6 @@ func TestDeleteNamespacePermission(t *testing.T) {
 			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			UserID:     user.ID,
-			Action:     "READ",
 		})
 		require.NoError(t, err)
 
@@ -159,7 +153,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		Namespace:  types.BatchChangesNamespace,
 		ResourceID: 1,
 		UserID:     user.ID,
-		Action:     "READ",
 	})
 	require.NoError(t, err)
 
@@ -173,7 +166,6 @@ func TestGetNamespacePermission(t *testing.T) {
 
 	t.Run("missing namespace", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Action:     "READ",
 			UserID:     user.ID,
 			ResourceID: 1,
 		})
@@ -185,7 +177,6 @@ func TestGetNamespacePermission(t *testing.T) {
 
 	t.Run("invalid namespace", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Action:     "READ",
 			UserID:     user.ID,
 			ResourceID: 1,
 			Namespace:  types.PermissionNamespace("TEST-NAMESPACE"),
@@ -212,7 +203,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
 			Namespace: types.BatchChangesNamespace,
 			UserID:    user.ID,
-			Action:    "READ",
 		})
 
 		require.Nil(t, n)
@@ -224,7 +214,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
 			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
-			Action:     "READ",
 		})
 
 		require.Nil(t, n)
@@ -238,7 +227,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, n.ID, np.ID)
 		require.Equal(t, n.Namespace, np.Namespace)
-		require.Equal(t, n.Action, np.Action)
 		require.Equal(t, n.ResourceID, np.ResourceID)
 		require.Equal(t, n.UserID, np.UserID)
 	})
@@ -246,7 +234,6 @@ func TestGetNamespacePermission(t *testing.T) {
 	t.Run("existing namespace permission", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
 			Namespace:  np.Namespace,
-			Action:     np.Action,
 			ResourceID: np.ResourceID,
 			UserID:     np.UserID,
 		})
@@ -254,7 +241,6 @@ func TestGetNamespacePermission(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, n.ID, np.ID)
 		require.Equal(t, n.Namespace, np.Namespace)
-		require.Equal(t, n.Action, np.Action)
 		require.Equal(t, n.ResourceID, np.ResourceID)
 		require.Equal(t, n.UserID, np.UserID)
 	})

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -15011,19 +15011,6 @@
       "Comment": "",
       "Columns": [
         {
-          "Name": "action",
-          "Index": 4,
-          "TypeName": "text",
-          "IsNullable": false,
-          "Default": "",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "created_at",
           "Index": 6,
           "TypeName": "timestamp with time zone",
@@ -15099,26 +15086,9 @@
           "IndexDefinition": "CREATE UNIQUE INDEX namespace_permissions_pkey ON namespace_permissions USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
-        },
-        {
-          "Name": "unique_resource_permission",
-          "IsPrimaryKey": false,
-          "IsUnique": true,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX unique_resource_permission ON namespace_permissions USING btree (namespace, resource_id, action, user_id)",
-          "ConstraintType": "u",
-          "ConstraintDefinition": "UNIQUE (namespace, resource_id, action, user_id)"
         }
       ],
       "Constraints": [
-        {
-          "Name": "action_not_blank",
-          "ConstraintType": "c",
-          "RefTableName": "",
-          "IsDeferrable": false,
-          "ConstraintDefinition": "CHECK (action \u003c\u003e ''::text)"
-        },
         {
           "Name": "namespace_not_blank",
           "ConstraintType": "c",

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -15086,6 +15086,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX namespace_permissions_pkey ON namespace_permissions USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "unique_resource_permission",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX unique_resource_permission ON namespace_permissions USING btree (namespace, resource_id, user_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2279,6 +2279,7 @@ Foreign-key constraints:
  created_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "namespace_permissions_pkey" PRIMARY KEY, btree (id)
+    "unique_resource_permission" UNIQUE, btree (namespace, resource_id, user_id)
 Check constraints:
     "namespace_not_blank" CHECK (namespace <> ''::text)
 Foreign-key constraints:

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2275,14 +2275,11 @@ Foreign-key constraints:
  id          | integer                  |           | not null | nextval('namespace_permissions_id_seq'::regclass)
  namespace   | text                     |           | not null | 
  resource_id | integer                  |           | not null | 
- action      | text                     |           | not null | 
  user_id     | integer                  |           | not null | 
  created_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "namespace_permissions_pkey" PRIMARY KEY, btree (id)
-    "unique_resource_permission" UNIQUE CONSTRAINT, btree (namespace, resource_id, action, user_id)
 Check constraints:
-    "action_not_blank" CHECK (action <> ''::text)
     "namespace_not_blank" CHECK (namespace <> ''::text)
 Foreign-key constraints:
     "namespace_permissions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -881,15 +881,14 @@ type NamespacePermission struct {
 	ID         int64
 	Namespace  PermissionNamespace
 	ResourceID int64
-	Action     string
 	UserID     int32
 	CreatedAt  time.Time
 }
 
 func (n *NamespacePermission) DisplayName() string {
 	// Based on the zanzibar representation for data relations:
-	// <namespace>:<object_id>#<relation>@<user_id | user_group>
-	return fmt.Sprintf("%s:%d#%s@%d", n.Namespace, n.ResourceID, n.Action, n.UserID)
+	// <namespace>:<object_id>#@<user_id | user_group>
+	return fmt.Sprintf("%s:%d@%d", n.Namespace, n.ResourceID, n.UserID)
 }
 
 type OrgMemberAutocompleteSearchItem struct {

--- a/migrations/frontend/1675962678_remove_action_namespace_perms/down.sql
+++ b/migrations/frontend/1675962678_remove_action_namespace_perms/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE namespace_permissions
+ADD COLUMN IF NOT EXISTS action text NOT NULL;

--- a/migrations/frontend/1675962678_remove_action_namespace_perms/down.sql
+++ b/migrations/frontend/1675962678_remove_action_namespace_perms/down.sql
@@ -1,2 +1,6 @@
 ALTER TABLE namespace_permissions
-ADD COLUMN IF NOT EXISTS action text NOT NULL;
+    ADD COLUMN IF NOT EXISTS action text NOT NULL;
+
+ALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_resource_permission ON namespace_permissions (namespace, resource_id, action, user_id);

--- a/migrations/frontend/1675962678_remove_action_namespace_perms/metadata.yaml
+++ b/migrations/frontend/1675962678_remove_action_namespace_perms/metadata.yaml
@@ -1,0 +1,2 @@
+name: remove_action_namespace_perms
+parents: [1675647612]

--- a/migrations/frontend/1675962678_remove_action_namespace_perms/up.sql
+++ b/migrations/frontend/1675962678_remove_action_namespace_perms/up.sql
@@ -1,1 +1,5 @@
 ALTER TABLE namespace_permissions DROP COLUMN IF EXISTS action;
+
+ALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_resource_permission ON namespace_permissions (namespace, resource_id, user_id);

--- a/migrations/frontend/1675962678_remove_action_namespace_perms/up.sql
+++ b/migrations/frontend/1675962678_remove_action_namespace_perms/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE namespace_permissions DROP COLUMN IF EXISTS action;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2973,10 +2973,8 @@ CREATE TABLE namespace_permissions (
     id integer NOT NULL,
     namespace text NOT NULL,
     resource_id integer NOT NULL,
-    action text NOT NULL,
     user_id integer NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT action_not_blank CHECK ((action <> ''::text)),
     CONSTRAINT namespace_not_blank CHECK ((namespace <> ''::text))
 );
 
@@ -4627,9 +4625,6 @@ ALTER TABLE ONLY temporary_settings
 
 ALTER TABLE ONLY temporary_settings
     ADD CONSTRAINT temporary_settings_user_id_key UNIQUE (user_id);
-
-ALTER TABLE ONLY namespace_permissions
-    ADD CONSTRAINT unique_resource_permission UNIQUE (namespace, resource_id, action, user_id);
 
 ALTER TABLE ONLY user_credentials
     ADD CONSTRAINT user_credentials_domain_user_id_external_service_type_exter_key UNIQUE (domain, user_id, external_service_type, external_service_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5058,6 +5058,8 @@ CREATE INDEX sub_repo_perms_user_id ON sub_repo_permissions USING btree (user_id
 
 CREATE UNIQUE INDEX teams_name ON teams USING btree (name);
 
+CREATE UNIQUE INDEX unique_resource_permission ON namespace_permissions USING btree (namespace, resource_id, user_id);
+
 CREATE INDEX user_credentials_credential_idx ON user_credentials USING btree (((encryption_key_id = ANY (ARRAY[''::text, 'previously-migrated'::text]))));
 
 CREATE UNIQUE INDEX user_emails_user_id_is_primary_idx ON user_emails USING btree (user_id, is_primary) WHERE (is_primary = true);


### PR DESCRIPTION
For the RBAC MVP, we want to support namespace permissions at the base level. We don't support different actions at the namespace level yet, and as such, this makes this field redundant. 
This PR removes the `action` column from the `namespace_permissions` table and removes the `action` field from the `NamespacePermission` struct.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Ensure existing unit tests are passing
* Ran `sg migration up` and `sg migration undo -db=frontend` to confirm the migrations work fine.