### PR TITLE
insights: add creator to the admin insight resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // This file just contains stub GraphQL resolvers and data types for Code Insights which merely
@@ -525,12 +524,13 @@ type RepositoryPreviewPayloadResolver interface {
 }
 
 type BackfillQueueItemResolver struct {
-	BackfillID     int
-	InsightTitle   string
-	CreatorID      *int
-	Label          string
-	Query          string
-	BackfillStatus BackfillQueueStatusResolver
+	BackfillID      int
+	InsightTitle    string
+	CreatorID       *int32
+	Label           string
+	Query           string
+	BackfillStatus  BackfillQueueStatusResolver
+	GetUserResolver func(*int32) (*UserResolver, error)
 }
 
 func (r *BackfillQueueItemResolver) ID() graphql.ID {
@@ -545,7 +545,7 @@ func (r *BackfillQueueItemResolver) InsightViewTitle() string {
 	return r.InsightTitle
 }
 func (r *BackfillQueueItemResolver) Creator(ctx context.Context) (*UserResolver, error) {
-	return nil, errors.New("not implemented")
+	return r.GetUserResolver(r.CreatorID)
 }
 func (r *BackfillQueueItemResolver) SeriesLabel() string {
 	return r.Label

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1423,7 +1423,7 @@ type InsightBackfillQueueItem {
     # """
     # The user that originally created the insight view
     # """
-    # creator: User
+    creator: User
     """
     The name of the series on the associated insight view
     """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1420,9 +1420,9 @@ type InsightBackfillQueueItem {
     The title of the insight view
     """
     insightViewTitle: String!
-    # """
-    # The user that originally created the insight view
-    # """
+    """
+    The user that originally created the insight view
+    """
     creator: User
     """
     The name of the series on the associated insight view


### PR DESCRIPTION
Adds the ability for an admin to get details about the creator of an insight.  This is only available within the insights admin UI. 

## Test plan
```graphql
{
  insightAdminBackfillQueue(first: 1) {
    nodes {
      id
      insightViewTitle
      seriesLabel
      creator{
        displayName
        username
      }
      backfillQueueStatus {
        state        
      }
    }
    totalCount
  }
}
```
response
```json
{
  "data": {
    "insightAdminBackfillQueue": {
      "nodes": [
        {
          "id": "YmFja2ZpbGw6NTcw",
          "insightViewTitle": "test",
          "seriesLabel": "",
          "creator": {
            "displayName": "Chris",
            "username": "chris"
          },
          "backfillQueueStatus": {
            "state": "PROCESSING"
          }
        }
      ],
      "totalCount": 3
    }
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
