### PR TITLE
Code intel index configuration: Split protected policies and improve messaging

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/CreatePolicyButtons.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/CreatePolicyButtons.module.scss
@@ -1,0 +1,21 @@
+.dropdown-list {
+    width: 22rem;
+}
+
+.dropdown-button {
+    border-left: 1px solid var(--border-primary-color);
+    padding: 0 0.25rem;
+}
+
+.dropdown-item {
+    padding: 1rem;
+    white-space: normal;
+
+    &:not(:last-child) {
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    &[data-reach-menu-item]:active {
+        --text-muted: var(--white);
+    }
+}

--- a/client/web/src/enterprise/codeintel/configuration/components/CreatePolicyButtons.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/CreatePolicyButtons.tsx
@@ -1,0 +1,66 @@
+import { FunctionComponent } from 'react'
+
+import { mdiChevronDown } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
+
+import {
+    Button,
+    ButtonGroup,
+    Icon,
+    Link,
+    Menu,
+    MenuButton,
+    MenuLink,
+    MenuList,
+    Position,
+    Text,
+} from '@sourcegraph/wildcard'
+
+import styles from './CreatePolicyButtons.module.scss'
+
+interface CreatePolicyButtonsProps {
+    repo?: { id: string; name: string }
+}
+
+export const CreatePolicyButtons: FunctionComponent<CreatePolicyButtonsProps> = ({ repo }) => (
+    <Menu>
+        <ButtonGroup>
+            <Button to="./configuration/new?type=head" variant="primary" as={Link}>
+                Create new {!repo && 'global'} policy
+            </Button>
+            <MenuButton variant="primary" className={styles.dropdownButton}>
+                <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                <VisuallyHidden>Actions</VisuallyHidden>
+            </MenuButton>
+        </ButtonGroup>
+        <MenuList position={Position.bottomEnd} className={styles.dropdownList}>
+            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=head">
+                <>
+                    <Text weight="medium" className="mb-2">
+                        Create new {!repo && 'global'} policy for HEAD
+                    </Text>
+                    <Text className="mb-0 text-muted">
+                        Match the tip of the default branch{' '}
+                        {repo ? 'within this repository' : 'across multiple repositories'}
+                    </Text>
+                </>
+            </MenuLink>
+            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=branch">
+                <Text weight="medium" className="mb-2">
+                    Create new {!repo && 'global'} branch policy
+                </Text>
+                <Text className="mb-0 text-muted">
+                    Match multiple branches {repo ? 'within this repository' : 'across multiple repositories'}
+                </Text>
+            </MenuLink>
+            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=tag">
+                <Text weight="medium" className="mb-2">
+                    Create new {!repo && 'global'} tag policy
+                </Text>
+                <Text className="mb-0 text-muted">
+                    Match multiple tags {repo ? 'within this repository' : 'across multiple repositories'}
+                </Text>
+            </MenuLink>
+        </MenuList>
+    </Menu>
+)

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.module.scss
@@ -1,0 +1,28 @@
+.text {
+    margin: 0 auto;
+    width: 50%;
+    display: block;
+}
+
+.content,
+.content-expanded {
+    width: 75%;
+    margin: 1.5rem 0 1rem;
+    display: grid;
+}
+
+.content {
+    grid-template-columns: 1fr [docs];
+    border-top: 1px solid var(--border-color);
+}
+
+.content-expanded {
+    grid-template-columns: 1fr [docs] min-content [divider] 1fr [cta];
+}
+
+.divider {
+    border-right: 1px solid var(--border-color);
+    height: 100%;
+    align-self: center;
+    margin: 0 0.5rem;
+}

--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.tsx
@@ -1,17 +1,60 @@
 import React from 'react'
 
-import { mdiMapSearch } from '@mdi/js'
+import { mdiMapSearch, mdiOpenInNew } from '@mdi/js'
 
-import { Link, Text, Icon } from '@sourcegraph/wildcard'
+import { Link, Text, Icon, H4 } from '@sourcegraph/wildcard'
 
-export const EmptyPoliciesList: React.FunctionComponent<unknown> = () => (
-    <Text alignment="center" className="text-muted w-100 mb-0 mt-1" data-testid="summary">
+import { CreatePolicyButtons } from './CreatePolicyButtons'
+
+import styles from './EmptyPoliciesList.module.scss'
+
+interface EmptyPoliciesListProps {
+    showCta?: boolean
+    repo?: { id: string; name: string }
+}
+
+export const EmptyPoliciesList: React.FunctionComponent<EmptyPoliciesListProps> = ({ repo, showCta }) => (
+    <div className="d-flex align-items-center flex-column w-100 mt-3" data-testid="summary">
         <Icon className="mb-2" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
-        <br />
-        {'No policies have been defined.  Enable precise code navigation by '}
-        <Link to="/help/code_navigation/how-to/configure_data_retention" target="_blank" rel="noreferrer noopener">
-            configuring data retention policies
-        </Link>
-        .
-    </Text>
+        <H4 className="mb-0">No policies found.</H4>
+        <div className={showCta ? styles.contentExpanded : styles.content}>
+            <div className="text-center p-3">
+                <Text weight="medium" className="mb-2">
+                    Documentation
+                </Text>
+                <Link
+                    className="d-block mb-1"
+                    to={`/help/code_navigation/how-to/configure_data_retention${
+                        !repo
+                            ? '#applying-data-retention-policies-globally'
+                            : '#applying-data-retention-policies-to-a-specific-repository'
+                    }`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    Data retention policies <Icon svgPath={mdiOpenInNew} aria-hidden={true} />
+                </Link>
+                <Link
+                    className="d-block"
+                    to={`/help/code_navigation/how-to/configure_auto_indexing${
+                        !repo
+                            ? '#applying-indexing-policies-globally'
+                            : '#applying-indexing-policies-to-a-specific-repository'
+                    }}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    Auto-indexing policies <Icon svgPath={mdiOpenInNew} aria-hidden={true} />
+                </Link>
+            </div>
+            {showCta && (
+                <>
+                    <div className={styles.divider} />
+                    <div className="d-flex align-items-center justify-content-center p-3">
+                        <CreatePolicyButtons repo={repo} />
+                    </div>
+                </>
+            )}
+        </div>
+    </div>
 )

--- a/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
@@ -1,6 +1,6 @@
 .loading {
     align-self: center;
-    justify-self: start;
+    justify-self: flex-start;
     margin: 0 0 0 0.5rem;
 }
 
@@ -24,7 +24,7 @@
 .input-actions {
     width: 10%;
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-self: stretch;
 }
 

--- a/client/web/src/enterprise/codeintel/configuration/hooks/queryPolicies.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/hooks/queryPolicies.tsx
@@ -26,6 +26,7 @@ export const POLICIES_CONFIGURATION = gql`
         $forIndexing: Boolean
         $first: Int
         $after: String
+        $protected: Boolean
     ) {
         codeIntelligenceConfigurationPolicies(
             repository: $repository
@@ -34,6 +35,7 @@ export const POLICIES_CONFIGURATION = gql`
             forIndexing: $forIndexing
             first: $first
             after: $after
+            protected: $protected
         ) {
             nodes {
                 ...CodeIntelligenceConfigurationPolicyFields
@@ -57,6 +59,7 @@ export const queryPolicies = (
         forDataRetention,
         forIndexing,
         after,
+        protected: varProtected,
     }: Partial<CodeIntelligenceConfigurationPoliciesVariables>,
     client: ApolloClient<object>
 ): Observable<PolicyConnection> => {
@@ -67,6 +70,7 @@ export const queryPolicies = (
         forIndexing: forIndexing ?? null,
         first: first ?? null,
         after: after ?? null,
+        protected: varProtected ?? null,
     }
 
     return from(

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.module.scss
@@ -31,25 +31,3 @@
     display: flex;
     align-items: center;
 }
-
-.dropdown-list {
-    width: 22rem;
-}
-
-.dropdown-button {
-    border-left: 1px solid var(--border-primary-color);
-    padding: 0 0.25rem;
-}
-
-.dropdown-item {
-    padding: 1rem;
-    white-space: normal;
-
-    &:not(:last-child) {
-        border-bottom: 1px solid var(--border-color);
-    }
-
-    &[data-reach-menu-item]:active {
-        --text-muted: var(--white);
-    }
-}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -1,9 +1,8 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import {
     mdiAlert,
-    mdiChevronDown,
     mdiCircleOffOutline,
     mdiDatabaseClock,
     mdiDelete,
@@ -13,7 +12,6 @@ import {
     mdiPencil,
     mdiSourceRepository,
 } from '@mdi/js'
-import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
 import { Subject } from 'rxjs'
@@ -22,23 +20,7 @@ import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import {
-    Badge,
-    Button,
-    ButtonGroup,
-    Container,
-    ErrorAlert,
-    Icon,
-    Link,
-    Menu,
-    MenuButton,
-    MenuLink,
-    MenuList,
-    PageHeader,
-    Position,
-    Text,
-    Tooltip,
-} from '@sourcegraph/wildcard'
+import { Badge, Button, Container, ErrorAlert, H3, Icon, Link, PageHeader, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import {
@@ -48,6 +30,7 @@ import {
 } from '../../../../components/FilteredConnection'
 import { PageTitle } from '../../../../components/PageTitle'
 import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
+import { CreatePolicyButtons } from '../components/CreatePolicyButtons'
 import { Duration } from '../components/Duration'
 import { EmptyPoliciesList } from '../components/EmptyPoliciesList'
 import { FlashMessage } from '../components/FlashMessage'
@@ -105,8 +88,14 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
     const updates = useMemo(() => new Subject<void>(), [])
 
     const apolloClient = useApolloClient()
-    const queryPoliciesCallback = useCallback(
-        (args: FilteredConnectionQueryArguments) => queryPolicies({ ...args, repository: repo?.id }, apolloClient),
+    const queryDefaultPoliciesCallback = useCallback(
+        (args: FilteredConnectionQueryArguments) =>
+            queryPolicies({ ...args, repository: repo?.id, protected: true }, apolloClient),
+        [queryPolicies, repo?.id, apolloClient]
+    )
+    const queryCustomPoliciesCallback = useCallback(
+        (args: FilteredConnectionQueryArguments) =>
+            queryPolicies({ ...args, repository: repo?.id, protected: false }, apolloClient),
         [queryPolicies, repo?.id, apolloClient]
     )
 
@@ -126,9 +115,10 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
 
                 navigate(
                     {
-                        pathname: './configuration',
+                        pathname: './',
                     },
                     {
+                        relative: 'path',
                         state: { modal: 'SUCCESS', message: `Configuration policy ${name} has been deleted.` },
                     }
                 )
@@ -179,8 +169,12 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
                 </Container>
             )}
 
-            <Container>
-                <FilteredConnection<CodeIntelligenceConfigurationPolicyFields, PoliciesNodeProps>
+            <Container className="mb-3 pb-3">
+                <H3>Custom policies</H3>
+                <FilteredConnection<
+                    CodeIntelligenceConfigurationPolicyFields,
+                    Omit<UnprotectedPoliciesNodeProps, 'node'>
+                >
                     listComponent="div"
                     listClassName={classNames(styles.grid, 'mb-3')}
                     showMoreClassName="mb-0"
@@ -188,76 +182,53 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
                     pluralNoun="configuration policies"
                     nodeComponent={PoliciesNode}
                     nodeComponentProps={{ isDeleting, onDelete, indexingEnabled }}
-                    queryConnection={queryPoliciesCallback}
+                    queryConnection={queryCustomPoliciesCallback}
                     cursorPaging={true}
                     filters={filters}
                     inputClassName="ml-2 flex-1"
-                    emptyElement={<EmptyPoliciesList />}
+                    emptyElement={<EmptyPoliciesList repo={repo} showCta={authenticatedUser?.siteAdmin} />}
                     updates={updates}
+                />
+            </Container>
+
+            <Container className="mb-3">
+                <H3>Default policies</H3>
+                <FilteredConnection<CodeIntelligenceConfigurationPolicyFields, Omit<PoliciesNodeProps, 'node'>>
+                    listComponent="div"
+                    listClassName={classNames(styles.grid, 'mb-3')}
+                    noun="configuration policy"
+                    pluralNoun="configuration policies"
+                    nodeComponent={PoliciesNode}
+                    nodeComponentProps={{ indexingEnabled }}
+                    queryConnection={queryDefaultPoliciesCallback}
+                    emptyElement={<EmptyPoliciesList repo={repo} />}
+                    hideSearch={true}
+                    summaryClassName="d-none"
+                    useURLQuery={false}
                 />
             </Container>
         </>
     )
 }
 
-interface CreatePolicyButtonsProps {
-    repo?: { id: string; name: string }
+interface ProtectedPoliciesNodeProps {
+    node: CodeIntelligenceConfigurationPolicyFields
+    indexingEnabled?: boolean
 }
 
-const CreatePolicyButtons: FunctionComponent<CreatePolicyButtonsProps> = ({ repo }) => (
-    <Menu>
-        <ButtonGroup>
-            <Button to="./configuration/new?type=head" variant="primary" as={Link}>
-                Create new {!repo && 'global'} policy
-            </Button>
-            <MenuButton variant="primary" className={styles.dropdownButton}>
-                <Icon aria-hidden={true} svgPath={mdiChevronDown} />
-                <VisuallyHidden>Actions</VisuallyHidden>
-            </MenuButton>
-        </ButtonGroup>
-        <MenuList position={Position.bottomEnd} className={styles.dropdownList}>
-            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=head">
-                <>
-                    <Text weight="medium" className="mb-2">
-                        Create new {!repo && 'global'} policy for HEAD
-                    </Text>
-                    <Text className="mb-0 text-muted">
-                        Match the tip of the default branch{' '}
-                        {repo ? 'within this repository' : 'across multiple repositories'}
-                    </Text>
-                </>
-            </MenuLink>
-            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=branch">
-                <Text weight="medium" className="mb-2">
-                    Create new {!repo && 'global'} branch policy
-                </Text>
-                <Text className="mb-0 text-muted">
-                    Match multiple branches {repo ? 'within this repository' : 'across multiple repositories'}
-                </Text>
-            </MenuLink>
-            <MenuLink as={Link} className={styles.dropdownItem} to="./configuration/new?type=tag">
-                <Text weight="medium" className="mb-2">
-                    Create new {!repo && 'global'} tag policy
-                </Text>
-                <Text className="mb-0 text-muted">
-                    Match multiple tags {repo ? 'within this repository' : 'across multiple repositories'}
-                </Text>
-            </MenuLink>
-        </MenuList>
-    </Menu>
-)
-
-interface PoliciesNodeProps {
+interface UnprotectedPoliciesNodeProps {
+    node: CodeIntelligenceConfigurationPolicyFields
     isDeleting: boolean
     onDelete: (id: string, name: string) => Promise<void>
     indexingEnabled?: boolean
 }
 
-const PoliciesNode: FunctionComponent<PoliciesNodeProps & { node: CodeIntelligenceConfigurationPolicyFields }> = ({
+type PoliciesNodeProps = ProtectedPoliciesNodeProps | UnprotectedPoliciesNodeProps
+
+const PoliciesNode: FunctionComponent<React.PropsWithChildren<PoliciesNodeProps>> = ({
     node: policy,
-    isDeleting,
-    onDelete,
     indexingEnabled = false,
+    ...props
 }) => (
     <>
         <span className={styles.separator} />
@@ -284,12 +255,12 @@ const PoliciesNode: FunctionComponent<PoliciesNodeProps & { node: CodeIntelligen
         </div>
 
         <div className="h-100">
-            {!policy.protected && (
+            {!policy.protected && 'onDelete' in props && 'isDeleting' in props && (
                 <Button
                     aria-label="Delete the configuration policy"
                     variant="icon"
-                    onClick={() => onDelete(policy.id, policy.name)}
-                    disabled={isDeleting}
+                    onClick={() => props.onDelete(policy.id, policy.name)}
+                    disabled={props.isDeleting}
                 >
                     <Tooltip content="Delete this policy">
                         <Icon className="text-danger" aria-label="Delete this policy" svgPath={mdiDelete} />

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import {

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -159,9 +159,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
                 ? { type: GitObjectType.GIT_TAG, pattern: '*' }
                 : { type: GitObjectType.GIT_COMMIT }
 
-        const repoDefaults = repo
-            ? { repository: repo, name: `Custom policy for ${displayRepoName(repo.name)}` }
-            : { name: 'Custom global policy' }
+        const repoDefaults = repo ? { repository: repo } : {}
         const typeDefaults = policyConfig?.type === GitObjectType.GIT_UNKNOWN ? defaultTypes : {}
         const configWithDefaults = policyConfig && { ...policyConfig, ...repoDefaults, ...typeDefaults }
 


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/sourcegraph/pull/47551 from @efritz 

## Description

Main goals here are:

- Avoid giving users the impression that policies are already configured (because they see 3 policies in the list when they scan it)
- Better introduce new users into the flow of creating a new policy. No custom policies -> Docs or CTA -> Create policy (pls)

Changes:

- Splits protected and unprotected policies into "Default" and "Custom" ones in the UI
- Updates empty policies UI:
  - Better links to documentation for both data retention and indexing. Links differ based on if the user is viewing from a repo or from site admin
  - Introduce CTA, to help encourage users that there is stuff they can do here (!). Also helped that the default policies are sectioned off. 
- Updates wording from "No policies defined" to "No policies found" (as this UI will also show if a user tries to filter by a nonexistent policy)


### Screenshots - (Admin)

![image](https://user-images.githubusercontent.com/9516420/219382840-c93ac69f-d548-4c76-bb53-aeb259909695.png)

![image](https://user-images.githubusercontent.com/9516420/219383310-6cb78303-253e-4a05-9b5d-92b8a6114dd2.png)


### Screenshots - (non admin)

![image](https://user-images.githubusercontent.com/9516420/219383199-1fec087b-b2c3-4e49-a3e8-063fd3b3ef51.png)





## Test plan

Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-index-config-updates.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
