### PR TITLE
rbac: create users and assign role in single transaction

### DIFF
--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -58,52 +58,32 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 		}
 	}
 
-	var user *types.User
-	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
-		user, err = tx.Users().Create(ctx, database.NewUser{
-			Username: args.Username,
-			Password: backend.MakeRandomHardToGuessPassword(),
+	user, err := r.db.Users().Create(ctx, database.NewUser{
+		Username: args.Username,
+		Password: backend.MakeRandomHardToGuessPassword(),
 
-			Email: email,
+		Email: email,
 
-			// In order to mark an email as unverified, we must generate a verification code.
-			EmailIsVerified:       !needsEmailVerification,
-			EmailVerificationCode: emailVerificationCode,
-		})
-		if err != nil {
-			msg := "failed to create user"
-			logger.Error(msg, log.Error(err))
-			return errors.Wrap(err, msg)
-		}
-
-		logger = logger.With(log.Int32("userID", user.ID))
-		logger.Debug("user created")
-
-		roles := []types.SystemRole{types.UserSystemRole}
-		if user.SiteAdmin {
-			roles = append(roles, types.SiteAdministratorSystemRole)
-		}
-		opts := database.BulkAssignSystemRolesToUserOpts{UserID: user.ID, Roles: roles}
-		if err = tx.UserRoles().BulkAssignSystemRolesToUser(ctx, opts); err != nil {
-			r.logger.Error("failed to assign system roles to user",
-				log.Error(err))
-			return errors.Wrap(err, "failed to assign system roles to user")
-		}
-
-		if err = tx.Authz().GrantPendingPermissions(ctx, &database.GrantPendingPermissionsArgs{
-			UserID: user.ID,
-			Perm:   authz.Read,
-			Type:   authz.PermRepos,
-		}); err != nil {
-			r.logger.Error("failed to grant user pending permissions",
-				log.Error(err))
-		}
-
-		return nil
+		// In order to mark an email as unverified, we must generate a verification code.
+		EmailIsVerified:       !needsEmailVerification,
+		EmailVerificationCode: emailVerificationCode,
 	})
-
 	if err != nil {
-		return nil, err
+		msg := "failed to create user"
+		logger.Error(msg, log.Error(err))
+		return nil, errors.Wrap(err, msg)
+	}
+
+	logger = logger.With(log.Int32("userID", user.ID))
+	logger.Debug("user created")
+
+	if err = r.db.Authz().GrantPendingPermissions(ctx, &database.GrantPendingPermissionsArgs{
+		UserID: user.ID,
+		Perm:   authz.Read,
+		Type:   authz.PermRepos,
+	}); err != nil {
+		r.logger.Error("failed to grant user pending permissions",
+			log.Error(err))
 	}
 
 	return &createUserResult{

--- a/cmd/frontend/graphqlbackend/users_create_test.go
+++ b/cmd/frontend/graphqlbackend/users_create_test.go
@@ -20,7 +20,7 @@ import (
 type mockFuncs struct {
 	dB             *database.MockDB
 	authzStore     *database.MockAuthzStore
-	userRoleStore  *database.MockUserRoleStore
+	usersStore     *database.MockUserStore
 	userEmailStore *database.MockUserEmailsStore
 }
 
@@ -34,24 +34,17 @@ func makeUsersCreateTestDB(t *testing.T) mockFuncs {
 	authz := database.NewMockAuthzStore()
 	authz.GrantPendingPermissionsFunc.SetDefaultReturn(nil)
 
-	userRoles := database.NewMockUserRoleStore()
-	userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultReturn(nil)
-
 	userEmails := database.NewMockUserEmailsStore()
 
 	db := database.NewMockDB()
-	db.WithTransactFunc.SetDefaultHook(func(ctx context.Context, f func(database.DB) error) error {
-		return f(db)
-	})
 	db.UsersFunc.SetDefaultReturn(users)
 	db.AuthzFunc.SetDefaultReturn(authz)
-	db.UserRolesFunc.SetDefaultReturn(userRoles)
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 
 	return mockFuncs{
 		dB:             db,
+		usersStore:     users,
 		authzStore:     authz,
-		userRoleStore:  userRoles,
 		userEmailStore: userEmails,
 	}
 }
@@ -84,7 +77,7 @@ func TestCreateUser(t *testing.T) {
 	})
 
 	mockrequire.CalledOnce(t, mocks.authzStore.GrantPendingPermissionsFunc)
-	mockrequire.CalledOnce(t, mocks.userRoleStore.BulkAssignSystemRolesToUserFunc)
+	mockrequire.CalledOnce(t, mocks.usersStore.CreateFunc)
 }
 
 func TestCreateUserResetPasswordURL(t *testing.T) {

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -165,69 +165,44 @@ func handleSignUp(logger log.Logger, db database.DB, w http.ResponseWriter, r *h
 		}
 	}
 
