### PR TITLE
nix: fix nodejs version used by pnpm

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -51,8 +51,7 @@ pkgs.mkShell {
     # Web tools. Need node 16.7 so we use unstable. Yarn should also be built
     # against it.
     nodejs-16_x
-    (nodePackages.pnpm.override {
-      nodejs = nodejs-16_x;
+    (nodejs-16_x.pkgs.pnpm.override {
       version = "7.24.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/pnpm/-/pnpm-7.24.2.tgz";


### PR DESCRIPTION
Very logically (not), the existing method doesnt actually work. This resulted in there being both nodejs18 and nodejs16 at work, with nodejs18 being used when running sg start (as evident by the warning log). 

## Test plan

Checked the paths:

```
$ cat (which pnpm)
...
exec -a "$0" "/nix/store/w8vn7zcdjk9bx0qcfw349v6bhf362zag-pnpm-7.24.2/bin/.pnpm-wrapped"  "$@" 
$ cat /nix/store/w8vn7zcdjk9bx0qcfw349v6bhf362zag-pnpm-7.24.2/bin/.pnpm-wrapped
#!/nix/store/48qwp6zx3gm8b89m812vn8h63kmnqb12-nodejs-16.19.0/bin/node
...
$ 
```