### PR TITLE
avoid duplicate but conflicting PROCESSING_TIMEOUT env var registrations

### DIFF
--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -50,7 +50,7 @@ func LoadSqliteConfig(baseConfig env.BaseConfig, ctags CtagsConfig, repositoryFe
 		CacheSizeMB:             baseConfig.GetInt("SYMBOLS_CACHE_SIZE_MB", "100000", "maximum size of the disk cache (in megabytes)"),
 		NumCtagsProcesses:       baseConfig.GetInt("CTAGS_PROCESSES", strconv.Itoa(runtime.GOMAXPROCS(0)), "number of concurrent parser processes to run"),
 		RequestBufferSize:       baseConfig.GetInt("REQUEST_BUFFER_SIZE", "8192", "maximum size of buffered parser request channel"),
-		ProcessingTimeout:       baseConfig.GetInterval("PROCESSING_TIMEOUT", "2h", "maximum time to spend processing a repository"),
+		ProcessingTimeout:       baseConfig.GetInterval("PROCESSING_TIMEOUT", "2h0m0s", "maximum time to spend processing a repository"),
 		MaxConcurrentlyIndexing: baseConfig.GetInt("MAX_CONCURRENTLY_INDEXING", "10", "maximum number of repositories to index at a time"),
 	}
 }


### PR DESCRIPTION
When running App, where all env vars are applied to the same process, the 2 env var `PROCESSING_TIMEOUT` definitions caused a panic:

```
panic: env var "PROCESSING_TIMEOUT" already registered with a different description or value
```

The values were the same, but the canonical string representation of `2h` as a Go `time.Duration` is actually `2h0m0s`. This change causes it not to panic.




## Test plan

Run `sg start app` and see it not panic.