### PR TITLE
Fix query submit for the expanded search aggregation mode

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -306,11 +306,20 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         [telemetryService, props, navigate, location, caseSensitive, patternType, submittedURLQuery]
     )
 
-    const handleSearchAggregationBarClick = (query: string): void => {
+    /**
+     * The `updatedSearchQuery` is required in case we synchronously update the search
+     * query in the event handlers and want to submit a new search. Without this argument,
+     * the `handleSidebarSearchSubmit` function uses the outdated location reference
+     * because the component was not re-rendered yet.
+     *
+     * Example use-case: search-aggregation result bar click where we first update the URL
+     * by settings the `groupBy` search param to `null` and then synchronously call `submitSearch`.
+     */
+    const handleSearchAggregationBarClick = (query: string, updatedSearchQuery: string): void => {
         const { selectedSearchContextSpec } = props
         submitSearch({
             historyOrNavigate: navigate,
-            location,
+            location: { ...location, search: updatedSearchQuery },
             selectedSearchContextSpec,
             caseSensitive,
             patternType,

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -38,14 +38,14 @@ interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HT
      * That should update the query and re-trigger search (but this should be connected
      * to this UI through its consumer)
      */
-    onQuerySubmit: (newQuery: string) => void
+    onQuerySubmit: (newQuery: string, updatedQuerySearch: string) => void
 }
 
 export const SearchAggregationResult: FC<SearchAggregationResultProps> = props => {
     const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, ...attributes } = props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
-    const [aggregationUIMode, setAggregationUIMode] = useAggregationUIMode()
+    const [, setAggregationUIMode] = useAggregationUIMode()
     const [aggregationMode, setAggregationMode] = useAggregationSearchMode()
     const { data, error, loading } = useSearchAggregationData({
         query,
@@ -62,20 +62,13 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         telemetryService.log(GroupResultsPing.CollapseFullViewPanel, { aggregationMode }, { aggregationMode })
     }
 
-    const resetUIMode = (): void => {
-        if (aggregationUIMode !== AggregationUIMode.Sidebar) {
-            setAggregationUIMode(AggregationUIMode.Sidebar)
-        }
-    }
-
     const handleBarLinkClick = (query: string, index: number): void => {
         // Clearing the aggregation mode on drill down would provide a better experience
         // in most cases and preserve the desired behavior of the capture group search
         // when the original query had multiple capture groups
-        setAggregationMode(null)
+        const updatedSearchQuery = setAggregationMode(null)
 
-        resetUIMode()
-        onQuerySubmit(query)
+        onQuerySubmit(query, updatedSearchQuery)
         telemetryService.log(
             GroupResultsPing.ChartBarClick,
             { aggregationMode, index, uiMode: 'resultsScreen' },


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/47719

Important note that reset UI logic here was broken too, we don't have good idea how to fix it so I removed it from the expanded mode, but I will file an issue to track this later.

## Test plan
## Test plan

- Go to the home page (search any query with capture group param, for example, `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log`
- You should see that by default, we provide capture group aggregation 
- Switch to expanded mode
- If you pick one of the aggregation bars, you probably should see the other aggregation type (not capture group since we replace the original query with a specific bar capture group value) 
- In case of `file:go\.mod go\s*(\d\.\d+) [\s\S]* github.com/sourcegraph/log` it should be repo aggregation 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
