### PR TITLE
add a flag to the stitch migration tool that will skip frozen migrations

### DIFF
--- a/internal/database/migration/stitch/git.go
+++ b/internal/database/migration/stitch/git.go
@@ -26,10 +26,15 @@ func readMigrationDirectoryFilenames(schemaName, dir, rev string) ([]string, err
 		return nil, err
 	}
 
+	// First we will try to look up using the version tag. This should succeed for
+	// historical releases that are already tagged. If we don't find the tag we will
+	// fallback below to a branch name matching the release branch.
 	cmd := exec.Command("git", "show", fmt.Sprintf("%s:%s", rev, pathForSchemaAtRev))
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		// Here we will try the release branch fallback. This should be encountered for future versions, in other words
+		// we are updating the max supported version to something that isn't yet tagged.
 		if branch, ok := tagRevToBranch(rev); ok && strings.Contains(string(out), "fatal: invalid object name") {
 			cmd := exec.Command("git", "show", fmt.Sprintf("origin/%s:%s", branch, pathForSchemaAtRev))
 			cmd.Dir = dir


### PR DESCRIPTION
Adds a new flag to the migration stitch tool that skips the frozen migrations step. This is primarily useful for the release tool to simplify updating the max version constant.

Also added a bit of logging and comments to help explain whats going on here.

## Test plan

Without flag (using go generate):
```
Generating stitched migration files for range [3.20, 4.4]
Wrote to /Users/coury@sourcegraph.com/Documents/code/sourcegraph/internal/database/migration/shared/data/stitched-migration-graph.json
Generating frozen migrations
Wrote to /Users/coury@sourcegraph.com/Documents/code/sourcegraph/internal/database/migration/shared/data/frozen/4.3.0.json
```

With flag:
```
go run ./data/cmd/generator --write-frozen=false
Generating stitched migration files for range [3.20, 4.4]
Wrote to /Users/coury@sourcegraph.com/Documents/code/sourcegraph/internal/database/migration/shared/data/stitched-migration-graph.json
```
