### PR TITLE
experimental search input: Hide copy and smart search buttons on homepage

### DIFF
--- a/client/branded/src/search-ui/input/toggles/Toggles.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.tsx
@@ -35,6 +35,7 @@ export interface TogglesProps
     navbarSearchQuery: string
     className?: string
     showCopyQueryButton?: boolean
+    showSmartSearchButton?: boolean
     /**
      * If set to false makes all buttons non-actionable. The main use case for
      * this prop is showing the toggles in examples. This is different from
@@ -73,6 +74,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         selectedSearchContextSpec,
         submitSearch,
         showCopyQueryButton = true,
+        showSmartSearchButton = true,
         structuralSearchDisabled,
     } = props
 
@@ -189,13 +191,15 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                         />
                     )}
                 </>
-                <div className={styles.separator} />
-                <SmartSearchToggle
-                    className="test-smart-search-toggle"
-                    isActive={searchMode === SearchMode.SmartSearch}
-                    onSelect={onSelectSmartSearch}
-                    interactive={props.interactive}
-                />
+                {(showSmartSearchButton || showCopyQueryButton) && <div className={styles.separator} />}
+                {showSmartSearchButton && (
+                    <SmartSearchToggle
+                        className="test-smart-search-toggle"
+                        isActive={searchMode === SearchMode.SmartSearch}
+                        onSelect={onSelectSmartSearch}
+                        interactive={props.interactive}
+                    />
+                )}
                 {showCopyQueryButton && (
                     <CopyQueryButton
                         fullQuery={fullQuery}

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -186,6 +186,8 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                 setSearchMode={setSearchMode}
                 settingsCascade={props.settingsCascade}
                 navbarSearchQuery={props.queryState.query}
+                showCopyQueryButton={false}
+                showSmartSearchButton={false}
             />
         </LazyCodeMirrorQueryInput>
     ) : (


### PR DESCRIPTION
To make the input less "noisy" on the homepage we are hiding the smart search and copy query buttons. The assumption is that those buttons are less relevant in this context (they are more relevant *after* you performed a query). The buttons will be available on the search results page (the experimental search input will be enabled on the search results page in another PR).

<img width="827" alt="2023-02-12_12-25" src="https://user-images.githubusercontent.com/179026/218310980-f43a12d4-a95c-4811-a86c-be944477fcf2.png">

## Test plan
Manual inspection.

## App preview:

- [Web](https://sg-web-fkling-search-input-toggle-buttons.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
