### PR TITLE
batches: `external_fork_name` OOB migration code is enterprise

### DIFF
--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -133,6 +133,6 @@
   component: frontend-db.changesets
   description: Populate external_fork_name column for existing changesets published on Bitbucket Server and Cloud.
   non_destructive: true
-  is_enterprise: false
+  is_enterprise: true
   introduced_version_major: 4
   introduced_version_minor: 5


### PR DESCRIPTION
The OOB migration from https://github.com/sourcegraph/sourcegraph/pull/47397 was supposed to be `is_enterprise: true`, because the code is in `enterprise`. This just corrects that.

## Test plan

N/A just a migration config change.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
