### PR TITLE
experimental search input: Fix context filter handling

### DIFF
--- a/client/branded/src/search-ui/input/experimental/LazyCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/experimental/LazyCodeMirrorQueryInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -8,4 +8,8 @@ const CodeMirrorQueryInput = lazyComponent(() => import('./CodeMirrorQueryInputW
 
 export const LazyCodeMirrorQueryInput: React.FunctionComponent<
     React.PropsWithChildren<CodeMirrorQueryInputWrapperProps>
-> = props => <CodeMirrorQueryInput {...props} />
+> = props => (
+    <Suspense fallback={null}>
+        <CodeMirrorQueryInput {...props} />
+    </Suspense>
+)

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -218,8 +218,9 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
     )
 
     const selectedSearchContextSpecRef = useRef(selectedSearchContextSpec)
-    selectedSearchContextSpecRef.current = selectedSearchContextSpec
-
+    useEffect(() => {
+        selectedSearchContextSpecRef.current = selectedSearchContextSpec
+    }, [selectedSearchContextSpec])
     const getSelectedSearchContextSpec = useCallback(
         (): string | undefined =>
             getExperimentalFeatures().showSearchContext ? selectedSearchContextSpecRef.current ?? undefined : undefined,

--- a/client/web/src/search/index.test.ts
+++ b/client/web/src/search/index.test.ts
@@ -190,7 +190,6 @@ describe('updateQueryStateFromURL', () => {
     }
 
     const isSearchContextAvailable = () => Promise.resolve(true)
-    const showSearchContext = false
 
     describe('search context', () => {
         it('should extract the search context from the query', () => {
@@ -199,63 +198,12 @@ describe('updateQueryStateFromURL', () => {
             return getQueryStateFromLocation({
                 location: location.pipe(first()),
                 isSearchContextAvailable,
-                showSearchContext,
             })
                 .pipe(
                     last(),
-                    tap(({ searchContextSpec }) => {
-                        expect(searchContextSpec).toEqual('me')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('remove the context filter from the URL if search contexts are enabled and available', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                isSearchContextAvailable: () => Promise.resolve(true),
-                showSearchContext: true,
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('test')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('should not remove the context filter from the URL if search context is not available', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                showSearchContext: true,
-                isSearchContextAvailable: () => Promise.resolve(false),
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('context:me test')
-                    })
-                )
-                .toPromise()
-        })
-
-        it('should not remove the context filter from the URL if search contexts are disabled', () => {
-            const [location] = createHistoryObservable('q=context:me+test')
-
-            return getQueryStateFromLocation({
-                location: location.pipe(first()),
-                showSearchContext: false,
-                isSearchContextAvailable: () => Promise.resolve(true),
-            })
-                .pipe(
-                    last(),
-                    tap(({ processedQuery }) => {
-                        expect(processedQuery).toBe('context:me test')
+                    tap(({ searchContextSpec, query }) => {
+                        expect(searchContextSpec?.spec).toEqual('me')
+                        expect(query).toEqual('context:me test')
                     })
                 )
                 .toPromise()

--- a/client/web/src/search/index.ts
+++ b/client/web/src/search/index.ts
@@ -216,13 +216,7 @@ interface ParsedSearchURLAndContext extends ParsedSearchURL {
     /**
      * Search context extracted from query.
      */
-    searchContextSpec: string | undefined
-    /**
-     * Cleaned up query (if search contexts are enabled and URL query contains a
-     * search context, this property contains the query without the context
-     * filter)
-     */
-    processedQuery: string
+    searchContextSpec: ReturnType<typeof getGlobalSearchContextFilter> | undefined
 }
 
 /**
@@ -235,15 +229,9 @@ interface ParsedSearchURLAndContext extends ParsedSearchURL {
  */
 export function getQueryStateFromLocation({
     location,
-    showSearchContext,
     isSearchContextAvailable,
 }: {
     location: Observable<Location>
-    /**
-     * Whether or not the search context should be shown or not.
-     * This is enabled on enterprise instances
-     */
-    showSearchContext: boolean
     /**
      * Resolves to true if the provided search context exists for the user.
      */
@@ -282,15 +270,10 @@ export function getQueryStateFromLocation({
         map(locationAndContextInformation => {
             const { parsedSearchURL, isSearchContextAvailable } = locationAndContextInformation
             const query = parsedSearchURL.query ?? ''
-            const globalSearchContextSpec = memoizedGetGlobalSearchContextSpec(query)
-            const cleanQuery =
-                // If a global search context spec is available to the user, we omit it from the
-                // query and move it to the search contexts dropdown
-                globalSearchContextSpec && isSearchContextAvailable && showSearchContext
-                    ? omitFilter(query, globalSearchContextSpec.filter)
-                    : query
-
-            return { ...parsedSearchURL, searchContextSpec: globalSearchContextSpec?.spec, processedQuery: cleanQuery }
+            const globalSearchContextSpec = isSearchContextAvailable
+                ? memoizedGetGlobalSearchContextSpec(query)
+                : undefined
+            return { ...parsedSearchURL, searchContextSpec: globalSearchContextSpec }
         })
     )
 }


### PR DESCRIPTION
This commit fixes an issue with the context filter on the search result and repo pages.
When we sync the query from the URL to the input we've been removing the context filter from the query, because we currently have a separate context selector. The new input doesn't have that though so the context filter needs to be preserved.

This required some refactoring of the code responsible for making the synchronization and was made more difficult by the fact that experimental feature flags have to be loaded asynchronously and can change over time.

Additionally there was an issue with React suspense when navigating from a non-repo/results page to the repo/results page after a full page reload, which is why I had to add `<Suspense>`.



https://user-images.githubusercontent.com/179026/219434156-f8a2c9fd-d0d0-4b40-900f-4b95ebac8bdc.mp4




## Test plan

Manual testing (behind feature flag)

- With the experimental search input enabled the context filter is preserved.
- With the experimental search input disabled the context filter is removed from the query and the search context selector is updated.

## App preview:

- [Web](https://sg-web-fkling-search-input-everywhere-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
