### PR TITLE
insights: admin UI graphql paging fix 

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -374,9 +374,16 @@ func (s *BackfillStore) GetBackfillQueueInfo(ctx context.Context, args BackfillQ
 		pagination = *args.PaginationArgs
 	}
 	p := pagination.SQL()
-	// Add in pagination where clause
-	if p.Where != nil {
-		where = append(where, p.Where)
+
+	// The underlying pagination helper makes the assumption that any sorted column is both non null and unique
+	// therefore we can't use the where clause it generates.  Below builds the correct where from the before or after
+	// from the cursor
+
+	if pagination.After != nil {
+		where = append(where, sqlf.Sprintf("isb.id > %s", *pagination.After))
+	}
+	if pagination.Before != nil {
+		where = append(where, sqlf.Sprintf(" isb.id < %s", *pagination.Before))
 	}
 	query := sqlf.Sprintf(backfillQueueSQL, sqlf.Sprintf("WHERE %s", sqlf.Join(where, " AND ")))
 	query = p.AppendOrderToQuery(query)
@@ -482,7 +489,7 @@ select isb.id,
        query,
        state.backfill_state,
        round(ri.percent_complete *100) percent_complete,
-       isb.estimated_cost,
+       round(isb.estimated_cost),
        ri.runtime_duration runtime_duration,
        ri.created_at backfill_created_at,
        ri.started_at backfill_started_at,

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -345,7 +345,7 @@ func backfillWhere(args BackfillQueueArgs) []*sqlf.Query {
 	where := []*sqlf.Query{sqlf.Sprintf("s.deleted_at IS NULL")}
 	if args.TextSearch != nil && len(*args.TextSearch) > 0 {
 		likeStr := "%" + *args.TextSearch + "%"
-		where = append(where, sqlf.Sprintf("(title LIKE %s OR label LIKE %s)", likeStr, likeStr))
+		where = append(where, sqlf.Sprintf("(title ILIKE %s OR label ILIKE %s)", likeStr, likeStr))
 	}
 
 	if args.States != nil && len(*args.States) > 0 {


### PR DESCRIPTION
The underlying paging controls made the assumption that any sort field is both non-null and unique.  This caused problems because we were allowing sorting by fields that can be null (queue position) and state which is not unique.  

This change simplifies the paging cursor so that it will only contain the backfill id then builds the where clause using that instead of the relying on the underlying paging controller.  

There does still remain the possibility that if a series were shared between multiple insights and thus shared the same backfill and that backfill fell at the border of a page, that paging could skip the additional instances of that backfill.  I consider this low ok for now because at least one instance of the backfill will always appear and any action on that will apply to all items.

## Test plan
Verify paging works for each sort option
verify search worked case insensitve

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
