### PR TITLE
[doc] Changing docs for repository permissions

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -1,8 +1,7 @@
-# User authentication (SSO)
+# User authentication
 
 Sourcegraph supports the following ways for users to sign in:
 
-- [Guidance](#guidance)
 - [Builtin password authentication](#builtin-password-authentication)
 - [GitHub](#github)
 - [GitLab](#gitlab)
@@ -18,7 +17,7 @@ Sourcegraph supports the following ways for users to sign in:
 
 The authentication provider is configured in the [`auth.providers`](../config/site_config.md#authentication-providers) site configuration option.
 
-## Guidance
+## Recommendations
 
 If you are unsure which auth provider is right for you, we recommend applying the following rules in
 order:

--- a/doc/admin/config/authorization_and_authentication.md
+++ b/doc/admin/config/authorization_and_authentication.md
@@ -1,4 +1,4 @@
-# Authentication and authorization in Sourcegraph
+# Authentication and authorization
 
 Sourcegraph has two authentication concepts:
 
@@ -7,7 +7,7 @@ Sourcegraph has two authentication concepts:
 
 We suggest configuring both when using Sourcegraph Enterprise. If you do not configure permissions, all users will be able to see all of the code in the instance.
 
-## Authentication in Sourcegraph
+## Authentication
 
 Sourcegraph supports username/password auth by default and SAML, OAuth, HTTP Proxy auth, and OpenID Connect if configured. Changing a username in Sourcegraph will allow the user to escalate permissions, so if you are syncing permissions, you will need to add the following to your site config at `https://sourcegraph.yourdomain.com/siteadmin/configuration` ([Learn more about viewing and editing your site configuration.](./site_config.md#view-and-edit-site-configuration))
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -73,7 +73,7 @@ Done! Sourcegraph will now receive webhook events from GitHub and use them to sy
 
 Follow the same steps as above, but ensure you include the `push` event under **Let me select individual events**
 
-#### User permissions
+#### Repository permissions
 
 Follow the same steps as above, but ensure you include the following events under **Let me select individual events**:
 - `Collaborator add, remove, or changed`

--- a/doc/admin/permissions/TODO.md
+++ b/doc/admin/permissions/TODO.md
@@ -1,0 +1,6 @@
+[] Write subsection for perms syncing
+[] Write subsection for webhooks perms
+[] Write subsection for explicit permissions API
+[] Rewrite the authorization_and_authentication.md
+[] Modify admin/auth/index.md
+[] Rewrite the section for code host configurations

--- a/doc/admin/permissions/api.md
+++ b/doc/admin/permissions/api.md
@@ -1,0 +1,107 @@
+# Explicit permissions API
+
+Sourcegraph exposes a set of GraphQL APIs to explicitly set repository permissions as an alternative to other mechanisms of getting the permissions directly from the code host.
+
+<span class="virtual-br"></span>
+
+> NOTE: If the permissions API is enabled, all the other repository permissions mechanisms are disabled.
+
+> NOTE: If you're using Sourcegraph with multiple code hosts, it's not possible to use the explicit permissions API for some repositories and inherit code host permissions for others.
+
+Both of the above behaviors are subject to change in the future as part of improving experience for Sourcegraph administrators.
+
+## Recommendations
+
+We only recommend to use explicit permissions API in cases, where the other methods are not possible or effective. 
+E.g. if a code host does not support permission syncing/webhooks or if it would take an unreasonable amount of resources/time to sync permissions from the code host.
+
+It's also a good idea to use explicit permissions API if the source of truth for the codehost permissions is already defined in some external system, e.g. LDAP group membership.
+In that case, it might be less resource intensive to sync the permissions from external source of truth directly via a periodically running routine.
+
+## Disadvantages
+
+It is important to note, that when using explicit permissions API, the permissions are written to the database as provided, without further verification that such permissions do exist on the code host side.
+
+Keeping the permissions in sync and fresh is the responsibility of the site admins.
+
+## Configuration
+
+To enable the permissions API, add the following to the [site configuration](../config/site_config.md):
+
+```json
+"permissions.userMapping": {
+    "enabled": true,
+    "bindID": "username"
+}
+```
+
+The `bindID` value specifies how to uniquely identify users when setting permissions:
+
+- `username`: You can [set permissions](#setting-repository-permissions-for-users) for users by specifying their Sourcegraph usernames. Using usernames is **preferred**, as usernames are required to be unique for each user.
+- `email`: You can [set permissions](#setting-repository-permissions-for-users) for users by specifying their email addresses (which must be verified emails associated with their Sourcegraph user account). This method can lead to unexpected results if there are multiple sourcegraph user accounts with the same verified email address.
+
+After you enable the permissions API, you must [set permissions](#setting-repository-permissions-for-users) to allow users to view repositories (site admins bypass all permissions checks and can always view all repositories).
+
+> NOTE: If you were previously using [permissions syncing](./syncing.md), e.g. syncing permissions from Github, then those permissions are used as the initial state after enabling explicit permissions. Otherwise, the initial state is for all repositories to have an empty set of authorized users, so users will not be able to view any repositories.
+
+<span class="virtual-br"></span>
+
+## Setting a repository as unrestricted
+
+Sometimes it can be useful to mark a repository as `unrestricted`, meaning that it is available to all Sourcegraph users. This can be done with the `setRepositoryPermissionsUnrestricted` mutation. Marking a repository as unrestricted will disregard any previously set explicit or synced permissions. Setting `unrestricted` back to `false` will restore the previous behaviour.
+
+For example:
+
+```graphql
+mutation {
+  setRepositoryPermissionsUnrestricted(repositories: ["<repo ID>", "<repo ID>", "<repo ID>"], unrestricted: true)
+}
+```
+
+## Setting repository permissions for users
+
+Setting the permissions for a user can be accomplished with 2 [GraphQL API](../../api/graphql.md) calls.
+
+First, obtain the ID of the repository from its name:
+
+```graphql
+query {
+  repository(name: "github.com/owner/repo") {
+    id
+  }
+}
+```
+
+Next, set the list of users allowed to view the repository:
+
+```graphql
+mutation {
+  setRepositoryPermissionsForUsers(
+    repository: "<repo ID>",
+    userPermissions: [
+      { bindID: "alice" },
+      { bindID: "bob" },
+    ]) {
+    alwaysNil
+  }
+}
+```
+
+Now, only the users specified in the `userPermissions` parameter will be allowed to view the repository. Sourcegraph automatically enforces these permissions for all operations. (Site admins bypass all permissions checks by default. See the [Site administrators](./index.md#site-administrators) section)
+
+You can call `setRepositoryPermissionsForUsers` repeatedly to set permissions for each repository, and whenever you want to change the list of authorized users.
+
+### Listing a user's authorized repositories
+
+You may query the set of repositories visible to a particular user with the `authorizedUserRepositories` [GraphQL API](../../api/graphql.md) query, which accepts a `username` or `email` parameter to specify the user:
+
+```graphql
+query {
+  authorizedUserRepositories(username: "alice", first: 100) {
+    nodes {
+      name
+    }
+    totalCount
+  }
+}
+```

--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -1,0 +1,53 @@
+# Permissions
+
+Sourcegraph can be configured to enforce the same access to repositories and underlying source files as your code host.
+If this is configured, Sourcegraph will only allow the user to see the entities that they can see on the code host.
+These permissions are enforced accross the product for all the use cases that need to read data from a repository, including
+the existence of such repository on the code host.
+
+> NOTE: historically, we have called this with different names: "authorization", "repository permissions", "code 
+host permissions". All of these terms were used interchangeably, but in general we do call it permissions or repository permissions.
+
+> NOTE: not to be confused with in-product permissions, e.g. determine who can create a batch change or who is a site admin.
+
+## Example
+
+Imagine a scenario, with 2 users, `alice` and `bob`. 
+
+- `alice` can access repositories `horsegraph/global` and `horsegraph/alice` on the code host
+- `bob` has access to repositories `horsegraph/global` and `horsegraph/docs` on the code host
+- there is also a public repository `horsegraph/public`
+- all of the mentioned repositories are synced to sourcegraph
+
+If `alice` tries to run a search on sourcegraph, the result set will only contain data from the public `horsegraph/global` repository 
+and the ones she has access to (`horsegraph/global` and `horsegraph/alice`). `alice` will not be able to see results
+from the `horsegraph/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
+
+Same for `bob`, the search results or any other feature will not show him the existence of `horsegraph/alice` repository on 
+Sourcegraph, since `bob` does not have access to it on the code host.
+
+## Supported methods to sync permissions
+
+Today, we support 3 different methods to get the permission data from code host to sourcegraph:
+
+1. [Background permission syncing from the code host](syncing.md)
+1. [Webhooks for getting permission events from code host](webhooks.md)
+1. [Explicit permissions API](api.md)
+
+To know more about each method that we support, please follow the link above.
+
+## Licensing
+
+To have permission syncing available, the Sourcegraph instance needs to be configured with a license that has `acls` feature enabled.
+If it is not present, Sourcegraph will not enforce repository permissions and each repository will be treated as 
+public - any user that has access to Sourcegraph will be able to access it.
+
+## Site administrators
+
+By default, site-admins bypass all of the permissions checks. Which means, all site admins are able to view all the repositories by default.
+The default can be changed by setting the site config option `authz.enforceForSiteAdmins` to `true`.
+
+> NOTE: However, we recommend to be cautious with this option, as it might make some operations for site admins more complicated or impossible. 
+
+E.g. trying to figure out if a specific repository is syncing source code to Sourcegraph correctly 
+might become an impossible task if the site admin cannot access that repository.

--- a/doc/admin/permissions/webhooks.md
+++ b/doc/admin/permissions/webhooks.md
@@ -1,0 +1,30 @@
+# Webhooks for repository permissions
+
+Sourcegraph allows customers to use webhooks to react to events that modify user permissions on the code host.
+Currently the only supported code host for webhooks is [Github](../external_service/github.md)
+
+> NOTE: Using webhooks is the *recommended* way to get code host permissions to Sourcegraph
+
+## How it works
+
+Sourcegraph exposes endpoints to receive webhooks. These endpoints are authenticated, so we make sure the requests come from a trusted source.
+
+1. Sourcegraph receives a webhook request with one of the supported events
+1. Based on the event data, sourcegraph schedules a permission sync job
+1. Standard permission syncing mechanism handles the scheduled job, leading to a sync of permissions of the relevant user or repository from the code host
+
+## Advantages
+
+- the eventual consistency time is the lowest. Our SLA is, that p95 of webhook requests will be processed within 5 minutes. This means, that when the permissions are changed on the code host, it takes at most 5 minutes for the same permissions to be reflected on the Sourcegraph side
+- least amount of resource usage (bandwidth, code host rate limit), as we only ask code host for permission data when there is an actual change
+
+## Disadvantages
+
+Webhooks are best effort and there is no 100% guarantee that a webhook will be fired from the code host side when the data change.
+Especially with permissions, this is something to be aware of, as important permission related webhooks might not be sent to Sourcegraph.
+
+> NOTE: That's why we recommend to use webhooks alongside the permission syncing mechanism.
+
+## Configuring webhooks
+
+Please follow the link for [configuring permission syncing webhooks for Github](../config/webhooks.md#user-permissions)


### PR DESCRIPTION
> Not looking for feedback right now, just WIP branch for transparency purposes

So far touched:
- sidebar to create the Permissions section
- Permissions landing page
- Explicit Permissions API
- Webhooks for permissions

TODO:

- [ ] Need to rewrite the whole perms syncing page, which will be the gist of the work.
- [ ]  need to change the authentication & authorization page.
- [ ]  need to figure out what to do with code host configuration pages, since the configuration is today scattered in multiple places and I would like to streamline it more.

## Link

[Link to the docs page with code from this branch](https://docs.sourcegraph.com/@milan_docs_permissions/admin/permissions)
(But for some reason, the sidebar is not updated on that link 🤦 )


## Test plan

Docs changes only, so eyeballing is the only method.

