### PR TITLE
gRPC: close connections to gitserver

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -601,6 +601,7 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, errRe
 		if err != nil {
 			return nil, err
 		}
+		defer conn.Close()
 
 		client := proto.NewGitserverServiceClient(conn)
 		stream, err := client.Exec(ctx, req)


### PR DESCRIPTION
This missing conn.Close() seems to be causing a goroutine leak in gitserver.

## Test plan

Merge and see if it fixes goroutine leaks

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
