### PR TITLE
web: migrate `Redirect` to `Navigate`

### DIFF
--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -1,4 +1,3 @@
-import { Redirect } from 'react-router'
 import { Navigate } from 'react-router-dom-v5-compat'
 
 import { isErrorLike } from '@sourcegraph/common'
@@ -98,7 +97,7 @@ export const enterpriseRoutes: readonly LayoutRouteProps[] = [
         render: props => {
             const { showSearchNotebook } = useExperimentalFeatures.getState()
 
-            return showSearchNotebook ? <NotebookPage {...props} /> : <Redirect to={PageRoutes.Search} />
+            return showSearchNotebook ? <NotebookPage {...props} /> : <Navigate to={PageRoutes.Search} replace={true} />
         },
     },
     {

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
-import { Redirect } from 'react-router'
-import { useLocation } from 'react-router-dom-v5-compat'
+import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 
 import {
@@ -53,7 +52,7 @@ export const AuthenticatedCreateSearchContextPage: React.FunctionComponent<
     )
 
     if (!authenticatedUser) {
-        return <Redirect to="/sign-in" />
+        return <Navigate to="/sign-in" replace={true} />
     }
 
     return (

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-import { Redirect } from 'react-router'
+import { Navigate } from 'react-router-dom-v5-compat'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
@@ -32,7 +32,7 @@ export const CreateNotebookPage: React.FunctionComponent<
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookCreated')
-        return <Redirect to={EnterprisePageRoutes.Notebook.replace(':id', notebookOrError.id)} />
+        return <Navigate to={EnterprisePageRoutes.Notebook.replace(':id', notebookOrError.id)} replace={true} />
     }
 
     return (

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -3,8 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { mdiPlayCircleOutline, mdiDownload, mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
-import { useLocation } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 import { catchError, delay, startWith, switchMap, tap } from 'rxjs/operators'
 
@@ -464,7 +463,9 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
         }, [])
 
         if (copiedNotebookOrError && !isErrorLike(copiedNotebookOrError) && copiedNotebookOrError !== LOADING) {
-            return <Redirect to={EnterprisePageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} />
+            return (
+                <Navigate to={EnterprisePageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} replace={true} />
+            )
         }
 
         return (

--- a/client/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -16,7 +16,7 @@ describe('SiteInitPage', () => {
     })
 
     test('site already initialized', () => {
-        const history = createMemoryHistory({ initialEntries: ['/'] })
+        const history = createMemoryHistory({ initialEntries: ['/init'] })
         renderWithBrandedContext(
             <SiteInitPage
                 isLightTheme={true}
@@ -29,7 +29,7 @@ describe('SiteInitPage', () => {
                     authMinPasswordLength: 12,
                 }}
             />,
-            { history }
+            { history, path: '/init' }
         )
         expect(history.location.pathname).toEqual('/search')
     })

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Redirect } from 'react-router'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { logger } from '@sourcegraph/common'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -68,7 +68,7 @@ export const SiteInitPage: React.FunctionComponent<React.PropsWithChildren<Props
     context,
 }) => {
     if (!needsSiteInit) {
-        return <Redirect to={PageRoutes.Search} />
+        return <Navigate to={PageRoutes.Search} replace={true} />
     }
 
     return (

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -1,4 +1,4 @@
-import { Redirect } from 'react-router-dom'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Text } from '@sourcegraph/wildcard'
@@ -50,7 +50,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'password',
-        render: () => <Redirect to="./security" />,
+        render: () => <Navigate to="../security" replace={true} />,
     },
     {
         path: 'emails',


### PR DESCRIPTION
## Context

- Part of #33834 

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-react-router-migration-5.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
