### PR TITLE
basestore: rearrange keyed collection scanner type parameters

### DIFF
--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -69,7 +69,7 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	}
 
 	depReposMap := basestore.NewOrderedMap[int, shared.PackageRepoReference]()
-	scanner := basestore.NewKeyedCollectionScanner[*basestore.OrderedMap[int, shared.PackageRepoReference], int, shared.PackageRepoReference, shared.PackageRepoReference](depReposMap, func(s dbutil.Scanner) (int, shared.PackageRepoReference, error) {
+	scanner := basestore.NewKeyedCollectionScanner[int, shared.PackageRepoReference, shared.PackageRepoReference](depReposMap, func(s dbutil.Scanner) (int, shared.PackageRepoReference, error) {
 		dep, err := scanDependencyRepo(s)
 		return dep.ID, dep, err
 	}, dependencyVersionsReducer{})

--- a/internal/database/basestore/scan_collections.go
+++ b/internal/database/basestore/scan_collections.go
@@ -95,7 +95,7 @@ func NewSliceWithCountScanner[T any](f func(dbutil.Scanner) (T, int, error)) fun
 // query result organized as a map. The given function is invoked multiple times with a SQL rows
 // object to scan a single map value. The given reducer provides a way to customize how multiple
 // values are reduced into a collection.
-func NewKeyedCollectionScanner[Map keyedMap[K, Vs], K comparable, V, Vs any](
+func NewKeyedCollectionScanner[K comparable, V, Vs any, Map keyedMap[K, Vs]](
 	values Map,
 	scanPair func(dbutil.Scanner) (K, V, error),
 	reducer CollectionReducer[V, Vs],
@@ -127,7 +127,7 @@ func NewKeyedCollectionScanner[Map keyedMap[K, Vs], K comparable, V, Vs any](
 func NewMapScanner[K comparable, V any](f func(dbutil.Scanner) (K, V, error)) func(rows Rows, queryErr error) (map[K]V, error) {
 	return func(rows Rows, queryErr error) (map[K]V, error) {
 		m := NewUnorderedmap[K, V]()
-		err := NewKeyedCollectionScanner[*UnorderedMap[K, V], K, V, V](m, f, SingleValueReducer[V]{})(rows, queryErr)
+		err := NewKeyedCollectionScanner[K, V, V](m, f, SingleValueReducer[V]{})(rows, queryErr)
 		return m.ToMap(), err
 	}
 }
@@ -138,7 +138,7 @@ func NewMapScanner[K comparable, V any](f func(dbutil.Scanner) (K, V, error)) fu
 func NewMapSliceScanner[K comparable, V any](f func(dbutil.Scanner) (K, V, error)) func(rows Rows, queryErr error) (map[K][]V, error) {
 	return func(rows Rows, queryErr error) (map[K][]V, error) {
 		m := NewUnorderedmap[K, []V]()
-		err := NewKeyedCollectionScanner[*UnorderedMap[K, []V], K, V, []V](m, f, SliceReducer[V]{})(rows, queryErr)
+		err := NewKeyedCollectionScanner[K, V, []V](m, f, SliceReducer[V]{})(rows, queryErr)
 		return m.ToMap(), err
 	}
 }

--- a/internal/database/basestore/scan_collections_test.go
+++ b/internal/database/basestore/scan_collections_test.go
@@ -79,7 +79,7 @@ func Test_KeyedCollectionScannerOrdered(t *testing.T) {
 	})
 
 	m := &OrderedMap[int, reducee]{m: orderedmap.New[int, reducee]()}
-	NewKeyedCollectionScanner[*OrderedMap[int, reducee], int, reduceeRow, reducee](m, func(s dbutil.Scanner) (int, reduceeRow, error) {
+	NewKeyedCollectionScanner[int, reduceeRow, reducee](m, func(s dbutil.Scanner) (int, reduceeRow, error) {
 		var red reduceeRow
 		err := s.Scan(&red.ID, &red.Value)
 		return red.ID, red, err


### PR DESCRIPTION
Re-arranged type parameters on `KeyedCollectionScanner` to move the map-type to the end. This way its type can be inferred by the map-type passed in as a parameter, allowing us to omit the type parameter at instantiation sites

## Test plan

:sparkles: the Go compiler :sparkles: 
