### PR TITLE
Client routing top level paper cuts

### DIFF
--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -14,7 +14,7 @@ const config = {
        * Primary cause is due to multiple ongoing migrations that mean we are duplicating similar dependencies.
        * Issue to track: https://github.com/sourcegraph/sourcegraph/issues/37845
        */
-      maxSize: '425kb',
+      maxSize: '455kb',
       compression: 'none',
     },
     {

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { ApolloProvider } from '@apollo/client'
 import ServerIcon from 'mdi-react/ServerIcon'
 import { Router } from 'react-router'
-import { CompatRouter, Routes, Route } from 'react-router-dom-v5-compat'
+import { CompatRouter } from 'react-router-dom-v5-compat'
 import { combineLatest, from, Subscription, fromEvent, of, Subject, Observable } from 'rxjs'
 import { first, startWith, switchMap } from 'rxjs/operators'
 import * as uuid from 'uuid'
@@ -356,45 +356,36 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
             >
                 <Router history={globalHistory}>
                     <CompatRouter>
-                        <Routes>
-                            <Route
-                                path="*"
-                                element={
-                                    <Layout
-                                        {...this.props}
-                                        authenticatedUser={authenticatedUser}
-                                        viewerSubject={this.state.viewerSubject}
-                                        settingsCascade={this.state.settingsCascade}
-                                        batchChangesEnabled={this.props.batchChangesEnabled}
-                                        batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                            this.state.settingsCascade
-                                        )}
-                                        batchChangesWebhookLogsEnabled={window.context.batchChangesWebhookLogsEnabled}
-                                        // Search query
-                                        fetchHighlightedFileLineRanges={this.fetchHighlightedFileLineRanges}
-                                        // Extensions
-                                        platformContext={this.platformContext}
-                                        extensionsController={this.extensionsController}
-                                        telemetryService={eventLogger}
-                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                        searchContextsEnabled={this.props.searchContextsEnabled}
-                                        selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                        setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
-                                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                                        fetchSearchContexts={fetchSearchContexts}
-                                        fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                        fetchSearchContext={fetchSearchContext}
-                                        createSearchContext={createSearchContext}
-                                        updateSearchContext={updateSearchContext}
-                                        deleteSearchContext={deleteSearchContext}
-                                        isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                                        globbing={this.state.globbing}
-                                        streamSearch={aggregateStreamingSearch}
-                                        onCreateNotebookFromNotepad={this.onCreateNotebook}
-                                    />
-                                }
-                            />
-                        </Routes>
+                        <Layout
+                            {...this.props}
+                            authenticatedUser={authenticatedUser}
+                            viewerSubject={this.state.viewerSubject}
+                            settingsCascade={this.state.settingsCascade}
+                            batchChangesEnabled={this.props.batchChangesEnabled}
+                            batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(this.state.settingsCascade)}
+                            batchChangesWebhookLogsEnabled={window.context.batchChangesWebhookLogsEnabled}
+                            // Search query
+                            fetchHighlightedFileLineRanges={this.fetchHighlightedFileLineRanges}
+                            // Extensions
+                            platformContext={this.platformContext}
+                            extensionsController={this.extensionsController}
+                            telemetryService={eventLogger}
+                            isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                            searchContextsEnabled={this.props.searchContextsEnabled}
+                            selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                            setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
+                            getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                            fetchSearchContexts={fetchSearchContexts}
+                            fetchSearchContextBySpec={fetchSearchContextBySpec}
+                            fetchSearchContext={fetchSearchContext}
+                            createSearchContext={createSearchContext}
+                            updateSearchContext={updateSearchContext}
+                            deleteSearchContext={deleteSearchContext}
+                            isSearchContextSpecAvailable={isSearchContextSpecAvailable}
+                            globbing={this.state.globbing}
+                            streamSearch={aggregateStreamingSearch}
+                            onCreateNotebookFromNotepad={this.onCreateNotebook}
+                        />
                     </CompatRouter>
                 </Router>
                 {this.extensionsController !== null && window.context.enableLegacyExtensions ? (

--- a/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
@@ -24,7 +24,7 @@
 .input-actions {
     width: 10%;
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-self: stretch;
 }
 

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -7,9 +7,10 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteComponentProps } from '../routes'
 
+import { SearchPage } from './home/SearchPage'
+
 import { parseSearchURLQuery } from '.'
 
-const SearchPage = lazyComponent(() => import('./home/SearchPage'), 'SearchPage')
 const StreamingSearchResults = lazyComponent(() => import('./results/StreamingSearchResults'), 'StreamingSearchResults')
 
 /**


### PR DESCRIPTION
This PR does three things
- Removes top level route from the SourcegraphApp.tsx @valerybugakov 
- Fixes flex-start/start warning cc @umpox 
- Make home page built-in/not lazy loaded (in order to avoid loading spinner flashes) 

## Test plan
- Make sure that top routing is fine (search, search result page work properly)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-clean-up-top-level-routing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
