### PR TITLE
doc: document shard merging

### DIFF
--- a/doc/code_search/explanations/search_details.md
+++ b/doc/code_search/explanations/search_details.md
@@ -58,3 +58,32 @@ except the path separator `/`.
 
 Note that invalid globbing patterns will cause an error and searches over commits containing a broken _ignore_ file 
 will not return any result.
+
+## Shard merging
+
+Shard merging is a feature of Zoekt that enables the combination of smaller
+index files, or shards, into one larger file, a compound shard. This can reduce
+memory costs for Zoekt webserver. This feature is particularly useful for
+customers with many small and rarely updated repositories, and can result in a
+significant reduction in memory. Shard merging can be enabled by setting
+`SRC_ENABLE_SHARD_MERGING="1"` for Zoekt indexserver.
+
+Shard merging can be fine-tuned by setting ENV variables for Zoekt indexserver:
+
+| Env Variable           | Description                                                                                     | Default                                                |
+|------------------------|-------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| SRC_VACUUM_INTERVAL    | Run vacuum this often, specified as a duration                                                 | 24 hours                                               |
+| SRC_MERGE_INTERVAL     | Run merge this often, specified as a duration                                                  | 8 hours                                                |
+| SRC_MERGE_TARGET_SIZE  | The target size of compound shards in MiB                                                      | 2000                                                   |
+| SRC_MERGE_MIN_SIZE     | The minimum size of a compound shard in MiB                                                    | 1800                                                   |
+| SRC_MERGE_MIN_AGE      | The time since the last commit in days. Shards with newer commits are excluded from merging.   | 7                                                      |
+| SRC_MERGE_MAX_PRIORITY | The maximum priority a shard can have to be considered for merging, specified as a float value | 100.0                                                  |
+
+When repostiories receive udpates, Zoekt reindexes them and tombstones their
+old index data. As a result, compound shards can shrink and be dismantled into
+individual shards once they reach a critical minimum size. These individual
+shards are then considered for future merge operations.
+
+Shard merging can be monitored via the "Compound shards" panel in Zoekt's
+Grafana dashboard.
+


### PR DESCRIPTION
Shard merging has been live on .com for well over 1 year now. It is time to roll it out and let customers profit too. For now it will be on an opt-in basis.

## Test plan
Only a doc change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
