### PR TITLE
permissions: remove unused

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permission_sync_jobs.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
@@ -18,10 +17,7 @@ import (
 var _ graphqlbackend.PermissionSyncJobsResolver = &permissionSyncJobsResolver{}
 
 type permissionSyncJobsResolver struct {
-	db   database.DB
-	once sync.Once
-	jobs []*database.PermissionSyncJob
-	err  error
+	db database.DB
 }
 
 func NewPermissionSyncJobsResolver(db database.DB) graphqlbackend.PermissionSyncJobsResolver {


### PR DESCRIPTION
Linter complains about these unused vars. I think the original intention was to use `sync.Once` with `ComputeNodes` but with `ConnectionStore` it isn't needed anymore - cc @sashaostrikov 

## Test plan
Ci + lint
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
