### PR TITLE
disable release protector

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -13,174 +13,175 @@ jobs:
       - name: Disable workflow
         run: exit 0
 
-  # validate_release_branch:
-  #   runs-on: ubuntu-latest
-  #   if: ${{ github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}
-  #   outputs:
-  #     releaseBranchExists: ${{ steps.checkout.outputs.exists }}
-  #   steps:
-  #     - name: Check if latest release branch exists
-  #       id: checkout
-  #       run: |
-  #         branch="4.5"
-  #         if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
-  #           echo "::set-output name=exists::true"
-  #         else
-  #           echo "::set-output name=exists::false"
-  #         fi
+  validate_release_branch:
+    needs: disable_release_protector
+    runs-on: ubuntu-latest
+    if: ${{ failure() && github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}
+    outputs:
+      releaseBranchExists: ${{ steps.checkout.outputs.exists }}
+    steps:
+      - name: Check if latest release branch exists
+        id: checkout
+        run: |
+          branch="4.5"
+          if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
 
-  # protect-pr:
-  #   runs-on: ubuntu-latest
-  #   needs: validate_release_branch
-  #   if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'false' }}
-  #   steps:
-  #     - name: Check date and labels
-  #       id: check-date-and-labels
-  #       run: |
-  #         # Does this PR have the acknowledgement label?
-  #         has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-the-release')}}"
+  protect-pr:
+    runs-on: ubuntu-latest
+    needs: validate_release_branch
+    if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'false' }}
+    steps:
+      - name: Check date and labels
+        id: check-date-and-labels
+        run: |
+          # Does this PR have the acknowledgement label?
+          has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-the-release')}}"
 
-  #         # According to the handbook [https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#when-we-release], we
-  #         # release on the 22nd of each month, If the 22nd falls on a non-working day,
-  #         # the release captain will shift the release earlier to the last working day before the 22nd.
+          # According to the handbook [https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#when-we-release], we
+          # release on the 22nd of each month, If the 22nd falls on a non-working day,
+          # the release captain will shift the release earlier to the last working day before the 22nd.
 
-  #         # ALL dates must be in the format YYYY-MM-DD
+          # ALL dates must be in the format YYYY-MM-DD
 
-  #         # This returns true or false depending on if the date passed is a working day.
-  #         # We use this to adjust the release date / freeze date from the usual date defined in
-  #         # the handbook.
-  #         function is_weekend() {
-  #           # Parse the date string
-  #           local date_string="$1"
-  #           # Get the day of the week (0-6, where Sunday is 0)
-  #           local day_of_week
-  #           day_of_week=$(date -d "$date_string" +%u)
-  #           # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
-  #           if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
-  #             return 0
-  #           else
-  #             return 1
-  #           fi
-  #         }
+          # This returns true or false depending on if the date passed is a working day.
+          # We use this to adjust the release date / freeze date from the usual date defined in
+          # the handbook.
+          function is_weekend() {
+            # Parse the date string
+            local date_string="$1"
+            # Get the day of the week (0-6, where Sunday is 0)
+            local day_of_week
+            day_of_week=$(date -d "$date_string" +%u)
+            # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
+            if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
+              return 0
+            else
+              return 1
+            fi
+          }
 
-  #         # Use the this to get the last working day before the date passed in as an argument
-  #         function find_last_working_day() {
-  #           local date_string="$1"
-  #           while is_weekend "$date_string"; do
-  #             date_string=$(date -d "$date_string 1 day ago" +%F)
-  #           done
-  #           echo "$date_string"
-  #         }
+          # Use the this to get the last working day before the date passed in as an argument
+          function find_last_working_day() {
+            local date_string="$1"
+            while is_weekend "$date_string"; do
+              date_string=$(date -d "$date_string 1 day ago" +%F)
+            done
+            echo "$date_string"
+          }
 
