### PR TITLE
own: align search event types with ownership API

### DIFF
--- a/cmd/frontend/backend/own.go
+++ b/cmd/frontend/backend/own.go
@@ -34,7 +34,6 @@ func NewOwnService(g gitserver.Client, db database.DB) OwnService {
 	return &ownService{
 		gitserverClient: g,
 		userStore:       db.Users(),
-		userEmailsStore: db.UserEmails(),
 		teamStore:       db.Teams(),
 		ownerCache:      make(map[ownerKey]codeowners.ResolvedOwner),
 	}
@@ -43,7 +42,6 @@ func NewOwnService(g gitserver.Client, db database.DB) OwnService {
 type ownService struct {
 	gitserverClient gitserver.Client
 	userStore       database.UserStore
-	userEmailsStore database.UserEmailsStore
 	teamStore       database.TeamStore
 
 	mu         sync.Mutex

--- a/cmd/frontend/backend/own.go
+++ b/cmd/frontend/backend/own.go
@@ -135,6 +135,8 @@ func (s *ownService) resolveOwner(ctx context.Context, handle, email string) (co
 		if err != nil {
 			return personOrError(handle, email, err)
 		}
+	} else {
+		return nil, nil
 	}
 	resolvedOwner.SetOwnerData(handle, email)
 	return resolvedOwner, nil

--- a/cmd/frontend/backend/own_test.go
+++ b/cmd/frontend/backend/own_test.go
@@ -129,8 +129,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
 			&codeowners.Person{
-				User:            testUser,
-				OwnerIdentifier: handle,
+				User:   testUser,
+				Handle: handle,
 			},
 		}, got)
 	})
@@ -153,8 +153,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
 			&codeowners.Person{
-				User:            testUser,
-				OwnerIdentifier: email,
+				User:  testUser,
+				Email: email,
 			},
 		}, got)
 	})
@@ -178,8 +178,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
 			&codeowners.Team{
-				Team:            testTeam,
-				OwnerIdentifier: handle,
+				Team:   testTeam,
+				Handle: handle,
 			},
 		}, got)
 	})
@@ -250,9 +250,9 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err := ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		want := []codeowners.ResolvedOwner{
-			&codeowners.Person{User: testUserWithHandle, OwnerIdentifier: userHandle},
-			&codeowners.Person{User: testUserWithEmail, OwnerIdentifier: userEmail},
-			&codeowners.Team{Team: testTeamWithHandle, OwnerIdentifier: teamHandle},
+			&codeowners.Person{User: testUserWithHandle, Handle: userHandle},
+			&codeowners.Person{User: testUserWithEmail, Email: userEmail},
+			&codeowners.Team{Team: testTeamWithHandle, Handle: teamHandle},
 			testUnknownOwner,
 		}
 		sort.Slice(want, func(x, j int) bool {
@@ -283,8 +283,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
 			&codeowners.Person{
-				User:            testUser,
-				OwnerIdentifier: email,
+				User:  testUser,
+				Email: email,
 			},
 		}, got)
 		// do it again
@@ -292,8 +292,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
 			&codeowners.Person{
-				User:            testUser,
-				OwnerIdentifier: email,
+				User:  testUser,
+				Email: email,
 			},
 		}, got)
 	})
@@ -352,8 +352,9 @@ func newTestTeam(teamName string) *types.Team {
 	}
 }
 
