### PR TITLE
trace: repo-update warns if slower than 10m

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -97,7 +97,9 @@ func RequestSource(ctx context.Context) SourceType {
 // which we only want to log a message if the duration is slower than the
 // threshold here.
 var slowPaths = map[string]time.Duration{
-	"/repo-update": 5 * time.Second,
+	// this blocks on running git fetch which depending on repo size can take
+	// a long time. As such we use a very high duration to avoid log spam.
+	"/repo-update": 10 * time.Minute,
 }
 
 var (


### PR DESCRIPTION
Previously we would warn after 5s. Personally on my dev machine (in South Africa) this would fire very often since GitHub isn't as fast for me. Additionally for customers with large monorepos I expect this log is constantly spamming. I think a better approach is to instead put an extremely high value which if exceeded truly indicates a warning.

Test Plan: go test