### PR TITLE
Search: do not append revision to repo predicates

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -567,11 +567,11 @@ func ConcatRevFilters(b Basic) Basic {
 	if revision == "" {
 		return b
 	}
-	modified := MapField(nodes, FieldRepo, func(value string, negated bool, _ Annotation) Node {
-		if !negated {
-			return Parameter{Value: value + "@" + revision, Field: FieldRepo, Negated: negated}
+	modified := MapField(nodes, FieldRepo, func(value string, negated bool, ann Annotation) Node {
+		if !negated && !ann.Labels.IsSet(IsPredicate) {
+			return Parameter{Value: value + "@" + revision, Field: FieldRepo, Negated: negated, Annotation: ann}
 		}
-		return Parameter{Value: value, Field: FieldRepo, Negated: negated}
+		return Parameter{Value: value, Field: FieldRepo, Negated: negated, Annotation: ann}
 	})
 	return Basic{Parameters: toParameters(modified), Pattern: b.Pattern}
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -442,6 +442,10 @@ func TestConcatRevFilters(t *testing.T) {
 			input: "repo:foo file:bas qux AND (rev:a or rev:b)",
 			want:  `("repo:foo@a" "file:bas" "qux") OR ("repo:foo@b" "file:bas" "qux")`,
 		},
+		{
+			input: "repo:foo rev:4.2.1 repo:has.file(content:fix)",
+			want:  `("repo:foo@4.2.1" "repo:has.file(content:fix)")`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {


### PR DESCRIPTION
This fixes an issue where we would append the value of a `rev:` filter to a repo predicate, so `repo:a rev:b repo:has.file(path:c)` would be transformed to `repo:a@b repo:has.file(path:c)@b`, which makes the predicate syntax invalid, causing us to interpret it as a regex filter.

[Slack Thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1676391192551899)

## Test plan

Added a test case covering this case and manually tested that this fixes the observable problem. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