-  #         function get_closest_working_day() {
-  #           if [ -z "$1" ]; then
-  #             echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
-  #             return 1
-  #           fi
+          function get_closest_working_day() {
+            if [ -z "$1" ]; then
+              echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+              return 1
+            fi
 
-  #           local date_to_check="$1"
-  #           if is_weekend "$date_to_check"; then
-  #             date_to_check=$(find_last_working_day "$date_to_check")
-  #           fi
-  #           echo "$date_to_check"
-  #         }
+            local date_to_check="$1"
+            if is_weekend "$date_to_check"; then
+              date_to_check=$(find_last_working_day "$date_to_check")
+            fi
+            echo "$date_to_check"
+          }
 
-  #         function get_epoch() {
-  #           if [ -z "$1" ]; then
-  #             echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
-  #             return 1
-  #           fi
+          function get_epoch() {
+            if [ -z "$1" ]; then
+              echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+              return 1
+            fi
 
-  #           date -d "$1" +%s
-  #         }
+            date -d "$1" +%s
+          }
 
-  #         release_day=22
-  #         current_month=$(date +'%m')
-  #         current_year=$(date +'%Y')
+          release_day=22
+          current_month=$(date +'%m')
+          current_year=$(date +'%Y')
 
-  #         release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
-  #         cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
-  #         if [ "$current_month" -eq "03" ]; then
-  #           freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 4 days" +%F)")
-  #         else
-  #           freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
-  #         fi
-  #         todays_date=$(date +'%Y-%m-%d %H:%M')
+          release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
+          cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
+          if [ "$current_month" -eq "03" ]; then
+            freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 4 days" +%F)")
+          else
+            freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
+          fi
+          todays_date=$(date +'%Y-%m-%d %H:%M')
 
-  #         todays_date_epoch=$(get_epoch "$todays_date")
-  #         freeze_date_epoch=$(get_epoch "$freeze_date 00:00")
-  #         release_date_epoch=$(get_epoch "$release_date 23:59")
+          todays_date_epoch=$(get_epoch "$todays_date")
+          freeze_date_epoch=$(get_epoch "$freeze_date 00:00")
+          release_date_epoch=$(get_epoch "$release_date 23:59")
 
