### PR TITLE
rbac: always upsert role assignment and permission assignment

### DIFF
--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -84,7 +84,7 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 			roles = append(roles, types.SiteAdministratorSystemRole)
 		}
 		opts := database.BulkAssignSystemRolesToUserOpts{UserID: user.ID, Roles: roles}
-		if _, err = tx.UserRoles().BulkAssignSystemRolesToUser(ctx, opts); err != nil {
+		if err = tx.UserRoles().BulkAssignSystemRolesToUser(ctx, opts); err != nil {
 			r.logger.Error("failed to assign system roles to user",
 				log.Error(err))
 			return errors.Wrap(err, "failed to assign system roles to user")

--- a/cmd/frontend/graphqlbackend/users_create_test.go
+++ b/cmd/frontend/graphqlbackend/users_create_test.go
@@ -35,7 +35,7 @@ func makeUsersCreateTestDB(t *testing.T) mockFuncs {
 	authz.GrantPendingPermissionsFunc.SetDefaultReturn(nil)
 
 	userRoles := database.NewMockUserRoleStore()
-	userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultReturn([]*types.UserRole{}, nil)
+	userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultReturn(nil)
 
 	userEmails := database.NewMockUserEmailsStore()
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -203,7 +203,7 @@ func handleSignUp(logger log.Logger, db database.DB, w http.ResponseWriter, r *h
 			roles = append(roles, types.SiteAdministratorSystemRole)
 		}
 
-		if _, err = tx.UserRoles().BulkAssignSystemRolesToUser(r.Context(), database.BulkAssignSystemRolesToUserOpts{
+		if err = tx.UserRoles().BulkAssignSystemRolesToUser(r.Context(), database.BulkAssignSystemRolesToUserOpts{
 			UserID: usr.ID,
 			Roles:  roles,
 		}); err != nil {

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -426,7 +426,7 @@ func TestHandleSignUp(t *testing.T) {
 		})
 
 		userRoles := database.NewMockUserRoleStore()
-		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, basrtuo database.BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
+		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, basrtuo database.BulkAssignSystemRolesToUserOpts) error {
 			if len(basrtuo.Roles) != 1 {
 				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with one role, got %d", len(basrtuo.Roles))
 			}
@@ -435,7 +435,7 @@ func TestHandleSignUp(t *testing.T) {
 				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with %s role, got %s", types.UserSystemRole, basrtuo.Roles[0])
 			}
 
-			return []*types.UserRole{}, nil
+			return nil
 		})
 
 		authz := database.NewMockAuthzStore()
@@ -517,7 +517,7 @@ func TestHandleSiteInit(t *testing.T) {
 		})
 
 		userRoles := database.NewMockUserRoleStore()
-		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, opts database.BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
+		userRoles.BulkAssignSystemRolesToUserFunc.SetDefaultHook(func(ctx context.Context, opts database.BulkAssignSystemRolesToUserOpts) error {
 			if len(opts.Roles) != 2 {
 				t.Fatalf("expected UserRoles().BulkAssignSystemRolesToUser to be called with two system roles, got %d", len(opts.Roles))
 			}
@@ -528,7 +528,7 @@ func TestHandleSiteInit(t *testing.T) {
 				t.Fatalf("Mismatch (-want +got):\n%s", diff)
 			}
 
-			return []*types.UserRole{}, nil
+			return nil
 		})
 
 		authz := database.NewMockAuthzStore()

--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -52,7 +52,7 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 				// current experience and always assume that everyone has access until a site administrator revokes that
 				// access.
 				// Context: https://sourcegraph.slack.com/archives/C044BUJET7C/p1675292124253779?thread_ts=1675280399.192819&cid=C044BUJET7C
-				if _, err := rolePermissionStore.BulkAssignPermissionsToSystemRoles(ctx, database.BulkAssignPermissionsToSystemRolesOpts{
+				if err := rolePermissionStore.BulkAssignPermissionsToSystemRoles(ctx, database.BulkAssignPermissionsToSystemRolesOpts{
 					Roles:        []types.SystemRole{types.SiteAdministratorSystemRole, types.UserSystemRole},
 					PermissionID: permission.ID,
 				}); err != nil {

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -195,7 +195,7 @@ func dbAddUserAction(cmd *cli.Context) error {
 
 		// tx.Users().SetIsSiteAdmin assigns the `SITE_ADMINISTRATOR` role to the created user, we also need to
 		// assign the `USER` role to the created user.
-		if _, err = tx.UserRoles().AssignSystemRole(ctx, database.AssignSystemRoleOpts{
+		if err = tx.UserRoles().AssignSystemRole(ctx, database.AssignSystemRoleOpts{
 			UserID: user.ID,
 			Role:   types.UserSystemRole,
 		}); err != nil {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
@@ -152,7 +152,7 @@ func TestUserPermissionsListing(t *testing.T) {
 	role, err := db.Roles().Create(ctx, "TEST-ROLE", false)
 	require.NoError(t, err)
 
-	_, err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
+	err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
 		RoleID: role.ID,
 		UserID: userID,
 	})
@@ -164,7 +164,7 @@ func TestUserPermissionsListing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
+	err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
 		RoleID:       role.ID,
 		PermissionID: p.ID,
 	})

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/role_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/role_test.go
@@ -46,7 +46,7 @@ func TestRoleResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
+	err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
 		RoleID:       role.ID,
 		PermissionID: perm.ID,
 	})

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -148,7 +148,7 @@ func TestUserRoleListing(t *testing.T) {
 	role, err := db.Roles().Create(ctx, "TEST-ROLE", false)
 	assert.NoError(t, err)
 
-	_, err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
+	err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
 		RoleID: role.ID,
 		UserID: userID,
 	})

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -271,7 +271,7 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 
 	// We use the BulkAssignSystemRolesToUser method here because in cases where the created
 	// user is also a site admin, we want to assign them both USER and SITE_ADMINISTRATOR roles.
-	if _, err := UserRolesWith(tx).BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
+	if err := UserRolesWith(tx).BulkAssignSystemRolesToUser(ctx, BulkAssignSystemRolesToUserOpts{
 		UserID: createdUser.ID,
 		Roles:  roles,
 	}); err != nil {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -41557,17 +41557,17 @@ type MockRolePermissionStore struct {
 func NewMockRolePermissionStore() *MockRolePermissionStore {
 	return &MockRolePermissionStore{
 		AssignFunc: &RolePermissionStoreAssignFunc{
-			defaultHook: func(context.Context, AssignRolePermissionOpts) (r0 *types.RolePermission, r1 error) {
+			defaultHook: func(context.Context, AssignRolePermissionOpts) (r0 error) {
 				return
 			},
 		},
 		AssignToSystemRoleFunc: &RolePermissionStoreAssignToSystemRoleFunc{
-			defaultHook: func(context.Context, AssignToSystemRoleOpts) (r0 *types.RolePermission, r1 error) {
+			defaultHook: func(context.Context, AssignToSystemRoleOpts) (r0 error) {
 				return
 			},
 		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
-			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) (r0 []*types.RolePermission, r1 error) {
+			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) (r0 error) {
 				return
 			},
 		},
@@ -41615,17 +41615,17 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 	return &MockRolePermissionStore{
 		AssignFunc: &RolePermissionStoreAssignFunc{
-			defaultHook: func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error) {
+			defaultHook: func(context.Context, AssignRolePermissionOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.Assign")
 			},
 		},
 		AssignToSystemRoleFunc: &RolePermissionStoreAssignToSystemRoleFunc{
-			defaultHook: func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error) {
+			defaultHook: func(context.Context, AssignToSystemRoleOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.AssignToSystemRole")
 			},
 		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
-			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error) {
+			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToSystemRoles")
 			},
 		},
@@ -41708,24 +41708,24 @@ func NewMockRolePermissionStoreFrom(i RolePermissionStore) *MockRolePermissionSt
 // RolePermissionStoreAssignFunc describes the behavior when the Assign
 // method of the parent MockRolePermissionStore instance is invoked.
 type RolePermissionStoreAssignFunc struct {
-	defaultHook func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error)
-	hooks       []func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error)
+	defaultHook func(context.Context, AssignRolePermissionOpts) error
+	hooks       []func(context.Context, AssignRolePermissionOpts) error
 	history     []RolePermissionStoreAssignFuncCall
 	mutex       sync.Mutex
 }
 
 // Assign delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockRolePermissionStore) Assign(v0 context.Context, v1 AssignRolePermissionOpts) (*types.RolePermission, error) {
-	r0, r1 := m.AssignFunc.nextHook()(v0, v1)
-	m.AssignFunc.appendCall(RolePermissionStoreAssignFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockRolePermissionStore) Assign(v0 context.Context, v1 AssignRolePermissionOpts) error {
+	r0 := m.AssignFunc.nextHook()(v0, v1)
+	m.AssignFunc.appendCall(RolePermissionStoreAssignFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the Assign method of the
 // parent MockRolePermissionStore instance is invoked and the hook queue is
 // empty.
-func (f *RolePermissionStoreAssignFunc) SetDefaultHook(hook func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error)) {
+func (f *RolePermissionStoreAssignFunc) SetDefaultHook(hook func(context.Context, AssignRolePermissionOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -41733,7 +41733,7 @@ func (f *RolePermissionStoreAssignFunc) SetDefaultHook(hook func(context.Context
 // Assign method of the parent MockRolePermissionStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *RolePermissionStoreAssignFunc) PushHook(hook func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error)) {
+func (f *RolePermissionStoreAssignFunc) PushHook(hook func(context.Context, AssignRolePermissionOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -41741,20 +41741,20 @@ func (f *RolePermissionStoreAssignFunc) PushHook(hook func(context.Context, Assi
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RolePermissionStoreAssignFunc) SetDefaultReturn(r0 *types.RolePermission, r1 error) {
-	f.SetDefaultHook(func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreAssignFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, AssignRolePermissionOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RolePermissionStoreAssignFunc) PushReturn(r0 *types.RolePermission, r1 error) {
-	f.PushHook(func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreAssignFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, AssignRolePermissionOpts) error {
+		return r0
 	})
 }
 
-func (f *RolePermissionStoreAssignFunc) nextHook() func(context.Context, AssignRolePermissionOpts) (*types.RolePermission, error) {
+func (f *RolePermissionStoreAssignFunc) nextHook() func(context.Context, AssignRolePermissionOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -41795,10 +41795,7 @@ type RolePermissionStoreAssignFuncCall struct {
 	Arg1 AssignRolePermissionOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *types.RolePermission
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -41810,31 +41807,31 @@ func (c RolePermissionStoreAssignFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreAssignFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // RolePermissionStoreAssignToSystemRoleFunc describes the behavior when the
 // AssignToSystemRole method of the parent MockRolePermissionStore instance
 // is invoked.
 type RolePermissionStoreAssignToSystemRoleFunc struct {
-	defaultHook func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error)
-	hooks       []func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error)
+	defaultHook func(context.Context, AssignToSystemRoleOpts) error
+	hooks       []func(context.Context, AssignToSystemRoleOpts) error
 	history     []RolePermissionStoreAssignToSystemRoleFuncCall
 	mutex       sync.Mutex
 }
 
 // AssignToSystemRole delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockRolePermissionStore) AssignToSystemRole(v0 context.Context, v1 AssignToSystemRoleOpts) (*types.RolePermission, error) {
-	r0, r1 := m.AssignToSystemRoleFunc.nextHook()(v0, v1)
-	m.AssignToSystemRoleFunc.appendCall(RolePermissionStoreAssignToSystemRoleFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockRolePermissionStore) AssignToSystemRole(v0 context.Context, v1 AssignToSystemRoleOpts) error {
+	r0 := m.AssignToSystemRoleFunc.nextHook()(v0, v1)
+	m.AssignToSystemRoleFunc.appendCall(RolePermissionStoreAssignToSystemRoleFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the AssignToSystemRole
 // method of the parent MockRolePermissionStore instance is invoked and the
 // hook queue is empty.
-func (f *RolePermissionStoreAssignToSystemRoleFunc) SetDefaultHook(hook func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error)) {
+func (f *RolePermissionStoreAssignToSystemRoleFunc) SetDefaultHook(hook func(context.Context, AssignToSystemRoleOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -41843,7 +41840,7 @@ func (f *RolePermissionStoreAssignToSystemRoleFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *RolePermissionStoreAssignToSystemRoleFunc) PushHook(hook func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error)) {
+func (f *RolePermissionStoreAssignToSystemRoleFunc) PushHook(hook func(context.Context, AssignToSystemRoleOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -41851,20 +41848,20 @@ func (f *RolePermissionStoreAssignToSystemRoleFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RolePermissionStoreAssignToSystemRoleFunc) SetDefaultReturn(r0 *types.RolePermission, r1 error) {
-	f.SetDefaultHook(func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreAssignToSystemRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, AssignToSystemRoleOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RolePermissionStoreAssignToSystemRoleFunc) PushReturn(r0 *types.RolePermission, r1 error) {
-	f.PushHook(func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreAssignToSystemRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, AssignToSystemRoleOpts) error {
+		return r0
 	})
 }
 
-func (f *RolePermissionStoreAssignToSystemRoleFunc) nextHook() func(context.Context, AssignToSystemRoleOpts) (*types.RolePermission, error) {
+func (f *RolePermissionStoreAssignToSystemRoleFunc) nextHook() func(context.Context, AssignToSystemRoleOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -41907,10 +41904,7 @@ type RolePermissionStoreAssignToSystemRoleFuncCall struct {
 	Arg1 AssignToSystemRoleOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *types.RolePermission
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -41922,31 +41916,31 @@ func (c RolePermissionStoreAssignToSystemRoleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreAssignToSystemRoleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc describes the
 // behavior when the BulkAssignPermissionsToSystemRoles method of the parent
 // MockRolePermissionStore instance is invoked.
 type RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc struct {
-	defaultHook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error)
-	hooks       []func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error)
+	defaultHook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error
+	hooks       []func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error
 	history     []RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall
 	mutex       sync.Mutex
 }
 
 // BulkAssignPermissionsToSystemRoles delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockRolePermissionStore) BulkAssignPermissionsToSystemRoles(v0 context.Context, v1 BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error) {
-	r0, r1 := m.BulkAssignPermissionsToSystemRolesFunc.nextHook()(v0, v1)
-	m.BulkAssignPermissionsToSystemRolesFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockRolePermissionStore) BulkAssignPermissionsToSystemRoles(v0 context.Context, v1 BulkAssignPermissionsToSystemRolesOpts) error {
+	r0 := m.BulkAssignPermissionsToSystemRolesFunc.nextHook()(v0, v1)
+	m.BulkAssignPermissionsToSystemRolesFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // BulkAssignPermissionsToSystemRoles method of the parent
 // MockRolePermissionStore instance is invoked and the hook queue is empty.
-func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error)) {
+func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -41955,7 +41949,7 @@ func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) SetDefaultHo
 // MockRolePermissionStore instance invokes the hook at the front of the
 // queue and discards it. After the queue is empty, the default hook
 // function is invoked for any future action.
-func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error)) {
+func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -41963,20 +41957,20 @@ func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) PushHook(hoo
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) SetDefaultReturn(r0 []*types.RolePermission, r1 error) {
-	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) PushReturn(r0 []*types.RolePermission, r1 error) {
-	f.PushHook(func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error) {
-		return r0, r1
+func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
+		return r0
 	})
 }
 
-func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) nextHook() func(context.Context, BulkAssignPermissionsToSystemRolesOpts) ([]*types.RolePermission, error) {
+func (f *RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc) nextHook() func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -42020,10 +42014,7 @@ type RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall struct {
 	Arg1 BulkAssignPermissionsToSystemRolesOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*types.RolePermission
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -42035,7 +42026,7 @@ func (c RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall) Args() []
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreBulkAssignPermissionsToSystemRolesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // RolePermissionStoreGetByPermissionIDFunc describes the behavior when the
@@ -56809,22 +56800,22 @@ type MockUserRoleStore struct {
 func NewMockUserRoleStore() *MockUserRoleStore {
 	return &MockUserRoleStore{
 		AssignFunc: &UserRoleStoreAssignFunc{
-			defaultHook: func(context.Context, AssignUserRoleOpts) (r0 *types.UserRole, r1 error) {
+			defaultHook: func(context.Context, AssignUserRoleOpts) (r0 error) {
 				return
 			},
 		},
 		AssignSystemRoleFunc: &UserRoleStoreAssignSystemRoleFunc{
-			defaultHook: func(context.Context, AssignSystemRoleOpts) (r0 *types.UserRole, r1 error) {
+			defaultHook: func(context.Context, AssignSystemRoleOpts) (r0 error) {
 				return
 			},
 		},
 		BulkAssignSystemRolesToUserFunc: &UserRoleStoreBulkAssignSystemRolesToUserFunc{
-			defaultHook: func(context.Context, BulkAssignSystemRolesToUserOpts) (r0 []*types.UserRole, r1 error) {
+			defaultHook: func(context.Context, BulkAssignSystemRolesToUserOpts) (r0 error) {
 				return
 			},
 		},
 		BulkAssignToUserFunc: &UserRoleStoreBulkAssignToUserFunc{
-			defaultHook: func(context.Context, BulkAssignToUserOpts) (r0 []*types.UserRole, r1 error) {
+			defaultHook: func(context.Context, BulkAssignToUserOpts) (r0 error) {
 				return
 			},
 		},
@@ -56876,22 +56867,22 @@ func NewMockUserRoleStore() *MockUserRoleStore {
 func NewStrictMockUserRoleStore() *MockUserRoleStore {
 	return &MockUserRoleStore{
 		AssignFunc: &UserRoleStoreAssignFunc{
-			defaultHook: func(context.Context, AssignUserRoleOpts) (*types.UserRole, error) {
+			defaultHook: func(context.Context, AssignUserRoleOpts) error {
 				panic("unexpected invocation of MockUserRoleStore.Assign")
 			},
 		},
 		AssignSystemRoleFunc: &UserRoleStoreAssignSystemRoleFunc{
-			defaultHook: func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error) {
+			defaultHook: func(context.Context, AssignSystemRoleOpts) error {
 				panic("unexpected invocation of MockUserRoleStore.AssignSystemRole")
 			},
 		},
 		BulkAssignSystemRolesToUserFunc: &UserRoleStoreBulkAssignSystemRolesToUserFunc{
-			defaultHook: func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
+			defaultHook: func(context.Context, BulkAssignSystemRolesToUserOpts) error {
 				panic("unexpected invocation of MockUserRoleStore.BulkAssignSystemRolesToUser")
 			},
 		},
 		BulkAssignToUserFunc: &UserRoleStoreBulkAssignToUserFunc{
-			defaultHook: func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error) {
+			defaultHook: func(context.Context, BulkAssignToUserOpts) error {
 				panic("unexpected invocation of MockUserRoleStore.BulkAssignToUser")
 			},
 		},
@@ -56985,23 +56976,23 @@ func NewMockUserRoleStoreFrom(i UserRoleStore) *MockUserRoleStore {
 // UserRoleStoreAssignFunc describes the behavior when the Assign method of
 // the parent MockUserRoleStore instance is invoked.
 type UserRoleStoreAssignFunc struct {
-	defaultHook func(context.Context, AssignUserRoleOpts) (*types.UserRole, error)
-	hooks       []func(context.Context, AssignUserRoleOpts) (*types.UserRole, error)
+	defaultHook func(context.Context, AssignUserRoleOpts) error
+	hooks       []func(context.Context, AssignUserRoleOpts) error
 	history     []UserRoleStoreAssignFuncCall
 	mutex       sync.Mutex
 }
 
 // Assign delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserRoleStore) Assign(v0 context.Context, v1 AssignUserRoleOpts) (*types.UserRole, error) {
-	r0, r1 := m.AssignFunc.nextHook()(v0, v1)
-	m.AssignFunc.appendCall(UserRoleStoreAssignFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockUserRoleStore) Assign(v0 context.Context, v1 AssignUserRoleOpts) error {
+	r0 := m.AssignFunc.nextHook()(v0, v1)
+	m.AssignFunc.appendCall(UserRoleStoreAssignFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the Assign method of the
 // parent MockUserRoleStore instance is invoked and the hook queue is empty.
-func (f *UserRoleStoreAssignFunc) SetDefaultHook(hook func(context.Context, AssignUserRoleOpts) (*types.UserRole, error)) {
+func (f *UserRoleStoreAssignFunc) SetDefaultHook(hook func(context.Context, AssignUserRoleOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -57009,7 +57000,7 @@ func (f *UserRoleStoreAssignFunc) SetDefaultHook(hook func(context.Context, Assi
 // Assign method of the parent MockUserRoleStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *UserRoleStoreAssignFunc) PushHook(hook func(context.Context, AssignUserRoleOpts) (*types.UserRole, error)) {
+func (f *UserRoleStoreAssignFunc) PushHook(hook func(context.Context, AssignUserRoleOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -57017,20 +57008,20 @@ func (f *UserRoleStoreAssignFunc) PushHook(hook func(context.Context, AssignUser
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserRoleStoreAssignFunc) SetDefaultReturn(r0 *types.UserRole, r1 error) {
-	f.SetDefaultHook(func(context.Context, AssignUserRoleOpts) (*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreAssignFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, AssignUserRoleOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserRoleStoreAssignFunc) PushReturn(r0 *types.UserRole, r1 error) {
-	f.PushHook(func(context.Context, AssignUserRoleOpts) (*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreAssignFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, AssignUserRoleOpts) error {
+		return r0
 	})
 }
 
-func (f *UserRoleStoreAssignFunc) nextHook() func(context.Context, AssignUserRoleOpts) (*types.UserRole, error) {
+func (f *UserRoleStoreAssignFunc) nextHook() func(context.Context, AssignUserRoleOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -57071,10 +57062,7 @@ type UserRoleStoreAssignFuncCall struct {
 	Arg1 AssignUserRoleOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *types.UserRole
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -57086,31 +57074,31 @@ func (c UserRoleStoreAssignFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserRoleStoreAssignFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // UserRoleStoreAssignSystemRoleFunc describes the behavior when the
 // AssignSystemRole method of the parent MockUserRoleStore instance is
 // invoked.
 type UserRoleStoreAssignSystemRoleFunc struct {
-	defaultHook func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error)
-	hooks       []func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error)
+	defaultHook func(context.Context, AssignSystemRoleOpts) error
+	hooks       []func(context.Context, AssignSystemRoleOpts) error
 	history     []UserRoleStoreAssignSystemRoleFuncCall
 	mutex       sync.Mutex
 }
 
 // AssignSystemRole delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserRoleStore) AssignSystemRole(v0 context.Context, v1 AssignSystemRoleOpts) (*types.UserRole, error) {
-	r0, r1 := m.AssignSystemRoleFunc.nextHook()(v0, v1)
-	m.AssignSystemRoleFunc.appendCall(UserRoleStoreAssignSystemRoleFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockUserRoleStore) AssignSystemRole(v0 context.Context, v1 AssignSystemRoleOpts) error {
+	r0 := m.AssignSystemRoleFunc.nextHook()(v0, v1)
+	m.AssignSystemRoleFunc.appendCall(UserRoleStoreAssignSystemRoleFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the AssignSystemRole
 // method of the parent MockUserRoleStore instance is invoked and the hook
 // queue is empty.
-func (f *UserRoleStoreAssignSystemRoleFunc) SetDefaultHook(hook func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error)) {
+func (f *UserRoleStoreAssignSystemRoleFunc) SetDefaultHook(hook func(context.Context, AssignSystemRoleOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -57118,7 +57106,7 @@ func (f *UserRoleStoreAssignSystemRoleFunc) SetDefaultHook(hook func(context.Con
 // AssignSystemRole method of the parent MockUserRoleStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *UserRoleStoreAssignSystemRoleFunc) PushHook(hook func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error)) {
+func (f *UserRoleStoreAssignSystemRoleFunc) PushHook(hook func(context.Context, AssignSystemRoleOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -57126,20 +57114,20 @@ func (f *UserRoleStoreAssignSystemRoleFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserRoleStoreAssignSystemRoleFunc) SetDefaultReturn(r0 *types.UserRole, r1 error) {
-	f.SetDefaultHook(func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreAssignSystemRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, AssignSystemRoleOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserRoleStoreAssignSystemRoleFunc) PushReturn(r0 *types.UserRole, r1 error) {
-	f.PushHook(func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreAssignSystemRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, AssignSystemRoleOpts) error {
+		return r0
 	})
 }
 
-func (f *UserRoleStoreAssignSystemRoleFunc) nextHook() func(context.Context, AssignSystemRoleOpts) (*types.UserRole, error) {
+func (f *UserRoleStoreAssignSystemRoleFunc) nextHook() func(context.Context, AssignSystemRoleOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -57181,10 +57169,7 @@ type UserRoleStoreAssignSystemRoleFuncCall struct {
 	Arg1 AssignSystemRoleOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *types.UserRole
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -57196,31 +57181,31 @@ func (c UserRoleStoreAssignSystemRoleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserRoleStoreAssignSystemRoleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // UserRoleStoreBulkAssignSystemRolesToUserFunc describes the behavior when
 // the BulkAssignSystemRolesToUser method of the parent MockUserRoleStore
 // instance is invoked.
 type UserRoleStoreBulkAssignSystemRolesToUserFunc struct {
-	defaultHook func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error)
-	hooks       []func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error)
+	defaultHook func(context.Context, BulkAssignSystemRolesToUserOpts) error
+	hooks       []func(context.Context, BulkAssignSystemRolesToUserOpts) error
 	history     []UserRoleStoreBulkAssignSystemRolesToUserFuncCall
 	mutex       sync.Mutex
 }
 
 // BulkAssignSystemRolesToUser delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockUserRoleStore) BulkAssignSystemRolesToUser(v0 context.Context, v1 BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
-	r0, r1 := m.BulkAssignSystemRolesToUserFunc.nextHook()(v0, v1)
-	m.BulkAssignSystemRolesToUserFunc.appendCall(UserRoleStoreBulkAssignSystemRolesToUserFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockUserRoleStore) BulkAssignSystemRolesToUser(v0 context.Context, v1 BulkAssignSystemRolesToUserOpts) error {
+	r0 := m.BulkAssignSystemRolesToUserFunc.nextHook()(v0, v1)
+	m.BulkAssignSystemRolesToUserFunc.appendCall(UserRoleStoreBulkAssignSystemRolesToUserFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // BulkAssignSystemRolesToUser method of the parent MockUserRoleStore
 // instance is invoked and the hook queue is empty.
-func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) SetDefaultHook(hook func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error)) {
+func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) SetDefaultHook(hook func(context.Context, BulkAssignSystemRolesToUserOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -57229,7 +57214,7 @@ func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) PushHook(hook func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error)) {
+func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) PushHook(hook func(context.Context, BulkAssignSystemRolesToUserOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -57237,20 +57222,20 @@ func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) PushHook(hook func(contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) SetDefaultReturn(r0 []*types.UserRole, r1 error) {
-	f.SetDefaultHook(func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignSystemRolesToUserOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) PushReturn(r0 []*types.UserRole, r1 error) {
-	f.PushHook(func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkAssignSystemRolesToUserOpts) error {
+		return r0
 	})
 }
 
-func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) nextHook() func(context.Context, BulkAssignSystemRolesToUserOpts) ([]*types.UserRole, error) {
+func (f *UserRoleStoreBulkAssignSystemRolesToUserFunc) nextHook() func(context.Context, BulkAssignSystemRolesToUserOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -57293,10 +57278,7 @@ type UserRoleStoreBulkAssignSystemRolesToUserFuncCall struct {
 	Arg1 BulkAssignSystemRolesToUserOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*types.UserRole
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -57308,31 +57290,31 @@ func (c UserRoleStoreBulkAssignSystemRolesToUserFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserRoleStoreBulkAssignSystemRolesToUserFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // UserRoleStoreBulkAssignToUserFunc describes the behavior when the
 // BulkAssignToUser method of the parent MockUserRoleStore instance is
 // invoked.
 type UserRoleStoreBulkAssignToUserFunc struct {
-	defaultHook func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error)
-	hooks       []func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error)
+	defaultHook func(context.Context, BulkAssignToUserOpts) error
+	hooks       []func(context.Context, BulkAssignToUserOpts) error
 	history     []UserRoleStoreBulkAssignToUserFuncCall
 	mutex       sync.Mutex
 }
 
 // BulkAssignToUser delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserRoleStore) BulkAssignToUser(v0 context.Context, v1 BulkAssignToUserOpts) ([]*types.UserRole, error) {
-	r0, r1 := m.BulkAssignToUserFunc.nextHook()(v0, v1)
-	m.BulkAssignToUserFunc.appendCall(UserRoleStoreBulkAssignToUserFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockUserRoleStore) BulkAssignToUser(v0 context.Context, v1 BulkAssignToUserOpts) error {
+	r0 := m.BulkAssignToUserFunc.nextHook()(v0, v1)
+	m.BulkAssignToUserFunc.appendCall(UserRoleStoreBulkAssignToUserFuncCall{v0, v1, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the BulkAssignToUser
 // method of the parent MockUserRoleStore instance is invoked and the hook
 // queue is empty.
-func (f *UserRoleStoreBulkAssignToUserFunc) SetDefaultHook(hook func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error)) {
+func (f *UserRoleStoreBulkAssignToUserFunc) SetDefaultHook(hook func(context.Context, BulkAssignToUserOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -57340,7 +57322,7 @@ func (f *UserRoleStoreBulkAssignToUserFunc) SetDefaultHook(hook func(context.Con
 // BulkAssignToUser method of the parent MockUserRoleStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *UserRoleStoreBulkAssignToUserFunc) PushHook(hook func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error)) {
+func (f *UserRoleStoreBulkAssignToUserFunc) PushHook(hook func(context.Context, BulkAssignToUserOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -57348,20 +57330,20 @@ func (f *UserRoleStoreBulkAssignToUserFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserRoleStoreBulkAssignToUserFunc) SetDefaultReturn(r0 []*types.UserRole, r1 error) {
-	f.SetDefaultHook(func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreBulkAssignToUserFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignToUserOpts) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserRoleStoreBulkAssignToUserFunc) PushReturn(r0 []*types.UserRole, r1 error) {
-	f.PushHook(func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error) {
-		return r0, r1
+func (f *UserRoleStoreBulkAssignToUserFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkAssignToUserOpts) error {
+		return r0
 	})
 }
 
-func (f *UserRoleStoreBulkAssignToUserFunc) nextHook() func(context.Context, BulkAssignToUserOpts) ([]*types.UserRole, error) {
+func (f *UserRoleStoreBulkAssignToUserFunc) nextHook() func(context.Context, BulkAssignToUserOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -57403,10 +57385,7 @@ type UserRoleStoreBulkAssignToUserFuncCall struct {
 	Arg1 BulkAssignToUserOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*types.UserRole
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -57418,7 +57397,7 @@ func (c UserRoleStoreBulkAssignToUserFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserRoleStoreBulkAssignToUserFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // UserRoleStoreGetByRoleIDFunc describes the behavior when the GetByRoleID

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -350,19 +350,19 @@ func seedPermissionDataForList(ctx context.Context, t *testing.T, store Permissi
 	role, err := createTestRole(ctx, "TEST-ROLE", false, t, db.Roles())
 	require.NoError(t, err)
 
-	_, err = db.RolePermissions().Assign(ctx, AssignRolePermissionOpts{
+	err = db.RolePermissions().Assign(ctx, AssignRolePermissionOpts{
 		RoleID:       role.ID,
 		PermissionID: perms[0].ID,
 	})
 	require.NoError(t, err)
 
-	_, err = db.RolePermissions().Assign(ctx, AssignRolePermissionOpts{
+	err = db.RolePermissions().Assign(ctx, AssignRolePermissionOpts{
 		RoleID:       role.ID,
 		PermissionID: perms[1].ID,
 	})
 	require.NoError(t, err)
 
-	_, err = db.UserRoles().Assign(ctx, AssignUserRoleOpts{
+	err = db.UserRoles().Assign(ctx, AssignUserRoleOpts{
 		RoleID: role.ID,
 		UserID: user.ID,
 	})

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -23,32 +23,40 @@ func TestRolePermissionAssign(t *testing.T) {
 	r, p := createRoleAndPermission(ctx, t, db)
 
 	t.Run("without permission id", func(t *testing.T) {
-		rp, err := store.Assign(ctx, AssignRolePermissionOpts{
+		err := store.Assign(ctx, AssignRolePermissionOpts{
 			RoleID: r.ID,
 		})
-		require.Nil(t, rp)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "missing permission id")
+		require.ErrorContains(t, err, "missing permission id")
 	})
 
 	t.Run("without role id", func(t *testing.T) {
-		rp, err := store.Assign(ctx, AssignRolePermissionOpts{
+		err := store.Assign(ctx, AssignRolePermissionOpts{
 			PermissionID: p.ID,
 		})
-		require.Nil(t, rp)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "missing role id")
+		require.ErrorContains(t, err, "missing role id")
 	})
 
-	t.Run("with correct args", func(t *testing.T) {
-		rp, err := store.Assign(ctx, AssignRolePermissionOpts{
+	t.Run("success", func(t *testing.T) {
+		err := store.Assign(ctx, AssignRolePermissionOpts{
 			RoleID:       r.ID,
 			PermissionID: p.ID,
 		})
 		require.NoError(t, err)
+
+		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
 		require.NotNil(t, rp)
 		require.Equal(t, rp.RoleID, r.ID)
 		require.Equal(t, rp.PermissionID, p.ID)
+
+		// This shouldn't fail the second time since we're upserting.
+		err = store.Assign(ctx, AssignRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+		require.NoError(t, err)
 	})
 }
 
@@ -63,29 +71,38 @@ func TestRolePermissionAssignToSystemRole(t *testing.T) {
 	_, p := createRoleAndPermission(ctx, t, db)
 
 	t.Run("without permission id", func(t *testing.T) {
-		rp, err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
+		err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
 			Role: types.SiteAdministratorSystemRole,
 		})
-		require.Nil(t, rp)
 		require.ErrorContains(t, err, "permission id is required")
 	})
 
 	t.Run("without role", func(t *testing.T) {
-		rp, err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
+		err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
 			PermissionID: p.ID,
 		})
-		require.Nil(t, rp)
 		require.ErrorContains(t, err, "role is required")
 	})
 
 	t.Run("success", func(t *testing.T) {
-		rp, err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
+		err := store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
 			PermissionID: p.ID,
 			Role:         types.SiteAdministratorSystemRole,
 		})
 		require.NoError(t, err)
-		require.NotNil(t, rp)
-		require.Equal(t, rp.PermissionID, p.ID)
+
+		rps, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+		require.NotNil(t, rps)
+		require.Len(t, rps, 1)
+
+		// This shouldn't fail the second time since we're upserting.
+		err = store.AssignToSystemRole(ctx, AssignToSystemRoleOpts{
+			PermissionID: p.ID,
+			Role:         types.SiteAdministratorSystemRole,
+		})
+		require.NoError(t, err)
 	})
 }
 
@@ -100,28 +117,37 @@ func TestRolePermissionBulkAssignPermissionsToSystemRoles(t *testing.T) {
 	_, p := createRoleAndPermission(ctx, t, db)
 
 	t.Run("without permission id", func(t *testing.T) {
-		rp, err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{})
-		require.Nil(t, rp)
+		err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{})
 		require.ErrorContains(t, err, "permission id is required")
 	})
 
 	t.Run("without roles", func(t *testing.T) {
-		rp, err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{
+		err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{
 			PermissionID: p.ID,
 		})
-		require.Nil(t, rp)
 		require.ErrorContains(t, err, "roles are required")
 	})
 
 	t.Run("success", func(t *testing.T) {
 		systemRoles := []types.SystemRole{types.SiteAdministratorSystemRole, types.UserSystemRole}
-		rp, err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{
+		err := store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{
 			PermissionID: p.ID,
 			Roles:        systemRoles,
 		})
 		require.NoError(t, err)
-		require.NotNil(t, rp)
-		require.Len(t, rp, len(systemRoles))
+
+		rps, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+		require.NotNil(t, rps)
+		require.Len(t, rps, len(systemRoles))
+
+		// This shouldn't fail the second time since we're upserting.
+		err = store.BulkAssignPermissionsToSystemRoles(ctx, BulkAssignPermissionsToSystemRolesOpts{
+			PermissionID: p.ID,
+			Roles:        systemRoles,
+		})
+		require.NoError(t, err)
 	})
 }
 
@@ -132,7 +158,7 @@ func TestRolePermissionGetByRoleIDAndPermissionID(t *testing.T) {
 	store := db.RolePermissions()
 
 	r, p := createRoleAndPermission(ctx, t, db)
-	_, err := store.Assign(ctx, AssignRolePermissionOpts{
+	err := store.Assign(ctx, AssignRolePermissionOpts{
 		RoleID:       r.ID,
 		PermissionID: p.ID,
 	})
@@ -171,7 +197,7 @@ func TestRolePermissionGetByRoleIDAndPermissionID(t *testing.T) {
 		require.Equal(t, err, &RolePermissionNotFoundErr{PermissionID: pid, RoleID: rid})
 	})
 
-	t.Run("with correct args", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
 			PermissionID: p.ID,
 			RoleID:       r.ID,
@@ -194,7 +220,7 @@ func TestRolePermissionGetByRoleID(t *testing.T) {
 	totalRolePermissions := 5
 	for i := 1; i <= totalRolePermissions; i++ {
 		p := createTestPermissionForRolePermission(ctx, fmt.Sprintf("action-%d", i), t, db)
-		_, err := store.Assign(ctx, AssignRolePermissionOpts{
+		err := store.Assign(ctx, AssignRolePermissionOpts{
 			RoleID:       r.ID,
 			PermissionID: p.ID,
 		})
@@ -237,7 +263,7 @@ func TestRolePermissionGetByPermissionID(t *testing.T) {
 	totalRolePermissions := 5
 	for i := 1; i <= totalRolePermissions; i++ {
 		r := createTestRoleForRolePermission(ctx, fmt.Sprintf("TEST ROLE-%d", i), t, db)
-		_, err := store.Assign(ctx, AssignRolePermissionOpts{
+		err := store.Assign(ctx, AssignRolePermissionOpts{
 			RoleID:       r.ID,
 			PermissionID: p.ID,
 		})
@@ -279,7 +305,7 @@ func TestRolePermissionDelete(t *testing.T) {
 
 	r, p := createRoleAndPermission(ctx, t, db)
 
-	_, err := store.Assign(ctx, AssignRolePermissionOpts{
+	err := store.Assign(ctx, AssignRolePermissionOpts{
 		RoleID:       r.ID,
 		PermissionID: p.ID,
 	})

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -47,6 +47,7 @@ func TestRolePermissionAssign(t *testing.T) {
 			RoleID:       r.ID,
 			PermissionID: p.ID,
 		})
+		require.NoError(t, err)
 		require.NotNil(t, rp)
 		require.Equal(t, rp.RoleID, r.ID)
 		require.Equal(t, rp.PermissionID, p.ID)
@@ -94,6 +95,7 @@ func TestRolePermissionAssignToSystemRole(t *testing.T) {
 		rps, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{
 			PermissionID: p.ID,
 		})
+		require.NoError(t, err)
 		require.NotNil(t, rps)
 		require.Len(t, rps, 1)
 
@@ -139,6 +141,7 @@ func TestRolePermissionBulkAssignPermissionsToSystemRoles(t *testing.T) {
 		rps, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{
 			PermissionID: p.ID,
 		})
+		require.NoError(t, err)
 		require.NotNil(t, rps)
 		require.Len(t, rps, len(systemRoles))
 

--- a/internal/database/roles_test.go
+++ b/internal/database/roles_test.go
@@ -64,7 +64,7 @@ func TestRoleList(t *testing.T) {
 	roles, total := createTestRoles(ctx, t, store)
 	user := createTestUserForUserRole(ctx, "test@test.com", "test-user-1", t, db)
 
-	_, err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{
+	err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{
 		RoleID: roles[0].ID,
 		UserID: user.ID,
 	})
@@ -140,7 +140,7 @@ func TestRoleCount(t *testing.T) {
 	user := createTestUserForUserRole(ctx, "test@test.com", "test-user-1", t, db)
 	roles, total := createTestRoles(ctx, t, store)
 
-	_, err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{
+	err := db.UserRoles().Assign(ctx, AssignUserRoleOpts{
 		RoleID: roles[0].ID,
 		UserID: user.ID,
 	})

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -784,7 +784,7 @@ func (u *userStore) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bo
 
 		userRoleStore := tx.UserRoles()
 		if isSiteAdmin {
-			_, err := userRoleStore.AssignSystemRole(ctx, AssignSystemRoleOpts{
+			err := userRoleStore.AssignSystemRole(ctx, AssignSystemRoleOpts{
 				UserID: id,
 				Role:   types.SiteAdministratorSystemRole,
 			})


### PR DESCRIPTION
## Context
We have several `Assign`-ment methods in the store for `user_roles` and `role_permissions`, however most of the call site for these methods don't use the `types.UserRole` or `types.RolePermission` returned.
While working on #47700, I noticed that some tests were failing because:

* The tests had a call to `db.Users().Create`, which creates a site admin user because the `GlobalState` hasn't been initialized.  Then calling `db.Users().SetIsSiteAdmin` after that results in a `sql: no rows in result set` error being returned because the [`ON CONFLICT DO NOTHING` clause](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/user_roles.go?L111) in the upsert statement doesn't return a result set if the user is already assigned a role.

This PR adds an extra check so that we don't return an error when an upsert is done. I also updated the signature to only return an error since we never use the relationship result in the call site for Role / Permission assignment.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Update unit tests