### PR TITLE
Sourcegraph App - use native ctags

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -133,11 +133,17 @@ func Init(logger log.Logger) {
 	}
 
 	setDefaultEnv(logger, "CTAGS_PROCESSES", "2")
-	// Write script that invokes universal-ctags via Docker.
-	// TODO(sqs): TODO(single-binary): stop relying on a ctags Docker image
-	ctagsPath := filepath.Join(cacheDir, "universal-ctags-dev")
-	writeFile(ctagsPath, []byte(universalCtagsDevScript), 0700)
-	setDefaultEnv(logger, "CTAGS_COMMAND", ctagsPath)
+
+	// generate a shell script to run a ctags Docker image
+	// unless the environment is already set up to find ctags
+	ctagsPath := os.Getenv("CTAGS_COMMAND")
+	if stat, err := os.Stat(ctagsPath); err != nil || stat.IsDir() {
+		// Write script that invokes universal-ctags via Docker.
+		// TODO(sqs): TODO(single-binary): stop relying on a ctags Docker image
+		ctagsPath = filepath.Join(cacheDir, "universal-ctags-dev")
+		writeFile(ctagsPath, []byte(universalCtagsDevScript), 0700)
+		setDefaultEnv(logger, "CTAGS_COMMAND", ctagsPath)
+	}
 }
 
 // universalCtagsDevScript is copied from cmd/symbols/universal-ctags-dev.


### PR DESCRIPTION
If the CTAGS_COMMAND environment variable is already defined and points to a file,
don't create the temporary shell script that uses a ctags Docker image.



## Test plan

Build ctags for your platform so that it has `json` enabled and (optionally) is named `universal-ctags`.

I (@peterguy) did this initially by modifying the Homebrew `ctags` formula (since Homebrew no longer supports build options):

```bash
brew tap universal-ctags/universal-ctags
brew fetch --HEAD universal-ctags/universal-ctags/universal-ctags
brew edit universal-ctags/universal-ctags/universal-ctags
```

change the line

`system "./configure", "--prefix=#{prefix}", *opts`

to

`system "./configure", "--prefix=#{prefix}", "--program-prefix=universal-", "--enable-json", *opts`

and then install it using

`brew install --HEAD universal-ctags/universal-ctags/universal-ctags`

which results in the executable binary `$(brew --prefix)/bin/universal-ctags`

Then you can set your environment:

```
export CTAGS_COMMAND=$(brew --prefix)/bin/universal-ctags
```

Run `sg start app`, notice that the debug output does not contain "slimsag/ctags:latest" anywhere.

To verify that the native `ctags` binary is behaving, run searches in Sourcegraph and look for indications of proper `ctags` behavior, such as symbol recognition (Go to definition, Find references, etc...) in the results.