-  #         if [ "$todays_date_epoch" -ge "$freeze_date_epoch" ] && [ "$todays_date_epoch" -lt "$release_date_epoch" ]; then
-  #           if [ "${has_label}" = "true" ]; then
-  #             echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
-  #             exit 0
-  #           else
-  #             echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
-  #             echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
-  #             echo "❓ The code freeze is active until ${release_date} at 23:59 UTC."
-  #             echo "release_date=${release_date}" >> $GITHUB_ENV
-  #             exit 1
-  #           fi
-  #         else
-  #           echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
-  #           exit 0
-  #         fi
-  #     - name: "Post comment if failed"
-  #       uses: actions/github-script@v6
-  #       # We need always() otherwise, the step won't run if the previous one exited, regardless of the predicate value when evaluated.
-  #       #
-  #       # Because we have other actions labeling the PR, they can trigger the entire job to run twice simultaneously, preventing the
-  #       # code ensuring that we're not commenting again if a comment has been posted by us. Basically, with cla-bot labels being instant
-  #       # means that this job is ran twice at the same time, but always second.
-  #       # To fix that, we specifically check the event.label.name value and the event.action.
-  #       #
-  #       # In essence, we're always running the check, but only commenting if we really need to. This can't be done at the job level, because
-  #       # it would be mean the job would be first run by the pr creation, but then skipped when the cla-bot triggered job completes, which
-  #       # is very confusing for the user in the UI (you get a comment about a failure, but it appears skipped).
-  #       if: |-
-  #         always()
-  #         &&
-  #         steps.check-date-and-labels.outcome != 'success'
-  #         &&
-  #         (
-  #           (
-  #             contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
-  #             &&
-  #             github.event.label.name == 'i-acknowledge-this-goes-into-the-release'
-  #           )
-  #           ||
-  #           !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
-  #         )
-  #       with:
-  #         github-token: ${{secrets.GITHUB_TOKEN}}
-  #         script: |
-  #           let d = new Date()
-  #           d.setHours(d.getHours() -1) // Yes, this handles properly midnight.
+          if [ "$todays_date_epoch" -ge "$freeze_date_epoch" ] && [ "$todays_date_epoch" -lt "$release_date_epoch" ]; then
+            if [ "${has_label}" = "true" ]; then
+              echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
+              exit 0
+            else
+              echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
+              echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
+              echo "❓ The code freeze is active until ${release_date} at 23:59 UTC."
+              echo "release_date=${release_date}" >> $GITHUB_ENV
+              exit 1
+            fi
+          else
+            echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
+            exit 0
+          fi
+      - name: "Post comment if failed"
+        uses: actions/github-script@v6
+        # We need always() otherwise, the step won't run if the previous one exited, regardless of the predicate value when evaluated.
+        #
+        # Because we have other actions labeling the PR, they can trigger the entire job to run twice simultaneously, preventing the
+        # code ensuring that we're not commenting again if a comment has been posted by us. Basically, with cla-bot labels being instant
+        # means that this job is ran twice at the same time, but always second.
+        # To fix that, we specifically check the event.label.name value and the event.action.
+        #
+        # In essence, we're always running the check, but only commenting if we really need to. This can't be done at the job level, because
+        # it would be mean the job would be first run by the pr creation, but then skipped when the cla-bot triggered job completes, which
+        # is very confusing for the user in the UI (you get a comment about a failure, but it appears skipped).
+        if: |-
+          always()
+          &&
+          steps.check-date-and-labels.outcome != 'success'
+          &&
+          (
+            (
+              contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
+              &&
+              github.event.label.name == 'i-acknowledge-this-goes-into-the-release'
+            )
+            ||
+            !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
+          )
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            let d = new Date()
+            d.setHours(d.getHours() -1) // Yes, this handles properly midnight.
 
-  #           let body = `❌ **Problem**: the label \`i-acknowledge-this-goes-into-the-release\` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with \`i-acknowledge-this-goes-into-the-release\`.\n❓ **When does the freeze end?** The code freeze is active until ${process.env.release_date} at 23:59 UTC.`
-  #           let skip = false
+            let body = `❌ **Problem**: the label \`i-acknowledge-this-goes-into-the-release\` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with \`i-acknowledge-this-goes-into-the-release\`.\n❓ **When does the freeze end?** The code freeze is active until ${process.env.release_date} at 23:59 UTC.`
+            let skip = false
 
-  #           const { data: comments } = await github.rest.issues.listComments({
-  #             issue_number: context.issue.number,
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             since: d.toISOString(),
-  #           })
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              since: d.toISOString(),
+            })
 
-  #           if (Array.isArray(comments) && comments.length > 0) {
-  #             comments.forEach((comment => {
-  #               if (comment.body == body) {
-  #                 skip = true
-  #               }
-  #             }))
-  #           }
+            if (Array.isArray(comments) && comments.length > 0) {
+              comments.forEach((comment => {
+                if (comment.body == body) {
+                  skip = true
+                }
+              }))
+            }
 
-  #           if (!skip) {
-  #             await github.rest.issues.createComment({
-  #               issue_number: context.issue.number,
-  #               owner: context.repo.owner,
-  #               repo: context.repo.repo,
-  #               body: body,
-  #             })
-  #           }
+            if (!skip) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              })
+            }

--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -13,174 +13,174 @@ jobs:
       - name: Disable workflow
         run: exit 0
 
