### PR TITLE
docs: update Perforce docs to make setup steps clearer and document permissions

### DIFF
--- a/doc/admin/repo/index.md
+++ b/doc/admin/repo/index.md
@@ -10,3 +10,4 @@
 - [Configure repository permissions](permissions.md)
   - [Row-level security](row_level_security.md)
 - [Configure repository metadata](metadata.md)
+- [Set up Perforce depots](perforce.md)

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -118,7 +118,7 @@ write user alice * //TestDepot/*/spec/...
 write user alice * //TestDepot/.../spec/...
 ```
 
-But permissions are only enforced per repository, **not per file**. For that you need to configure [file-level permissions](#file-level-permissions).
+But permissions are only enforced per repository and **not per file**. For that you need to configure [file-level permissions](#file-level-permissions).
 
 ### File-level permissions
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -72,7 +72,7 @@ To enforce repository-level permissions for Perforce depots using [Perforce perm
 }
 ```
 
-Adding the `authorization` field to the code host connection configuration will enable partial parsing of the permissions tables.
+Adding the `authorization` field to the code host connection configuration will enable partial parsing of the permissions tables. [Learn more about the partial support of permission table parsing](#known-issues-and-limitations).
 
 ### Syncing subdirectories to match permission boundaries
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -171,7 +171,7 @@ To enable file-level permissions:
 
 ### Notes about permissions
 
-- Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
+- Sourcegraph users are mapped to Perforce users based on their verified email addresses.
 - As long as a user has been granted at least `Read` permissions in Perforce they will be able to view content in Sourcegraph.
 - As a special case, commits in which a user does not have permissions to read any files are hidden. If a user can read a subset of files in a commit, only those files are shown.
 - [The host field from protections are not supported](#known-issues-and-limitations).

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -80,7 +80,7 @@ By default Sourcegraph only supports repository-level permissions and does not m
 
 If you don't [activate file-level permissions](#file-level-permissions) you should sync subdirectories of a depot using the `depots` configuration that best describes the most concrete path of your permissions boundary.
 
-For example, if your Perforce depot `//depot/Talkhouse` has different permissions for `//depot/Talkhouse/main-dev` and some subdirectories of `//depot/Talkhouse/rel1.0`, we recommend setting the following `depots`:
+For example, if your Perforce depot `//depot/Talkhouse` has different permissions for `//depot/Talkhouse/main-dev` and subdirectories `//depot/Talkhouse/rel1.0/front`, `//depot/Talkhouse/rel1.0/back` we recommend setting the following `depots`:
 
 ```json
 {

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -13,45 +13,45 @@ Perforce depots can be added to a Sourcegraph instance by adding the appropriate
 Perforce code host connections are still an experimental feature.
 To enable Perforce code host connections, a site admin must:
 
-**1.** Enable the experimental feature in the [site configuration](../config/site_config.md):
+1. Enable the experimental feature in the [site configuration](../config/site_config.md):
 
-```json
-{
-  "experimentalFeatures": {
-    "perforce": "enabled"
-  }
-  // ...
-}
-```
+    ```json
+    {
+      "experimentalFeatures": {
+        "perforce": "enabled"
+      }
+      // ...
+    }
+    ```
 
-**2.** Go to **Site admin > Manage code hosts > Add code host**
+1. Go to **Site admin > Manage code hosts > Add code host**
 
-**3.** Select **Perforce**.
+1. Select **Perforce**.
 
-**4.** Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
+1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
-- [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
-- [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
-- [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
-- See the [configuration documentation below](#configuration) for other fields you can configure.
+    - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
+    - [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
+    - [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+    - See the [configuration documentation below](#configuration) for other fields you can configure.
 
-**5.** Configure `fusionClient`:
+1. Configure `fusionClient`:
 
-```json
-{
-  // ...
-  "fusionClient": {
-    "enabled": true,
-    "lookAhead": 2000
-  }
-}
-```
+    ```json
+    {
+      // ...
+      "fusionClient": {
+        "enabled": true,
+        "lookAhead": 2000
+      }
+    }
+    ```
 
-> NOTE: While the `fusionClient` configuration is otional, without it the code host connection uses `git p4`, which has performance issues so we strongly recommend `p4-fusion`.
+    > NOTE: While the `fusionClient` configuration is otional, without it the code host connection uses `git p4`, which has performance issues so we strongly recommend `p4-fusion`.
 
-Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
+    Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
 
-**6.** Click **Add repositories**.
+1. Click **Add repositories**.
 
 Sourcegraph will now talk to the Perforce host and sync the configured `depots` to the Sourcegraph instance.
 
@@ -126,39 +126,35 @@ File-level permissions make the [syncing of subdirectories to match permission b
 
 To enable file-level permissions:
 
-**1.** Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227&subtree=true?L227):
+1. Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227&subtree=true?L227):
 
-```json
-{
-  // ...
-  "experimentalFeatures": {
-    "perforce": "enabled",
-    "subRepoPermissions": { "enabled": true }
-  }
-}
-```
+    ```json
+    {
+      // ...
+      "experimentalFeatures": {
+        "perforce": "enabled",
+        "subRepoPermissions": { "enabled": true }
+      }
+    }
+    ```
 
-**2.** Enable the feature in the code host configuration by adding `subRepoPermissions` to the `authorization` object:
+1. Enable the feature in the code host configuration by adding `subRepoPermissions` to the `authorization` object:
 
-```json
-{
-  // ...
-  "authorization": {
-    "subRepoPermissions": true
-  }
-}
-```
+    ```json
+    {
+      // ...
+      "authorization": {
+        "subRepoPermissions": true
+      }
+    }
+    ```
 
-**3.** Save the configuration. Permissions will be synced in the background based on your [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
+1. Save the configuration. Permissions will be synced in the background based on your [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
 
-Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
-
-As long as a user has been granted at least `Read` permissions in Perforce they will be able to view content in Sourcegraph.
-
-As a special case, commits in which a user does not have permissions to read any files are hidden. If a user can read a subset of files in a commit, only those files are shown.
-
-### Caveats about permissions
-
+### Notes about permissions
+- Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
+- As long as a user has been granted at least `Read` permissions in Perforce they will be able to view content in Sourcegraph.
+- As a special case, commits in which a user does not have permissions to read any files are hidden. If a user can read a subset of files in a commit, only those files are shown.
 - [the host field from protections are not supported](#known-issues-and-limitations).
 
 ## Configuration
@@ -173,4 +169,4 @@ We are actively working to significantly improve Sourcegraph's Perforce support.
 - The commit messages for a Perforce depot converted to a Git repository have an extra line at the end with Perforce information, such as `[git-p4: depot-paths = "//guest/example_org/myproject/": change = 12345]`.
 - [Permissions](#repository-permissions)
   - [File-level permissions](#file-level-permissions) are not supported when syncing permissions via the [code host integration](#add-a-perforce-code-host).
-  - The [host field](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html#Form_Fields_..361) in protections are not supported.
+  - The [host field](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html#Form_Fields_..361) in protections is not supported.

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -10,43 +10,48 @@ Sourcegraph supports [Perforce Helix](https://www.perforce.com/solutions/version
 
 Perforce depots can be added to a Sourcegraph instance by adding the appropriate [code host connection](../external_service/index.md).
 
-1. Perforce code host connections are still an experimental feature. To access this functionality, a site admin must enable the experimental feature in the [site configuration](../config/site_config.md):
+Perforce code host connections are still an experimental feature.
+To enable Perforce code host connections, a site admin must:
 
-    ```json
-    {
-      "experimentalFeatures": {
-        "perforce": "enabled"
-      }
-      // ...
-    }
-    ```
-1. Go to **Site admin > Manage code hosts > Add code host**
-1. Select **Perforce**.
-1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
+**1.** Enable the experimental feature in the [site configuration](../config/site_config.md):
 
-    - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
-    - [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
-    - [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+```json
+{
+  "experimentalFeatures": {
+    "perforce": "enabled"
+  }
+  // ...
+}
+```
 
-    See the [configuration documentation below](#configuration) for other fields you can configure.
+**2.** Go to **Site admin > Manage code hosts > Add code host**
 
-1. **Optional, but recommended**: use the [`p4-fusion`](https://github.com/salesforce/p4-fusion) client by configuring `fusionClient` for better performance:
+**3.** Select **Perforce**.
 
-    ```json
-    {
-        // ...
-        "fusionClient": {
-          "enabled": true,
-          "lookAhead": 2000
-        }
-    }
-    ```
+**4.** Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
-    Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
+- [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
+- [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
+- [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+- See the [configuration documentation below](#configuration) for other fields you can configure.
 
-    Without the `fusionClient` configuration, the code host connection uses `git p4`, but we recommend `p4-fusion` for better performance.
+**5.** Configure `fusionClient`:
 
-1. Click **Add repositories**.
+```json
+{
+  // ...
+  "fusionClient": {
+    "enabled": true,
+    "lookAhead": 2000
+  }
+}
+```
+
+> NOTE: While the `fusionClient` configuration is otional, without it the code host connection uses `git p4`, which has performance issues so we strongly recommend `p4-fusion`.
+
+Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
+
+**6.** Click **Add repositories**.
 
 Sourcegraph will now talk to the Perforce host and sync the configured `depots` to the Sourcegraph instance.
 
@@ -58,7 +63,7 @@ It's worthwhile to note some limitations of this process:
 
 ## Repository permissions
 
-To enforce repository-level permissions for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67) to the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
+To enforce repository-level permissions for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67) in the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
 
 ```json
 {
@@ -121,29 +126,30 @@ File-level permissions make the [syncing of subdirectories to match permission b
 
 To enable file-level permissions:
 
-1. Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227&subtree=true?L227):
+**1.** Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227&subtree=true?L227):
 
-    ```json
-    {
-      // ...
-      "experimentalFeatures": {
-        "perforce": "enabled",
-        "subRepoPermissions": { "enabled": true }
-      }
-    }
-    ```
-1. Enable the feature in the code host configuration by adding `subRepoPermissions` to the `authorization` object:
+```json
+{
+  // ...
+  "experimentalFeatures": {
+    "perforce": "enabled",
+    "subRepoPermissions": { "enabled": true }
+  }
+}
+```
 
-    ```json
-    {
-      // ...
-      "authorization": {
-        "subRepoPermissions": true
-      }
-    }
-    ```
+**2.** Enable the feature in the code host configuration by adding `subRepoPermissions` to the `authorization` object:
 
-2. Save the configuration. Permissions will be synced in the background based on your [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
+```json
+{
+  // ...
+  "authorization": {
+    "subRepoPermissions": true
+  }
+}
+```
+
+**3.** Save the configuration. Permissions will be synced in the background based on your [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
 
 Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -30,21 +30,27 @@ To enable Perforce code host connections, a site admin must:
 
 1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
-    - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
+    - [`depots`](perforce.md#depots)
+      
+      A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
+
     - [`p4.user`](perforce.md#p4-user)
-       
-       The user to be authenticated for `p4` CLI, and should be capable of performing:
-           - `p4 ping`,
-           - `p4 login`,
-           - `p4 trust`
-           - and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`.
+      
+      The user to be authenticated for `p4` CLI, and should be capable of performing:
+      - `p4 ping`
+      - `p4 login`
+      - `p4 trust`
+      - and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`.
            
-       If repository permissions are mirrored, the user needs additional ability to perform the
-           - `p4 protects`, 
-           - `p4 groups`, 
-           - `p4 group`, 
-           -`p4 users` commands (aka. "super" access level).
-    - [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+      If repository permissions are mirrored, the user needs additional ability (aka. "super" access level) to perform the commands
+      - `p4 protects`
+      - `p4 groups`
+      - `p4 group` 
+      - `p4 users`
+    - [`p4.passwd`](perforce.md#p4-passwd)
+      
+      The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+      
     - See the [configuration documentation below](#configuration) for other fields you can configure.
 
 1. Configure `fusionClient`:
@@ -59,9 +65,9 @@ To enable Perforce code host connections, a site admin must:
     }
     ```
 
-    > NOTE: While the `fusionClient` configuration is otional, without it the code host connection uses `git p4`, which has performance issues so we strongly recommend `p4-fusion`.
+    > NOTE: While the `fusionClient` configuration is optional, without it the code host connection uses `git p4`, which has performance issues so we strongly recommend `p4-fusion`.
 
-    Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
+    Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84-147).
 
 1. Click **Add repositories**.
 
@@ -75,7 +81,7 @@ It's worthwhile to note some limitations of this process:
 
 ## Repository permissions
 
-To enforce repository-level permissions for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67) in the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
+To enforce repository-level permissions for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67-78) in the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
 
 ```json
 {
@@ -122,7 +128,7 @@ Since that would override the permissions for the `//depot/Talkhouse/rel1.0/back
 
 #### Wildcards
 
-In the default configuration Sourcegraph provides limited support for `*` and `...` paths ("wildcards") in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). For example, the following can be supported using [the workaround described in repository permissions](#repository-permissions):
+In the default configuration Sourcegraph provides limited support for `*` and `...` paths ("wildcards") in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). For example, the following can be supported using [the workaround described in repository permissions](#syncing-subdirectories-to-match-permission-boundaries):
 
 ```sh
 write user alice * //TestDepot/...
@@ -138,7 +144,7 @@ File-level permissions make the [syncing of subdirectories to match permission b
 
 To enable file-level permissions:
 
-1. Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227&subtree=true?L227):
+1. Enable [the feature in the site config](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd/-/blob/schema/site.schema.json?L227-249):
 
     ```json
     {
@@ -164,6 +170,7 @@ To enable file-level permissions:
 1. Save the configuration. Permissions will be synced in the background based on your [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
 
 ### Notes about permissions
+
 - Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
 - As long as a user has been granted at least `Read` permissions in Perforce they will be able to view content in Sourcegraph.
 - As a special case, commits in which a user does not have permissions to read any files are hidden. If a user can read a subset of files in a commit, only those files are shown.
@@ -171,7 +178,7 @@ To enable file-level permissions:
 
 ## Configuration
 
-<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/perforce.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/perforce) to see rendered content.</div>
+<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/perforce.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/perforce.schema.json) to see rendered content.</div>
 
 ## Known issues and limitations
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -59,7 +59,7 @@ It's worthwhile to note some limitations of this process:
 
 - When syncing depots either [git p4](https://git-scm.com/docs/git-p4) or [p4-fusion](https://github.com/salesforce/p4-fusion) (recommended) are used to convert Perforce depots into git repositories so that Sourcegraph can index them.
 - Rename of a Perforce depot, including changing the depot on the Perforce server or the `repositoryPathPattern` config option, will cause a re-import of the depot.
-- Unless [permissions syncing](#repository-permissions) is enabled, Sourcegraph knows nothing of the permissions on the depots, so it can't enforce access restrictions.
+- Unless [permissions syncing](#repository-permissions) is enabled, Sourcegraph is not aware of the depot permissions, so it can't enforce access restrictions.
 
 ## Repository permissions
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -23,10 +23,14 @@ To enable Perforce code host connections, a site admin must:
       // ...
     }
     ```
+    It is highly recommended that you also enable [file-level permissions](#file-level-permissions) (step 1) at this time.
+    <br/>**Save your changes before continuing**.
 
 1. Go to **Site admin > Manage code hosts > Add code host**
 
-1. Select **Perforce**.
+    you may need to manually refresh the page in order to display the **Perforce** option.
+
+1. Scroll down the list of supported code hosts and select **Perforce**.
 
 1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
@@ -128,15 +132,8 @@ Since that would override the permissions for the `//depot/Talkhouse/rel1.0/back
 
 #### Wildcards
 
-In the default configuration Sourcegraph provides limited support for `*` and `...` paths ("wildcards") in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). For example, the following can be supported using [the workaround described in repository permissions](#syncing-subdirectories-to-match-permission-boundaries):
-
-```sh
-write user alice * //TestDepot/...
-write user alice * //TestDepot/*/spec/...
-write user alice * //TestDepot/.../spec/...
-```
-
-But permissions are only enforced per repository and **not per file**. For that you need to configure [file-level permissions](#file-level-permissions).
+[File-level permissions](#file-level-permissions) can handle wildcards in the protections table.
+If file-level permissions is not enabled, Sourcegraph provides limited support for `*` and `...` paths, so the workaround of [adding sub-folders as separate repositories](#syncing-subdirectories-to-match-permission-boundaries) for the paths that employ wildcards needs to be followed.
 
 ### File-level permissions
 
@@ -178,7 +175,7 @@ To enable file-level permissions:
 
 ## Configuration
 
-<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/perforce.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/perforce.schema.json) to see rendered content.</div>
+<div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/perforce.schema.json">[View page on docs.sourcegraph.com](../../admin/external_service/perforce.schema.json) to see rendered content.</div>
 
 ## Known issues and limitations
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -155,7 +155,7 @@ To enable file-level permissions:
 - Sourcegraph users are mapped to Perforce users based on their verified e-mail addresses.
 - As long as a user has been granted at least `Read` permissions in Perforce they will be able to view content in Sourcegraph.
 - As a special case, commits in which a user does not have permissions to read any files are hidden. If a user can read a subset of files in a commit, only those files are shown.
-- [the host field from protections are not supported](#known-issues-and-limitations).
+- [The host field from protections are not supported](#known-issues-and-limitations).
 
 ## Configuration
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -58,7 +58,7 @@ It's worthwhile to note some limitations of this process:
 
 ## Repository permissions
 
-To enable permissions syncing for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67) to the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
+To enforce repository-level permissions for Perforce depots using [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67) to the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
 
 ```json
 {
@@ -67,7 +67,13 @@ To enable permissions syncing for Perforce depots using [Perforce permissions ta
 }
 ```
 
-Adding the `authorization` field to the code host connection configugation will enable partial parsing of the permissions tables. If this is the extent of your configuring, then you should sync subdirectories of a depot using the `depots` configuration that best describes the most concrete path of your permissions boundary.
+Adding the `authorization` field to the code host connection configuration will enable partial parsing of the permissions tables.
+
+### Syncing subdirectories to match permission boundaries
+
+By default Sourcegraph only supports repository-level permissions and does not match the granularity of [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
+
+If you don't [activate file-level permissions](#file-level-permissions) you should sync subdirectories of a depot using the `depots` configuration that best describes the most concrete path of your permissions boundary.
 
 For example, if your Perforce depot `//depot/Talkhouse` has different permissions for `//depot/Talkhouse/main-dev` and some subdirectories of `//depot/Talkhouse/rel1.0`, we recommend setting the following `depots`:
 
@@ -97,9 +103,21 @@ By configuring each subdirectory that has unique permissions, Sourcegraph is abl
 
 Since that would override the permissions for the `//depot/Talkhouse/rel1.0/back` depot.
 
+#### Wildcards 
+
+In the default configuration Sourcegraph provides limited support for `*` and `...` paths ("wildcards") in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). For example, the following can be supported using [the workaround described in repository permissions](#repository-permissions):
+
+```sh
+write user alice * //TestDepot/...
+write user alice * //TestDepot/*/spec/...
+write user alice * //TestDepot/.../spec/...
+```
+
+But permissions are only enforced per repository, **not per file**. For that you need to configure [file-level permissions](#file-level-permissions).
+
 ### File-level permissions
 
-File-level permissions make the splitting of depots by sub-directory unnecessary.
+File-level permissions make the [syncing of subdirectories to match permission boundaries](#syncing-subdirectories-to-match-permission-boundaries) unnecessary.
 
 To enable file-level permissions:
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -22,9 +22,15 @@ Perforce depots can be added to a Sourcegraph instance by adding the appropriate
     ```
 1. Go to **Site admin > Manage code hosts > Add code host**
 1. Select **Perforce**.
-1. Configure the connection to Perforce using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
-   Be sure to enable `p4-fusion` in the `fusionClient` setting in your code host [config](#configuration). For example:
+    - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
+    - [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
+    - [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
+
+    See the [configuration documentation below](#configuration) for other fields you can configure.
+
+1. **Optional, but recommended**: use the [`p4-fusion`](https://github.com/salesforce/p4-fusion) client by configuring `fusionClient` for better performance:
 
     ```json
     {
@@ -39,21 +45,14 @@ Perforce depots can be added to a Sourcegraph instance by adding the appropriate
     Details of all `p4-fusion` configuration fields can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L84).
 
     Without the `fusionClient` configuration, the code host connection uses `git p4`, but we recommend `p4-fusion` for better performance.
+
 1. Click **Add repositories**.
 
-### Depot syncing
+Sourcegraph will now talk to the Perforce host and sync the configured `depots` to the Sourcegraph instance.
 
-> NOTE: Only "local" type depots are supported.
+It's worthwhile to note some limitations of this process:
 
-Use the `depots` field to configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
-
-- [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory.
-- [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
-- [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
-
-Notable things about depot syncing:
-
-- Depot syncing uses [p4-fusion](https://github.com/salesforce/p4-fusion) to convert Perforce depots into git repositories so that Sourcegraph can index them.
+- When syncing depots either [git p4](https://git-scm.com/docs/git-p4) or [p4-fusion](https://github.com/salesforce/p4-fusion) (recommended) are used to convert Perforce depots into git repositories so that Sourcegraph can index them.
 - Rename of a Perforce depot, including changing the depot on the Perforce server or the `repositoryPathPattern` config option, will cause a re-import of the depot.
 - Unless [permissions syncing](#repository-permissions) is enabled, Sourcegraph knows nothing of the permissions on the depots, so it can't enforce access restrictions.
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -31,7 +31,19 @@ To enable Perforce code host connections, a site admin must:
 1. Configure which depots are mirrored/synchronized as Git repositories to Sourcegraph:
 
     - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory. **Note**: Only `"local"` type depots are supported.
-    - [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
+    - [`p4.user`](perforce.md#p4-user)
+       
+       The user to be authenticated for `p4` CLI, and should be capable of performing:
+           - `p4 ping`,
+           - `p4 login`,
+           - `p4 trust`
+           - and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`.
+           
+       If repository permissions are mirrored, the user needs additional ability to perform the
+           - `p4 protects`, 
+           - `p4 groups`, 
+           - `p4 group`, 
+           -`p4 users` commands (aka. "super" access level).
     - [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets of users in a group that never expire. Use the command `p4 -u <p4.user> login -p -a` to obtain a ticket value.
     - See the [configuration documentation below](#configuration) for other fields you can configure.
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -108,7 +108,7 @@ By configuring each subdirectory that has unique permissions, Sourcegraph is abl
 
 Since that would override the permissions for the `//depot/Talkhouse/rel1.0/back` depot.
 
-#### Wildcards 
+#### Wildcards
 
 In the default configuration Sourcegraph provides limited support for `*` and `...` paths ("wildcards") in [Perforce permissions tables](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html). For example, the following can be supported using [the workaround described in repository permissions](#repository-permissions):
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -42,7 +42,7 @@ To enable Perforce code host connections, a site admin must:
       - `p4 trust`
       - and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`.
            
-      If repository permissions are mirrored, the user needs additional ability (aka. "super" access level) to perform the commands
+      If repository permissions are mirrored, the user needs additional ability (aka. "super" access level) to perform the commands:
       - `p4 protects`
       - `p4 groups`
       - `p4 group` 


### PR DESCRIPTION
This changes the Perforce docs to

- remove a lot of outdated `Experimental` tags
- make recommendations clearer
- remove old workarounds
- mention file-level permissions

## Screenshots

| Before | After |
|-------|------|
| ![screenshot_2023-02-14_15 25 09@2x](https://user-images.githubusercontent.com/1185253/218766528-66486905-c125-46cd-beef-47c9adec2858.png) | ![after](https://user-images.githubusercontent.com/129280/219820258-9d4b6a24-7b73-4c97-879a-2daf556c55ea.png)|

## Test plan
Docs change
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
