### PR TITLE
web: fix edit insight param

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -81,10 +81,10 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
 
                 <Route
                     // Deprecated URL, delete this in the 4.10
-                    path="insight/:id"
+                    path="insight/:insightId"
                     element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}`} />}
                 />
-                <Route path=":id" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
+                <Route path=":insightId" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
 
                 <Route element={<NotFoundPage pageType="code insights" />} />
             </Routes>

--- a/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
@@ -37,7 +37,7 @@ type ShareLinkModalProps = ModalProps & {
 export const ShareLinkModal: FC<ShareLinkModalProps> = props => {
     const { insight, isOpen, onDismiss, ...attributes } = props
 
-    const shareableUrl = `${window.location.origin}/insights/insight/${insight.id}`
+    const shareableUrl = `${window.location.origin}/insights/${insight.id}`
     const copyButtonReference = useRef<HTMLButtonElement>(null)
     const [copyURL, isCopied] = useCopyURLHandler()
 

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -26,14 +26,14 @@ import { useEditPageHandlers } from './hooks/use-edit-page-handlers'
 
 export interface EditInsightPageProps {}
 
-export const EditInsightPage: FC<EditInsightPageProps> = props => {
+export const EditInsightPage: FC<EditInsightPageProps> = () => {
     /** Normalized insight id <type insight>.insight.<name of insight> */
-    const { insightID } = useParams()
+    const { insightId } = useParams()
 
     const { getInsightById } = useContext(CodeInsightsBackendContext)
     const { licensed, insight: insightFeatures } = useUiFeatures()
 
-    const insight = useObservable(useMemo(() => getInsightById(insightID!), [getInsightById, insightID]))
+    const insight = useObservable(useMemo(() => getInsightById(insightId!), [getInsightById, insightId]))
     const { handleSubmit, handleCancel } = useEditPageHandlers({ id: insight?.id })
 
     const editPermission = useObservable(


### PR DESCRIPTION
## Context

Fixes the issue reported in Slack — the edit insight page used the wrong variable as an insight ID because of the typo.

## Test plan

1. `sg start web-standalone`
2. open insights and click "edit" on any of the insights

## App preview:

- [Web](https://sg-web-vb-fix-edit-insight-page.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

