### PR TITLE
Search: add proper parsing for repo:has() params

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -315,12 +315,56 @@ type RepoHasKVPPredicate struct {
 }
 
 func (p *RepoHasKVPPredicate) Unmarshal(params string, negated bool) (err error) {
-	split := strings.Split(params, ":")
-	if len(split) != 2 || len(split[0]) == 0 {
-		return errors.New("expected params in the form of key:value")
+	scanLiteral := func(data string) (string, int, error) {
+		if strings.HasPrefix(data, `"`) {
+			return ScanDelimited([]byte(data), true, '"')
+		}
+		if strings.HasPrefix(data, `'`) {
+			return ScanDelimited([]byte(data), true, '\'')
+		}
+		loc := strings.Index(data, ":")
+		if loc >= 0 {
+			return data[:loc], loc, nil
+		}
+		return data, len(data), nil
 	}
-	p.Key = split[0]
-	p.Value = split[1]
+
+	// Trim leading and trailing spaces in params
+	params = strings.Trim(params, " \t")
+
+	// Scan the possibly-quoted key
+	key, advance, err := scanLiteral(params)
+	if err != nil {
+		return err
+	}
+	params = params[advance:]
+
+	// Chomp the leading ":"
+	if !strings.HasPrefix(params, ":") {
+		return errors.New("expected params of the form key:value")
+	}
+	params = params[len(":"):]
+
+	// Scan the possibly-quoted value
+	value, advance, err := scanLiteral(params)
+	if err != nil {
+		return err
+	}
+	params = params[advance:]
+
+	// If we have more text after scanning both the key and the value,
+	// that means someone tried to use a quoted string with data outside
+	// the quotes.
+	if len(params) != 0 {
+		return errors.New("unexpected content outside of quoted value")
+	}
+
+	if len(key) == 0 {
+		return errors.New("key cannot be empty")
+	}
+
+	p.Key = key
+	p.Value = value
 	p.Negated = negated
 	return nil
 }

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -138,6 +138,10 @@ func TestRepoHasKVPPredicate(t *testing.T) {
 		valid := []test{
 			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "key", Value: "value", Negated: false}},
 			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "key", Value: "", Negated: false}},
+			{`quoted special characters`, `"key:colon":"value:colon"`, &RepoHasKVPPredicate{Key: "key:colon", Value: "value:colon", Negated: false}},
+			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasKVPPredicate{Key: `key"quote`, Value: `value"quote`, Negated: false}},
+			{`space padding`, `  key:value  `, &RepoHasKVPPredicate{Key: `key`, Value: `value`, Negated: false}},
+			{`single quoted`, `'  key:':'value : '`, &RepoHasKVPPredicate{Key: `  key:`, Value: `value : `, Negated: false}},
 		}
 
 		for _, tc := range valid {
@@ -159,6 +163,7 @@ func TestRepoHasKVPPredicate(t *testing.T) {
 			{`no key`, `:value`, nil},
 			{`no key or value`, `:`, nil},
 			{`invalid syntax`, `key-value`, nil},
+			{`content outside of qutoes`, `key:"quoted value" abc`, nil},
 		}
 
 		for _, tc := range invalid {


### PR DESCRIPTION
Previously, we just split the params on `:`, which works alright unless you want to search for something that has `:` in it. This updates our params parsing to be more complete, allowing single and double-quoted strings 

## Test plan

Added a bunch of unit tests covering these cases.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
