### PR TITLE
codeintel: Fix css warning about start vs flex-start

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
@@ -24,7 +24,7 @@
 .input-actions {
     width: 10%;
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-self: stretch;
 }
 


### PR DESCRIPTION
```
[webpack-dev-server] WARNING in ./src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss (../../node_modules/.pnpm/css-loader@6.7.2_webpack@5.75.0/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[2].use[1]!../../node_modules/.pnpm/postcss-loader@7.0.2_6jdsrmfenkuhhw3gx4zvjlznce/node_modules/postcss-loader/dist/cjs.js!../../node_modules/.pnpm/sass-loader@13.2.0_sass@1.32.4+webpack@5.75.0/node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[2].use[3]!./src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss)
Module Warning (from ../../node_modules/.pnpm/postcss-loader@7.0.2_6jdsrmfenkuhhw3gx4zvjlznce/node_modules/postcss-loader/dist/cjs.js):
Warning

(27:3) autoprefixer: start value has mixed support, consider using flex-start instead
```


## Test plan

Warning gone. 

## App preview:

- [Web](https://sg-web-es-fix-css-warning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
