### PR TITLE
Revert "codeintel: Fix css warning about start vs flex-start (#47857)"

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/RepositoryPatternList.module.scss
@@ -24,7 +24,7 @@
 .input-actions {
     width: 10%;
     display: flex;
-    justify-content: flex-start;
+    justify-content: start;
     align-self: stretch;
 }
 


### PR DESCRIPTION
This reverts commit 14e84e7f07b8f02b2d9d90a5880eda0bba279d32.

## Test plan

CI

## App preview:

- [Web](https://sg-web-es-revert-123.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
