### PR TITLE
rbac: convert permission namespce to enum

### DIFF
--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -19,7 +19,7 @@ type RoleResolver interface {
 
 type PermissionResolver interface {
 	ID() graphql.ID
-	Namespace() string
+	Namespace() (string, error)
 	DisplayName() string
 	Action() string
 	CreatedAt() gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -78,10 +78,10 @@ type PermissionConnection {
 }
 
 """
-The different namespaces guarded by the RBAC system.
-A namespace represents a project / feature on a Sourcegraph instance.
+A namespace represents a distinct context within which permission policies
+are defined and enforced.
 """
-enum Namespace {
+enum PermissionNamespace {
     """
     This represents the Batch Changes namespace.
     """
@@ -99,7 +99,7 @@ type Permission implements Node {
     """
     The namespace in which this permission belongs to.
     """
-    namespace: Namespace!
+    namespace: PermissionNamespace!
     """
     The unique action which is granted to a bearer of this permission.
     """

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -78,6 +78,17 @@ type PermissionConnection {
 }
 
 """
+The different namespaces guarded by the RBAC system.
+A namespace represents a project / feature on a Sourcegraph instance.
+"""
+enum Namespace {
+    """
+    This represents the Batch Changes namespace.
+    """
+    BATCH_CHANGES
+}
+
+"""
 A permission
 """
 type Permission implements Node {
@@ -88,7 +99,7 @@ type Permission implements Node {
     """
     The namespace in which this permission belongs to.
     """
-    namespace: String!
+    namespace: Namespace!
     """
     The unique action which is granted to a bearer of this permission.
     """

--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -28,7 +28,6 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 		}
 
 		toBeAdded, toBeDeleted := rbac.ComparePermissions(dbPerms, rbac.RBACSchema)
-		scopedLog.Info("RBAC Permissions update", log.Int("added", len(toBeAdded)), log.Int("deleted", len(toBeDeleted)))
 
 		if len(toBeDeleted) > 0 {
 			// We delete all the permissions that need to be deleted from the database. The role <> permissions are
@@ -61,6 +60,7 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 			}
 		}
 
+		scopedLog.Info("RBAC Permissions update", log.Int("added", len(toBeAdded)), log.Int("deleted", len(toBeDeleted)))
 		return nil
 	})
 

--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -28,6 +28,7 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 		}
 
 		toBeAdded, toBeDeleted := rbac.ComparePermissions(dbPerms, rbac.RBACSchema)
+		scopedLog.Info("RBAC Permissions update", log.Int("added", len(toBeAdded)), log.Int("deleted", len(toBeDeleted)))
 
 		if len(toBeDeleted) > 0 {
 			// We delete all the permissions that need to be deleted from the database. The role <> permissions are
@@ -60,7 +61,6 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 			}
 		}
 
-		scopedLog.Info("RBAC Permissions update", log.Int("added", len(toBeAdded)), log.Int("deleted", len(toBeDeleted)))
 		return nil
 	})
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/apitest/types.go
@@ -8,7 +8,7 @@ import (
 type Permission struct {
 	Typename    string `json:"__typename"`
 	ID          string
-	Namespace   types.Namespace
+	Namespace   types.PermissionNamespace
 	DisplayName string
 	Action      string
 	CreatedAt   gqlutil.DateTime

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/apitest/types.go
@@ -1,11 +1,14 @@
 package apitest
 
-import "github.com/sourcegraph/sourcegraph/internal/gqlutil"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
 
 type Permission struct {
 	Typename    string `json:"__typename"`
 	ID          string
-	Namespace   string
+	Namespace   types.Namespace
 	DisplayName string
 	Action      string
 	CreatedAt   gqlutil.DateTime

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permission.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permission.go
@@ -7,6 +7,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type permissionResolver struct {
@@ -28,8 +29,11 @@ func (r *permissionResolver) ID() graphql.ID {
 	return marshalPermissionID(r.permission.ID)
 }
 
-func (r *permissionResolver) Namespace() string {
-	return r.permission.Namespace
+func (r *permissionResolver) Namespace() (string, error) {
+	if r.permission.Namespace.Valid() {
+		return r.permission.Namespace.String(), nil
+	}
+	return "", errors.New("invalid namespace")
 }
 
 func (r *permissionResolver) Action() string {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permission_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permission_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestPermissionResolver(t *testing.T) {
@@ -34,7 +35,7 @@ func TestPermissionResolver(t *testing.T) {
 	adminCtx := actor.WithActor(ctx, actor.FromUser(admin.ID))
 
 	perm, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
-		Namespace: "BATCHCHANGES",
+		Namespace: types.BatchChangesNamespace,
 		Action:    "READ",
 	})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permission_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permission_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/rbac/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -57,8 +57,8 @@ func TestPermissionResolver(t *testing.T) {
 		var response struct{ Node apitest.Permission }
 		errs := apitest.Exec(userCtx, t, s, input, &response, queryPermissionNode)
 
-		assert.Len(t, errs, 1)
-		assert.Equal(t, errs[0].Message, "must be site admin")
+		require.Len(t, errs, 1)
+		require.Equal(t, errs[0].Message, "must be site admin")
 	})
 
 	t.Run(" as site-administrator", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/role_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/role_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestRoleResolver(t *testing.T) {
@@ -33,7 +34,7 @@ func TestRoleResolver(t *testing.T) {
 	adminCtx := actor.WithActor(ctx, actor.FromUser(adminUserID))
 
 	perm, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
-		Namespace: "BATCHCHANGES",
+		Namespace: types.BatchChangesNamespace,
 		Action:    "READ",
 	})
 	if err != nil {

--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -78,8 +78,12 @@ func (n *namespacePermissionStore) Create(ctx context.Context, opts CreateNamesp
 		return nil, errors.New("user id is required")
 	}
 
+	if opts.Action == "" {
+		return nil, errors.New("action is required")
+	}
+
 	if !opts.Namespace.Valid() {
-		return nil, errors.New("invalid namespace")
+		return nil, errors.New("valid namespace is required")
 	}
 
 	q := sqlf.Sprintf(

--- a/internal/database/namespace_permissions.go
+++ b/internal/database/namespace_permissions.go
@@ -63,7 +63,7 @@ INSERT INTO
 `
 
 type CreateNamespacePermissionOpts struct {
-	Namespace  string
+	Namespace  types.PermissionNamespace
 	ResourceID int64
 	Action     string
 	UserID     int32
@@ -76,6 +76,10 @@ func (n *namespacePermissionStore) Create(ctx context.Context, opts CreateNamesp
 
 	if opts.UserID == 0 {
 		return nil, errors.New("user id is required")
+	}
+
+	if !opts.Namespace.Valid() {
+		return nil, errors.New("invalid namespace")
 	}
 
 	q := sqlf.Sprintf(
@@ -141,7 +145,7 @@ SELECT %s FROM namespace_permissions WHERE %s
 // 2. The Namespace, ResourceID, Action and UserID associated with the namespace permission.
 type GetNamespacePermissionOpts struct {
 	ID         int64
-	Namespace  string
+	Namespace  types.PermissionNamespace
 	ResourceID int64
 	Action     string
 	UserID     int32
@@ -184,7 +188,7 @@ func (n *namespacePermissionStore) Get(ctx context.Context, opts GetNamespacePer
 // 1. ID is provided
 // 2. Namespace, Actions, UserID and ResourceID is provided.
 func isGetNamsepaceOptsValid(opts GetNamespacePermissionOpts) bool {
-	areNonIDOptsValid := opts.Namespace != "" && opts.Action != "" && opts.UserID != 0 && opts.ResourceID != 0
+	areNonIDOptsValid := opts.Namespace.Valid() && opts.Action != "" && opts.UserID != 0 && opts.ResourceID != 0
 	if areNonIDOptsValid || opts.ID != 0 {
 		return true
 	}

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -23,7 +23,7 @@ func TestCreateNamespacePermission(t *testing.T) {
 
 	t.Run("missing resource id", func(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-			Namespace: "TestNamespace",
+			Namespace: types.BatchChangesNamespace,
 			UserID:    user.ID,
 			Action:    "READ",
 		})
@@ -34,7 +34,7 @@ func TestCreateNamespacePermission(t *testing.T) {
 
 	t.Run("missing user id", func(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-			Namespace:  "TestNamespace",
+			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			Action:     "READ",
 		})
@@ -43,9 +43,45 @@ func TestCreateNamespacePermission(t *testing.T) {
 		require.ErrorContains(t, err, "user id is required")
 	})
 
+	t.Run("missing action", func(t *testing.T) {
+		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+			ResourceID: 1,
+			UserID:     user.ID,
+		})
+
+		require.Nil(t, np)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "action is required")
+	})
+
+	t.Run("missing namespace", func(t *testing.T) {
+		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+			ResourceID: 1,
+			UserID:     user.ID,
+			Action:     "READ",
+		})
+
+		require.Nil(t, np)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "valid namespace is required")
+	})
+
+	t.Run("invalid namespace", func(t *testing.T) {
+		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
+			Namespace:  types.PermissionNamespace("TEST_NAMESPACE"),
+			ResourceID: 1,
+			Action:     "READ",
+			UserID:     user.ID,
+		})
+
+		require.Nil(t, np)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "valid namespace is required")
+	})
+
 	t.Run("success", func(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-			Namespace:  "TestNamespace",
+			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			UserID:     user.ID,
 			Action:     "READ",
@@ -81,7 +117,7 @@ func TestDeleteNamespacePermission(t *testing.T) {
 
 	t.Run("existing namespace permissions", func(t *testing.T) {
 		np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-			Namespace:  "TestNamespace",
+			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			UserID:     user.ID,
 			Action:     "READ",
@@ -120,7 +156,7 @@ func TestGetNamespacePermission(t *testing.T) {
 	user := createUserForNamespacePermission(ctx, t, db, "user1")
 
 	np, err := store.Create(ctx, CreateNamespacePermissionOpts{
-		Namespace:  "TESTNAMESPACE",
+		Namespace:  types.BatchChangesNamespace,
 		ResourceID: 1,
 		UserID:     user.ID,
 		Action:     "READ",
@@ -147,9 +183,22 @@ func TestGetNamespacePermission(t *testing.T) {
 		require.Equal(t, err.Error(), "missing namespace permission query")
 	})
 
+	t.Run("invalid namespace", func(t *testing.T) {
+		n, err := store.Get(ctx, GetNamespacePermissionOpts{
+			Action:     "READ",
+			UserID:     user.ID,
+			ResourceID: 1,
+			Namespace:  types.PermissionNamespace("TEST-NAMESPACE"),
+		})
+
+		require.Nil(t, n)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "missing namespace permission query")
+	})
+
 	t.Run("missing action", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Namespace:  "BATCH_CHANGES",
+			Namespace:  types.BatchChangesNamespace,
 			UserID:     user.ID,
 			ResourceID: 1,
 		})
@@ -161,7 +210,7 @@ func TestGetNamespacePermission(t *testing.T) {
 
 	t.Run("missing resource id", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Namespace: "BATCH_CHANGES",
+			Namespace: types.BatchChangesNamespace,
 			UserID:    user.ID,
 			Action:    "READ",
 		})
@@ -173,7 +222,7 @@ func TestGetNamespacePermission(t *testing.T) {
 
 	t.Run("missing user id", func(t *testing.T) {
 		n, err := store.Get(ctx, GetNamespacePermissionOpts{
-			Namespace:  "BATCH_CHANGES",
+			Namespace:  types.BatchChangesNamespace,
 			ResourceID: 1,
 			Action:     "READ",
 		})

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -50,7 +50,7 @@ type PermissionStore interface {
 }
 
 type CreatePermissionOpts struct {
-	Namespace string
+	Namespace types.PermissionNamespace
 	Action    string
 }
 
@@ -106,6 +106,10 @@ func (p *permissionStore) WithTransact(ctx context.Context, f func(PermissionSto
 }
 
 func (p *permissionStore) Create(ctx context.Context, opts CreatePermissionOpts) (*types.Permission, error) {
+	if opts.Action != "" || opts.Namespace.Valid() {
+		return nil, errors.New("a valid action and namespace is required")
+	}
+
 	q := sqlf.Sprintf(
 		permissionCreateQueryFmtStr,
 		sqlf.Join(permissionInsertColumns, ", "),
@@ -138,6 +142,9 @@ func scanPermission(sc dbutil.Scanner) (*types.Permission, error) {
 func (p *permissionStore) BulkCreate(ctx context.Context, opts []CreatePermissionOpts) ([]*types.Permission, error) {
 	var values []*sqlf.Query
 	for _, opt := range opts {
+		if !opt.Namespace.Valid() {
+			return nil, errors.New("invalid namespace")
+		}
 		values = append(values, sqlf.Sprintf("(%s, %s)", opt.Namespace, opt.Action))
 	}
 

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -106,8 +106,8 @@ func (p *permissionStore) WithTransact(ctx context.Context, f func(PermissionSto
 }
 
 func (p *permissionStore) Create(ctx context.Context, opts CreatePermissionOpts) (*types.Permission, error) {
-	if opts.Action != "" || opts.Namespace.Valid() {
-		return nil, errors.New("a valid action and namespace is required")
+	if opts.Action == "" || !opts.Namespace.Valid() {
+		return nil, errors.New("valid action and namespace is required")
 	}
 
 	q := sqlf.Sprintf(
@@ -143,7 +143,7 @@ func (p *permissionStore) BulkCreate(ctx context.Context, opts []CreatePermissio
 	var values []*sqlf.Query
 	for _, opt := range opts {
 		if !opt.Namespace.Valid() {
-			return nil, errors.New("invalid namespace")
+			return nil, errors.New("valid namespace is required")
 		}
 		values = append(values, sqlf.Sprintf("(%s, %s)", opt.Namespace, opt.Action))
 	}

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -208,10 +208,11 @@ func TestPermissionBulkCreate(t *testing.T) {
 			{Action: "READ", Namespace: types.PermissionNamespace("TEST-NAMESPACE")},
 		}
 
-	ps, err := store.BulkCreate(ctx, perms)
-	require.NoError(t, err)
-	require.NotNil(t, ps)
-	require.Len(t, ps, 5)
+		ps, err := store.BulkCreate(ctx, opts)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+		require.Len(t, ps, 5)
+	})
 }
 
 func TestPermissionBulkDelete(t *testing.T) {

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -178,7 +178,7 @@ func TestPermissionBulkCreate(t *testing.T) {
 		}
 		perms = append(perms, CreatePermissionOpts{
 			Action:    action,
-			Namespace: fmt.Sprintf("namespace-%d", i),
+			Namespace: types.PermissionNamespace(fmt.Sprintf("namespace-%d", i)),
 		})
 	}
 
@@ -206,7 +206,7 @@ func TestPermissionBulkDelete(t *testing.T) {
 		}
 		perms = append(perms, CreatePermissionOpts{
 			Action:    action,
-			Namespace: fmt.Sprintf("namespace-for-deletion-%d", i),
+			Namespace: types.PermissionNamespace(fmt.Sprintf("namespace-for-deletion-%d", i)),
 		})
 	}
 
@@ -332,7 +332,7 @@ func createTestPermissions(ctx context.Context, t *testing.T, store PermissionSt
 	totalPerms := 10
 	for i := 1; i <= totalPerms; i++ {
 		permission, err := store.Create(ctx, CreatePermissionOpts{
-			Namespace: fmt.Sprintf("PERMISSION-%d", i),
+			Namespace: types.PermissionNamespace(fmt.Sprintf("PERMISSION-%d", i)),
 			Action:    "READ",
 		})
 		require.NoError(t, err)

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -21,7 +21,7 @@ func TestPermissionGetByID(t *testing.T) {
 	store := db.Permissions()
 
 	created, err := store.Create(ctx, CreatePermissionOpts{
-		Namespace: "BATCHCHANGES",
+		Namespace: types.BatchChangesNamespace,
 		Action:    "READ",
 	})
 	if err != nil {
@@ -59,11 +59,46 @@ func TestPermissionCreate(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.Permissions()
 
-	_, err := store.Create(ctx, CreatePermissionOpts{
-		Namespace: "BATCHCHANGES",
-		Action:    "READ",
+	t.Run("invalid namespace", func(t *testing.T) {
+		p, err := store.Create(ctx, CreatePermissionOpts{
+			Namespace: types.PermissionNamespace("TEST-NAMESPACE"),
+			Action:    "READ",
+		})
+
+		require.Nil(t, p)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "valid action and namespace is required")
 	})
-	require.NoError(t, err)
+
+	t.Run("missing namespace", func(t *testing.T) {
+		p, err := store.Create(ctx, CreatePermissionOpts{
+			Action: "READ",
+		})
+
+		require.Nil(t, p)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "valid action and namespace is required")
+	})
+
+	t.Run("missing action", func(t *testing.T) {
+		p, err := store.Create(ctx, CreatePermissionOpts{
+			Namespace: types.PermissionNamespace("TEST-NAMESPACE"),
+		})
+
+		require.Nil(t, p)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "valid action and namespace is required")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		p, err := store.Create(ctx, CreatePermissionOpts{
+			Namespace: types.BatchChangesNamespace,
+			Action:    "READ",
+		})
+
+		require.NotNil(t, p)
+		require.NoError(t, err)
+	})
 }
 
 func TestPermissionList(t *testing.T) {
@@ -132,7 +167,7 @@ func TestPermissionDelete(t *testing.T) {
 	store := db.Permissions()
 
 	p, err := store.Create(ctx, CreatePermissionOpts{
-		Namespace: "BATCHCHANGES",
+		Namespace: types.BatchChangesNamespace,
 		Action:    "READ",
 	})
 	require.NoError(t, err)
@@ -168,19 +203,10 @@ func TestPermissionBulkCreate(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.Permissions()
 
-	var perms []CreatePermissionOpts
-	for i := 1; i <= 5; i++ {
-		var action string
-		if i%2 == 0 {
-			action = "READ"
-		} else {
-			action = "WRITE"
+	t.Run("invalid namespace", func(t *testing.T) {
+		opts := []CreatePermissionOpts{
+			{Action: "READ", Namespace: types.PermissionNamespace("TEST-NAMESPACE")},
 		}
-		perms = append(perms, CreatePermissionOpts{
-			Action:    action,
-			Namespace: types.PermissionNamespace(fmt.Sprintf("namespace-%d", i)),
-		})
-	}
 
 	ps, err := store.BulkCreate(ctx, perms)
 	require.NoError(t, err)
@@ -205,8 +231,8 @@ func TestPermissionBulkDelete(t *testing.T) {
 			action = "WRITE"
 		}
 		perms = append(perms, CreatePermissionOpts{
-			Action:    action,
-			Namespace: types.PermissionNamespace(fmt.Sprintf("namespace-for-deletion-%d", i)),
+			Action:    fmt.Sprintf("%s-%d", action, i),
+			Namespace: types.BatchChangesNamespace,
 		})
 	}
 
@@ -222,7 +248,6 @@ func TestPermissionBulkDelete(t *testing.T) {
 
 	t.Run("no options provided", func(t *testing.T) {
 		err = store.BulkDelete(ctx, []DeletePermissionOpts{})
-
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "missing ids from sql query")
 	})
@@ -332,8 +357,8 @@ func createTestPermissions(ctx context.Context, t *testing.T, store PermissionSt
 	totalPerms := 10
 	for i := 1; i <= totalPerms; i++ {
 		permission, err := store.Create(ctx, CreatePermissionOpts{
-			Namespace: types.PermissionNamespace(fmt.Sprintf("PERMISSION-%d", i)),
-			Action:    "READ",
+			Namespace: types.BatchChangesNamespace,
+			Action:    fmt.Sprintf("READ-%d", i),
 		})
 		require.NoError(t, err)
 		permissions = append(permissions, permission)

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -209,9 +209,30 @@ func TestPermissionBulkCreate(t *testing.T) {
 		}
 
 		ps, err := store.BulkCreate(ctx, opts)
+		require.ErrorContains(t, err, "valid namespace is required")
+		require.Nil(t, ps)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		noOfPerms := 5
+		var opts []CreatePermissionOpts
+		for i := 1; i <= noOfPerms; i++ {
+			var action string
+			if i%2 == 0 {
+				action = "READ"
+			} else {
+				action = "WRITE"
+			}
+			opts = append(opts, CreatePermissionOpts{
+				Action:    fmt.Sprintf("%s-%d", action, i),
+				Namespace: types.BatchChangesNamespace,
+			})
+		}
+
+		ps, err := store.BulkCreate(ctx, opts)
 		require.NoError(t, err)
 		require.NotNil(t, ps)
-		require.Len(t, ps, 5)
+		require.Len(t, ps, noOfPerms)
 	})
 }
 

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -335,7 +335,7 @@ func TestRolePermissionDelete(t *testing.T) {
 	})
 }
 
-func createTestPermissionForRolePermission(ctx context.Context, namespace, action string, t *testing.T, db DB) *types.Permission {
+func createTestPermissionForRolePermission(ctx context.Context, namespace types.PermissionNamespace, action string, t *testing.T, db DB) *types.Permission {
 	t.Helper()
 	p, err := db.Permissions().Create(ctx, CreatePermissionOpts{
 		Namespace: namespace,
@@ -350,7 +350,7 @@ func createTestPermissionForRolePermission(ctx context.Context, namespace, actio
 
 func createRoleAndPermission(ctx context.Context, t *testing.T, db DB) (*types.Role, *types.Permission) {
 	t.Helper()
-	permission := createTestPermissionForRolePermission(ctx, "BATCHCHANGE", "READ", t, db)
+	permission := createTestPermissionForRolePermission(ctx, types.BatchChangesNamespace, "READ", t, db)
 	role := createTestRoleForRolePermission(ctx, "TEST ROLE", t, db)
 	return role, permission
 }

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -193,7 +193,7 @@ func TestRolePermissionGetByRoleID(t *testing.T) {
 
 	totalRolePermissions := 5
 	for i := 1; i <= totalRolePermissions; i++ {
-		p := createTestPermissionForRolePermission(ctx, "BATCH CHANGES", fmt.Sprintf("action-%d", i), t, db)
+		p := createTestPermissionForRolePermission(ctx, fmt.Sprintf("action-%d", i), t, db)
 		_, err := store.Assign(ctx, AssignRolePermissionOpts{
 			RoleID:       r.ID,
 			PermissionID: p.ID,

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -232,7 +232,7 @@ func TestRolePermissionGetByPermissionID(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.RolePermissions()
 
-	p := createTestPermissionForRolePermission(ctx, "BATCH CHANGES", "READ", t, db)
+	p := createTestPermissionForRolePermission(ctx, "READ", t, db)
 
 	totalRolePermissions := 5
 	for i := 1; i <= totalRolePermissions; i++ {
@@ -335,10 +335,10 @@ func TestRolePermissionDelete(t *testing.T) {
 	})
 }
 
-func createTestPermissionForRolePermission(ctx context.Context, namespace types.PermissionNamespace, action string, t *testing.T, db DB) *types.Permission {
+func createTestPermissionForRolePermission(ctx context.Context, action string, t *testing.T, db DB) *types.Permission {
 	t.Helper()
 	p, err := db.Permissions().Create(ctx, CreatePermissionOpts{
-		Namespace: namespace,
+		Namespace: types.BatchChangesNamespace,
 		Action:    action,
 	})
 	if err != nil {
@@ -350,7 +350,7 @@ func createTestPermissionForRolePermission(ctx context.Context, namespace types.
 
 func createRoleAndPermission(ctx context.Context, t *testing.T, db DB) (*types.Role, *types.Permission) {
 	t.Helper()
-	permission := createTestPermissionForRolePermission(ctx, types.BatchChangesNamespace, "READ", t, db)
+	permission := createTestPermissionForRolePermission(ctx, "READ", t, db)
 	role := createTestRoleForRolePermission(ctx, "TEST ROLE", t, db)
 	return role, permission
 }

--- a/internal/rbac/types.go
+++ b/internal/rbac/types.go
@@ -1,5 +1,7 @@
 package rbac
 
+import "github.com/sourcegraph/sourcegraph/internal/types"
+
 // Schema refers to the RBAC structure which acts as a source of truth for permissions within
 // the RBAC system.
 type Schema struct {
@@ -8,6 +10,6 @@ type Schema struct {
 
 // Namespace represents a feature to be guarded by RBAC. (example: Batch Changes, Code Insights e.t.c)
 type Namespace struct {
-	Name    string   `json:"name"`
-	Actions []string `json:"actions"`
+	Name    types.PermissionNamespace `json:"name"`
+	Actions []string                  `json:"actions"`
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -814,8 +814,12 @@ type UserForSCIM struct {
 
 type SystemRole string
 
-var (
-	UserSystemRole              SystemRole = "USER"
+const (
+	// UserSystemRole represents the role associated with all users on a Sourcegraph instance.
+	UserSystemRole SystemRole = "USER"
+
+	// SiteAdministratorSystemRole represents the role associated with Site Administrators
+	// on a sourcegraph instance.
 	SiteAdministratorSystemRole SystemRole = "SITE_ADMINISTRATOR"
 )
 
@@ -826,9 +830,31 @@ type Role struct {
 	CreatedAt time.Time
 }
 
+// A PermissionNamespace represents a distinct context within which permission policies
+// are defined and enforced.
+type PermissionNamespace string
+
+func (n PermissionNamespace) String() string {
+	return string(n)
+}
+
+// Valid checks if a namespace is valid and supported by the Sourcegraph RBAC system.
+func (n PermissionNamespace) Valid() bool {
+	switch n {
+	case BatchChangesNamespace, NotebookNamespace:
+		return true
+	default:
+		return false
+	}
+}
+
+// BatchChangesNamespace represents the Batch Changes namespace.
+const BatchChangesNamespace PermissionNamespace = "BATCH_CHANGES"
+const NotebookNamespace PermissionNamespace = "NOTEBOOKS"
+
 type Permission struct {
 	ID        int32
-	Namespace string
+	Namespace PermissionNamespace
 	Action    string
 	CreatedAt time.Time
 }
@@ -854,7 +880,7 @@ type UserRole struct {
 
 type NamespacePermission struct {
 	ID         int64
-	Namespace  string
+	Namespace  PermissionNamespace
 	ResourceID int64
 	Action     string
 	UserID     int32

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -841,7 +841,7 @@ func (n PermissionNamespace) String() string {
 // Valid checks if a namespace is valid and supported by the Sourcegraph RBAC system.
 func (n PermissionNamespace) Valid() bool {
 	switch n {
-	case BatchChangesNamespace, NotebookNamespace:
+	case BatchChangesNamespace:
 		return true
 	default:
 		return false
@@ -850,7 +850,6 @@ func (n PermissionNamespace) Valid() bool {
 
 // BatchChangesNamespace represents the Batch Changes namespace.
 const BatchChangesNamespace PermissionNamespace = "BATCH_CHANGES"
-const NotebookNamespace PermissionNamespace = "NOTEBOOKS"
 
 type Permission struct {
 	ID        int32


### PR DESCRIPTION
Closes #47468

This PR adds an extra validation to `Permission` and `NamespacePermission` by ensuring only valid namespaces can be created and queried via the GraphQL API.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Updated and ran unit tests