### PR TITLE
Enable the permissions settings page for every user, not just site admins

### DIFF
--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -95,7 +95,7 @@ class ScheduleUserPermissionsSyncActionContainer extends React.PureComponent<Sch
         return (
             <ActionContainer
                 title="Manually schedule a permissions sync"
-                description={<div>Site admins are able to manually schedule a permissions sync for this user.</div>}
+                description={<div>Schedule a permissions sync for user: {this.props.user.username}.</div>}
                 buttonLabel="Schedule now"
                 flashText="Added to queue"
                 run={this.scheduleUserPermissions}

--- a/client/web/src/enterprise/user/settings/routes.tsx
+++ b/client/web/src/enterprise/user/settings/routes.tsx
@@ -17,7 +17,6 @@ export const enterpriseUserSettingsAreaRoutes: readonly UserSettingsAreaRoute[] 
     {
         path: 'permissions',
         render: lazyComponent(() => import('./auth/UserSettingsPermissionsPage'), 'UserSettingsPermissionsPage'),
-        condition: ({ authenticatedUser }) => authenticatedUser.siteAdmin,
     },
     {
         path: 'event-log',

--- a/client/web/src/enterprise/user/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/user/settings/sidebaritems.ts
@@ -25,7 +25,6 @@ export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = [
         label: 'Permissions',
         to: '/permissions',
         exact: true,
-        condition: ({ authenticatedUser }) => !!authenticatedUser.siteAdmin,
     },
     {
         to: '/event-log',

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -309,7 +310,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 		)
 		got := fmt.Sprintf("%v", err)
-		want := "must be authenticated as the authorized user or site admin"
+		want := auth.ErrMustBeSiteAdminOrSameUser.Error()
 		assert.Equal(t, want, got)
 		assert.Nil(t, result)
 	})
@@ -625,7 +626,7 @@ func TestUser_Organizations(t *testing.T) {
 
 	expectOrgFailure := func(t *testing.T, actorUID int32) {
 		t.Helper()
-		wantErr := "must be authenticated as the authorized user or site admin"
+		wantErr := auth.ErrMustBeSiteAdminOrSameUser.Error()
 		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: actorUID}),

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -353,14 +353,14 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 	t.Cleanup(reset)
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 123})
 
