### PR TITLE
app: add syntax highlighting support via Chroma

### DIFF
--- a/cmd/frontend/internal/highlight/chroma.go
+++ b/cmd/frontend/internal/highlight/chroma.go
@@ -1,0 +1,103 @@
+package highlight
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// returns (nil, nil) if highlighting the given language is not supported.
+func highlightWithChroma(code string, filepath string) (*scip.Document, error) {
+	// Identify the Chroma lexer to use.
+	lexer := lexers.Match(filepath)
+	if lexer == nil {
+		lexer = lexers.Analyse(code)
+		if lexer == nil {
+			return nil, nil
+		}
+	}
+
+	// Some lexers can be extremely chatty. To mitigate this, we use the coalescing lexer to
+	// coalesce runs of identical token types into a single token:
+	lexer = chroma.Coalesce(lexer)
+
+	iterator, err := lexer.Tokenise(nil, code)
+	if err != nil {
+		return nil, errors.Wrap(err, "Tokenise")
+	}
+
+	formatter := &chromaSCIPFormatter{}
+	occurrences, err := formatter.Format(iterator)
+	if err != nil {
+		return nil, errors.Wrap(err, "Format")
+	}
+	return &scip.Document{
+		RelativePath: filepath,
+		Occurrences:  occurrences,
+		Symbols:      []*scip.SymbolInformation{},
+	}, nil
+}
+
+// A Chroma formatter which produces a SCIP occurrences  with highlighting information.
+type chromaSCIPFormatter struct {
+}
+
+func (f *chromaSCIPFormatter) Format(iterator chroma.Iterator) (occurrences []*scip.Occurrence, err error) {
+	tokens := iterator.Tokens()
+	lines := chroma.SplitTokensIntoLines(tokens)
+
+	for line, tokens := range lines {
+		offset := 0
+		for _, token := range tokens {
+			offsetEnd := offset + len(token.Value)
+			occurrence := &scip.Occurrence{
+				// [startLine, startCharacter, endCharacter]
+				Range:      []int32{int32(line), int32(offset), int32(offsetEnd)},
+				SyntaxKind: translateTokenType(token.Type),
+			}
+			occurrences = append(occurrences, occurrence)
+			offset = offsetEnd
+		}
+	}
+	return occurrences, nil
+}
+
+func translateTokenType(t chroma.TokenType) scip.SyntaxKind {
+	direct := map[chroma.TokenType]scip.SyntaxKind{
+		chroma.Operator:           scip.SyntaxKind_IdentifierOperator,
+		chroma.OperatorWord:       scip.SyntaxKind_IdentifierOperator,
+		chroma.LiteralDate:        scip.SyntaxKind_StringLiteralSpecial,
+		chroma.LiteralOther:       scip.SyntaxKind_StringLiteralSpecial,
+		chroma.NameNamespace:      scip.SyntaxKind_IdentifierNamespace,
+		chroma.NameFunction:       scip.SyntaxKind_IdentifierFunction,
+		chroma.NameConstant:       scip.SyntaxKind_IdentifierConstant,
+		chroma.Punctuation:        scip.SyntaxKind_PunctuationBracket,
+		chroma.NameVariableGlobal: scip.SyntaxKind_IdentifierMutableGlobal,
+		chroma.NameTag:            scip.SyntaxKind_Tag,
+		chroma.NameAttribute:      scip.SyntaxKind_IdentifierAttribute,
+	}
+	categories := map[chroma.TokenType]scip.SyntaxKind{
+		chroma.Comment:       scip.SyntaxKind_Comment,
+		chroma.Keyword:       scip.SyntaxKind_IdentifierBuiltin,
+		chroma.LiteralNumber: scip.SyntaxKind_NumericLiteral,
+		chroma.LiteralString: scip.SyntaxKind_StringLiteral,
+		chroma.NameBuiltin:   scip.SyntaxKind_Identifier, // Chroma considers "foo" in "package foo" to be a builtin
+		chroma.Name:          scip.SyntaxKind_Identifier,
+	}
+
+	mapping, ok := direct[t]
+	if ok {
+		return mapping
+	}
+	for category, mapping := range categories {
+		if t.InCategory(category) {
+			return mapping
+		}
+	}
+
+	// could not be tokenised, or some other type of token we don't have a
+	// mapping for.
+	return scip.SyntaxKind_UnspecifiedSyntaxKind
+}

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/html/atom"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
@@ -446,6 +447,38 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 	//       case to make sure that we have normalized the names of the language by then.
 	if filetypeQuery.LanguageOverride || filetypeQuery.Engine == EngineTreeSitter {
 		query.Filetype = filetypeQuery.Language
+	}
+
+	// Sourcegraph App: we do not use syntect_server/syntax-highlighter
+	//
+	// 1. It makes cross-compilation harder (requires a full Rust toolchain for the target, plus
+	//    a full C/C++ toolchain for the target.) Complicates macOS code signing.
+	// 2. Requires adding a C ABI so we can invoke it via CGO. Or as an external process
+	//    complicates distribution and/or requires Docker.
+	// 3. syntect_server/syntax-highlighter still uses the absolutely awful http-server-stabilizer
+	//    hack to workaround https://github.com/trishume/syntect/issues/202 - and by extension needs
+	//    two separate binaries, and separate processes, to function semi-reliably.
+	//
+	// Instead, in Sourcegraph App we defer to Chroma for syntax highlighting.
+	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
+	if isSingleProgram {
+		document, err := highlightWithChroma(code, p.Filepath)
+		if err != nil {
+			return unhighlightedCode(err, code)
+		}
+		if document == nil {
+			// Highlighting this language is not supported, so fallback to plain text.
+			plainResponse, err := generatePlainTable(code)
+			if err != nil {
+				return nil, false, err
+			}
+			return plainResponse, false, nil
+		}
+		return &HighlightedCode{
+			code:     code,
+			html:     "",
+			document: document,
+		}, false, nil
 	}
 
 	resp, err := client.Highlight(ctx, query, p.Format)

