### PR TITLE
Render GitHub links in more places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added Gerrit as an officially supported code host with permissions syncing. [#46763](https://github.com/sourcegraph/sourcegraph/pull/46763)
 - Markdown files now support `<picture>` and `<video>` elements in the rendered view. [#47074](https://github.com/sourcegraph/sourcegraph/pull/47074)
 - Batch Changes: Log outputs from execution steps are now paginated in the web interface. [#46335](https://github.com/sourcegraph/sourcegraph/pull/46335)
+- Renders GitHub pull request references in the commit list. [#47593](https://github.com/sourcegraph/sourcegraph/pull/47593)
 
 ### Changed
 

--- a/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
@@ -10,7 +10,8 @@ import { asGraphQLResult, hasNextPage, parseQueryInt } from '../utils'
 
 import { useShowMorePaginationUrl } from './useShowMorePaginationUrl'
 
-export interface UseShowMorePaginationResult<TData> {
+export interface UseShowMorePaginationResult<TResult, TData> {
+    data?: TResult
     connection?: Connection<TData>
     error?: ApolloError
     fetchMore: () => void
@@ -73,7 +74,7 @@ export const useShowMorePagination = <TResult, TVariables, TData>({
     variables,
     getConnection: getConnectionFromGraphQLResult,
     options,
-}: UseShowMorePaginationParameters<TResult, TVariables, TData>): UseShowMorePaginationResult<TData> => {
+}: UseShowMorePaginationParameters<TResult, TVariables, TData>): UseShowMorePaginationResult<TResult, TData> => {
     const searchParameters = useSearchParameters()
 
     const { first = DEFAULT_FIRST, after = DEFAULT_AFTER } = variables
@@ -209,6 +210,7 @@ export const useShowMorePagination = <TResult, TVariables, TData>({
     const { startExecution, stopExecution } = useInterval(refetchAll, options?.pollInterval || -1)
 
     return {
+        data,
         connection,
         loading,
         error,

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -254,7 +254,7 @@ export const EXTERNAL_SERVICE_IDS_AND_NAMES = gql`
 
 export const useExternalServicesConnection = (
     vars: ExternalServicesVariables
-): UseShowMorePaginationResult<ListExternalServiceFields> =>
+): UseShowMorePaginationResult<ExternalServicesResult, ListExternalServiceFields> =>
     useShowMorePagination<ExternalServicesResult, ExternalServicesVariables, ListExternalServiceFields>({
         query: EXTERNAL_SERVICES,
         variables: { after: vars.after, first: vars.first ?? 10 },

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
@@ -13,13 +13,17 @@ import {
     ShowMoreButton,
     SummaryContainer,
 } from '../../../../../components/FilteredConnection/ui'
+import { BatchSpecImportingChangesetsResult } from '../../../../../graphql-operations'
 
 import { ImportingChangesetFields } from './useImportingChangesets'
 
 import styles from './ImportingChangesetsPreviewList.module.scss'
 
 interface ImportingChangesetsPreviewListProps {
-    importingChangesetsConnection: UseShowMorePaginationResult<ImportingChangesetFields>
+    importingChangesetsConnection: UseShowMorePaginationResult<
+        BatchSpecImportingChangesetsResult,
+        ImportingChangesetFields
+    >
     /**
      * Whether or not the changesets in this list are up-to-date with the current batch
      * spec input YAML in the editor.

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
@@ -11,6 +11,7 @@ import {
     ShowMoreButton,
 } from '../../../../../components/FilteredConnection/ui'
 import {
+    BatchSpecWorkspacesPreviewResult,
     PreviewHiddenBatchSpecWorkspaceFields,
     PreviewVisibleBatchSpecWorkspaceFields,
 } from '../../../../../graphql-operations'
@@ -21,6 +22,7 @@ import { WorkspacesPreviewListItem } from './WorkspacesPreviewListItem'
 interface WorkspacesPreviewListProps {
     /** The current workspaces preview connection result used to render the list. */
     workspacesConnection: UseShowMorePaginationResult<
+        BatchSpecWorkspacesPreviewResult,
         PreviewHiddenBatchSpecWorkspaceFields | PreviewVisibleBatchSpecWorkspaceFields
     >
     /**

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useImportingChangesets.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useImportingChangesets.ts
@@ -25,7 +25,7 @@ export type ImportingChangesetFields =
  */
 export const useImportingChangesets = (
     batchSpecID: Scalars['ID']
-): UseShowMorePaginationResult<ImportingChangesetFields> =>
+): UseShowMorePaginationResult<BatchSpecImportingChangesetsResult, ImportingChangesetFields> =>
     useShowMorePagination<
         BatchSpecImportingChangesetsResult,
         BatchSpecImportingChangesetsVariables,

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspaces.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspaces.ts
@@ -30,7 +30,10 @@ export interface WorkspacePreviewFilters {
 export const useWorkspaces = (
     batchSpecID: Scalars['ID'],
     filters?: WorkspacePreviewFilters
-): UseShowMorePaginationResult<PreviewHiddenBatchSpecWorkspaceFields | PreviewVisibleBatchSpecWorkspaceFields> =>
+): UseShowMorePaginationResult<
+    BatchSpecWorkspacesPreviewResult,
+    PreviewHiddenBatchSpecWorkspaceFields | PreviewVisibleBatchSpecWorkspaceFields
+> =>
     useShowMorePagination<
         BatchSpecWorkspacesPreviewResult,
         BatchSpecWorkspacesPreviewVariables,

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -80,7 +80,7 @@ const BATCH_COUNT = 15
 
 const useBulkOperationsListConnection = (
     batchChangeID: Scalars['ID']
-): UseShowMorePaginationResult<BulkOperationFields> => {
+): UseShowMorePaginationResult<BatchChangeBulkOperationsResult, BulkOperationFields> => {
     const { connection, startPolling, stopPolling, ...rest } = useShowMorePagination<
         BatchChangeBulkOperationsResult,
         BatchChangeBulkOperationsVariables,

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -12,7 +12,12 @@ import {
     ShowMoreButton,
     SummaryContainer,
 } from '../../../components/FilteredConnection/ui'
-import { BatchChangesCodeHostFields, Scalars } from '../../../graphql-operations'
+import {
+    BatchChangesCodeHostFields,
+    GlobalBatchChangesCodeHostsResult,
+    Scalars,
+    UserBatchChangesCodeHostsResult,
+} from '../../../graphql-operations'
 
 import { useGlobalBatchChangesCodeHostConnection, useUserBatchChangesCodeHostConnection } from './backend'
 import { CodeHostConnectionNode } from './CodeHostConnectionNode'
@@ -37,7 +42,10 @@ export const UserCodeHostConnections: React.FunctionComponent<
 
 interface CodeHostConnectionsProps extends GlobalCodeHostConnectionsProps {
     userID: Scalars['ID'] | null
-    connectionResult: UseShowMorePaginationResult<BatchChangesCodeHostFields>
+    connectionResult: UseShowMorePaginationResult<
+        GlobalBatchChangesCodeHostsResult | UserBatchChangesCodeHostsResult,
+        BatchChangesCodeHostFields
+    >
 }
 
 const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeHostConnectionsProps>> = ({

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -109,7 +109,7 @@ export const USER_CODE_HOSTS = gql`
 
 export const useUserBatchChangesCodeHostConnection = (
     user: Scalars['ID']
-): UseShowMorePaginationResult<BatchChangesCodeHostFields> =>
+): UseShowMorePaginationResult<UserBatchChangesCodeHostsResult, BatchChangesCodeHostFields> =>
     useShowMorePagination<
         UserBatchChangesCodeHostsResult,
         UserBatchChangesCodeHostsVariables,
@@ -148,7 +148,10 @@ export const GLOBAL_CODE_HOSTS = gql`
     ${CODE_HOST_FIELDS_FRAGMENT}
 `
 
-export const useGlobalBatchChangesCodeHostConnection = (): UseShowMorePaginationResult<BatchChangesCodeHostFields> =>
+export const useGlobalBatchChangesCodeHostConnection = (): UseShowMorePaginationResult<
+    GlobalBatchChangesCodeHostsResult,
+    BatchChangesCodeHostFields
+> =>
     useShowMorePagination<
         GlobalBatchChangesCodeHostsResult,
         GlobalBatchChangesCodeHostsVariables,

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.tsx
@@ -12,7 +12,14 @@ import {
     ShowMoreButton,
     SummaryContainer,
 } from '../../../components/FilteredConnection/ui'
-import { ExecutorSecretFields, ExecutorSecretScope, Scalars } from '../../../graphql-operations'
+import {
+    ExecutorSecretFields,
+    ExecutorSecretScope,
+    GlobalExecutorSecretsResult,
+    OrgExecutorSecretsResult,
+    Scalars,
+    UserExecutorSecretsResult,
+} from '../../../graphql-operations'
 
 import { AddSecretModal } from './AddSecretModal'
 import {
@@ -97,7 +104,12 @@ export const OrgExecutorSecretsListPage: FC<OrgExecutorSecretsListPageProps> = p
 export interface ExecutorSecretsListPageProps extends GlobalExecutorSecretsListPageProps {
     namespaceID: Scalars['ID'] | null
     headerLine: JSX.Element
-    connectionLoader: (scope: ExecutorSecretScope) => UseShowMorePaginationResult<ExecutorSecretFields>
+    connectionLoader: (
+        scope: ExecutorSecretScope
+    ) => UseShowMorePaginationResult<
+        OrgExecutorSecretsResult | UserExecutorSecretsResult | GlobalExecutorSecretsResult,
+        ExecutorSecretFields
+    >
 }
 
 const ExecutorSecretsListPage: FC<ExecutorSecretsListPageProps> = ({ namespaceID, headerLine, connectionLoader }) => {

--- a/client/web/src/enterprise/executors/secrets/backend.ts
+++ b/client/web/src/enterprise/executors/secrets/backend.ts
@@ -119,7 +119,7 @@ export const USER_EXECUTOR_SECRETS = gql`
 export const userExecutorSecretsConnectionFactory = (
     user: Scalars['ID'],
     scope: ExecutorSecretScope
-): UseShowMorePaginationResult<ExecutorSecretFields> =>
+): UseShowMorePaginationResult<UserExecutorSecretsResult, ExecutorSecretFields> =>
     // Scope has to be injected dynamically.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useShowMorePagination<UserExecutorSecretsResult, UserExecutorSecretsVariables, ExecutorSecretFields>({
@@ -165,7 +165,7 @@ export const ORG_EXECUTOR_SECRETS = gql`
 export const orgExecutorSecretsConnectionFactory = (
     org: Scalars['ID'],
     scope: ExecutorSecretScope
-): UseShowMorePaginationResult<ExecutorSecretFields> =>
+): UseShowMorePaginationResult<OrgExecutorSecretsResult, ExecutorSecretFields> =>
     // Scope has to be injected dynamically.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useShowMorePagination<OrgExecutorSecretsResult, OrgExecutorSecretsVariables, ExecutorSecretFields>({
@@ -205,7 +205,7 @@ export const GLOBAL_EXECUTOR_SECRETS = gql`
 
 export const globalExecutorSecretsConnectionFactory = (
     scope: ExecutorSecretScope
-): UseShowMorePaginationResult<ExecutorSecretFields> =>
+): UseShowMorePaginationResult<GlobalExecutorSecretsResult, ExecutorSecretFields> =>
     // Scope has to be injected dynamically.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useShowMorePagination<GlobalExecutorSecretsResult, GlobalExecutorSecretsVariables, ExecutorSecretFields>({
@@ -264,7 +264,7 @@ export const EXECUTOR_SECRET_ACCESS_LOGS = gql`
 
 export const useExecutorSecretAccessLogsConnection = (
     secret: Scalars['ID']
-): UseShowMorePaginationResult<ExecutorSecretAccessLogFields> =>
+): UseShowMorePaginationResult<ExecutorSecretAccessLogsResult, ExecutorSecretAccessLogFields> =>
     useShowMorePagination<
         ExecutorSecretAccessLogsResult,
         ExecutorSecretAccessLogsVariables,

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -50,6 +50,13 @@ export const getCommonRepositoryGraphQlResults = (
     TreeCommits: () => ({
         node: {
             __typename: 'Repository',
+            externalURLs: [
+                {
+                    __typename: 'ExternalLink',
+                    serviceKind: ExternalServiceKind.GITHUB,
+                    url: 'https://' + repositoryName,
+                },
+            ],
             commit: { ancestors: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } },
         },
     }),
@@ -100,6 +107,13 @@ describe('Repository', () => {
                 TreeCommits: () => ({
                     node: {
                         __typename: 'Repository',
+                        externalURLs: [
+                            {
+                                __typename: 'ExternalLink',
+                                serviceKind: ExternalServiceKind.GITHUB,
+                                url: 'https://' + repositoryName,
+                            },
+                        ],
                         commit: {
                             ancestors: {
                                 nodes: [
@@ -635,6 +649,13 @@ describe('Repository', () => {
                     __typename: 'Query',
                     node: {
                         __typename: 'Repository',
+                        externalURLs: [
+                            {
+                                __typename: 'ExternalLink',
+                                serviceKind: ExternalServiceKind.GITHUB,
+                                url: 'https://' + repositoryName,
+                            },
+                        ],
                         commit: {
                             __typename: 'GitCommit',
                             ancestors: {

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
@@ -10,7 +10,7 @@ import {
 
 import { ConnectionPopoverContainer, ConnectionPopoverForm, ConnectionPopoverList } from './components'
 
-interface RevisionsPopoverTabProps extends UseShowMorePaginationResult<unknown> {
+interface RevisionsPopoverTabProps extends UseShowMorePaginationResult<unknown, unknown> {
     inputValue: string
     onInputChange: (value: string) => void
     query: string

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -19,11 +19,11 @@ import {
     useObservable,
 } from '@sourcegraph/wildcard'
 
-import { ExternalServiceKind } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { UserAvatar } from '../../user/UserAvatar'
 import { replaceRevisionInURL } from '../../util/url'
 import { BlameHunk, BlameHunkData } from '../blame/useBlameHunks'
+import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 
 import { useBlameRecencyColor } from './BlameRecency'
 
@@ -251,8 +251,13 @@ export const BlameDecoration: React.FunctionComponent<BlameDecorationProps> = ({
                                     as={SourceCommitIcon}
                                     className={classNames('mr-2 flex-shrink-0', styles.icon)}
                                 />
-
-                                {generateCommitMessageWithLinks(blameHunk, externalURLs)}
+                                <CommitMessageWithLinks
+                                    message={blameHunk.message}
+                                    to={blameHunk.displayInfo.linkURL}
+                                    className={styles.link}
+                                    onClick={logCommitClick}
+                                    externalURLs={externalURLs}
+                                />
                             </div>
                             {blameHunk.commit.parents.length > 0 && (
                                 <>
@@ -280,61 +285,6 @@ export const BlameDecoration: React.FunctionComponent<BlameDecorationProps> = ({
             ) : null}
         </div>
     )
-}
-
-// This regex is supposed to match in the following cases:
-//
-//  - Create search and search-ui packages (#29773)
-//  - Fix #123 for xyz
-//
-// However it is supposed not to mach in:
-//
-// - Something sourcegraph/other-repo#123 or so
-// - 123#123
-const GH_ISSUE_NUMBER_IN_COMMIT = /([^\dA-Za-z](#\d+))/g
-
-const generateCommitMessageWithLinks = (
-    blameHunk: BlameHunk,
-    externalURLs: BlameHunkData['externalURLs']
-): React.ReactNode => {
-    const commitLinkProps = {
-        to: blameHunk.displayInfo.linkURL,
-        target: '_blank',
-        rel: 'noreferrer noopener',
-        className: styles.link,
-        onClick: logCommitClick,
-    }
-
-    const github = externalURLs ? externalURLs.find(url => url.serviceKind === ExternalServiceKind.GITHUB) : null
-    const message = blameHunk.message
-    const matches = [...message.matchAll(GH_ISSUE_NUMBER_IN_COMMIT)]
-    if (github && matches.length > 0) {
-        let remainingMessage = message
-        let skippedCharacters = 0
-        const linkSegments: React.ReactNode[] = []
-
-        for (const match of matches) {
-            if (match.index === undefined) {
-                continue
-            }
-            const issueNumber = match[2]
-            const index = remainingMessage.indexOf(issueNumber, match.index - skippedCharacters)
-            const before = remainingMessage.slice(0, index)
-
-            linkSegments.push(<Link {...commitLinkProps}>{before}</Link>)
-            linkSegments.push(<Link to={`${github.url}/pull/${issueNumber.replace('#', '')}`}>{issueNumber}</Link>)
-
-            const nextIndex = index + issueNumber.length
-            remainingMessage = remainingMessage.slice(index + issueNumber.length)
-            skippedCharacters += nextIndex
-        }
-
-        linkSegments.push(<Link {...commitLinkProps}>{remainingMessage}</Link>)
-
-        return <div>{linkSegments}</div>
-    }
-
-    return <Link {...commitLinkProps}>{blameHunk.message}</Link>
 }
 
 const logCommitClick = (): void => {

--- a/client/web/src/repo/commit/CommitMessageWithLinks.tsx
+++ b/client/web/src/repo/commit/CommitMessageWithLinks.tsx
@@ -1,0 +1,68 @@
+import { Link } from '@sourcegraph/wildcard'
+
+import { ExternalServiceKind } from '../../graphql-operations'
+
+// This regex is supposed to match in the following cases:
+//
+//  - Create search and search-ui packages (#29773)
+//  - Fix #123 for xyz
+//
+// However it is supposed not to mach in:
+//
+// - Something sourcegraph/other-repo#123 or so
+// - 123#123
+const GH_ISSUE_NUMBER_IN_COMMIT = /([^\dA-Za-z](#\d+))/g
+
+interface Props {
+    message: string
+    to: string
+    className: string
+    onClick?: () => void
+    externalURLs: { url: string; serviceKind: ExternalServiceKind | null }[] | undefined
+}
+export const CommitMessageWithLinks = ({
+    message,
+    to,
+    className,
+    onClick,
+    externalURLs,
+}: Props): React.ReactElement => {
+    const commitLinkProps = {
+        'data-testid': 'git-commit-node-message-subject',
+        className,
+        onClick,
+        rel: 'noreferrer noopener',
+        target: '_blank',
+        to,
+    }
+
+    const github = externalURLs ? externalURLs.find(url => url.serviceKind === ExternalServiceKind.GITHUB) : null
+    const matches = [...message.matchAll(GH_ISSUE_NUMBER_IN_COMMIT)]
+    if (github && matches.length > 0) {
+        let remainingMessage = message
+        let skippedCharacters = 0
+        const linkSegments: React.ReactNode[] = []
+
+        for (const match of matches) {
+            if (match.index === undefined) {
+                continue
+            }
+            const issueNumber = match[2]
+            const index = remainingMessage.indexOf(issueNumber, match.index - skippedCharacters)
+            const before = remainingMessage.slice(0, index)
+
+            linkSegments.push(<Link {...commitLinkProps}>{before}</Link>)
+            linkSegments.push(<Link to={`${github.url}/pull/${issueNumber.replace('#', '')}`}>{issueNumber}</Link>)
+
+            const nextIndex = index + issueNumber.length
+            remainingMessage = remainingMessage.slice(index + issueNumber.length)
+            skippedCharacters += nextIndex
+        }
+
+        linkSegments.push(<Link {...commitLinkProps}>{remainingMessage}</Link>)
+
+        return <>{linkSegments}</>
+    }
+
+    return <Link {...commitLinkProps}>{message}</Link>
+}

--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -74,12 +74,13 @@
     }
 
     &-subject {
-        font-weight: 600;
         flex: 0 1 auto;
-        padding-right: 0.5rem;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+    }
+
+    &-link {
         color: var(--body-color);
     }
 

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -102,7 +102,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             className={classNames('flex-grow-1', styles.message, compact && styles.messageSmall)}
             data-testid="git-commit-node-message"
         >
-            <span className={classNames('mr-1', styles.messageSubject)}>
+            <span className={classNames('mr-2', styles.messageSubject)}>
                 <CommitMessageWithLinks
                     to={node.canonicalURL}
                     className={classNames(messageSubjectClassName, styles.messageLink)}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -8,8 +8,9 @@ import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
 import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
-import { GitCommitFields } from '../../graphql-operations'
+import { ExternalServiceKind, GitCommitFields } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
+import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { DiffModeSelector } from '../commit/DiffModeSelector'
 import { DiffMode } from '../commit/RepositoryCommitPage'
 
@@ -57,6 +58,8 @@ export interface GitCommitNodeProps {
      * Tracking issue to migrate away from this component: https://github.com/sourcegraph/sourcegraph/issues/23157
      * */
     wrapperElement?: 'div' | 'li'
+
+    externalURLs?: { url: string; serviceKind: ExternalServiceKind | null }[] | undefined
 }
 
 /** Displays a Git commit. */
@@ -73,6 +76,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     diffMode,
     onHandleDiffMode,
     wrapperElement: WrapperElement = 'div',
+    externalURLs,
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
@@ -98,13 +102,15 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             className={classNames('flex-grow-1', styles.message, compact && styles.messageSmall)}
             data-testid="git-commit-node-message"
         >
-            <Link
-                to={node.canonicalURL}
-                className={classNames(messageSubjectClassName, styles.messageSubject)}
-                data-testid="git-commit-node-message-subject"
-            >
-                {node.subject}
-            </Link>
+            <span className={classNames('mr-1', styles.messageSubject)}>
+                <CommitMessageWithLinks
+                    to={node.canonicalURL}
+                    className={classNames(messageSubjectClassName, styles.messageLink)}
+                    message={node.subject}
+                    externalURLs={externalURLs}
+                />
+            </span>
+
             {node.body && !hideExpandCommitMessageBody && !expandCommitMessageBody && (
                 <Button
                     className={styles.messageToggle}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -5,7 +5,7 @@ import { formatISO, subYears } from 'date-fns'
 import * as H from 'history'
 import { escapeRegExp } from 'lodash'
 import { Observable } from 'rxjs'
-import { map, switchMap } from 'rxjs/operators'
+import { map, switchMap, tap } from 'rxjs/operators'
 
 import { memoizeObservable, numberWithCommas, pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
@@ -15,7 +15,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Button, Card, CardHeader, Link, Tooltip, Text } from '@sourcegraph/wildcard'
+import { Button, Card, CardHeader, Link, Tooltip, Text, useObservable } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -56,9 +56,10 @@ import styles from './TreePageContent.module.scss'
 import contributorsStyles from './TreePageContentContributors.module.scss'
 import panelStyles from './TreePagePanels.module.scss'
 
-export type TreeCommitsRepositoryCommit = NonNullable<
-    Extract<TreeCommitsResult['node'], { __typename: 'Repository' }>['commit']
->
+export interface TreeCommitsResponse {
+    ancestors: NonNullable<Extract<TreeCommitsResult['node'], { __typename: 'Repository' }>['commit']>['ancestors']
+    externalURLs: Extract<TreeCommitsResult['node'], { __typename: 'Repository' }>['externalURLs']
+}
 
 export const fetchTreeCommits = memoizeObservable(
     (args: {
@@ -67,13 +68,17 @@ export const fetchTreeCommits = memoizeObservable(
         first?: number
         filePath?: string
         after?: string
-    }): Observable<TreeCommitsRepositoryCommit['ancestors']> =>
+    }): Observable<TreeCommitsResponse> =>
         requestGraphQL<TreeCommitsResult, TreeCommitsVariables>(
             gql`
                 query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
                     node(id: $repo) {
                         __typename
                         ... on Repository {
+                            externalURLs {
+                                url
+                                serviceKind
+                            }
                             commit(rev: $revspec) {
                                 ancestors(first: $first, path: $filePath, after: $after) {
                                     nodes {
@@ -107,7 +112,7 @@ export const fetchTreeCommits = memoizeObservable(
                 if (!data.node.commit) {
                     throw new Error('Commit not found')
                 }
-                return data.node.commit.ancestors
+                return { ancestors: data.node.commit.ancestors, externalURLs: data.node.externalURLs }
             })
         ),
     args => `${args.repo}:${args.revspec}:${String(args.first)}:${String(args.filePath)}:${String(args.after)}`
@@ -265,8 +270,8 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         return () => subscription.unsubscribe()
     }, [repo.name, revision, filePath])
 
-    const queryCommits = useCallback(
-        (args: { first?: number }): Observable<TreeCommitsRepositoryCommit['ancestors']> => {
+    const queryTreeCommits = useCallback(
+        (args: { first?: number }): Observable<TreeCommitsResponse> => {
             const after: string | undefined = showOlderCommits ? undefined : formatISO(subYears(Date.now(), 1))
             return fetchTreeCommits({
                 ...args,
@@ -277,6 +282,21 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
             })
         },
         [filePath, repo.id, revision, showOlderCommits]
+    )
+    const [externalURLs, setExternalURLs] = useState<undefined | TreeCommitsResponse['externalURLs']>(undefined)
+    const queryCommits = useCallback(
+        (args: { first?: number }): Observable<TreeCommitsResponse['ancestors']> => {
+            const treeCommits = queryTreeCommits(args)
+            return treeCommits.pipe(
+                tap(data => {
+                    if (data.externalURLs) {
+                        setExternalURLs(data.externalURLs)
+                    }
+                }),
+                map(data => data.ancestors)
+            )
+        },
+        [queryTreeCommits]
     )
 
     const onShowOlderCommitsClicked = useCallback((event: React.MouseEvent): void => {
@@ -347,6 +367,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                             messageSubjectClassName: styles.gitCommitNodeMessageSubject,
                             compact: true,
                             wrapperElement: 'li',
+                            externalURLs,
                         }}
                         updateOnChange={`${repo.name}:${revision}:${filePath}:${String(showOlderCommits)}`}
                         defaultFirst={20}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -355,7 +355,10 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
                     <FilteredConnection<
                         GitCommitFields,
-                        Pick<GitCommitNodeProps, 'className' | 'compact' | 'messageSubjectClassName' | 'wrapperElement'>
+                        Pick<
+                            GitCommitNodeProps,
+                            'className' | 'compact' | 'messageSubjectClassName' | 'wrapperElement' | 'externalURLs'
+                        >
                     >
                         listClassName="list-group list-group-flush"
                         noun="commit in this tree"

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -15,7 +15,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Button, Card, CardHeader, Link, Tooltip, Text, useObservable } from '@sourcegraph/wildcard'
+import { Button, Card, CardHeader, Link, Tooltip, Text } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -836,7 +836,7 @@ export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number;
     return { loading, totalErrors, totalNoEvents }
 }
 
-export const useWebhooksConnection = (): UseShowMorePaginationResult<WebhookFields> =>
+export const useWebhooksConnection = (): UseShowMorePaginationResult<WebhooksListResult, WebhookFields> =>
     useShowMorePagination<WebhooksListResult, WebhooksListVariables, WebhookFields>({
         query: WEBHOOKS,
         variables: {},
@@ -855,7 +855,7 @@ export const useWebhookLogsConnection = (
     webhookID: string,
     first: number,
     onlyErrors: boolean
-): UseShowMorePaginationResult<WebhookLogFields> =>
+): UseShowMorePaginationResult<WebhookLogsByWebhookIDResult, WebhookLogFields> =>
     useShowMorePagination<WebhookLogsByWebhookIDResult, WebhookLogsByWebhookIDVariables, WebhookLogFields>({
         query: WEBHOOK_LOGS_BY_ID,
         variables: {

--- a/client/web/src/site-admin/outbound-webhooks/backend.ts
+++ b/client/web/src/site-admin/outbound-webhooks/backend.ts
@@ -89,7 +89,10 @@ export const UPDATE_OUTBOUND_WEBHOOK = gql`
     }
 `
 
-export const useOutboundWebhooksConnection = (): UseShowMorePaginationResult<OutboundWebhookFieldsWithStats> =>
+export const useOutboundWebhooksConnection = (): UseShowMorePaginationResult<
+    OutboundWebhooksListResult,
+    OutboundWebhookFieldsWithStats
+> =>
     useShowMorePagination<OutboundWebhooksListResult, OutboundWebhooksListVariables, OutboundWebhookFieldsWithStats>({
         query: OUTBOUND_WEBHOOKS,
         variables: {

--- a/client/web/src/site-admin/outbound-webhooks/logs/backend.ts
+++ b/client/web/src/site-admin/outbound-webhooks/logs/backend.ts
@@ -56,7 +56,7 @@ export const OUTBOUND_WEBHOOK_LOGS = gql`
 export const useOutboundWebhookLogsConnection = (
     id: string,
     onlyErrors: boolean
-): UseShowMorePaginationResult<OutboundWebhookLogFields> =>
+): UseShowMorePaginationResult<OutboundWebhookLogsResult, OutboundWebhookLogFields> =>
     useShowMorePagination<OutboundWebhookLogsResult, OutboundWebhookLogsVariables, OutboundWebhookLogFields>({
         query: OUTBOUND_WEBHOOK_LOGS,
         variables: {


### PR DESCRIPTION
Quick follow-up as people seem to like the GitHub PR reference rendering. We now use the same logic in the commit list on the repo home page and the repo commits page.

## Test plan

<img width="1402" alt="Screenshot 2023-02-14 at 11 40 40" src="https://user-images.githubusercontent.com/458591/218712661-7278add7-105a-478e-bfb0-867bf6b2becd.png">
<img width="1108" alt="Screenshot 2023-02-14 at 11 29 04" src="https://user-images.githubusercontent.com/458591/218712682-040efc4e-5f23-45db-b97a-36b3c17adc8d.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-render-gh-links-in-more-places.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
