### PR TITLE
switch to indexed params when displaying sg db add-user output

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -204,17 +204,14 @@ func dbAddUserAction(cmd *cli.Context) error {
 
 		// Report back the new user information.
 		std.Out.WriteSuccessf(
-			// the space after the last %s is so the user can select the password easily in the shell to copy it.
-			"User '%s%s%s' (%s%s%s) has been created and its password is '%s%s%s'.",
-			output.StyleOrange,
-			username,
-			output.StyleReset,
-			output.StyleOrange,
-			email,
-			output.StyleReset,
-			output.StyleOrange,
-			password,
-			output.StyleReset,
+			fmt.Sprintf("User '%[1]s%[3]s%[2]s' (%[1]s%[4]s%[2]s) has been created and its password is '%[1]s%[5]s%[6]s'.",
+				output.StyleOrange,
+				output.StyleSuccess,
+				username,
+				email,
+				password,
+				output.StyleReset,
+			),
 		)
 
 		return nil


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing `sg db add-user` 

<img width="764" alt="CleanShot 2023-02-15 at 18 11 27@2x" src="https://user-images.githubusercontent.com/25608335/219102484-fac3395c-62f0-49a1-b8da-961c19f741b7.png">
