### PR TITLE
Search: fix goroutine leak for comby streaming

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -389,7 +389,13 @@ type subset []string
 
 var all universalSet = struct{}{}
 
+var mockStructuralSearch func(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) error = nil
+
 func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) (err error) {
+	if mockStructuralSearch != nil {
+		return mockStructuralSearch(ctx, inputType, paths, extensionHint, pattern, rule, languages, repo, sender)
+	}
+
 	span, ctx := ot.StartSpanFromContext(ctx, "StructuralSearch") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", repo)
 	defer func() {

--- a/cmd/searcher/internal/search/zoekt_search_test.go
+++ b/cmd/searcher/internal/search/zoekt_search_test.go
@@ -43,6 +43,7 @@ func Test_zoektSearch(t *testing.T) {
 	mockStructuralSearch = func(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) error {
 		return errors.New("oops")
 	}
+	t.Cleanup(func() { mockStructuralSearch = nil })
 
 	// Ensure that this returns an error from structuralSearch, and does not block
 	// indefinitely because the reader returns early.

--- a/cmd/searcher/internal/search/zoekt_search_test.go
+++ b/cmd/searcher/internal/search/zoekt_search_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/comby"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/query"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClient struct {
+	zoekt.Streamer
+	mockStreamSearch func(context.Context, query.Q, *zoekt.SearchOptions, zoekt.Sender) error
+}
+
+func (mc *mockClient) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) (err error) {
+	return mc.mockStreamSearch(ctx, q, opts, sender)
+}
+
+func Test_zoektSearch(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock client that will send a few files worth of matches
+	client := &mockClient{
+		mockStreamSearch: func(ctx context.Context, q query.Q, so *zoekt.SearchOptions, s zoekt.Sender) error {
+			for i := 0; i < 10; i++ {
+				s.Send(&zoekt.SearchResult{
+					Files: []zoekt.FileMatch{{}, {}},
+				})
+			}
+			return nil
+		},
+	}
+
+	// Structural search fails immediately, so can't consume the events from the zoekt stream
+	mockStructuralSearch = func(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) error {
+		return errors.New("oops")
+	}
+
+	// Ensure that this returns an error from structuralSearch, and does not block
+	// indefinitely because the reader returns early.
+	err := zoektSearch(
+		ctx,
+		client,
+		&search.TextPatternInfo{},
+		[]query.BranchRepos{{Branch: "test", Repos: roaring.BitmapOf(1, 2, 3)}},
+		time.Since,
+		"",
+		matchSender(nil),
+	)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This fixes an issue with the code that streams to comby where an error from comby would cause the writer to block indefinitely because the channel it was writing to was no longer being read from. Additionally, it propagates the error from comby rather than just logging it, and converts the goroutine spawning to use conc/pool for clarity on errors and panic safety.

I noticed the goroutine leak while investigating [a separate goroutine leak](https://github.com/sourcegraph/sourcegraph/pull/47715). 

## Test plan

Added a fragile unit test to ensure that an error from comby does not cause the call to block indefinitely. Integration tests are running.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
