### PR TITLE
experimental search input: Enable in navbar

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -71,7 +71,7 @@ function showWhenEmptyWithoutContext(state: EditorState): boolean {
 }
 
 // For simplicity we will recompute all extensions when input changes using
-// this ocmpartment
+// this compartment
 const extensionsCompartment = new Compartment()
 
 // Helper function to update extensions dependent on props. Used when
@@ -240,7 +240,7 @@ export interface CodeMirrorQueryInputWrapperProps {
     interpretComments: boolean
     patternType: SearchPatternType
     placeholder: string
-    suggestionSource: Source
+    suggestionSource?: Source
     extensions?: Extension
 }
 

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -1,9 +1,12 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef, useMemo } from 'react'
 
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import shallow from 'zustand/shallow'
 
-import { SearchBox } from '@sourcegraph/branded'
+import { SearchBox, Toggles } from '@sourcegraph/branded'
+// The experimental search input should be shown in the navbar
+// eslint-disable-next-line no-restricted-imports
+import { LazyCodeMirrorQueryInput, searchHistoryExtension } from '@sourcegraph/branded/src/search-ui/experimental'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -15,6 +18,7 @@ import { AuthenticatedUser } from '../../auth'
 import { useExperimentalFeatures, useNavbarQueryState, setSearchCaseSensitivity } from '../../stores'
 import { NavbarQueryState, setSearchMode, setSearchPatternType } from '../../stores/navbarSearchQueryState'
 
+import { createSuggestionsSource } from './suggestions'
 import { useRecentSearches } from './useRecentSearches'
 
 interface Props
@@ -54,8 +58,11 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
 
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
+    const experimentalQueryInput = useExperimentalFeatures(features => features.searchQueryInput === 'experimental')
 
     const { recentSearches } = useRecentSearches()
+    const recentSearchesRef = useRef(recentSearches)
+    recentSearchesRef.current = recentSearches
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
@@ -69,14 +76,83 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
         },
         [submitSearch, navigate, location, props.selectedSearchContextSpec]
     )
+    const submitSearchOnChangeRef = useRef(submitSearchOnChange)
+    submitSearchOnChangeRef.current = submitSearchOnChange
 
     const onSubmit = useCallback(
         (event?: React.FormEvent): void => {
             event?.preventDefault()
-            submitSearchOnChange()
+            submitSearchOnChangeRef.current()
         },
-        [submitSearchOnChange]
+        [submitSearchOnChangeRef]
     )
