### PR TITLE
fix spacing

### DIFF
--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -2,7 +2,7 @@
     max-height: 30rem;
     overflow: hidden;
     margin-top: 1rem;
-    padding: 0 0.25rem 0 0;
+    padding: 0 0.2rem 0 0.2rem;
 
     &-fader {
         width: 100%;


### PR DESCRIPTION
README cut off on the left:

![image](https://user-images.githubusercontent.com/1646931/218831083-31475063-5cb1-4961-83e9-ae592d4d3c8f.png)

## Test plan

Tested locally, visual-only change

## App preview:

- [Web](https://sg-web-bl-fix-spacing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
