### PR TITLE
permissions-center: save `code_host_states` after successful permission sync.

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
@@ -109,7 +109,7 @@ func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType request
 
 		// NOTE(naman): here we are saving permissions added, removed and found results to the job record
 		if result != nil {
-			err = h.jobsStore.SaveSyncResult(ctx, recordID, result)
+			err = h.jobsStore.SaveSyncResult(ctx, recordID, result, providerStates.ToPermissionSyncCodeHostState())
 			if err != nil {
 				h.logger.Error(fmt.Sprintf("failed to save permissions sync job(%d) results", recordID), log.Error(err))
 			}

--- a/enterprise/cmd/repo-updater/internal/authz/provider_state.go
+++ b/enterprise/cmd/repo-updater/internal/authz/provider_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -53,4 +54,22 @@ func (ps providerStatesSet) SummaryField() log.Field {
 	return log.Object("providers",
 		log.Object("state.error", errored...),
 		log.Object("state.success", succeeded...))
+}
+
+// ToPermissionSyncCodeHostState converts slice of syncjobs.ProviderStatus to
+// slice of database.PermissionSyncCodeHostState.
+//
+// TODO(sashaostrikov): remove it when all syncjobs.ProviderStatus usages are
+// changed to database.PermissionSyncCodeHostState.
+func (ps providerStatesSet) ToPermissionSyncCodeHostState() []database.PermissionSyncCodeHostState {
+	states := make([]database.PermissionSyncCodeHostState, 0, len(ps))
+	for _, p := range ps {
+		states = append(states, database.PermissionSyncCodeHostState{
+			ProviderID:   p.ProviderID,
+			ProviderType: p.ProviderType,
+			Status:       p.Status,
+			Message:      p.Message,
+		})
+	}
+	return states
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -35524,7 +35524,7 @@ func NewMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 			},
 		},
 		SaveSyncResultFunc: &PermissionSyncJobStoreSaveSyncResultFunc{
-			defaultHook: func(context.Context, int, *SetPermissionsResult) (r0 error) {
+			defaultHook: func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) (r0 error) {
 				return
 			},
 		},
