### PR TITLE
codeintel: Remove oobmigration step from codeintel-qa

### DIFF
--- a/dev/ci/integration/code-intel/test.sh
+++ b/dev/ci/integration/code-intel/test.sh
@@ -39,20 +39,9 @@ go run ./cmd/download
 echo '--- :one: clearing existing state'
 go run ./cmd/clear
 
-# Disable migration #20 (LSIF -> SCIP)
-echo '--- :two: Disabling LSIF -> SCIP migration'
-"${root_dir}/init-sg" oobmigration -id T3V0T2ZCYW5kTWlncmF0aW9uOjIw -down
-
-echo '--- :three: integration test ./dev/codeintel-qa/cmd/upload'
+echo '--- :two: integration test ./dev/codeintel-qa/cmd/upload'
 env PATH="${root_dir}/.bin:${PATH}" go run ./cmd/upload --timeout=5m
 
-echo '--- :four: integration test ./dev/codeintel-qa/cmd/query'
-go run ./cmd/query
-
-# Enable migration #20 (LSIF -> SCIP) and wait for it to complete
-echo '--- :five: Running LSIF -> SCIP migration'
-"${root_dir}/init-sg" oobmigration -id T3V0T2ZCYW5kTWlncmF0aW9uOjIw
-
-echo '--- :six: integration test ./dev/codeintel-qa/cmd/query'
+echo '--- :three: integration test ./dev/codeintel-qa/cmd/query'
 go run ./cmd/query
 popd

--- a/dev/codeintel-qa/cmd/upload/upload.go
+++ b/dev/codeintel-qa/cmd/upload/upload.go
@@ -102,7 +102,6 @@ func upload(ctx context.Context, repoName, commit, file string) (string, error) 
 	for k, v := range argMap {
 		args = append(args, fmt.Sprintf("-%s=%s", k, v))
 	}
-	args = append(args, "--skip-scip")
 
 	tempDir, err := os.MkdirTemp("", "codeintel-qa")
 	if err != nil {


### PR DESCRIPTION
We no longer upload LSIF so this check is no longer necessary.

**Merge after 4.5 branch cut.**

## Test plan

Main-dry-run.