+
+    const suggestionSource = useMemo(
+        () =>
+            createSuggestionsSource({
+                platformContext: props.platformContext,
+                authenticatedUser: props.authenticatedUser,
+                fetchSearchContexts: props.fetchSearchContexts,
+                getUserSearchContextNamespaces: props.getUserSearchContextNamespaces,
+                isSourcegraphDotCom: props.isSourcegraphDotCom,
+            }),
+        [
+            props.platformContext,
+            props.authenticatedUser,
+            props.fetchSearchContexts,
+            props.getUserSearchContextNamespaces,
+            props.isSourcegraphDotCom,
+        ]
+    )
+
+    const experimentalExtensions = useMemo(
+        () =>
+            experimentalQueryInput
+                ? [
+                      searchHistoryExtension({
+                          mode: {
+                              name: 'History',
+                              placeholder: 'Filter history',
+                          },
+                          source: () => recentSearchesRef.current ?? [],
+                          submitQuery: query => submitSearchOnChangeRef.current({ query }),
+                      }),
+                  ]
+                : [],
+        [experimentalQueryInput, recentSearchesRef, submitSearchOnChangeRef]
+    )
+
+    if (experimentalQueryInput) {
+        return (
+            <Form
+                className="search--navbar-item d-flex align-items-flex-start flex-grow-1 flex-shrink-past-contents"
+                onSubmit={onSubmit}
+            >
+                <LazyCodeMirrorQueryInput
+                    patternType={searchPatternType}
+                    interpretComments={false}
+                    queryState={queryState}
+                    onChange={setQueryState}
+                    onSubmit={onSubmit}
+                    isLightTheme={props.isLightTheme}
+                    placeholder="Search for code or files..."
+                    suggestionSource={suggestionSource}
+                    extensions={experimentalExtensions}
+                >
+                    <Toggles
+                        patternType={searchPatternType}
+                        caseSensitive={searchCaseSensitivity}
+                        setPatternType={setSearchPatternType}
+                        setCaseSensitivity={setSearchCaseSensitivity}
+                        searchMode={searchMode}
+                        setSearchMode={setSearchMode}
+                        settingsCascade={props.settingsCascade}
+                        navbarSearchQuery={queryState.query}
+                    />
+                </LazyCodeMirrorQueryInput>
+            </Form>
+        )
+    }
 
     return (
         <Form

--- a/client/web/src/search/input/lazy.ts
+++ b/client/web/src/search/input/lazy.ts
@@ -1,0 +1,54 @@
+import { RefObject, useMemo } from 'react'
+
+import type { Extension } from '@codemirror/state'
+import { from, of } from 'rxjs'
+
+// The experimental search input should be shown on the search home page
+// eslint-disable-next-line no-restricted-imports
+import type { Source } from '@sourcegraph/branded/src/search-ui/experimental'
+import type { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
+import { useObservable } from '@sourcegraph/wildcard'
+
+import type { SuggestionsSourceConfig } from './suggestions'
+
+export function useLazyCreateSuggestions(enabled: boolean, parameters: SuggestionsSourceConfig): Source | undefined {
+    const suggestionsModule = useObservable(
+        useMemo(() => (enabled ? from(import('./suggestions')) : of(undefined)), [enabled])
+    )
+
+    return useMemo(
+        () => (suggestionsModule ? suggestionsModule.createSuggestionsSource(parameters) : undefined),
+        [suggestionsModule, parameters]
+    )
+}
+
+export function useLazyHistoryExtension(
+    enabled: boolean,
+    recentSearchesRef: RefObject<RecentSearch[] | undefined>,
+    submitRef: RefObject<({ query }: { query: string }) => void>
+): Extension {
+    const historyModule = useObservable(
+        useMemo(
+            () =>
+                enabled
+                    ? from(import('@sourcegraph/branded/src/search-ui/input/experimental/codemirror/history'))
+                    : of(undefined),
+            [enabled]
+        )
+    )
+
+    return useMemo(
+        () =>
+            historyModule
+                ? historyModule.searchHistoryExtension({
+                      mode: {
+                          name: 'History',
+                          placeholder: 'Filter history',
+                      },
+                      source: () => recentSearchesRef.current ?? [],
+                      submitQuery: query => submitRef.current?.({ query }),
+                  })
+                : [],
+        [historyModule, recentSearchesRef, submitRef]
+    )
+}

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -570,7 +570,7 @@ interface Caches {
     symbol: ContextualCache<CodeSymbol, FzfResultItem<CodeSymbol>>
 }
 
-interface SuggestionsSourceConfig
+export interface SuggestionsSourceConfig
     extends Pick<SearchContextProps, 'fetchSearchContexts' | 'getUserSearchContextNamespaces'> {
     platformContext: Pick<PlatformContext, 'requestGraphQL'>
     authenticatedUser?: AuthenticatedUser | null


### PR DESCRIPTION
This diff brings the experimental search input to the navbar and thus enables it on the search result page and the repo pages. I basically just applied the same changes to the navbar input as to the search home input.


https://user-images.githubusercontent.com/179026/218379022-298757c6-8312-41a7-a7fa-e3da5bfa7e67.mp4



## Test plan

Manual testing (feature flagged).

## App preview:

- [Web](https://sg-web-fkling-experimental-search-input.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
