### PR TITLE
Enable new perms syncer by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch Changes: Log outputs from execution steps are now paginated in the web interface. [#46335](https://github.com/sourcegraph/sourcegraph/pull/46335)
 - Monitoring: the searcher dashboard now contains more detailed request metrics as well as information on interactions with the local cache (via gitserver). [#47654](https://github.com/sourcegraph/sourcegraph/pull/47654)
 - Renders GitHub pull request references in the commit list. [#47593](https://github.com/sourcegraph/sourcegraph/pull/47593)
-- Added a new background permissions syncer & scheduler which is backed by database, unlike the old one having an in-memory processing queue. The new system is enabled by default, but can be disabled and reverted to the old one using the feature flag `database-permission-sync-worker` set to `false`. [#47783](https://github.com/sourcegraph/sourcegraph/pull/47783) 
+- Added a new background permissions syncer & scheduler which is backed by database, unlike the old one having an in-memory processing queue. The new system is enabled by default, but can be disabled and reverted to the old one using the feature flag `database-permission-sync-worker` set to `false`. [#47783](https://github.com/sourcegraph/sourcegraph/pull/47783)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch Changes: Log outputs from execution steps are now paginated in the web interface. [#46335](https://github.com/sourcegraph/sourcegraph/pull/46335)
 - Monitoring: the searcher dashboard now contains more detailed request metrics as well as information on interactions with the local cache (via gitserver). [#47654](https://github.com/sourcegraph/sourcegraph/pull/47654)
 - Renders GitHub pull request references in the commit list. [#47593](https://github.com/sourcegraph/sourcegraph/pull/47593)
+- Added a new background permissions syncer & scheduler which is backed by database, unlike the old one having an in-memory processing queue. The new system is enabled by default, but can be disabled and reverted to the old one using the feature flag `database-permission-sync-worker` set to `false`. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch Changes: Log outputs from execution steps are now paginated in the web interface. [#46335](https://github.com/sourcegraph/sourcegraph/pull/46335)
 - Monitoring: the searcher dashboard now contains more detailed request metrics as well as information on interactions with the local cache (via gitserver). [#47654](https://github.com/sourcegraph/sourcegraph/pull/47654)
 - Renders GitHub pull request references in the commit list. [#47593](https://github.com/sourcegraph/sourcegraph/pull/47593)
-- Added a new background permissions syncer & scheduler which is backed by database, unlike the old one having an in-memory processing queue. The new system is enabled by default, but can be disabled and reverted to the old one using the feature flag `database-permission-sync-worker` set to `false`. 
+- Added a new background permissions syncer & scheduler which is backed by database, unlike the old one having an in-memory processing queue. The new system is enabled by default, but can be disabled and reverted to the old one using the feature flag `database-permission-sync-worker` set to `false`. [#47783](https://github.com/sourcegraph/sourcegraph/pull/47783) 
 
 ### Changed
 

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -82,8 +82,7 @@ func (p *permissionSyncJobScheduler) Routines(_ context.Context, observationCtx 
 			goroutine.HandlerFunc(
 				func(ctx context.Context) error {
 					if !permssync.PermissionSyncWorkerEnabled(ctx, db, logger) || permissionSyncingDisabled() {
-						// TODO(naman): convert log to debug level post testing
-						logger.Info("disabled")
+						logger.Debug("disabled")
 						return nil
 					}
 
@@ -109,7 +108,7 @@ func scheduleJobs(ctx context.Context, db database.DB, logger log.Logger) (int, 
 		return 0, err
 	}
 
-	logger.Info("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
+	logger.Debug("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
 
 	for _, u := range schedule.Users {
 		opts := database.PermissionSyncJobOpts{Reason: u.reason, Priority: u.priority, NoPerms: u.noPerms}

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -82,7 +82,7 @@ func (p *permissionSyncJobScheduler) Routines(_ context.Context, observationCtx 
 			goroutine.HandlerFunc(
 				func(ctx context.Context) error {
 					if !permssync.PermissionSyncWorkerEnabled(ctx, db, logger) || permissionSyncingDisabled() {
-						logger.Debug("disabled")
+						logger.Debug("new scheduler disabled due to either permission syncing disabled or feature flag not enabled")
 						return nil
 					}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1130,9 +1130,6 @@ func (s *PermsSyncer) isDisabled() bool { return PermissionSyncingDisabled() }
 func (s *PermsSyncer) runSchedule(ctx context.Context) {
 	logger := s.logger.Scoped("runSchedule", "periodically queue old records for sync")
 
-	logger.Debug("started")
-	defer logger.Debug("stopped")
-
 	ticker := time.NewTicker(s.scheduleInterval)
 	defer ticker.Stop()
 
@@ -1144,7 +1141,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 		}
 
 		if s.isDisabled() || permssync.PermissionSyncWorkerEnabled(ctx, s.db, logger) {
-			logger.Debug("disabled")
+			logger.Debug("old scheduler disabled due to either permission syncing disabled or new schduler enabled")
 			continue
 		}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -910,7 +910,6 @@ func (s *PermsSyncer) syncPerms(ctx context.Context, syncGroups map[requestType]
 
 func (s *PermsSyncer) runSync(ctx context.Context) {
 	logger := s.logger.Scoped("runSync", "routine to start processing the sync request queue")
-	defer logger.Debug("stopped")
 
 	userMaxConcurrency := syncUsersMaxConcurrency()
 	logger.Debug("started", log.Int("syncUsersMaxConcurrency", userMaxConcurrency))

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1141,7 +1141,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 		}
 
 		if s.isDisabled() || permssync.PermissionSyncWorkerEnabled(ctx, s.db, logger) {
-			logger.Debug("old scheduler disabled due to either permission syncing disabled or new schduler enabled")
+			logger.Debug("old scheduler disabled due to either permission syncing disabled or new scheduler enabled")
 			continue
 		}
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -910,7 +910,7 @@ func (s *PermsSyncer) syncPerms(ctx context.Context, syncGroups map[requestType]
 
 func (s *PermsSyncer) runSync(ctx context.Context) {
 	logger := s.logger.Scoped("runSync", "routine to start processing the sync request queue")
-	defer logger.Info("stopped")
+	defer logger.Debug("stopped")
 
 	userMaxConcurrency := syncUsersMaxConcurrency()
 	logger.Debug("started", log.Int("syncUsersMaxConcurrency", userMaxConcurrency))
@@ -1130,8 +1130,8 @@ func (s *PermsSyncer) isDisabled() bool { return PermissionSyncingDisabled() }
 func (s *PermsSyncer) runSchedule(ctx context.Context) {
 	logger := s.logger.Scoped("runSchedule", "periodically queue old records for sync")
 
-	logger.Info("started")
-	defer logger.Info("stopped")
+	logger.Debug("started")
+	defer logger.Debug("stopped")
 
 	ticker := time.NewTicker(s.scheduleInterval)
 	defer ticker.Stop()
@@ -1144,7 +1144,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 		}
 
 		if s.isDisabled() || permssync.PermissionSyncWorkerEnabled(ctx, s.db, logger) {
-			logger.Info("disabled")
+			logger.Debug("disabled")
 			continue
 		}
 
@@ -1154,7 +1154,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 			continue
 		}
 
-		logger.Info("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
+		logger.Debug("scheduling permission syncs", log.Int("users", len(schedule.Users)), log.Int("repos", len(schedule.Repos)))
 
 		s.scheduleUsers(ctx, schedule.Users...)
 		s.scheduleRepos(ctx, schedule.Repos...)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
@@ -74,7 +74,7 @@ func (h *permsSyncerWorker) Handle(ctx context.Context, _ log.Logger, record *da
 		reqID = int32(record.RepositoryID)
 	}
 
-	h.logger.Info(
+	h.logger.Debug(
 		"Handling permission sync job",
 		log.String("type", reqType.String()),
 		log.Int32("id", reqID),
@@ -107,7 +107,8 @@ func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType request
 	} else {
 		h.logger.Debug("succeeded in syncing permissions", providerStates.SummaryField())
 
-		// NOTE(naman): here we are saving permissions added, removed and found results to the job record
+		// NOTE(naman): here we are saving permissions added, removed and found results
+		// as well as the code host sync status to the job record.
 		if result != nil {
 			err = h.jobsStore.SaveSyncResult(ctx, recordID, result, providerStates.ToPermissionSyncCodeHostState())
 			if err != nil {

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -21,8 +21,7 @@ func PermissionSyncWorkerEnabled(ctx context.Context, db database.DB, logger log
 		return true
 	}
 
-	value, ok := globalFeatureFlags[featureFlagName]
-	if ok {
+	if value, ok := globalFeatureFlags[featureFlagName]; ok {
 		return value
 	}
 

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -18,9 +18,15 @@ func PermissionSyncWorkerEnabled(ctx context.Context, db database.DB, logger log
 		logger.
 			Scoped("PermissionSyncWorkerEnabled", "checking feature flag for permission sync worker").
 			Warn("failed to query global feature flags", log.Error(err))
-		return false
+		return true
 	}
-	return globalFeatureFlags[featureFlagName]
+
+	value, ok := globalFeatureFlags[featureFlagName]
+	if ok {
+		return value
+	}
+
+	return true
 }
 
 var MockSchedulePermsSync func(ctx context.Context, logger log.Logger, db database.DB, req protocol.PermsSyncRequest)

--- a/internal/authz/permssync/permssync_test.go
+++ b/internal/authz/permssync/permssync_test.go
@@ -21,7 +21,7 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	permsSyncStore.CreateRepoSyncJobFunc.SetDefaultReturn(nil)
 
 	featureFlags := database.NewMockFeatureFlagStore()
-	featureFlags.GetGlobalFeatureFlagsFunc.SetDefaultReturn(map[string]bool{featureFlagName: true}, nil)
+	featureFlags.GetGlobalFeatureFlagsFunc.SetDefaultReturn(map[string]bool{}, nil)
 
 	db := database.NewMockDB()
 	db.PermissionSyncJobsFunc.SetDefaultReturn(permsSyncStore)


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/47160

This PR enables the new perms syncer by default.

## Test plan

- new perms syncer should be running by default. check for logs
- create feature flag and set to false
- old `runSchedule` & `runSync` should log
- set feature flag to true
- new perms syncer should run. 
