### PR TITLE
scip-typescript: reduce memory requirement while indexing

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - run: pnpm generate
       - run: pnpm --filter ./client/web-sveltekit run sync
-      - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces
+      - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces --no-global-caches
       - run: cp index.scip dump.lsif-typed
       - name: Install src-cli
         run: |

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -644,5 +644,6 @@ function fuzzyResultId(id: number): string {
 function focusFuzzyInput(): void {
     // Redirect the focus to the fuzzy search bar
     const input = document.querySelector<HTMLInputElement>('#fuzzy-modal-input')
+
     input?.focus()
 }


### PR DESCRIPTION
Attempt to fix OOM errors in CI when indexing the `client/web` project, which is the biggest tsconfig project in our monorepo. The global caches option is enabled by default because it speeds up indexing up to ~40-50% for large multi-project codebases. However, this option requires holding onto more memory, and our CI job runners don't have so much memory.

## Test plan

See the scip-typescript CI job succeed without OOM.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-scip-typescript-memory.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
