### PR TITLE
do not show Feedback in global nav for unauthed users

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -17,7 +17,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildGetStartedURL, buildCloudTrialURL } from '@sourcegraph/shared/src/util/url'
-import { Button, Link, ButtonLink, useWindowSize, FeedbackPrompt, PopoverTrigger } from '@sourcegraph/wildcard'
+import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -29,7 +29,7 @@ import { BrandLogo } from '../components/branding/BrandLogo'
 import { getFuzzyFinderFeatureFlags } from '../components/fuzzyFinder/FuzzyFinderFeatureFlag'
 import { WebCommandListPopoverButton } from '../components/shared'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
-import { useHandleSubmitFeedback, useRoutesMatch } from '../hooks'
+import { useRoutesMatch } from '../hooks'
 import { CodeInsightsProps } from '../insights/types'
 import { isCodeInsightsEnabled } from '../insights/utils/is-code-insights-enabled'
 import { NotebookProps } from '../notebooks'
@@ -146,9 +146,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     const location = useLocation()
 
     const routeMatch = useRoutesMatch(props.routes)
-    const { handleSubmitFeedback } = useHandleSubmitFeedback({
-        routeMatch,
-    })
 
     const onNavbarQueryChange = useNavbarQueryState(state => state.setQueryState)
     // Search context management is still enabled on .com
@@ -275,25 +272,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                     </Link>
                                 </NavAction>
                             )}
-
-                            <NavAction className="d-sm-flex d-none">
-                                <FeedbackPrompt
-                                    onSubmit={handleSubmitFeedback}
-                                    productResearchEnabled={true}
-                                    authenticatedUser={props.authenticatedUser}
-                                >
-                                    <PopoverTrigger
-                                        as={Button}
-                                        aria-label="Feedback"
-                                        variant="secondary"
-                                        outline={true}
-                                        size="sm"
-                                        className={styles.feedbackTrigger}
-                                    >
-                                        <span>Feedback</span>
-                                    </PopoverTrigger>
-                                </FeedbackPrompt>
-                            </NavAction>
                         </>
                     )}
                     {props.authenticatedUser && isSourcegraphDotCom && (

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -259,20 +259,6 @@ exports[`GlobalNavbar default 1`] = `
         </a>
       </li>
       <li
-        class="action d-sm-flex d-none"
-      >
-        <button
-          aria-expanded="false"
-          aria-label="Feedback"
-          class="btn btnSecondary btnOutline btnSm feedbackTrigger"
-          type="button"
-        >
-          <span>
-            Feedback
-          </span>
-        </button>
-      </li>
-      <li
         class="action"
       >
         <div>


### PR DESCRIPTION
To give feedback, users on Sourcegraph.com need to sign in. (Other instances don't support unauthenticated users, so this only pertains to Sourcegraph.com.) This declutters the global nav.




## Test plan

Confirm that no "Feedback" global nav item shows up for unauthed users.

## App preview:

- [Web](https://sg-web-sqs-hide-feedback-for-unauthed.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
