### PR TITLE
upgrade esbuild and use tree shaking

### DIFF
--- a/client/build-config/src/esbuild/monacoPlugin.ts
+++ b/client/build-config/src/esbuild/monacoPlugin.ts
@@ -65,8 +65,8 @@ export const monacoPlugin = ({
 // using MonacoEnvironment#getWorker (from #getWorkerUrl), which would then let us use the worker
 // plugin (and in Webpack the worker-loader) to load these instead of needing to hardcode them as
 // build entrypoints.
-export const buildMonaco = async (outdir: string): Promise<void> => {
-    await esbuild.build({
+export const buildMonaco = async (outdir: string): Promise<esbuild.BuildContext> =>
+    esbuild.context({
         entryPoints: {
             'scripts/editor.worker.bundle': 'monaco-editor/esm/vs/editor/editor.worker.js',
             'scripts/json.worker.bundle': 'monaco-editor/esm/vs/language/json/json.worker.js',
@@ -76,4 +76,3 @@ export const buildMonaco = async (outdir: string): Promise<void> => {
         bundle: true,
         outdir,
     })
-}

--- a/client/jetbrains/scripts/build.ts
+++ b/client/jetbrains/scripts/build.ts
@@ -18,7 +18,7 @@ export async function build(): Promise<void> {
         rm('-rf', distributionPath)
     }
 
-    await esbuild.build({
+    const ctx = await esbuild.context({
         entryPoints: {
             search: path.resolve(webviewSourcePath, 'search', 'index.tsx'),
             bridgeMock: path.resolve(webviewSourcePath, 'bridge-mock', 'index.ts'),
@@ -50,11 +50,12 @@ export async function build(): Promise<void> {
             '.ttf': 'file',
         },
         assetNames: '[name]',
-        ignoreAnnotations: true,
-        treeShaking: false,
-        watch: !!process.env.WATCH,
         minify: true,
         sourcemap: true,
         outdir: distributionPath,
     })
+    if (process.env.WATCH) {
+        await ctx.watch()
+    }
+    await ctx.dispose()
 }

--- a/client/vscode/scripts/build.ts
+++ b/client/vscode/scripts/build.ts
@@ -15,7 +15,6 @@ import {
     buildTimerPlugin,
 } from '@sourcegraph/build-config'
 
-const watch = !!process.env.WATCH
 const minify = process.env.NODE_ENV === 'production'
 const outdir = path.join(__dirname, '../dist')
 const isTest = !!process.env.IS_TEST
@@ -24,7 +23,6 @@ const TARGET_TYPE = process.env.TARGET_TYPE
 
 const SHARED_CONFIG = {
     outdir,
-    watch,
     minify,
     sourcemap: true,
 }
@@ -34,11 +32,11 @@ export async function build(): Promise<void> {
         rm('-rf', outdir)
     }
 
-    const buildPromises = []
+    const buildPromises: Promise<esbuild.BuildContext>[] = []
 
     if (TARGET_TYPE === 'node' || !TARGET_TYPE) {
         buildPromises.push(
-            esbuild.build({
+            esbuild.context({
                 entryPoints: { extension: path.join(__dirname, '/../src/extension.ts') },
                 bundle: true,
                 format: 'cjs',
@@ -55,7 +53,7 @@ export async function build(): Promise<void> {
     }
     if (TARGET_TYPE === 'webworker' || !TARGET_TYPE) {
         buildPromises.push(
-            esbuild.build({
+            esbuild.context({
                 entryPoints: { extension: path.join(__dirname, '/../src/extension.ts') },
                 bundle: true,
                 format: 'cjs',
@@ -86,7 +84,7 @@ export async function build(): Promise<void> {
     }
 
     buildPromises.push(
-        esbuild.build({
+        esbuild.context({
             entryPoints: {
                 helpSidebar: path.join(__dirname, '../src/webview/sidebars/help'),
                 searchSidebar: path.join(__dirname, '../src/webview/sidebars/search'),
@@ -134,8 +132,6 @@ export async function build(): Promise<void> {
                 '.ttf': 'file',
             },
             assetNames: '[name]',
-            ignoreAnnotations: true,
-            treeShaking: false,
             ...SHARED_CONFIG,
             outdir: path.join(SHARED_CONFIG.outdir, 'webview'),
         })
@@ -143,5 +139,10 @@ export async function build(): Promise<void> {
 
     buildPromises.push(buildMonaco(outdir))
 
-    await Promise.all(buildPromises)
+    const ctxs = await Promise.all(buildPromises)
+
+    if (process.env.WATCH) {
+        await Promise.all(ctxs.map(ctx => ctx.watch()))
+    }
+    await Promise.all(ctxs.map(ctx => ctx.dispose()))
 }

--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import { serve } from 'esbuild'
+import { context as esbuildContext } from 'esbuild'
 import express from 'express'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import signale from 'signale'
@@ -21,15 +21,17 @@ export const esbuildDevelopmentServer = async (
     // One-time build (these files only change when the monaco-editor npm package is changed, which
     // is rare enough to ignore here).
     if (!ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS) {
-        await buildMonaco(STATIC_ASSETS_PATH)
+        const ctx = await buildMonaco(STATIC_ASSETS_PATH)
+        await ctx.dispose()
     }
 
+    const ctx = await esbuildContext(BUILD_OPTIONS)
+
     // Start esbuild's server on a random local port.
-    const {
-        host: esbuildHost,
-        port: esbuildPort,
-        wait: esbuildStopped,
-    } = await serve({ host: 'localhost', servedir: STATIC_ASSETS_PATH }, BUILD_OPTIONS)
+    const { host: esbuildHost, port: esbuildPort } = await ctx.serve({
+        host: 'localhost',
+        servedir: STATIC_ASSETS_PATH,
+    })
 
     // Start a proxy at :3080. Asset requests (underneath /.assets/) go to esbuild; all other
     // requests go to the upstream.
@@ -57,7 +59,6 @@ export const esbuildDevelopmentServer = async (
         proxyServer.once('listening', () => {
             signale.success(`esbuild server is ready after ${Math.round(performance.now() - start)}ms`)
             printSuccessBanner(['✱ Sourcegraph is really ready now!', `Click here: ${HTTPS_WEB_SERVER_URL}`])
-            esbuildStopped.finally(() => proxyServer.close(error => (error ? reject(error) : resolve())))
         })
         proxyServer.once('error', error => reject(error))
     })

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -70,13 +70,6 @@ export const ENVIRONMENT_CONFIG = {
     DEV_WEB_BUILDER_OMIT_SLOW_DEPS: Boolean(process.env.DEV_WEB_BUILDER_OMIT_SLOW_DEPS),
 
     /**
-     * Force tree-shaking in esbuild. Currently unsafe due to
-     * https://github.com/evanw/esbuild/pull/1458; see the other comments in this repository
-     * mentioning that PR for more information. (Esbuild only.)
-     */
-    DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING: Boolean(process.env.DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING),
-
-    /**
      * ----------------------------------------
      * Application features configuration.
      * ----------------------------------------

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "css-minimizer-webpack-plugin": "^4.2.2",
     "enhanced-resolve": "^5.9.3",
     "envalid": "^7.3.1",
-    "esbuild": "^0.16.10",
+    "esbuild": "^0.17.7",
     "eslint": "^8.13.0",
     "eslint-plugin-monorepo": "^0.3.2",
     "events": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,7 +238,7 @@ importers:
       downshift: ^3.4.8
       enhanced-resolve: ^5.9.3
       envalid: ^7.3.1
-      esbuild: ^0.16.10
+      esbuild: ^0.17.7
       escape-html: ^1.0.3
       eslint: ^8.13.0
       eslint-plugin-monorepo: ^0.3.2
@@ -440,7 +440,7 @@ importers:
       '@react-aria/live-announcer': 3.1.0
       '@sentry/browser': 7.8.1
       '@sourcegraph/extension-api-classes': 1.1.0_sohmsbidf4ixb2vnv3mpdkpiau
-      '@storybook/addon-controls': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/addon-controls': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@visx/annotation': 2.10.0_ef5jwxihqo6n7gxfmzogljlgcm
       '@visx/axis': 2.11.1_react@18.1.0
       '@visx/event': 2.6.0
@@ -588,22 +588,22 @@ importers:
       '@storybook/addon-a11y': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/addon-actions': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/addon-console': 1.2.3_473b6rbrlfbkiblbxydosemc4u
-      '@storybook/addon-docs': 6.5.14_pj2nlckshw25raeqzlyf2nlzmi
+      '@storybook/addon-docs': 6.5.14_ljetz3726qf7xucp4u2fupswpy
       '@storybook/addon-links': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/addon-storyshots': 6.5.14_54nclm56el6phoiikwjg4vacwq
+      '@storybook/addon-storyshots': 6.5.14_lismubkolmefvcm6b5doxucyea
       '@storybook/addon-storyshots-puppeteer': 6.5.14_5bskxofbdzb2fai5lt3jrwan6e
       '@storybook/addon-storysource': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/addon-toolbars': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/builder-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/builder-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/client-api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/components': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core': 6.5.14_o2cbjy3xxqdj2tzzexfwchdcvq
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core': 6.5.14_6e575epsoqx4ub7bw6hd3oedoq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-events': 6.5.14
-      '@storybook/manager-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
-      '@storybook/react': 6.5.14_r4utchdsxdspndke4rlo2g3uya
+      '@storybook/manager-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
+      '@storybook/react': 6.5.14_xrf7na7sboklktnvabuwpsrod4
       '@storybook/theming': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@terminus-term/to-string-loader': 1.1.7-beta.1
       '@testing-library/dom': 8.13.0
@@ -613,7 +613,7 @@ importers:
       '@testing-library/user-event': 13.5.0_tlwynutqiyp5mns3woioasuxnq
       '@types/babel__core': 7.1.20
       '@types/bloomfilter': 0.0.0
-      '@types/case-sensitive-paths-webpack-plugin': 2.1.6_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/case-sensitive-paths-webpack-plugin': 2.1.6_ehsben5to4ps4x332te7f3wqri
       '@types/chrome': 0.0.127
       '@types/classnames': 2.2.10
       '@types/command-exists': 1.2.0
@@ -670,13 +670,13 @@ importers:
       '@types/simmerjs': 0.5.1
       '@types/sinon': 9.0.4
       '@types/socket.io-client': 1.4.33
-      '@types/speed-measure-webpack-plugin': 1.3.4_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/speed-measure-webpack-plugin': 1.3.4_ehsben5to4ps4x332te7f3wqri
       '@types/svgo': 2.6.0
       '@types/testing-library__jest-dom': 5.9.5
       '@types/uuid': 8.0.1
       '@types/vscode': 1.63.1
-      '@types/webpack-bundle-analyzer': 4.6.0_jh3afgd4dccyz4n3zkk5zvv5cy
-      '@types/webpack-stats-plugin': 0.3.2_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack-bundle-analyzer': 4.6.0_ehsben5to4ps4x332te7f3wqri
+      '@types/webpack-stats-plugin': 0.3.2_ehsben5to4ps4x332te7f3wqri
       '@types/yauzl': 2.10.0
       '@vscode/test-electron': 2.1.3
       abort-controller: 3.0.0
@@ -700,10 +700,10 @@ importers:
       connect-history-api-fallback: 1.6.0
       cross-env: 7.0.2
       css-loader: 6.7.2_webpack@5.75.0
-      css-minimizer-webpack-plugin: 4.2.2_htvmhiqynazf46fjrszipnqp7a
+      css-minimizer-webpack-plugin: 4.2.2_xu2wxxvlz6i25ro5n4mqcdafx4
       enhanced-resolve: 5.10.0
       envalid: 7.3.1
-      esbuild: 0.16.17
+      esbuild: 0.17.7
       eslint: 8.18.0
       eslint-plugin-monorepo: 0.3.2_fsuobzodmui5yhj7deh6fdsp7i
       events: 3.3.0
@@ -779,14 +779,14 @@ importers:
       stylelint: 14.3.0
       svgo: 2.8.0
       term-size: 2.2.0
-      terser-webpack-plugin: 5.3.6_htvmhiqynazf46fjrszipnqp7a
+      terser-webpack-plugin: 5.3.6_xu2wxxvlz6i25ro5n4mqcdafx4
       ts-loader: 9.4.2_vfotqvx6lgcbf3upbs6hgaza4q
       ts-node: 10.9.1_wh55dwo6xja56jtfktvlrff6xu
       typed-scss-modules: 4.1.1_sass@1.32.4
       typescript: 4.9.3
       utc-version: 2.0.2
       vsce: 2.7.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-bundle-analyzer: 4.7.0
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
       webpack-dev-server: 4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq
@@ -3375,10 +3375,28 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm/0.17.7:
+    resolution: {integrity: sha512-Np6Lg8VUiuzHP5XvHU7zfSVPN4ILdiOhxA1GQ1uvCK2T2l3nI8igQV0c9FJx4hTkq8WGqhGEvn5UuRH8jMkExg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-arm64/0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.7:
+    resolution: {integrity: sha512-fOUBZvcbtbQJIj2K/LMKcjULGfXLV9R4qjXFsi3UuqFhIRJHz0Fp6kFjsMFI6vLuPrfC5G9Dmh+3RZOrSKY2Lg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -3391,10 +3409,28 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64/0.17.7:
+    resolution: {integrity: sha512-6YILpPvop1rPAvaO/n2iWQL45RyTVTR/1SK7P6Xi2fyu+hpEeX22fE2U2oJd1sfpovUJOWTRdugjddX6QCup3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-arm64/0.16.17:
     resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.7:
+    resolution: {integrity: sha512-7i0gfFsDt1BBiurZz5oZIpzfxqy5QkJmhXdtrf2Hma/gI9vL2AqxHhRBoI1NeWc9IhN1qOzWZrslhiXZweMSFg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -3407,10 +3443,28 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64/0.17.7:
+    resolution: {integrity: sha512-hRvIu3vuVIcv4SJXEKOHVsNssM5tLE2xWdb9ZyJqsgYp+onRa5El3VJ4+WjTbkf/A2FD5wuMIbO2FCTV39LE0w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-arm64/0.16.17:
     resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.7:
+    resolution: {integrity: sha512-2NJjeQ9kiabJkVXLM3sHkySqkL1KY8BeyLams3ITyiLW10IwDL0msU5Lq1cULCn9zNxt1Seh1I6QrqyHUvOtQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -3423,10 +3477,28 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64/0.17.7:
+    resolution: {integrity: sha512-8kSxlbjuLYMoIgvRxPybirHJeW45dflyIgHVs+jzMYJf87QOay1ZUTzKjNL3vqHQjmkSn8p6KDfHVrztn7Rprw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm/0.16.17:
     resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.7:
+    resolution: {integrity: sha512-07RsAAzznWqdfJC+h3L2UVWwnUHepsFw5GmzySnUspHHb7glJ1+47rvlcH0SeUtoVOs8hF4/THgZbtJRyALaJA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3439,10 +3511,28 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64/0.17.7:
+    resolution: {integrity: sha512-43Bbhq3Ia/mGFTCRA4NlY8VRH3dLQltJ4cqzhSfq+cdvdm9nKJXVh4NUkJvdZgEZIkf/ufeMmJ0/22v9btXTcw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ia32/0.16.17:
     resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.17.7:
+    resolution: {integrity: sha512-ViYkfcfnbwOoTS7xE4DvYFv7QOlW8kPBuccc4erJ0jx2mXDPR7e0lYOH9JelotS9qe8uJ0s2i3UjUvjunEp53A==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -3455,10 +3545,28 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.17.7:
+    resolution: {integrity: sha512-H1g+AwwcqYQ/Hl/sMcopRcNLY/fysIb/ksDfCa3/kOaHQNhBrLeDYw+88VAFV5U6oJL9GqnmUj72m9Nv3th3hA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-mips64el/0.16.17:
     resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.7:
+    resolution: {integrity: sha512-MDLGrVbTGYtmldlbcxfeDPdhxttUmWoX3ovk9u6jc8iM+ueBAFlaXKuUMCoyP/zfOJb+KElB61eSdBPSvNcCEg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -3471,10 +3579,28 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64/0.17.7:
+    resolution: {integrity: sha512-UWtLhRPKzI+v2bKk4j9rBpGyXbLAXLCOeqt1tLVAt1mfagHpFjUzzIHCpPiUfY3x1xY5e45/+BWzGpqqvSglNw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-riscv64/0.16.17:
     resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.7:
+    resolution: {integrity: sha512-3C/RTKqZauUwBYtIQAv7ELTJd+H2dNKPyzwE2ZTbz2RNrNhNHRoeKnG5C++eM6nSZWUCLyyaWfq1v1YRwBS/+A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -3487,10 +3613,28 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x/0.17.7:
+    resolution: {integrity: sha512-x7cuRSCm998KFZqGEtSo8rI5hXLxWji4znZkBhg2FPF8A8lxLLCsSXe2P5utf0RBQflb3K97dkEH/BJwTqrbDw==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-x64/0.16.17:
     resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.7:
+    resolution: {integrity: sha512-1Z2BtWgM0Wc92WWiZR5kZ5eC+IetI++X+nf9NMbUvVymt74fnQqwgM5btlTW7P5uCHfq03u5MWHjIZa4o+TnXQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -3503,10 +3647,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64/0.17.7:
+    resolution: {integrity: sha512-//VShPN4hgbmkDjYNCZermIhj8ORqoPNmAnwSPqPtBB0xOpHrXMlJhsqLNsgoBm0zi/5tmy//WyL6g81Uq2c6Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/openbsd-x64/0.16.17:
     resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.7:
+    resolution: {integrity: sha512-IQ8BliXHiOsbQEOHzc7mVLIw2UYPpbOXJQ9cK1nClNYQjZthvfiA6rWZMz4BZpVzHZJ+/H2H23cZwRJ1NPYOGg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3519,10 +3681,28 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64/0.17.7:
+    resolution: {integrity: sha512-phO5HvU3SyURmcW6dfQXX4UEkFREUwaoiTgi1xH+CAFKPGsrcG6oDp1U70yQf5lxRKujoSCEIoBr0uFykJzN2g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-arm64/0.16.17:
     resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.7:
+    resolution: {integrity: sha512-G/cRKlYrwp1B0uvzEdnFPJ3A6zSWjnsRrWivsEW0IEHZk+czv0Bmiwa51RncruHLjQ4fGsvlYPmCmwzmutPzHA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3535,10 +3715,28 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32/0.17.7:
+    resolution: {integrity: sha512-/yMNVlMew07NrOflJdRAZcMdUoYTOCPbCHx0eHtg55l87wXeuhvYOPBQy5HLX31Ku+W2XsBD5HnjUjEUsTXJug==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-x64/0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.7:
+    resolution: {integrity: sha512-K9/YybM6WZO71x73Iyab6mwieHtHjm9hrPR/a9FBPZmFO3w+fJaM2uu2rt3JYf/rZR24MFwTliI8VSoKKOtYtg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -6172,7 +6370,7 @@ packages:
       react-refresh: 0.10.0
       schema-utils: 3.1.1
       source-map: 0.7.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-server: 4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq
     dev: true
 
@@ -6212,7 +6410,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-server: 4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq
     dev: true
 
@@ -7678,7 +7876,7 @@ packages:
       '@statoscope/webpack-stats-extension-package-info': 5.24.0_webpack@5.75.0
       '@statoscope/webpack-ui': 5.24.0
       open: 8.4.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /@statoscope/webpack-stats-extension-compressed/5.24.0_webpack@5.75.0:
@@ -7689,7 +7887,7 @@ packages:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-compressed': 5.24.0
       '@statoscope/webpack-model': 5.24.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /@statoscope/webpack-stats-extension-package-info/5.24.0_webpack@5.75.0:
@@ -7700,7 +7898,7 @@ packages:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-package-info': 5.24.0
       '@statoscope/webpack-model': 5.24.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /@statoscope/webpack-ui/5.24.0:
@@ -7783,7 +7981,7 @@ packages:
       global: 4.4.0
     dev: true
 
-  /@storybook/addon-controls/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/addon-controls/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-p16k/69GjwVtnpEiz0fmb1qoqp/H2d5aaSGDt7VleeXsdhs4Kh0kJyxfLpekHmlzT+5IkO08Nm/U8tJOHbw4Hw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7798,7 +7996,7 @@ packages:
       '@storybook/api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/client-logger': 6.5.14
       '@storybook/components': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.14
       '@storybook/store': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -7819,7 +8017,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/addon-docs/6.5.14_pj2nlckshw25raeqzlyf2nlzmi:
+  /@storybook/addon-docs/6.5.14_ljetz3726qf7xucp4u2fupswpy:
     resolution: {integrity: sha512-gapuzDY+dqgS4/Ap9zj5L76OSExBYtVNYej9xTiF+v0Gh4/kty9FIGlVWiqskffOmixL4nlyImpfsSH8V0JnCw==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -7840,7 +8038,7 @@ packages:
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/components': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-events': 6.5.14
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -7913,7 +8111,7 @@ packages:
         optional: true
     dependencies:
       '@axe-core/puppeteer': 4.4.2_puppeteer@13.7.0
-      '@storybook/addon-storyshots': 6.5.14_54nclm56el6phoiikwjg4vacwq
+      '@storybook/addon-storyshots': 6.5.14_lismubkolmefvcm6b5doxucyea
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.14
       '@types/jest-image-snapshot': 4.3.0
@@ -7925,7 +8123,7 @@ packages:
       - jest
     dev: true
 
-  /@storybook/addon-storyshots/6.5.14_54nclm56el6phoiikwjg4vacwq:
+  /@storybook/addon-storyshots/6.5.14_lismubkolmefvcm6b5doxucyea:
     resolution: {integrity: sha512-BSYt+GyMeTlxCwMNVwsmfetKjeIZVVRFdhvtyTuSf9MvikBq+SXw6IihkeWbX2g6pssCz9Wc+s6rRK/HJpqTlA==}
     peerDependencies:
       '@angular/core': '>=6.0.0'
@@ -7980,11 +8178,11 @@ packages:
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/babel-plugin-require-context-hook': 1.0.1
       '@storybook/client-api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core': 6.5.14_o2cbjy3xxqdj2tzzexfwchdcvq
+      '@storybook/core': 6.5.14_6e575epsoqx4ub7bw6hd3oedoq
       '@storybook/core-client': 6.5.14_77mmp7l52573w63t23u7ainpmu
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/react': 6.5.14_r4utchdsxdspndke4rlo2g3uya
+      '@storybook/react': 6.5.14_xrf7na7sboklktnvabuwpsrod4
       '@types/glob': 7.1.3
       '@types/jest': 26.0.24
       '@types/jest-specific-snapshot': 0.5.4
@@ -8122,7 +8320,7 @@ packages:
     resolution: {integrity: sha512-WM4vjgSVi8epvGiYfru7BtC3f0tGwNs7QK3Uc4xQn4t5hHQvISnCqbNrHdDYmNW56Do+bBztE8SwP6NGUvd7ww==}
     dev: true
 
-  /@storybook/builder-webpack4/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/builder-webpack4/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-0pv8BlsMeiP9VYU2CbCZaa3yXDt1ssb8OeTRDbFC0uFFb3eqslsH68I7XsC8ap/dr0RZR0Edtw0OW3HhkjUXXw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8140,7 +8338,7 @@ packages:
       '@storybook/client-api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/client-logger': 6.5.14
       '@storybook/components': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-events': 6.5.14
       '@storybook/node-logger': 6.5.14
       '@storybook/preview-web': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -8150,7 +8348,7 @@ packages:
       '@storybook/theming': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/ui': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@types/node': 16.11.36
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
       autoprefixer: 9.8.6
       babel-loader: 8.2.5_ztqwsvkb6z73luspkai6ilstpu
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -8162,7 +8360,7 @@ packages:
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
-      html-webpack-plugin: 4.5.2_nljosxlhezzfayhg2olmp6suom
+      html-webpack-plugin: 4.5.2_7domqanwj4vf2zv4qrbzwodcqy
       pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
@@ -8177,7 +8375,7 @@ packages:
       typescript: 4.9.3
       url-loader: 4.1.1_p5dl6emkcwslbw72e37w4ug7em
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-middleware: 3.7.3_webpack@5.75.0
       webpack-filter-warnings-plugin: 1.2.1_webpack@5.75.0
       webpack-hot-middleware: 2.25.1
@@ -8193,7 +8391,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/builder-webpack5/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/builder-webpack5/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-Ukj7Wwxz/3mKn5TI5mkm2mIm583LxOz78ZrpcOgI+vpjeRlMFXmGGEb68R47SiCdZoVCfIeCXXXzBd6Q6As6QQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8211,7 +8409,7 @@ packages:
       '@storybook/client-api': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/client-logger': 6.5.14
       '@storybook/components': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-events': 6.5.14
       '@storybook/node-logger': 6.5.14
       '@storybook/preview-web': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -8236,11 +8434,11 @@ packages:
       react-dom: 18.1.0_react@18.1.0
       stable: 0.1.8
       style-loader: 2.0.0_webpack@5.75.0
-      terser-webpack-plugin: 5.3.6_htvmhiqynazf46fjrszipnqp7a
+      terser-webpack-plugin: 5.3.6_xu2wxxvlz6i25ro5n4mqcdafx4
       ts-dedent: 2.0.0
       typescript: 4.9.3
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-middleware: 4.3.0_webpack@5.75.0
       webpack-hot-middleware: 2.25.1
       webpack-virtual-modules: 0.4.3
@@ -8370,10 +8568,10 @@ packages:
       typescript: 4.9.3
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
-  /@storybook/core-common/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/core-common/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-MrxhYXYrtN6z/+tydjPkCIwDQm5q8Jx+w4TPdLKBZu7vzfp6T3sT12Ym96j9MJ42CvE4vSDl/Njbw6C0D+yEVw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8435,7 +8633,7 @@ packages:
       ts-dedent: 2.0.0
       typescript: 4.9.3
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -8450,7 +8648,7 @@ packages:
     dependencies:
       core-js: 3.22.8
 
-  /@storybook/core-server/6.5.14_atn4omggkvboprklebowgbukgq:
+  /@storybook/core-server/6.5.14_6xfdtzdm674ncrlauud6s2o3gu:
     resolution: {integrity: sha512-+Z3lHEsDpiBXt6xBwU5AVBoEkicndnHoiLwhEGPkfixy7POYEEny3cm54tteVxV8O5AHMwsHs54/QD+hHxAXnQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -8467,23 +8665,23 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.14_gfp4q6646gfovewejhfnlg2afq
-      '@storybook/builder-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/builder-webpack4': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
+      '@storybook/builder-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-client': 6.5.14_77mmp7l52573w63t23u7ainpmu
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-events': 6.5.14
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.14
-      '@storybook/manager-webpack4': 6.5.14_gfp4q6646gfovewejhfnlg2afq
-      '@storybook/manager-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/manager-webpack4': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
+      '@storybook/manager-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/node-logger': 6.5.14
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/telemetry': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/telemetry': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@types/node': 16.11.36
       '@types/node-fetch': 2.5.10
       '@types/pretty-hrtime': 1.0.0
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
       better-opn: 2.1.1
       boxen: 5.1.2
       chalk: 4.1.2
@@ -8513,7 +8711,7 @@ packages:
       typescript: 4.9.3
       util-deprecate: 1.0.2
       watchpack: 2.4.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       ws: 8.11.0
       x-default-browser: 0.4.0
     transitivePeerDependencies:
@@ -8531,7 +8729,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/core/6.5.14_o2cbjy3xxqdj2tzzexfwchdcvq:
+  /@storybook/core/6.5.14_6e575epsoqx4ub7bw6hd3oedoq:
     resolution: {integrity: sha512-5rjwZXk++NkKWCmHt/CC+h2L4ZbOYkLJpMmaB97CwgQCA6kaF8xuJqlAwG72VUH3oV+6RntW02X6/ypgX1atPw==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -8548,14 +8746,14 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/builder-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/core-client': 6.5.14_77mmp7l52573w63t23u7ainpmu
-      '@storybook/core-server': 6.5.14_atn4omggkvboprklebowgbukgq
-      '@storybook/manager-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-server': 6.5.14_6xfdtzdm674ncrlauud6s2o3gu
+      '@storybook/manager-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
       typescript: 4.9.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@swc/core'
@@ -8618,7 +8816,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/manager-webpack4/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-ixfJuaG0eiOlxn4i+LJNRUZkm+3WMsiaGUm0hw2XHF0pW3cBIA/+HyzkEwVh/fROHbsOERTkjNl0Ygl12Imw9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8633,12 +8831,12 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/core-client': 6.5.14_77mmp7l52573w63t23u7ainpmu
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/node-logger': 6.5.14
       '@storybook/theming': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/ui': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@types/node': 16.11.36
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
       babel-loader: 8.2.5_ztqwsvkb6z73luspkai6ilstpu
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
@@ -8648,7 +8846,7 @@ packages:
       file-loader: 6.2.0_webpack@5.75.0
       find-up: 5.0.0
       fs-extra: 9.0.1
-      html-webpack-plugin: 4.5.2_nljosxlhezzfayhg2olmp6suom
+      html-webpack-plugin: 4.5.2_7domqanwj4vf2zv4qrbzwodcqy
       node-fetch: 2.6.7
       pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       react: 18.1.0
@@ -8663,7 +8861,7 @@ packages:
       typescript: 4.9.3
       url-loader: 4.1.1_p5dl6emkcwslbw72e37w4ug7em
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-middleware: 3.7.3_webpack@5.75.0
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
@@ -8678,7 +8876,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/manager-webpack5/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/manager-webpack5/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-Z9uXhaBPpUhbLEYkZVm95vKSmyxXk+DLqa1apAQEmHz3EBMTNk/2n0aZnNnsspYzjNP6wvXWT0sGyXG6yhX2cw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8693,7 +8891,7 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/core-client': 6.5.14_77mmp7l52573w63t23u7ainpmu
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/node-logger': 6.5.14
       '@storybook/theming': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/ui': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -8716,11 +8914,11 @@ packages:
       resolve-from: 5.0.0
       style-loader: 2.0.0_webpack@5.75.0
       telejson: 6.0.8
-      terser-webpack-plugin: 5.3.6_htvmhiqynazf46fjrszipnqp7a
+      terser-webpack-plugin: 5.3.6_xu2wxxvlz6i25ro5n4mqcdafx4
       ts-dedent: 2.0.0
       typescript: 4.9.3
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-dev-middleware: 4.3.0_webpack@5.75.0
       webpack-virtual-modules: 0.4.3
     transitivePeerDependencies:
@@ -8808,12 +9006,12 @@ packages:
       react-docgen-typescript: 2.2.2_typescript@4.9.3
       tslib: 2.1.0
       typescript: 4.9.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.14_r4utchdsxdspndke4rlo2g3uya:
+  /@storybook/react/6.5.14_xrf7na7sboklktnvabuwpsrod4:
     resolution: {integrity: sha512-SL0P5czN3g/IZAYw8ur9I/O8MPZI7Lyd46Pw+B1f7+Ou8eLmhqa8Uc8+3fU6v7ohtUDwsBiTsg3TAfTVEPog4A==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8846,13 +9044,13 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_unmakpayn7vcxadrrsbqlrpehy
       '@storybook/addons': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/builder-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/builder-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/client-logger': 6.5.14
-      '@storybook/core': 6.5.14_o2cbjy3xxqdj2tzzexfwchdcvq
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core': 6.5.14_6e575epsoqx4ub7bw6hd3oedoq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/manager-webpack5': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/manager-webpack5': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       '@storybook/node-logger': 6.5.14
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_vfotqvx6lgcbf3upbs6hgaza4q
       '@storybook/semver': 7.3.2
@@ -8882,7 +9080,7 @@ packages:
       ts-dedent: 2.0.0
       typescript: 4.9.3
       util-deprecate: 1.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@swc/core'
@@ -8970,11 +9168,11 @@ packages:
       ts-dedent: 2.0.0
       util-deprecate: 1.0.2
 
-  /@storybook/telemetry/6.5.14_gfp4q6646gfovewejhfnlg2afq:
+  /@storybook/telemetry/6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm:
     resolution: {integrity: sha512-AVSw7WyKHrVbXMSZZ0fvg3oAb8xAS7OrmNU6++yUfbuqpF0JNtNkNnRSaJ4Nh7Vujzloy5jYhbpfY44nb/hsCw==}
     dependencies:
       '@storybook/client-logger': 6.5.14
-      '@storybook/core-common': 6.5.14_gfp4q6646gfovewejhfnlg2afq
+      '@storybook/core-common': 6.5.14_y5zy5o7gcqq4ewzh3zsv3he6fm
       chalk: 4.1.2
       core-js: 3.22.8
       detect-package-manager: 2.0.1
@@ -9571,10 +9769,10 @@ packages:
       '@types/responselike': 1.0.0
     dev: false
 
-  /@types/case-sensitive-paths-webpack-plugin/2.1.6_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /@types/case-sensitive-paths-webpack-plugin/2.1.6_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-1bk/krfgJ2bVPUusnmvWHg8Xwr/4I29yFxvZBFi5FZOshQzfcZ7XdutFHpYMs1w5RD319pjJbDk7J2ibWSW6QQ==}
     dependencies:
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10304,10 +10502,10 @@ packages:
     dependencies:
       '@types/node': 18.8.3
 
-  /@types/speed-measure-webpack-plugin/1.3.4_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /@types/speed-measure-webpack-plugin/1.3.4_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-bTV+ZctiMPqufZXEnfkNL4DgXzgkq0AnN2hnwqfEZn5ZqqxbGi55Rtp3vrnr8U5jgFJoYFONQCCkGPWsLOT2Sg==}
     dependencies:
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10380,12 +10578,12 @@ packages:
     resolution: {integrity: sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==}
     dev: true
 
-  /@types/webpack-bundle-analyzer/4.6.0_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /@types/webpack-bundle-analyzer/4.6.0_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-XeQmQCCXdZdap+A/60UKmxW5Mz31Vp9uieGlHB3T4z/o2OLVLtTI3bvTuS6A2OWd/rbAAQiGGWIEFQACu16szA==}
     dependencies:
       '@types/node': 18.8.3
       tapable: 2.2.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10396,10 +10594,10 @@ packages:
   /@types/webpack-env/1.18.0:
     resolution: {integrity: sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==}
 
-  /@types/webpack-stats-plugin/0.3.2_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /@types/webpack-stats-plugin/0.3.2_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-wvIJrybgcuNZ+5sr99RAqr1FmC9tRjAyws7x3jPFHZxtyO+c5n/VbFZATKW5Wec3LOpEuLSFlfrmFF8TALAmwQ==}
     dependencies:
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10407,12 +10605,12 @@ packages:
       - webpack-cli
     dev: true
 
-  /@types/webpack/5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /@types/webpack/5.28.0_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==}
     dependencies:
       '@types/node': 18.8.3
       tapable: 2.2.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10961,7 +11159,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
 
   /@webpack-cli/info/2.0.1_rjsyjcrmk25kqsjzwkvj3a2evq:
@@ -10971,7 +11169,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
 
   /@webpack-cli/serve/2.0.1_ewykyfxtgmraekx43xa23ld4wa:
@@ -10985,7 +11183,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
       webpack-dev-server: 4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq
 
@@ -11853,7 +12051,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
 
   /babel-loader/9.1.0_ztqwsvkb6z73luspkai6ilstpu:
     resolution: {integrity: sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==}
@@ -11865,7 +12063,7 @@ packages:
       '@babel/core': 7.20.5
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /babel-plugin-add-react-displayname/0.0.5:
@@ -13508,7 +13706,7 @@ packages:
     dependencies:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /compression/1.7.4:
@@ -13973,7 +14171,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.0
       semver: 6.3.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /css-loader/5.2.6_webpack@5.75.0:
@@ -13992,7 +14190,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /css-loader/6.7.2_webpack@5.75.0:
@@ -14009,10 +14207,10 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.19
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
-  /css-minimizer-webpack-plugin/4.2.2_htvmhiqynazf46fjrszipnqp7a:
+  /css-minimizer-webpack-plugin/4.2.2_xu2wxxvlz6i25ro5n4mqcdafx4:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14038,13 +14236,13 @@ packages:
         optional: true
     dependencies:
       cssnano: 4.1.10
-      esbuild: 0.16.17
+      esbuild: 0.17.7
       jest-worker: 29.3.1
       postcss: 8.4.19
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
       source-map: 0.6.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /css-modules-loader-core/1.1.0:
@@ -15800,6 +15998,36 @@ packages:
       '@esbuild/win32-arm64': 0.16.17
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
+    dev: true
+
+  /esbuild/0.17.7:
+    resolution: {integrity: sha512-+5hHlrK108fT6C6/40juy0w4DYKtyZ5NjfBlTccBdsFutR7WBxpIY633JzZJewdsCy8xWA/u2z0MSniIJwufYg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.7
+      '@esbuild/android-arm64': 0.17.7
+      '@esbuild/android-x64': 0.17.7
+      '@esbuild/darwin-arm64': 0.17.7
+      '@esbuild/darwin-x64': 0.17.7
+      '@esbuild/freebsd-arm64': 0.17.7
+      '@esbuild/freebsd-x64': 0.17.7
+      '@esbuild/linux-arm': 0.17.7
+      '@esbuild/linux-arm64': 0.17.7
+      '@esbuild/linux-ia32': 0.17.7
+      '@esbuild/linux-loong64': 0.17.7
+      '@esbuild/linux-mips64el': 0.17.7
+      '@esbuild/linux-ppc64': 0.17.7
+      '@esbuild/linux-riscv64': 0.17.7
+      '@esbuild/linux-s390x': 0.17.7
+      '@esbuild/linux-x64': 0.17.7
+      '@esbuild/netbsd-x64': 0.17.7
+      '@esbuild/openbsd-x64': 0.17.7
+      '@esbuild/sunos-x64': 0.17.7
+      '@esbuild/win32-arm64': 0.17.7
+      '@esbuild/win32-ia32': 0.17.7
+      '@esbuild/win32-x64': 0.17.7
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -16810,7 +17038,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /file-system-cache/1.0.5:
@@ -17064,7 +17292,7 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       typescript: 4.9.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
@@ -17099,7 +17327,7 @@ packages:
       semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
 
   /fork-ts-checker-webpack-plugin/7.3.0_vfotqvx6lgcbf3upbs6hgaza4q:
     resolution: {integrity: sha512-IN+XTzusCjR5VgntYFgxbxVx3WraPRnKehBFrf00cMSrtUuW9MsG9dhL6MWpY6MkjC3wVwoujfCDgZZCQwbswA==}
@@ -18491,7 +18719,7 @@ packages:
     resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
     dev: true
 
-  /html-webpack-plugin/4.5.2_nljosxlhezzfayhg2olmp6suom:
+  /html-webpack-plugin/4.5.2_7domqanwj4vf2zv4qrbzwodcqy:
     resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
     engines: {node: '>=6.9'}
     peerDependencies:
@@ -18499,14 +18727,14 @@ packages:
     dependencies:
       '@types/html-minifier-terser': 5.1.1
       '@types/tapable': 1.0.7
-      '@types/webpack': 5.28.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      '@types/webpack': 5.28.0_ehsben5to4ps4x332te7f3wqri
       html-minifier-terser: 5.1.1
       loader-utils: 1.4.0
       lodash: 4.17.21
       pretty-error: 2.1.1
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -18525,7 +18753,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.75.0_cw4su4nzareykaft5p7arksy5i
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /htmlparser2/6.1.0:
@@ -23108,7 +23336,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /minimalistic-assert/1.0.1:
@@ -23281,7 +23509,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.24.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /monaco-editor/0.24.0:
@@ -24918,7 +25146,7 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /postcss-loader/7.0.2_upg3rk2kpasnbk27hkqapxaxfq:
@@ -24932,7 +25160,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.19
       semver: 7.3.8
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /postcss-media-query-parser/0.2.3:
@@ -25820,7 +26048,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /rc-progress/3.4.1_biqbaboplfbrettd7655fr4n2y:
@@ -27722,7 +27950,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.32.4
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /sass/1.32.4:
@@ -28509,7 +28737,7 @@ packages:
       webpack: ^1 || ^2 || ^3 || ^4 || ^5
     dependencies:
       chalk: 4.1.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /speedline-core/1.4.3:
@@ -28905,7 +29133,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /style-loader/2.0.0_webpack@5.75.0:
@@ -28916,7 +29144,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /style-loader/3.3.1_webpack@5.75.0:
@@ -28925,7 +29153,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /style-mod/4.0.0:
@@ -29390,35 +29618,11 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.16.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - bluebird
     dev: true
-
-  /terser-webpack-plugin/5.3.6_htvmhiqynazf46fjrszipnqp7a:
-    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.17
-      esbuild: 0.16.17
-      jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      terser: 5.16.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
 
   /terser-webpack-plugin/5.3.6_v7bbwjudcxv2o5c5io5ciwfori:
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
@@ -29445,6 +29649,30 @@ packages:
       terser: 5.16.1
       webpack: 5.75.0_cw4su4nzareykaft5p7arksy5i
     dev: true
+
+  /terser-webpack-plugin/5.3.6_xu2wxxvlz6i25ro5n4mqcdafx4:
+    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      esbuild: 0.17.7
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      terser: 5.16.1
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -29795,7 +30023,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.8
       typescript: 4.9.3
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /ts-log/2.2.3:
@@ -30553,7 +30781,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /url-parse-lax/1.0.0:
@@ -31151,7 +31379,7 @@ packages:
       import-local: 3.0.2
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-bundle-analyzer: 4.7.0
       webpack-dev-server: 4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq
       webpack-merge: 5.7.3
@@ -31166,7 +31394,7 @@ packages:
       mime: 2.6.0
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-log: 2.0.0
     dev: true
 
@@ -31182,7 +31410,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /webpack-dev-middleware/5.3.3_webpack@5.75.0:
@@ -31196,7 +31424,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
 
   /webpack-dev-server/4.11.1_rjsyjcrmk25kqsjzwkvj3a2evq:
     resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
@@ -31236,7 +31464,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
       webpack-dev-middleware: 5.3.3_webpack@5.75.0
       ws: 8.11.0
@@ -31300,7 +31528,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /webpack-hot-middleware/2.25.1:
@@ -31327,7 +31555,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
       webpack-sources: 2.3.0
     dev: true
 
@@ -31418,7 +31646,7 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack/5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy:
+  /webpack/5.75.0_ehsben5to4ps4x332te7f3wqri:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -31449,7 +31677,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6_htvmhiqynazf46fjrszipnqp7a
+      terser-webpack-plugin: 5.3.6_xu2wxxvlz6i25ro5n4mqcdafx4
       watchpack: 2.4.0
       webpack-cli: 5.0.1_y7ttplitmkohdpgkllksfboxwa
       webpack-sources: 3.2.3
@@ -31628,7 +31856,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.75.0_jh3afgd4dccyz4n3zkk5zvv5cy
+      webpack: 5.75.0_ehsben5to4ps4x332te7f3wqri
     dev: true
 
   /worker-rpc/0.1.1:


### PR DESCRIPTION
esbuild is an alternative to Webpack for TypeScript builds in local dev (https://docs.sourcegraph.com/dev/background-information/web/build#esbuild).

The latest release of esbuild fixes an issue (https://github.com/evanw/esbuild/issues/1370) that prevented us from using treeshaking. With esbuild 0.17.7, we can use treeshaking, which means smaller bundle sizes.




## Test plan

n/a (dev only)

## App preview:

- [Web](https://sg-web-sqs-upgrade-esbuild-treeshaking.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
