### PR TITLE
reference panel: Don't error when language spec cannot be found

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -425,13 +425,6 @@ export const languageSpecs: LanguageSpec[] = [
  * Returns the language spec with the given language identifier. If no language
  * matches is configured with the given identifier an error is thrown.
  */
-export function findLanguageSpec(languageID: string): LanguageSpec {
-    const languageSpec = languageSpecs.find(
-        spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID)
-    )
-    if (languageSpec) {
-        return languageSpec
-    }
-
-    throw new Error(`${languageID} is not defined`)
+export function findLanguageSpec(languageID: string): LanguageSpec | undefined {
+    return languageSpecs.find(spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID))
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -235,22 +235,24 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 > = props => {
     const languageId = getModeFromPath(props.token.filePath)
     const spec = findLanguageSpec(languageId)
-    const tokenResult = findSearchToken({
-        text: props.fileContent,
-        position: {
-            line: props.token.line - 1,
-            character: props.token.character - 1,
-        },
-        lineRegexes: spec.commentStyles.map(style => style.lineRegex).filter(isDefined),
-        blockCommentStyles: spec.commentStyles.map(style => style.block).filter(isDefined),
-        identCharPattern: spec.identCharPattern,
-    })
+    const tokenResult =
+        spec &&
+        findSearchToken({
+            text: props.fileContent,
+            position: {
+                line: props.token.line - 1,
+                character: props.token.character - 1,
+            },
+            lineRegexes: spec.commentStyles.map(style => style.lineRegex).filter(isDefined),
+            blockCommentStyles: spec.commentStyles.map(style => style.block).filter(isDefined),
+            identCharPattern: spec.identCharPattern,
+        })
     const shouldMixPreciseAndSearchBasedReferences: boolean = newSettingsGetter(props.settingsCascade)<boolean>(
         'codeIntel.mixPreciseAndSearchBasedReferences',
         false
     )
 
-    if (!tokenResult?.searchToken) {
+    if (!spec || !tokenResult?.searchToken) {
         return (
             <div>
                 <Text className="text-danger">Could not find token.</Text>


### PR DESCRIPTION
Partially addresses #47619 

I don't know what the original intend behind throwing an error was, but from a type safety perspective it seems better to return `undefined`/`null` when the spec is not available and let the UI handle the case.

In this PR I'm simply rendering the same UI as if the token wasn't found.

<img width="958" alt="2023-02-15_08-44" src="https://user-images.githubusercontent.com/179026/218996545-a8256b44-19ce-4f33-84c5-8096c6c50312.png">


## Test plan

https://sourcegraph.com/github.com/sourcegraph/terraform-google-executors/-/blob/modules/executors/README.md?L8:40-8:46#tab=references doesn't throw an error anymore.

## App preview:

- [Web](https://sg-web-fkling-47619-find-references-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
