### PR TITLE
bzl: add  backstage node_modules it bazel ignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -24,6 +24,7 @@ client/wildcard/node_modules
 client/vscode/node_modules
 dev/release/node_modules
 client/plugin-backstage/node_modules
+client/backstage-common/node_modules
 
 cmd/symbols/squirrel/test_repos/starlark
 

--- a/.bazelignore
+++ b/.bazelignore
@@ -25,6 +25,8 @@ client/vscode/node_modules
 dev/release/node_modules
 client/plugin-backstage/node_modules
 client/backstage-common/node_modules
+client/backstage-backend/node_modules
+client/backstage-frontend/node_modules
 
 cmd/symbols/squirrel/test_repos/starlark
 


### PR DESCRIPTION
Adds the latest backstage packages to bazel ignore to unblock further go testing


## Test plan

`bazel build //...`