--- a/go.mod
+++ b/go.mod
@@ -325,7 +325,7 @@ require (
 	github.com/dave/jennifer v1.5.0 // indirect
 	github.com/djherbis/buffer v1.2.0 // indirect
 	github.com/djherbis/nio/v3 v3.0.1 // indirect
-	github.com/dlclark/regexp2 v1.7.0 // indirect
+	github.com/dlclark/regexp2 v1.8.0 // indirect
 	github.com/docker/docker v20.10.21+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -632,6 +632,8 @@ github.com/djherbis/nio/v3 v3.0.1/go.mod h1:Ng4h80pbZFMla1yKzm61cF0tqqilXZYrogmW
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.8.0 h1:rJD5HeGIT/2b5CDk63FVCwZA3qgYElfg+oQK7uH5pfE=
+github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=


### PR DESCRIPTION
Today, Sourcegraph App has no syntax highlighting. This is for the reasons outlined in a new comment:

https://github.com/sourcegraph/sourcegraph/blob/96bcec929f3569c9e87755868e5458677eee8deb/cmd/frontend/internal/highlight/highlight.go#L452-L460

In this PR I pull in [Chroma](https://github.com/alecthomas/chroma), the most popular Go syntax highlighter used by e.g. Hugo. It is effectively a Go port of Pygments, and seems to have good compatibility with Pygments grammars and decent performance. It supports [a decent chunk of languages](https://github.com/alecthomas/chroma#supported-languages).

One challenge is that Chroma TokenTypes and SCIP SyntaxKinds do not exactly agree / match 1:1. In some cases, Chroma is more detailed, while in others SCIP is more detailed. In some cases Chroma has strange choices, like e.g. when highlighting Go code "foo" in "package foo" is considered a builtin. I did a best-effort mapping, and for most languages it seems to work pretty well.

I don't want to pretend this is a perfect solution (is there ever such a thing with syntax highlighting?); it's certainly not, and syntect is definitely better - but I think this is *good enough* for now for App, and it brings us from zero -> colors which is a clear win.

## Test plan

This change only affects App.

To test I manually reviewed a few handfuls of files:

Decent:

* Makefile https://user-images.githubusercontent.com/3173176/218580862-25d9a9a2-fe02-404e-b90d-0172409286f1.png
* Go https://user-images.githubusercontent.com/3173176/218580943-8b646a2f-8f65-49fd-bbd1-f9052e5239a9.png
* Typescript https://user-images.githubusercontent.com/3173176/218582523-fbd60a5f-d43e-4aa3-bd85-2a4efce0b7bd.png
* Bazel https://user-images.githubusercontent.com/3173176/218582689-d64cd875-3a46-4aa1-bf02-07c949cdef9b.png
* Nix https://user-images.githubusercontent.com/3173176/218582776-a1cbb10e-f71f-4044-9999-b0d144f2f25d.png
* Python https://user-images.githubusercontent.com/3173176/218582931-131f8737-87f0-463c-a121-117cd23667db.png
* C# https://user-images.githubusercontent.com/3173176/218583003-6a8a5d55-3115-4c6d-a269-099407322378.png
* SCSS https://user-images.githubusercontent.com/3173176/218583049-13010314-a139-4a7f-af6b-a1c8d26166c7.png
* Scala https://user-images.githubusercontent.com/3173176/218583104-9d1877db-c9be-49b5-bb9f-6b8cea37b9f1.png
* C https://user-images.githubusercontent.com/3173176/218583146-0fbf73f9-fd0a-4adf-8398-c8c4c2a902d9.png
* SQL https://user-images.githubusercontent.com/3173176/218583191-555f9c9a-ae58-4ca8-a752-4543ab9bc460.png
* CSS https://user-images.githubusercontent.com/3173176/218583242-c6c18357-01b4-4975-b23f-d19c04d565d7.png
* YAML https://user-images.githubusercontent.com/3173176/218581046-e106444e-4626-4789-a967-de144f4c0199.png
* Dockerfile https://user-images.githubusercontent.com/3173176/218581198-746d575f-ff84-45af-93c7-ee11150ea38d.png
* Plain text https://user-images.githubusercontent.com/3173176/218581291-f40fef95-8694-48ae-b41f-78c05287f32d.png
* ps1 https://user-images.githubusercontent.com/3173176/218581520-2ade3d56-5915-4b31-a202-86831941fcfb.png
* Makefile https://user-images.githubusercontent.com/3173176/218581779-e64bce10-8c37-425d-a5e4-fdded98b9f1a.png
* Shell https://user-images.githubusercontent.com/3173176/218581911-8a0d9753-4f97-47c5-a2e0-dde2576e9968.png

Poor:

* JSON https://user-images.githubusercontent.com/3173176/218581465-2894fa9c-7ca1-4336-855c-cf602a22d343.png
* Some YAML files (but not all)?
* go.mod https://user-images.githubusercontent.com/3173176/218582069-838f7ce1-6736-4a4b-aec8-d21dbe339596.png

No highlighting:

* Markdown
* Procfile
* .patch
