### PR TITLE
bext: fix e2e tests script

### DIFF
--- a/client/browser/package.json
+++ b/client/browser/package.json
@@ -27,7 +27,7 @@
     "lint:css": "stylelint 'src/**/*.scss'",
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
     "test": "jest --testPathIgnorePatterns end-to-end integration",
-    "test-e2e": "mocha './src/end-to-end/**/*.test.ts'",
+    "test-e2e": "TS_NODE_PROJECT=src/end-to-end/tsconfig.json mocha './src/end-to-end/**/*.test.ts'",
     "run-integration": "TS_NODE_PROJECT=src/integration/tsconfig.json SOURCEGRAPH_BASE_URL=https://sourcegraph.com mocha --parallel=${CI:-\"false\"} --retries=2 ./src/integration/**/*.test.ts",
     "test-integration": "node scripts/test-integration",
     "record-integration": "node scripts/record-integration",


### PR DESCRIPTION
Specify the TS config file for e2e tests.
Without this change, `test-e2e` (and `sg test bext-e2e`) fails with `None of the selected packages has a "mocha" script` error.


## Test plan
- `pnpm --filter @sourcegraph/browser` runs without failure

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-e2e-script.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