-	t.Run("authenticated as non-admin", func(t *testing.T) {
+	t.Run("authenticated as non-admin and not the same user", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 123}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := (&Resolver{db: db}).ScheduleUserPermissionsSync(ctx, &graphqlbackend.UserPermissionsSyncArgs{})
+		result, err := (&Resolver{db: db}).ScheduleUserPermissionsSync(ctx, &graphqlbackend.UserPermissionsSyncArgs{User: graphqlbackend.MarshalUserID(1)})
 		if want := auth.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -383,8 +383,8 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 		called := false
 		permssync.MockSchedulePermsSync = func(_ context.Context, _ log.Logger, _ database.DB, req protocol.PermsSyncRequest) {
 			called = true
-			if len(req.UserIDs) != 1 && req.UserIDs[0] == userID {
-				t.Errorf("unexpected UserIDs argument. want=%d have=%d", userID, req.UserIDs[0])
+			if len(req.UserIDs) != 1 || req.UserIDs[0] != userID {
+				t.Errorf("unexpected UserIDs argument. want=%d have=%v", userID, req.UserIDs)
 			}
 			if req.TriggeredByUserID != 123 {
 				t.Errorf("unexpected TriggeredByUserID argument. want=%d have=%d", 1, req.TriggeredByUserID)
@@ -394,6 +394,38 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 
 		_, err := r.ScheduleUserPermissionsSync(actor.WithActor(context.Background(), &actor.Actor{UID: 123}),
 			&graphqlbackend.UserPermissionsSyncArgs{User: graphqlbackend.MarshalUserID(userID)})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !called {
+			t.Fatal("expected SchedulePermsSync to be called but wasn't")
+		}
+	})
+
+	t.Run("queue the same user, not a site-admin", func(t *testing.T) {
+		userID := int32(123)
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: userID}, nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		r := &Resolver{db: db}
+
+		called := false
+		permssync.MockSchedulePermsSync = func(_ context.Context, _ log.Logger, _ database.DB, req protocol.PermsSyncRequest) {
+			called = true
+			if len(req.UserIDs) != 1 || req.UserIDs[0] != userID {
+				t.Errorf("unexpected UserIDs argument. want=%d have=%v", userID, req.UserIDs)
+			}
+			if req.TriggeredByUserID != userID {
+				t.Errorf("unexpected TriggeredByUserID argument. want=%d have=%d", 1, req.TriggeredByUserID)
+			}
+		}
+		t.Cleanup(func() { permssync.MockSchedulePermsSync = nil })
+
+		_, err := r.ScheduleUserPermissionsSync(actor.WithActor(context.Background(), &actor.Actor{UID: 123}),
+			&graphqlbackend.UserPermissionsSyncArgs{User: graphqlbackend.MarshalUserID(123)})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -361,7 +361,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		result, err := (&Resolver{db: db}).ScheduleUserPermissionsSync(ctx, &graphqlbackend.UserPermissionsSyncArgs{User: graphqlbackend.MarshalUserID(1)})
-		if want := auth.ErrMustBeSiteAdmin; err != want {
+		if want := auth.ErrMustBeSiteAdminOrSameUser; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
 		if result != nil {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1296,20 +1296,47 @@ func TestResolver_RepositoryPermissionsInfo(t *testing.T) {
 }
 
 func TestResolver_UserPermissionsInfo(t *testing.T) {
-	t.Run("authenticated as non-admin", func(t *testing.T) {
+	t.Run("authenticated as non-admin, asking not for self", func(t *testing.T) {
+		user := &types.User{ID: 42}
+
 		users := database.NewStrictMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(user, nil)
+		users.GetByIDFunc.SetDefaultReturn(user, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{db: db}).UserPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
-		if want := auth.ErrMustBeSiteAdmin; err != want {
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: user.ID})
+		result, err := (&Resolver{db: db}).UserPermissionsInfo(ctx, graphqlbackend.MarshalUserID(1))
+		if want := auth.ErrMustBeSiteAdminOrSameUser; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
 		if result != nil {
 			t.Errorf("result: want nil but got %v", result)
+		}
+	})
+
+	t.Run("authenticated as non-admin, asking for self succeeds", func(t *testing.T) {
+		user := &types.User{ID: 42}
+
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(user, nil)
+		users.GetByIDFunc.SetDefaultReturn(user, nil)
+
+		perms := edb.NewStrictMockPermsStore()
+		perms.LoadUserPermissionsFunc.SetDefaultReturn(nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		db.PermsFunc.SetDefaultReturn(perms)
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: user.ID})
+		result, err := (&Resolver{db: db}).UserPermissionsInfo(ctx, graphqlbackend.MarshalUserID(user.ID))
+		if err != nil {
+			t.Errorf("err: want nil but got %v", err)
+		}
+		if result == nil {
+			t.Errorf("result: want non-nil but got nil")
 		}
 	})
 

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -207,7 +208,7 @@ func TestIsAllowedToEdit(t *testing.T) {
 		}
 
 		_, err = r.UpdateCodeMonitor(ctx, args)
-		require.EqualError(t, err, "update namespace: must be authenticated as the authorized user or site admin")
+		require.EqualError(t, err, fmt.Sprintf("update namespace: %s", auth.ErrMustBeSiteAdminOrSameUser.Error()))
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions_test.go
@@ -12,6 +12,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/rbac/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -225,7 +226,7 @@ func TestUserPermissionsListing(t *testing.T) {
 		var response struct{}
 		errs := apitest.Exec(actorCtx, t, s, input, &response, listUserPermissions)
 		require.Len(t, errs, 1)
-		require.Equal(t, errs[0].Message, "must be authenticated as the authorized user or site admin")
+		require.Equal(t, auth.ErrMustBeSiteAdminOrSameUser.Error(), errs[0].Message)
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -12,6 +12,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/rbac/resolvers/apitest"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -209,7 +210,7 @@ func TestUserRoleListing(t *testing.T) {
 		var response struct{}
 		errs := apitest.Exec(actorCtx, t, s, input, &response, listUserRoles)
 		assert.Len(t, errs, 1)
-		assert.Equal(t, errs[0].Message, "must be authenticated as the authorized user or site admin")
+		assert.Equal(t, auth.ErrMustBeSiteAdminOrSameUser.Error(), errs[0].Message)
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -122,7 +123,7 @@ func TestSearchContextsStarDefaultPermissions(t *testing.T) {
 
 	// User not admin, trying to set things for another user
 	graphqlUserID2 := graphqlbackend.MarshalUserID(int32(2))
-	unauthorizedError := "must be authenticated as the authorized user or site admin"
+	unauthorizedError := auth.ErrMustBeSiteAdminOrSameUser.Error()
 
 	_, err = (&Resolver{db: db}).SetDefaultSearchContext(ctx, graphqlbackend.SetDefaultSearchContextArgs{SearchContextID: graphqlSearchContextID, UserID: graphqlUserID2})
 	if err.Error() != unauthorizedError {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1855,7 +1855,7 @@ changesetTemplate:
 				BatchChange:     batchChange.ID,
 			})
 
-			assert.Equal(t, auth.ErrMustBeSiteAdminOrSameUser, err)
+			assert.Equal(t, auth.ErrMustBeSiteAdminOrSameUser.Error(), err.Error())
 		})
 
 		t.Run("success - without batch change ID", func(t *testing.T) {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1855,7 +1855,7 @@ changesetTemplate:
 				BatchChange:     batchChange.ID,
 			})
 
-			assert.Equal(t, "must be authenticated as the authorized user or site admin", err.Error())
+			assert.Equal(t, auth.ErrMustBeSiteAdminOrSameUser, err)
 		})
 
 		t.Run("success - without batch change ID", func(t *testing.T) {

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -12,6 +12,7 @@ import (
 )
 
 var ErrMustBeSiteAdmin = errors.New("must be site admin")
+var ErrMustBeSiteAdminOrSameUser = &InsufficientAuthorizationError{"must be authenticated as the authorized user or site admin"}
 
 // CheckCurrentUserIsSiteAdmin returns an error if the current user is NOT a site admin.
 func CheckCurrentUserIsSiteAdmin(ctx context.Context, db database.DB) error {
@@ -75,7 +76,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db database.DB, subjectUserID
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	return &InsufficientAuthorizationError{"must be authenticated as the authorized user or site admin"}
+	return ErrMustBeSiteAdminOrSameUser
 }
 
 // CheckSameUser returns an error if the user is not the user specified by


### PR DESCRIPTION

## Test plan
Tested locally that it shows correctly for both normal user and site admin

- the last sync is visible
- schedule permissions button actually does what it says
