### PR TITLE
web: remove the remaining uses of `useHistory()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -212,11 +212,6 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
         message:
           'Use `react-router-dom-v5-compat` instead. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
       },
-      {
-        selector: 'CallExpression[callee.name="useHistory"]',
-        message:
-          'Use `useNavigate` from `react-router-dom-v5-compat` if possible. We are in the process of migrating from react-router v5 to v6. More info https://github.com/sourcegraph/sourcegraph/issues/33834',
-      },
     ],
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     'react/jsx-uses-react': 'off',

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -26,7 +26,7 @@ import {
     WidgetType,
 } from '@codemirror/view'
 import classNames from 'classnames'
-import { useHistory } from 'react-router'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
@@ -139,6 +139,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
     const [editor, setEditor] = useState<EditorView | undefined>()
     const editorReference = useRef<EditorView>()
     const focusSearchBarShortcut = useKeyboardShortcut('focusSearch')
+    const navigate = useNavigate()
 
     const editorCreated = useCallback(
         (editor: EditorView) => {
@@ -149,8 +150,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
         [editorReference, onEditorCreated]
     )
 
-    const history = useHistory()
-
     const autocompletion = useMemo(
         () =>
             createDefaultSuggestions({
@@ -158,13 +157,13 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
                     fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)),
                 globbing,
                 isSourcegraphDotCom,
-                history,
+                navigate,
                 applyOnEnter: applySuggestionsOnEnter,
             }),
         [
             globbing,
             isSourcegraphDotCom,
-            history,
+            navigate,
             applySuggestionsOnEnter,
             fetchStreamSuggestions,
             selectedSearchContextSpec,

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react'
+import { FC, useCallback, useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
 
@@ -68,7 +68,7 @@ export interface SearchBoxProps
     recentSearches?: RecentSearch[]
 }
 
-export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBoxProps>> = props => {
+export const SearchBox: FC<SearchBoxProps> = props => {
     const {
         queryState,
         onEditorCreated: onEditorCreatedCallback,

--- a/client/branded/src/search-ui/input/SearchButton.tsx
+++ b/client/branded/src/search-ui/input/SearchButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
 import classNames from 'classnames'
@@ -15,7 +15,7 @@ interface Props {
  * A search button with a dropdown with related links. It must be wrapped in a form whose onSubmit
  * handler performs the search.
  */
-export const SearchButton: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ className }) => (
+export const SearchButton: FC<Props> = ({ className }) => (
     <div className={className}>
         <Button
             data-search-button={true}

--- a/client/branded/src/search-ui/input/codemirror/completion.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.ts
@@ -45,8 +45,8 @@ import {
     mdiWeb,
     mdiWrench,
 } from '@mdi/js'
-import * as H from 'history'
 import { isEqual, startCase } from 'lodash'
+import { NavigateFunction } from 'react-router-dom-v5-compat'
 
 import { isDefined } from '@sourcegraph/common'
 import { SymbolKind } from '@sourcegraph/shared/src/graphql-operations'
@@ -131,7 +131,7 @@ export type StandardSuggestionSource = SuggestionSource<CompletionResult | null,
  */
 export function searchQueryAutocompletion(
     sources: StandardSuggestionSource[],
-    history?: H.History,
+    navigate?: NavigateFunction,
     // By default we do not enable suggestion selection with enter because that
     // interferes with the query submission logic.
     applyOnEnter = false
@@ -247,8 +247,8 @@ export function searchQueryAutocompletion(
                                   const selected = selectedCompletion(view.state)
                                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
                                   const url = (selected as any)?.url
-                                  if (history && typeof url === 'string') {
-                                      history.push(url)
+                                  if (navigate && typeof url === 'string') {
+                                      navigate(url)
                                       return true
                                   }
                                   // Otherwise apply the selected completion item

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef } from 'react'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { EMPTY, NEVER } from 'rxjs'
 import { useDarkMode } from 'storybook-dark-mode'
+import { BrowserRouter } from 'react-router-dom'
+import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -42,43 +44,47 @@ export const JetBrainsSearchBoxStory: Story = () => {
 
     return (
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
-            <div ref={rootElementRef}>
-                <div className="d-flex justify-content-center">
-                    <div className="mx-6">
-                        <JetBrainsSearchBox
-                            caseSensitive={true}
-                            setCaseSensitivity={() => {}}
-                            patternType={SearchPatternType.regexp}
-                            setPatternType={() => {}}
-                            isSourcegraphDotCom={false}
-                            structuralSearchDisabled={false}
-                            queryState={{ query: 'type:file test AND test repo:contains.file(CHANGELOG)' }}
-                            onChange={() => {}}
-                            onSubmit={() => {}}
-                            authenticatedUser={null}
-                            searchContextsEnabled={true}
-                            showSearchContext={true}
-                            showSearchContextManagement={false}
-                            setSelectedSearchContextSpec={() => {}}
-                            selectedSearchContextSpec={undefined}
-                            fetchSearchContexts={() => {
-                                throw new Error('fetchSearchContexts')
-                            }}
-                            getUserSearchContextNamespaces={() => []}
-                            fetchStreamSuggestions={() => NEVER}
-                            settingsCascade={EMPTY_SETTINGS_CASCADE}
-                            globbing={false}
-                            isLightTheme={!isDarkTheme}
-                            telemetryService={NOOP_TELEMETRY_SERVICE}
-                            platformContext={{ requestGraphQL: () => EMPTY }}
-                            className=""
-                            containerClassName=""
-                            autoFocus={true}
-                            hideHelpButton={true}
-                        />
+            <BrowserRouter>
+                <CompatRouter>
+                    <div ref={rootElementRef}>
+                        <div className="d-flex justify-content-center">
+                            <div className="mx-6">
+                                <JetBrainsSearchBox
+                                    caseSensitive={true}
+                                    setCaseSensitivity={() => {}}
+                                    patternType={SearchPatternType.regexp}
+                                    setPatternType={() => {}}
+                                    isSourcegraphDotCom={false}
+                                    structuralSearchDisabled={false}
+                                    queryState={{ query: 'type:file test AND test repo:contains.file(CHANGELOG)' }}
+                                    onChange={() => {}}
+                                    onSubmit={() => {}}
+                                    authenticatedUser={null}
+                                    searchContextsEnabled={true}
+                                    showSearchContext={true}
+                                    showSearchContextManagement={false}
+                                    setSelectedSearchContextSpec={() => {}}
+                                    selectedSearchContextSpec={undefined}
+                                    fetchSearchContexts={() => {
+                                        throw new Error('fetchSearchContexts')
+                                    }}
+                                    getUserSearchContextNamespaces={() => []}
+                                    fetchStreamSuggestions={() => NEVER}
+                                    settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                    globbing={false}
+                                    isLightTheme={!isDarkTheme}
+                                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                                    platformContext={{ requestGraphQL: () => EMPTY }}
+                                    className=""
+                                    containerClassName=""
+                                    autoFocus={true}
+                                    hideHelpButton={true}
+                                />
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
+                </CompatRouter>
+            </BrowserRouter>
         </WildcardThemeContext.Provider>
     )
 }

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react'
 
 import { DecoratorFn, Meta, Story } from '@storybook/react'
-import { EMPTY, NEVER } from 'rxjs'
-import { useDarkMode } from 'storybook-dark-mode'
 import { BrowserRouter } from 'react-router-dom'
 import { CompatRouter } from 'react-router-dom-v5-compat'
+import { EMPTY, NEVER } from 'rxjs'
+import { useDarkMode } from 'storybook-dark-mode'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/hooks/useScrollManager/useScrollManager.ts
+++ b/client/web/src/hooks/useScrollManager/useScrollManager.ts
@@ -1,8 +1,7 @@
 import { useEffect } from 'react'
 
 import { debounce } from 'lodash'
-import { useHistory } from 'react-router'
-import { useLocation } from 'react-router-dom-v5-compat'
+import { useLocation, useNavigationType } from 'react-router-dom-v5-compat'
 
 import { logger } from '@sourcegraph/common'
 
@@ -34,8 +33,8 @@ const SCROLL_RETRY_TIMEOUT = 3000
  * @param containerRef A React ref object of the container where scrolling will be managed.
  */
 export function useScrollManager(containerKey: string, containerRef: React.RefObject<HTMLElement>): void {
-    const history = useHistory()
     const location = useLocation()
+    const navigationType = useNavigationType()
 
     // Set up the maps for this containerKey if they haven't been created yet
     useEffect(() => {
@@ -75,7 +74,7 @@ export function useScrollManager(containerKey: string, containerRef: React.RefOb
 
         // Attempt a scroll if we have a saved position for the pathname; if the scroll doesn't work, set up an observer to
         // retry up until a given timeout
-        if (history.action === 'POP' && SAVED_SCROLL_POSITIONS[containerKey].has(pathname)) {
+        if (navigationType === 'POP' && SAVED_SCROLL_POSITIONS[containerKey].has(pathname)) {
             const scrollPosition = SAVED_SCROLL_POSITIONS[containerKey].get(pathname) ?? 0
 
             const attemptScroll = (): boolean => {
@@ -104,12 +103,12 @@ export function useScrollManager(containerKey: string, containerRef: React.RefOb
                         }
                     })
             }
-        } else if (history.action === 'PUSH') {
+        } else if (navigationType === 'PUSH') {
             // In the case of pushing new history (e.g. clicking a navigation link), make sure we always start at the top of the container
             containerRef.current?.scrollTo(0, 0)
         }
 
         // This should only run when `pathname`/`action` change; ignore changes to `containerKey` or `containerRef` as those should not trigger a scroll restoration
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [location.pathname, history.action])
+    }, [location.pathname, navigationType])
 }

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -55,9 +55,6 @@ export function submitSearch({
         searchQueryParameter = searchQueryParameter + '&' + preserved
     }
 
-    // Go to search results page
-    const path = '/search?' + searchQueryParameter
-
     const queryWithContext = appendContextFilter(query, selectedSearchContextSpec)
     eventLogger.log(
         'SearchSubmitted',
@@ -67,7 +64,16 @@ export function submitSearch({
         },
         { source }
     )
-    const state = { ...(typeof location.state === 'object' ? location.state : null), query }
 
-    compatNavigate(historyOrNavigate, path, { state })
+    const state = {
+        ...(typeof location.state === 'object' ? location.state : null),
+        queryTimestamp: Date.now(),
+        query,
+    }
+
+    // Go to search results page
+    compatNavigate(historyOrNavigate, '/search?' + searchQueryParameter, {
+        state,
+        replace: searchQueryParameter === location.search.slice(1),
+    })
 }


### PR DESCRIPTION
## Context

- Part of #33834 

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-react-router-migration-7.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
