### PR TITLE
Code Insights: Make insight live preview cancellable

### DIFF
--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-compute-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-compute-insight.ts
@@ -17,7 +17,7 @@ export interface Props {
 
 interface Result<R> {
     state: State<ComputeDatum[]>
-    refetch: () => {}
+    refetch: () => unknown
 }
 
 /**

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-compute-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-compute-insight.ts
@@ -1,7 +1,7 @@
 import { groupBy } from 'lodash'
 
 import { GroupByField } from '@sourcegraph/shared/src/graphql-operations'
-import { Series } from '@sourcegraph/wildcard'
+import { Series, useDeepMemo } from '@sourcegraph/wildcard'
 
 import { LivePreviewStatus, State } from './types'
 import { Datum, SeriesWithStroke, useLivePreviewSeriesInsight } from './use-live-preview-series-insight'
@@ -33,7 +33,7 @@ interface Result<R> {
 export function useLivePreviewComputeInsight(props: Props): Result<ComputeDatum[]> {
     const { skip, repositories, series, groupBy } = props
 
-    const { state, refetch } = useLivePreviewSeriesInsight({
+    const settings = useDeepMemo({
         skip,
         repoScope: { repositories },
         series: series.map(srs => ({
@@ -45,6 +45,8 @@ export function useLivePreviewComputeInsight(props: Props): Result<ComputeDatum[
         //  for `searchInsightPreview`
         step: { days: 1 },
     })
+
+    const { state, refetch } = useLivePreviewSeriesInsight(settings)
 
     // Post process data from series insight preview since compute is based
     // on series live preview handler

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -1,7 +1,8 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
-import { ApolloError, gql, useQuery } from '@apollo/client'
+import { ApolloError, gql, useApolloClient } from '@apollo/client'
 import { Duration } from 'date-fns'
+import { noop } from 'lodash'
 
 import { HTTPStatusError } from '@sourcegraph/http-client'
 import { RepositoryScopeInput } from '@sourcegraph/shared/src/graphql-operations'
@@ -44,7 +45,14 @@ interface Props {
 
 interface Result<R> {
     state: State<R>
-    refetch: () => {}
+    refetch: () => unknown
+}
+
+interface QueryResult {
+    loading: boolean
+    data?: GetInsightPreviewResult
+    error?: ApolloError
+    refetch: () => unknown
 }
 
 /**
@@ -58,10 +66,36 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
     const { skip, repoScope, step, series } = props
     const [unit, value] = getStepInterval(step)
 
-    const { data, loading, error, refetch } = useQuery<GetInsightPreviewResult, GetInsightPreviewVariables>(
-        GET_INSIGHT_PREVIEW_GQL,
-        {
-            skip,
+    const client = useApolloClient()
+    const [{ data, loading, error, refetch }, setResult] = useState<QueryResult>({
+        data: undefined,
+        loading: true,
+        error: undefined,
+        refetch: noop,
+    })
+
+    useEffect(() => {
+        // Reset internal query result state if we run query again
+        setResult({
+            loading: !skip,
+            data: undefined,
+            error: undefined,
+            refetch: noop,
+        })
+
+        if (skip) {
+            return
+        }
+
+        // We have to work with apollo client directly since use query hook doesn't
+        // cancel request automatically, there is a long conversation about it here
+        // https://github.com/apollographql/apollo-client/issues/8858
+        //
+        // In the future we could write our own link to work with useQuery but cancel
+        // all request from previously calls, for now since watchQuery supports unsubscribe
+        // we use it instead of generic solution.
+        const query = client.watchQuery<GetInsightPreviewResult, GetInsightPreviewVariables>({
+            query: GET_INSIGHT_PREVIEW_GQL,
             variables: {
                 input: {
                     series: series.map(srs => ({
@@ -74,8 +108,17 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
                     timeScope: { stepInterval: { unit, value: +value } },
                 },
             },
-        }
-    )
+        })
+
+        const subscription = query.subscribe(event =>
+            setResult({
+                ...event,
+                refetch: () => query.refetch(),
+            })
+        )
+
+        return () => subscription.unsubscribe()
+    }, [client, repoScope, series, skip, unit, value])
 
     const parsedSeries = useMemo(() => {
         if (data) {

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -173,7 +173,11 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                 <hr aria-hidden={true} className="my-4 w-100" />
 
                 <FormGroup name="map result" title="Map result">
-                    <ComputeInsightMapPicker series={validSeries} {...groupBy.input} />
+                    <ComputeInsightMapPicker
+                        series={validSeries}
+                        value={groupBy.input.value}
+                        onChange={groupBy.input.onChange}
+                    />
                 </FormGroup>
 
                 <hr aria-hidden={true} className="my-4 w-100" />

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightMapPicker.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightMapPicker.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, useEffect, useMemo } from 'react'
+import { FC, MouseEvent, useEffect, useMemo, forwardRef } from 'react'
 
 import { FilterType, resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
@@ -94,12 +94,12 @@ interface OptionButtonProps extends ButtonProps {
     active?: boolean
 }
 
-const OptionButton: FC<OptionButtonProps> = props => {
+const OptionButton = forwardRef<HTMLButtonElement, OptionButtonProps>((props, reference) => {
     const { children, active, value, ...attributes } = props
 
     return (
-        <Button {...attributes} variant="secondary" outline={!active} value={value}>
+        <Button ref={reference} {...attributes} variant="secondary" outline={!active} value={value}>
             {children}
         </Button>
     )
-}
+})


### PR DESCRIPTION
Prior to this PR our live preview run all time when we changed something in the creation UI and didn't cancel the previous still on-going request, in this PR we cancel all prev request and run only the latest query for the live preview

Related issue about more generic approach for this https://github.com/sourcegraph/sourcegraph/issues/47706

## Test plan
- Run live preview
- Change anything in the creation UI that effects live preview (like query)
- See that the prev request is canceled 
- Check that refresh preview button works
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-make-insight-preview-cancelable.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
