### PR TITLE
web: fix aggregation search bar click

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
+import { To, useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 
 import { limitHit, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/branded'
@@ -263,12 +263,24 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     }, [location.search])
 
     const handleSidebarSearchSubmit = useCallback(
-        (updates: QueryUpdate[]) =>
+        /**
+         * The `updatedSearchQuery` is required in case we synchronously update the search
+         * query in the event handlers and want to submit a new search. Without this argument,
+         * the `handleSidebarSearchSubmit` function uses the outdated location reference
+         * because the component was not re-rendered yet.
+         *
+         * Example use-case: search-aggregation result bar click where we first update the URL
+         * by settings the `groupBy` search param to `null` and then synchronously call `submitSearch`.
+         */
+        (updates: QueryUpdate[], updatedSearchQuery?: string) =>
             submitQuerySearch(
                 {
                     selectedSearchContextSpec: props.selectedSearchContextSpec,
                     historyOrNavigate: navigate,
-                    location,
+                    location: {
+                        ...location,
+                        search: updatedSearchQuery || location.search,
+                    },
                     source: 'filter',
                 },
                 updates

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
-import { To, useLocation, useNavigate } from 'react-router-dom-v5-compat'
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import { Observable } from 'rxjs'
 
 import { limitHit, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/branded'

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
+import { useNavigate, useLocation, To } from 'react-router-dom-v5-compat'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -23,7 +23,8 @@ interface URLStateOptions<State, SerializedState> {
     serializer: (state: State) => string | null
 }
 
-type SetStateResult<State> = [state: State, dispatch: (state: State) => void]
+type UpdatedSearchQuery = string
+type SetStateResult<State> = [state: State, dispatch: (state: State) => UpdatedSearchQuery]
 
 /**
  * React hook analog standard react useState hook but with synced value with URL
@@ -52,7 +53,10 @@ function useSyncedWithURLState<State, SerializedState>(
                 urlSearchParameters.set(urlKey, serializedValue)
             }
 
-            navigate({ search: `?${urlSearchParameters.toString()}` }, { replace: true })
+            const search = `?${urlSearchParameters.toString()}`
+            navigate({ search }, { replace: true })
+
+            return search
         },
         [navigate, serializer, urlKey, urlSearchParameters]
     )

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
-import { useNavigate, useLocation, To } from 'react-router-dom-v5-compat'
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -41,7 +41,7 @@ interface SearchAggregationsProps extends TelemetryProps {
      * That should update the query and re-trigger search (but this should be connected
      * to this UI through its consumer)
      */
-    onQuerySubmit: (newQuery: string) => void
+    onQuerySubmit: (newQuery: string, updatedSearchQuery: string) => void
 }
 
 export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
@@ -70,9 +70,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         // Clearing the aggregation mode on drill down would provide a better experience
         // in most cases and preserve the desired behavior of the capture group search
         // when the original query had multiple capture groups
-        setAggregationMode(null)
+        const updatedSearchQuery = setAggregationMode(null)
 
-        onQuerySubmit(query)
+        onQuerySubmit(query, updatedSearchQuery)
         telemetryService.log(
             GroupResultsPing.ChartBarClick,
             { aggregationMode, index, uiMode: 'sidebar' },

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -38,7 +38,7 @@ export interface SearchFiltersSidebarProps extends TelemetryProps, SettingsCasca
     selectedSearchContextSpec?: string
     aggregationUIMode?: AggregationUIMode
     onNavbarQueryChange: (queryState: QueryStateUpdate) => void
-    onSearchSubmit: (updates: QueryUpdate[]) => void
+    onSearchSubmit: (updates: QueryUpdate[], updatedSearchQuery?: string) => void
     setSidebarCollapsed: (collapsed: boolean) => void
 }
 
@@ -88,8 +88,8 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
     )
 
     const handleAggregationBarLinkClick = useCallback(
-        (query: string): void => {
-            onSearchSubmit([{ type: 'replaceQuery', value: query }])
+        (query: string, updatedSearchQuery: string): void => {
+            onSearchSubmit([{ type: 'replaceQuery', value: query }], updatedSearchQuery)
         },
         [onSearchSubmit]
     )


### PR DESCRIPTION
## Context

An alternative fix for the issue described in this PR
- https://github.com/sourcegraph/sourcegraph/pull/47713

We discussed the problem with Vova on the Zoom call. The root cause of the issue is that previously we used mutable location object that didn't depend on component re-renders which is not the case anymore. That's why the `submitSearch` handler uses the outdated search query.

## Test plan

- Go to the home page (search any query with capture group param, for example, `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log`
- You should see that by default, we provide capture group aggregation 
- If you pick one of the aggregation bars, you probably should see the other aggregation type (not capture group since we replace the original query with a specific bar capture group value) 
- In case of `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log` it should be repo aggregation 

## App preview:

- [Web](https://sg-web-vb-aggregation-search-bar-click.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

