### PR TITLE
doc: Add background information on git-gc modes of operations

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -63,6 +63,7 @@ const (
 )
 
 // gitGCMode describes which mode we should be running git gc.
+// See for a detailed description of the modes: https://docs.sourcegraph.com/dev/background-information/git_gc
 var gitGCMode = func() int {
 	// EnableGCAuto is a temporary flag that allows us to control whether or not
 	// `git gc --auto` is invoked during janitorial activities. This flag will

--- a/doc/dev/background-information/git_gc.md
+++ b/doc/dev/background-information/git_gc.md
@@ -1,6 +1,6 @@
 # Git GC and its modes of operations in Sourcegraph
 
-`git-gc` is git's in-built mechanism to optimise git objects in a repository. Sourcegraph runs `git gc` in `gitserver` to clean up cruft in git repos, sometimes when executing git commands and other times as part of regular clean up jobs.
+`git-gc` is git's built-in mechanism to optimise git objects in a repository. Sourcegraph runs `git gc` in `gitserver` to clean up cruft in git repos, sometimes when executing git commands and other times as part of regular clean up jobs.
 
 We have three possible modes of operation. Two of them circumvent git's default behaviour (more on it later):
 

--- a/doc/dev/background-information/git_gc.md
+++ b/doc/dev/background-information/git_gc.md
@@ -2,7 +2,7 @@
 
 `git-gc` is git's in-built mechanism to optimise git objects in a repository. Sourcegraph runs `git gc` in `gitserver` to clean up cruft in git repos, sometimes when executing git commands and other times as part of regular clean up jobs.
 
-We have two possible modes of operation outside of git's default behaviour (more on it later):
+We have three possible modes of operation. Two of them circumvent git's default behaviour (more on it later):
 
 1. If `SRC_ENABLE_GC_AUTO` is set to `true` and `SRC_ENABLE_SG_MAINTENANCE` is `false`, then we run `git gc --auto` with the value of `gc.auto` set to `1`. This tells `git gc --auto` to pack all loose objects if the number of these objects is greater than `1`.
 2. But if the opposite is true, that is `SRC_ENABLE_GC_AUTO` is set to `false` while `SRC_ENABLE_SG_MAINTENANCE` is `true` then we run `sg maintenance` and `git prune`. In this mode `gc.auto` is set to `0` which effectively disables automatic packing of loose objects along with any other heuristics that `git gc --auto` keeps an eye out to decide if it should run or not.

--- a/doc/dev/background-information/git_gc.md
+++ b/doc/dev/background-information/git_gc.md
@@ -9,6 +9,6 @@ We have three possible modes of operation. Two of them circumvent git's default 
 
 The frequency of both these modes of operation is controlled by an environment variable `SRC_REPOS_JANITOR_INTERVAL` - which is set to 1 minute by default. But if the job itself takes longer than the interval, then we ensure to wait for it to finish and then wait for the interval as determined by the environment variable to expire before launching a new iteration of that job.
 
-However the third and final mode of operation is git's default behaviour which is not controlled by Sourcegraph and the value of `SRC_REPOS_JANITOR_INTERVAL` has no effect on its frequency.
+However the third and final mode of operation is git's default behaviour and is not controlled by Sourcegraph. The value of `SRC_REPOS_JANITOR_INTERVAL` has no effect on its frequency.
 
 If both `SRC_ENABLE_GC_AUTO` and `SRC_ENABLE_SG_MAINTENANCE` are enabled or disabled at the same time, we fall back to the default value of the `gc.auto` flag - `6700`, indicating the number of loose objects above which `git gc --auto` will automatically start repacking them. The frequency of this depends on the frequency and volume of updates to the repository. However, it should be noted that this is not the only heuristic monitored by `git` to decide if it should run `git gc --auto` or not. For more information, see: _[git-gc(1)](https://www.man7.org/linux/man-pages/man1/git-gc.1.html)_.

--- a/doc/dev/background-information/git_gc.md
+++ b/doc/dev/background-information/git_gc.md
@@ -1,0 +1,14 @@
+# Git GC and its modes of operations in Sourcegraph
+
+`git-gc` is git's in-built mechanism to optimise git objects in a repository. Sourcegraph runs `git gc` in `gitserver` to clean up cruft in git repos, sometimes when executing git commands and other times as part of regular clean up jobs.
+
+We have two possible modes of operation outside of git's default behaviour (more on it later):
+
+1. If `SRC_ENABLE_GC_AUTO` is set to `true` and `SRC_ENABLE_SG_MAINTENANCE` is `false`, then we run `git gc --auto` with the value of `gc.auto` set to `1`. This tells `git gc --auto` to pack all loose objects if the number of these objects is greater than `1`.
+2. But if the opposite is true, that is `SRC_ENABLE_GC_AUTO` is set to `false` while `SRC_ENABLE_SG_MAINTENANCE` is `true` then we run `sg maintenance` and `git prune`. In this mode `gc.auto` is set to `0` which effectively disables automatic packing of loose objects along with any other heuristics that `git gc --auto` keeps an eye out to decide if it should run or not.
+
+The frequency of both these modes of operation is controlled by an environment variable `SRC_REPOS_JANITOR_INTERVAL` - which is set to 1 minute by default. But if the job itself takes longer than the interval, then we ensure to wait for it to finish and then wait for the interval as determined by the environment variable to expire before launching a new iteration of that job.
+
+However the third and final mode of operation is git's default behaviour which is not controlled by Sourcegraph and the value of `SRC_REPOS_JANITOR_INTERVAL` has no effect on its frequency.
+
+If both `SRC_ENABLE_GC_AUTO` and `SRC_ENABLE_SG_MAINTENANCE` are enabled or disabled at the same time, we fall back to the default value of the `gc.auto` flag - `6700`, indicating the number of loose objects above which `git gc --auto` will automatically start repacking them. The frequency of this depends on the frequency and volume of updates to the repository. However, it should be noted that this is not the only heuristic monitored by `git` to decide if it should run `git gc --auto` or not. For more information, see: _[git-gc(1)](https://www.man7.org/linux/man-pages/man1/git-gc.1.html)_.

--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -1,3 +1,5 @@
+<!-- Link back any new sections to doc/dev/index.md as well -->
+
 # Background information
 
 ## Overview

--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -41,6 +41,10 @@
 - [Building p4-fusion](./build_p4_fusion.md)
 - [The `gitserver` API](./gitserver-api.md)
 
+## Git
+
+- [`git gc` and its modes of operations in Sourcegraph](./git_gc.md)
+
 ## [Languages](languages/index.md)
 
 - [Go](languages/go.md)

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -35,7 +35,6 @@ body.theme-dark .markdown-body ul li:before {
 <a class="btn" href="https://github.com/sourcegraph/sourcegraph/issues">Issue Tracker</a>
 </div>
 
-
 ## [Setup](setup/index.md)
 
 <p class="subtitle">Learn how to develop Sourcegraph on your machine.</p>
@@ -109,6 +108,10 @@ Clarification and discussion about key concepts, architecture, and development s
     - [Testing web code](background-information/testing_web_code.md)
 - [Building p4-fusion](background-information/build_p4_fusion.md)
 - [The `gitserver` API](background-information/gitserver-api.md)
+
+## Git
+
+- [`git gc` and its modes of operations in Sourcegraph](./git_gc.md)
 
 ### [Languages](background-information/languages/index.md)
 


### PR DESCRIPTION

## Test plan

Doc only change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
