### PR TITLE
Reproducible test case for hacking on autogold/v2 with bazel hacks 

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -31,7 +31,5 @@ cmd/symbols/squirrel/test_repos/starlark
 cmd/sitemap
 docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/
 
-lib/codeintel/precise/diff/testdata/
-
 # temporary ignores
 internal/cmd/progress-bot

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,6 +76,11 @@ http_archive(
     ],
 )
 
+local_repository(
+    name = "com_github_hexops_autogold",
+    path = "/Users/tech/play/autogold",
+)
+
 # Node toolchain setup ==========================
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,9 +76,10 @@ http_archive(
     ],
 )
 
+# @slimsag 👋😊, just change the path below 👇 to wherever you're putting your local copy of autogold
 local_repository(
-    name = "com_github_hexops_autogold",
-    path = "/Users/tech/play/autogold",
+    name = "com_github_hexops_autogold_v2",
+    path = "/Users/tech/work/autogold",
 )
 
 # Node toolchain setup ==========================

--- a/cmd/blobstore/internal/blobstore/BUILD.bazel
+++ b/cmd/blobstore/internal/blobstore/BUILD.bazel
@@ -30,4 +30,5 @@ go_test(
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
     ],
+    env = {"ENABLE_BAZEL_HACKS":"1"},
 )

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -63,6 +63,23 @@ func assertObjectDoesNotExist(ctx context.Context, store uploadstore.Store, t *t
 	}
 }
 
+type fooStruct struct {
+	A string
+	B string
+}
+
+func foo() fooStruct {
+	return fooStruct{
+		A: "a",
+		B: "b",
+	}
+}
+
+func TestFoo(t *testing.T) {
+	got := foo()
+	autogold.Expect(nil).Equal(t, got)
+}
+
 // Initialize uploadstore, upload an object
 func TestUpload(t *testing.T) {
 	ctx := context.Background()

--- a/deps.bzl
+++ b/deps.bzl
@@ -3972,13 +3972,14 @@ def go_dependencies():
         sum = "h1:WCmFAhLRooih2QHAsbCbEdpIHnshQQmrPqsr3rHE1Ow=",
         version = "v1.35.3",
     )
