### PR TITLE
codeintel: Move common graphql utils to shared package

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/shared/indexers.go
+++ b/enterprise/internal/codeintel/autoindexing/shared/indexers.go
@@ -1,0 +1,44 @@
+package shared
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+)
+
+type AvailableIndexer struct {
+	Roots   []string
+	Indexer types.CodeIntelIndexer
+}
+
+type JobsOrHints interface {
+	config.IndexJob | config.IndexJobHint
+	GetIndexerName() string
+	GetRoot() string
+}
+
+func PopulateInferredAvailableIndexers[J JobsOrHints](jobsOrHints []J, blocklist map[string]struct{}, inferredAvailableIndexers map[string]AvailableIndexer) map[string]AvailableIndexer {
+	for _, job := range jobsOrHints {
+		indexer := job.GetIndexerName()
+		key := GetKeyForLookup(indexer, job.GetRoot())
+		// Only add them to the inferred jobs map if they're not already in the recent uploads
+		// blocklist. This is to avoid hinting at an available index if we've already indexed it.
+		if _, ok := blocklist[key]; !ok {
+			ai := inferredAvailableIndexers[key]
+			ai.Roots = append(ai.Roots, job.GetRoot())
+			if p, ok := types.PreferredIndexers[indexer]; ok {
+				ai.Indexer = p
+			}
+
+			inferredAvailableIndexers[indexer] = ai
+		}
+	}
+
+	return inferredAvailableIndexers
+}
+
+// GetKeyForLookup creates a quick unique key for a map lookup.
+func GetKeyForLookup(indexer, root string) string {
+	return fmt.Sprintf("%s:%s", indexer, root)
+}

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -197,7 +195,7 @@ func (r *rootResolver) PreciseIndexes(ctx context.Context, args *resolverstubs.P
 
 	resolvers := make([]resolverstubs.PreciseIndexResolver, 0, len(pairs))
 	for _, pair := range pairs {
-		resolver, err := NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, pair.upload, pair.index)
+		resolver, err := sharedresolvers.NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, pair.upload, pair.index)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +229,7 @@ func (r *rootResolver) PreciseIndexByID(ctx context.Context, id graphql.ID) (_ r
 			return nil, err
 		}
 
-		return NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, &upload, nil)
+		return sharedresolvers.NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, &upload, nil)
 	}
 	if indexID != 0 {
 		index, ok, err := r.autoindexSvc.GetIndexByID(ctx, indexID)
@@ -239,7 +237,7 @@ func (r *rootResolver) PreciseIndexByID(ctx context.Context, id graphql.ID) (_ r
 			return nil, err
 		}
 
-		return NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, nil, &index)
+		return sharedresolvers.NewPreciseIndexResolver(ctx, r.autoindexSvc, r.uploadSvc, r.policySvc, prefetcher, locationResolver, errTracer, nil, &index)
 	}
 
 	return nil, errors.New("invalid identifier")
@@ -446,292 +444,6 @@ func (r *preciseIndexConnectionResolver) PageInfo(ctx context.Context) (resolver
 	}
 
 	return &pageInfo{hasNextPage: false}, nil