-	var usr *types.User
-	err := db.WithTransact(r.Context(), func(tx database.DB) (err error) {
-		usr, err = tx.Users().Create(r.Context(), newUserData)
-		if err != nil {
-			var (
-				message    string
-				statusCode int
-			)
-			switch {
-			case database.IsUsernameExists(err):
-				message = "Username is already in use. Try a different username."
-				statusCode = http.StatusConflict
-			case database.IsEmailExists(err):
-				message = "Email address is already in use. Try signing into that account instead, or use a different email address."
-				statusCode = http.StatusConflict
-			case errcode.PresentationMessage(err) != "":
-				message = errcode.PresentationMessage(err)
-				statusCode = http.StatusConflict
-			default:
-				// Do not show non-allowed error messages to user, in case they contain sensitive or confusing
-				// information.
-				message = defaultErrorMessage
-				statusCode = http.StatusInternalServerError
-			}
-			logger.Error("Error in user signup.", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
-			http.Error(w, message, statusCode)
-
-			if err = usagestats.LogBackendEvent(db, sgactor.FromContext(r.Context()).UID, deviceid.FromContext(r.Context()), "SignUpFailed", nil, nil, featureflag.GetEvaluatedFlagSet(r.Context()), nil); err != nil {
-				logger.Warn("Failed to log event SignUpFailed", log.Error(err))
-			}
-			return err
-		}
-
-		roles := []types.SystemRole{types.UserSystemRole}
-		if usr.SiteAdmin {
-			roles = append(roles, types.SiteAdministratorSystemRole)
-		}
-
-		if err = tx.UserRoles().BulkAssignSystemRolesToUser(r.Context(), database.BulkAssignSystemRolesToUserOpts{
-			UserID: usr.ID,
-			Roles:  roles,
-		}); err != nil {
-			logger.Error("Error assigning role to user", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
-			http.Error(w, "Unable to assign system role to user", http.StatusBadRequest)
-			return err
-		}
-
-		if err = tx.Authz().GrantPendingPermissions(r.Context(), &database.GrantPendingPermissionsArgs{
-			UserID: usr.ID,
-			Perm:   authz.Read,
-			Type:   authz.PermRepos,
-		}); err != nil {
-			logger.Error("Failed to grant user pending permissions", log.Int32("userID", usr.ID), log.Error(err))
-		}
-
-		return nil
-	})
-
+	usr, err := db.Users().Create(r.Context(), newUserData)
 	if err != nil {
-		// It's okay to simply return here because any error that occur in the transaction above,
-		// will result in `http.Error` been called to respond to the request early. This will also
-		// result in the transaction being rolled back.
+		var (
+			message    string
+			statusCode int
+		)
+		switch {
+		case database.IsUsernameExists(err):
+			message = "Username is already in use. Try a different username."
+			statusCode = http.StatusConflict
+		case database.IsEmailExists(err):
+			message = "Email address is already in use. Try signing into that account instead, or use a different email address."
+			statusCode = http.StatusConflict
+		case errcode.PresentationMessage(err) != "":
+			message = errcode.PresentationMessage(err)
+			statusCode = http.StatusConflict
+		default:
+			// Do not show non-allowed error messages to user, in case they contain sensitive or confusing
+			// information.
+			message = defaultErrorMessage
+			statusCode = http.StatusInternalServerError
+		}
+		logger.Error("Error in user signup.", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
+		http.Error(w, message, statusCode)
+
+		if err = usagestats.LogBackendEvent(db, sgactor.FromContext(r.Context()).UID, deviceid.FromContext(r.Context()), "SignUpFailed", nil, nil, featureflag.GetEvaluatedFlagSet(r.Context()), nil); err != nil {
+			logger.Warn("Failed to log event SignUpFailed", log.Error(err))
+		}
+
 		return
+	}
+
+	if err = db.Authz().GrantPendingPermissions(r.Context(), &database.GrantPendingPermissionsArgs{
+		UserID: usr.ID,
+		Perm:   authz.Read,
+		Type:   authz.PermRepos,
+	}); err != nil {
+		logger.Error("Failed to grant user pending permissions", log.Int32("userID", usr.ID), log.Error(err))
 	}
 
 	if conf.EmailVerificationRequired() && !newUserData.EmailIsVerified {

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -425,6 +424,7 @@ func TestHandleSignUp(t *testing.T) {
 			return &types.User{ID: 1, SiteAdmin: false, CreatedAt: time.Now()}, nil
 		})
 
+<<<<<<< HEAD
 		userRoles := database.NewMockUserRoleStore()
 		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, basrtuo database.BulkAssignSystemRolesToUserOpts) error {
 			if len(basrtuo.Roles) != 1 {
@@ -438,6 +438,8 @@ func TestHandleSignUp(t *testing.T) {
 			return nil
 		})
 
+=======
+>>>>>>> 4485830332 (update tests)
 		authz := database.NewMockAuthzStore()
 		authz.GrantPendingPermissionsFunc.SetDefaultReturn(nil)
 
@@ -449,7 +451,6 @@ func TestHandleSignUp(t *testing.T) {
 			return f(db)
 		})
 		db.UsersFunc.SetDefaultReturn(users)
-		db.UserRolesFunc.SetDefaultReturn(userRoles)
 		db.AuthzFunc.SetDefaultReturn(authz)
 		db.EventLogsFunc.SetDefaultReturn(eventLogs)
 
@@ -477,7 +478,6 @@ func TestHandleSignUp(t *testing.T) {
 
 		mockrequire.CalledOnce(t, authz.GrantPendingPermissionsFunc)
 		mockrequire.CalledOnce(t, users.CreateFunc)
-		mockrequire.CalledOnce(t, userRoles.BulkAssignSystemRolesToUserFunc)
 	})
 }
 
