### PR TITLE
rbac: implement mutation for assigning permissions to a role

### DIFF
--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -29,7 +29,7 @@ type RBACResolver interface {
 	// MUTATIONS
 	DeleteRole(ctx context.Context, args *DeleteRoleArgs) (*EmptyResponse, error)
 	CreateRole(ctx context.Context, args *CreateRoleArgs) (RoleResolver, error)
-	SyncPermissionsForRole(ctx context.Context, args SyncPermissionsForRoleArgs) (*EmptyResponse, error)
+	SetPermissions(ctx context.Context, args SetPermissionsArgs) (*EmptyResponse, error)
 
 	// QUERIES
 	Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error)
@@ -61,7 +61,7 @@ type ListPermissionArgs struct {
 	User *graphql.ID
 }
 
-type SyncPermissionsForRoleArgs struct {
+type SetPermissionsArgs struct {
 	Role        graphql.ID
 	Permissions []graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -29,6 +29,7 @@ type RBACResolver interface {
 	// MUTATIONS
 	DeleteRole(ctx context.Context, args *DeleteRoleArgs) (*EmptyResponse, error)
 	CreateRole(ctx context.Context, args *CreateRoleArgs) (RoleResolver, error)
+	AssignPermissionsToRole(ctx context.Context, args AssignPermissionToRoleArgs) (*EmptyResponse, error)
 
 	// QUERIES
 	Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error)
@@ -58,4 +59,9 @@ type ListPermissionArgs struct {
 
 	Role *graphql.ID
 	User *graphql.ID
+}
+
+type AssignPermissionToRoleArgs struct {
+	Role        graphql.ID
+	Permissions []graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -29,7 +29,7 @@ type RBACResolver interface {
 	// MUTATIONS
 	DeleteRole(ctx context.Context, args *DeleteRoleArgs) (*EmptyResponse, error)
 	CreateRole(ctx context.Context, args *CreateRoleArgs) (RoleResolver, error)
-	AssignPermissionsToRole(ctx context.Context, args AssignPermissionToRoleArgs) (*EmptyResponse, error)
+	SyncPermissionsForRole(ctx context.Context, args SyncPermissionsForRoleArgs) (*EmptyResponse, error)
 
 	// QUERIES
 	Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error)
@@ -61,7 +61,7 @@ type ListPermissionArgs struct {
 	User *graphql.ID
 }
 
-type AssignPermissionToRoleArgs struct {
+type SyncPermissionsForRoleArgs struct {
 	Role        graphql.ID
 	Permissions []graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -173,11 +173,11 @@ extend type Mutation {
     createRole(name: String!, permissions: [ID!]!): Role!
 
     """
-    Sync permissions for role. This updates the permissions assigned to a role based on the `permissions` passed
+    Set permissions for role. This updates the permissions assigned to a role based on the `permissions` passed
     in the argument. Permissions already assigned to the role that aren't part of the arguments of this mutation
     will be revoked for the role.
     """
-    syncPermissionsForRole(role: ID!, permissions: [ID!]!): EmptyResponse!
+    setPermissions(role: ID!, permissions: [ID!]!): EmptyResponse!
 }
 
 extend type User {

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -171,6 +171,11 @@ extend type Mutation {
     Creates a role.
     """
     createRole(name: String!, permissions: [ID!]!): Role!
+
+    """
+    Assign permissions to a role.
+    """
+    assignPermissionsToRole(role: ID!, permissions: [ID!]!): EmptyResponse!
 }
 
 extend type User {

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -173,9 +173,11 @@ extend type Mutation {
     createRole(name: String!, permissions: [ID!]!): Role!
 
     """
-    Assign permissions to a role.
+    Sync permissions for role. This updates the permissions assigned to a role based on the `permissions` passed
+    in the argument. Permissions already assigned to the role that aren't part of the arguments of this mutation
+    will be revoked for the role.
     """
-    assignPermissionsToRole(role: ID!, permissions: [ID!]!): EmptyResponse!
+    syncPermissionsForRole(role: ID!, permissions: [ID!]!): EmptyResponse!
 }
 
 extend type User {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -98,10 +98,6 @@ func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignP
 		return nil, err
 	}
 
-	if len(args.Permissions) == 0 {
-		return nil, errors.New("permissions are required")
-	}
-
 	roleID, err := unmarshalRoleID(args.Role)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -99,7 +99,7 @@ func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignP
 	}
 
 	if len(args.Permissions) == 0 {
-		return nil, errors.New("permissions is required")
+		return nil, errors.New("permissions are required")
 	}
 
 	roleID, err := unmarshalRoleID(args.Role)

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -107,8 +107,9 @@ func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignP
 		return nil, err
 	}
 
-	opts := database.BulkAssignPermissionsToRoleOpts{}
-	opts.RoleID = roleID
+	opts := database.SyncPermissionsToRoleOpts{
+		RoleID: roleID,
+	}
 
 	for _, p := range args.Permissions {
 		pID, err := unmarshalPermissionID(p)
@@ -118,7 +119,7 @@ func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignP
 		opts.Permissions = append(opts.Permissions, pID)
 	}
 
-	if _, err = r.db.RolePermissions().BulkAssignPermissionsToRole(ctx, opts); err != nil {
+	if err = r.db.RolePermissions().SyncPermissionsToRole(ctx, opts); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -91,3 +91,36 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 		},
 	)
 }
+
+func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignPermissionToRoleArgs) (*gql.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site administrators can assign a permission to a role.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	if len(args.Permissions) == 0 {
+		return nil, errors.New("permissions is required")
+	}
+
+	roleID, err := unmarshalRoleID(args.Role)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := database.BulkAssignPermissionsToRoleOpts{}
+	opts.RoleID = roleID
+
+	for _, p := range args.Permissions {
+		pID, err := unmarshalPermissionID(p)
+		if err != nil {
+			return nil, err
+		}
+		opts.Permissions = append(opts.Permissions, pID)
+	}
+
+	if _, err = r.db.RolePermissions().BulkAssignPermissionsToRole(ctx, opts); err != nil {
+		return nil, err
+	}
+
+	return &gql.EmptyResponse{}, nil
+}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -92,7 +92,7 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 	)
 }
 
-func (r *Resolver) SyncPermissionsForRole(ctx context.Context, args gql.SyncPermissionsForRoleArgs) (*gql.EmptyResponse, error) {
+func (r *Resolver) SetPermissions(ctx context.Context, args gql.SetPermissionsArgs) (*gql.EmptyResponse, error) {
 	// 🚨 SECURITY: Only site administrators can sync permissions for a role.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -93,7 +93,7 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 }
 
 func (r *Resolver) SetPermissions(ctx context.Context, args gql.SetPermissionsArgs) (*gql.EmptyResponse, error) {
-	// 🚨 SECURITY: Only site administrators can sync permissions for a role.
+	// 🚨 SECURITY: Only site administrators can set permissions for a role.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -92,8 +92,8 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 	)
 }
 
-func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignPermissionToRoleArgs) (*gql.EmptyResponse, error) {
-	// 🚨 SECURITY: Only site administrators can assign a permission to a role.
+func (r *Resolver) SyncPermissionsForRole(ctx context.Context, args gql.SyncPermissionsForRoleArgs) (*gql.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site administrators can sync permissions for a role.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
@@ -306,9 +306,11 @@ func TestAssignPermissionsToRole(t *testing.T) {
 	t.Run("as site-admin", func(t *testing.T) {
 		input := map[string]any{"role": roleID, "permissions": permissionIDs}
 		var response struct{ Permissions apitest.EmptyResponse }
-		errs := apitest.Exec(adminCtx, t, s, input, &response, assignPermissionsToRoleQuery)
+		apitest.MustExec(adminCtx, t, s, input, &response, assignPermissionsToRoleQuery)
 
-		require.Len(t, errs, 0)
+		rps, err := db.RolePermissions().GetByRoleID(ctx, database.GetRolePermissionOpts{RoleID: r.ID})
+		require.NoError(t, err)
+		require.Equal(t, rps, len(ps))
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
@@ -297,7 +297,7 @@ func TestAssignPermissionsToRole(t *testing.T) {
 	t.Run("as non-site-admin", func(t *testing.T) {
 		input := map[string]any{"role": roleID, "permissions": permissionIDs}
 		var response struct{ Permissions apitest.EmptyResponse }
-		errs := apitest.Exec(userCtx, t, s, input, &response, queryPermissionConnection)
+		errs := apitest.Exec(userCtx, t, s, input, &response, assignPermissionsToRoleQuery)
 
 		require.Len(t, errs, 1)
 		require.ErrorContains(t, errs[0], "must be site admin")
@@ -306,14 +306,14 @@ func TestAssignPermissionsToRole(t *testing.T) {
 	t.Run("as site-admin", func(t *testing.T) {
 		input := map[string]any{"role": roleID, "permissions": permissionIDs}
 		var response struct{ Permissions apitest.EmptyResponse }
-		errs := apitest.Exec(adminCtx, t, s, input, &response, queryPermissionConnection)
+		errs := apitest.Exec(adminCtx, t, s, input, &response, assignPermissionsToRoleQuery)
 
 		require.Len(t, errs, 0)
 	})
 }
 
 const assignPermissionsToRoleQuery = `
-mutation($role: ID!, $permissions: ID!) {
+mutation($role: ID!, $permissions: [ID!]!) {
 	assignPermissionsToRole(role: $role, permissions: $permissions) {
 		alwaysNil
 	}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Resolver is the GraphQL resolver of all things related to batch changes.
@@ -32,37 +30,4 @@ func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
 			return r.permissionByID(ctx, id)
 		},
 	}
-}
-
-func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignPermissionToRoleArgs) (*gql.EmptyResponse, error) {
-	// 🚨 SECURITY: Only site administrators can assign a permission to a role.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
-	}
-
-	if len(args.Permissions) == 0 {
-		return nil, errors.New("permissions is required")
-	}
-
-	roleID, err := unmarshalRoleID(args.Role)
-	if err != nil {
-		return nil, err
-	}
-
-	opts := database.BulkAssignPermissionsToRoleOpts{}
-	opts.RoleID = roleID
-
-	for _, p := range args.Permissions {
-		pID, err := unmarshalPermissionID(p)
-		if err != nil {
-			return nil, err
-		}
-		opts.Permissions = append(opts.Permissions, pID)
-	}
-
-	if _, err = r.db.RolePermissions().BulkAssignPermissionsToRole(ctx, opts); err != nil {
-		return nil, err
-	}
-
-	return &gql.EmptyResponse{}, nil
 }

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Resolver is the GraphQL resolver of all things related to batch changes.
@@ -30,4 +32,37 @@ func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
 			return r.permissionByID(ctx, id)
 		},
 	}
+}
+
+func (r *Resolver) AssignPermissionsToRole(ctx context.Context, args gql.AssignPermissionToRoleArgs) (*gql.EmptyResponse, error) {
+	// 🚨 SECURITY: Only site administrators can assign a permission to a role.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	if len(args.Permissions) == 0 {
+		return nil, errors.New("permissions is required")
+	}
+
+	roleID, err := unmarshalRoleID(args.Role)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := database.BulkAssignPermissionsToRoleOpts{}
+	opts.RoleID = roleID
+
+	for _, p := range args.Permissions {
+		pID, err := unmarshalPermissionID(p)
+		if err != nil {
+			return nil, err
+		}
+		opts.Permissions = append(opts.Permissions, pID)
+	}
+
+	if _, err = r.db.RolePermissions().BulkAssignPermissionsToRole(ctx, opts); err != nil {
+		return nil, err
+	}
+
+	return &gql.EmptyResponse{}, nil
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -42703,7 +42703,11 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 			},
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
+<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
+=======
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 []*types.RolePermission, r1 error) {
+>>>>>>> 0d99fa2106 (update mock db funcs)
 				return
 			},
 		},
@@ -42766,7 +42770,11 @@ func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 			},
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
+<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+=======
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
+>>>>>>> 0d99fa2106 (update mock db funcs)
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToRole")
 			},
 		},
@@ -43072,24 +43080,40 @@ func (c RolePermissionStoreAssignToSystemRoleFuncCall) Results() []interface{} {
 // when the BulkAssignPermissionsToRole method of the parent
 // MockRolePermissionStore instance is invoked.
 type RolePermissionStoreBulkAssignPermissionsToRoleFunc struct {
+<<<<<<< HEAD
 	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
 	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
+=======
+	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
+	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
+>>>>>>> 0d99fa2106 (update mock db funcs)
 	history     []RolePermissionStoreBulkAssignPermissionsToRoleFuncCall
 	mutex       sync.Mutex
 }
 
 // BulkAssignPermissionsToRole delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
+<<<<<<< HEAD
 func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) error {
 	r0 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
 	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0})
 	return r0
+=======
+func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
+	r0, r1 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
+	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0, r1})
+	return r0, r1
+>>>>>>> 0d99fa2106 (update mock db funcs)
 }
 
 // SetDefaultHook sets function that is called when the
 // BulkAssignPermissionsToRole method of the parent MockRolePermissionStore
 // instance is invoked and the hook queue is empty.
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
+>>>>>>> 0d99fa2106 (update mock db funcs)
 	f.defaultHook = hook
 }
 
@@ -43098,7 +43122,11 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
+>>>>>>> 0d99fa2106 (update mock db funcs)
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -43106,13 +43134,20 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
 		return r0
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 []*types.RolePermission, r1 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
+		return r0, r1
+>>>>>>> 0d99fa2106 (update mock db funcs)
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
 		return r0
@@ -43120,6 +43155,15 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error
 }
 
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 []*types.RolePermission, r1 error) {
+	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
+		return r0, r1
+	})
+}
+
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
+>>>>>>> 0d99fa2106 (update mock db funcs)
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -43162,7 +43206,14 @@ type RolePermissionStoreBulkAssignPermissionsToRoleFuncCall struct {
 	Arg1 BulkAssignPermissionsToRoleOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
+<<<<<<< HEAD
 	Result0 error
+=======
+	Result0 []*types.RolePermission
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+>>>>>>> 0d99fa2106 (update mock db funcs)
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -43174,7 +43225,11 @@ func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Args() []interfa
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Results() []interface{} {
+<<<<<<< HEAD
 	return []interface{}{c.Result0}
+=======
+	return []interface{}{c.Result0, c.Result1}
+>>>>>>> 0d99fa2106 (update mock db funcs)
 }
 
 // RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc describes the

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -42663,6 +42663,10 @@ type MockRolePermissionStore struct {
 	// function object controlling the behavior of the method
 	// BulkAssignPermissionsToSystemRoles.
 	BulkAssignPermissionsToSystemRolesFunc *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc
+	// BulkRevokePermissionsForRoleFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// BulkRevokePermissionsForRole.
+	BulkRevokePermissionsForRoleFunc *RolePermissionStoreBulkRevokePermissionsForRoleFunc
 	// GetByPermissionIDFunc is an instance of a mock function object
 	// controlling the behavior of the method GetByPermissionID.
 	GetByPermissionIDFunc *RolePermissionStoreGetByPermissionIDFunc
@@ -42679,6 +42683,9 @@ type MockRolePermissionStore struct {
 	// RevokeFunc is an instance of a mock function object controlling the
 	// behavior of the method Revoke.
 	RevokeFunc *RolePermissionStoreRevokeFunc
+	// SyncPermissionsToRoleFunc is an instance of a mock function object
+	// controlling the behavior of the method SyncPermissionsToRole.
+	SyncPermissionsToRoleFunc *RolePermissionStoreSyncPermissionsToRoleFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *RolePermissionStoreWithFunc
@@ -42704,15 +42711,24 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
 <<<<<<< HEAD
+<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
 =======
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 []*types.RolePermission, r1 error) {
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
+>>>>>>> 3310ac74b6 (add sync permissions method)
 				return
 			},
 		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
 			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) (r0 error) {
+				return
+			},
+		},
+		BulkRevokePermissionsForRoleFunc: &RolePermissionStoreBulkRevokePermissionsForRoleFunc{
+			defaultHook: func(context.Context, BulkRevokePermissionsForRoleOpts) (r0 error) {
 				return
 			},
 		},
@@ -42738,6 +42754,11 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 		},
 		RevokeFunc: &RolePermissionStoreRevokeFunc{
 			defaultHook: func(context.Context, RevokeRolePermissionOpts) (r0 error) {
+				return
+			},
+		},
+		SyncPermissionsToRoleFunc: &RolePermissionStoreSyncPermissionsToRoleFunc{
+			defaultHook: func(context.Context, SyncPermissionsToRoleOpts) (r0 error) {
 				return
 			},
 		},
@@ -42771,16 +42792,25 @@ func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
 <<<<<<< HEAD
+<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
 =======
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+>>>>>>> 3310ac74b6 (add sync permissions method)
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToRole")
 			},
 		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
 			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToSystemRoles")
+			},
+		},
+		BulkRevokePermissionsForRoleFunc: &RolePermissionStoreBulkRevokePermissionsForRoleFunc{
+			defaultHook: func(context.Context, BulkRevokePermissionsForRoleOpts) error {
+				panic("unexpected invocation of MockRolePermissionStore.BulkRevokePermissionsForRole")
 			},
 		},
 		GetByPermissionIDFunc: &RolePermissionStoreGetByPermissionIDFunc{
@@ -42806,6 +42836,11 @@ func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 		RevokeFunc: &RolePermissionStoreRevokeFunc{
 			defaultHook: func(context.Context, RevokeRolePermissionOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.Revoke")
+			},
+		},
+		SyncPermissionsToRoleFunc: &RolePermissionStoreSyncPermissionsToRoleFunc{
+			defaultHook: func(context.Context, SyncPermissionsToRoleOpts) error {
+				panic("unexpected invocation of MockRolePermissionStore.SyncPermissionsToRole")
 			},
 		},
 		WithFunc: &RolePermissionStoreWithFunc{
@@ -42838,6 +42873,9 @@ func NewMockRolePermissionStoreFrom(i RolePermissionStore) *MockRolePermissionSt
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
 			defaultHook: i.BulkAssignPermissionsToSystemRoles,
 		},
+		BulkRevokePermissionsForRoleFunc: &RolePermissionStoreBulkRevokePermissionsForRoleFunc{
+			defaultHook: i.BulkRevokePermissionsForRole,
+		},
 		GetByPermissionIDFunc: &RolePermissionStoreGetByPermissionIDFunc{
 			defaultHook: i.GetByPermissionID,
 		},
@@ -42852,6 +42890,9 @@ func NewMockRolePermissionStoreFrom(i RolePermissionStore) *MockRolePermissionSt
 		},
 		RevokeFunc: &RolePermissionStoreRevokeFunc{
 			defaultHook: i.Revoke,
+		},
+		SyncPermissionsToRoleFunc: &RolePermissionStoreSyncPermissionsToRoleFunc{
+			defaultHook: i.SyncPermissionsToRole,
 		},
 		WithFunc: &RolePermissionStoreWithFunc{
 			defaultHook: i.With,
@@ -43081,12 +43122,17 @@ func (c RolePermissionStoreAssignToSystemRoleFuncCall) Results() []interface{} {
 // MockRolePermissionStore instance is invoked.
 type RolePermissionStoreBulkAssignPermissionsToRoleFunc struct {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
 	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
 =======
 	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
 	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
+	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
+>>>>>>> 3310ac74b6 (add sync permissions method)
 	history     []RolePermissionStoreBulkAssignPermissionsToRoleFuncCall
 	mutex       sync.Mutex
 }
@@ -43094,26 +43140,36 @@ type RolePermissionStoreBulkAssignPermissionsToRoleFunc struct {
 // BulkAssignPermissionsToRole delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 3310ac74b6 (add sync permissions method)
 func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) error {
 	r0 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
 	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0})
 	return r0
+<<<<<<< HEAD
 =======
 func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
 	r0, r1 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
 	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0, r1})
 	return r0, r1
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+>>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // SetDefaultHook sets function that is called when the
 // BulkAssignPermissionsToRole method of the parent MockRolePermissionStore
 // instance is invoked and the hook queue is empty.
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
 =======
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+>>>>>>> 3310ac74b6 (add sync permissions method)
 	f.defaultHook = hook
 }
 
@@ -43123,10 +43179,14 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook
 // After the queue is empty, the default hook function is invoked for any
 // future action.
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
 =======
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+>>>>>>> 3310ac74b6 (add sync permissions method)
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -43134,6 +43194,7 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
+<<<<<<< HEAD
 <<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
@@ -43143,10 +43204,16 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0
 	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
 		return r0, r1
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+		return r0
+>>>>>>> 3310ac74b6 (add sync permissions method)
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
+<<<<<<< HEAD
 <<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
@@ -43164,6 +43231,15 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 []*ty
 
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+		return r0
+	})
+}
+
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+>>>>>>> 3310ac74b6 (add sync permissions method)
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -43207,6 +43283,7 @@ type RolePermissionStoreBulkAssignPermissionsToRoleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 <<<<<<< HEAD
+<<<<<<< HEAD
 	Result0 error
 =======
 	Result0 []*types.RolePermission
@@ -43214,6 +43291,9 @@ type RolePermissionStoreBulkAssignPermissionsToRoleFuncCall struct {
 	// invocation.
 	Result1 error
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+	Result0 error
+>>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -43226,10 +43306,14 @@ func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Args() []interfa
 // invocation.
 func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Results() []interface{} {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	return []interface{}{c.Result0}
 =======
 	return []interface{}{c.Result0, c.Result1}
 >>>>>>> 0d99fa2106 (update mock db funcs)
+=======
+	return []interface{}{c.Result0}
+>>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc describes the
@@ -43339,6 +43423,115 @@ func (c RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall) Args() []
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RolePermissionStoreBulkRevokePermissionsForRoleFunc describes the
+// behavior when the BulkRevokePermissionsForRole method of the parent
+// MockRolePermissionStore instance is invoked.
+type RolePermissionStoreBulkRevokePermissionsForRoleFunc struct {
+	defaultHook func(context.Context, BulkRevokePermissionsForRoleOpts) error
+	hooks       []func(context.Context, BulkRevokePermissionsForRoleOpts) error
+	history     []RolePermissionStoreBulkRevokePermissionsForRoleFuncCall
+	mutex       sync.Mutex
+}
+
+// BulkRevokePermissionsForRole delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockRolePermissionStore) BulkRevokePermissionsForRole(v0 context.Context, v1 BulkRevokePermissionsForRoleOpts) error {
+	r0 := m.BulkRevokePermissionsForRoleFunc.nextHook()(v0, v1)
+	m.BulkRevokePermissionsForRoleFunc.appendCall(RolePermissionStoreBulkRevokePermissionsForRoleFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// BulkRevokePermissionsForRole method of the parent MockRolePermissionStore
+// instance is invoked and the hook queue is empty.
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) SetDefaultHook(hook func(context.Context, BulkRevokePermissionsForRoleOpts) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// BulkRevokePermissionsForRole method of the parent MockRolePermissionStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) PushHook(hook func(context.Context, BulkRevokePermissionsForRoleOpts) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkRevokePermissionsForRoleOpts) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkRevokePermissionsForRoleOpts) error {
+		return r0
+	})
+}
+
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) nextHook() func(context.Context, BulkRevokePermissionsForRoleOpts) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) appendCall(r0 RolePermissionStoreBulkRevokePermissionsForRoleFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RolePermissionStoreBulkRevokePermissionsForRoleFuncCall objects
+// describing the invocations of this function.
+func (f *RolePermissionStoreBulkRevokePermissionsForRoleFunc) History() []RolePermissionStoreBulkRevokePermissionsForRoleFuncCall {
+	f.mutex.Lock()
+	history := make([]RolePermissionStoreBulkRevokePermissionsForRoleFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RolePermissionStoreBulkRevokePermissionsForRoleFuncCall is an object that
+// describes an invocation of method BulkRevokePermissionsForRole on an
+// instance of MockRolePermissionStore.
+type RolePermissionStoreBulkRevokePermissionsForRoleFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 BulkRevokePermissionsForRoleOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RolePermissionStoreBulkRevokePermissionsForRoleFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RolePermissionStoreBulkRevokePermissionsForRoleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -43877,6 +44070,115 @@ func (c RolePermissionStoreRevokeFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreRevokeFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RolePermissionStoreSyncPermissionsToRoleFunc describes the behavior when
+// the SyncPermissionsToRole method of the parent MockRolePermissionStore
+// instance is invoked.
+type RolePermissionStoreSyncPermissionsToRoleFunc struct {
+	defaultHook func(context.Context, SyncPermissionsToRoleOpts) error
+	hooks       []func(context.Context, SyncPermissionsToRoleOpts) error
+	history     []RolePermissionStoreSyncPermissionsToRoleFuncCall
+	mutex       sync.Mutex
+}
+
+// SyncPermissionsToRole delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockRolePermissionStore) SyncPermissionsToRole(v0 context.Context, v1 SyncPermissionsToRoleOpts) error {
+	r0 := m.SyncPermissionsToRoleFunc.nextHook()(v0, v1)
+	m.SyncPermissionsToRoleFunc.appendCall(RolePermissionStoreSyncPermissionsToRoleFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// SyncPermissionsToRole method of the parent MockRolePermissionStore
+// instance is invoked and the hook queue is empty.
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, SyncPermissionsToRoleOpts) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SyncPermissionsToRole method of the parent MockRolePermissionStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) PushHook(hook func(context.Context, SyncPermissionsToRoleOpts) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, SyncPermissionsToRoleOpts) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, SyncPermissionsToRoleOpts) error {
+		return r0
+	})
+}
+
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) nextHook() func(context.Context, SyncPermissionsToRoleOpts) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) appendCall(r0 RolePermissionStoreSyncPermissionsToRoleFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RolePermissionStoreSyncPermissionsToRoleFuncCall objects describing the
+// invocations of this function.
+func (f *RolePermissionStoreSyncPermissionsToRoleFunc) History() []RolePermissionStoreSyncPermissionsToRoleFuncCall {
+	f.mutex.Lock()
+	history := make([]RolePermissionStoreSyncPermissionsToRoleFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RolePermissionStoreSyncPermissionsToRoleFuncCall is an object that
+// describes an invocation of method SyncPermissionsToRole on an instance of
+// MockRolePermissionStore.
+type RolePermissionStoreSyncPermissionsToRoleFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 SyncPermissionsToRoleOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RolePermissionStoreSyncPermissionsToRoleFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RolePermissionStoreSyncPermissionsToRoleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -42710,15 +42710,7 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 			},
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
-<<<<<<< HEAD
-<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
-=======
-			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 []*types.RolePermission, r1 error) {
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
->>>>>>> 3310ac74b6 (add sync permissions method)
 				return
 			},
 		},
@@ -42791,15 +42783,7 @@ func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 			},
 		},
 		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
-<<<<<<< HEAD
-<<<<<<< HEAD
 			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
-=======
-			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
->>>>>>> 3310ac74b6 (add sync permissions method)
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToRole")
 			},
 		},
@@ -43121,55 +43105,24 @@ func (c RolePermissionStoreAssignToSystemRoleFuncCall) Results() []interface{} {
 // when the BulkAssignPermissionsToRole method of the parent
 // MockRolePermissionStore instance is invoked.
 type RolePermissionStoreBulkAssignPermissionsToRoleFunc struct {
-<<<<<<< HEAD
-<<<<<<< HEAD
 	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
 	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
-=======
-	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
-	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
-	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
->>>>>>> 3310ac74b6 (add sync permissions method)
 	history     []RolePermissionStoreBulkAssignPermissionsToRoleFuncCall
 	mutex       sync.Mutex
 }
 
 // BulkAssignPermissionsToRole delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 3310ac74b6 (add sync permissions method)
 func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) error {
 	r0 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
 	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0})
 	return r0
-<<<<<<< HEAD
-=======
-func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
-	r0, r1 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
-	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0, r1})
-	return r0, r1
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
->>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // SetDefaultHook sets function that is called when the
 // BulkAssignPermissionsToRole method of the parent MockRolePermissionStore
 // instance is invoked and the hook queue is empty.
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
->>>>>>> 3310ac74b6 (add sync permissions method)
 	f.defaultHook = hook
 }
 
@@ -43178,15 +43131,7 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error)) {
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
->>>>>>> 3310ac74b6 (add sync permissions method)
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -43194,27 +43139,13 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
 		return r0
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 []*types.RolePermission, r1 error) {
-	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
-		return r0, r1
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
-		return r0
->>>>>>> 3310ac74b6 (add sync permissions method)
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
 		return r0
@@ -43222,24 +43153,6 @@ func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error
 }
 
 func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) error {
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 []*types.RolePermission, r1 error) {
-	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
-		return r0, r1
-	})
-}
-
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) ([]*types.RolePermission, error) {
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
-		return r0
-	})
-}
-
-func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) error {
->>>>>>> 3310ac74b6 (add sync permissions method)
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -43282,18 +43195,7 @@ type RolePermissionStoreBulkAssignPermissionsToRoleFuncCall struct {
 	Arg1 BulkAssignPermissionsToRoleOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-<<<<<<< HEAD
-<<<<<<< HEAD
 	Result0 error
-=======
-	Result0 []*types.RolePermission
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-	Result0 error
->>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -43305,15 +43207,7 @@ func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Args() []interfa
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Results() []interface{} {
-<<<<<<< HEAD
-<<<<<<< HEAD
 	return []interface{}{c.Result0}
-=======
-	return []interface{}{c.Result0, c.Result1}
->>>>>>> 0d99fa2106 (update mock db funcs)
-=======
-	return []interface{}{c.Result0}
->>>>>>> 3310ac74b6 (add sync permissions method)
 }
 
 // RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc describes the

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -298,7 +298,7 @@ func TestRolePermissionGetByPermissionID(t *testing.T) {
 	})
 }
 
-func TestRolePermissionDelete(t *testing.T) {
+func TestRolePermissionRevoke(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -421,13 +421,6 @@ func TestBulkRevokePermissionsForRole(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.RolePermissions()
 
-	numberOfPerms := 4
-	var perms []int32
-	for i := 0; i < numberOfPerms; i++ {
-		perm := createTestPermissionForRolePermission(ctx, fmt.Sprintf("READ-%d", i), t, db)
-		perms = append(perms, perm.ID)
-	}
-
 	role, permission := createRoleAndPermission(ctx, t, db)
 	permissionTwo := createTestPermissionForRolePermission(ctx, "READ-1-2", t, db)
 

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
@@ -458,6 +459,86 @@ func TestBulkRevokePermissionsForRole(t *testing.T) {
 		rps, err := store.GetByRoleID(ctx, GetRolePermissionOpts{RoleID: role.ID})
 		require.NoError(t, err)
 		require.Len(t, rps, 0)
+	})
+}
+
+func TestSyncPermissionsToRole(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	role := createTestRoleForRolePermission(ctx, "TEST-ROLE-1", t, db)
+	role2 := createTestRoleForRolePermission(ctx, "TEST-ROLE-2", t, db)
+	role3 := createTestRoleForRolePermission(ctx, "TEST-ROLE-3", t, db)
+
+	permissionOne := createTestPermissionForRolePermission(ctx, "READ-1-1", t, db)
+	permissionTwo := createTestPermissionForRolePermission(ctx, "READ-1-2", t, db)
+
+	err := store.BulkAssignPermissionsToRole(ctx, BulkAssignPermissionsToRoleOpts{
+		RoleID:      role.ID,
+		Permissions: []int32{permissionOne.ID},
+	})
+	require.NoError(t, err)
+
+	err = store.BulkAssignPermissionsToRole(ctx, BulkAssignPermissionsToRoleOpts{
+		RoleID:      role2.ID,
+		Permissions: []int32{permissionOne.ID},
+	})
+	require.NoError(t, err)
+
+	t.Run("without role id", func(t *testing.T) {
+		err := store.SyncPermissionsToRole(ctx, SyncPermissionsToRoleOpts{})
+		require.ErrorContains(t, err, "missing role id")
+	})
+
+	t.Run("revoke only", func(t *testing.T) {
+		err := store.SyncPermissionsToRole(ctx, SyncPermissionsToRoleOpts{
+			RoleID:      role.ID,
+			Permissions: []int32{},
+		})
+		require.NoError(t, err)
+
+		rps, err := store.GetByRoleID(ctx, GetRolePermissionOpts{RoleID: role.ID})
+		require.NoError(t, err)
+		require.Len(t, rps, 0)
+	})
+
+	t.Run("assign and revoke", func(t *testing.T) {
+		err := store.SyncPermissionsToRole(ctx, SyncPermissionsToRoleOpts{
+			RoleID:      role2.ID,
+			Permissions: []int32{permissionTwo.ID},
+		})
+		require.NoError(t, err)
+
+		rps, err := store.GetByRoleID(ctx, GetRolePermissionOpts{RoleID: role2.ID})
+		require.NoError(t, err)
+		require.Len(t, rps, 1)
+		require.Equal(t, rps[0].RoleID, role2.ID)
+		require.Equal(t, rps[0].PermissionID, permissionTwo.ID)
+	})
+
+	t.Run("assign only", func(t *testing.T) {
+		permissions := []int32{permissionOne.ID, permissionTwo.ID}
+		err := store.SyncPermissionsToRole(ctx, SyncPermissionsToRoleOpts{
+			RoleID:      role3.ID,
+			Permissions: permissions,
+		})
+		require.NoError(t, err)
+
+		rps, err := store.GetByRoleID(ctx, GetRolePermissionOpts{RoleID: role3.ID})
+		require.NoError(t, err)
+		require.Len(t, rps, 2)
+
+		sort.Slice(rps, func(i, j int) bool {
+			return rps[i].PermissionID < rps[j].PermissionID
+		})
+		for index, rp := range rps {
+			require.Equal(t, rp.RoleID, role3.ID)
+			require.Equal(t, rp.PermissionID, permissions[index])
+		}
 	})
 }
 


### PR DESCRIPTION
Closes #45444
This PR implements a mutation that allows assigning multiple permissions to a role.

Following Kelli's amazing suggestion, I named the mutation `SyncPermissionsForRole` so it's descriptive of what it does.

> Mutation assignPermissionsToRole takes a role ID! and a list of permissions [ID]!. This is the same as you have it, except the only difference is we allow permissions to be an empty list, too.
Resolver does all the unmarshaling business, then calls store method SyncPermissionsToRole(ctx, opts)
SyncPermissionsToRole has the exact same signature as your BulkAssignPermissionsToRole, but its implementation is as follows:
It looks up the current set of role_permissions for the role
It determines based on opts.Permissions which role_permissions it needs to add, which can stay, and which it needs to delete
It performs the insertions/deletions and returns the resultant complete set of role_permissions
This would allow us in the frontend to just directly call the mutation with the set of checked permissions any time the admin makes changes, rather than needing to perform comparisons on the frontend and split the work into two mutations to assign and delete.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing
* Add unit tests