### PR TITLE
dev/sg: candidate-notest now publishs final images to docker hub

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -898,7 +898,7 @@ func publishFinalDockerImage(c Config, app string) operations.Operation {
 
 		var imgs []string
 		for _, image := range []string{publishImage, devImage} {
-			if app != "server" || c.RunType.Is(runtype.TaggedRelease, runtype.ImagePatch, runtype.ImagePatchNoTest) {
+			if app != "server" || c.RunType.Is(runtype.TaggedRelease, runtype.ImagePatch, runtype.ImagePatchNoTest, runtype.CandidatesNoTest) {
 				imgs = append(imgs, fmt.Sprintf("%s:%s", image, c.Version))
 			}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -236,10 +236,20 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			publishFinalDockerImage(c, patchImage))
 
 	case runtype.CandidatesNoTest:
+		imageBuildOps := operations.NewNamedSet("Image builds")
 		for _, dockerImage := range images.SourcegraphDockerImages {
-			ops.Append(
+			imageBuildOps.Append(
 				buildCandidateDockerImage(dockerImage, c.Version, c.candidateImageTag(), false))
 		}
+		ops.Merge(imageBuildOps)
+
+		ops.Append(wait)
+
+		publishOps := operations.NewNamedSet("Publish images")
+		for _, dockerImage := range images.SourcegraphDockerImages {
+			publishOps.Append(publishFinalDockerImage(c, dockerImage))
+		}
+		ops.Merge(publishOps)
 
 	case runtype.ExecutorPatchNoTest:
 		executorVMImage := "executor-vm"


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1676482700598499

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

preview pipeline

```sh
go run ./dev/sg ci preview -b docker-images-candidates-notest/02-15-dev/sg_candidate-notest_now_publishs_final_images_to_docker_hub    
```

```
If the current branch were to be pushed, the following pipeline would be run:

                                                                                                                                                                                                                                                                                              
  • Detected run type: Build all candidates without testing                                                                                                                                                                                                                                   
  • Detected diffs: Go, Docs                                                                                                                                                                                                                                                                  
  • Computed build steps:                                                                                                                                                                                                                                                                     
    • Metadata                                                                                                                                                                                                                                                                                
      • 📝:pipeline: Pipeline metadata                                                                                                                                                                                                                                                        
    • Image builds                                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build alpine-3.14                                                                                                                                                                                                                                                         
      • :docker: 🚧 Build cadvisor                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build codeinsights-db                                                                                                                                                                                                                                                     
      • :docker: 🚧 Build codeintel-db                                                                                                                                                                                                                                                        
      • :docker: 🚧 Build frontend                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build github-proxy                                                                                                                                                                                                                                                        
      • :docker: 🚧 Build gitserver                                                                                                                                                                                                                                                           
      • :docker: 🚧 Build grafana                                                                                                                                                                                                                                                             
      • :docker: 🚧 Build indexed-searcher                                                                                                                                                                                                                                                    
      • :docker: 🚧 Build jaeger-agent                                                                                                                                                                                                                                                        
      • :docker: 🚧 Build jaeger-all-in-one                                                                                                                                                                                                                                                   
      • :docker: 🚧 Build blobstore                                                                                                                                                                                                                                                           
      • :docker: 🚧 Build blobstore2                                                                                                                                                                                                                                                          
      • :docker: 🚧 Build node-exporter                                                                                                                                                                                                                                                       
      • :docker: 🚧 Build postgres-12-alpine                                                                                                                                                                                                                                                  
      • :docker: 🚧 Build postgres_exporter                                                                                                                                                                                                                                                   
      • :docker: 🚧 Build precise-code-intel-worker                                                                                                                                                                                                                                           
      • :docker: 🚧 Build prometheus                                                                                                                                                                                                                                                          
      • :docker: 🚧 Build prometheus-gcp                                                                                                                                                                                                                                                      
      • :docker: 🚧 Build redis-cache                                                                                                                                                                                                                                                         
      • :docker: 🚧 Build redis-store                                                                                                                                                                                                                                                         
      • :docker: 🚧 Build redis_exporter                                                                                                                                                                                                                                                      
      • :docker: 🚧 Build repo-updater                                                                                                                                                                                                                                                        
      • :docker: 🚧 Build search-indexer                                                                                                                                                                                                                                                      
      • :docker: 🚧 Build searcher                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build symbols                                                                                                                                                                                                                                                             
      • :docker: 🚧 Build syntax-highlighter                                                                                                                                                                                                                                                  
      • :docker: 🚧 Build worker                                                                                                                                                                                                                                                              
      • :docker: 🚧 Build migrator                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build executor                                                                                                                                                                                                                                                            
      • :docker: 🚧 Build executor-vm                                                                                                                                                                                                                                                         
      • :docker: 🚧 Build batcheshelper                                                                                                                                                                                                                                                       
      • :docker: 🚧 Build opentelemetry-collector                                                                                                                                                                                                                                             
      • :docker: 🚧 Build server                                                                                                                                                                                                                                                              
      • :docker: 🚧 Build sg                                                                                                                                                                                                                                                                  
    • Publish images                                                                                                                                                                                                                                                                          
      • :docker: 🚚 alpine-3.14                                                                                                                                                                                                                                                               
      • :docker: 🚚 cadvisor                                                                                                                                                                                                                                                                  
      • :docker: 🚚 codeinsights-db                                                                                                                                                                                                                                                           
      • :docker: 🚚 codeintel-db                                                                                                                                                                                                                                                              
      • :docker: 🚚 frontend                                                                                                                                                                                                                                                                  
      • :docker: 🚚 github-proxy                                                                                                                                                                                                                                                              
      • :docker: 🚚 gitserver                                                                                                                                                                                                                                                                 
      • :docker: 🚚 grafana                                                                                                                                                                                                                                                                   
      • :docker: 🚚 indexed-searcher                                                                                                                                                                                                                                                          
      • :docker: 🚚 jaeger-agent                                                                                                                                                                                                                                                              
      • :docker: 🚚 jaeger-all-in-one                                                                                                                                                                                                                                                         
      • :docker: 🚚 blobstore                                                                                                                                                                                                                                                                 
      • :docker: 🚚 blobstore2                                                                                                                                                                                                                                                                
      • :docker: 🚚 node-exporter                                                                                                                                                                                                                                                             
      • :docker: 🚚 postgres-12-alpine                                                                                                                                                                                                                                                        
      • :docker: 🚚 postgres_exporter                                                                                                                                                                                                                                                         
      • :docker: 🚚 precise-code-intel-worker                                                                                                                                                                                                                                                 
      • :docker: 🚚 prometheus                                                                                                                                                                                                                                                                
      • :docker: 🚚 prometheus-gcp                                                                                                                                                                                                                                                            
      • :docker: 🚚 redis-cache                                                                                                                                                                                                                                                               
      • :docker: 🚚 redis-store                                                                                                                                                                                                                                                               
      • :docker: 🚚 redis_exporter                                                                                                                                                                                                                                                            
      • :docker: 🚚 repo-updater                                                                                                                                                                                                                                                              
      • :docker: 🚚 search-indexer                                                                                                                                                                                                                                                            
      • :docker: 🚚 searcher                                                                                                                                                                                                                                                                  
      • :docker: 🚚 symbols                                                                                                                                                                                                                                                                   
      • :docker: 🚚 syntax-highlighter                                                                                                                                                                                                                                                        
      • :docker: 🚚 worker                                                                                                                                                                                                                                                                    
      • :docker: 🚚 migrator                                                                                                                                                                                                                                                                  
      • :docker: 🚚 executor                                                                                                                                                                                                                                                                  
      • :docker: 🚚 executor-vm                                                                                                                                                                                                                                                               
      • :docker: 🚚 batcheshelper                                                                                                                                                                                                                                                             
      • :docker: 🚚 opentelemetry-collector                                                                                                                                                                                                                                                   
      • :docker: 🚚 server                                                                                                                                                                                                                                                                    
      • :docker: 🚚 sg                                                                                                                                                                                                                                                                        
    • ⤴️ Upload build trace 
```

run it

```sh
go run ./dev/sg ci build docker-images-candidates-notest 
```

all images are published to docker hub

sample build: https://buildkite.com/sourcegraph/sourcegraph/builds/199040