### PR TITLE
Remove jsprism pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,6 @@
     "history": "4.5.1",
     "cssnano": "4.1.10",
     "webpack": "5",
-    "tslib": "2.1.0",
-    "jsprim": "1.4.2"
+    "tslib": "2.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ overrides:
   cssnano: 4.1.10
   webpack: '5'
   tslib: 2.1.0
-  jsprim: 1.4.2
 
 packageExtensionsChecksum: 4b1de42ef6cd5dc58798836c97782882
 


### PR DESCRIPTION
Doesn't seem like we use jsprism anywhere so we can remove the version pin.

## Test plan

- Grep for `jsprism` and observe 0 results
- Pray for CI to pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-rm-jsprism-pin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
