### PR TITLE
web: drop `RouteDescriptor` and update imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -217,21 +217,6 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
         message:
           'Use `useNavigate` from `react-router-dom-v5-compat` if possible. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
       },
-      {
-        selector: 'ImportSpecifier[imported.name="RouteDescriptor"]',
-        message:
-          'Use `RouteV6Descriptor` instead. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
-      },
-      {
-        selector: 'ImportSpecifier[imported.name="RouteComponentProps"]',
-        message:
-          'Use `react-router-dom-v5-compat` hooks instead. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
-      },
-      {
-        selector: 'TSInterfaceHeritage[expression.name="RouteComponentProps"]',
-        message:
-          'Use `react-router-dom-v5-compat` hooks instead. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
-      },
     ],
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     'react/jsx-uses-react': 'off',

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 
 import { TraceSpanProvider } from '@sourcegraph/observability-client'

--- a/client/web/src/components/Breadcrumbs.tsx
+++ b/client/web/src/components/Breadcrumbs.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import React, { FC, useState, useEffect, useMemo, useCallback } from 'react'
 
 import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
-import * as H from 'history'
 import { sortBy } from 'lodash'
+import { useLocation } from 'react-router-dom-v5-compat'
 import { Unsubscribable } from 'rxjs'
 
 import { isDefined } from '@sourcegraph/common'
@@ -148,46 +148,53 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
     }
 }
 
+interface BreadcrumbsInternalProps {
+    breadcrumbs: BreadcrumbAtDepth[]
+    className?: string
+}
+
 /**
  * Renders breadcrumbs by depth.
  */
-export const Breadcrumbs: React.FunctionComponent<
-    React.PropsWithChildren<{ breadcrumbs: BreadcrumbAtDepth[]; location: H.Location; className?: string }>
-> = ({ breadcrumbs, location, className }) => (
-    <nav
-        className={classNames('d-flex container-fluid flex-shrink-past-contents px-0', className)}
-        aria-label="Breadcrumbs"
-    >
-        {sortBy(breadcrumbs, 'depth')
-            .map(({ breadcrumb }) => breadcrumb)
-            .filter(isDefined)
-            .map((breadcrumb, index, validBreadcrumbs) => {
-                const divider = breadcrumb.divider ?? (
-                    <Icon className={styles.divider} aria-hidden={true} svgPath={mdiChevronRight} />
-                )
-                // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
-                // render link breadcrumbs as plain text
-                return (
-                    <span
-                        key={breadcrumb.key}
-                        className={classNames(
-                            'text-muted d-flex align-items-center test-breadcrumb',
-                            breadcrumb.className
-                        )}
-                    >
-                        {index !== 0 && <span className="font-weight-medium">{divider}</span>}
-                        {isElementBreadcrumb(breadcrumb) ? (
-                            breadcrumb.element
-                        ) : index === validBreadcrumbs.length - 1 && !location.hash ? (
-                            breadcrumb.link.label
-                        ) : (
-                            <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
-                        )}
-                    </span>
-                )
-            })}
-    </nav>
-)
+export const Breadcrumbs: FC<BreadcrumbsInternalProps> = ({ breadcrumbs, className }) => {
+    const location = useLocation()
+
+    return (
+        <nav
+            className={classNames('d-flex container-fluid flex-shrink-past-contents px-0', className)}
+            aria-label="Breadcrumbs"
+        >
+            {sortBy(breadcrumbs, 'depth')
+                .map(({ breadcrumb }) => breadcrumb)
+                .filter(isDefined)
+                .map((breadcrumb, index, validBreadcrumbs) => {
+                    const divider = breadcrumb.divider ?? (
+                        <Icon className={styles.divider} aria-hidden={true} svgPath={mdiChevronRight} />
+                    )
+                    // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
+                    // render link breadcrumbs as plain text
+                    return (
+                        <span
+                            key={breadcrumb.key}
+                            className={classNames(
+                                'text-muted d-flex align-items-center test-breadcrumb',
+                                breadcrumb.className
+                            )}
+                        >
+                            {index !== 0 && <span className="font-weight-medium">{divider}</span>}
+                            {isElementBreadcrumb(breadcrumb) ? (
+                                breadcrumb.element
+                            ) : index === validBreadcrumbs.length - 1 && !location.hash ? (
+                                breadcrumb.link.label
+                            ) : (
+                                <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
+                            )}
+                        </span>
+                    )
+                })}
+        </nav>
+    )
+}
 
 /**
  * To be used in unit tests, it minimally fulfills the BreadcrumbSetters interface.

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react'
+import { FC } from 'react'
 
-import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
+import { MemoryRouter, MemoryRouterProps } from 'react-router'
 import { Routes, Route, CompatRouter } from 'react-router-dom-v5-compat'
 
 import { MockedStoryProvider, MockedStoryProviderProps } from '@sourcegraph/shared/src/stories'
@@ -22,16 +22,12 @@ if (!window.context) {
     window.context = {} as SourcegraphContext & Mocha.SuiteFunction
 }
 
-export type WebStoryChildrenProps = ThemeProps &
-    BreadcrumbSetters &
-    BreadcrumbsProps &
-    TelemetryProps &
-    RouteComponentProps<any>
+export type WebStoryChildrenProps = ThemeProps & BreadcrumbSetters & BreadcrumbsProps & TelemetryProps
 
 export interface WebStoryProps
     extends Omit<MemoryRouterProps, 'children'>,
         Pick<MockedStoryProviderProps, 'mocks' | 'useStrictMocking'> {
-    children: React.FunctionComponent<WebStoryChildrenProps>
+    children: FC<WebStoryChildrenProps>
     path?: string
 }
 
@@ -39,8 +35,8 @@ export interface WebStoryProps
  * Wrapper component for webapp Storybook stories that provides light theme and react-router props.
  * Takes a render function as children that gets called with the props.
  */
