### PR TITLE
build-tracker: fix new var assignment in loop

### DIFF
--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -183,7 +183,7 @@ func (c *NotificationClient) createMessageBlocks(logger log.Logger, build *Build
 
 	jobSection := ""
 	for group, groupJobs := range filteredJobs {
-		jobSection := fmt.Sprintf("*%s jobs:*\n\n", group)
+		jobSection = fmt.Sprintf("*%s jobs:*\n\n", group)
 		// if there are more than JobShowLimit of failed jobs, we cannot print all of it
 		// since the message will to big and slack will reject the message with "invalid_blocks"
 		if len(groupJobs) > JobShowLimit {


### PR DESCRIPTION
new var was being created in a loop shadowing the outer var leading it to be empty forever ...
## Test plan
deploy and see. Also run integration tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
