### PR TITLE
Streaming blame: fix leaks

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -219,7 +219,8 @@ type RawBatchLogResult struct {
 type BatchLogCallback func(repoCommit api.RepoCommit, gitLogResult RawBatchLogResult) error
 
 type HunkReader interface {
-	Read() (hunks []*Hunk, done bool, err error)
+	Read() (*Hunk, error)
+	Close() error
 }
 
 type Client interface {

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -737,7 +737,7 @@ func streamBlameFileCmd(ctx context.Context, checker authz.SubRepoPermissionChec
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed", args))
 	}
 
-	return newBlameHunkReader(ctx, rc), nil
+	return newBlameHunkReader(rc), nil
 }
 
 // BlameFile returns Git blame information about a file.


### PR DESCRIPTION
Streaming git blame was not closing the `io.ReadCloser` it takes
ownership of. This adds a `Close()` method to the `HunkReader` type that
cleans up its resources. This is one of the places that may be causing
goroutine leaks on gitserver.

Because the `ReadCloser` is passed into a spawned goroutine, I can't
close it without both holding a reference both from the reader and the
spawned goroutine, and waiting for the goroutine to exit first, which
was not easy to do. Instead, I did a small refactor that avoids spawning
a new goroutine, preferring to lazily parse the stream. This has the
added benefit of being simpler to reason about.

## Test plan

There are existing tests that lock in the parsing behavior. I manually tested that streaming git blame still works, and works well for large files with complex history. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