-export const WebStory: React.FunctionComponent<WebStoryProps> = ({
-    children,
+export const WebStory: FC<WebStoryProps> = ({
+    children: Children,
     mocks,
     path = '*',
     useStrictMocking,
@@ -48,7 +44,6 @@ export const WebStory: React.FunctionComponent<WebStoryProps> = ({
 }) => {
     const isLightTheme = useTheme()
     const breadcrumbSetters = useBreadcrumbs()
-    const Children = useMemo(() => withRouter(children), [children])
 
     usePrependStyles('web-styles', webStyles)
     setExperimentalFeaturesForTesting()

--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { createLinkUrl, Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/components/diff/DiffSplitHunk.tsx
+++ b/client/web/src/components/diff/DiffSplitHunk.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { DiffHunkLineType, FileDiffHunkFields } from '../../graphql-operations'
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react'
 
 import { mdiChevronDoubleLeft, mdiChevronDoubleRight, mdiOpenInNew } from '@mdi/js'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 import { animated, useSpring } from 'react-spring'
 
 import { Button, useLocalStorage, H3, H4, Icon, Link, Text, VIEWPORT_XL } from '@sourcegraph/wildcard'

--- a/client/web/src/enterprise/batches/create/useInsightTemplates.ts
+++ b/client/web/src/enterprise/batches/create/useInsightTemplates.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 

--- a/client/web/src/enterprise/batches/create/useSearchTemplate.ts
+++ b/client/web/src/enterprise/batches/create/useSearchTemplate.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import helloWorldSample from '../batch-spec/edit/library/hello-world.batch.yaml'
 import { insertQueryIntoLibraryItem, insertNameIntoLibraryItem } from '../batch-spec/yaml-util'

--- a/client/web/src/enterprise/batches/detail/changesets/EmptyDraftChangesetListElement.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/EmptyDraftChangesetListElement.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Link, H3, Text } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 import { of } from 'rxjs'
 
 import { buildCloudTrialURL } from '@sourcegraph/shared/src/util/url'

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
 
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, H2, Text } from '@sourcegraph/wildcard'

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -1,4 +1,3 @@
-import { Redirect } from 'react-router'
 import { Navigate } from 'react-router-dom-v5-compat'
 
 import { isErrorLike } from '@sourcegraph/common'
@@ -98,7 +97,7 @@ export const enterpriseRoutes: readonly LayoutRouteProps[] = [
         render: props => {
             const { showSearchNotebook } = useExperimentalFeatures.getState()
 
-            return showSearchNotebook ? <NotebookPage {...props} /> : <Redirect to={PageRoutes.Search} />
+            return showSearchNotebook ? <NotebookPage {...props} /> : <Navigate to={PageRoutes.Search} replace={true} />
         },
     },
     {

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
-import { Redirect } from 'react-router'
-import { useLocation } from 'react-router-dom-v5-compat'
+import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 
 import {
@@ -53,7 +52,7 @@ export const AuthenticatedCreateSearchContextPage: React.FunctionComponent<
     )
 
     if (!authenticatedUser) {
-        return <Redirect to="/sign-in" />
+        return <Navigate to="/sign-in" replace={true} />
     }
 
     return (

--- a/client/web/src/nav/NavBar/NavDropdown.tsx
+++ b/client/web/src/nav/NavBar/NavDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Link, Menu, MenuButton, MenuLink, MenuList, EMPTY_RECTANGLE, Icon } from '@sourcegraph/wildcard'
 

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-import { Redirect } from 'react-router'
+import { Navigate } from 'react-router-dom-v5-compat'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
@@ -32,7 +32,7 @@ export const CreateNotebookPage: React.FunctionComponent<
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookCreated')
-        return <Redirect to={EnterprisePageRoutes.Notebook.replace(':id', notebookOrError.id)} />
+        return <Navigate to={EnterprisePageRoutes.Notebook.replace(':id', notebookOrError.id)} replace={true} />
     }
 
     return (

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -3,8 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { mdiPlayCircleOutline, mdiDownload, mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
-import { useLocation } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 import { catchError, delay, startWith, switchMap, tap } from 'rxjs/operators'
 
@@ -464,7 +463,9 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
         }, [])
 
         if (copiedNotebookOrError && !isErrorLike(copiedNotebookOrError) && copiedNotebookOrError !== LOADING) {
-            return <Redirect to={EnterprisePageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} />
+            return (
+                <Navigate to={EnterprisePageRoutes.Notebook.replace(':id', copiedNotebookOrError.id)} replace={true} />
+            )
         }
 
         return (

--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { mdiPlus, mdiGithub } from '@mdi/js'
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { SourcegraphIcon, Card, CardBody, Link, H2, Text, Icon } from '@sourcegraph/wildcard'
 

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -204,7 +204,6 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                 {/* Breadcrumb for the nav elements */}
                 <Breadcrumbs
                     breadcrumbs={props.breadcrumbs}
-                    location={location}
                     className={classNames('justify-content-start', !props.forceWrap ? styles.breadcrumbWrap : '')}
                 />
             </div>

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import * as H from 'history'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import * as H from 'history'
 import SearchIcon from 'mdi-react/SearchIcon'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { createAggregateError, escapeRevspecForURL } from '@sourcegraph/common'
 import { GitRefType, Scalars } from '@sourcegraph/shared/src/graphql-operations'

--- a/client/web/src/repo/blob/BlobLoadingSpinner.tsx
+++ b/client/web/src/repo/blob/BlobLoadingSpinner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Link, LoadingSpinner } from '@sourcegraph/wildcard'
 

--- a/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
+++ b/client/web/src/repo/blob/actions/ToggleRenderedFileMode.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { mdiEye } from '@mdi/js'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { RenderMode } from '@sourcegraph/shared/src/util/url'
 import { createLinkUrl, Icon, Link, Tooltip } from '@sourcegraph/wildcard'

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Link, Text, Tooltip } from '@sourcegraph/wildcard'
 

--- a/client/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -16,7 +16,7 @@ describe('SiteInitPage', () => {
     })
 
     test('site already initialized', () => {
-        const history = createMemoryHistory({ initialEntries: ['/'] })
+        const history = createMemoryHistory({ initialEntries: ['/init'] })
         renderWithBrandedContext(
             <SiteInitPage
                 isLightTheme={true}
@@ -29,7 +29,7 @@ describe('SiteInitPage', () => {
                     authMinPasswordLength: 12,
                 }}
             />,
-            { history }
+            { history, path: '/init' }
         )
         expect(history.location.pathname).toEqual('/search')
     })

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Redirect } from 'react-router'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { logger } from '@sourcegraph/common'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -68,7 +68,7 @@ export const SiteInitPage: React.FunctionComponent<React.PropsWithChildren<Props
     context,
 }) => {
     if (!needsSiteInit) {
-        return <Redirect to={PageRoutes.Search} />
+        return <Navigate to={PageRoutes.Search} replace={true} />
     }
 
     return (

--- a/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
 import { catchError, filter, mergeMap, tap } from 'rxjs/operators'
 
@@ -28,7 +27,7 @@ import { updatePassword } from '../backend'
 
 import styles from './UserSettingsPasswordPage.module.scss'
 
-interface Props extends RouteComponentProps<{}> {
+interface Props {
     user: UserAreaUserFields
     authenticatedUser: AuthenticatedUser
 }

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -1,4 +1,4 @@
-import { Redirect } from 'react-router-dom'
+import { Navigate } from 'react-router-dom-v5-compat'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Text } from '@sourcegraph/wildcard'
@@ -50,7 +50,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'password',
-        render: () => <Redirect to="./security" />,
+        render: () => <Navigate to="../security" replace={true} />,
     },
     {
         path: 'emails',

--- a/client/web/src/util/contributions.ts
+++ b/client/web/src/util/contributions.ts
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { RouteComponentProps } from 'react-router'
-
 interface Conditional<C extends object> {
     /** Optional condition under which this item should be used */
     readonly condition?: (context: C) => boolean
@@ -18,18 +16,6 @@ interface WithIcon {
  */
 export interface ComponentDescriptor<C extends object = {}> extends Conditional<C> {
     readonly render: (props: C) => React.ReactNode
-}
-
-/**
- * Configuration for a route.
- *
- * @template C Context information that is passed to `render` and `condition`
- */
-export interface RouteDescriptor<C extends object = {}, P extends object = any> extends Conditional<C> {
-    /** Path of this route (appended to the current match) */
-    readonly path: string
-    readonly exact?: boolean
-    readonly render: (props: C & RouteComponentProps<P>) => React.ReactNode
 }
 
 /**

--- a/client/wildcard/src/hooks/useSearchParameters.ts
+++ b/client/wildcard/src/hooks/useSearchParameters.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 /**
  * Return a new search parameters object based on the current URL.


### PR DESCRIPTION
## Context

- Part of #33834 

## Test plan

CI 

## App preview:

- [Web](https://sg-web-vb-react-router-migration-6.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
