### PR TITLE
chore: bump docsite version to 1.9.1 in sg config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -443,7 +443,7 @@ commands:
     cmd: .bin/docsite_${DOCSITE_VERSION} -config doc/docsite.json serve -http=localhost:5080
     install_func: 'installDocsite'
     env:
-      DOCSITE_VERSION: v1.9.0 # Update in all places (including outside this repo)
+      DOCSITE_VERSION: v1.9.1 # Update in all places (including outside this repo)
 
   syntax-highlighter:
     ignoreStdout: true
@@ -1176,7 +1176,7 @@ tests:
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc
     env:
-      DOCSITE_VERSION: v1.9.0 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
+      DOCSITE_VERSION: v1.9.1 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
 
   web-e2e:
     preamble: |


### PR DESCRIPTION
To include patch for https://github.com/sourcegraph/docsite/issues/91

## Test plan

Only changes `sg.config.yaml` for local dev.
