### PR TITLE
Add note on repo built in predicates with search contexts

### DIFF
--- a/doc/code_search/how-to/search_contexts.md
+++ b/doc/code_search/how-to/search_contexts.md
@@ -106,7 +106,7 @@ You will be returned to the list of search contexts. Your new search context wil
 ## Beta: Query-based search contexts
 As of release 3.36, search contexts can be defined with a restricted search query as an alternative to a specific list of repositories and revisions. This feature is in beta and may change in following releases. Allowed filters are: `repo`, `rev`, `file`, `lang`, `case`, `fork`, and `visibility`. `OR` and `AND` expressions are also allowed.
 
-> NOTE: Currently, repo built in predicates for example `repo:has.file`, `repo:has.content` etc aren't currently supported in search contexts.
+> NOTE: Currently, repo built in predicates for example `repo:has.file`, `repo:has.content` etc, aren't currently supported in search contexts.
 
 If you're an admin, to enable this feature for all users set `experimentalFeatures.searchContextsQuery` to `true` in your global settings (for regular users, just use the normal settings menu). You'll then see a "Create context" button from the search results page and a "Query" input field in the search contexts form. If you want revisions specified in these query based search contexts to be indexed, set `experimentalFeatures.search.index.query.contexts` to `true` in site configuration.
 

--- a/doc/code_search/how-to/search_contexts.md
+++ b/doc/code_search/how-to/search_contexts.md
@@ -106,6 +106,8 @@ You will be returned to the list of search contexts. Your new search context wil
 ## Beta: Query-based search contexts
 As of release 3.36, search contexts can be defined with a restricted search query as an alternative to a specific list of repositories and revisions. This feature is in beta and may change in following releases. Allowed filters are: `repo`, `rev`, `file`, `lang`, `case`, `fork`, and `visibility`. `OR` and `AND` expressions are also allowed.
 
+> NOTE: Currently, repo built in predicates for example `repo:has.file`, `repo:has.content` etc aren't currently supported in search contexts.
+
 If you're an admin, to enable this feature for all users set `experimentalFeatures.searchContextsQuery` to `true` in your global settings (for regular users, just use the normal settings menu). You'll then see a "Create context" button from the search results page and a "Query" input field in the search contexts form. If you want revisions specified in these query based search contexts to be indexed, set `experimentalFeatures.search.index.query.contexts` to `true` in site configuration.
 
 ### Creating search contexts from search results


### PR DESCRIPTION
This doc clarifies that built in repo predicates aren't supported in search contexts at the moment.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

No test plan required. Doc update.