### PR TITLE
executors: Use /var/lib/firecracker for data

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace/util.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/util.go
@@ -10,19 +10,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
 )
 
+const loopDevPath = "/var/lib/firecracker/loop-devices"
+const mountpointsPath = "/var/lib/firecracker/mountpoints"
+
 // MakeTempFile defaults to makeTemporaryFile and can be replaced for testing
 // with determinstic workspace/scripts directories.
 var MakeTempFile = makeTemporaryFile
 
 func makeTemporaryFile(prefix string) (*os.File, error) {
-	if tempdir := os.Getenv("TMPDIR"); tempdir != "" {
-		if err := os.MkdirAll(tempdir, os.ModePerm); err != nil {
-			return nil, err
-		}
-		return os.CreateTemp(tempdir, prefix+"-*")
+	if err := os.MkdirAll(loopDevPath, os.ModePerm); err != nil {
+		return nil, err
 	}
-
-	return os.CreateTemp("", prefix+"-*")
+	return os.CreateTemp(loopDevPath, prefix+"-*")
 }
 
 // MakeTempDirectory defaults to makeTemporaryDirectory and can be replaced for testing
@@ -30,14 +29,11 @@ func makeTemporaryFile(prefix string) (*os.File, error) {
 var MakeTempDirectory = MakeTemporaryDirectory
 
 func MakeTemporaryDirectory(prefix string) (string, error) {
-	if tempdir := os.Getenv("TMPDIR"); tempdir != "" {
-		if err := os.MkdirAll(tempdir, os.ModePerm); err != nil {
-			return "", err
-		}
-		return os.MkdirTemp(tempdir, prefix+"-*")
+	if err := os.MkdirAll(mountpointsPath, os.ModePerm); err != nil {
+		return "", err
 	}
 
-	return os.MkdirTemp("", prefix+"-*")
+	return os.MkdirTemp(mountpointsPath, prefix+"-*")
 }
 
 // runs the given command with args and logs the invocation and output to the provided log entry handle.

--- a/enterprise/cmd/executor/internal/worker/workspace_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/apiclient"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/apiclient/queue"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/workspace"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -22,6 +23,12 @@ var ignorePort = cmpopts.IgnoreSliceElements(func(v string) bool {
 })
 
 func TestPrepareWorkspace_Clone(t *testing.T) {
+	testDir := t.TempDir()
+	workspace.MakeTempDirectory = func(string) (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		workspace.MakeTempDirectory = workspace.MakeTemporaryDirectory
+	})
+
 	options := Options{
 		QueueOptions: queue.Options{
 			BaseClientOptions: apiclient.BaseClientOptions{
@@ -72,6 +79,12 @@ func TestPrepareWorkspace_Clone(t *testing.T) {
 }
 
 func TestPrepareWorkspace_Clone_Subdirectory(t *testing.T) {
+	testDir := t.TempDir()
+	workspace.MakeTempDirectory = func(string) (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		workspace.MakeTempDirectory = workspace.MakeTemporaryDirectory
+	})
+
 	options := Options{
 		QueueOptions: queue.Options{
 			BaseClientOptions: apiclient.BaseClientOptions{
@@ -124,6 +137,12 @@ func TestPrepareWorkspace_Clone_Subdirectory(t *testing.T) {
 }
 
 func TestPrepareWorkspace_ShallowClone(t *testing.T) {
+	testDir := t.TempDir()
+	workspace.MakeTempDirectory = func(string) (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		workspace.MakeTempDirectory = workspace.MakeTemporaryDirectory
+	})
+
 	options := Options{
 		QueueOptions: queue.Options{
 			BaseClientOptions: apiclient.BaseClientOptions{
@@ -174,6 +193,12 @@ func TestPrepareWorkspace_ShallowClone(t *testing.T) {
 }
 
 func TestPrepareWorkspace_SparseCheckout(t *testing.T) {
+	testDir := t.TempDir()
+	workspace.MakeTempDirectory = func(string) (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		workspace.MakeTempDirectory = workspace.MakeTemporaryDirectory
+	})
+
 	options := Options{
 		QueueOptions: queue.Options{
 			BaseClientOptions: apiclient.BaseClientOptions{
@@ -227,6 +252,12 @@ func TestPrepareWorkspace_SparseCheckout(t *testing.T) {
 }
 
 func TestPrepareWorkspace_NoRepository(t *testing.T) {
+	testDir := t.TempDir()
+	workspace.MakeTempDirectory = func(string) (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		workspace.MakeTempDirectory = workspace.MakeTemporaryDirectory
+	})
+
 	options := Options{}
 	runner := NewMockRunner()
 	handler := &handler{


### PR DESCRIPTION
Instead of using a tmp dir in a tmpfs (which might be limited in size, too), we store all executors things in the same directory now - /var/lib/firecracker, just as ignite does. This makes it easier to place it all on a separate disk by just mounting it into that one directory.

## Test plan

Worked on dotcom over the weekend.
