### PR TITLE
blob: show code-intel tooltips only for languages supported

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -152,7 +152,7 @@ function toTextDocument(textDocument: TextDocumentIdentifier): sourcegraph.TextD
     }
 }
 
-function findLanguageMatchingDocument(textDocument: TextDocumentIdentifier): Language | undefined {
+export function findLanguageMatchingDocument(textDocument: TextDocumentIdentifier): Language | undefined {
     const document: Pick<TextDocument, 'uri' | 'languageId'> = toTextDocument(textDocument)
     for (const language of languages) {
         if (match(language.selector, document)) {

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -15,6 +15,7 @@ import {
     formatSearchParameters,
     toPositionOrRangeQueryParameter,
 } from '@sourcegraph/common'
+import { findLanguageMatchingDocument } from '@sourcegraph/shared/src/codeintel/api'
 import { editorHeight, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -22,7 +23,7 @@ import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
+import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash, toURIWithPath } from '@sourcegraph/shared/src/util/url'
 import { useLocalStorage } from '@sourcegraph/wildcard'
 
 import { BlobStencilFields, ExternalLinkFields, Scalars } from '../../graphql-operations'
@@ -276,6 +277,10 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         },
         [customHistoryAction]
     )
+    const isLanguageSupported = useMemo(
+        () => !!findLanguageMatchingDocument({ uri: toURIWithPath(props.blobInfo) }),
+        [props.blobInfo]
+    )
     const extensions = useMemo(
         () => [
             // Log uncaught errors that happen in callbacks that we pass to
@@ -292,7 +297,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
                 enableSelectionDrivenCodeNavigation,
             }),
             codeFoldingExtension(),
-            enableSelectionDrivenCodeNavigation ? tokenSelectionExtension() : [],
+            enableSelectionDrivenCodeNavigation && isLanguageSupported ? tokenSelectionExtension() : [],
             enableLinkDrivenCodeNavigation
                 ? tokensAsLinks({ navigate: navigateRef.current, blobInfo, preloadGoToDefinition })
                 : [],

--- a/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
@@ -23,6 +23,7 @@ import { positionToOffset, preciseOffsetAtCoords, uiPositionToOffset } from '../
 
 import { preloadDefinition } from './definition'
 import { showDocumentHighlightsForOccurrence } from './document-highlights'
+import { languageSupport } from './languageSupport'
 
 type CodeIntelTooltipTrigger = 'focus' | 'hover' | 'pin'
 type CodeIntelTooltipState = { occurrence: Occurrence; tooltip: Tooltip | null } | null
@@ -69,6 +70,7 @@ export const codeIntelTooltipsState = StateField.define<Record<CodeIntelTooltipT
         return [
             showTooltip.computeN([field], state => {
                 const { hover, focus, pin } = state.field(field)
+                const isLanguageSupported = state.facet(languageSupport)
 
                 // Only show one tooltip for the occurrence at a time
                 const uniqueTooltips = [pin, focus, hover]
@@ -79,6 +81,9 @@ export const codeIntelTooltipsState = StateField.define<Record<CodeIntelTooltipT
                         return acc
                     }, [] as NonNullable<CodeIntelTooltipState>[])
                     .map(({ tooltip }) => tooltip)
+                    .filter(tooltip =>
+                        tooltip instanceof CodeIntelTooltip ? (isLanguageSupported ? tooltip : null) : tooltip
+                    )
 
                 return uniqueTooltips
             }),

--- a/client/web/src/repo/blob/codemirror/token-selection/languageSupport.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/languageSupport.ts
@@ -1,0 +1,14 @@
+import { Facet } from '@codemirror/state'
+
+import { findLanguageMatchingDocument } from '@sourcegraph/shared/src/codeintel/api'
+import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
+
+import type { BlobInfo } from '../../CodeMirrorBlob'
+
+/**
+ * Facet providing information whether the current blob language has code intelligence support.
+ */
+export const languageSupport = Facet.define<BlobInfo, boolean>({
+    static: true,
+    combine: blobInfos => (blobInfos[0] ? !!findLanguageMatchingDocument({ uri: toURIWithPath(blobInfos[0]) }) : false),
+})


### PR DESCRIPTION
Partially addresses https://github.com/sourcegraph/sourcegraph/issues/47619

Do not show code-intel tooltips if language is not supported ("No hover info" message is always shown for such languages).

We still enable [`tokenSelectionExtension`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4e4ff62a3d7a60abb0616aba500d7b24508d672d/-/blob/client/web/src/repo/blob/codemirror/token-selection/extension.ts?L47-105&subtree=true) if language is not supported (despite extensions enabled by `tokenSelectionExtension` completely relying on [`Language['providers']`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ff466c55b67a09c03769a0e56a9677a99943850b/-/blob/client/shared/src/codeintel/legacy-extensions/providers.ts?L31-37), see [`findLanguageMatchingDocument`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ff466c55b67a09c03769a0e56a9677a99943850b/-/blob/client/shared/src/codeintel/api.ts?L155-163)) for selection-driven navigation and go to definition (resulting in "No definition found") to work.


https://user-images.githubusercontent.com/25318659/220310060-ef39b341-cdb1-4f5a-9c32-e4ef68812b0d.mov



## Test plan
- Ensure selection-based navigation and go to definition work for all languages (supported and not)
- Ensure that no code-intel tooltips are displayed only for [supported languages](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ff466c55b67a09c03769a0e56a9677a99943850b/-/blob/client/shared/src/codeintel/api.ts?L155-163)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-cm-blob-do-not-init.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