-  validate_release_branch:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}
-    outputs:
-      releaseBranchExists: ${{ steps.checkout.outputs.exists }}
-    steps:
-      - name: Check if latest release branch exists
-        id: checkout
-        run: |
-          branch="4.5"
-          if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
-            echo "::set-output name=exists::true"
-          else
-            echo "::set-output name=exists::false"
-          fi
+  # validate_release_branch:
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}
+  #   outputs:
+  #     releaseBranchExists: ${{ steps.checkout.outputs.exists }}
+  #   steps:
+  #     - name: Check if latest release branch exists
+  #       id: checkout
+  #       run: |
+  #         branch="4.5"
+  #         if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
+  #           echo "::set-output name=exists::true"
+  #         else
+  #           echo "::set-output name=exists::false"
+  #         fi
 
-  protect-pr:
-    runs-on: ubuntu-latest
-    needs: validate_release_branch
-    if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'false' }}
-    steps:
-      - name: Check date and labels
-        id: check-date-and-labels
-        run: |
-          # Does this PR have the acknowledgement label?
-          has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-the-release')}}"
+  # protect-pr:
+  #   runs-on: ubuntu-latest
+  #   needs: validate_release_branch
+  #   if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'false' }}
+  #   steps:
+  #     - name: Check date and labels
+  #       id: check-date-and-labels
+  #       run: |
+  #         # Does this PR have the acknowledgement label?
+  #         has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-the-release')}}"
 
-          # According to the handbook [https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#when-we-release], we
-          # release on the 22nd of each month, If the 22nd falls on a non-working day,
-          # the release captain will shift the release earlier to the last working day before the 22nd.
+  #         # According to the handbook [https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#when-we-release], we
+  #         # release on the 22nd of each month, If the 22nd falls on a non-working day,
+  #         # the release captain will shift the release earlier to the last working day before the 22nd.
 
-          # ALL dates must be in the format YYYY-MM-DD
+  #         # ALL dates must be in the format YYYY-MM-DD
 
-          # This returns true or false depending on if the date passed is a working day.
-          # We use this to adjust the release date / freeze date from the usual date defined in
-          # the handbook.
-          function is_weekend() {
-            # Parse the date string
-            local date_string="$1"
-            # Get the day of the week (0-6, where Sunday is 0)
-            local day_of_week
-            day_of_week=$(date -d "$date_string" +%u)
-            # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
-            if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
-              return 0
-            else
-              return 1
-            fi
-          }
+  #         # This returns true or false depending on if the date passed is a working day.
+  #         # We use this to adjust the release date / freeze date from the usual date defined in
+  #         # the handbook.
+  #         function is_weekend() {
+  #           # Parse the date string
+  #           local date_string="$1"
+  #           # Get the day of the week (0-6, where Sunday is 0)
+  #           local day_of_week
+  #           day_of_week=$(date -d "$date_string" +%u)
+  #           # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
+  #           if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
+  #             return 0
+  #           else
+  #             return 1
+  #           fi
+  #         }
 
-          # Use the this to get the last working day before the date passed in as an argument
-          function find_last_working_day() {
-            local date_string="$1"
-            while is_weekend "$date_string"; do
-              date_string=$(date -d "$date_string 1 day ago" +%F)
-            done
-            echo "$date_string"
-          }
+  #         # Use the this to get the last working day before the date passed in as an argument
+  #         function find_last_working_day() {
+  #           local date_string="$1"
+  #           while is_weekend "$date_string"; do
+  #             date_string=$(date -d "$date_string 1 day ago" +%F)
+  #           done
+  #           echo "$date_string"
+  #         }
 
-          function get_closest_working_day() {
-            if [ -z "$1" ]; then
-              echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
-              return 1
-            fi
+  #         function get_closest_working_day() {
+  #           if [ -z "$1" ]; then
+  #             echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+  #             return 1
+  #           fi
 
-            local date_to_check="$1"
-            if is_weekend "$date_to_check"; then
-              date_to_check=$(find_last_working_day "$date_to_check")
-            fi
-            echo "$date_to_check"
-          }
+  #           local date_to_check="$1"
+  #           if is_weekend "$date_to_check"; then
+  #             date_to_check=$(find_last_working_day "$date_to_check")
+  #           fi
+  #           echo "$date_to_check"
+  #         }
 