-    go_repository(
-        name = "com_github_hexops_autogold",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/hexops/autogold",
-        sum = "h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=",
-        version = "v1.3.1",
-    )
+    # go_repository(
+    #     name = "com_github_hexops_autogold",
+    #     build_file_proto_mode = "disable_global",
+    #     importpath = "github.com/hexops/autogold",
+    #     sum = "h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=",
+    #     version = "v1.3.1",
+    # )
+
     go_repository(
         name = "com_github_hexops_autogold_v2",
         build_file_proto_mode = "disable_global",

--- a/dev/buildchecker/BUILD.bazel
+++ b/dev/buildchecker/BUILD.bazel
@@ -31,6 +31,18 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+# filegroup(
+#     name = "testfiles",
+#     srcs = glob(["slack_test.go"]),
+# )
+#
+# genrule(
+#     name = "autogold",
+#     srcs = [":testfiles"],
+#     outs = ["slack_test.go"],
+#     cmd = "cp $(locations :testfiles) slack_test.go",
+# )
+
 go_test(
     name = "buildchecker_test",
     srcs = [
@@ -39,7 +51,9 @@ go_test(
         "failures_test.go",
         "history_test.go",
         "slack_test.go",
+        # ":autogold",
     ],
+    env = {"GODEBUG":"execerrdot=0"},
     data = glob(["testdata/**"]),
     embed = [":buildchecker_lib"],
     deps = [

--- a/dev/buildchecker/slack_test.go
+++ b/dev/buildchecker/slack_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestBranchEventSummary(t *testing.T) {
+	autogold.RootPath = "/Users/tech/work/sourcegraph/dev/buildchecker"
 	t.Run("unlocked", func(t *testing.T) {
 		got := generateBranchEventSummary(false, "main", "#buildkite-main", []CommitInfo{})
 

--- a/lib/codeintel/lsif/conversion/BUILD.bazel
+++ b/lib/codeintel/lsif/conversion/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     # The testdata folders lives in our parent folder, which cannot be referenced directly.
     # therefore, we have to create a filegroup with the correct visibility and reference
     # it manually below.
-    data = ["//lib/codeintel/lsif/testdata:data"], # keep
+    data = ["//lib/codeintel/lsif/testdata:data"],  # keep
     embed = [":conversion"],
     deps = [
         "//lib/codeintel/lsif/conversion/datastructures",

--- a/lib/codeintel/lsif/conversion/BUILD.bazel
+++ b/lib/codeintel/lsif/conversion/BUILD.bazel
@@ -32,6 +32,10 @@ go_test(
         "group_test.go",
         "prune_test.go",
     ],
+    # The testdata folders lives in our parent folder, which cannot be referenced directly.
+    # therefore, we have to create a filegroup with the correct visibility and reference
+    # it manually below.
+    data = ["//lib/codeintel/lsif/testdata:data"] # keep,
     embed = [":conversion"],
     deps = [
         "//lib/codeintel/lsif/conversion/datastructures",

--- a/lib/codeintel/lsif/conversion/BUILD.bazel
+++ b/lib/codeintel/lsif/conversion/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     # The testdata folders lives in our parent folder, which cannot be referenced directly.
     # therefore, we have to create a filegroup with the correct visibility and reference
     # it manually below.
-    data = ["//lib/codeintel/lsif/testdata:data"] # keep,
+    data = ["//lib/codeintel/lsif/testdata:data"], # keep
     embed = [":conversion"],
     deps = [
         "//lib/codeintel/lsif/conversion/datastructures",

--- a/lib/codeintel/lsif/testdata/BUILD.bazel
+++ b/lib/codeintel/lsif/testdata/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "data",
+    srcs = glob(["*.lsif"]),
+    visibility = ["//lib/codeintel:__subpackages__"],
+)

--- a/lib/codeintel/precise/diff/BUILD.bazel
+++ b/lib/codeintel/precise/diff/BUILD.bazel
@@ -16,8 +16,8 @@ go_library(
 go_test(
     name = "diff_test",
     srcs = ["diff_test.go"],
-    embed = [":diff"],
     data = ["//lib/codeintel/precise/diff/testdata:data"],
+    embed = [":diff"],
     deps = [
         "//lib/codeintel/lsif/conversion",
         "//lib/codeintel/precise",

--- a/lib/codeintel/precise/diff/BUILD.bazel
+++ b/lib/codeintel/precise/diff/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:exclude testdata
+
 go_library(
     name = "diff",
     srcs = ["diff.go"],
@@ -15,6 +17,7 @@ go_test(
     name = "diff_test",
     srcs = ["diff_test.go"],
     embed = [":diff"],
+    data = ["//lib/codeintel/precise/diff/testdata:data"],
     deps = [
         "//lib/codeintel/lsif/conversion",
         "//lib/codeintel/precise",

--- a/lib/codeintel/precise/diff/diff_test.go
+++ b/lib/codeintel/precise/diff/diff_test.go
@@ -2,6 +2,8 @@ package diff
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -17,6 +19,13 @@ var dumpOldPath = "./testdata/project1/dump-old.lsif"
 var dumpNewPath = "./testdata/project1/dump-new.lsif"
 
 func TestNoDiffOnPermutedDumps(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer func() { os.Chdir(cwd) }()
+
+	tmpdir1, teardown := createTmpRepo(t, dumpPath)
+	t.Cleanup(teardown)
+	os.Chdir(tmpdir1)
+
 	bundle1, err := conversion.CorrelateLocalGit(
 		context.Background(),
 		dumpPath,
@@ -25,6 +34,10 @@ func TestNoDiffOnPermutedDumps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error reading dump path: %v", err)
 	}
+
+	tmpdir2, teardown := createTmpRepo(t, dumpPermutedPath)
+	t.Cleanup(teardown)
+	os.Chdir(tmpdir2)
 
 	bundle2, err := conversion.CorrelateLocalGit(
 		context.Background(),
@@ -41,6 +54,13 @@ func TestNoDiffOnPermutedDumps(t *testing.T) {
 }
 
 func TestDiffOnEditedDumps(t *testing.T) {
+	cwd, _ := os.Getwd()
+	defer func() { os.Chdir(cwd) }()
+
+	tmpdir1, teardown := createTmpRepo(t, dumpOldPath)
+	t.Cleanup(teardown)
+	os.Chdir(tmpdir1)
+
 	bundle1, err := conversion.CorrelateLocalGit(
 		context.Background(),
 		dumpOldPath,
@@ -49,6 +69,10 @@ func TestDiffOnEditedDumps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error reading dump: %v", err)
 	}
+
+	tmpdir2, teardown := createTmpRepo(t, dumpNewPath)
+	t.Cleanup(teardown)
+	os.Chdir(tmpdir2)
 
 	bundle2, err := conversion.CorrelateLocalGit(
 		context.Background(),
@@ -65,4 +89,40 @@ func TestDiffOnEditedDumps(t *testing.T) {
 	)
 
 	autogold.Equal(t, autogold.Raw(computedDiff))
+}
+
+// createTmpRepo returns a temp directory with the testdata copied over from the
+// enclosing folder of path, with a newly initialized git repository.
+func createTmpRepo(t *testing.T, path string) (string, func()) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error creating dump tmp folder: %v", err)
+	}
+
+	fullpath := filepath.Join(tmpdir, "testdata")
+	os.MkdirAll(fullpath, os.ModePerm)
+
+	if err := exec.Command("cp", "-R", filepath.Dir(path), fullpath).Run(); err != nil {
+		t.Fatalf("Unexpected error copying dump tmp folder: %v", err)
+	}
+
+	gitcmd := exec.Command("git", "init")
+	gitcmd.Dir = tmpdir
+	if err := gitcmd.Run(); err != nil {
+		t.Fatalf("Unexpected error git: %v", err)
+	}
+
+	gitcmd = exec.Command("git", "add", ".")
+	gitcmd.Dir = tmpdir
+	if err := gitcmd.Run(); err != nil {
+		t.Fatalf("Unexpected error git: %v", err)
+	}
+
+	gitcmd = exec.Command("git", "commit", "-m", "initial commit")
+	gitcmd.Dir = tmpdir
+	if err := gitcmd.Run(); err != nil {
+		t.Fatalf("Unexpected error git: %v", err)
+	}
+
+	return tmpdir, func() { os.RemoveAll(tmpdir) }
 }

--- a/lib/codeintel/precise/diff/testdata/BUILD.bazel
+++ b/lib/codeintel/precise/diff/testdata/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "data",
+    srcs = glob(["**/**"]),
+    visibility = ["//lib/codeintel:__subpackages__"],
+)

--- a/lib/codeintel/precise/diff/testdata/project1/BUILD.bazel
+++ b/lib/codeintel/precise/diff/testdata/project1/BUILD.bazel
@@ -1,9 +1,0 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-go_library(
-    name = "project1",
-    srcs = ["test.go"],
-    importpath = "github.com/sourcegraph/sourcegraph/lib/codeintel/precise/diff/testdata/project1",
-    visibility = ["//visibility:public"],
-    deps = ["@com_github_google_go_cmp//cmp"],
-)


### PR DESCRIPTION
@slimsag Don't forget to update `WORKSPACE` (search for your handle) with the correct path on your filesystem where `autogold` is checked out, *with* the Bazel files (they are needed when we use `local_repository`) 

Observing the failure I mentioned over [Slack](https://sourcegraph.slack.com/archives/C03LUEB7TJS/p1676577764119509?thread_ts=1676477125.177599&cid=C03LUEB7TJS)

```
cd cmd/blobstore/internal/blobstore
AUTOGOLD_DEBUG=1 ENABLE_BAZEL_HACKS=1 go test -update ./...
``` 

Observing the other tests working as intended: 

```
# Put a t.Skip() in TestFoo() to avoid the failing case. 
bazel test //cmd/blobstore/internal/...
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
