### PR TITLE
Storm 🌪️: Preload logo via <link rel="preload">

### DIFF
--- a/client/web/src/components/branding/BrandLogo.tsx
+++ b/client/web/src/components/branding/BrandLogo.tsx
@@ -42,7 +42,8 @@ export const BrandLogo: React.FunctionComponent<React.PropsWithChildren<Props>> 
 
     const sourcegraphLogoUrl =
         variant === 'symbol'
-            ? `${assetsRoot}/img/sourcegraph-mark.svg?v2` // Add query parameter for cache busting.
+            ? // When changed, update cmd/frontend/internal/app/ui/handlers.go for proper preloading
+              `${assetsRoot}/img/sourcegraph-mark.svg?v2` // Add query parameter for cache busting.
             : `${assetsRoot}/img/sourcegraph-logo-${themeProperty}.svg`
 
     const customBrandingLogoUrl = branding?.[themeProperty]?.[variant]

--- a/cmd/frontend/internal/app/misc_handlers.go
+++ b/cmd/frontend/internal/app/misc_handlers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -53,9 +54,9 @@ func favicon(w http.ResponseWriter, r *http.Request) {
 
 	// Add query parameter for cache busting.
 	query := url.Query()
-	query.Set("v", "2")
+	query.Set("v2", "")
 	url.RawQuery = query.Encode()
-	path := url.String()
+	path := strings.Replace(url.String(), "v2=", "v2", 1)
 
 	if branding := globals.Branding(); branding.Favicon != "" {
 		path = branding.Favicon

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -31,6 +31,11 @@
 	{{if .Manifest.AppCSSBundlePath}}<link rel="stylesheet" href="{{.Manifest.AppCSSBundlePath}}">{{end}}
 	<link id='sourcegraph-chrome-webstore-item' rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack">
 	<link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Sourcegraph Search">
+	{{if .PreloadedAssets}}
+	{{range .PreloadedAssets}}
+	<link rel="preload" href="{{.Href}}" as="{{.As}}" />
+	{{end}}
+	{{end}}
 	{{ if .Context.SourcegraphDotComMode }}
 	<!-- Google Tag Manager -->
 	<script ignore-csp>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot/hubspotutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assetsutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/jscontext"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
@@ -68,12 +69,21 @@ type Metadata struct {
 	PreviewImage string
 }
 
+type PreloadedAsset struct {
+	// The as property. E.g. `image`
+	As string
+	// The href property. It should be set to a resolved path using `assetsutil.URL`
+	Href string
+}
+
 type Common struct {
 	Injected InjectedHTML
 	Metadata *Metadata
 	Context  jscontext.JSContext
 	Title    string
 	Error    *pageError
+
+	PreloadedAssets *[]PreloadedAsset
 
 	Manifest *assets.WebpackManifest
 
@@ -151,6 +161,10 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 		Context:  jscontext.NewJSContextFromRequest(r, db),
 		Title:    title,
 		Manifest: manifest,
+		PreloadedAssets: &[]PreloadedAsset{
+			// sourcegraph-mark.svg is always loaded as part of the layout component
+			{As: "image", Href: assetsutil.URL("/img/sourcegraph-mark.svg").Path + "?v2"},
+		},
 		Metadata: &Metadata{
 			Title:       globals.Branding().BrandName,
 			Description: "Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.",

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -151,6 +151,16 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 		w.Header().Set("X-Robots-Tag", "noindex")
 	}
 
+	var preloadedAssets *[]PreloadedAsset
+	preloadedAssets = nil
+	if globals.Branding() == nil || (globals.Branding().Dark == nil && globals.Branding().Light == nil) {
+		preloadedAssets = &[]PreloadedAsset{
+			// sourcegraph-mark.svg is always loaded as part of the layout component unless a custom
+			// branding is defined
+			{As: "image", Href: assetsutil.URL("/img/sourcegraph-mark.svg").String() + "?v2"},
+		}
+	}
+
 	common := &Common{
 		Injected: InjectedHTML{
 			HeadTop:    template.HTML(conf.Get().HtmlHeadTop),
@@ -158,13 +168,10 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 			BodyTop:    template.HTML(conf.Get().HtmlBodyTop),
 			BodyBottom: template.HTML(conf.Get().HtmlBodyBottom),
 		},
-		Context:  jscontext.NewJSContextFromRequest(r, db),
-		Title:    title,
-		Manifest: manifest,
-		PreloadedAssets: &[]PreloadedAsset{
-			// sourcegraph-mark.svg is always loaded as part of the layout component
-			{As: "image", Href: assetsutil.URL("/img/sourcegraph-mark.svg").Path + "?v2"},
-		},
+		Context:         jscontext.NewJSContextFromRequest(r, db),
+		Title:           title,
+		Manifest:        manifest,
+		PreloadedAssets: preloadedAssets,
 		Metadata: &Metadata{
 			Title:       globals.Branding().BrandName,
 			Description: "Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.",


### PR DESCRIPTION
Digging through the resource water-falling of our navbar component, I noticed that we start to load the logo relatively late, even though it's shown on any route. Additionally, we use the same SVG as the favicon but with a slightly different URL causing the browser to have to make another request:

<img width="1942" alt="Screenshot 2023-02-20 at 15 45 11" src="https://user-images.githubusercontent.com/458591/220137301-37ba262d-498d-4bf3-9554-3e7ea218b4f3.png">

This PR adds a way for the server-generated HTML to include `<link rel="preload">` elements to preload the .svg in question.

It also fixes the favicon to now use the same URL. It does seem that `<link rel="preload">` is not used by the browser for the favicon but the request might still be cached with the right cache headers (and if that also doesn't apply, at least a CDN might be able to do that!)

The lazy loading nature of the image also caused it to flicker during page loads (this video is from dotcom):

https://user-images.githubusercontent.com/458591/220139052-355448d7-3a7a-4d8e-bb78-ea61dca7b8dc.mov

With preloading, it appears instantly. 💥 


## Future improvement

- [ ] We should also do this for the avatar if the user is logged in


## Test plan

### Before on localhost

<img width="1946" alt="Screenshot 2023-02-20 at 15 49 04" src="https://user-images.githubusercontent.com/458591/220138183-c113901e-99fb-4d36-bc23-b0c9046d1d4e.png">


### After on localhost

<img width="633" alt="Screenshot 2023-02-20 at 15 39 30" src="https://user-images.githubusercontent.com/458591/220137716-9b4ed3d3-bbff-4126-8567-e546dd499348.png">
<img width="1942" alt="Screenshot 2023-02-20 at 15 51 14" src="https://user-images.githubusercontent.com/458591/220138655-0b42ebeb-88cd-4403-beb4-4f34d3481bd5.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
