### PR TITLE
Outbound requests: Add "Pause polling" button

### DIFF
--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -14,6 +14,7 @@ import {
     Button,
     Code,
     Container,
+    ErrorAlert,
     Icon,
     Link,
     LoadingSpinner,
@@ -24,7 +25,6 @@ import {
     Position,
     Text,
     Tooltip,
-    ErrorAlert,
 } from '@sourcegraph/wildcard'
 
 import {
@@ -89,6 +89,15 @@ export const SiteAdminOutboundRequestsPage: React.FunctionComponent<
         variables: { after: lastId },
         pollInterval: OUTBOUND_REQUESTS_PAGE_POLL_INTERVAL_MS,
     })
+    const [polling, setPolling] = useState(true)
+    const togglePolling = useCallback(() => {
+        if (polling) {
+            stopPolling()
+        } else {
+            startPolling(OUTBOUND_REQUESTS_PAGE_POLL_INTERVAL_MS)
+        }
+        setPolling(!polling)
+    }, [polling, startPolling, stopPolling])
 
     useEffect(() => {
         if (data?.outboundRequests?.nodes?.length && (!lastId || data?.outboundRequests.nodes[0].id > lastId)) {
@@ -137,6 +146,9 @@ export const SiteAdminOutboundRequestsPage: React.FunctionComponent<
     return (
         <div className="site-admin-outbound-requests-page">
             <PageTitle title="Outbound requests - Admin" />
+            <Button variant="secondary" onClick={togglePolling} className="float-right">
+                {polling ? 'Pause polling' : 'Resume polling'}
+            </Button>
             <PageHeader
                 path={[{ text: 'Outbound requests' }]}
                 headingElement="h2"


### PR DESCRIPTION
I've found that on dotcom, there are so many outbound requests per minute that it's practically impossible to investigate the requests because of the 5-sec polling. [Annoying vid that demoes this in 25 seconds](https://www.loom.com/share/bc4008481c574e4f92e9ece7cffc2ea1)

In this PR, I add this button to the top-right to pause/resume polling:

<img width="1182" alt="CleanShot 2023-02-17 at 16 42 28@2x" src="https://user-images.githubusercontent.com/2552265/219699389-866529e8-bc75-425b-8748-392755bd8504.png">

## Test plan

Tested it locally, it nicely pauses and resumes polling: [20-sec Loom](https://www.loom.com/share/cc5c83ba54ce442f86df948ceef2cb55)