@@ -516,21 +516,6 @@ func TestHandleSiteInit(t *testing.T) {
 			return &types.User{ID: 1, SiteAdmin: true, CreatedAt: time.Now()}, nil
 		})
 
-		userRoles := database.NewMockUserRoleStore()
-		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, opts database.BulkAssignSystemRolesToUserOpts) error {
-			if len(opts.Roles) != 2 {
-				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with two system roles, got %d", len(opts.Roles))
-			}
-
-			want := []types.SystemRole{types.UserSystemRole, types.SiteAdministratorSystemRole}
-			have := opts.Roles
-			if diff := cmp.Diff(want, have); diff != "" {
-				t.Fatalf("Mismatch (-want +got):\n%s", diff)
-			}
-
-			return nil
-		})
-
 		authz := database.NewMockAuthzStore()
 		authz.GrantPendingPermissionsFunc.SetDefaultReturn(nil)
 
@@ -542,7 +527,6 @@ func TestHandleSiteInit(t *testing.T) {
 			return f(db)
 		})
 		db.UsersFunc.SetDefaultReturn(users)
-		db.UserRolesFunc.SetDefaultReturn(userRoles)
 		db.AuthzFunc.SetDefaultReturn(authz)
 		db.EventLogsFunc.SetDefaultReturn(eventLogs)
 
@@ -570,7 +554,6 @@ func TestHandleSiteInit(t *testing.T) {
 
 		mockrequire.CalledOnce(t, authz.GrantPendingPermissionsFunc)
 		mockrequire.CalledOnce(t, users.CreateFunc)
-		mockrequire.CalledOnce(t, userRoles.BulkAssignSystemRolesToUserFunc)
 		mockrequire.CalledOnce(t, eventLogs.BulkInsertFunc)
 	})
 }

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -424,22 +424,6 @@ func TestHandleSignUp(t *testing.T) {
 			return &types.User{ID: 1, SiteAdmin: false, CreatedAt: time.Now()}, nil
 		})
 
