### PR TITLE
batches: reorder empty spec ids

### DIFF
--- a/enterprise/internal/batches/testing/batch_spec.go
+++ b/enterprise/internal/batches/testing/batch_spec.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"gopkg.in/yaml.v2"
+
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 )
@@ -15,6 +17,14 @@ type CreateBatchSpecer interface {
 func CreateBatchSpec(t *testing.T, ctx context.Context, store CreateBatchSpecer, name string, userID int32, bcID int64) *btypes.BatchSpec {
 	t.Helper()
 
+	rawSpec, err := yaml.Marshal(struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+	}{Name: name, Description: "the description"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	s := &btypes.BatchSpec{
 		UserID:          userID,
 		NamespaceUserID: userID,
@@ -25,7 +35,33 @@ func CreateBatchSpec(t *testing.T, ctx context.Context, store CreateBatchSpecer,
 				Branch: "branch-name",
 			},
 		},
+		RawSpec:       string(rawSpec),
 		BatchChangeID: bcID,
+	}
+
+	if err := store.CreateBatchSpec(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+
+	return s
+}
+
+func CreateEmptyBatchSpec(t *testing.T, ctx context.Context, store CreateBatchSpecer, name string, userID int32, bcID int64) *btypes.BatchSpec {
+	t.Helper()
+
+	rawSpec, err := yaml.Marshal(struct {
+		Name string `yaml:"name"`
+	}{Name: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &btypes.BatchSpec{
+		UserID:          userID,
+		NamespaceUserID: userID,
+		Spec:            &batcheslib.BatchSpec{Name: name},
+		RawSpec:         string(rawSpec),
+		BatchChangeID:   bcID,
 	}
 
 	if err := store.CreateBatchSpec(ctx, s); err != nil {

--- a/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator.go
@@ -142,6 +142,7 @@ FOR spec IN
 				AND spec_id != min_id
 				-- We only need to re-id the empty ones.
 				AND is_empty
+			LIMIT 500
 	)
 	SELECT * FROM to_be_reordered_specs
 	LOOP

--- a/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator.go
@@ -1,0 +1,201 @@
+package batches
+
+import (
+	"context"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+type emptySpecIDMigrator struct {
+	store *basestore.Store
+}
+
+func NewEmptySpecIDMigrator(store *basestore.Store) *emptySpecIDMigrator {
+	return &emptySpecIDMigrator{store: store}
+}
+
+var _ oobmigration.Migrator = &emptySpecIDMigrator{}
+
+func (m *emptySpecIDMigrator) ID() int                 { return 23 }
+func (m *emptySpecIDMigrator) Interval() time.Duration { return time.Second * 5 }
+
+// Progress returns the percentage (ranged [0, 1]) of changesets published to a fork on
+// Bitbucket Server or Bitbucket Cloud that have not had `external_fork_name` set on their
+// DB record.
+func (m *emptySpecIDMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(emptySpecIDMigratorProgressQuery, sqlf.Sprintf(specsForDraftsQuery))))
+	return progress, err
+}
+
+const specsForDraftsQuery = `
+-- Get all batch specs for DRAFT batch changes
+SELECT
+	bc.id AS bc_id,
+	bs1.is_empty,
+	bs.id AS spec_id,
+	bs.*
+FROM
+	batch_changes bc
+	JOIN batch_specs bs ON bc.name = bs.spec ->> 'name'
+		AND bc.namespace_user_id IS NOT DISTINCT FROM bs.namespace_user_id
+		AND bc.namespace_org_id IS NOT DISTINCT FROM bs.namespace_org_id
+	JOIN (
+		SELECT
+			id,
+			raw_spec SIMILAR TO 'name: \S+\n*' AS is_empty
+		FROM
+			batch_specs) bs1 ON bs.id = bs1.id
+		-- We filter to specs that belong to batch changes where last_applied_at IS NULL as this is our way of distinguishing DRAFT batch changes. The migrations that caused this regression deleted and then reconstructed batch specs based on this condition, so we know the empty ones we want to re-ID are included in here.
+	WHERE
+		bc.last_applied_at IS NULL
+		-- The ordering doesn't actually matter here, this just makes the behavior more predictable.
+	ORDER BY
+		bc.id DESC,
+		spec_id DESC`
+
+// This query compares the count of migrated changesets, which should have
+// external_fork_name set, vs. the total count of changesets on a fork on Bitbucket Server
+// or Cloud.
+const emptySpecIDMigratorProgressQuery = `
+WITH specs AS (%s)
+SELECT
+	CASE total.count WHEN 0 THEN 1 ELSE
+		CAST(migrated.count AS float) / CAST(total.count AS float)
+	END
+FROM
+(SELECT COUNT(*) FROM specs
+	JOIN (SELECT bc_id, MIN(spec_id) AS min_spec_id FROM specs GROUP BY bc_id) mids ON mids.bc_id = specs.bc_id
+	WHERE is_empty) total,
+(SELECT COUNT(*) FROM specs
+	JOIN (SELECT bc_id, MIN(spec_id) AS min_spec_id FROM specs GROUP BY bc_id) mids ON mids.bc_id = specs.bc_id
+	WHERE is_empty
+	AND spec_id = min_spec_id) migrated;`
+
+func (m *emptySpecIDMigrator) Up(ctx context.Context) (err error) {
+	if err = m.store.Exec(ctx, sqlf.Sprintf(nextAvailableIDFunctionQuery)); err != nil {
+		return err
+	}
+	if err = m.store.Exec(ctx, sqlf.Sprintf(emptySpecIDMigratorUpdateQuery, sqlf.Sprintf(specsForDraftsQuery))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const nextAvailableIDFunctionQuery = `
+-- The function next_available_id takes a starting_id and returns the first id lower than
+-- starting_id which is unused on the batch_specs. The arg starting_id representing the batch
+-- spec ID we need to beat to re-order an "empty" batch spec record _before_ any non-empty
+-- records on the same batch change. For values of starting_id we will be calling this with,
+-- we know at least one lower id must exist, for the id of the original empty batch spec
+-- which was deleted in the original migration.
+CREATE OR REPLACE FUNCTION next_available_id (starting_id int8) RETURNS int8 AS $$
+	DECLARE
+	first_available_id integer := $1;
+	BEGIN
+		LOOP
+			IF NOT EXISTS (SELECT FROM batch_specs WHERE id = first_available_id) THEN
+				RETURN first_available_id;
+			END IF;
+			first_available_id := first_available_id-1;
+		END LOOP;
+	END;
+$$ LANGUAGE plpgsql;
+`
+
+const emptySpecIDMigratorUpdateQuery = `
+DO
+$$
+DECLARE spec RECORD;
+BEGIN
+FOR spec IN
+	WITH specs AS (%s),
+	to_be_reordered_specs AS (
+		SELECT * FROM specs
+			-- Tally up how many specs we have for each DRAFT batch change.
+			JOIN (
+				SELECT
+					bc_id,
+					COUNT(*) AS spec_count
+				FROM
+					specs
+				GROUP BY
+					bc_id) bs_count ON bs_count.bc_id = specs.bc_id
+			-- We also look for the lowest spec id for a given batch change, so we know
+			-- which id we need to go beneath to achieve the proper ordering.
+			JOIN (
+				SELECT
+					bc_id,
+					MIN(spec_id) AS min_id
+				FROM
+					specs
+				GROUP BY
+					bc_id) min_spec_id ON min_spec_id.bc_id = specs.bc_id
+			WHERE
+				-- If a batch change only has a single spec, there's nothing to fix.
+				spec_count > 1
+				-- If a batch spec is already the lowest id, there's nothing to fix.
+				AND spec_id != min_id
+				-- We only need to re-id the empty ones.
+				AND is_empty
+	)
+	SELECT * FROM to_be_reordered_specs
+	LOOP
+		-- Find the next available id lower than the min_id for this batch spec
+		DECLARE
+			new_spec_id integer := next_available_id(spec.min_id);
+			new_rand_id text := spec.rand_id;
+		BEGIN
+			-- First, update the existing batch spec's rand id, so we don't violate
+			-- the unique constraint when we copy the row.
+			UPDATE batch_specs SET rand_id = rand_id || '_temp' WHERE id = spec.spec_id;
+			-- Copy the spec into a row with the new id.
+			INSERT INTO batch_specs (
+				id,
+				rand_id,
+				raw_spec,
+				spec,
+				namespace_user_id,
+				namespace_org_id,
+				user_id,
+				created_at,
+				updated_at,
+				created_from_raw,
+				allow_unsupported,
+				allow_ignored,
+				no_cache,
+				batch_change_id
+			) VALUES (
+				new_spec_id,
+				new_rand_id,
+				spec.raw_spec,
+				spec.spec,
+				spec.namespace_user_id,
+				spec.namespace_org_id,
+				spec.user_id,
+				spec.created_at,
+				spec.updated_at,
+				spec.created_from_raw,
+				spec.allow_unsupported,
+				spec.allow_ignored,
+				spec.no_cache,
+				spec.batch_change_id
+			);
+			-- Update batch changes that were using the old spec to use the new one.
+			UPDATE batch_changes SET batch_spec_id = new_spec_id WHERE batch_spec_id = spec.spec_id;
+			-- Finally, delete the old batch spec.
+			DELETE FROM batch_specs WHERE id = spec.spec_id;
+		END;
+	END LOOP;
+END
+$$;
+`
+
+func (m *emptySpecIDMigrator) Down(ctx context.Context) (err error) {
+	// Non-destructive
+	return nil
+}

--- a/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
@@ -1,0 +1,145 @@
+package batches
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/tj/assert"
+
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestEmptySpecIDMigrator(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	s := bstore.New(db, &observation.TestContext, nil)
+
+	migrator := NewEmptySpecIDMigrator(s.Store)
+	progress, err := migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	if have, want := progress, 1.0; have != want {
+		t.Fatalf("got invalid progress with no DB entries, want=%f have=%f", want, have)
+	}
+
+	user := bt.CreateTestUser(t, db, true)
+
+	testData := []struct {
+		bcName string
+		// We use IDs in the 1000s to avoid collisions with the auto-incrementing ID of
+		// the spec inserted with the store method.
+		initialEmptyID int64
+		nonEmptyIDs    []int64
+		wantEmptyID    int64
+	}{
+		// A batch change that only has one spec. The ID of the spec should not change.
+		{bcName: "test-batch-change-0", initialEmptyID: 1001, nonEmptyIDs: []int64{}, wantEmptyID: 1001},
+		// A batch change that has one non-empty spec that suceeds the empty one. The ID
+		// of the empty spec should not change.
+		{bcName: "test-batch-change-1", initialEmptyID: 1011, nonEmptyIDs: []int64{1012}, wantEmptyID: 1011},
+		// A batch change that has one non-empty spec that precedes the empty one. The ID
+		// of the empty spec should be set to the first available ID less than that of the
+		// non-empty spec.
+		{bcName: "test-batch-change-2", initialEmptyID: 1022, nonEmptyIDs: []int64{1021}, wantEmptyID: 1020},
+		// A batch change that has multiple non-empty specs that suceed the empty one. The
+		// ID of the empty spec should not change.
+		{bcName: "test-batch-change-3", initialEmptyID: 1031, nonEmptyIDs: []int64{1032, 1033, 1034}, wantEmptyID: 1031},
+		// Batch changes that have multiple non-empty specs that precede the empty one. The
+		// ID of the empty spec should be set to the first available ID less than all of the
+		// IDs of the non-empty specs.
+		{bcName: "test-batch-change-4", initialEmptyID: 1049, nonEmptyIDs: []int64{1041, 1043, 1048}, wantEmptyID: 1039},
+		{bcName: "test-batch-change-5", initialEmptyID: 1050, nonEmptyIDs: []int64{1042, 1044, 1047}, wantEmptyID: 1040},
+	}
+
+	for _, tc := range testData {
+		emptySpec := bt.CreateEmptyBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
+		if tc.initialEmptyID != emptySpec.ID {
+			s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", tc.initialEmptyID, emptySpec.ID))
+		}
+
+		batchChange := &btypes.BatchChange{
+			CreatorID:       user.ID,
+			NamespaceUserID: user.ID,
+			BatchSpecID:     tc.initialEmptyID,
+			Name:            tc.bcName,
+		}
+		if err := s.CreateBatchChange(ctx, batchChange); err != nil {
+			t.Fatal(err)
+		}
+		for _, id := range tc.nonEmptyIDs {
+			spec := bt.CreateBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
+			if id != spec.ID {
+				s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, spec.ID))
+			}
+		}
+	}
+
+	count, _, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf("SELECT count(*) FROM batch_specs")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 17 {
+		t.Fatalf("got %d batch specs, want %d", count, 17)
+	}
+
+	progress, err = migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	// We expect to start with progress at 50% because 3 of the 6 empty batch specs are
+	// already in the correct order.
+	if have, want := progress, 0.5; have != want {
+		t.Fatalf("got invalid progress with unmigrated entries, want=%f have=%f", want, have)
+	}
+
+	if err := migrator.Up(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err = migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	if have, want := progress, 1.0; have != want {
+		t.Fatalf("got invalid progress after up migration, want=%f have=%f", want, have)
+	}
+
+	for _, tc := range testData {
+		// Check that we can find the empty spec with its new ID.
+		emptySpec, err := s.GetBatchSpec(ctx, bstore.GetBatchSpecOpts{ID: tc.wantEmptyID})
+		if err != nil {
+			t.Fatalf("could not locate empty spec with ID %d after migration", tc.wantEmptyID)
+		}
+		wantRaw := "name: " + tc.bcName
+		gotRaw := strings.Trim(emptySpec.RawSpec, "\n")
+		if gotRaw != wantRaw {
+			t.Fatalf("empty spec has wrong raw spec. got %q, want %q", gotRaw, wantRaw)
+		}
+
+		// If we updated the ID, check that we _can't_ find the empty spec with its old ID.
+		if tc.initialEmptyID != tc.wantEmptyID {
+			_, err = s.GetBatchSpec(ctx, bstore.GetBatchSpecOpts{ID: tc.initialEmptyID})
+			if err == nil {
+				t.Fatalf("empty spec still found with original ID %d after migration", tc.initialEmptyID)
+			}
+		}
+
+		// Check that batch change has the new batch spec ID assigned.
+		batchChange, err := s.GetBatchChange(ctx, bstore.GetBatchChangeOpts{Name: tc.bcName})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if batchChange.BatchSpecID != tc.wantEmptyID {
+			t.Fatalf("got batch change with batch spec ID %d, want %d", batchChange.BatchSpecID, tc.wantEmptyID)
+		}
+
+	}
+}

--- a/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
@@ -87,7 +87,10 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 		for _, id := range tc.initialEmptyIDs {
 			emptySpec := bt.CreateEmptyBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
 			if id != emptySpec.ID {
-				s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, emptySpec.ID))
+				err = s.Exec(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, emptySpec.ID))
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		}
 
@@ -103,7 +106,10 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 		for _, id := range tc.nonEmptyIDs {
 			spec := bt.CreateBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
 			if id != spec.ID {
-				s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, spec.ID))
+				err = s.Exec(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, spec.ID))
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		}
 	}

