### PR TITLE
[Form]: Add controlled field hook

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.module.scss
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.module.scss
@@ -97,6 +97,7 @@
 
     &-content {
         grid-area: content;
+        min-width: 0;
 
         &--non-active {
             opacity: 0.5;

--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/use-repo-fields.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/use-repo-fields.ts
@@ -82,7 +82,6 @@ export function useRepoFields<FormFields extends RepositoriesFields>(props: Inpu
         formApi,
         name: 'repositories',
         disabled: !isURLsListMode,
-        required: isRepoURLsListRequired,
         validators: {
             // Turn off any validations for the repositories' field in we are in all repos mode
             sync: isRepoURLsListRequired ? insightRepositoriesValidator : undefined,

--- a/client/web/src/enterprise/insights/components/form/hooks/index.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/index.ts
@@ -2,7 +2,7 @@
 export { useForm, FORM_ERROR } from './useForm'
 export type { Form, SubmissionErrors, FormChangeEvent } from './useForm'
 
-export { useField } from './useField'
+export { useField, useControlledField } from './useField'
 export type { useFieldAPI } from './useField'
 
 export { useCheckboxes } from './useCheckboxes'

--- a/client/web/src/enterprise/insights/components/form/hooks/useField.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/useField.ts
@@ -1,8 +1,17 @@
-import { ChangeEvent, Dispatch, InputHTMLAttributes, RefObject, useCallback, useLayoutEffect, useRef } from 'react'
+import {
+    ChangeEvent,
+    Dispatch,
+    InputHTMLAttributes,
+    RefObject,
+    useCallback,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react'
 
 import { noop } from 'rxjs'
 
-import { FieldState, FormAPI } from './useForm'
+import { FieldMetaState, FieldState, FormAPI } from './useForm'
 import { getEventValue } from './utils/get-event-value'
 import { useAsyncValidation } from './utils/use-async-validation'
 import { AsyncValidator, getCustomValidationContext, getCustomValidationMessage, Validator } from './validators'
@@ -24,7 +33,7 @@ export interface InputProps<Value>
 /**
  * Public API for input element. Contains all handlers and props for
  * native input element and expose meta state of input like touched,
- * validState and etc.
+ * validState etc.
  */
 export interface useFieldAPI<FieldValue, ErrorContext = unknown> {
     /**
@@ -107,7 +116,7 @@ export function useField<ErrorContext, FormValues, Key extends keyof FormValues>
         const customValidationMessage = getCustomValidationMessage(customValidationResult)
         const customValidationContext = getCustomValidationContext(customValidationResult)
 
-        if (customValidationMessage) {
+        if (customValidationMessage || (!customValidationResult && nativeErrorMessage)) {
             // We have to cancel async validation from previous call
             // if we got sync validation native or custom.
             cancelAsyncValidation()
@@ -128,7 +137,7 @@ export function useField<ErrorContext, FormValues, Key extends keyof FormValues>
 
         if (asyncValidator) {
             // Due to the call of start async validation in useLayoutEffect we have to
-            // schedule the async validation event in the next tick to be able run
+            // schedule the async validation event in the next tick to be able to run
             // observable pipeline validation since useAsyncValidation hook use
             // useObservable hook internally which calls '.subscribe' in useEffect.
             requestAnimationFrame(() => {
@@ -220,4 +229,148 @@ function useFormFieldState<FormValues, Key extends keyof FormValues>(
     )
 
     return [state, setState]
+}
+
+export type UseControlledFieldProps<Value> = {
+    value: Value
+    name: string
+    submitted: boolean
+    formTouched: boolean
+    validators?: Validators<Value, unknown>
+} & InputProps<Value>
+
+/**
+ * React hook to manage validation of a single form input field.
+ * `useInputValidation` helps with coordinating the constraint validation API
+ * and custom synchronous and asynchronous validators.
+ *
+ * Should be used with useForm hook to connect field and form component's states.
+ */
+export function useControlledField<Value>(props: UseControlledFieldProps<Value>): useFieldAPI<Value, unknown> {
+    const { value, validators, submitted, formTouched, onChange = noop, name, disabled, ...inputProps } = props
+    const { sync: syncValidator, async: asyncValidator } = validators ?? {}
+
+    const inputReference = useRef<HTMLInputElement & HTMLFieldSetElement>(null)
+    const [state, setState] = useState<FieldMetaState<Value>>({
+        touched: false,
+        dirty: false,
+        validState: 'NOT_VALIDATED',
+        validity: null,
+        initialValue: value,
+    })
+
+    const { start: startAsyncValidation, cancel: cancelAsyncValidation } = useAsyncValidation({
+        inputReference,
+        asyncValidator,
+        onValidationChange: asyncState => setState(previousState => ({ ...previousState, ...asyncState })),
+    })
+
+    useLayoutEffect(() => {
+        const inputElement = inputReference.current
+
+        // Clear custom validity from the last validation call.
+        inputElement?.setCustomValidity?.('')
+
+        const validity = inputElement?.validity ?? null
+
+        // If we got error from native attr validation (required, pattern, type)
+        // we still run validator in order to get some custom error message for
+        // standard validation error if validator doesn't provide message we fall back
+        // on standard validationMessage string [1] (ex. Please fill in input.)
+        const nativeErrorMessage = inputElement?.validationMessage ?? ''
+        const customValidationResult = syncValidator ? syncValidator(value, validity) : undefined
+
+        const customValidationMessage = getCustomValidationMessage(customValidationResult)
+        const customValidationContext = getCustomValidationContext(customValidationResult)
+
+        if (customValidationMessage || (!customValidationResult && nativeErrorMessage)) {
+            // We have to cancel async validation from previous call
+            // if we got sync validation native or custom.
+            cancelAsyncValidation()
+
+            // [1] Custom error message or fallback on native error message
+            const validationMessage = customValidationMessage || nativeErrorMessage
+
+            inputElement?.setCustomValidity?.(validationMessage)
+
+            return setState(state => ({
+                ...state,
+                validState: 'INVALID',
+                error: validationMessage,
+                errorContext: customValidationContext,
+                validity,
+            }))
+        }
+
+        if (asyncValidator) {
+            // Due to the call of start async validation in useLayoutEffect we have to
+            // schedule the async validation event in the next tick to be able to run
+            // observable pipeline validation since useAsyncValidation hook use
+            // useObservable hook internally which calls '.subscribe' in useEffect.
+            requestAnimationFrame(() => {
+                startAsyncValidation({ value, validity })
+            })
+
+            return setState(state => ({
+                ...state,
+                validState: 'CHECKING' as const,
+                error: '',
+                validity,
+            }))
+        }
+
+        // Hide any validation errors by default if the field is in the disabled
+        // state.
+        if (disabled && !syncValidator && !asyncValidator) {
+            return setState(state => ({
+                ...state,
+                validState: 'NOT_VALIDATED',
+                error: '',
+                validity,
+            }))
+        }
+
+        return setState(state => ({
+            ...state,
+            validState: 'VALID' as const,
+            error: '',
+            errorContext: customValidationContext,
+            validity,
+        }))
+    }, [value, syncValidator, startAsyncValidation, asyncValidator, cancelAsyncValidation, setState, disabled])
+
+    const handleBlur = useCallback(() => setState(state => ({ ...state, touched: true })), [setState])
+    const handleChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement> | Value) => {
+            const value = getEventValue(event)
+
+            onChange(value)
+            setState(state => ({ ...state, dirty: true }))
+        },
+        [onChange, setState]
+    )
+
+    return {
+        input: {
+            value,
+            name: name.toString(),
+            ref: inputReference,
+            onBlur: handleBlur,
+            onChange: handleChange,
+            disabled,
+            ...inputProps,
+        },
+        meta: {
+            ...state,
+            value,
+            validationContext: state.errorContext,
+            touched: state.touched || submitted || formTouched,
+            // Set state dispatcher gives access to set inner state of useField.
+            // Useful for complex cases when you need to deal with custom react input
+            // components.
+            setState: dispatch => {
+                setState(state => ({ ...dispatch({ value, ...state }) }))
+            },
+        },
+    }
 }

--- a/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/useForm.ts
@@ -325,7 +325,9 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
                 // properly updated with aria invalid attributes (it happens when user touched fields
                 // or when user hits submit button)
                 requestAnimationFrame(() => {
-                    formElement.querySelector<HTMLInputElement>(':invalid:not(fieldset) [aria-invalid="true"]')?.focus()
+                    formElement
+                        .querySelector<HTMLInputElement>(':invalid:not(fieldset), [aria-invalid="true"]')
+                        ?.focus()
                 })
             }
         },

--- a/client/web/src/enterprise/insights/components/form/hooks/utils/use-async-validation.ts
+++ b/client/web/src/enterprise/insights/components/form/hooks/utils/use-async-validation.ts
@@ -5,7 +5,7 @@ import { debounceTime, switchMap, tap } from 'rxjs/operators'
 
 import { useEventObservable } from '@sourcegraph/wildcard'
 
-import { FieldState } from '../useForm'
+import { FieldMetaState } from '../useForm'
 import { AsyncValidator, getCustomValidationContext, getCustomValidationMessage } from '../validators'
 
 const ASYNC_VALIDATION_DEBOUNCE_TIME = 500
@@ -27,7 +27,7 @@ export interface UseAsyncValidationProps<FieldValue> {
      * Validation state change handler. Used below to update state of consumer
      * according to async logic aspects (mark field as touched, set validity state, etc).
      * */
-    onValidationChange: (state: Partial<FieldState<FieldValue>>) => void
+    onValidationChange: (state: Partial<FieldMetaState<FieldValue>>) => void
 }
 
 /**

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/use-insight-creation-form.ts
@@ -66,9 +66,9 @@ export function useInsightCreationForm(props: UseInsightCreationFormProps): Insi
 
     const form = useForm<CreateInsightFormFields>({
         initialValues,
+        touched,
         onSubmit,
         onChange,
-        touched,
     })
 
     const { repoMode, repoQuery, repositories } = useRepoFields({ formApi: form.formAPI })


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47237
Preparation for https://github.com/sourcegraph/sourcegraph/pull/47572

This PR adds a new type of file hook - useControlledField. There are a few cases when we want to store the field's value, not in the form but somewhere else (like in another field store, or some external store) useControlledField doesn't bind with useForm it only adds a validation pipeline to the data; that consumer is supposed to provide. 

Also, this PR fixes one small visual problem with insight creation UI (I didn't want to open yet another one-line PR for it)

## Test plan
- Check that code insight creation UI works properly 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-controlled-field-hook.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
