### PR TITLE
client/web: Add UI elements for Azure DevOps auth provider

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { mdiBitbucket, mdiGithub, mdiGitlab, mdiEmail } from '@mdi/js'
+import { mdiBitbucket, mdiGithub, mdiGitlab, mdiEmail, mdiMicrosoftAzureDevops } from '@mdi/js'
 import classNames from 'classnames'
 import { partition } from 'lodash'
 import { Navigate, useLocation, useSearchParams } from 'react-router-dom-v5-compat'
@@ -102,6 +102,9 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                                 {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
                                 {provider.serviceType === 'bitbucketCloud' && (
                                     <Icon aria-hidden={true} svgPath={mdiBitbucket} />
+                                )}{' '}
+                                {provider.serviceType === 'azuredevops' && (
+                                    <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
                                 )}{' '}
                                 Continue with {provider.displayName}
                             </Button>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -100,9 +100,12 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                             >
                                 {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
                                 {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
-                                {provider.serviceType === 'bitbucketCloud' && <Icon aria-hidden={true} svgPath={mdiBitbucket} />}
-                                {provider.serviceType === 'azuredevops' && <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />}
-                                {' '}
+                                {provider.serviceType === 'bitbucketCloud' && (
+                                    <Icon aria-hidden={true} svgPath={mdiBitbucket} />
+                                )}
+                                {provider.serviceType === 'azuredevops' && (
+                                    <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
+                                )}{' '}
                                 Continue with {provider.displayName}
                             </Button>
                         </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -100,12 +100,9 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                             >
                                 {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
                                 {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
-                                {provider.serviceType === 'bitbucketCloud' && (
-                                    <Icon aria-hidden={true} svgPath={mdiBitbucket} />
-                                )}{' '}
-                                {provider.serviceType === 'azuredevops' && (
-                                    <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
-                                )}{' '}
+                                {provider.serviceType === 'bitbucketCloud' && <Icon aria-hidden={true} svgPath={mdiBitbucket} />}
+                                {provider.serviceType === 'azuredevops' && <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />}
+                                {' '}
                                 Continue with {provider.displayName}
                             </Button>
                         </div>

--- a/client/web/src/components/externalAccounts/externalAccounts.ts
+++ b/client/web/src/components/externalAccounts/externalAccounts.ts
@@ -4,6 +4,7 @@ import AccountCircleIcon from 'mdi-react/AccountCircleIcon'
 import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import GitLabIcon from 'mdi-react/GitlabIcon'
+import MicrosoftAzureDevopsIcon from 'mdi-react/MicrosoftAzureDevOpsIcon'
 
 import { AuthProvider } from '../../jscontext'
 import { GerritIcon } from '../externalServices/GerritIcon'
@@ -26,6 +27,10 @@ export interface ExternalAccount {
 }
 
 export const defaultExternalAccounts: Record<ExternalAccountKind, ExternalAccount> = {
+    azuredevops: {
+        title: 'Azure DevOps',
+        icon: MicrosoftAzureDevopsIcon,
+    },
     github: {
         title: 'GitHub',
         icon: GithubIcon,

--- a/client/web/src/components/externalAccounts/externalAccounts.ts
+++ b/client/web/src/components/externalAccounts/externalAccounts.ts
@@ -4,7 +4,7 @@ import AccountCircleIcon from 'mdi-react/AccountCircleIcon'
 import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import GitLabIcon from 'mdi-react/GitlabIcon'
-import MicrosoftAzureDevopsIcon from 'mdi-react/MicrosoftAzureDevOpsIcon'
+import MicrosoftAzureDevopsIcon from 'mdi-react/MicrosoftAzureDevopsIcon'
 
 import { AuthProvider } from '../../jscontext'
 import { GerritIcon } from '../externalServices/GerritIcon'

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -8,15 +8,16 @@ export type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 
 
 export interface AuthProvider {
     serviceType:
-        | 'github'
-        | 'gitlab'
-        | 'bitbucketCloud'
-        | 'http-header'
-        | 'openidconnect'
-        | 'sourcegraph-operator'
-        | 'saml'
-        | 'builtin'
-        | 'gerrit'
+    | 'github'
+    | 'gitlab'
+    | 'bitbucketCloud'
+    | 'http-header'
+    | 'openidconnect'
+    | 'sourcegraph-operator'
+    | 'saml'
+    | 'builtin'
+    | 'gerrit'
+    | 'azuredevops'
     displayName: string
     isBuiltin: boolean
     authenticationURL: string

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -8,16 +8,16 @@ export type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 
 
 export interface AuthProvider {
     serviceType:
-    | 'github'
-    | 'gitlab'
-    | 'bitbucketCloud'
-    | 'http-header'
-    | 'openidconnect'
-    | 'sourcegraph-operator'
-    | 'saml'
-    | 'builtin'
-    | 'gerrit'
-    | 'azuredevops'
+        | 'github'
+        | 'gitlab'
+        | 'bitbucketCloud'
+        | 'http-header'
+        | 'openidconnect'
+        | 'sourcegraph-operator'
+        | 'saml'
+        | 'builtin'
+        | 'gerrit'
+        | 'azuredevops'
     displayName: string
     isBuiltin: boolean
     authenticationURL: string

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -53,21 +53,23 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
             accountConnection = account.external?.displayName || 'Not connected'
             break
         default:
-            accountConnection = (
-                <>
-                    {account.external?.url ? (
-                        <>
-                            {account.external.displayName} (
+            if (account.external?.displayName) {
+                accountConnection = (
+                    <>
+                        {account.external.displayName} (
+                        {account.external?.url ? (
                             <Link to={account.external.url} target="_blank" rel="noopener noreferrer">
                                 @{account.external.login}
                             </Link>
-                            )
-                        </>
-                    ) : (
-                        'Not connected'
-                    )}
-                </>
-            )
+                        ) : (
+                            <>@{account.external.login}</>
+                        )}
+                        )
+                    </>
+                )
+            } else {
+                accountConnection = 'Not connected'
+            }
     }
 
     return (

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -51,25 +51,25 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
         case 'saml':
         case 'gerrit':
             accountConnection = account.external?.displayName || 'Not connected'
+        case 'azuredevops':
+            accountConnection = (<>{account.external?.displayName}(@{account.external?.login})</>)
             break
         default:
-            if (account.external?.displayName) {
-                accountConnection = (
-                    <>
-                        {account.external.displayName} (
-                        {account.external?.url ? (
+            accountConnection = (
+                <>
+                    {account.external?.url ? (
+                        <>
+                            {account.external.displayName}(
                             <Link to={account.external.url} target="_blank" rel="noopener noreferrer">
                                 @{account.external.login}
                             </Link>
-                        ) : (
-                            <>@{account.external.login}</>
-                        )}
-                        )
-                    </>
-                )
-            } else {
-                accountConnection = 'Not connected'
-            }
+                            )
+                        </>
+                    ) : (
+                        accountConnection = 'Not connected'
+                    )}
+                </>
+            )
     }
 
     return (

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -54,7 +54,7 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
         case 'azuredevops':
             accountConnection = (
                 <>
-                    {account.external?.displayName}(@{account.external?.login})
+                    {account.external?.displayName} (@{account.external?.login})
                 </>
             )
             break
@@ -63,14 +63,14 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
                 <>
                     {account.external?.url ? (
                         <>
-                            {account.external.displayName}(
+                            {account.external.displayName} (
                             <Link to={account.external.url} target="_blank" rel="noopener noreferrer">
                                 @{account.external.login}
                             </Link>
                             )
                         </>
                     ) : (
-                        (accountConnection = 'Not connected')
+                        'Not connected'
                     )}
                 </>
             )

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -52,7 +52,11 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
         case 'gerrit':
             accountConnection = account.external?.displayName || 'Not connected'
         case 'azuredevops':
-            accountConnection = (<>{account.external?.displayName}(@{account.external?.login})</>)
+            accountConnection = (
+                <>
+                    {account.external?.displayName}(@{account.external?.login})
+                </>
+            )
             break
         default:
             accountConnection = (
@@ -66,7 +70,7 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
                             )
                         </>
                     ) : (
-                        accountConnection = 'Not connected'
+                        (accountConnection = 'Not connected')
                     )}
                 </>
             )

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
@@ -133,7 +133,7 @@ func parseProvider(logger log.Logger, db database.DB, sourceCfg schema.AuthProvi
 		return nil, messages
 	}
 
-	codeHost := extsvc.NewCodeHost(parsedURL, extsvc.KindAzureDevOps)
+	codeHost := extsvc.NewCodeHost(parsedURL, extsvc.TypeAzureDevOps)
 
 	sessionHandler := oauth.SessionIssuer(
 		logger,

--- a/enterprise/cmd/frontend/internal/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -89,10 +90,11 @@ func (p *Provider) ExternalAccountInfo(ctx context.Context, account extsvc.Accou
 		return gitlab.GetPublicExternalAccountData(ctx, &account.AccountData)
 	case extsvc.TypeBitbucketCloud:
 		return bitbucketcloud.GetPublicExternalAccountData(ctx, &account.AccountData)
+	case extsvc.TypeAzureDevOps:
+		return azuredevops.GetPublicExternalAccountData(ctx, &account.AccountData)
 	}
 
-	// TODO: add bitbucket cloud when the bitbucket oauth provider is merged
-	return nil, errors.Errorf("Sourcegraph currently only supports GitHub and GitLab as OAuth providers")
+	return nil, errors.Errorf("Sourcegraph currently only supports Azure DevOps, Bitbucket Cloud, GitHub, GitLab as OAuth providers")
 }
 
 type ProviderOp struct {


### PR DESCRIPTION
This PR does a few related things:

1. Add an icon on the signin page for Azure DevOps
1. Implement external data functions and add code to show the connected account data for Azure DevOps
1. ~~Changes the code to display connected account information to use the `displayName` instead of the `url` property~~
  - ~~This change was required because the closest thing to an account page (equivalent of github.com/indradhanush for example) for ADO that I found was: https://aex.dev.azure.com/me. Which shows the currently logged in user, but I couldn't find a permanent URI for a user. As a result the connected account information could not be displayed if we continued to display it against the check for a non-null `url` in the frontend code~~
  - ~~Additionally, presence of a display name as the primary check makes more sense~~
  - On code review, I've reverted this change and instead added a special `case` handling for `azuredevops`


👉 Finally, it fixes a bug (discovered as a result of implementing this) with the `parseProvider` where I was incorrectly using the `Kind` instead of `Type`. 

Sidenote: Since both are strings and the only difference is that the former is in `UPPERCASE` while the latter is in `lowercase`, this is an easy mistake to make. The real fix should be that these should be custom types so that methods that accept these as an argument get the powers of type checking. Expect a follow up PR.


## Test plan

- Builds should pass
- Tested locally

**Sign in page (notice the cute icon)**

<img width="871" alt="image" src="https://user-images.githubusercontent.com/2682729/220039661-c1307e7a-b3a5-4e9e-b630-50b57d20e70a.png">


**Accounts security page, not connected account**

<img width="1458" alt="image" src="https://user-images.githubusercontent.com/2682729/220119551-0aefa5f4-60a9-4535-b2b8-b755991a2cf3.png">

**Accounts security page, connected account**

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/2682729/220119345-ff0913a5-5edf-4932-83e5-12f83abff4a5.png">

**Account disconnection prompt**

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/2682729/220119506-6799a911-ceff-4382-b7df-b027a4426d00.png">









<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-ado-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
