### PR TITLE
Fix search aggregation mode auto detection

### DIFF
--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -5,14 +5,14 @@ import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { eventLogger } from '../tracking/eventLogger'
 
-import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results/components/aggregation/constants'
+import { AGGREGATION_UI_MODE_URL_KEY } from './results/components/aggregation/constants'
 
 /**
  * By default {@link submitSearch} overrides all existing query parameters.
  * This breaks all functionality that is built on top of URL query params and history
  * state. This list of query keys will be preserved between searches.
  */
-const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
+const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_UI_MODE_URL_KEY]
 
 /**
  * Returns a URL query string with only the parameters in PRESERVED_QUERY_PARAMETERS.


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/47707

## Context

Probably this is a regression after react-router migration, in the nutshell the problem happened because submitSearch sets old value of aggregation type. And because of this search aggregation UX has been broken, prior react-router migration submitSearch has the most recent value of the location search, not it seems like it preserves the old one, so something around location search updating has been changed. 

The flow that we had before migration 
- Click the aggregation bar
- We remove aggregation mode type in URL 
- We call onQuerySubmit and this updates query 
- since query also lives in URL search ui logic about query sets new query value 
- we run search aggregation with new query and without aggregation type

The flow that we have now
- Click the aggregation bar
- We remove aggregation mode type in URL 
- We call onQuerySubmit and this updates query 
- Since query also lives in URL search ui logic about query sets new query value **but this time for some reason location inside this logic about query updating in URL has the old value of location, it hasn't been updated since we updated aggregation mode** 
- we run search aggregation with new query and with aggregation mode and this aggregation mode breaks UX 

## Test plan
- Go to the home page (search any query with capture group param, for example `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log`
- You should see that be default we provided capture group aggregation 
- If you pick one of aggregation bars you probably should see other aggregation type (not capture group since we replaces original query with specific bar capture group value) 
- In case of `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log` it should be repo aggregation 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-aggregation-flow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
