### PR TITLE
Remove logic to filter extensions

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -52,12 +52,11 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/vhdl":       true,
 }
 
-func defaultSettings(db database.DB) map[string]any {
+func defaultSettings() map[string]any {
 	extensionIDs := []string{}
 	for id := range builtinExtensions {
 		extensionIDs = append(extensionIDs, id)
 	}
-	extensionIDs = ExtensionRegistry(db).FilterRemoteExtensions(extensionIDs)
 	extensions := map[string]bool{}
 	for _, id := range extensionIDs {
 		extensions[id] = true
@@ -83,7 +82,7 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	contents, err := json.Marshal(defaultSettings(r.db))
+	contents, err := json.Marshal(defaultSettings())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -27,12 +27,6 @@ var ExtensionRegistry func(db database.DB) ExtensionRegistryResolver
 // ExtensionRegistryResolver is the interface for the GraphQL type ExtensionRegistry.
 type ExtensionRegistryResolver interface {
 	Extensions(context.Context, *RegistryExtensionConnectionArgs) (RegistryExtensionConnection, error)
-
-	// FilterRemoteExtensions enforces `allowRemoteExtensions` by returning a
-	// new slice with extension IDs that were present in
-	// `allowRemoteExtensions`. It returns the original extension IDs if
-	// `allowRemoteExtensions` is not set.
-	FilterRemoteExtensions([]string) []string // not exposed via GraphQL
 }
 
 type RegistryExtensionConnectionArgs struct {

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -70,15 +70,6 @@ func getRemoteRegistryExtension(ctx context.Context, field, value string) (*regi
 	return x, err
 }
 
-// FilterRemoteExtensions is called to filter the list of extensions retrieved from the remote
-// registry before the list is used by any other part of the application.
-//
-// It can be overridden to use custom logic.
-var FilterRemoteExtensions = func(extensions []*registry.Extension) []*registry.Extension {
-	// By default, all remote extensions are allowed.
-	return extensions
-}
-
 // listRemoteRegistryExtensions lists the remote registry extensions and rewrites their fields to be
 // from the frame-of-reference of this site.
 func listRemoteRegistryExtensions(ctx context.Context, query string) ([]*registry.Extension, error) {
@@ -91,7 +82,6 @@ func listRemoteRegistryExtensions(ctx context.Context, query string) ([]*registr
 	if err != nil {
 		return nil, err
 	}
-	xs = FilterRemoteExtensions(xs)
 	for _, x := range xs {
 		x.RegistryURL = registryURL.String()
 	}

--- a/cmd/frontend/registry/api/registry_graphql.go
+++ b/cmd/frontend/registry/api/registry_graphql.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -22,17 +21,4 @@ var ExtensionRegistry extensionRegistryResolver
 // extensionRegistryResolver implements the GraphQL type ExtensionRegistry.
 type extensionRegistryResolver struct {
 	db database.DB
-}
-
-func (r *extensionRegistryResolver) FilterRemoteExtensions(ids []string) []string {
-	extensions := make([]*registry.Extension, len(ids))
-	for i, id := range ids {
-		extensions[i] = &registry.Extension{ExtensionID: id}
-	}
-	keepExtensions := FilterRemoteExtensions(extensions)
-	keep := make([]string, len(keepExtensions))
-	for i, extension := range keepExtensions {
-		keep[i] = extension.ExtensionID
-	}
-	return keep
 }


### PR DESCRIPTION
The enterprise override doesn't exist anymore, so this is not required anymore! This was the last blocker to being able to calculate the user settings outside of the frontend service!

## Test plan

Still starts up.