### PR TITLE
Revert "gRPC: close connections to gitserver (#47715), 2023-02-15)"

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -601,7 +601,6 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, errRe
 		if err != nil {
 			return nil, err
 		}
-		defer conn.Close()
 
 		client := proto.NewGitserverServiceClient(conn)
 		stream, err := client.Exec(ctx, req)


### PR DESCRIPTION
This reverts commit 9cad3e2f34

This will cause goroutine leaks to happen again.

This change is supected to have caused the outage observed on sourcegraph.com and it still happening on s2, where "Empty repository" is returned. Please see incident-169 for more information

## Test plan
Once deployed on S2 we should not see empty repository anymore for known repositories
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
