### PR TITLE
[fix] Better UX for test connection button

### DIFF
--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -8,9 +8,11 @@ export interface LoaderButtonProps extends ButtonProps {
     loading: boolean
     label: string
     alwaysShowLabel: boolean
+    icon?: JSX.Element
 }
 
 export const LoaderButton: React.FunctionComponent<React.PropsWithChildren<Partial<LoaderButtonProps>>> = ({
+    icon,
     loading,
     label,
     alwaysShowLabel,
@@ -21,6 +23,10 @@ export const LoaderButton: React.FunctionComponent<React.PropsWithChildren<Parti
             <>
                 <LoadingSpinner />
                 {alwaysShowLabel && <span className="ml-1">{label}</span>}
+            </>
+        ) : icon ? (
+            <>
+                {icon}&nbsp;{label}
             </>
         ) : (
             label

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -133,7 +133,13 @@ export const ExternalServicePage: FC<Props> = props => {
     const checkConnectionNode = data?.node?.__typename === 'ExternalService' ? data.node.checkConnection : null
 
     let externalServiceAvailabilityStatus
-    if (!error && !loading) {
+    if (loading) {
+        externalServiceAvailabilityStatus = (
+            <Alert className="mt-2" variant="waiting">
+                Checking code host connection status...
+            </Alert>
+        )
+    } else if (!error) {
         if (checkConnectionNode?.__typename === 'ExternalServiceAvailable') {
             externalServiceAvailabilityStatus = (
                 <Alert className="mt-2" variant="success">
@@ -149,6 +155,14 @@ export const ExternalServicePage: FC<Props> = props => {
                 />
             )
         }
+    } else {
+        externalServiceAvailabilityStatus = (
+            <ErrorAlert
+                className="mt-2"
+                prefix="Unexpected error during code host connection check"
+                error={error.message}
+            />
+        )
     }
 
     return (
@@ -187,15 +201,17 @@ export const ExternalServicePage: FC<Props> = props => {
                                                 : 'Connection check unavailable'
                                         }
                                     >
-                                        <Button
+                                        <LoaderButton
                                             className="test-connection-external-service-button"
                                             variant="secondary"
                                             onClick={() => doCheckConnection()}
                                             disabled={!externalService.hasConnectionCheck || loading}
                                             size="sm"
-                                        >
-                                            <Icon aria-hidden={true} svgPath={mdiConnection} /> Test connection
-                                        </Button>
+                                            loading={loading}
+                                            alwaysShowLabel={true}
+                                            icon={<Icon aria-hidden={true} svgPath={mdiConnection} />}
+                                            label="Test connection"
+                                        />
                                     </Tooltip>
                                 </div>
                                 {editingEnabled && (


### PR DESCRIPTION
## Description

Previously, the behavior was not showing enough feedback that there is an ongoing process running in the background. Added a loading spinner on the button and a message below it saying, that we load data.

Also, previously we did not handle errors correctly. Now we show an error alert even if there is an error communicating to the graphql backend or some other unexpected problem.

Related: https://github.com/sourcegraph/sourcegraph/issues/47522

## Video

https://www.loom.com/share/e6a09b86a2bb4c1d9e39c3274cacdce5

## Test plan

Tested locally with various failure modes:
- connection succeeds
- connection does not succeed because of bad URL for code host
- connection does not succeed because of bad token for code host
- kill frontend - graphql request fails

I was not able to reproduce the redis problem locally though, even when I used the suggested settings.

## App preview:

- [Web](https://sg-web-milan-test-connection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
