### PR TITLE
result: sort matches of OR-queries by source count

### DIFF
--- a/internal/search/result/merger.go
+++ b/internal/search/result/merger.go
@@ -40,7 +40,7 @@ type byPopCount []mergeVal
 
 func (s byPopCount) Len() int           { return len(s) }
 func (s byPopCount) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s byPopCount) Less(i, j int) bool { return s[i].seen.Count() > s[j].seen.Count() }
+func (s byPopCount) Less(i, j int) bool { return s[i].seen.Count() < s[j].seen.Count() }
 
 // AddMatches adds a set of Matches from the given source to the merger.
 // For each of these matches, if that match has been seen by every source, we
@@ -125,7 +125,7 @@ func (lm *merger) UnsentTracked() Matches {
 	}
 
 	// Prioritize matches that were found by multiple sources.
-	sort.Sort(byPopCount(matches))
+	sort.Sort(sort.Reverse(byPopCount(matches)))
 
 	res := make(Matches, 0, len(matches))
 	for _, val := range matches {

--- a/internal/search/result/merger.go
+++ b/internal/search/result/merger.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/bits-and-blooms/bitset"
@@ -34,6 +35,12 @@ type mergeVal struct {
 	seen  *bitset.BitSet
 	sent  bool
 }
+
+type byPopCount []mergeVal
+
+func (s byPopCount) Len() int           { return len(s) }
+func (s byPopCount) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byPopCount) Less(i, j int) bool { return s[i].seen.Count() > s[j].seen.Count() }
 
 // AddMatches adds a set of Matches from the given source to the merger.
 // For each of these matches, if that match has been seen by every source, we
@@ -108,11 +115,21 @@ func (lm *merger) addMatch(m Match, source int) Match {
 // Stated differently, when added to the matches that were already returned
 // by AddMatches, you get the union of sources.
 func (lm *merger) UnsentTracked() Matches {
-	var res Matches
+	// We possibly allocate more than is needed. However, assuming that most matches
+	// will not been seen by all sources, the limit should be fine.
+	matches := make([]mergeVal, 0, len(lm.matches))
 	for _, val := range lm.matches {
 		if !val.sent {
-			res = append(res, val.match)
+			matches = append(matches, val)
 		}
+	}
+
+	// Prioritize matches that were found by multiple sources.
+	sort.Sort(byPopCount(matches))
+
+	res := make(Matches, 0, len(matches))
+	for _, val := range matches {
+		res = append(res, val.match)
 	}
 	return res
 }

--- a/internal/search/result/merger_test.go
+++ b/internal/search/result/merger_test.go
@@ -43,7 +43,7 @@ func TestMerger(t *testing.T) {
 		{mkFileMatch(repo, "all_sources", 1), 2},
 		// 2 sources
 		{mkFileMatch(repo, "2_of_3", 1), 0},
-		{mkFileMatch(repo, "2_of_3", 1), 1}, // should be depuped by merger
+		{mkFileMatch(repo, "2_of_3", 1), 1}, // should be deduped by merger
 		// 1 source
 		{mkFileMatch(repo, "1_of_3", 1), 0},
 		{mkFileMatch(repo, "1_of_3_other", 1), 1},

--- a/internal/search/result/merger_test.go
+++ b/internal/search/result/merger_test.go
@@ -1,0 +1,73 @@
+package result
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) Match {
+	var hms ChunkMatches
+	for _, n := range lineNumbers {
+		hms = append(hms, ChunkMatch{
+			Ranges: []Range{{
+				Start: Location{Line: n},
+				End:   Location{Line: n},
+			}},
+		})
+	}
+
+	return &FileMatch{
+		File: File{
+			Path: path,
+			Repo: repo,
+		},
+		ChunkMatches: hms,
+	}
+}
+
+func TestMerger(t *testing.T) {
+	sources := 3
+	m := NewMerger(sources)
+	repo := types.MinimalRepo{Name: "r"}
+
+	sourcedMatch := []struct {
+		match  Match
+		source int
+	}{
+		// all sources
+		{mkFileMatch(repo, "all_sources", 1), 0},
+		{mkFileMatch(repo, "all_sources", 1), 1},
+		{mkFileMatch(repo, "all_sources", 1), 2},
+		// 2 sources
+		{mkFileMatch(repo, "2_of_3", 1), 0},
+		{mkFileMatch(repo, "2_of_3", 1), 1}, // should be depuped by merger
+		// 1 source
+		{mkFileMatch(repo, "1_of_3", 1), 0},
+		{mkFileMatch(repo, "1_of_3_other", 1), 1},
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(sourcedMatch), func(i, j int) {
+		sourcedMatch[i], sourcedMatch[j] = sourcedMatch[j], sourcedMatch[i]
+	})
+
+	for _, sm := range sourcedMatch {
+		m.addMatch(sm.match, sm.source)
+	}
+
+	unsent := m.UnsentTracked()
+
+	// all matches seen by a subset of sources minus deduped results.
+	wantUnsent := 3
+	if gotUnsent := len(unsent); gotUnsent != wantUnsent {
+		t.Fatalf("len(unsent): wanted %d, got %d", wantUnsent, gotUnsent)
+	}
+
+	wantPath := "2_of_3"
+	if gotPath := unsent[0].(*FileMatch).Path; gotPath != wantPath {
+		t.Fatalf("best unsent match: want %s, got %s", wantPath, gotPath)
+	}
+}


### PR DESCRIPTION
We already prioritze matches found by all sources. However, for OR-Queries with many terms, such as keyword queries, it is reasonable to assume that most matches will only relate to a subset of the terms. So far we returned those matches in random order.



## Test plan 
- new unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
