### PR TITLE
codeintel: Do not alert on limit errors

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -73,7 +73,7 @@ func NewScheduler(
 			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.As(err, &inference.LimitError{}) {
-					return observation.EmitForDefault.Without(observation.EmitForMetrics)
+					return observation.EmitForNone
 				}
 				return observation.EmitForDefault
 			},

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -135,9 +135,11 @@ func (b indexSchedulerJob) handleScheduler(
 		go func(repositoryID int) {
 			defer sema.Release(1)
 			if repositoryErr := b.handleRepository(ctx, repositoryID, policyBatchSize, now); repositoryErr != nil {
-				errMu.Lock()
-				errs = errors.Append(errs, repositoryErr)
-				errMu.Unlock()
+				if !errors.As(err, &inference.LimitError{}) {
+					errMu.Lock()
+					errs = errors.Append(errs, repositoryErr)
+					errMu.Unlock()
+				}
 			}
 		}(repositoryID)
 	}

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
@@ -3,8 +3,10 @@ package enqueuer
 import (
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type operations struct {
@@ -29,6 +31,12 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.enqueuer.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if errors.As(err, &inference.LimitError{}) {
+					return observation.EmitForNone
+				}
+				return observation.EmitForDefault
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/observability.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type operations struct {
@@ -35,6 +36,12 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.inference.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           redMetrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if errors.As(err, &LimitError{}) {
+					return observation.EmitForNone
+				}
+				return observation.EmitForDefault
+			},
 		})
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/observability.go
@@ -3,8 +3,10 @@ package autoindexing
 import (
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type operations struct {
@@ -61,6 +63,12 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("codeintel.autoindexing.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           m,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if errors.As(err, &inference.LimitError{}) {
+					return observation.EmitForNone
+				}
+				return observation.EmitForDefault
+			},
 		})
 	}
 


### PR DESCRIPTION
Put error filters around inference errors.

## Test plan

Tested locally, saw less blather.