### PR TITLE
docs: chore: update admin pings list with all existing insights and aggregations pings

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -108,26 +108,44 @@ This telemetry can be disabled using the `disableNonCriticalTelemetry` option in
   - Total number of users that use non-default Sourcegraph extensions
   - Average number of non-default extensions enabled for users that use non-default Sourcegraph extensions
 - Code insights usage data
-  - Total count of page views on the insights page
-  - Count of unique viewers on the insights page
-  - Total counts of hovers, clicks, and drags of insights by type (e.g. search, code stats)
-  - Total counts of edits, additions, and removals of insights by type
+  - Weekly count of page views on the insights pages
+  - Weekly count of unique viewers on the insights pages
+  - Weekly counts of hovers and clicks insights by type (e.g. search, code stats)
+  - Weekly counts of resizing of insights by type
+  - Weekly counts of edits, additions, and removals of insights by type
   - Total count of clicks on the "Add more insights" and "Configure insights" buttons on the insights page
-  - Weekly count of users that have created an insight, and count of users that have created their first insight this week
-  - Weekly count of total and unique views to the `Create new insight`, `Create search insight`, and `Create language insight` pages
-  - Weekly count of total and unique clicks of the `Create search insight`, `Create language usage insight`, and `Explore the extensions` buttons on the `Create new insight` page
+  - Weekly count of users that have created an insight
+  - Weekly count of users that have created their first insight this week
+  - Weekly count of total and unique views to the different `Create`, `Create search insight`, and `Create language insight` pages
+  - Weekly count of total and unique clicks of the different `Create search insight` and `Create language usage insight`, and `Explore the extensions` buttons on the `Create new insight` page
   - Weekly count of total and unique clicks of the `Create` and `Cancel` buttons on the `Create search insight` and `Create language insight` pages
   - Total count of insights grouped by time interval (step size) in days
-  - Total count of insights set organization visible grouped by insight type
+  - Total count of insights that are organization visible grouped by insight type
   - Total count of insights grouped by presentation type, series type, and presentation-series type.
   - Weekly count of unique users that have viewed code insights in-product landing page
   - Weekly count of per user changes that have been made over the query field insight example.
   - Weekly count of per user changes that have been made over the repositories field insight example.
   - Weekly count of clicks on the "Create your first insight" CTA button on the in-product landing page.
-  - Weekly count of clicks on the code insights in-product template section's tabs.
+  - Weekly count of clicks on the code insights in-product template section's tabs, with tab title data.
   - Weekly count of clicks on the use/explore template card's button.
   - Weekly count of clicks on the "view more" template section button.
   - Weekly count of clicks on the in-product landing page documentation links.
+  - Weekly count of filters usage on the standalone insight page
+  - Weekly count of navigation to dashboards from the standalone insight page
+  - Weekly count of clicks on "Edit" from the standalone insight page
+  - Total count of individual view series, grouped by presentation type and generation method
+  - Total count of insight series, grouped by generation method
+  - Total count of views, grouped by presentation type
+  - Total count of organisations with at least one dashboard
+  - Total count of dashboards
+  - Total count of insights per dashboard
+  - Weekly count of time to complete an insight series backfill in seconds 
+- Search aggregations usage data
+  - Weekly count of hovers over the search aggregations information icon
+  - Weekly count of open/collapse clicks on the sidebar and expanded view of search aggregations
+  - Weekly count of search aggregation mode clicks and hovers
+  - Weekly count of search aggregation bars clicks and hovers
+  - Weekly count of search aggregation success and timeouts 
 - Code monitoring usage data
   - Total number of views of the code monitoring page
   - Total number of views of the create code monitor page


### PR DESCRIPTION
no issue, just pure resolve

The list of pings in our documentation was very out of date for code insights. This adds/updates missing pings as pulled from https://docs.sourcegraph.com/dev/background-information/insights/code_insights_pings

## Test plan

Docsite check