### PR TITLE
web: fix third-party sing-in buttons

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { partition } from 'lodash'
 import { Navigate, useLocation, useSearchParams } from 'react-router-dom-v5-compat'
 
-import { Alert, Icon, Text, Link, Button, ErrorAlert } from '@sourcegraph/wildcard'
+import { Alert, Icon, Text, Link, Button, ErrorAlert, AnchorLink } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { HeroPage } from '../components/HeroPage'
@@ -96,7 +96,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                                 to={provider.authenticationURL}
                                 display="block"
                                 variant={showBuiltInAuthForm ? 'secondary' : 'primary'}
-                                as={Link}
+                                as={AnchorLink}
                             >
                                 {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
                                 {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}


### PR DESCRIPTION
## Context

Fixes the issue [reported in Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1676323346585499). Recently, we [changed](https://github.com/sourcegraph/sourcegraph/pull/47330/files#diff-d1031296cb4f1aaa5aed5312fa9d062b763186328ef812ba29694282705a0601R99) the thirdPartyAuthProviders buttons to use Link instead of AnchorLink which causes client-side navigation instead of going back to the server for a response.

## Test plan

1. sg start
2. sign in with GitHub

## App preview:

- [Web](https://sg-web-vb-fix-third-party-sign-in.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
