### PR TITLE
RFC rcache: use context for FIFOList.Insert

### DIFF
--- a/cmd/frontend/graphqlbackend/slow_requests_tracer.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer.go
@@ -35,7 +35,7 @@ func captureSlowRequest(logger log.Logger, req *types.SlowRequest) {
 		logger.Warn("failed to marshal slowRequest", log.Error(err))
 		return
 	}
-	if err := slowRequestRedisFIFOList.Insert(b); err != nil {
+	if err := slowRequestRedisFIFOList.Insert(context.Background(), b); err != nil {
 		logger.Warn("failed to capture slowRequest", log.Error(err))
 	}
 }

--- a/internal/goroutine/recorder/recorder.go
+++ b/internal/goroutine/recorder/recorder.go
@@ -1,6 +1,7 @@
 package recorder
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -173,7 +174,7 @@ func (m *Recorder) saveRun(jobName string, routineName string, hostName string, 
 	}
 
 	// Save run
-	err = getRecentRuns(m.rcache, jobName, routineName, hostName).Insert(runJson)
+	err = getRecentRuns(m.rcache, jobName, routineName, hostName).Insert(context.Background(), runJson)
 	if err != nil {
 		return errors.Wrap(err, "save run")
 	}

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -109,7 +109,8 @@ func redisLoggerMiddleware() Middleware {
 			}
 
 			// Save new item
-			if err := outboundRequestsRedisFIFOList.Insert(logItemJson); err != nil {
+			recordCtx := context.Background() // the request context may have been canceled.
+			if err := outboundRequestsRedisFIFOList.Insert(recordCtx, logItemJson); err != nil {
 				middlewareErrors = errors.Append(middlewareErrors,
 					errors.Wrap(err, "insert log item"))
 			}

--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -54,7 +54,7 @@ func Test_FIFOList_All_OK(t *testing.T) {
 		r := NewFIFOList(c.key, c.size)
 		t.Run(fmt.Sprintf("size %d with %d entries", c.size, len(c.inserts)), func(t *testing.T) {
 			for _, b := range c.inserts {
-				if err := r.Insert(b); err != nil {
+				if err := r.Insert(context.Background(), b); err != nil {
 					t.Errorf("expected no error, got %q", err)
 				}
 			}
@@ -143,7 +143,7 @@ func Test_FIFOList_Slice_OK(t *testing.T) {
 		r := NewFIFOList(c.key, c.size)
 		t.Run(fmt.Sprintf("size %d with %d entries, [%d,%d]", c.size, len(c.inserts), c.from, c.to), func(t *testing.T) {
 			for _, b := range c.inserts {
-				if err := r.Insert(b); err != nil {
+				if err := r.Insert(context.Background(), b); err != nil {
 					t.Errorf("expected no error, got %q", err)
 				}
 			}
@@ -162,7 +162,7 @@ func Test_NewFIFOListDynamic(t *testing.T) {
 	maxSize := 3
 	r := NewFIFOListDynamic("a", func() int { return maxSize })
 	for i := 0; i < 10; i++ {
-		err := r.Insert([]byte("a"))
+		err := r.Insert(context.Background(), []byte("a"))
 		if err != nil {
 			t.Errorf("expected no error, got %q", err)
 		}
@@ -178,7 +178,7 @@ func Test_NewFIFOListDynamic(t *testing.T) {
 
 	maxSize = 2
 	for i := 0; i < 10; i++ {
-		err := r.Insert([]byte("b"))
+		err := r.Insert(context.Background(), []byte("b"))
 		if err != nil {
 			t.Errorf("expected no error, got %q", err)
 		}
@@ -195,7 +195,7 @@ func Test_NewFIFOListDynamic(t *testing.T) {
 
 func Test_FIOListContextCancellation(t *testing.T) {
 	r := NewFIFOList("a", 3)
-	err := r.Insert([]byte("a"))
+	err := r.Insert(context.Background(), []byte("a"))
 	if err != nil {
 		t.Errorf("expected no error, got %q", err)
 	}

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -109,7 +109,8 @@ func (rc *RecordingCmd) after(ctx context.Context, logger log.Logger, cmd *exec.
 		return
 	}
 
-	rc.store.Insert(data)
+	// We ignore ctx since it may be cancelled.
+	rc.store.Insert(context.Background(), data)
 }
 
 // RecordingCommandFactory stores a ShouldRecord that will be used to create a new RecordingCommand


### PR DESCRIPTION
We want to be able to timeout inserts just in case redis is acting slow. However, for every call-site to Insert we probably want the same behaviour:

- Ignore passed in ctx (it may be canceled).
- Run in background.
- Use a timeout.

This makes me think this design is the incorrect one, but I am sending it out anyways to spark discussion.

I think a nicer approach is instead for FIFOList to have a configurable timeout and not take in a context. Since that will be a footgun. It may be nicer to wrap FIFOList with something like "BackgroundRecorder" or something which does what we expect, and leave FIFOList to be a nice pure FIFOList.

WDYT?

Test Plan: CI
