### PR TITLE
Code Insights: Add missing error handling for insight previews query

### DIFF
--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -110,11 +110,10 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
             },
         })
 
-        const subscription = query.subscribe(event =>
-            setResult({
-                ...event,
-                refetch: () => query.refetch(),
-            })
+        const refetch = (): Promise<unknown> => query.refetch()
+        const subscription = query.subscribe(
+            event => setResult({ ...event, refetch }),
+            error => setResult({ loading: false, data: undefined, error, refetch })
         )
 
         return () => subscription.unsubscribe()


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/47705

## Test plan
- Go to creation UI 
- Try to get live preview error (for example in the search based insight type repo query that resolves more than 20 repositories)
- Check that you have actually error UI in the live preview and not infinity loading state

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-error-handling-in-insight.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
