### PR TITLE
Release protector: Include freeze end date in comment

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -112,6 +112,8 @@ jobs:
             else
               echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
               echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
+              echo "❓ The code freeze is active until ${release_date} at 23:59."
+              echo "release_date=${release_date}" >> $GITHUB_ENV
               exit 1
             fi
           else
@@ -150,7 +152,7 @@ jobs:
             let d = new Date()
             d.setHours(d.getHours() -1) // Yes, this handles properly midnight.
 
-            let body = "❌ **Problem**: the label `i-acknowledge-this-goes-into-the-release` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with `i-acknowledge-this-goes-into-the-release`."
+            let body = `❌ **Problem**: the label \`i-acknowledge-this-goes-into-the-release\` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with \`i-acknowledge-this-goes-into-the-release\`.\n❓ **When does the freeze end?** The code freeze is active until ${process.env.release_date} at 23:59.`
             let skip = false
 
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Description

I was on leave when discussions around the code freeze were ongoing. I think it's useful to know when the freeze (and thus release) ends when deciding if a change should be released.

## Test plan

Hopefully it will comment on this PR (:

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
