### PR TITLE
doc: fix bad links

### DIFF
--- a/doc/admin/deploy/docker-compose/aws.md
+++ b/doc/admin/deploy/docker-compose/aws.md
@@ -1,6 +1,6 @@
 # Install Sourcegraph on Amazon Web Services (AWS)
 
-> ⚠️ We recommend new users use our [AWS AMI](../machine-images/aws-oneclick) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
+> ⚠️ We recommend new users use our [AWS AMI](../machine-images/aws-oneclick.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
 ---
 

--- a/doc/admin/deploy/machine-images/aws-oneclick.md
+++ b/doc/admin/deploy/machine-images/aws-oneclick.md
@@ -112,10 +112,6 @@ By default Sourcegraph will be available over HTTP on the public internet. To se
 2. [Configure user authentication](../../../admin/auth/index.md) (SSO, SAML, OpenID Connect, etc.)
 3. [Review the new Network Security Group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) to prevent access from the public internet and follow the principle of least privilege.
 
-### Share with your team
-
-[See here](/adopt/trial#3-share-with-the-trial-team) for some tips on how to share Sourcegraph with your team!
-
 ## Managing Sourcegraph
 
 ### Backup and restore

--- a/doc/admin/enterprise_getting_started_guide/index.md
+++ b/doc/admin/enterprise_getting_started_guide/index.md
@@ -5,33 +5,33 @@ If you're deploying a new Enterprise instance, this page covers our most frequen
 ## Admin articles
 
 ### General
-- [Deployment overview](../admin/deploy/index.md)
-- [Resource estimator](../admin/deploy/resource_estimator.md)
-- [SAML config](../admin/auth/saml/index.md)
-- [Configuring authorization and authentication](../admin/config/authorization_and_authentication.md) - We recommend starting here for access and permissions configuration before moving on to the more specific pages on these topics.
-- [Built-in password authentication](../admin/auth/index.md#builtin-password-authentication)
-- [GitHub authentication](../admin/auth/index.md#github)
-- [GitLab authentication](../admin/auth/index.md#gitlab)
-- [OpenID connect](../admin/auth/index.md#openid-connect)
-- [HTTP authentication proxy](../admin/auth/index.md#http-authentication-proxies)
+- [Deployment overview](../deploy/index.md)
+- [Resource estimator](../deploy/resource_estimator.md)
+- [SAML config](../auth/saml/index.md)
+- [Configuring authorization and authentication](../config/authorization_and_authentication.md) - We recommend starting here for access and permissions configuration before moving on to the more specific pages on these topics.
+- [Built-in password authentication](../auth/index.md#builtin-password-authentication)
+- [GitHub authentication](../auth/index.md#github)
+- [GitLab authentication](../auth/index.md#gitlab)
+- [OpenID connect](../auth/index.md#openid-connect)
+- [HTTP authentication proxy](../auth/index.md#http-authentication-proxies)
 - [GitLab integration](../integration/gitlab.md)
 - [GitHub integration](../integration/github.md)
 - [All code host integrations (not GitLab or GitHub)](../integration/index.md#integrations)
-- [Full guide to site config options](../admin/config/site_config.md#auth-sessionExpiry)
+- [Full guide to site config options](../config/site_config.md#auth-sessionExpiry)
 - [Changelog](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md) to track releases and updates
 
 ### Docker-compose
-- [Basic installation guide](../admin/deploy/docker-compose/index.md)
-- [AWS installation](../admin/deploy/docker-compose/aws.md)
-- [Digital Ocean installation](../admin/deploy/docker-compose/digitalocean.md)
-- [Google Cloud installlation](../admin/deploy/docker-compose/google_cloud.md)
+- [Basic installation guide](../deploy/docker-compose/index.md)
+- [AWS installation](../deploy/docker-compose/aws.md)
+- [Digital Ocean installation](../deploy/docker-compose/digitalocean.md)
+- [Google Cloud installlation](../deploy/docker-compose/google_cloud.md)
 
 ### Kubernetes admin
-- [All Kubernetes with Helm guidance](../admin/deploy/kubernetes/helm.md)
-- [Amazon EKS](../admin/deploy/kubernetes/helm.md#configure-sourcegraph-on-elastic-kubernetes-service-eks)
-- [Google GKE](../admin/deploy/kubernetes/helm.md#configure-sourcegraph-on-google-kubernetes-engine-gke)
-- [Azure](../admin/deploy/kubernetes/helm.md#configure-sourcegraph-on-azure-managed-kubernetes-service-aks)
-- [Configure Sourcegraph on other Cloud providers or on-prem](../admin/deploy/kubernetes/helm.md#configure-sourcegraph-on-other-cloud-providers-or-on-prem)
+- [All Kubernetes with Helm guidance](../deploy/kubernetes/helm.md)
+- [Amazon EKS](../deploy/kubernetes/helm.md#configure-sourcegraph-on-elastic-kubernetes-service-eks)
+- [Google GKE](../deploy/kubernetes/helm.md#configure-sourcegraph-on-google-kubernetes-engine-gke)
+- [Azure](../deploy/kubernetes/helm.md#configure-sourcegraph-on-azure-managed-kubernetes-service-aks)
+- [Configure Sourcegraph on other Cloud providers or on-prem](../deploy/kubernetes/helm.md#configure-sourcegraph-on-other-cloud-providers-or-on-prem)
 
 ## User articles
 - [Search syntax](../code_search/reference/queries.md)

--- a/doc/admin/observability/outbound-request-log.md
+++ b/doc/admin/observability/outbound-request-log.md
@@ -10,7 +10,7 @@ This document assumes you are a [site admin](../index.md).
 
 ## Enabling the logs
 
-This feature is off by default. You can enable it by setting `outboundRequestLogLimit` to a non-zero value in the [site config](../config/site_config#outboundRequestLogLimit). The recommended value is `50`.
+This feature is off by default. You can enable it by setting `outboundRequestLogLimit` to a non-zero value in the [site config](../config/site_config.md#outboundRequestLogLimit). The recommended value is `50`.
 
 You can later disable it by setting `outboundRequestLogLimit` to `0`, or by removing the setting entirely.
 
@@ -40,9 +40,9 @@ To recreate a request for debugging, you can copy the cURL command for any reque
 
 Keep in mind that some headers might be redacted (you'll see the word "REDACTED" in their place), in which case you'll need to add the missing pieces manually.
 
-Note: You can set the `redactOutboundRequestHeaders` [site config](../config/site_config#redactOutboundRequestHeaders) option to `false` to disable the redaction of headers and make the "Copy curl" function more convenient. But for security reasons, this setting is only respected in development environments. 
+Note: You can set the `redactOutboundRequestHeaders` [site config](../config/site_config.md#redactOutboundRequestHeaders) option to `false` to disable the redaction of headers and make the "Copy curl" function more convenient. But for security reasons, this setting is only respected in development environments. 
 
 ## Trouble Shooting
 
 ### Page failing to load, or loading slowly
-If the Outbound Request Log page is failing to load, or loading slowly, you may need to allocate more resources to Redis. To confirm, please check the charts for Redis under the `provisioning indicators` dropdown in grafana. If these charts show that your CPU usage is consistently over the threshold,  allocate more resources to Redis. You can use our [resource estimator](https://docs.sourcegraph.com/admin/deploy/resource_estimator) as a guide.
+If the Outbound Request Log page is failing to load, or loading slowly, you may need to allocate more resources to Redis. To confirm, please check the charts for Redis under the `provisioning indicators` dropdown in grafana. If these charts show that your CPU usage is consistently over the threshold,  allocate more resources to Redis. You can use our [resource estimator](../deploy/resource_estimator.md) as a guide.

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -24,7 +24,7 @@
 
 <!-- Add changes changes to this section before release. -->
 
-- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](/admin/how-to/lsif_scip_migration) for more details.
+- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](../how-to/lsif_scip_migration.md) for more details.
 
 ## v4.4.1 ➔ v4.4.2
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -12,7 +12,7 @@ Each section comprehensively describes the changes needed in Docker images, envi
 
 <!-- Add changes changes to this section before release. -->
 
-- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](/admin/how-to/lsif_scip_migration) for more details.
+- This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](../how-to/lsif_scip_migration.md) for more details.
 
 ## v4.4.1 ➔ v4.4.2
 

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -11,8 +11,8 @@
 1. [Setup webhooks](../../admin/config/webhooks.md) to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
 
 1. Configure any desired optional features, such as:
-    * [Rollout windows](../../../admin/config/batch_changes#rollout-windows), which control the rate at which Batch Changes will publish changesets on code hosts.
-    * [Forks](../../../admin/config/batch_changes#forks), which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
+    * [Rollout windows](../../../admin/config/batch_changes.md#rollout-windows), which control the rate at which Batch Changes will publish changesets on code hosts.
+    * [Forks](../../../admin/config/batch_changes.md#forks), which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
 
 #### Disable Batch Changes
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).

--- a/doc/dev/adr/1658418787-deprecate-raw-git-commands.md
+++ b/doc/dev/adr/1658418787-deprecate-raw-git-commands.md
@@ -6,7 +6,7 @@ Date: 2022-07-21
 
 It was common in the past to treat gitserver as a simple wrapper around git where users could send any combination of git arguments.
 
-This made it difficult to provide a consistent API to users of gitserver as well as making it difficult to apply certain security checks and filtering. 
+This made it difficult to provide a consistent API to users of gitserver as well as making it difficult to apply certain security checks and filtering.
 
 ## Decision
 
@@ -16,5 +16,5 @@ It should no longer be possible to send "raw" commands to gitserver. All communi
 
 When new functionality is required, it should be added to the gitserver client interface or existing methods should be updated. 
 
-Currently, [the interface](../../dev/background-api/gitserver.md) is pretty large but we have plans to clean it up over time.
+Currently, [the interface](../background-information/gitserver-api.md) is pretty large but we have plans to clean it up over time.
 

--- a/doc/dev/background-information/gitserver-api.md
+++ b/doc/dev/background-information/gitserver-api.md
@@ -6,7 +6,7 @@
 It clones repositories and exposes an API for interacting with that clone.
 
 `gitserver` used to expose a simple "run any Git command" interface, 
-but [that was removed](../../dev/adr/1658418787-deprecate-raw-git-commands)
+but [that was removed](../../dev/adr/1658418787-deprecate-raw-git-commands.md)
 and in its place the `gitserver client` exposes an API supporting specific Git operations.
 
 | Method                | Description                                                                                                                                                                                             | Notes                                                                                                                                                                                                                                                                                                                                                              | Git Command or GitServer Endpoint                                                                                                                                                                                                                                                      |

--- a/doc/index.md
+++ b/doc/index.md
@@ -118,6 +118,6 @@ For our largest customers, we also offer a Kubernetes multi-node cluster deploym
 
 ## Explanations
 
-- [About deploying Sourcegraph, upgrades, etc.](/admin/deploy.md)
-- [How GitHub code search compares to Sourcegraph](https://docs.sourcegraph.com/getting-started/github-vs-sourcegraph)
-- [How Sourcegraph is licensed](https://docs.sourcegraph.com/getting-started/oss-enterprise)
+- [About deploying Sourcegraph, upgrades, etc.](admin/deploy/index.md)
+- [How GitHub code search compares to Sourcegraph](getting-started/github-vs-sourcegraph.md)
+- [How Sourcegraph is licensed](getting-started/oss-enterprise.md)


### PR DESCRIPTION
Fix _some but not all_ (>70 down to 39) link issues reported by `docsite check`.

_This is part of the effort to [bring back the `sg lint docs`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/sg/linters/linters.go?L54-55)._

## Test plan

n/a