-<<<<<<< HEAD
-		userRoles := database.NewMockUserRoleStore()
-		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, basrtuo database.BulkAssignSystemRolesToUserOpts) error {
-			if len(basrtuo.Roles) != 1 {
-				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with one role, got %d", len(basrtuo.Roles))
-			}
-
-			if basrtuo.Roles[0] != types.UserSystemRole {
-				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with %s role, got %s", types.UserSystemRole, basrtuo.Roles[0])
-			}
-
-			return nil
-		})
-
-=======
->>>>>>> 4485830332 (update tests)
 		authz := database.NewMockAuthzStore()
 		authz.GrantPendingPermissionsFunc.SetDefaultReturn(nil)
 

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -193,6 +193,7 @@ func dbAddUserAction(cmd *cli.Context) error {
 			return err
 		}
 
+<<<<<<< HEAD
 		// tx.Users().SetIsSiteAdmin assigns the `SITE_ADMINISTRATOR` role to the created user, we also need to
 		// assign the `USER` role to the created user.
 		if err = tx.UserRoles().AssignSystemRole(ctx, database.AssignSystemRoleOpts{
@@ -202,6 +203,8 @@ func dbAddUserAction(cmd *cli.Context) error {
 			return err
 		}
 
+=======
+>>>>>>> 62a497ede9 (assign roles in the same transaction as user creation)
 		// Report back the new user information.
 		std.Out.WriteSuccessf(
 			// the space after the last %s is so the user can select the password easily in the shell to copy it.

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -193,18 +193,6 @@ func dbAddUserAction(cmd *cli.Context) error {
 			return err
 		}
 
-<<<<<<< HEAD
-		// tx.Users().SetIsSiteAdmin assigns the `SITE_ADMINISTRATOR` role to the created user, we also need to
-		// assign the `USER` role to the created user.
-		if err = tx.UserRoles().AssignSystemRole(ctx, database.AssignSystemRoleOpts{
-			UserID: user.ID,
-			Role:   types.UserSystemRole,
-		}); err != nil {
-			return err
-		}
-
-=======
->>>>>>> 62a497ede9 (assign roles in the same transaction as user creation)
 		// Report back the new user information.
 		std.Out.WriteSuccessf(
 			// the space after the last %s is so the user can select the password easily in the shell to copy it.

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
@@ -74,7 +74,7 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 		assert func(t *testing.T, uid int32, db database.DB)
 	}{
 		{
-			name: "user is not a side admin",
+			name: "user is not a site admin",
 			setup: func(t *testing.T) (int32, database.DB) {
 				providers.MockProviders = []providers.Provider{soap}
 				t.Cleanup(func() { providers.MockProviders = nil })
@@ -127,6 +127,12 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 
 				logger := logtest.NoOp(t)
 				db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+				// We ensure the GlobalState is initialized so that the first user isn't
+				// a site administrator.
+				_, err := db.GlobalState().EnsureInitialized(ctx)
+				require.NoError(t, err)
+
 				u, err := db.Users().Create(
 					ctx,
 					database.NewUser{
@@ -134,8 +140,10 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
+
 				err = db.Users().SetIsSiteAdmin(ctx, u.ID, true)
 				require.NoError(t, err)
+
 				return u.ID, db
 			},
 			accountDetails: &accountDetailsBody{
@@ -174,6 +182,12 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 
 				logger := logtest.NoOp(t)
 				db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+				// We ensure the GlobalState is initialized so that the first user isn't
+				// a site administrator.
+				_, err := db.GlobalState().EnsureInitialized(ctx)
+				require.NoError(t, err)
+
 				u, err := db.Users().Create(
 					ctx,
 					database.NewUser{

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -262,25 +262,6 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 		return nil, err
 	}
 
-<<<<<<< HEAD
-	// Every user on a Sourcegraph instance is assigned the `USER` role.
-	roles := []types.SystemRole{types.UserSystemRole}
-	if createdUser.SiteAdmin {
-		// if the created user is a site admin, assign them the SITE_ADMINISTRATOR role.
-		roles = append(roles, types.SiteAdministratorSystemRole)
-	}
-
-	// We use the BulkAssignSystemRolesToUser method here because in cases where the created
-	// user is also a site admin, we want to assign them both USER and SITE_ADMINISTRATOR roles.
-	if err := UserRolesWith(tx).BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
-		UserID: createdUser.ID,
-		Roles:  roles,
-	}); err != nil {
-		s.logger.Error("failed to assign system role to user", log.Error(err))
-	}
-
-=======
->>>>>>> 62a497ede9 (assign roles in the same transaction as user creation)
 	err = tx.Insert(ctx, createdUser.ID, spec, data)
 	if err == nil {
 		logAccountCreatedEvent(ctx, NewDBWith(s.logger, s), createdUser, spec.ServiceType)

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -262,6 +262,7 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 		return nil, err
 	}
 
+<<<<<<< HEAD
 	// Every user on a Sourcegraph instance is assigned the `USER` role.
 	roles := []types.SystemRole{types.UserSystemRole}
 	if createdUser.SiteAdmin {
@@ -278,6 +279,8 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 		s.logger.Error("failed to assign system role to user", log.Error(err))
 	}
 
+=======
+>>>>>>> 62a497ede9 (assign roles in the same transaction as user creation)
 	err = tx.Insert(ctx, createdUser.ID, spec, data)
 	if err == nil {
 		logAccountCreatedEvent(ctx, NewDBWith(s.logger, s), createdUser, spec.ServiceType)

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -346,7 +346,7 @@ func seedPermissionDataForList(ctx context.Context, t *testing.T, store Permissi
 	t.Helper()
 
 	perms, totalPerms := createTestPermissions(ctx, t, store)
-	user := createTestUserForUserRole(ctx, "test@test.com", "test-user-1", t, db)
+	user := createTestUserWithoutRoles(t, db, "test-user-1", false)
 	role, err := createTestRole(ctx, "TEST-ROLE", false, t, db.Roles())
 	require.NoError(t, err)
 

--- a/internal/database/roles_test.go
+++ b/internal/database/roles_test.go
@@ -62,7 +62,7 @@ func TestRoleList(t *testing.T) {
 	store := db.Roles()
 
 	roles, total := createTestRoles(ctx, t, store)
-	user := createTestUserForUserRole(ctx, "test@test.com", "test-user-1", t, db)
+	user := createTestUserWithoutRoles(t, db, "test-user-1", false)
 
 	err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{
 		RoleID: roles[0].ID,
@@ -115,6 +115,7 @@ func TestRoleList(t *testing.T) {
 			UserID: user.ID,
 		})
 		require.NoError(t, err)
+
 		require.Len(t, userRoles, 1)
 		require.Equal(t, userRoles[0].ID, roles[0].ID)
 	})
@@ -137,7 +138,7 @@ func TestRoleCount(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.Roles()
 
-	user := createTestUserForUserRole(ctx, "test@test.com", "test-user-1", t, db)
+	user := createTestUserWithoutRoles(t, db, "test-user-1", false)
 	roles, total := createTestRoles(ctx, t, store)
 
 	err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -376,6 +376,12 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser, spec 
 		InvalidatedSessionsAt: invalidatedSessionsAt,
 		Searchable:            searchable,
 	}
+
+	{
+		// Assign roles to the created user. We do this in here to ensure user creation occurs in the same transaction
+		// as role assignment. This ensures we don't have "zombie" users (users with no role assigned to them).
+	}
+
 	{
 		// Run hooks.
 		//

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -388,11 +388,10 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser, spec 
 		}
 
 		db := NewDBWith(u.logger, u)
-		_, err := db.UserRoles().BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
+		if _, err := db.UserRoles().BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
 			UserID: user.ID,
 			Roles:  roles,
-		})
-		if err != nil {
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -388,7 +388,7 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser, spec 
 		}
 
 		db := NewDBWith(u.logger, u)
-		if _, err := db.UserRoles().BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
+		if err := db.UserRoles().BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
 			UserID: user.ID,
 			Roles:  roles,
 		}); err != nil {


### PR DESCRIPTION
This is a follow-up to [this comment](https://github.com/sourcegraph/sourcegraph/pull/47406#discussion_r1106606664) on  [#47406](https://github.com/sourcegraph/sourcegraph/pull/47406). 

This ensures that we don't have `zombie` users (users without any role assigned to them) on a Sourcegraph instance.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Updated unit tests