### PR TITLE
Fix tabs component lazy rendering

### DIFF
--- a/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
+++ b/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 import { useTabsContext as useReachTabsContext } from '@reach/tabs'
 
@@ -11,17 +11,10 @@ export function useShouldPanelRender(children: React.ReactNode): boolean {
         settings: { lazy, behavior },
     } = useTabsState()
     const [wasRendered, setWasRendered] = useState(selectedIndex === index)
-    const previousChildren = useRef(children)
 
-    useEffect(() => {
-        if (lazy) {
-            // If children change, we should invalidate "cache" and unrender
-            if (children !== previousChildren.current) {
-                setWasRendered(index === selectedIndex)
-                previousChildren.current = children
-            } else if (index === selectedIndex) {
-                setWasRendered(true)
-            }
+    useLayoutEffect(() => {
+        if (lazy && index === selectedIndex) {
+            setWasRendered(true)
         }
     }, [lazy, children, index, selectedIndex])
 


### PR DESCRIPTION
Preparation for https://github.com/sourcegraph/sourcegraph/pull/47572

Prior to this PR, even if we specified the Tab component with lazy true and behaviour memoise, we rendered only the active tab, and there was a jump between tab switching since we were doing show logic in the use effect hook. In this PR we 
- fix memorize behaviour (render opened at least once tab always and do not trigger their life hooks - mount/unmount) 
- fix the flash problem by using the layout effect instead

## Test plan
- Check tab storybook with lazy true and behaviour memoise; tabs should work as expected

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-lazy-tab-rendering.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
