### PR TITLE
web: remove `.tsx` extension from jest snapshots

### DIFF
--- a/client/web/src/global/__snapshots__/Notices.test.snap
+++ b/client/web/src/global/__snapshots__/Notices.test.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notices no notices 1`] = `<DocumentFragment />`;
+
+exports[`Notices shows notices for location 1`] = `
+<DocumentFragment>
+  <div
+    class="notices"
+  >
+    <div
+      aria-live="polite"
+      class="alert bg transparent border p-2"
+      data-testid="notice-alert"
+      role="alert"
+    >
+      <div
+        class="markdown"
+      >
+        <p>
+          a
+        </p>
+        
+
+      </div>
+    </div>
+    <div
+      aria-live="polite"
+      class="alert container bg transparent border p-2"
+      role="alert"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="markdown"
+        >
+          <p>
+            a
+          </p>
+          
+
+        </div>
+      </div>
+      <button
+        aria-label="Dismiss alert"
+        class="btn btnIcon closeButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -71,6 +71,8 @@ const config = {
   // `--coverageReporters text` jest option.
   coverageReporters: ['json', 'lcov', 'text-summary'],
 
+  snapshotResolver: path.join(__dirname, './jest.snapshot-resolver.js'),
+
   setupFiles: [
     path.join(__dirname, 'client/shared/dev/mockDate.js'),
     // Needed for reusing API functions that use fetch

--- a/jest.snapshot-resolver.js
+++ b/jest.snapshot-resolver.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+const path = require('path')
+
+const SNAPSHOT_EXTENSION = '.snap'
+const TEST_EXTENSION = '.tsx'
+
+module.exports = {
+  resolveSnapshotPath: testPath => {
+    const filename = path.parse(testPath).name + SNAPSHOT_EXTENSION
+
+    return path.join(path.join(path.dirname(testPath), '__snapshots__'), filename)
+  },
+
+  resolveTestPath: snapshotPath => {
+    const filename = path.parse(snapshotPath).name + TEST_EXTENSION
+
+    return path.join(path.dirname(path.dirname(snapshotPath)), filename)
+  },
+
+  testPathForConsistencyCheck: path.posix.join('consistency_check', '__tests__', 'example.test.tsx'),
+}


### PR DESCRIPTION
## Context

Fixes the issue with snapshots in `rules_jest` when running jest in bazel, all the `ts[x]` is pre-compiled, jest is running `.js` files and doesn’t even know they originally came from `.ts`. But all the snapshots have the `.ts` file extension.

## Test plan

pnpm test

## App preview:

- [Web](https://sg-web-vb-remove-tsx-extension-from.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