-          function get_epoch() {
-            if [ -z "$1" ]; then
-              echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
-              return 1
-            fi
+  #         function get_epoch() {
+  #           if [ -z "$1" ]; then
+  #             echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+  #             return 1
+  #           fi
 
-            date -d "$1" +%s
-          }
+  #           date -d "$1" +%s
+  #         }
 
-          release_day=22
-          current_month=$(date +'%m')
-          current_year=$(date +'%Y')
+  #         release_day=22
+  #         current_month=$(date +'%m')
+  #         current_year=$(date +'%Y')
 
-          release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
-          cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
-          if [ "$current_month" -eq "03" ]; then
-            freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 4 days" +%F)")
-          else
-            freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
-          fi
-          todays_date=$(date +'%Y-%m-%d %H:%M')
+  #         release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
+  #         cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
+  #         if [ "$current_month" -eq "03" ]; then
+  #           freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 4 days" +%F)")
+  #         else
+  #           freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
+  #         fi
+  #         todays_date=$(date +'%Y-%m-%d %H:%M')
 
-          todays_date_epoch=$(get_epoch "$todays_date")
-          freeze_date_epoch=$(get_epoch "$freeze_date 00:00")
-          release_date_epoch=$(get_epoch "$release_date 23:59")
+  #         todays_date_epoch=$(get_epoch "$todays_date")
+  #         freeze_date_epoch=$(get_epoch "$freeze_date 00:00")
+  #         release_date_epoch=$(get_epoch "$release_date 23:59")
 
-          if [ "$todays_date_epoch" -ge "$freeze_date_epoch" ] && [ "$todays_date_epoch" -lt "$release_date_epoch" ]; then
-            if [ "${has_label}" = "true" ]; then
-              echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
-              exit 0
-            else
-              echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
-              echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
-              echo "❓ The code freeze is active until ${release_date} at 23:59 UTC."
-              echo "release_date=${release_date}" >> $GITHUB_ENV
-              exit 1
-            fi
-          else
-            echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
-            exit 0
-          fi
-      - name: "Post comment if failed"
-        uses: actions/github-script@v6
-        # We need always() otherwise, the step won't run if the previous one exited, regardless of the predicate value when evaluated.
-        #
-        # Because we have other actions labeling the PR, they can trigger the entire job to run twice simultaneously, preventing the
-        # code ensuring that we're not commenting again if a comment has been posted by us. Basically, with cla-bot labels being instant
-        # means that this job is ran twice at the same time, but always second.
-        # To fix that, we specifically check the event.label.name value and the event.action.
-        #
-        # In essence, we're always running the check, but only commenting if we really need to. This can't be done at the job level, because
-        # it would be mean the job would be first run by the pr creation, but then skipped when the cla-bot triggered job completes, which
-        # is very confusing for the user in the UI (you get a comment about a failure, but it appears skipped).
-        if: |-
-          always()
-          &&
-          steps.check-date-and-labels.outcome != 'success'
-          &&
-          (
-            (
-              contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
-              &&
-              github.event.label.name == 'i-acknowledge-this-goes-into-the-release'
-            )
-            ||
-            !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
-          )
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            let d = new Date()
-            d.setHours(d.getHours() -1) // Yes, this handles properly midnight.
+  #         if [ "$todays_date_epoch" -ge "$freeze_date_epoch" ] && [ "$todays_date_epoch" -lt "$release_date_epoch" ]; then
+  #           if [ "${has_label}" = "true" ]; then
+  #             echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
+  #             exit 0
+  #           else
+  #             echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
+  #             echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
+  #             echo "❓ The code freeze is active until ${release_date} at 23:59 UTC."
+  #             echo "release_date=${release_date}" >> $GITHUB_ENV
+  #             exit 1
+  #           fi
+  #         else
+  #           echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
+  #           exit 0
+  #         fi
+  #     - name: "Post comment if failed"
+  #       uses: actions/github-script@v6
+  #       # We need always() otherwise, the step won't run if the previous one exited, regardless of the predicate value when evaluated.
+  #       #
+  #       # Because we have other actions labeling the PR, they can trigger the entire job to run twice simultaneously, preventing the
+  #       # code ensuring that we're not commenting again if a comment has been posted by us. Basically, with cla-bot labels being instant
+  #       # means that this job is ran twice at the same time, but always second.
+  #       # To fix that, we specifically check the event.label.name value and the event.action.
+  #       #
+  #       # In essence, we're always running the check, but only commenting if we really need to. This can't be done at the job level, because
+  #       # it would be mean the job would be first run by the pr creation, but then skipped when the cla-bot triggered job completes, which
+  #       # is very confusing for the user in the UI (you get a comment about a failure, but it appears skipped).
+  #       if: |-
+  #         always()
+  #         &&
+  #         steps.check-date-and-labels.outcome != 'success'
+  #         &&
+  #         (
+  #           (
+  #             contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
+  #             &&
+  #             github.event.label.name == 'i-acknowledge-this-goes-into-the-release'
+  #           )
+  #           ||
+  #           !contains(fromJSON('["labeled", "unlabeled"]'), github.event.action)
+  #         )
+  #       with:
+  #         github-token: ${{secrets.GITHUB_TOKEN}}
+  #         script: |
+  #           let d = new Date()
+  #           d.setHours(d.getHours() -1) // Yes, this handles properly midnight.
 
