### PR TITLE
own: allow users to see others' emails in non-dotcom instances

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -45,6 +45,7 @@ export const Default: Story = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                isSourcegraphDotCom={true}
             />
         )}
     </WebStory>
@@ -60,6 +61,7 @@ export const EmailForm: Story = () => (
                 context={context}
                 showEmailForm={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                isSourcegraphDotCom={true}
             />
         )}
     </WebStory>
@@ -75,6 +77,7 @@ export const InvalidSource: Story = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                isSourcegraphDotCom={true}
             />
         )}
     </WebStory>
@@ -90,6 +93,7 @@ export const OptimizationSignup: Story = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                isSourcegraphDotCom={true}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -29,6 +29,7 @@ interface Props extends ThemeProps, TelemetryProps {
         SourcegraphContext,
         'authProviders' | 'experimentalFeatures' | 'authPasswordPolicy' | 'authMinPasswordLength'
     >
+    isSourcegraphDotCom: boolean
 }
 
 const SourceToTitleMap = {
@@ -55,6 +56,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     onSignUp,
     context,
     telemetryService,
+    isSourcegraphDotCom,
 }) => {
     const location = useLocation()
 
@@ -72,7 +74,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const invitedBy = queryWithUseEmailToggled.get('invitedBy')
     const { data } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(USER_AREA_USER_PROFILE, {
-        variables: { username: invitedBy || '' },
+        variables: { username: invitedBy || '', isSourcegraphDotCom },
         skip: !invitedBy,
     })
     const invitedByUser = data?.user

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -108,6 +108,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
                 telemetryService={telemetryService}
+                isSourcegraphDotCom={context.sourcegraphDotComMode}
             />
         )
     }

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -342,7 +342,7 @@ function mockCommonGraphQLResponses(
                 siteAdmin: true,
                 builtinAuth: true,
                 createdAt: '2020-04-10T21:11:42Z',
-                emails: [{ email: 'alice@example.com', verified: true }],
+                emails: [{ email: 'alice@example.com', verified: true, isPrimary: true }],
                 organizations: { nodes: [] },
                 permissionsInfo: null,
                 tags: [],

--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -28,7 +28,7 @@ const USER: UserSettingsAreaUserFields = {
     siteAdmin: true,
     builtinAuth: true,
     createdAt: subDays(now, 732).toISOString(),
-    emails: [{ email: 'test@example.com', verified: true }],
+    emails: [{ email: 'test@example.com', verified: true, isPrimary: true }],
     organizations: { nodes: [] },
     tags: [],
 }
@@ -166,7 +166,7 @@ describe('User Different Settings Page', () => {
                     siteAdmin: true,
                     builtinAuth: true,
                     createdAt: '2020-03-02T11:52:15Z',
-                    emails: [{ email: 'test@sourcegraph.test', verified: true }],
+                    emails: [{ email: 'test@sourcegraph.test', verified: true, isPrimary: true }],
                     organizations: { nodes: [] },
                     permissionsInfo: null,
                     tags: [],

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -90,7 +90,7 @@ describe('Settings', () => {
                         siteAdmin: true,
                         builtinAuth: true,
                         createdAt: '2020-03-02T11:52:15Z',
-                        emails: [{ email: 'test@sourcegraph.test', verified: true }],
+                        emails: [{ email: 'test@sourcegraph.test', verified: true, isPrimary: true }],
                         organizations: { nodes: [] },
                         permissionsInfo: null,
                         tags: [],

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -44,11 +44,15 @@ export const UserAreaGQLFragment = gql`
         viewerCanAdminister
         builtinAuth
         createdAt
+        emails @skip(if: $isSourcegraphDotCom) {
+            email
+            isPrimary
+        }
     }
 `
 
 export const USER_AREA_USER_PROFILE = gql`
-    query UserAreaUserProfile($username: String!) {
+    query UserAreaUserProfile($username: String!, $isSourcegraphDotCom: Boolean!) {
         user(username: $username) {
             ...UserAreaUserFields
         }
@@ -119,7 +123,7 @@ export interface UserAreaRouteContext
 /**
  * A user's public profile area.
  */
-export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, ...props }) => {
+export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, isSourcegraphDotCom, ...props }) => {
     const location = useLocation()
     const { username } = useParams()
     const userAreaMainUrl = `/users/${username}`
@@ -127,7 +131,7 @@ export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, ...
     const { data, error, loading, previousData } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
         USER_AREA_USER_PROFILE,
         {
-            variables: { username: username! },
+            variables: { username: username!, isSourcegraphDotCom },
         }
     )
 
@@ -169,6 +173,7 @@ export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, ...
         user,
         namespace: user,
         ...childBreadcrumbSetters,
+        isSourcegraphDotCom,
     }
 
     return (

--- a/client/web/src/user/profile/UserProfile.tsx
+++ b/client/web/src/user/profile/UserProfile.tsx
@@ -5,6 +5,8 @@ import { formatDistanceToNowStrict } from 'date-fns'
 import { UserAreaRouteContext } from '../area/UserArea'
 
 export const UserProfile: FC<Pick<UserAreaRouteContext, 'user'>> = ({ user }) => {
+    const primaryEmail = user.emails?.find(email => email.isPrimary)?.email
+
     const userData: {
         name: string
         value: string
@@ -24,6 +26,11 @@ export const UserProfile: FC<Pick<UserAreaRouteContext, 'user'>> = ({ user }) =>
             name: 'User since',
             value: formatDistanceToNowStrict(new Date(user.createdAt), { addSuffix: true }),
             visible: true,
+        },
+        {
+            name: 'Email',
+            value: primaryEmail || 'Not set',
+            visible: !!primaryEmail,
         },
     ]
 

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -35,6 +35,7 @@ export interface UserSettingsAreaProps extends UserAreaRouteContext, ThemeProps,
     sideBarItems: UserSettingsSidebarItems
     routes: readonly UserSettingsAreaRoute[]
     user: UserAreaUserFields
+    isSourcegraphDotCom: boolean
 }
 
 export interface UserSettingsAreaRouteContext extends UserSettingsAreaProps {
@@ -54,9 +55,10 @@ const UserSettingsAreaGQLFragment = gql`
         siteAdmin @include(if: $siteAdmin)
         builtinAuth
         createdAt
-        emails @include(if: $siteAdmin) {
+        emails @skip(if: $isSourcegraphDotCom) {
             email
             verified
+            isPrimary
         }
         organizations {
             nodes {
@@ -72,7 +74,7 @@ const UserSettingsAreaGQLFragment = gql`
 `
 
 const USER_SETTINGS_AREA_USER_PROFILE = gql`
-    query UserSettingsAreaUserProfile($userID: ID!, $siteAdmin: Boolean!) {
+    query UserSettingsAreaUserProfile($userID: ID!, $siteAdmin: Boolean!, $isSourcegraphDotCom: Boolean!) {
         node(id: $userID) {
             __typename
             ...UserSettingsAreaUserFields
@@ -97,6 +99,7 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
         variables: {
             userID: props.user.id,
             siteAdmin: authenticatedUser.siteAdmin,
+            isSourcegraphDotCom: props.isSourcegraphDotCom,
         },
     })
 

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -8,6 +8,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -17,9 +18,11 @@ var timeNow = time.Now
 
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {
 	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
-	// emails.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-		return nil, err
+	// emails on Sourcegraph.com.
+	if envvar.SourcegraphDotComMode() {
+		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+			return nil, err
+		}
 	}
 
 	userEmails, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47630

Makes user emails accessible from the GraphQL API when not on Sourcegraph.com

Also displays the email in the user profile page.

## Test plan

Tested with both `sg start` and `sg start dotcom` by loading another user's profile.

![image](https://user-images.githubusercontent.com/206864/218833948-fbbfbf56-496f-4d1b-9328-d786b748ce44.png)
