### PR TITLE
Outbound requests: Extract logging into goroutine to prevent blocking

### DIFF
--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -32,87 +32,90 @@ func redisLoggerMiddleware() Middleware {
 			start := time.Now()
 			resp, err := cli.Do(req)
 			duration := time.Since(start)
-			limit := OutboundRequestLogLimit()
-			shouldRedactSensitiveHeaders := !deploy.IsDev(deploy.Type()) || RedactOutboundRequestHeaders()
 
-			// Feature is turned off, do not log
-			if limit == 0 {
-				return resp, err
-			}
+			go func() {
+				limit := OutboundRequestLogLimit()
+				shouldRedactSensitiveHeaders := !deploy.IsDev(deploy.Type()) || RedactOutboundRequestHeaders()
 
-			// middlewareErrors will be set later if there is an error
-			var middlewareErrors error
-			defer func() {
-				if middlewareErrors != nil {
-					*req = *req.WithContext(context.WithValue(req.Context(),
-						redisLoggingMiddlewareErrorKey, middlewareErrors))
+				// Feature is turned off, do not log
+				if limit == 0 {
+					return
 				}
-			}()
 
-			// Read body
-			var requestBody []byte
-			if req != nil && req.Body != nil {
-				body, _ := req.GetBody()
-				if body != nil {
-					var readErr error
-					requestBody, readErr = io.ReadAll(body)
-					if err != nil {
-						middlewareErrors = errors.Append(middlewareErrors,
-							errors.Wrap(readErr, "read body"))
+				// middlewareErrors will be set later if there is an error
+				var middlewareErrors error
+				defer func() {
+					if middlewareErrors != nil {
+						*req = *req.WithContext(context.WithValue(req.Context(),
+							redisLoggingMiddlewareErrorKey, middlewareErrors))
+					}
+				}()
+
+				// Read body
+				var requestBody []byte
+				if req != nil && req.Body != nil {
+					body, _ := req.GetBody()
+					if body != nil {
+						var readErr error
+						requestBody, readErr = io.ReadAll(body)
+						if err != nil {
+							middlewareErrors = errors.Append(middlewareErrors,
+								errors.Wrap(readErr, "read body"))
+						}
 					}
 				}
-			}
 
-			// Pull out data if we have `resp`
-			var responseHeaders http.Header
-			var statusCode int32
-			if resp != nil {
-				responseHeaders = resp.Header
-				statusCode = int32(resp.StatusCode)
-			}
+				// Pull out data if we have `resp`
+				var responseHeaders http.Header
+				var statusCode int32
+				if resp != nil {
+					responseHeaders = resp.Header
+					statusCode = int32(resp.StatusCode)
+				}
 
-			// Redact sensitive headers
-			requestHeaders := req.Header
+				// Redact sensitive headers
+				requestHeaders := req.Header
 
-			if shouldRedactSensitiveHeaders {
-				requestHeaders = redactSensitiveHeaders(requestHeaders)
-				responseHeaders = redactSensitiveHeaders(responseHeaders)
-			}
+				if shouldRedactSensitiveHeaders {
+					requestHeaders = redactSensitiveHeaders(requestHeaders)
+					responseHeaders = redactSensitiveHeaders(responseHeaders)
+				}
 
-			// Create log item
-			var errorMessage string
-			if err != nil {
-				errorMessage = err.Error()
-			}
-			key := time.Now().UTC().Format("2006-01-02T15_04_05.999999999")
-			callerStackFrames := getFrames(4) // Starts at the caller of the caller of redisLoggerMiddleware
-			logItem := types.OutboundRequestLogItem{
-				ID:                 key,
-				StartedAt:          start,
-				Method:             req.Method,
-				URL:                req.URL.String(),
-				RequestHeaders:     requestHeaders,
-				RequestBody:        string(requestBody),
-				StatusCode:         statusCode,
-				ResponseHeaders:    responseHeaders,
-				Duration:           duration.Seconds(),
-				ErrorMessage:       errorMessage,
-				CreationStackFrame: formatStackFrame(creatorStackFrame.Function, creatorStackFrame.File, creatorStackFrame.Line),
-				CallStackFrame:     formatStackFrames(callerStackFrames),
-			}
+				// Create log item
+				var errorMessage string
+				if err != nil {
+					errorMessage = err.Error()
+				}
+				key := time.Now().UTC().Format("2006-01-02T15_04_05.999999999")
+				callerStackFrames := getFrames(4) // Starts at the caller of the caller of redisLoggerMiddleware
+				logItem := types.OutboundRequestLogItem{
+					ID:                 key,
+					StartedAt:          start,
+					Method:             req.Method,
+					URL:                req.URL.String(),
+					RequestHeaders:     requestHeaders,
+					RequestBody:        string(requestBody),
+					StatusCode:         statusCode,
+					ResponseHeaders:    responseHeaders,
+					Duration:           duration.Seconds(),
+					ErrorMessage:       errorMessage,
+					CreationStackFrame: formatStackFrame(creatorStackFrame.Function, creatorStackFrame.File, creatorStackFrame.Line),
+					CallStackFrame:     formatStackFrames(callerStackFrames),
+				}
 
-			// Serialize log item
-			logItemJson, jsonErr := json.Marshal(logItem)
-			if jsonErr != nil {
-				middlewareErrors = errors.Append(middlewareErrors,
-					errors.Wrap(jsonErr, "marshal log item"))
-			}
+				// Serialize log item
+				logItemJson, jsonErr := json.Marshal(logItem)
+				if jsonErr != nil {
+					middlewareErrors = errors.Append(middlewareErrors,
+						errors.Wrap(jsonErr, "marshal log item"))
+				}
 
-			// Save new item
-			if err := outboundRequestsRedisFIFOList.Insert(logItemJson); err != nil {
-				middlewareErrors = errors.Append(middlewareErrors,
-					errors.Wrap(err, "insert log item"))
-			}
+				// Save new item
+				if err := outboundRequestsRedisFIFOList.Insert(logItemJson); err != nil {
+					middlewareErrors = errors.Append(middlewareErrors,
+						errors.Wrap(err, "insert log item"))
+				}
+			}()
 
 			return resp, err
 		})

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -24,7 +25,7 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 	complexReq, _ := http.NewRequest("PATCH", "http://test.aa?a=2", strings.NewReader("graph"))
 	complexReq.Header.Set("Cache-Control", "no-cache")
 
-	for _, tc := range []struct {
+	testCases := []struct {
 		req  *http.Request
 		name string
 		cli  Doer
@@ -67,12 +68,14 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 			}),
 			err: "oh no",
 		},
-	} {
+	}
+
+	// Enable feature
+	setOutboundRequestLogLimit(t, 1)
+
+	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Enable the feature
-			setOutboundRequestLogLimit(t, 1)
-
 			// Build client with middleware
 			cli := redisLoggerMiddleware()(tc.cli)
 
