### PR TITLE
Ranking: Exercise new file-based ranking logic in tests

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -90,6 +90,20 @@ func TestSearch(t *testing.T) {
 	})
 
 	testSearchOther(t)
+
+	// Run the search tests with file-based ranking enabled
+	err = client.SetFeatureFlag("search-ranking", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("graphql with file ranking", func(t *testing.T) {
+		testSearchClient(t, client)
+	})
+
+	t.Run("stream with file ranking", func(t *testing.T) {
+		testSearchClient(t, streamClient)
+	})
 }
 
 // searchClient is an interface so we can swap out a streaming vs graphql

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -125,6 +125,85 @@ func TestHorizontalSearcher(t *testing.T) {
 	searcher.Close()
 }
 
+func TestHorizontalSearcherWithFileRanks(t *testing.T) {
+	var endpoints atomicMap
+	endpoints.Store(prefixMap{})
+
+	searcher := &HorizontalSearcher{
+		Map: &endpoints,
+		Dial: func(endpoint string) zoekt.Streamer {
+			repoID, _ := strconv.Atoi(endpoint)
+			var rle zoekt.RepoListEntry
+			rle.Repository.Name = endpoint
+			rle.Repository.ID = uint32(repoID)
+			return &FakeSearcher{
+				Result: &zoekt.SearchResult{
+					Files: []zoekt.FileMatch{{
+						Score:      float64(repoID),
+						Repository: endpoint,
+					}},
+				},
+				Repos: []*zoekt.RepoListEntry{&rle},
+			}
+		},
+	}
+	defer searcher.Close()
+
+	// Start up background goroutines which continuously hit the searcher
+	// methods to ensure we are safe under concurrency.
+	for i := 0; i < 5; i++ {
+		cleanup := backgroundSearch(searcher)
+		defer cleanup(t)
+	}
+
+	// each map is the set of servers at a point in time. This is to mainly
+	// stress the management code.
+	maps := []prefixMap{
+		// Start with a normal config of two replicas
+		{"1", "2"},
+
+		// Add two
+		{"1", "2", "3", "4"},
+
+		// Lose two
+		{"2", "4"},
+
+		// Lose and add
+		{"1", "2"},
+
+		// Lose all
+		{},
+
+		// Lots
+		{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+	}
+
+	opts := zoekt.SearchOptions{
+		UseDocumentRanks: true,
+		FlushWallTime:    100 * time.Millisecond,
+	}
+
+	for _, m := range maps {
+		t.Log("current", searcher.String(), "next", m)
+		endpoints.Store(m)
+
+		// Our search results should be one per server
+		sr, err := searcher.Search(context.Background(), nil, &opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, fm := range sr.Files {
+			got = append(got, fm.Repository)
+		}
+		sort.Strings(got)
+		want := []string(m)
+		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
+			t.Errorf("search mismatch (-want +got):\n%s", cmp.Diff(want, got))
+		}
+	}
+}
+
 func TestDoStreamSearch(t *testing.T) {
 	var endpoints atomicMap
 	endpoints.Store(prefixMap{"1"})


### PR DESCRIPTION
This adds minimal coverage for the file-based ranking logic (the
`search-ranking` feature flag):
* Add a case to horizontal search tests
* Exercise the feature flag in API integration tests

In the future, we should add more detailed tests for the result ordering. I
plan to do this after we're done solidifying the implementation to make ranking
more deterministic.

## Test plan

Test-only change