### PR TITLE
blob: fix "no definition found" tooltip

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -100,8 +100,11 @@ const keybindings: KeyBinding[] = [
                     () => {}
                 )
                 .finally(() => {
-                    // hide loading tooltip
-                    view.dispatch({ effects: setFocusedOccurrenceTooltip.of(null) })
+                    // close loading tooltip if any
+                    const current = getCodeIntelTooltipState(view, 'focus')
+                    if (current?.tooltip instanceof LoadingTooltip && current?.occurrence === selected.occurrence) {
+                        view.dispatch({ effects: setFocusedOccurrenceTooltip.of(null) })
+                    }
                 })
 
             return true


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47459

Fixes bug when the temporary tooltip has been closed right after the definition promise had been resolved. 

## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
