### PR TITLE
remove "Saved searches" link from user menu

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -112,9 +112,6 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                             <MenuLink as={Link} to={props.authenticatedUser.settingsURL!}>
                                 Settings
                             </MenuLink>
-                            <MenuLink as={Link} to={`/users/${props.authenticatedUser.username}/searches`}>
-                                Saved searches
-                            </MenuLink>
                             <MenuDivider />
                             <div className="px-2 py-1">
                                 <div className="d-flex align-items-center">


### PR DESCRIPTION
You can still get to this by going to your settings page and then clicking the "Saved searches" tab. This is a rarely used feature and does not merit inclusion in the user menu.




## Test plan

View the user menu and confirm there is no "Saved searches" item.

## App preview:

- [Web](https://sg-web-sqs-rm-saved-searches-user-menu.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