--- a/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/tj/assert"
+	"github.com/stretchr/testify/assert"
 
 	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -38,39 +38,63 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 		bcName string
 		// We use IDs in the 1000s to avoid collisions with the auto-incrementing ID of
 		// the spec inserted with the store method.
-		initialEmptyID int64
-		nonEmptyIDs    []int64
-		wantEmptyID    int64
+		initialEmptyIDs []int64
+		nonEmptyIDs     []int64
+		wantEmptyID     int64
 	}{
-		// A batch change that only has one spec. The ID of the spec should not change.
-		{bcName: "test-batch-change-0", initialEmptyID: 1001, nonEmptyIDs: []int64{}, wantEmptyID: 1001},
-		// A batch change that has one non-empty spec that suceeds the empty one. The ID
-		// of the empty spec should not change.
-		{bcName: "test-batch-change-1", initialEmptyID: 1011, nonEmptyIDs: []int64{1012}, wantEmptyID: 1011},
-		// A batch change that has one non-empty spec that precedes the empty one. The ID
-		// of the empty spec should be set to the first available ID less than that of the
-		// non-empty spec.
-		{bcName: "test-batch-change-2", initialEmptyID: 1022, nonEmptyIDs: []int64{1021}, wantEmptyID: 1020},
-		// A batch change that has multiple non-empty specs that suceed the empty one. The
-		// ID of the empty spec should not change.
-		{bcName: "test-batch-change-3", initialEmptyID: 1031, nonEmptyIDs: []int64{1032, 1033, 1034}, wantEmptyID: 1031},
-		// Batch changes that have multiple non-empty specs that precede the empty one. The
-		// ID of the empty spec should be set to the first available ID less than all of the
-		// IDs of the non-empty specs.
-		{bcName: "test-batch-change-4", initialEmptyID: 1049, nonEmptyIDs: []int64{1041, 1043, 1048}, wantEmptyID: 1039},
-		{bcName: "test-batch-change-5", initialEmptyID: 1050, nonEmptyIDs: []int64{1042, 1044, 1047}, wantEmptyID: 1040},
+		// A batch change that only has one spec, which is an empty one. The ID of the
+		// spec should not change.
+		{bcName: "test-batch-change-0",
+			initialEmptyIDs: []int64{1001},
+			nonEmptyIDs:     []int64{},
+			wantEmptyID:     1001},
+		// A batch change that has one non-empty spec that suceeds the empty one. Since
+		// the empty spec is already ordered first, its ID should not change.
+		{bcName: "test-batch-change-1",
+			initialEmptyIDs: []int64{1011},
+			nonEmptyIDs:     []int64{1012},
+			wantEmptyID:     1011},
+		// A batch change that has one non-empty spec that precedes the empty one. Since
+		// the empty spec is out-of-order, it should be assigned the first available ID
+		// lower than 1012, which in this case is 1011.
+		{bcName: "test-batch-change-2",
+			initialEmptyIDs: []int64{1022},
+			nonEmptyIDs:     []int64{1021},
+			wantEmptyID:     1020},
+		// A batch change that has multiple non-empty specs that suceed the empty one.
+		// Since the empty spec is already ordered first, its ID should not change.
+		{bcName: "test-batch-change-3",
+			initialEmptyIDs: []int64{1031},
+			nonEmptyIDs:     []int64{1032, 1033, 1034},
+			wantEmptyID:     1031},
+		// Two batch changes that have multiple, interweaving, non-empty and empty specs.
+		{bcName: "test-batch-change-4",
+			initialEmptyIDs: []int64{1045, 1051},
+			nonEmptyIDs:     []int64{1043, 1048, 1050},
+			// Since neither empty spec was in order, once they have been de-duped, we
+			// expect the remaining empty spec to be assigned the first available ID lower
+			// than 1043, which is 1041.
+			wantEmptyID: 1041},
+		{bcName: "test-batch-change-5",
+			initialEmptyIDs: []int64{1040, 1099},
+			nonEmptyIDs:     []int64{1042, 1044, 1047},
+			// Since one of the empty specs was in order, we expect it to not change, but
+			// the other spec to be de-duped.
+			wantEmptyID: 1040},
 	}
 
 	for _, tc := range testData {
-		emptySpec := bt.CreateEmptyBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
-		if tc.initialEmptyID != emptySpec.ID {
-			s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", tc.initialEmptyID, emptySpec.ID))
+		for _, id := range tc.initialEmptyIDs {
+			emptySpec := bt.CreateEmptyBatchSpec(t, ctx, s, tc.bcName, user.ID, 0)
+			if id != emptySpec.ID {
+				s.Query(ctx, sqlf.Sprintf("UPDATE batch_specs SET id = %d WHERE id = %d", id, emptySpec.ID))
+			}
 		}
 
 		batchChange := &btypes.BatchChange{
 			CreatorID:       user.ID,
 			NamespaceUserID: user.ID,
-			BatchSpecID:     tc.initialEmptyID,
+			BatchSpecID:     tc.initialEmptyIDs[0],
 			Name:            tc.bcName,
 		}
 		if err := s.CreateBatchChange(ctx, batchChange); err != nil {
@@ -88,14 +112,14 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 17 {
-		t.Fatalf("got %d batch specs, want %d", count, 17)
+	if count != 19 {
+		t.Fatalf("got %d batch specs, want %d", count, 19)
 	}
 
 	progress, err = migrator.Progress(ctx, false)
 	assert.NoError(t, err)
 
-	// We expect to start with progress at 50% because 3 of the 6 empty batch specs are
+	// We expect to start with progress at 50% because 4 of the 8 empty batch specs are
 	// already in the correct order.
 	if have, want := progress, 0.5; have != want {
 		t.Fatalf("got invalid progress with unmigrated entries, want=%f have=%f", want, have)
@@ -125,10 +149,12 @@ func TestEmptySpecIDMigrator(t *testing.T) {
 		}
 
 		// If we updated the ID, check that we _can't_ find the empty spec with its old ID.
-		if tc.initialEmptyID != tc.wantEmptyID {
-			_, err = s.GetBatchSpec(ctx, bstore.GetBatchSpecOpts{ID: tc.initialEmptyID})
-			if err == nil {
-				t.Fatalf("empty spec still found with original ID %d after migration", tc.initialEmptyID)
+		if tc.initialEmptyIDs[0] != tc.wantEmptyID {
+			for _, id := range tc.initialEmptyIDs {
+				_, err = s.GetBatchSpec(ctx, bstore.GetBatchSpecOpts{ID: id})
+				if err == nil {
+					t.Fatalf("empty spec still found with original ID %d after migration", id)
+				}
 			}
 		}
 

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -96,6 +96,7 @@ func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps
 		iam.NewUnifiedPermissionsMigrator(deps.store),
 		batches.NewSSHMigratorWithDB(deps.store, deps.keyring.BatchChangesCredentialKey, 5),
 		batches.NewExternalForkNameMigrator(deps.store, 500),
+		batches.NewEmptySpecIDMigrator(deps.store),
 		codeintel.NewDiagnosticsCountMigrator(deps.codeIntelStore, 1000, 0),
 		codeintel.NewDefinitionLocationsCountMigrator(deps.codeIntelStore, 1000, 0),
 		codeintel.NewReferencesLocationsCountMigrator(deps.codeIntelStore, 1000, 0),

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -144,3 +144,11 @@
   is_enterprise: true
   introduced_version_major: 5
   introduced_version_minor: 0
+- id: 23
+  team: batch-changes
+  component: frontend-db.batch_specs
+  description: Re-ID empty batch specs belonging to draft batch changes.
+  non_destructive: true
+  is_enterprise: true
+  introduced_version_major: 5
+  introduced_version_minor: 0


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47154.

To recap, applying the up and down migrations from https://github.com/sourcegraph/sourcegraph/pull/44840 actually leave the database in a different state than it started, but this is exactly what we end up running since we reverted the first PR with https://github.com/sourcegraph/sourcegraph/pull/46341. Our empty batch specs get out of order when they're deleted and then reconstructed, and this has the effect that when listing batch specs for a draft batch change, the empty one would appear to be the "most recent" and supersede any others, even ones that had already been executed.

It turns out this is a bit complicated to rectify, on account of a couple things:

- We can't just retroactively adjust `created_at` timestamps and order by that instead of `id`, because pagination cursors and offsets are id-based.
- We can't trivially swap the batch spec IDs, because a draft batch change may have 0-N other batch specs outside of the empty one, so we'd have to rotate _all_ of their IDs, and cascading the ID changes to all the foreign key references is a nightmare and extremely error-prone.

What this PR does instead is best demonstrated with an example. Say we have a draft batch change with 4 batch specs:
- Spec 50, which is the reconstructed empty one that's out of order
- Spec 40, which is a WIP draft that hasn't been executed yet
- Spec 39, which is an earlier draft that was executed
- Spec 30, which is an earlier draft that was executed

We know that prior to the migration from https://github.com/sourcegraph/sourcegraph/pull/44840, there was an empty batch spec with an ID lower than 30 for this batch change. Let's say in our example it was spec 28. It was then deleted in the first up migration, leaving 28 as an unused ID. If we can find this ID hole (or any other), we can safely reassign the ID of spec 50 to 28. It will then be ordered correctly, without us needing to touch any of the other batch specs. And since it was an empty spec, we know it won't be referenced as a foreign key on any other tables except `batch_changes.batch_spec_id`, so it's easy to update references.

In practice, this is still a bit of a hassle to accomplish, mostly because it's not easy to query for "unused IDs" on a table. But we achieve this with a couple steps, which are documented inline with SQL comments. Because the end result is such a monstrous looking series of queries, I've chosen to contain it in an OOB migration, even though it's technically possible to execute the whole thing as a normal in-bounds migration. That way, we're able to properly test it, and monitor for any problems when it gets rolled out. 😄

There's probably more optimizations/clean-ups that could be done to the SQL, but it's been so hard to debug that I'm not really motivated to continue to try. 😅

I recognize this is a somewhat large migration to include last minute in the release branch (and I don't expect it to be merged before the cut), but as a bug fix I think it might still be worth cherry-picking in, once we've validated it on at least s2.

## Test plan

Added tests, manually tested on my own DB with 100+ affected entries.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