-}
-
-type preciseIndexResolver struct {
-	upload         *types.Upload
-	index          *types.Index
-	uploadResolver resolverstubs.LSIFUploadResolver
-	indexResolver  resolverstubs.LSIFIndexResolver
-}
-
-func NewPreciseIndexResolver(
-	ctx context.Context,
-	autoindexingSvc AutoIndexingService,
-	uploadsSvc UploadsService,
-	policySvc PolicyService,
-	prefetcher *sharedresolvers.Prefetcher,
-	locationResolver *sharedresolvers.CachedLocationResolver,
-	traceErrs *observation.ErrCollector,
-	upload *types.Upload,
-	index *types.Index,
-) (resolverstubs.PreciseIndexResolver, error) {
-	if index != nil && index.AssociatedUploadID != nil && upload == nil {
-		v, ok, err := prefetcher.GetUploadByID(ctx, *index.AssociatedUploadID)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			upload = &v
-		}
-	}
-
-	var uploadResolver resolverstubs.LSIFUploadResolver
-	if upload != nil {
-		uploadResolver = sharedresolvers.NewUploadResolver(uploadsSvc, autoindexingSvc, policySvc, *upload, prefetcher, locationResolver, traceErrs)
-
-		if upload.AssociatedIndexID != nil {
-			v, ok, err := prefetcher.GetIndexByID(ctx, *upload.AssociatedIndexID)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				index = &v
-			}
-		}
-	}
-
-	var indexResolver resolverstubs.LSIFIndexResolver
-	if index != nil {
-		indexResolver = sharedresolvers.NewIndexResolver(autoindexingSvc, uploadsSvc, policySvc, *index, prefetcher, locationResolver, traceErrs)
-	}
-
-	return &preciseIndexResolver{
-		upload:         upload,
-		index:          index,
-		uploadResolver: uploadResolver,
-		indexResolver:  indexResolver,
-	}, nil
-}
-
-func (r *preciseIndexResolver) ID() graphql.ID {
-	var parts []string
-	if r.upload != nil {
-		parts = append(parts, fmt.Sprintf("U:%d", r.upload.ID))
-	}
-	if r.index != nil {
-		parts = append(parts, fmt.Sprintf("I:%d", r.index.ID))
-	}
-
-	return relay.MarshalID("PreciseIndex", strings.Join(parts, ":"))
-}
-
-func (r *preciseIndexResolver) ProjectRoot(ctx context.Context) (resolverstubs.GitTreeEntryResolver, error) {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.ProjectRoot(ctx)
-	}
-
-	return r.indexResolver.ProjectRoot(ctx)
-}
-
-func (r *preciseIndexResolver) InputCommit() string {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.InputCommit()
-	}
-
-	return r.indexResolver.InputCommit()
-}
-
-func (r *preciseIndexResolver) Tags(ctx context.Context) ([]string, error) {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.Tags(ctx)
-	}
-
-	return r.indexResolver.Tags(ctx)
-}
-
-func (r *preciseIndexResolver) InputRoot() string {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.InputRoot()
-	}
-
-	return r.indexResolver.InputRoot()
-}
-
-func (r *preciseIndexResolver) InputIndexer() string {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.InputIndexer()
-	}
-
-	return r.indexResolver.InputIndexer()
-}
-
-func (r *preciseIndexResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.Indexer()
-	}
-
-	return r.indexResolver.Indexer()
-}
-
-func (r *preciseIndexResolver) State() string {
-	if r.upload != nil {
-		switch strings.ToUpper(r.upload.State) {
-		case "UPLOADING":
-			return "UPLOADING_INDEX"
-
-		case "QUEUED":
-			return "QUEUED_FOR_PROCESSING"
-
-		case "PROCESSING":
-			return "PROCESSING"
-
-		case "FAILED":
-			fallthrough
-		case "ERRORED":
-			return "PROCESSING_ERRORED"
-
-		case "COMPLETED":
-			return "COMPLETED"
-
-		case "DELETING":
-			return "DELETING"
-
-		case "DELETED":
-			return "DELETED"
-
-		default:
-			panic(fmt.Sprintf("unrecognized upload state %q", r.upload.State))
-		}
-	}
-
-	switch strings.ToUpper(r.index.State) {
-	case "QUEUED":
-		return "QUEUED_FOR_INDEXING"
-
-	case "PROCESSING":
-		return "INDEXING"
-
-	case "FAILED":
-		fallthrough
-	case "ERRORED":
-		return "INDEXING_ERRORED"
-
-	case "COMPLETED":
-		// Should not actually occur in practice (where did upload go?)
-		return "INDEXING_COMPLETED"
-
-	default:
-		panic(fmt.Sprintf("unrecognized index state %q", r.index.State))
-	}
-}
-
-func (r *preciseIndexResolver) QueuedAt() *gqlutil.DateTime {
-	if r.indexResolver != nil {
-		t := r.indexResolver.QueuedAt()
-		return &t
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) UploadedAt() *gqlutil.DateTime {
-	if r.uploadResolver != nil {
-		t := r.uploadResolver.UploadedAt()
-		return &t
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) IndexingStartedAt() *gqlutil.DateTime {
-	if r.indexResolver != nil {
-		return r.indexResolver.StartedAt()
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) ProcessingStartedAt() *gqlutil.DateTime {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.StartedAt()
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) IndexingFinishedAt() *gqlutil.DateTime {
-	if r.indexResolver != nil {
-		return r.indexResolver.FinishedAt()
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) ProcessingFinishedAt() *gqlutil.DateTime {
-	if r.uploadResolver != nil {
-		return r.uploadResolver.FinishedAt()
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) Steps() resolverstubs.IndexStepsResolver {
-	if r.indexResolver == nil {
-		return nil
-	}
-
-	return r.indexResolver.Steps()
-}
-
-func (r *preciseIndexResolver) Failure() *string {
-	if r.upload != nil && r.upload.FailureMessage != nil {
-		return r.upload.FailureMessage
-	} else if r.index != nil {
-		return r.index.FailureMessage
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) PlaceInQueue() *int32 {
-	if r.index != nil && r.index.Rank != nil {
-		return toInt32(r.index.Rank)
-	}
-
-	if r.upload != nil && r.upload.Rank != nil {
-		return toInt32(r.upload.Rank)
-	}
-
-	return nil
-}
-
-func (r *preciseIndexResolver) ShouldReindex(ctx context.Context) bool {
-	if r.index != nil {
-		if r.upload != nil {
-			return r.upload.ShouldReindex && r.index.ShouldReindex
-		}
-
-		return r.index.ShouldReindex
-	}
-	if r.upload != nil {
-		return r.upload.ShouldReindex
-	}
-	return false
-}
-
-func (r *preciseIndexResolver) IsLatestForRepo() bool {
-	if r.upload == nil {
-		return false
-	}
-
-	return r.upload.VisibleAtTip
-}
-
-func (r *preciseIndexResolver) RetentionPolicyOverview(ctx context.Context, args *resolverstubs.LSIFUploadRetentionPolicyMatchesArgs) (resolverstubs.CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error) {
-	if r.uploadResolver == nil {
-		return nil, nil
-	}
-
-	return r.uploadResolver.RetentionPolicyOverview(ctx, args)
-}
-
-func (r *preciseIndexResolver) AuditLogs(ctx context.Context) (*[]resolverstubs.LSIFUploadsAuditLogsResolver, error) {
-	if r.uploadResolver == nil {
-		return nil, nil
-	}
-
-	return r.uploadResolver.AuditLogs(ctx)
 }
 
 func unmarshalPreciseIndexGQLID(id graphql.ID) (uploadID, indexID int, err error) {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/regexp"
@@ -424,7 +425,7 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ 
 	// Create blocklist for indexes that have already been uploaded.
 	blocklist := map[string]struct{}{}
 	for _, u := range recentUploads {
-		key := getKeyForLookup(u.Indexer, u.Root)
+		key := shared.GetKeyForLookup(u.Indexer, u.Root)
 		blocklist[key] = struct{}{}
 	}
 
@@ -434,14 +435,14 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ 
 		return nil, err
 	}
 
-	availableIndexersMap := map[string]availableIndexer{}
-	inferredAvailableIndexers := populateInferredAvailableIndexers(indexJobs, blocklist, availableIndexersMap)
+	availableIndexersMap := map[string]shared.AvailableIndexer{}
+	inferredAvailableIndexers := shared.PopulateInferredAvailableIndexers(indexJobs, blocklist, availableIndexersMap)
 
 	indexJobHints, err := r.autoindexSvc.InferIndexJobHintsFromRepositoryStructure(ctx, repoID, commit)
 	if err != nil {
 		return nil, err
 	}
-	inferredAvailableIndexers = populateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
+	inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
 
 	inferredAvailableIndexersResolver := make([]sharedresolvers.InferredAvailableIndexers, 0, len(inferredAvailableIndexers))
 	for indexName, indexer := range inferredAvailableIndexers {
@@ -449,7 +450,7 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ 
 			sharedresolvers.InferredAvailableIndexers{
 				Roots: indexer.Roots,
 				Index: indexName,
-				URL:   indexer.URL,
+				URL:   fmt.Sprintf("https://%s", indexer.Indexer.URN),
 			},
 		)
 	}

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/utils.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/utils.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -11,10 +10,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
 
 // strPtr creates a pointer to the given value. If the value is an
@@ -25,42 +22,6 @@ func strPtr(val string) *string {
 	}
 
 	return &val
-}
-
-// getKeyForLookup creates a quick unique key for a map lookup.
-func getKeyForLookup(indexer, root string) string {
-	return fmt.Sprintf("%s:%s", indexer, root)
-}
-
-type availableIndexer struct {
-	Roots []string
-	URL   string
-}
-
-type JobsOrHints interface {
-	config.IndexJob | config.IndexJobHint
-	GetIndexerName() string
-	GetRoot() string
-}
-
-func populateInferredAvailableIndexers[J JobsOrHints](jobsOrHints []J, blocklist map[string]struct{}, inferredAvailableIndexers map[string]availableIndexer) map[string]availableIndexer {
-	for _, job := range jobsOrHints {
-		indexer := job.GetIndexerName()
-		key := getKeyForLookup(indexer, job.GetRoot())
-		// Only add them to the inferred jobs map if they're not already in the recent uploads
-		// blocklist. This is to avoid hinting at an available index if we've already indexed it.
-		if _, ok := blocklist[key]; !ok {
-			ai := inferredAvailableIndexers[key]
-			ai.Roots = append(ai.Roots, job.GetRoot())
-			if p, ok := types.PreferredIndexers[indexer]; ok {
-				ai.URL = fmt.Sprintf("https://%s", p.URN)
-			}
-
-			inferredAvailableIndexers[indexer] = ai
-		}
-	}
-
-	return inferredAvailableIndexers
 }
 
 func marshalLSIFIndexGQLID(indexID int64) graphql.ID {

--- a/enterprise/internal/codeintel/shared/resolvers/precise_indexes.go
+++ b/enterprise/internal/codeintel/shared/resolvers/precise_indexes.go
@@ -1,0 +1,301 @@
+package sharedresolvers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type preciseIndexResolver struct {
+	upload         *types.Upload
+	index          *types.Index
+	uploadResolver resolverstubs.LSIFUploadResolver
+	indexResolver  resolverstubs.LSIFIndexResolver
+}
+
+func NewPreciseIndexResolver(
+	ctx context.Context,
+	autoindexingSvc AutoIndexingService,
+	uploadsSvc UploadsService,
+	policySvc PolicyService,
+	prefetcher *Prefetcher,
+	locationResolver *CachedLocationResolver,
+	traceErrs *observation.ErrCollector,
+	upload *types.Upload,
+	index *types.Index,
+) (resolverstubs.PreciseIndexResolver, error) {
+	if index != nil && index.AssociatedUploadID != nil && upload == nil {
+		v, ok, err := prefetcher.GetUploadByID(ctx, *index.AssociatedUploadID)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			upload = &v
+		}
+	}
+
+	var uploadResolver resolverstubs.LSIFUploadResolver
+	if upload != nil {
+		uploadResolver = NewUploadResolver(uploadsSvc, autoindexingSvc, policySvc, *upload, prefetcher, locationResolver, traceErrs)
+
+		if upload.AssociatedIndexID != nil {
+			v, ok, err := prefetcher.GetIndexByID(ctx, *upload.AssociatedIndexID)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				index = &v
+			}
+		}
+	}
+
+	var indexResolver resolverstubs.LSIFIndexResolver
+	if index != nil {
+		indexResolver = NewIndexResolver(autoindexingSvc, uploadsSvc, policySvc, *index, prefetcher, locationResolver, traceErrs)
+	}
+
+	return &preciseIndexResolver{
+		upload:         upload,
+		index:          index,
+		uploadResolver: uploadResolver,
+		indexResolver:  indexResolver,
+	}, nil
+}
+
+func (r *preciseIndexResolver) ID() graphql.ID {
+	var parts []string
+	if r.upload != nil {
+		parts = append(parts, fmt.Sprintf("U:%d", r.upload.ID))
+	}
+	if r.index != nil {
+		parts = append(parts, fmt.Sprintf("I:%d", r.index.ID))
+	}
+
+	return relay.MarshalID("PreciseIndex", strings.Join(parts, ":"))
+}
+
+func (r *preciseIndexResolver) ProjectRoot(ctx context.Context) (resolverstubs.GitTreeEntryResolver, error) {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.ProjectRoot(ctx)
+	}
+
+	return r.indexResolver.ProjectRoot(ctx)
+}
+
+func (r *preciseIndexResolver) InputCommit() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputCommit()
+	}
+
+	return r.indexResolver.InputCommit()
+}
+
+func (r *preciseIndexResolver) Tags(ctx context.Context) ([]string, error) {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.Tags(ctx)
+	}
+
+	return r.indexResolver.Tags(ctx)
+}
+
+func (r *preciseIndexResolver) InputRoot() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputRoot()
+	}
+
+	return r.indexResolver.InputRoot()
+}
+
+func (r *preciseIndexResolver) InputIndexer() string {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.InputIndexer()
+	}
+
+	return r.indexResolver.InputIndexer()
+}
+
+func (r *preciseIndexResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.Indexer()
+	}
+
+	return r.indexResolver.Indexer()
+}
+
+func (r *preciseIndexResolver) State() string {
+	if r.upload != nil {
+		switch strings.ToUpper(r.upload.State) {
+		case "UPLOADING":
+			return "UPLOADING_INDEX"
+
+		case "QUEUED":
+			return "QUEUED_FOR_PROCESSING"
+
+		case "PROCESSING":
+			return "PROCESSING"
+
+		case "FAILED":
+			fallthrough
+		case "ERRORED":
+			return "PROCESSING_ERRORED"
+
+		case "COMPLETED":
+			return "COMPLETED"
+
+		case "DELETING":
+			return "DELETING"
+
+		case "DELETED":
+			return "DELETED"
+
+		default:
+			panic(fmt.Sprintf("unrecognized upload state %q", r.upload.State))
+		}
+	}
+
+	switch strings.ToUpper(r.index.State) {
+	case "QUEUED":
+		return "QUEUED_FOR_INDEXING"
+
+	case "PROCESSING":
+		return "INDEXING"
+
+	case "FAILED":
+		fallthrough
+	case "ERRORED":
+		return "INDEXING_ERRORED"
+
+	case "COMPLETED":
+		// Should not actually occur in practice (where did upload go?)
+		return "INDEXING_COMPLETED"
+
+	default:
+		panic(fmt.Sprintf("unrecognized index state %q", r.index.State))
+	}
+}
+
+func (r *preciseIndexResolver) QueuedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		t := r.indexResolver.QueuedAt()
+		return &t
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) UploadedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		t := r.uploadResolver.UploadedAt()
+		return &t
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) IndexingStartedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		return r.indexResolver.StartedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ProcessingStartedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.StartedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) IndexingFinishedAt() *gqlutil.DateTime {
+	if r.indexResolver != nil {
+		return r.indexResolver.FinishedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ProcessingFinishedAt() *gqlutil.DateTime {
+	if r.uploadResolver != nil {
+		return r.uploadResolver.FinishedAt()
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) Steps() resolverstubs.IndexStepsResolver {
+	if r.indexResolver == nil {
+		return nil
+	}
+
+	return r.indexResolver.Steps()
+}
+
+func (r *preciseIndexResolver) Failure() *string {
+	if r.upload != nil && r.upload.FailureMessage != nil {
+		return r.upload.FailureMessage
+	} else if r.index != nil {
+		return r.index.FailureMessage
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) PlaceInQueue() *int32 {
+	if r.index != nil && r.index.Rank != nil {
+		return toInt32(r.index.Rank)
+	}
+
+	if r.upload != nil && r.upload.Rank != nil {
+		return toInt32(r.upload.Rank)
+	}
+
+	return nil
+}
+
+func (r *preciseIndexResolver) ShouldReindex(ctx context.Context) bool {
+	if r.index != nil {
+		if r.upload != nil {
+			return r.upload.ShouldReindex && r.index.ShouldReindex
+		}
+
+		return r.index.ShouldReindex
+	}
+	if r.upload != nil {
+		return r.upload.ShouldReindex
+	}
+	return false
+}
+
+func (r *preciseIndexResolver) IsLatestForRepo() bool {
+	if r.upload == nil {
+		return false
+	}
+
+	return r.upload.VisibleAtTip
+}
+
+func (r *preciseIndexResolver) RetentionPolicyOverview(ctx context.Context, args *resolverstubs.LSIFUploadRetentionPolicyMatchesArgs) (resolverstubs.CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error) {
+	if r.uploadResolver == nil {
+		return nil, nil
+	}
+
+	return r.uploadResolver.RetentionPolicyOverview(ctx, args)
+}
+
+func (r *preciseIndexResolver) AuditLogs(ctx context.Context) (*[]resolverstubs.LSIFUploadsAuditLogsResolver, error) {
+	if r.uploadResolver == nil {
+		return nil, nil
+	}
+
+	return r.uploadResolver.AuditLogs(ctx)
+}


### PR DESCRIPTION
Move some useful functions into shared package. Pulled from #47287.

## Test plan

Existing unit tests.