### PR TITLE
Fix references panel links

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -87,6 +87,8 @@ export interface BlobProps
 
     isBlameVisible?: boolean
     blameHunks?: BlameHunkData
+
+    activeURL?: string
 }
 
 export interface BlobPropsFacet extends BlobProps {
@@ -200,7 +202,17 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
     // This is used to avoid reinitializing the editor when new locations in the
     // same file are opened inside the reference panel.
     const blobInfo = useDistinctBlob(props.blobInfo)
-    const position = useMemo(() => parseQueryAndHash(location.search, location.hash), [location.search, location.hash])
+    const position = useMemo(() => {
+        // When an activeURL is passed, it takes presedence over the react
+        // router location API.
+        //
+        // This is needed to support the reference panel
+        if (props.activeURL) {
+            const url = new URL(props.activeURL, window.location.href)
+            return parseQueryAndHash(url.search, url.hash)
+        }
+        return parseQueryAndHash(location.search, location.hash)
+    }, [props.activeURL, location.search, location.hash])
     const hasPin = useMemo(() => urlIsPinned(location.search), [location.search])
 
     const blobProps = useMemo(


### PR DESCRIPTION
Part of #33834 

Fixes an issue reported in [Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1676373314250949).

The references panel needs a way to overwrite the react router location for the blob view it renders.

## Test plan


https://user-images.githubusercontent.com/458591/218727814-26e5bc97-e919-4b47-a4bb-f630f1e18306.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-references-panel-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
