### PR TITLE
Ignore context filter in 1 click insight creation flow

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
@@ -17,7 +17,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repoQuery: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$',
+                repoQuery: 'repo:^github\\.com/sourcegraph/sourcegraph$',
                 seriesQuery: 'test patterntype:literal',
             })
         })
@@ -35,13 +35,12 @@ describe('getInsightDataFromQuery', () => {
 
         it('with multiple repo: filters and "test" pattern query', () => {
             const queryString =
-                'context:global test repo:^github\\.com/sourcegraph/sourcegraph$ repo:^github\\.com/sourcegraph/about patterntype:literal'
+                'test repo:^github\\.com/sourcegraph/sourcegraph$ repo:^github\\.com/sourcegraph/about patterntype:literal'
 
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repoQuery:
-                    'context:global repo:^github\\.com/sourcegraph/sourcegraph$ repo:^github\\.com/sourcegraph/about',
+                repoQuery: 'repo:^github\\.com/sourcegraph/sourcegraph$ repo:^github\\.com/sourcegraph/about',
                 seriesQuery: 'test patterntype:literal',
             })
         })
@@ -53,7 +52,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repoQuery: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$|^github\\.com/sourcegraph/about',
+                repoQuery: 'repo:^github\\.com/sourcegraph/sourcegraph$|^github\\.com/sourcegraph/about',
                 seriesQuery: 'test patterntype:literal',
             })
         })
@@ -65,7 +64,7 @@ describe('getInsightDataFromQuery', () => {
             const result = getInsightDataFromQuery(queryString)
 
             expect(result).toStrictEqual({
-                repoQuery: 'context:global repo:^github\\.com/sourcegraph/sourcegraph$',
+                repoQuery: 'repo:^github\\.com/sourcegraph/sourcegraph$',
                 seriesQuery: '"repo: " patterntype:literal',
             })
         })

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -65,9 +65,7 @@ export function getInsightDataFromQuery(searchQuery: string | null): InsightData
 
     // Generate a string query from tokens with repo: and context filters only
     // in order to put this in the repo query field
-    const tokensWithRepoFiltersAndContext = tokens.filter(
-        token => isRepoFilter(token) || isFilterType(token, FilterType.context) || token.type === 'whitespace'
-    )
+    const tokensWithRepoFiltersOnly = tokens.filter(token => isRepoFilter(token) || token.type === 'whitespace')
 
     // Generate a string query from tokens without repo: filters for the insight
     // query field.
@@ -76,7 +74,7 @@ export function getInsightDataFromQuery(searchQuery: string | null): InsightData
     )
 
     return {
+        repoQuery: dedupeWhitespace(stringHuman(tokensWithRepoFiltersOnly)),
         seriesQuery: dedupeWhitespace(stringHuman(tokensWithoutRepoFiltersAndContext)),
-        repoQuery: dedupeWhitespace(stringHuman(tokensWithRepoFiltersAndContext)),
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/47810

## Test plan
- Go to the search 
- Try to create insight from it 
- See that you don't have context value in the repo query or data series query 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-1-click-creation.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
