### PR TITLE
doc: fix bad links

### DIFF
--- a/doc/admin/deploy/instance-size.md
+++ b/doc/admin/deploy/instance-size.md
@@ -50,10 +50,10 @@ table.
 
 | **Provider**                       | **Node type**                   | **Boot/ephemeral disk size** |
 |------------------------------------|---------------------------------|------------------------------|
-|[Amazon EKS (better than plain EC2)](eks.md)| m5.4xlarge | 100 GB (SSD preferred) |
+|[Amazon EKS (better than plain EC2)](kubernetes/eks.md)| m5.4xlarge | 100 GB (SSD preferred) |
 |[AWS EC2](https://kubernetes.io/docs/getting-started-guides/aws/)| m5.4xlarge |  100 GB (SSD preferred) |
 |[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/quickstart)| n2-standard-16 | 100 GB (default) |
-|[Azure](azure.md)| D16 v3 | 100 GB (SSD preferred) |
+|[Azure](kubernetes/azure.md)| D16 v3 | 100 GB (SSD preferred) |
 |[Other](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/)| 16 vCPU, 60 GiB memory per node | 100 GB (SSD preferred) |
 
 <span class="virtual-br"></span>

--- a/doc/admin/how-to/clear_codeintel_data.md
+++ b/doc/admin/how-to/clear_codeintel_data.md
@@ -4,7 +4,7 @@ Clear all precise code intelligence data from your instance and start fresh.
 
 ## Clearing the `frontend` database
 
-The following commands assume a connection to the `frontend` database. Refer to our guide on [`psql`](/admin/how-to/run-psql) if you do not use an [external database](/admin/external_services).
+The following commands assume a connection to the `frontend` database. Refer to our guide on [`psql`](run-psql.md) if you do not use an [external database](../external_services/index.md).
 
 If you are clearing **all** code intelligence data, then you will need to clear the metadata information in the frontend database. This will clear the high-level information about code intelligence indexes, but the raw data will remain in the `codeintel-db` database, which will also need to be cleared (see the next section).
 
@@ -25,13 +25,13 @@ COMMIT;
 
 ## Clearing the `codeintel-db` database
 
-The following commands assume a connection to the `codeintel-db` database. Refer to our guide on [`psql`](/admin/how-to/run-psql) if you do not use an [external database](/admin/external_services).
+The following commands assume a connection to the `codeintel-db` database. Refer to our guide on [`psql`](run-psql.md) if you do not use an [external database](../external_services/index.md).
 
 ### Clearing LSIF data
 
 Truncate the following tables to clear all LSIF-encoded information from the database. This command can be run when clearing **all** data from the instance, in which case the associated records in the `frontend` database must also be cleared.
 
-This command can also be run after a completed [migration from LSIF to SCIP](/admin/how-to/lsif_scip_migration), in which case these tables should be empty but may retain a number of blocks containing a large number of dead tuples. Truncating these _empty_ tables acts like a `VACUUM FULL` and releases the previously used disk space.
+This command can also be run after a completed [migration from LSIF to SCIP](lsif_scip_migration.md), in which case these tables should be empty but may retain a number of blocks containing a large number of dead tuples. Truncating these _empty_ tables acts like a `VACUUM FULL` and releases the previously used disk space.
 
 ```sql
 BEGIN;

--- a/doc/admin/how-to/lsif_scip_migration.md
+++ b/doc/admin/how-to/lsif_scip_migration.md
@@ -2,7 +2,7 @@
 
 > WARNING: The migration from LSIF -> SCIP is **destructive and irreversible**. A downgrade from 4.6 to a previous version will result in the inability to access migrated code intelligence data (powering precise code navigation features).
 
-Sourcegraph 4.5 introduced an [out-of-band migration](/admin/how-to/unfinished_migration#checking-progress) that re-encodes LSIF code intelligence data as SCIP in the `codeintel-db`. This migration is required to complete prior to a subsequent upgrade to 4.6, as support for reading LSIF-encoded data has been removed as of this version.
+Sourcegraph 4.5 introduced an [out-of-band migration](unfinished_migration.md#checking-progress) that re-encodes LSIF code intelligence data as SCIP in the `codeintel-db`. This migration is required to complete prior to a subsequent upgrade to 4.6, as support for reading LSIF-encoded data has been removed as of this version.
 
 As of [src-cli 4.5](https://github.com/sourcegraph/src-cli/releases/tag/4.5.0), LSIF indexes will be converted to SCIP prior to upload. This ensures that only _existing_ data needs to be migrated in the background. Using an older version of src-cli to upload code intelligence to your index may continue to feed additional LSIF data that needs to be subsequently migrated. This will ultimately block the ability to upgrade to the next version as the migration will never reach 100% (and remain there).
 

--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -21,7 +21,7 @@ This document describes the exact changes needed to update a single-node Sourceg
 
 <!-- Add changes changes to this section before release. -->
 
-- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](/admin/how-to/lsif_scip_migration) for more details.
+- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](../how-to/lsif_scip_migration.md) for more details.
 
 ## v4.4.1 ➔ v4.4.2
 


### PR DESCRIPTION
Fix _some but not all_ link issues reported by `docsite check`.

_This is part of the effort to [bring back the `sg lint docs`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/sg/linters/linters.go?L54-55)._

## Test plan

n/a