-            let body = `❌ **Problem**: the label \`i-acknowledge-this-goes-into-the-release\` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with \`i-acknowledge-this-goes-into-the-release\`.\n❓ **When does the freeze end?** The code freeze is active until ${process.env.release_date} at 23:59 UTC.`
-            let skip = false
+  #           let body = `❌ **Problem**: the label \`i-acknowledge-this-goes-into-the-release\` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with \`i-acknowledge-this-goes-into-the-release\`.\n❓ **When does the freeze end?** The code freeze is active until ${process.env.release_date} at 23:59 UTC.`
+  #           let skip = false
 
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              since: d.toISOString(),
-            })
+  #           const { data: comments } = await github.rest.issues.listComments({
+  #             issue_number: context.issue.number,
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             since: d.toISOString(),
+  #           })
 
-            if (Array.isArray(comments) && comments.length > 0) {
-              comments.forEach((comment => {
-                if (comment.body == body) {
-                  skip = true
-                }
-              }))
-            }
+  #           if (Array.isArray(comments) && comments.length > 0) {
+  #             comments.forEach((comment => {
+  #               if (comment.body == body) {
+  #                 skip = true
+  #               }
+  #             }))
+  #           }
 
-            if (!skip) {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body,
-              })
-            }
+  #           if (!skip) {
+  #             await github.rest.issues.createComment({
+  #               issue_number: context.issue.number,
+  #               owner: context.repo.owner,
+  #               repo: context.repo.repo,
+  #               body: body,
+  #             })
+  #           }

--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check if latest release branch exists
         id: checkout
         run: |
-          branch="4.5"
+          branch="4.6"
           if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
             echo "::set-output name=exists::true"
           else

--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check if latest release branch exists
         id: checkout
         run: |
-          branch="4.6"
+          branch="4.5"
           if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
             echo "::set-output name=exists::true"
           else

--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -7,6 +7,12 @@ on:
       - main
 
 jobs:
+  disable_release_protector:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable workflow
+        run: exit 0
+
   validate_release_branch:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}


### PR DESCRIPTION
The release protector keeps firing after branch cut (possibly due to a rate limit hit on GitHub's API), we are working on not [using this action anymore for > 4.6](https://sourcegraph.slack.com/archives/C032Z79NZQC/p1676665768875939?thread_ts=1676664110.264459&cid=C032Z79NZQC) (pending confirmation from Coury), so I'm temporarily disabling this to allow folks merge PRs.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
This PR is the test.