### PR TITLE
Ranking: Add an experimental flag for FlushWallTime

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -340,6 +340,18 @@ func SearchDocumentRanksWeight() float64 {
 	}
 }
 
+// SearchFlushWallTime controls the amount of time that Zoekt shards collect and rank results when
+// the 'search-ranking' feature is enabled. We plan to eventually remove this, once we experiment
+// on real data to find a good default.
+func SearchFlushWallTime() time.Duration {
+	ranking := ExperimentalFeatures().Ranking
+	if ranking != nil && ranking.FlushWallTimeMS > 0 {
+		return time.Duration(ranking.FlushWallTimeMS) * time.Millisecond
+	} else {
+		return 500 * time.Millisecond
+	}
+}
+
 func ExperimentalFeatures() schema.ExperimentalFeatures {
 	val := Get().ExperimentalFeatures
 	if val == nil {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -110,9 +110,9 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 	}
 
 	if o.Features.Ranking {
-		// This enables our stream based ranking were we wait upto 500ms to
-		// collect results before ranking.
-		searchOpts.FlushWallTime = 500 * time.Millisecond
+		// This enables our stream based ranking, where we wait a certain amount
+		// of time to collect results before ranking.
+		searchOpts.FlushWallTime = conf.SearchFlushWallTime()
 
 		// This enables the use of document ranks in scoring, if they are available.
 		searchOpts.UseDocumentRanks = true

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1733,7 +1733,7 @@ type Ranking struct {
 	// DocumentRanksWeight description: Controls the impact of document ranks on the final ranking when the 'search-ranking' feature is enabled. This is intended for internal testing purposes only, it's not recommended for users to change this.
 	DocumentRanksWeight *float64 `json:"documentRanksWeight,omitempty"`
 	// FlushWallTimeMS description: Controls the amount of time that Zoekt shards collect and rank results when the 'search-ranking' feature is enabled. Larger values give a more stable ranking, but searches can take longer to return an initial result.
-	FlushWallTimeMS int `json:"flushWallTimeMS,omitEmpty"`
+	FlushWallTimeMS int `json:"flushWallTimeMS,omitempty"`
 	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
 	// MaxQueueSizeBytes description: The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1732,6 +1732,8 @@ type QuickLink struct {
 type Ranking struct {
 	// DocumentRanksWeight description: Controls the impact of document ranks on the final ranking when the 'search-ranking' feature is enabled. This is intended for internal testing purposes only, it's not recommended for users to change this.
 	DocumentRanksWeight *float64 `json:"documentRanksWeight,omitempty"`
+	// FlushWallTimeMS description: Controls the amount of time that Zoekt shards collect and rank results when the 'search-ranking' feature is enabled. Larger values give a more stable ranking, but searches can take longer to return an initial result.
+	FlushWallTimeMS int `json:"flushWallTimeMS,omitEmpty"`
 	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
 	// MaxQueueSizeBytes description: The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -414,6 +414,12 @@
               "default": 4500,
               "group": "Search",
               "!go": { "pointer": true }
+            },
+            "flushWallTimeMS": {
+              "description": "Controls the amount of time that Zoekt shards collect and rank results when the 'search-ranking' feature is enabled. Larger values give a more stable ranking, but searches can take longer to return an initial result.",
+              "type": "integer",
+              "default": 500,
+              "group": "Search"
             }
           }
         },


### PR DESCRIPTION
This PR adds an experimental feature setting for adjusting FlushWallTime. This
will help us find a better default for the parameter by testing different
values on the scaletesting instance. The goal is to find a value that makes
search results more deterministic while maintaining reasonable time + memory
limits.

## Test plan

Add a unit test to check the flag is read correctly.