### PR TITLE
experimental search input: Simplify context: filter decoration

### DIFF
--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -2,9 +2,10 @@ import { RangeSetBuilder } from '@codemirror/state'
 import { Decoration, EditorView } from '@codemirror/view'
 import inRange from 'lodash/inRange'
 
-import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { isFilterOfType } from '@sourcegraph/shared/src/search/query/utils'
+
+import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
 
 const validFilter = Decoration.mark({ class: 'sg-filter' })
 const invalidFilter = Decoration.mark({ class: 'sg-filter sg-invalid-filter' })

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -1,55 +1,14 @@
 import { RangeSetBuilder } from '@codemirror/state'
-import {
-    Decoration,
-    DecorationSet,
-    EditorView,
-    PluginValue,
-    ViewPlugin,
-    ViewUpdate,
-    WidgetType,
-} from '@codemirror/view'
-import { mdiClose } from '@mdi/js'
+import { Decoration, EditorView } from '@codemirror/view'
 import inRange from 'lodash/inRange'
 
-import { Token } from '@sourcegraph/shared/src/search/query/token'
-import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
-
 import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { isFilterOfType } from '@sourcegraph/shared/src/search/query/utils'
 
 const validFilter = Decoration.mark({ class: 'sg-filter' })
 const invalidFilter = Decoration.mark({ class: 'sg-filter sg-invalid-filter' })
-const contextFilter = Decoration.mark({ class: 'sg-context-filter', inclusiveEnd: true })
-const replaceContext = Decoration.replace({})
-class ClearTokenWidget extends WidgetType {
-    constructor(private token: Token) {
-        super()
-    }
-
-    public toDOM(view: EditorView): HTMLElement {
-        const wrapper = document.createElement('span')
-        wrapper.setAttribute('aria-hidden', 'true')
-        wrapper.className = 'sg-clear-filter'
-
-        const button = document.createElement('button')
-        button.type = 'button'
-        button.addEventListener('click', () => {
-            view.dispatch({
-                // -1/+1 to include possible leading and trailing whitespace
-                changes: {
-                    from: Math.max(this.token.range.start - 1, 0),
-                    to: Math.min(this.token.range.end + 1, view.state.doc.length),
-                },
-            })
-            if (!view.hasFocus) {
-                view.focus()
-            }
-        })
-        button.append(createSVGIcon(mdiClose))
-        wrapper.append(button)
-
-        return wrapper
-    }
-}
+const contextFilter = Decoration.mark({ class: 'sg-context-filter', inclusiveEnd: false })
 
 export const filterHighlight = [
     EditorView.baseTheme({
@@ -87,8 +46,10 @@ export const filterHighlight = [
                     token?.value?.quoted || // or is quoted
                     withinRange // or cursor is within field
 
-                // context: filters are handled by the view plugin defined below
-                if (token.field.value !== 'context') {
+                // context: filters are styled differnetly
+                if (isFilterOfType(token, FilterType.context)) {
+                    builder.add(token.range.start, token.range.end, contextFilter)
+                } else {
                     // +1 to include the colon (:)
                     builder.add(token.range.start, token.field.range.end + 1, isValid ? validFilter : invalidFilter)
                 }
@@ -96,48 +57,4 @@ export const filterHighlight = [
         }
         return builder.finish()
     }),
-    // ViewPlugin handling decorating context: filters
-    ViewPlugin.fromClass(
-        class implements PluginValue {
-            public decorations: DecorationSet
-
-            constructor(view: EditorView) {
-                this.decorations = this.createDecorations(view)
-            }
-
-            public update(update: ViewUpdate): void {
-                if (update.focusChanged || update.selectionSet || update.docChanged) {
-                    this.decorations = this.createDecorations(update.view)
-                }
-            }
-
-            private createDecorations(view: EditorView): DecorationSet {
-                const query = view.state.facet(queryTokens)
-                const builder = new RangeSetBuilder<Decoration>()
-                for (const token of query.tokens) {
-                    if (token.type === 'filter' && token.field.value === 'context') {
-                        const withinRange = inRange(
-                            view.state.selection.main.head,
-                            token.range.start,
-                            token.range.end + 1
-                        ) // or cursor is within field
-                        if (token.value?.value && (!withinRange || !view.hasFocus)) {
-                            // hide context: field name and show remove button
-                            builder.add(token.range.start, token.field.range.end + 1, replaceContext)
-                            builder.add(token.range.start, token.range.end, contextFilter)
-                            builder.add(
-                                token.range.end,
-                                token.range.end,
-                                Decoration.widget({ widget: new ClearTokenWidget(token), side: -1 })
-                            )
-                        } else {
-                            builder.add(token.range.start, token.range.end, contextFilter)
-                        }
-                    }
-                }
-                return builder.finish()
-            }
-        },
-        { decorations: plugin => plugin.decorations }
-    ),
 ]

--- a/client/shared/src/search/query/utils.ts
+++ b/client/shared/src/search/query/utils.ts
@@ -1,8 +1,13 @@
-import type { Token } from './token'
+import { FilterType, resolveFilter } from './filters'
+import type { Filter, Token } from './token'
 
 /**
  * Returns the (string) length of the provided token.
  */
 export function getTokenLength(token: Token): number {
     return token.range.end - token.range.start
+}
+
+export function isFilterOfType(filter: Filter, type: FilterType): boolean {
+    return resolveFilter(filter.field.value)?.type === type
 }


### PR DESCRIPTION
This PR simplifies the `context:` selector decoration by removing the `x` button and keeping the `context:` part always visible.

<img width="842" alt="2023-02-12_11-32" src="https://user-images.githubusercontent.com/179026/218308453-398d6e2e-05d2-4f07-a6bc-afab732ae93e.png">


## Test plan

Manual testing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-fkling-search-input-context.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
