### PR TITLE
experimental search input: Fix resolving filters

### DIFF
--- a/client/shared/src/search/query/utils.ts
+++ b/client/shared/src/search/query/utils.ts
@@ -1,3 +1,5 @@
+import { memoize } from 'lodash'
+
 import { FilterType, resolveFilter } from './filters'
 import type { Filter, Token } from './token'
 
@@ -8,6 +10,8 @@ export function getTokenLength(token: Token): number {
     return token.range.end - token.range.start
 }
 
-export function isFilterOfType(filter: Filter, type: FilterType): boolean {
-    return resolveFilter(filter.field.value)?.type === type
+export const resolveFilterMemoized = memoize(resolveFilter)
+
+export function isFilterOfType(filter: Filter, filterType: FilterType): boolean {
+    return resolveFilterMemoized(filter.field.value)?.type === filterType
 }


### PR DESCRIPTION
This fixes various issues that occurred because I haven't properly resolved filters. E.g. as it was the code wouldn't work as expected when abbreviated filter names have been used.

## Test plan

Manual testing. An input like `r:sourcegraph test` now properly restricts file suggestions to repositories containing `sourcegraph`.

## App preview:

- [Web](https://sg-web-fkling-fix-filter-logic.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
