### PR TITLE
nix: use go1.20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674971084,
-        "narHash": "sha256-YxBWj2t75Jun+NJUwr2vvtcfLwvGcazSo+pnNxpt+tU=",
+        "lastModified": 1676110339,
+        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22c4a7a4796a91c297a7e59078a84ec29515f86e",
+        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.11",
+        "ref": "nixos-unstable",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Sourcegraph developer environment Nix Flake";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-22.11";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
   };
 
   outputs = { self, nixpkgs }:

--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ pkgs.mkShell {
     universal-ctags
 
     # Build our backend.
-    go_1_19
+    go_1_20
 
     # Lots of our tooling and go tests rely on git et al.
     git


### PR DESCRIPTION
Had to move to unstable for this, but everything seems to be working. I wonder if we should introduce both stable and unstable pkgs? IE it kind of sucks needing to download 4G from the cache every update (which I think is mostly bazel?).

Test Plan: nix develop