### PR TITLE
experimental search input: Remove current query as first suggestion

### DIFF
--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -442,7 +442,7 @@ class SuggestionsState {
                 !registeredSource.inactive,
                 state.source.state === RegisteredSourceState.Inactive ||
                 state.source.state === RegisteredSourceState.Complete
-                    ? 0
+                    ? -1
                     : state.selectedOption
             )
         }


### PR DESCRIPTION
Until now the first suggestion reflected the current input and was selected by default, to make it explicit that pressing return would execute the query.

In the first internal test we want to validate the user experience without this behavior. By default no suggestion is selected.


https://user-images.githubusercontent.com/179026/218310605-a0fa3cac-3817-496e-9082-39b34850946f.mp4


## Test plan
Manual testing.

## App preview:

- [Web](https://sg-web-fkling-remove-query-as-first.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
