### PR TITLE
Wrap the correct error

### DIFF
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -492,7 +492,7 @@ func (c *clientImplementor) lStat(ctx context.Context, checker authz.SubRepoPerm
 		return fis[0], nil
 	} else {
 		if filteringErr != nil {
-			err = errors.Wrap(err, "filtering paths")
+			err = errors.Wrap(filteringErr, "filtering paths")
 		} else {
 			err = &os.PathError{Op: "ls-tree", Path: path, Err: os.ErrNotExist}
 		}


### PR DESCRIPTION
On this line, we are wrapping `err`, which is guaranteed to be `nil`. Wrapping a `nil` error returns `nil`. Instead, I expect the intent here was to wrap `filteringErr`, which is guaranteed to be non-nil here. I expect that this was causing [an issue](https://sourcegraph.slack.com/archives/C04NWG2TYH1/p1676490516048189) where we would return a `nil` `fs.FileInfo`, but also a `nil` error, which would cause a panic further up the line when a caller tried to use `fs.FileInfo`.

## Test plan

Tested manually that I can reproduce the panic when `filteringErr` is non-nil, and that referring to the correct error fixes the panics.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
