### PR TITLE
doc: fix unclosed link syntax

### DIFF
--- a/doc/getting-started/index.md
+++ b/doc/getting-started/index.md
@@ -122,7 +122,7 @@ _Note: Enterprise Feature_
 
 Automate changes to your codebase. Reduce effort, reduce errors and enable developers to focus on high value work.
 
-Read the [batch changes documentation](../batch_changes/index.md) to learn more, including useful how-to guides. Want a video tutorial? Check out this batch change tutorial](https://www.youtube.com/watch?v=eOmiyXIWTCw)
+Read the [batch changes documentation](../batch_changes/index.md) to learn more, including useful how-to guides. Want a video tutorial? Check out this [batch change tutorial](https://www.youtube.com/watch?v=eOmiyXIWTCw)
 
 ---
 


### PR DESCRIPTION

<img width="838" alt="CleanShot 2023-02-17 at 21 59 45@2x" src="https://user-images.githubusercontent.com/2946214/219675752-6b2c5445-35cc-44bd-af12-5164cb345f6c.png">


## Test plan

n/a
