### PR TITLE
SCIM: Implement user creation

### DIFF
--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -64,6 +64,7 @@ func (h *UserResourceHandler) Create(_ *http.Request, attributes scim.ResourceAt
 	if optionalExternalID.Present() {
 		accountSpec := extsvc.AccountSpec{
 			ServiceType: "scim",
+			// TODO: provide proper service ID
 			ServiceID:   "TODO",
 			AccountID:   optionalExternalID.Value(),
 		}

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -128,8 +128,9 @@ func extractDisplayName(attributes scim.ResourceAttributes) (displayName string)
 		displayName = attributes["displayName"].(string)
 	} else if attributes["name"] != nil {
 		name := attributes["name"].(map[string]interface{})
-		displayName = name["formatted"].(string)
-		if displayName == "" && name["givenName"] != nil && name["familyName"] != nil {
+		if name["formatted"] != nil {
+			displayName = name["formatted"].(string)
+		} else if name["givenName"] != nil && name["familyName"] != nil {
 			displayName = name["givenName"].(string) + " " + name["familyName"].(string)
 		}
 	} else if attributes["userName"] != nil {

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -65,8 +65,8 @@ func (h *UserResourceHandler) Create(_ *http.Request, attributes scim.ResourceAt
 		accountSpec := extsvc.AccountSpec{
 			ServiceType: "scim",
 			// TODO: provide proper service ID
-			ServiceID:   "TODO",
-			AccountID:   optionalExternalID.Value(),
+			ServiceID: "TODO",
+			AccountID: optionalExternalID.Value(),
 		}
 		user, err = h.db.UserExternalAccounts().CreateUserAndSave(h.ctx, newUser, accountSpec, extsvc.AccountData{})
 	} else {

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -51,9 +51,10 @@ func (h *UserResourceHandler) Create(_ *http.Request, attributes scim.ResourceAt
 		return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{"emails missing"})
 	}
 	emails := attributes["emails"].([]interface{})
-	for _, email := range emails {
-		if email.(map[string]interface{})["primary"] == true {
-			primaryEmail = email.(map[string]interface{})["value"].(string)
+	for _, emailRaw := range emails {
+		email := emailRaw.(map[string]interface{})
+		if email["primary"] == true {
+			primaryEmail = email["value"].(string)
 			break
 		}
 	}
@@ -72,9 +73,10 @@ func (h *UserResourceHandler) Create(_ *http.Request, attributes scim.ResourceAt
 	if attributes["displayName"] != nil {
 		displayName = attributes["displayName"].(string)
 	} else if attributes["name"] != nil {
-		displayName = attributes["name"].(map[string]interface{})["formatted"].(string)
-		if displayName == "" && attributes["name"].(map[string]interface{})["givenName"] != nil && attributes["name"].(map[string]interface{})["familyName"] != nil {
-			displayName = attributes["name"].(map[string]interface{})["givenName"].(string) + " " + attributes["name"].(map[string]interface{})["familyName"].(string)
+		name := attributes["name"].(map[string]interface{})
+		displayName = name["formatted"].(string)
+		if displayName == "" && name["givenName"] != nil && name["familyName"] != nil {
+			displayName = name["givenName"].(string) + " " + name["familyName"].(string)
 		}
 	}
 

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -74,7 +74,7 @@ func (h *UserResourceHandler) Create(_ *http.Request, attributes scim.ResourceAt
 	}
 	if err != nil {
 		if dbErr, ok := containsDBError(err); ok {
-			if dbErr.Code() == database.ErrorCodeUsernameExists || dbErr.Code() == database.ErrorCodeEmailExists {
+			if code := dbErr.Code(); code == database.ErrorCodeUsernameExists || code == database.ErrorCodeEmailExists {
 				return scim.Resource{}, scimerrors.ScimError{Status: http.StatusConflict, Detail: err.Error()}
 			}
 		}

--- a/enterprise/internal/scim/user_test.go
+++ b/enterprise/internal/scim/user_test.go
@@ -14,6 +14,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUserResourceHandler_Create(t *testing.T) {
+	db := getMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	user, err := userResourceHandler.Create(&http.Request{}, scim.ResourceAttributes{
+		"userName": "user1",
+		"name": map[string]interface{}{
+			"givenName":  "First",
+			"middleName": "Middle",
+			"familyName": "Last",
+		},
+		"emails": []interface{}{
+			map[string]interface{}{
+				"value":   "a@b.c",
+				"primary": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that ID is correct
+	if user.ID != "1" {
+		t.Errorf("expected ID = 1, got %s", user.ID)
+	}
+}
+
 func TestUserResourceHandler_Get(t *testing.T) {
 	db := getMockDB()
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)

--- a/enterprise/internal/scim/user_test.go
+++ b/enterprise/internal/scim/user_test.go
@@ -36,9 +36,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 	}
 
 	// Assert that ID is correct
-	if user.ID != "1" {
-		t.Errorf("expected ID = 1, got %s", user.ID)
-	}
+	assert.Equal(t, "5", user.ID)
 }
 
 func TestUserResourceHandler_Get(t *testing.T) {
@@ -183,6 +181,9 @@ func getMockDB() *database.MockDB {
 		return applyLimitOffset(users, opt.LimitOffset)
 	})
 	userStore.CountFunc.SetDefaultReturn(4, nil)
+	userStore.CreateFunc.SetDefaultHook(func(ctx context.Context, user database.NewUser) (*types.User, error) {
+		return &types.User{ID: 5, Username: user.Username, DisplayName: user.DisplayName}, nil
+	})
 
 	// Create DB
 	db := database.NewMockDB()

--- a/internal/database/mockerr.go
+++ b/internal/database/mockerr.go
@@ -1,8 +1,8 @@
 package database
 
 var (
-	MockCannotCreateUserUsernameExistsErr = errCannotCreateUser{errorCodeUsernameExists}
-	MockCannotCreateUserEmailExistsErr    = errCannotCreateUser{errorCodeEmailExists}
+	MockCannotCreateUserUsernameExistsErr = ErrCannotCreateUser{ErrorCodeUsernameExists}
+	MockCannotCreateUserEmailExistsErr    = ErrCannotCreateUser{ErrorCodeEmailExists}
 	MockUserNotFoundErr                   = userNotFoundErr{}
 	MockUserEmailNotFoundErr              = userEmailNotFoundError{}
 )

--- a/internal/database/test_util.go
+++ b/internal/database/test_util.go
@@ -7,11 +7,11 @@ import (
 )
 
 func MockEmailExistsErr() error {
-	return errCannotCreateUser{errorCodeEmailExists}
+	return ErrCannotCreateUser{ErrorCodeEmailExists}
 }
 
 func MockUsernameExistsErr() error {
-	return errCannotCreateUser{errorCodeEmailExists}
+	return ErrCannotCreateUser{ErrorCodeEmailExists}
 }
 
 func strptr(s string) *string {

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -89,7 +89,7 @@ func TestUsers_ValidUsernames(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			valid := true
 			if _, err := db.Users().Create(ctx, NewUser{Username: test.name}); err != nil {
-				var e errCannotCreateUser
+				var e ErrCannotCreateUser
 				if errors.As(err, &e) && (e.Code() == "users_username_max_length" || e.Code() == "users_username_valid_chars") {
 					valid = false
 				} else {
@@ -147,7 +147,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 		EmailVerificationCode: "c3",
 		FailIfNotInitialUser:  true,
 	})
-	if want := (errCannotCreateUser{"site_already_initialized"}); !errors.Is(err, want) {
+	if want := (ErrCannotCreateUser{"site_already_initialized"}); !errors.Is(err, want) {
 		t.Fatalf("got error %v, want %v", err, want)
 	}
 
@@ -183,7 +183,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 		EmailVerificationCode: "c5",
 		FailIfNotInitialUser:  true,
 	})
-	if want := (errCannotCreateUser{"initial_site_admin_must_be_first_user"}); !errors.Is(err, want) {
+	if want := (ErrCannotCreateUser{"initial_site_admin_must_be_first_user"}); !errors.Is(err, want) {
 		t.Fatalf("got error %v, want %v", err, want)
 	}
 }


### PR DESCRIPTION
This PR implements the "Create user" functionality for POST requests on the `/Users` SCIM endpoint.

Also had to make some errors public that weren't public before. This makes sense to me because some public functions throw them, so to identify them, they need to be public.

**Caveat:** the new test doesn't work yet. I'll fix that for CI, just I got mixed up with the types there, but will untangle it.

## Test plan

Tested with Postman locally, then with Okta's Runscope test suite. It works for all cases!