@@ -35582,7 +35582,7 @@ func NewStrictMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 			},
 		},
 		SaveSyncResultFunc: &PermissionSyncJobStoreSaveSyncResultFunc{
-			defaultHook: func(context.Context, int, *SetPermissionsResult) error {
+			defaultHook: func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error {
 				panic("unexpected invocation of MockPermissionSyncJobStore.SaveSyncResult")
 			},
 		},
@@ -36391,24 +36391,24 @@ func (c PermissionSyncJobStoreListFuncCall) Results() []interface{} {
 // SaveSyncResult method of the parent MockPermissionSyncJobStore instance
 // is invoked.
 type PermissionSyncJobStoreSaveSyncResultFunc struct {
-	defaultHook func(context.Context, int, *SetPermissionsResult) error
-	hooks       []func(context.Context, int, *SetPermissionsResult) error
+	defaultHook func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error
+	hooks       []func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error
 	history     []PermissionSyncJobStoreSaveSyncResultFuncCall
 	mutex       sync.Mutex
 }
 
 // SaveSyncResult delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockPermissionSyncJobStore) SaveSyncResult(v0 context.Context, v1 int, v2 *SetPermissionsResult) error {
-	r0 := m.SaveSyncResultFunc.nextHook()(v0, v1, v2)
-	m.SaveSyncResultFunc.appendCall(PermissionSyncJobStoreSaveSyncResultFuncCall{v0, v1, v2, r0})
+func (m *MockPermissionSyncJobStore) SaveSyncResult(v0 context.Context, v1 int, v2 *SetPermissionsResult, v3 []PermissionSyncCodeHostState) error {
+	r0 := m.SaveSyncResultFunc.nextHook()(v0, v1, v2, v3)
+	m.SaveSyncResultFunc.appendCall(PermissionSyncJobStoreSaveSyncResultFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the SaveSyncResult
 // method of the parent MockPermissionSyncJobStore instance is invoked and
 // the hook queue is empty.
-func (f *PermissionSyncJobStoreSaveSyncResultFunc) SetDefaultHook(hook func(context.Context, int, *SetPermissionsResult) error) {
+func (f *PermissionSyncJobStoreSaveSyncResultFunc) SetDefaultHook(hook func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error) {
 	f.defaultHook = hook
 }
 
@@ -36417,7 +36417,7 @@ func (f *PermissionSyncJobStoreSaveSyncResultFunc) SetDefaultHook(hook func(cont
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermissionSyncJobStoreSaveSyncResultFunc) PushHook(hook func(context.Context, int, *SetPermissionsResult) error) {
+func (f *PermissionSyncJobStoreSaveSyncResultFunc) PushHook(hook func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -36426,19 +36426,19 @@ func (f *PermissionSyncJobStoreSaveSyncResultFunc) PushHook(hook func(context.Co
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermissionSyncJobStoreSaveSyncResultFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, *SetPermissionsResult) error {
+	f.SetDefaultHook(func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermissionSyncJobStoreSaveSyncResultFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, *SetPermissionsResult) error {
+	f.PushHook(func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error {
 		return r0
 	})
 }
 
-func (f *PermissionSyncJobStoreSaveSyncResultFunc) nextHook() func(context.Context, int, *SetPermissionsResult) error {
+func (f *PermissionSyncJobStoreSaveSyncResultFunc) nextHook() func(context.Context, int, *SetPermissionsResult, []PermissionSyncCodeHostState) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -36482,6 +36482,9 @@ type PermissionSyncJobStoreSaveSyncResultFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 *SetPermissionsResult
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []PermissionSyncCodeHostState
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -36490,7 +36493,7 @@ type PermissionSyncJobStoreSaveSyncResultFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermissionSyncJobStoreSaveSyncResultFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -61,20 +61,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	opts = PermissionSyncJobOpts{Priority: LowPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 	err = store.CreateUserSyncJob(ctx, user2.ID, opts)
 	require.NoError(t, err)
-	codeHostStates := []PermissionSyncCodeHostState{
-		{
-			ProviderID:   "ID",
-			ProviderType: "Type",
-			Status:       "SUCCESS",
-			Message:      "successful success",
-		},
-		{
-			ProviderID:   "ID",
-			ProviderType: "Type",
-			Status:       "ERROR",
-			Message:      "unsuccessful unsuccess :(",
-		},
-	}
+	codeHostStates := getSampleCodeHostStates()
 	_, err = db.ExecContext(ctx, "UPDATE permission_sync_jobs SET code_host_states=array["+
 		"'{\"provider_id\":\"ID\",\"provider_type\":\"Type\",\"status\":\"SUCCESS\",\"message\":\"successful success\"}',"+
 		"'{\"provider_id\":\"ID\",\"provider_type\":\"Type\",\"status\":\"ERROR\",\"message\":\"unsuccessful unsuccess :(\"}'"+
@@ -397,21 +384,25 @@ func TestPermissionSyncJobs_SaveSyncResult(t *testing.T) {
 		Found:   5,
 	}
 
+	// Creating code host states.
+	codeHostStates := getSampleCodeHostStates()
 	// Adding a job.
 	err = store.CreateRepoSyncJob(ctx, repo1.ID, PermissionSyncJobOpts{Reason: ReasonManualUserSync})
 	require.NoError(t, err)
 
 	// Saving result should be successful.
-	err = store.SaveSyncResult(ctx, 1, &result)
+	err = store.SaveSyncResult(ctx, 1, &result, codeHostStates)
 	require.NoError(t, err)
 
 	// Checking that all the results are set.
 	jobs, err := store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
-	require.Equal(t, 1, jobs[0].PermissionsAdded)
-	require.Equal(t, 2, jobs[0].PermissionsRemoved)
-	require.Equal(t, 5, jobs[0].PermissionsFound)
+	theJob := jobs[0]
+	require.Equal(t, 1, theJob.PermissionsAdded)
+	require.Equal(t, 2, theJob.PermissionsRemoved)
+	require.Equal(t, 5, theJob.PermissionsFound)
+	require.Equal(t, codeHostStates, theJob.CodeHostStates)
 }
 
 func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
@@ -594,4 +585,22 @@ func reverse(jobs []*PermissionSyncJob) []*PermissionSyncJob {
 		reversed = append(reversed, jobs[len(jobs)-i-1])
 	}
 	return reversed
+}
+
+func getSampleCodeHostStates() []PermissionSyncCodeHostState {
+	return []PermissionSyncCodeHostState{
+		{
+			ProviderID:   "ID",
+			ProviderType: "Type",
+			Status:       "SUCCESS",
+			Message:      "successful success",
+		},
+		{
+			ProviderID:   "ID",
+			ProviderType: "Type",
+			Status:       "ERROR",
+			Message:      "unsuccessful unsuccess :(",
+		},
+	}
+
 }


### PR DESCRIPTION
Test plan:
Unit tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/47082