+// an unknown owner is just a person with no user set
 func newTestUnknownOwner(handle, email string) codeowners.ResolvedOwner {
-	return &codeowners.UnknownOwner{
+	return &codeowners.Person{
 		Handle: handle,
 		Email:  email,
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -522,23 +522,25 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
 	switch v := owner.ResolvedOwner.(type) {
 	case *codeowners.Person:
-		return &streamhttp.EventPersonMatch{
-			Type:        streamhttp.PersonMatchType,
-			Username:    v.User.Username,
-			DisplayName: v.User.DisplayName,
-			AvatarURL:   v.User.AvatarURL,
+		var person *streamhttp.EventPersonMatch
+		if v.User != nil {
+			person = &streamhttp.EventPersonMatch{
+				Type:        streamhttp.PersonMatchType,
+				Username:    v.User.Username,
+				DisplayName: v.User.DisplayName,
+				AvatarURL:   v.User.AvatarURL,
+			}
 		}
+		person.Handle = v.Handle
+		person.Email = v.Email
+		return person
 	case *codeowners.Team:
 		return &streamhttp.EventTeamMatch{
 			Type:        streamhttp.TeamMatchType,
+			Handle:      v.Handle,
+			Email:       v.Email,
 			Name:        v.Team.Name,
 			DisplayName: v.Team.DisplayName,
-		}
-	case *codeowners.UnknownOwner:
-		return &streamhttp.EventUnknownOwnerMatch{
-			Type:   streamhttp.UnknownOwnerMatchType,
-			Handle: v.Handle,
-			Email:  v.Email,
 		}
 	default:
 		panic(fmt.Sprintf("unknown owner match type %T", v))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -520,20 +520,18 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 }
 
 func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
-	fmt.Println(owner)
 	switch v := owner.ResolvedOwner.(type) {
 	case *codeowners.Person:
-		var person *streamhttp.EventPersonMatch
-		if v.User != nil {
-			person = &streamhttp.EventPersonMatch{
-				Username:    v.User.Username,
-				DisplayName: v.User.DisplayName,
-				AvatarURL:   v.User.AvatarURL,
-			}
+		person := &streamhttp.EventPersonMatch{
+			Type:   streamhttp.PersonMatchType,
+			Handle: v.Handle,
+			Email:  v.Email,
 		}
-		person.Type = streamhttp.PersonMatchType
-		person.Handle = v.Handle
-		person.Email = v.Email
+		if v.User != nil {
+			person.Username = v.User.Username
+			person.DisplayName = v.User.DisplayName
+			person.AvatarURL = v.User.AvatarURL
+		}
 		return person
 	case *codeowners.Team:
 		return &streamhttp.EventTeamMatch{

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -528,9 +528,11 @@ func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
 			Email:  v.Email,
 		}
 		if v.User != nil {
-			person.Username = v.User.Username
-			person.DisplayName = v.User.DisplayName
-			person.AvatarURL = v.User.AvatarURL
+			person.User = streamhttp.UserMetadata{
+				Username:    v.User.Username,
+				DisplayName: v.User.DisplayName,
+				AvatarURL:   v.User.AvatarURL,
+			}
 		}
 		return person
 	case *codeowners.Team:

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -520,17 +520,18 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 }
 
 func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
+	fmt.Println(owner)
 	switch v := owner.ResolvedOwner.(type) {
 	case *codeowners.Person:
 		var person *streamhttp.EventPersonMatch
 		if v.User != nil {
 			person = &streamhttp.EventPersonMatch{
-				Type:        streamhttp.PersonMatchType,
 				Username:    v.User.Username,
 				DisplayName: v.User.DisplayName,
 				AvatarURL:   v.User.AvatarURL,
 			}
 		}
+		person.Type = streamhttp.PersonMatchType
 		person.Handle = v.Handle
 		person.Email = v.Email
 		return person

--- a/internal/own/codeowners/owner_types.go
+++ b/internal/own/codeowners/owner_types.go
@@ -5,61 +5,61 @@ import "github.com/sourcegraph/sourcegraph/internal/types"
 type ResolvedOwner interface {
 	Type() OwnerType
 	Identifier() string
+
+	SetOwnerData(handle, email string)
 }
 
 // Guard to ensure all resolved owner types implement the interface
 var (
 	_ ResolvedOwner = (*Person)(nil)
 	_ ResolvedOwner = (*Team)(nil)
-	_ ResolvedOwner = (*UnknownOwner)(nil)
 )
 
 type OwnerType string
 
 const (
-	OwnerTypePerson  OwnerType = "person"
-	OwnerTypeTeam    OwnerType = "team"
-	OwnerTypeUnknown OwnerType = "unknownOwner"
+	OwnerTypePerson OwnerType = "person"
+	OwnerTypeTeam   OwnerType = "team"
 )
 
 type Person struct {
-	User *types.User // todo(leo): extend to hold email using UserEmailStore.
+	User *types.User // If this is nil we've been unable to identify a user from the owner proto. Matches Own API.
 
-	OwnerIdentifier string // Handle OR email from the proto.
+	// Original proto fields.
+	Handle string
+	Email  string
 }
 
-func (p Person) Type() OwnerType {
+func (p *Person) Type() OwnerType {
 	return OwnerTypePerson
 }
 
-func (p Person) Identifier() string {
-	return p.OwnerIdentifier
+func (p *Person) Identifier() string {
+	return p.Handle + p.Email
+}
+
+func (p *Person) SetOwnerData(handle, email string) {
+	p.Handle = handle
+	p.Email = email
 }
 
 type Team struct {
 	Team *types.Team
 
-	OwnerIdentifier string // Handle OR email from the proto.
-}
-
-func (t Team) Type() OwnerType {
-	return OwnerTypeTeam
-}
-
-func (t Team) Identifier() string {
-	return t.OwnerIdentifier
-}
-
-type UnknownOwner struct {
-	// We were unable to resolve ownership information to any kind of known Sourcegraph entity.
+	// Original proto fields.
 	Handle string
 	Email  string
 }
 
-func (u UnknownOwner) Type() OwnerType {
-	return OwnerTypeUnknown
+func (t *Team) Type() OwnerType {
+	return OwnerTypeTeam
 }
 
-func (u UnknownOwner) Identifier() string {
-	return u.Handle + u.Email // only one of the two should be set.
+func (t *Team) Identifier() string {
+	return t.Handle + t.Email
+}
+
+func (t *Team) SetOwnerData(handle, email string) {
+	t.Handle = handle
+	t.Email = email
 }

--- a/internal/search/codeownership/select_job.go
+++ b/internal/search/codeownership/select_job.go
@@ -2,7 +2,6 @@ package codeownership
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -106,7 +105,6 @@ matchesLoop:
 			errs = errors.Append(errs, err)
 			continue matchesLoop
 		}
-		fmt.Println(resolvedOwners)
 		for _, o := range resolvedOwners {
 			ownerMatch := &result.OwnerMatch{
 				ResolvedOwner: o,

--- a/internal/search/codeownership/select_job.go
+++ b/internal/search/codeownership/select_job.go
@@ -2,6 +2,7 @@ package codeownership
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -105,6 +106,7 @@ matchesLoop:
 			errs = errors.Append(errs, err)
 			continue matchesLoop
 		}
+		fmt.Println(resolvedOwners)
 		for _, o := range resolvedOwners {
 			ownerMatch := &result.OwnerMatch{
 				ResolvedOwner: o,

--- a/internal/search/codeownership/select_job_test.go
+++ b/internal/search/codeownership/select_job_test.go
@@ -139,7 +139,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.Person{User: personOwnerByHandle, Email: "testUserHandle"},
+				ResolvedOwner: &codeowners.Person{User: personOwnerByHandle, Handle: "testUserHandle"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -147,7 +147,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.Team{Team: teamOwner, Email: "testTeamHandle"},
+				ResolvedOwner: &codeowners.Team{Team: teamOwner, Handle: "testTeamHandle"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -182,12 +182,5 @@ func newTestTeam(teamName string) *types.Team {
 		ID:          1,
 		Name:        teamName,
 		DisplayName: "Team " + teamName,
-	}
-}
-
-func newTestUnknownOwner(handle, email string) codeowners.ResolvedOwner {
-	return &codeowners.Person{
-		Handle: handle,
-		Email:  email,
 	}
 }

--- a/internal/search/codeownership/select_job_test.go
+++ b/internal/search/codeownership/select_job_test.go
@@ -123,7 +123,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		}
 		want := []result.Match{
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.Person{User: personOwnerByEmail, OwnerIdentifier: "user@email.com"},
+				ResolvedOwner: &codeowners.Person{User: personOwnerByEmail, Email: "user@email.com"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -131,7 +131,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.UnknownOwner{Handle: "unknown"},
+				ResolvedOwner: &codeowners.Person{Handle: "unknown"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -139,7 +139,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.Person{User: personOwnerByHandle, OwnerIdentifier: "testUserHandle"},
+				ResolvedOwner: &codeowners.Person{User: personOwnerByHandle, Email: "testUserHandle"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -147,7 +147,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &codeowners.Team{Team: teamOwner, OwnerIdentifier: "testTeamHandle"},
+				ResolvedOwner: &codeowners.Team{Team: teamOwner, Email: "testTeamHandle"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -186,7 +186,7 @@ func newTestTeam(teamName string) *types.Team {
 }
 
 func newTestUnknownOwner(handle, email string) codeowners.ResolvedOwner {
-	return &codeowners.UnknownOwner{
+	return &codeowners.Person{
 		Handle: handle,
 		Email:  email,
 	}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -175,6 +175,7 @@ type EventPersonMatch struct {
 	Email  string `json:"email"`
 
 	// The following are a subset of types.User fields.
+	// These will not be set if no user was matched.
 	Username    string `json:"username"`
 	DisplayName string `json:"displayName"`
 	AvatarURL   string `json:"avatarURL"`
@@ -195,16 +196,6 @@ type EventTeamMatch struct {
 }
 
 func (e *EventTeamMatch) eventMatch() {}
-
-type EventUnknownOwnerMatch struct {
-	// Type is always UnknownOwnerMatchType. Included here for marshalling.
-	Type MatchType `json:"type"`
-
-	Handle string `json:"handle"`
-	Email  string `json:"email"`
-}
-
-func (e *EventUnknownOwnerMatch) eventMatch() {}
 
 // EventFilter is a suggestion for a search filter. Currently has a 1-1
 // correspondance with the SearchFilter graphql type.
@@ -253,7 +244,6 @@ const (
 	PathMatchType
 	PersonMatchType
 	TeamMatchType
-	UnknownOwnerMatchType
 )
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
@@ -272,8 +262,6 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"person"`), nil
 	case TeamMatchType:
 		return []byte(`"team"`), nil
-	case UnknownOwnerMatchType:
-		return []byte(`"unknownOwner"`), nil
 	default:
 		return nil, errors.Errorf("unknown MatchType: %d", t)
 	}
@@ -294,8 +282,6 @@ func (t *MatchType) UnmarshalJSON(b []byte) error {
 		*t = PersonMatchType
 	} else if bytes.Equal(b, []byte(`"team"`)) {
 		*t = TeamMatchType
-	} else if bytes.Equal(b, []byte(`"unknownOwner"`)) {
-		*t = UnknownOwnerMatchType
 	} else {
 		return errors.Errorf("unknown MatchType: %s", b)
 	}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -174,8 +174,11 @@ type EventPersonMatch struct {
 	Handle string `json:"handle"`
 	Email  string `json:"email"`
 
-	// The following are a subset of types.User fields.
-	// These will not be set if no user was matched.
+	// User will not be set if no user was matched.
+	User UserMetadata `json:"user,omitempty"`
+}
+
+type UserMetadata struct {
 	Username    string `json:"username"`
 	DisplayName string `json:"displayName"`
 	AvatarURL   string `json:"avatarURL"`


### PR DESCRIPTION
follow-up on comments on the [ownership API PR](https://github.com/sourcegraph/sourcegraph/pull/46591#issuecomment-1433055279). 

Essentially all this does is scrap the "unknown owner type" (which I saw wasn't being used so far in the webapp PR). if we have the user data we display it in `Person` otherwise we don't. This will match behaviour for Ownership GraphQL objects.

## Test plan

Updated existing unit tests.
Ran manual search API query again:
```
curl \
  -H 'Authorization: token x' -H 'Accept: text/event-stream' --get --url 'https://sourcegraph.test:3443/.api/search/stream' --data-urlencode "q=repo:sourcegraph-test leo select:file.owners"

event: matches
data: [{"type":"person","handle":"notadmin","email":"","username":"notadmin","displayName":"","avatarURL":""},{"type":"person","handle":"notadmin","email":"","username":"notadmin","displayName":"","avatarURL":""},{"type":"person","handle":"leonore","email":"","username":"","displayName":"","avatarURL":""}]

event: progress
data: {"done":true,"repositoriesCount":1,"matchCount":3,"durationMs":119,"skipped":[]}

event: done
data: {}
```