### PR TITLE
gRPC: close conn when we get an error from gitserver

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -606,6 +606,7 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, errRe
 		client := proto.NewGitserverServiceClient(conn)
 		stream, err := client.Exec(ctx, req)
 		if err != nil {
+			conn.Close()
 			return nil, err
 		}
 		r := streamio.NewReader(func() ([]byte, error) {


### PR DESCRIPTION
In the case of an error, we were not closing the connection. In the non-error case, we return a `ReadCloser`, which should be closed by the caller. 

## Test plan

Manually ran a couple of searches.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
