### PR TITLE
fix bug where release branch is calculated using minor.minor

### DIFF
--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -63,7 +63,7 @@ export async function getActiveRelease(config: ReleaseConfig): Promise<ActiveRel
         previous: new SemVer(rel.previous),
         ...(def as ReleaseDates),
         ...(def as ReleaseCaptainInformation),
-        branch: `${version.minor}.${version.minor}`,
+        branch: `${version.major}.${version.minor}`,
     }
 }
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -334,9 +334,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 await execa('git', ['branch', release.branch])
                 await execa('git', ['push', 'origin', release.branch])
                 await postMessage(message, config.metadata.slackAnnounceChannel)
-                console.log(
-                    `To check the status of the branch, run:\nsg ci status -branch ${release.branch} --wait\n`
-                )
+                console.log(`To check the status of the branch, run:\nsg ci status -branch ${release.branch} --wait\n`)
             } catch (error) {
                 console.error('Failed to create release branch', error)
             }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -335,7 +335,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 await execa('git', ['push', 'origin', release.branch])
                 await postMessage(message, config.metadata.slackAnnounceChannel)
                 console.log(
-                    `To check the status of the branch, run:\nsg ci status -branch ${release.version.version} --wait\n`
+                    `To check the status of the branch, run:\nsg ci status -branch ${release.branch} --wait\n`
                 )
             } catch (error) {
                 console.error('Failed to create release branch', error)


### PR DESCRIPTION
Fix a bug where release branch was calculating using minor.minor, for example release 4.5.0 would generate 5.5.
## Test plan
Tested live in 4.5 release 😄 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-fix-bug-with-release-branch.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
