### PR TITLE
cmd/frontend/auth: Add username and email in error message

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var MockGetAndSaveUser func(ctx context.Context, op GetAndSaveUserOp) (userID int32, safeErrMsg string, err error)
@@ -124,7 +125,7 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (u
 		case errcode.PresentationMessage(err) != "":
 			return 0, false, false, errcode.PresentationMessage(err), err
 		case err != nil:
-			return 0, false, false, "Unable to create a new user account due to a unexpected error. Ask a site admin for help.", err
+			return 0, false, false, "Unable to create a new user account due to a unexpected error. Ask a site admin for help.", errors.Wrapf(err, "username: %q, email: %q", op.UserProps.Username, op.UserProps.Email)
 		}
 		act.UID = user.ID
 

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -300,7 +300,7 @@ func TestGetAndSaveUser(t *testing.T) {
 			innerCases: []innerCase{{
 				op:         getNonExistentUserCreateIfNotExistOp,
 				expSafeErr: "Unable to create a new user account due to a unexpected error. Ask a site admin for help.",
-				expErr:     unexpectedErr,
+				expErr:     errors.Wrap(unexpectedErr, `username: "nonexistent", email: "nonexistent@example.com"`),
 			}},
 		},
 		{

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -3,12 +3,11 @@ package auth
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -300,7 +299,7 @@ func TestGetAndSaveUser(t *testing.T) {
 			innerCases: []innerCase{{
 				op:         getNonExistentUserCreateIfNotExistOp,
 				expSafeErr: "Unable to create a new user account due to a unexpected error. Ask a site admin for help.",
-				expErr:     errors.Wrap(unexpectedErr, `username: "nonexistent", email: "nonexistent@example.com"`),
+				expErr:     errors.Wrapf(unexpectedErr, `username: "nonexistent", email: "nonexistent@example.com"`),
 			}},
 		},
 		{
@@ -395,23 +394,29 @@ func TestGetAndSaveUser(t *testing.T) {
 						op := c.op
 						op.CreateIfNotExist = createIfNotExist
 						userID, safeErr, err := GetAndSaveUser(ctx, m.DB(), op)
-						for _, v := range []struct {
-							label string
-							got   any
-							want  any
-						}{
-							{"userID", userID, c.expUserID},
-							{"safeErr", safeErr, c.expSafeErr},
-							{"err", err, c.expErr},
-							{"savedExtAccts (side-effect)", m.savedExtAccts, c.expSavedExtAccts},
-							{"updatedUsers (side-effect)", m.updatedUsers, c.expUpdatedUsers},
-							{"createdUsers (side-effect)", m.createdUsers, c.expCreatedUsers},
-						} {
-							if label, got, want := v.label, v.got, v.want; !reflect.DeepEqual(got, want) {
-								dmp := diffmatchpatch.New()
-								t.Errorf("%s: got != want\n%#v != %#v\ndiff(got, want):\n%s",
-									label, got, want, dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(want), spew.Sdump(got), false)))
-							}
+
+						if userID != c.expUserID {
+							t.Errorf("mismatched userID, want: %v, but got %v", c.expUserID, userID)
+						}
+
+						if diff := cmp.Diff(safeErr, c.expSafeErr); diff != "" {
+							t.Errorf("mismatched safeErr, got != want, diff(-got, +want):\n%s", diff)
+						}
+
+						if !errors.Is(err, c.expErr) {
+							t.Errorf("mismatched errors, want %#v, but got %#v", c.expErr, err)
+						}
+
+						if diff := cmp.Diff(m.savedExtAccts, c.expSavedExtAccts); diff != "" {
+							t.Errorf("mismatched side-effect savedExtAccts, got != want, diff(-got, +want):\n%s", diff)
+						}
+
+						if diff := cmp.Diff(m.updatedUsers, c.expUpdatedUsers); diff != "" {
+							t.Errorf("mismatched side-effect updatedUsers, got != want, diff(-got, +want):\n%s", diff)
+						}
+
+						if diff := cmp.Diff(m.createdUsers, c.expCreatedUsers); diff != "" {
+							t.Errorf("mismatched side-effect createdUsers, got != want, diff(-got, +want):\n%s", diff)
 						}
 
 						if c.expCalledGrantPendingPermissions != m.calledGrantPendingPermissions {

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	mockrequire "github.com/derision-test/go-mockgen/testutil/require"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -18,12 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func init() {
-	spew.Config.DisablePointerAddresses = true
-	spew.Config.SortKeys = true
-	spew.Config.SpewKeys = true
-}
 
 // TestGetAndSaveUser ensures the correctness of the GetAndSaveUser function.
 //


### PR DESCRIPTION
I was working on #47163 when I saw this error which originates from the code in question in this PR:

> [       frontend] ERROR enterprise.auth.azuredoauth oauth/session.go:105 OAuth failed: error looking up or creating user from OAuth token. {"trace.family": "session > oauth.SessionIssuer", "ProviderID": "https://app.vssps.visualstudio.com/::redacted", "Op": "", "error": "cannot create user: users_username_valid_chars", "userErr": "Unable to create a new user account due to a unexpected error. Ask a site admin for help."}

I found it not very helpful and decided to add the username and email to the error message as a result. Now it looks like which adds some helpful information:

> [       frontend] ERROR enterprise.auth.azuredoauth oauth/session.go:105 OAuth failed: error looking up or creating user from OAuth token. {"trace.family": "session > oauth.SessionIssuer", "ProviderID": "https://app.vssps.visualstudio.com/::redacted", "Op": "", "error": "username: \"indradhanush@sourcegraph.com\", email: \"indradhanush@sourcegraph.com\": cannot create user: users_username_valid_chars", "userErr": "Unable to create a new user account due to a unexpected error. Ask a site admin for help."}


## Test plan

No functional change. Better error message only.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
