### PR TITLE
Upgrade docsite version to 1.9.1 in dev/docsite.sh

### DIFF
--- a/dev/docsite.sh
+++ b/dev/docsite.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
-version=v1.8.7
+version=v1.9.1
 suffix="${version}_$(go env GOOS)_$(go env GOARCH)"
 url="https://github.com/sourcegraph/docsite/releases/download/${version}/docsite_${suffix}"
 


### PR DESCRIPTION
Looks like this is still used by some tasks in `package.json` and in the `sg` linter.

@unknwon already updated the other places, but this one we missed.

## Test plan

- N/A