### PR TITLE
Codemirror blob: enable dy default

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -490,13 +490,10 @@ describe('Repository component', () => {
                 }
                 await link.click()
 
-                await driver.page.waitForSelector('.test-blob .selected .line')
-                const selectedLineNumber = await driver.page.evaluate(() => {
-                    const element = document.querySelector<HTMLElement>('.test-blob .selected .line')
-                    return element?.dataset.line && parseInt(element.dataset.line, 10)
-                })
-
-                expect(selectedLineNumber).toEqual(line)
+                const selectedLine = await driver.page.waitForSelector(
+                    `[data-testid="repo-blob"] .cm-line:nth-child(${line}).selected-line`
+                )
+                expect(selectedLine).not.toBeNull()
             })
         }
     })

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -17,7 +17,7 @@ import {
     createTreeEntriesResult,
     createBlobContentResult,
 } from './graphQlResponseHelpers'
-import { commonWebGraphQlResults } from './graphQlResults'
+import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
 import { percySnapshotWithVariants } from './utils'
 
 describe('Blob viewer', () => {
@@ -44,6 +44,13 @@ describe('Blob viewer', () => {
 
     const commonBlobGraphQlResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
         ...commonWebGraphQlResults,
+        ...createViewerSettingsGraphQLOverride({
+            user: {
+                experimentalFeatures: {
+                    enableCodeMirrorFileView: false,
+                },
+            },
+        }),
         ResolveRepoRev: () => createResolveRepoRevisionResult(repositorySourcegraphUrl),
         FileExternalLinks: ({ filePath }) =>
             createFileExternalLinksResult(`https://${repositoryName}/blob/master/${filePath}`),

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -26,7 +26,7 @@ import {
     createFileNamesResult,
     createResolveCloningRepoRevisionResult,
 } from './graphQlResponseHelpers'
-import { commonWebGraphQlResults } from './graphQlResults'
+import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
 import { createEditorAPI, percySnapshotWithVariants } from './utils'
 
 export const getCommonRepositoryGraphQlResults = (
@@ -35,6 +35,13 @@ export const getCommonRepositoryGraphQlResults = (
     fileEntries: string[] = []
 ): Partial<WebGraphQlOperations & SharedGraphQlOperations> => ({
     ...commonWebGraphQlResults,
+    ...createViewerSettingsGraphQLOverride({
+        user: {
+            experimentalFeatures: {
+                enableCodeMirrorFileView: false,
+            },
+        },
+    }),
     RepoChangesetsStats: () => createRepoChangesetsStatsResult(),
     ResolveRepoRev: () => createResolveRepoRevisionResult(repositoryName),
     FileNames: () => createFileNamesResult(),

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -123,7 +123,7 @@ export const BlobPage: FC<BlobPageProps> = ({ className, ...props }) => {
     const [wrapCode, setWrapCode] = useState(ToggleLineWrap.getValue())
     let renderMode = getModeFromURL(location)
     const { repoID, repoName, revision, commitID, filePath, isLightTheme, useBreadcrumb, mode } = props
-    const enableCodeMirror = useExperimentalFeatures(features => features.enableCodeMirrorFileView ?? false)
+    const enableCodeMirror = useExperimentalFeatures(features => features.enableCodeMirrorFileView ?? true)
     const experimentalCodeNavigation = useExperimentalFeatures(features => features.codeNavigation)
     const enableLazyBlobSyntaxHighlighting = useExperimentalFeatures(
         features => features.enableLazyBlobSyntaxHighlighting ?? false


### PR DESCRIPTION
The original PR https://github.com/sourcegraph/sourcegraph/pull/45514 has been reverted as it was breaking e2e tests. This PR reverts the latter PR and enables the CodeMirror blob view by default.

## Test plan
- Sourcegraph e2e tests pass: [buildkite](https://buildkite.com/sourcegraph/sourcegraph/builds/198542)
- original PR (https://github.com/sourcegraph/sourcegraph/pull/45514) test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-re-enable-codemirror.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