@@ -82,34 +85,31 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 				t.Fatalf("have error: %q\nwant error: %q", have, want)
 			}
 
-			// Wait for two seconds to make sure the async logging gets done
-			time.Sleep(2 * time.Second)
+			assert.Eventually(t, func() bool {
+				// Check logged request
+				logged, err := GetOutboundRequestLogItems(context.Background(), "")
+				if err != nil {
+					t.Fatalf("couldnt get logged requests: %s", err)
+				}
 
-			// Check logged request
-			logged, err := GetOutboundRequestLogItems(context.Background(), "")
-			if err != nil {
-				t.Fatalf("couldnt get logged requests: %s", err)
-			}
-			if len(logged) != 1 {
-				t.Fatalf("request was not logged")
-			}
-
-			if tc.want == nil {
-				return
-			}
-
-			if diff := cmp.Diff(tc.want, logged[0], cmpopts.IgnoreFields(
-				types.OutboundRequestLogItem{},
-				"ID",
-				"StartedAt",
-				"Duration",
-				"CreationStackFrame",
-				"CallStackFrame",
-			)); diff != "" {
-				t.Fatalf("wrong request logged: %s", diff)
-			}
+				return len(logged) == 1 && equal(tc.want, logged[0])
+			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}
+}
+
+func equal(a, b *types.OutboundRequestLogItem) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	return cmp.Diff(a, b, cmpopts.IgnoreFields(
+		types.OutboundRequestLogItem{},
+		"ID",
+		"StartedAt",
+		"Duration",
+		"CreationStackFrame",
+		"CallStackFrame",
+	)) == ""
 }
 
 func TestRedisLoggerMiddleware_multiple(t *testing.T) {

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -82,6 +82,9 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 				t.Fatalf("have error: %q\nwant error: %q", have, want)
 			}
 
+			// Wait for two seconds to make sure the async logging gets done
+			time.Sleep(2 * time.Second)
+
 			// Check logged request
 			logged, err := GetOutboundRequestLogItems(context.Background(), "")
 			if err != nil {


### PR DESCRIPTION
My first implementation for outbound request logging worked so that it blocked the request for the duration of the logging.
This didn't seem to be a problem at first because logging into Redis is usually fast. However, that implementation didn't consider the case when Redis is _slow_.
This PR modifies the logging behavior to make the logging non-blocking.

## Test plan

I've run the code, and it logs requests and reads the logs as intended. Also updated the tests.