### PR TITLE
insights: Fix admin ui queue items to use a compound key 

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -523,8 +523,13 @@ type RepositoryPreviewPayloadResolver interface {
 	NumberOfRepositories(ctx context.Context) *int32
 }
 
+type BackfillQueueID struct {
+	BackfillID int
+	InsightID  string
+}
 type BackfillQueueItemResolver struct {
 	BackfillID      int
+	InsightUniqueID string
 	InsightTitle    string
 	CreatorID       *int32
 	Label           string
@@ -534,7 +539,7 @@ type BackfillQueueItemResolver struct {
 }
 
 func (r *BackfillQueueItemResolver) ID() graphql.ID {
-	return relay.MarshalID("backfill", r.BackfillID)
+	return relay.MarshalID("backfillQueueItem", BackfillQueueID{BackfillID: r.BackfillID, InsightID: r.InsightUniqueID})
 }
 
 func (r *BackfillQueueItemResolver) IDInt32() int32 {

--- a/enterprise/cmd/frontend/internal/insights/resolvers/admin_resolver.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/admin_resolver.go
@@ -121,13 +121,13 @@ func (r *Resolver) RetryInsightSeriesBackfill(ctx context.Context, args *graphql
 	if err := auth.CheckUserIsSiteAdmin(ctx, r.postgresDB, actr.UID); err != nil {
 		return nil, err
 	}
-	var backfillID int
-	err := relay.UnmarshalSpec(args.Id, &backfillID)
+	var backfillQueueID graphqlbackend.BackfillQueueID
+	err := relay.UnmarshalSpec(args.Id, &backfillQueueID)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the backfill id")
 	}
 	backfillStore := scheduler.NewBackfillStore(r.insightsDB)
-	backfill, err := backfillStore.LoadBackfill(ctx, backfillID)
+	backfill, err := backfillStore.LoadBackfill(ctx, backfillQueueID.BackfillID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load backfill")
 	}
@@ -148,10 +148,11 @@ func (r *Resolver) RetryInsightSeriesBackfill(ctx context.Context, args *graphql
 	}
 	updatedItem := backfillItems[0]
 	return &graphqlbackend.BackfillQueueItemResolver{
-		BackfillID:   updatedItem.ID,
-		InsightTitle: updatedItem.InsightTitle,
-		Label:        updatedItem.SeriesLabel,
-		Query:        updatedItem.SeriesSearchQuery,
+		BackfillID:      updatedItem.ID,
+		InsightTitle:    updatedItem.InsightTitle,
+		Label:           updatedItem.SeriesLabel,
+		Query:           updatedItem.SeriesSearchQuery,
+		InsightUniqueID: updatedItem.InsightUniqueID,
 		BackfillStatus: &backfillStatusResolver{
 			queueItem: updatedItem,
 		},
@@ -163,13 +164,13 @@ func (r *Resolver) MoveInsightSeriesBackfillToFrontOfQueue(ctx context.Context, 
 	if err := auth.CheckUserIsSiteAdmin(ctx, r.postgresDB, actr.UID); err != nil {
 		return nil, err
 	}
-	var backfillID int
-	err := relay.UnmarshalSpec(args.Id, &backfillID)
+	var backfillQueueID graphqlbackend.BackfillQueueID
+	err := relay.UnmarshalSpec(args.Id, &backfillQueueID)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the backfill id")
 	}
 	backfillStore := scheduler.NewBackfillStore(r.insightsDB)
-	backfill, err := backfillStore.LoadBackfill(ctx, backfillID)
+	backfill, err := backfillStore.LoadBackfill(ctx, backfillQueueID.BackfillID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load backfill")
 	}
@@ -189,10 +190,11 @@ func (r *Resolver) MoveInsightSeriesBackfillToFrontOfQueue(ctx context.Context, 
 	}
 	updatedItem := backfillItems[0]
 	return &graphqlbackend.BackfillQueueItemResolver{
-		BackfillID:   updatedItem.ID,
-		InsightTitle: updatedItem.InsightTitle,
-		Label:        updatedItem.SeriesLabel,
-		Query:        updatedItem.SeriesSearchQuery,
+		BackfillID:      updatedItem.ID,
+		InsightTitle:    updatedItem.InsightTitle,
+		Label:           updatedItem.SeriesLabel,
+		Query:           updatedItem.SeriesSearchQuery,
+		InsightUniqueID: updatedItem.InsightUniqueID,
 		BackfillStatus: &backfillStatusResolver{
 			queueItem: updatedItem,
 		},
@@ -204,13 +206,13 @@ func (r *Resolver) MoveInsightSeriesBackfillToBackOfQueue(ctx context.Context, a
 	if err := auth.CheckUserIsSiteAdmin(ctx, r.postgresDB, actr.UID); err != nil {
 		return nil, err
 	}
-	var backfillID int
-	err := relay.UnmarshalSpec(args.Id, &backfillID)
+	var backfillQueueID graphqlbackend.BackfillQueueID
+	err := relay.UnmarshalSpec(args.Id, &backfillQueueID)
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling the backfill id")
 	}
 	backfillStore := scheduler.NewBackfillStore(r.insightsDB)
-	backfill, err := backfillStore.LoadBackfill(ctx, backfillID)
+	backfill, err := backfillStore.LoadBackfill(ctx, backfillQueueID.BackfillID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load backfill")
 	}
@@ -230,10 +232,11 @@ func (r *Resolver) MoveInsightSeriesBackfillToBackOfQueue(ctx context.Context, a
 	}
 	updatedItem := backfillItems[0]
 	return &graphqlbackend.BackfillQueueItemResolver{
-		BackfillID:   updatedItem.ID,
-		InsightTitle: updatedItem.InsightTitle,
-		Label:        updatedItem.SeriesLabel,
-		Query:        updatedItem.SeriesSearchQuery,
+		BackfillID:      updatedItem.ID,
+		InsightTitle:    updatedItem.InsightTitle,
+		Label:           updatedItem.SeriesLabel,
+		Query:           updatedItem.SeriesSearchQuery,
+		InsightUniqueID: updatedItem.InsightUniqueID,
 		BackfillStatus: &backfillStatusResolver{
 			queueItem: updatedItem,
 		},
@@ -463,11 +466,12 @@ func (a *adminBackfillQueueConnectionStore) ComputeNodes(ctx context.Context, ar
 	resolvers := make([]*graphqlbackend.BackfillQueueItemResolver, 0, len(backfillItems))
 	for _, item := range backfillItems {
 		resolvers = append(resolvers, &graphqlbackend.BackfillQueueItemResolver{
-			BackfillID:   item.ID,
-			InsightTitle: item.InsightTitle,
-			CreatorID:    item.CreatorID,
-			Label:        item.SeriesLabel,
-			Query:        item.SeriesSearchQuery,
+			BackfillID:      item.ID,
+			InsightTitle:    item.InsightTitle,
+			CreatorID:       item.CreatorID,
+			Label:           item.SeriesLabel,
+			Query:           item.SeriesSearchQuery,
+			InsightUniqueID: item.InsightUniqueID,
 			BackfillStatus: &backfillStatusResolver{
 				queueItem: item,
 			},

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -319,6 +319,7 @@ type BackfillQueueItem struct {
 	ID                  int
 	InsightTitle        string
 	SeriesID            int
+	InsightUniqueID     string
 	SeriesLabel         string
 	SeriesSearchQuery   string
 	BackfillState       string
@@ -401,6 +402,7 @@ func scanAllBackfillQueueItems(rows *sql.Rows, queryErr error) (_ []BackfillQueu
 			&temp.ID,
 			&temp.InsightTitle,
 			&temp.SeriesID,
+			&temp.InsightUniqueID,
 			&temp.SeriesLabel,
 			&temp.SeriesSearchQuery,
 			&temp.BackfillState,
@@ -475,6 +477,7 @@ END backfill_state
 select isb.id,
        title,
        s.id,
+	   iv.unique_id insight_id,
        label,
        query,
        state.backfill_state,

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -459,7 +459,7 @@ const (
 var backfillQueueSQL = `
 WITH job_queue as (
     select backfill_id, state, row_number() over (ORDER BY estimated_cost, backfill_id)  queue_position
-    from insights_jobs_backfill_in_progress where state = 'queued' order by estimated_cost, backfill_id
+    from insights_jobs_backfill_in_progress where state = 'queued'
 ),
 errors as (
     select repo_iterator_id, array_agg(err_msg) error_messages

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -458,7 +458,7 @@ const (
 
 var backfillQueueSQL = `
 WITH job_queue as (
-    select backfill_id, state, row_number() over () queue_position
+    select backfill_id, state, row_number() over (ORDER BY estimated_cost, backfill_id)  queue_position
     from insights_jobs_backfill_in_progress where state = 'queued' order by estimated_cost, backfill_id
 ),
 errors as (


### PR DESCRIPTION
It is possible for a single series to appear within multiple insights.  This change makes the ID of the queue item a compound key composed on the backfill id and the unique id of the insight.  The backfill ID is required because that is the ID that all mutations are applied to. It is not possible to retry, or reprioritize an insight or series, only the backfill that has/will occur.

Also includes a sql fix for the queue position to properly sort the backfills by cost, backfill_id.

## Test plan
Setup insights so the same series is reused on 2 insights.  
Pull admin queue via `insightAdminBackfillQueue`
ensure each item has a unique id

Test each mutation with the new ID 
 - moveInsightSeriesBackfillToFrontOfQueue
 - moveInsightSeriesBackfillToBackOfQueue
 - moveInsightSeriesBackfillToFrontOfQueue

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
