### PR TITLE
Code Insights: Make insight series number optional

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
@@ -14,6 +14,7 @@
 
     &--icon {
         color: var(--gray-06);
+        margin-bottom: 0.25rem;
     }
 
     &--title {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
@@ -40,7 +40,7 @@ export const BackendAlertOverlay: FC<BackendAlertOverLayProps> = props => {
         return (
             <AlertOverlay
                 title="This insight is still being processed"
-                icon={<ProgressWrench className={classNames('mb-3')} size={33} />}
+                icon={<ProgressWrench size={33} />}
                 className={className}
             />
         )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -52,7 +52,7 @@ export interface DrillDownFiltersFormValues {
     excludeRepoRegexp: string
     seriesDisplayOptions: {
         numSamples: number | null
-        limit: number
+        limit: number | null
         sortOptions: {
             mode: SeriesSortMode
             direction: SeriesSortDirection

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -363,7 +363,7 @@ export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
     const { numSamples, sortOptions, limit } = seriesDisplayOptions
     const hasDisplayOptionChanged =
         numSamples !== null ||
-        limit !== 20 ||
+        limit !== null ||
         sortOptions.mode !== SeriesSortMode.RESULT_COUNT ||
         sortOptions.direction !== SeriesSortDirection.DESC
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
@@ -24,7 +24,7 @@ export const getSerializedSortAndLimitFilter = (seriesDisplayOptions: InsightSer
             break
     }
 
-    return `Sorted ${sortBy}, limit ${limit} series, max point per series ${numSamples ?? 90}`
+    return `Sorted ${sortBy}, limit ${limit ?? 20} series, max point per series ${numSamples ?? 90}`
 }
 
 type InsightContextsFilter = string

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
@@ -31,6 +31,8 @@ export const SortFilterSeriesPanel: FC<SortFilterSeriesPanelProps> = props => {
         if (inputValue.length > 0) {
             const limit = Math.max(Math.min(parseInt(inputValue, 10), MAX_NUMBER_OF_SERIES), 1)
             onChange({ ...value, limit })
+        } else {
+            onChange({ ...value, limit: null })
         }
     }
 
@@ -50,7 +52,7 @@ export const SortFilterSeriesPanel: FC<SortFilterSeriesPanelProps> = props => {
         const limit = event.target.value
 
         if (limit === '') {
-            onChange({ ...value, limit: MAX_NUMBER_OF_SERIES })
+            onChange({ ...value, limit: null })
         }
     }
 
@@ -139,7 +141,8 @@ export const SortFilterSeriesPanel: FC<SortFilterSeriesPanelProps> = props => {
                     step="1"
                     min={1}
                     max={MAX_NUMBER_OF_SERIES}
-                    value={value.limit}
+                    placeholder={`${MAX_NUMBER_OF_SERIES}`}
+                    value={value.limit ?? undefined}
                     onChange={handleSeriesCountChange}
                     onBlur={handleSeriesCountBlur}
                     variant="small"

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/field-parsers.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/field-parsers.ts
@@ -7,7 +7,7 @@ import {
     SeriesSortMode,
     TimeIntervalStepUnit,
 } from '../../../../../../graphql-operations'
-import { MAX_NUMBER_OF_SAMPLES, MAX_NUMBER_OF_SERIES } from '../../../../constants'
+import { MAX_NUMBER_OF_SAMPLES } from '../../../../constants'
 import { InsightFilters, InsightSeriesDisplayOptions } from '../../../types/insight/common'
 
 export function getDurationFromStep(step: TimeIntervalStepInput): Duration {
@@ -42,7 +42,6 @@ export function getParsedFilters(
 
 function getParsedSeriesOption(response: ResponseSeriesDisplayOptions): InsightSeriesDisplayOptions {
     const { limit, numSamples, sortOptions } = response
-    const parsedLimit = Math.min(limit ?? 20, MAX_NUMBER_OF_SERIES)
 
     // Have to check zero value because of backend problem (it always returns 0 when
     // numSamples isn't applied
@@ -54,7 +53,7 @@ function getParsedSeriesOption(response: ResponseSeriesDisplayOptions): InsightS
     }
 
     return {
-        limit: parsedLimit,
+        limit,
         numSamples: parsedNumSamples,
         sortOptions: parsedSortOptions,
     }

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -33,7 +33,7 @@ export interface InsightFilters {
 
 export interface InsightSeriesDisplayOptions {
     numSamples: number | null
-    limit: number
+    limit: number | null
     sortOptions: {
         mode: SeriesSortMode
         direction: SeriesSortDirection

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/capture-group-insight-sanitizer.ts
@@ -3,7 +3,6 @@ import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter } from '@sourcegraph/shared/src/search/query/token'
 
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../graphql-operations'
-import { MAX_NUMBER_OF_SERIES } from '../../../../../constants'
 import { InsightType, MinimalCaptureGroupInsightData } from '../../../../../core'
 import { CaptureGroupFormFields } from '../types'
 
@@ -21,7 +20,7 @@ export function getSanitizedCaptureGroupInsight(values: CaptureGroupFormFields):
             excludeRepoRegexp: '',
             context: '',
             seriesDisplayOptions: {
-                limit: MAX_NUMBER_OF_SERIES,
+                limit: null,
                 numSamples: null,
                 sortOptions: {
                     direction: SeriesSortDirection.DESC,

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/utils/insight-sanitaizer.ts
@@ -1,6 +1,5 @@
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../graphql-operations'
 import { getSanitizedSeries } from '../../../../../components'
-import { MAX_NUMBER_OF_SERIES } from '../../../../../constants'
 import { ComputeInsight, InsightType } from '../../../../../core'
 import { CreateComputeInsightFormFields } from '../types'
 
@@ -20,7 +19,7 @@ export const getSanitizedComputeInsight = (values: CreateComputeInsightFormField
         context: '',
         seriesDisplayOptions: {
             numSamples: null,
-            limit: MAX_NUMBER_OF_SERIES,
+            limit: null,
             sortOptions: {
                 direction: SeriesSortDirection.DESC,
                 mode: SeriesSortMode.RESULT_COUNT,

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/insight-sanitizer.ts
@@ -1,6 +1,5 @@
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../graphql-operations'
 import { getSanitizedSeries } from '../../../../../components'
-import { MAX_NUMBER_OF_SERIES } from '../../../../../constants'
 import { MinimalSearchBasedInsightData, InsightType } from '../../../../../core'
 import { CreateInsightFormFields } from '../types'
 
@@ -22,7 +21,7 @@ export function getSanitizedSearchInsight(rawInsight: CreateInsightFormFields): 
             includeRepoRegexp: '',
             context: '',
             seriesDisplayOptions: {
-                limit: MAX_NUMBER_OF_SERIES,
+                limit: null,
                 numSamples: null,
                 sortOptions: {
                     direction: SeriesSortDirection.DESC,

--- a/client/web/src/integration/insights/drill-down-filters.test.ts
+++ b/client/web/src/integration/insights/drill-down-filters.test.ts
@@ -130,7 +130,7 @@ describe('Backend insight drill down filters', () => {
                 excludeRepoRegex: 'github.com/sourcegraph/sourcegraph',
             },
             seriesDisplayOptions: {
-                limit: 20,
+                limit: null,
                 numSamples: null,
                 sortOptions: {
                     direction: 'DESC',
@@ -232,7 +232,7 @@ describe('Backend insight drill down filters', () => {
                     searchContexts: [''],
                 },
                 seriesDisplayOptions: {
-                    limit: 20,
+                    limit: null,
                     numSamples: null,
                     sortOptions: {
                         direction: 'DESC',

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -236,7 +236,7 @@ describe('Code insight edit insight page', () => {
                         searchContexts: [],
                     },
                     seriesDisplayOptions: {
-                        limit: 20,
+                        limit: null,
                         numSamples: null,
                         sortOptions: {
                             direction: 'DESC',

--- a/client/web/src/integration/insights/fixtures/dashboards.ts
+++ b/client/web/src/integration/insights/fixtures/dashboards.ts
@@ -39,7 +39,7 @@ export const GET_DASHBOARD_INSIGHTS_EMPTY: GetDashboardInsightsResult = {
 export const CAPTURE_GROUP_INSIGHT: InsightViewNode = {
     id: 'aW5zaWdodF92aWV3OiIyQnF6ZnBQQzFYUVJTeFpkUnhOWk5jYW1jQ1ki',
     defaultSeriesDisplayOptions: {
-        limit: 20,
+        limit: null,
         numSamples: null,
         sortOptions: {
             mode: SeriesSortMode.RESULT_COUNT,

--- a/client/web/src/integration/insights/fixtures/insights-metadata.ts
+++ b/client/web/src/integration/insights/fixtures/insights-metadata.ts
@@ -1,7 +1,7 @@
 import { InsightViewNode, SeriesSortDirection, SeriesSortMode, TimeIntervalStepUnit } from '../../../graphql-operations'
 
 const DEFAULT_SERIES_DISPLAY_OPTIONS = {
-    limit: 20,
+    limit: null,
     numSamples: null,
     sortOptions: {
         direction: SeriesSortDirection.DESC,
@@ -78,90 +78,3 @@ export const createJITMigrationToGQLInsightMetadataFixture = (options: InsightOp
         },
     ],
 })
-
-export const STORYBOOK_GROWTH_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
-    __typename: 'InsightView',
-    id: '002',
-    defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
-    dashboardReferenceCount: 0,
-    dashboards: { nodes: [] },
-
-    isFrozen: false,
-    defaultFilters: {
-        __typename: 'InsightViewFilters',
-        includeRepoRegex: '',
-        excludeRepoRegex: '',
-        searchContexts: [],
-    },
-    repositoryDefinition: {
-        __typename: 'InsightRepositoryScope',
-        repositories: ['github.com/sourcegraph/sourcegraph'],
-    },
-    presentation: {
-        __typename: 'LineChartInsightViewPresentation',
-        title: 'Team head count',
-        seriesPresentation: [
-            {
-                __typename: 'LineChartDataSeriesPresentation',
-                seriesId: '001',
-                label: 'Client storybook tests',
-                color: 'var(--oc-blue-7)',
-            },
-        ],
-    },
-    dataSeriesDefinitions: [
-        {
-            __typename: 'SearchInsightDataSeriesDefinition',
-            seriesId: '001',
-            query: 'patternType:regexp f:\\.story\\.tsx$ \\badd\\(',
-            isCalculated: false,
-            generatedFromCaptureGroups: false,
-            timeScope: {
-                __typename: 'InsightIntervalTimeScope',
-                unit: TimeIntervalStepUnit.WEEK,
-                value: 6,
-            },
-            groupBy: null,
-        },
-    ],
-}
-
-export const SOURCEGRAPH_LANG_STATS_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
-    __typename: 'InsightView',
-    id: '003',
-    defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
-    dashboardReferenceCount: 0,
-    dashboards: { nodes: [] },
-
-    isFrozen: false,
-    defaultFilters: {
-        __typename: 'InsightViewFilters',
-        includeRepoRegex: '',
-        excludeRepoRegex: '',
-        searchContexts: [],
-    },
-    presentation: {
-        __typename: 'PieChartInsightViewPresentation',
-        title: 'Sourcegraph languages',
-        otherThreshold: 0.03,
-    },
-    repositoryDefinition: {
-        __typename: 'InsightRepositoryScope',
-        repositories: ['github.com/sourcegraph/sourcegraph'],
-    },
-    dataSeriesDefinitions: [
-        {
-            seriesId: '001',
-            query: '',
-            timeScope: {
-                unit: TimeIntervalStepUnit.MONTH,
-                value: 0,
-                __typename: 'InsightIntervalTimeScope',
-            },
-            isCalculated: false,
-            generatedFromCaptureGroups: false,
-            groupBy: null,
-            __typename: 'SearchInsightDataSeriesDefinition',
-        },
-    ],
-}


### PR DESCRIPTION
It fixes the problem that @leonore reported a few days ago with num series filter
> it impossible to overwrite single digit values in sort & limit using the keyboard

https://user-images.githubusercontent.com/18492575/219145897-4ca0295b-c476-4d8c-a39c-af9da1530db1.mov

This PR makes this field (num of series) optional that means that we don't have any default values for this filter, now it works similar to what we have in points num filter, it's null until it's filled out by user

## Test plan
- Make sure that drill down filters works as expected, you can save update or remove num of series filter

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-series-num-input.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
