### PR TITLE
blob: always show tooltips for interactive occurrences

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -1,6 +1,6 @@
 import { castArray } from 'lodash'
 import { Observable, of } from 'rxjs'
-import { catchError, defaultIfEmpty, map, tap } from 'rxjs/operators'
+import { defaultIfEmpty, map } from 'rxjs/operators'
 
 import {
     fromHoverMerged,

--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -1,6 +1,6 @@
 import { castArray } from 'lodash'
 import { Observable, of } from 'rxjs'
-import { defaultIfEmpty, map } from 'rxjs/operators'
+import { catchError, defaultIfEmpty, map, tap } from 'rxjs/operators'
 
 import {
     fromHoverMerged,
@@ -38,7 +38,7 @@ interface CodeIntelAPI {
         context: sourcegraph.ReferenceContext
     ): Observable<clientType.Location[]>
     getImplementations(parameters: TextDocumentPositionParameters): Observable<clientType.Location[]>
-    getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null>
+    getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null | undefined>
     getDocumentHighlights(textParameters: TextDocumentPositionParameters): Observable<DocumentHighlight[]>
 }
 
@@ -110,7 +110,7 @@ class DefaultCodeIntelAPI implements CodeIntelAPI {
             request.providers.implementations.provideLocations(request.document, request.position)
         )
     }
-    public getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null> {
+    public getHover(textParameters: TextDocumentPositionParameters): Observable<HoverMerged | null | undefined> {
         const request = requestFor(textParameters)
         return (
             request.providers.hover

--- a/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
@@ -189,7 +189,7 @@ async function hoverRequest(
     const hover = await api.getHover(params).toPromise()
 
     let markdownContents: string =
-        hover === null || hover.contents.length === 0
+        hover === null || hover === undefined || hover.contents.length === 0
             ? ''
             : hover.contents
                   .map(({ value }) => value)
@@ -201,7 +201,7 @@ async function hoverRequest(
     return { markdownContents, hoverMerged: hover, isPrecise: isPrecise(hover) }
 }
 
-function isPrecise(hover: HoverMerged | null): boolean {
+function isPrecise(hover: HoverMerged | null | undefined): boolean {
     for (const badge of hover?.aggregatedBadges || []) {
         if (badge.text === 'precise') {
             return true

--- a/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
@@ -1,7 +1,7 @@
 import { countColumn, Extension, Prec, StateEffect, StateField } from '@codemirror/state'
 import { EditorView, getTooltip, PluginValue, showTooltip, Tooltip, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { BehaviorSubject, from, fromEvent, of, Subject, Subscription } from 'rxjs'
-import { catchError, debounceTime, filter, map, scan, switchMap, tap } from 'rxjs/operators'
+import { debounceTime, filter, map, scan, switchMap, tap } from 'rxjs/operators'
 
 import { HoverMerged, TextDocumentPositionParameters } from '@sourcegraph/client-api/src'
 import { formatSearchParameters, LineOrPositionOrRange } from '@sourcegraph/common/src'
@@ -349,7 +349,6 @@ const hoverManager = ViewPlugin.fromClass(
                                     }
 
                                     return from(getHoverTooltip(view, offset)).pipe(
-                                        catchError(() => of(null)),
                                         map(tooltip => (tooltip ? { tooltip, occurrence } : null))
                                     )
                                 }),


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47604

Hover result for certain interactive occurrences can be `undefined` ([`DefaultCodeIntelApi.getHover`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/api.ts?L113-122&subtree=true) => [`requestFor`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/api.ts?L138-145) => [`LanguageRequest`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/api.ts?L132-136) => [`SourcegraphProviders`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/legacy-extensions/providers.ts?L31-37) => [`HoverProvider`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/legacy-extensions/api.ts?L586-588) => [`ProviderResult`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/shared/src/codeintel/legacy-extensions/api.ts?L442-452)) and this case is not handled by [`hoverRequest`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts?L183-211&subtree=true), causing the latter to throw.  Previously we [ignored such errors](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts?L351-354&subtree=true) and didn't show code-intel popovers for these occurrences. 
This PR handles `undefined` hover results by showing "No hover information" message as code-intel popover content. 


https://user-images.githubusercontent.com/25318659/219024441-59b5ebc3-08f4-4b90-9f91-da43dc8b7a03.mov



## Test plan
See steps to reproduce in the original issue.
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-cm-blob-show.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

