### PR TITLE
notebooks: Group notebook routes

### DIFF
--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -6,15 +6,9 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { isCodeInsightsEnabled } from '../insights/utils/is-code-insights-enabled'
 import { LayoutRouteProps, routes } from '../routes'
-import { EnterprisePageRoutes, PageRoutes } from '../routes.constants'
-import { useExperimentalFeatures } from '../stores'
+import { EnterprisePageRoutes } from '../routes.constants'
 
-const NotebookPage = lazyComponent(() => import('../notebooks/notebookPage/NotebookPage'), 'NotebookPage')
-const CreateNotebookPage = lazyComponent(
-    () => import('../notebooks/createPage/CreateNotebookPage'),
-    'CreateNotebookPage'
-)
-const NotebooksListPage = lazyComponent(() => import('../notebooks/listPage/NotebooksListPage'), 'NotebooksListPage')
+const GlobalNotebooksArea = lazyComponent(() => import('../notebooks/GlobalNotebooksArea'), 'GlobalNotebooksArea')
 const GlobalBatchChangesArea = lazyComponent(
     () => import('./batches/global/GlobalBatchChangesArea'),
     'GlobalBatchChangesArea'
@@ -85,30 +79,8 @@ export const enterpriseRoutes: readonly LayoutRouteProps[] = [
         render: () => <Navigate to={EnterprisePageRoutes.Notebooks} replace={true} />,
     },
     {
-        path: EnterprisePageRoutes.NotebookCreate,
-        render: props =>
-            useExperimentalFeatures.getState().showSearchNotebook && props.authenticatedUser ? (
-                <CreateNotebookPage {...props} authenticatedUser={props.authenticatedUser} />
-            ) : (
-                <Navigate to={EnterprisePageRoutes.Notebooks} replace={true} />
-            ),
-    },
-    {
-        path: EnterprisePageRoutes.Notebook,
-        render: props => {
-            const { showSearchNotebook } = useExperimentalFeatures.getState()
-
-            return showSearchNotebook ? <NotebookPage {...props} /> : <Navigate to={PageRoutes.Search} replace={true} />
-        },
-    },
-    {
-        path: EnterprisePageRoutes.Notebooks,
-        render: props =>
-            useExperimentalFeatures.getState().showSearchNotebook ? (
-                <NotebooksListPage {...props} />
-            ) : (
-                <Navigate to={PageRoutes.Search} replace={true} />
-            ),
+        path: EnterprisePageRoutes.Notebooks + '/*',
+        render: props => <GlobalNotebooksArea {...props} />,
     },
     {
         path: EnterprisePageRoutes.Cody,

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -1,0 +1,60 @@
+import React, { FC } from 'react'
+
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat'
+import type { Observable } from 'rxjs'
+
+import { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { SearchContextProps } from '@sourcegraph/shared/src/search'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+
+import { AuthenticatedUser } from '../auth'
+import { EnterprisePageRoutes } from '../routes.constants'
+import { SearchStreamingProps } from '../search'
+
+import { NotebookProps } from '.'
+
+const NotebookPage = lazyComponent(() => import('./notebookPage/NotebookPage'), 'NotebookPage')
+const CreateNotebookPage = lazyComponent(() => import('./createPage/CreateNotebookPage'), 'CreateNotebookPage')
+const NotebooksListPage = lazyComponent(() => import('./listPage/NotebooksListPage'), 'NotebooksListPage')
+
+export interface GlobalNotebooksAreaProps
+    extends ThemeProps,
+        TelemetryProps,
+        PlatformContextProps,
+        SettingsCascadeProps,
+        NotebookProps,
+        SearchStreamingProps,
+        SearchContextProps {
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+    globbing: boolean
+}
+/**
+ * The global code monitoring area.
+ */
+export const GlobalNotebooksArea: FC<React.PropsWithChildren<GlobalNotebooksAreaProps>> = ({
+    authenticatedUser,
+    ...outerProps
+}) => {
+    return (
+        <Routes>
+            <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+            <Route
+                path="new"
+                element={
+                    authenticatedUser ? (
+                        <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
+                    ) : (
+                        <Navigate to={EnterprisePageRoutes.Notebooks} replace={true} />
+                    )
+                }
+            />
+            <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+        </Routes>
+    )
+}

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import type { Observable } from 'rxjs'
 
 import { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -40,21 +40,19 @@ export interface GlobalNotebooksAreaProps
 export const GlobalNotebooksArea: FC<React.PropsWithChildren<GlobalNotebooksAreaProps>> = ({
     authenticatedUser,
     ...outerProps
-}) => {
-    return (
-        <Routes>
-            <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-            <Route
-                path="new"
-                element={
-                    authenticatedUser ? (
-                        <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
-                    ) : (
-                        <Navigate to={EnterprisePageRoutes.Notebooks} replace={true} />
-                    )
-                }
-            />
-            <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
-        </Routes>
-    )
-}
+}) => (
+    <Routes>
+        <Route index={true} element={<NotebooksListPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+        <Route
+            path="new"
+            element={
+                authenticatedUser ? (
+                    <CreateNotebookPage authenticatedUser={authenticatedUser} {...outerProps} />
+                ) : (
+                    <Navigate to={EnterprisePageRoutes.Notebooks} replace={true} />
+                )
+            }
+        />
+        <Route path=":id" element={<NotebookPage authenticatedUser={authenticatedUser} {...outerProps} />} />
+    </Routes>
+)

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -10,8 +10,6 @@ const defaultSettings: SettingsExperimentalFeatures = {
      * Whether we show the multiline editor at /search/console
      */
     showMultilineSearchConsole: false,
-    showSearchContext: true,
-    showSearchNotebook: true,
     codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
     codeInsightsCompute: false,

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -10,6 +10,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
      * Whether we show the multiline editor at /search/console
      */
     showMultilineSearchConsole: false,
+    showSearchContext: true,
     codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
     codeInsightsCompute: false,


### PR DESCRIPTION
This PR consolidates notebook routes into a single component.

I hope that doesn't interfere with the React router migration efforts. It makes it easier to integrate notebooks with the SvelteKit app and is also more in line with how other product areas are structured (e.g. insights, code monitors, ...).

This also removes the use of `showSearchNotebooks`, which has been removed in https://github.com/sourcegraph/sourcegraph/pull/46086.

(note: Adding people as reviewers who have better knowledge about react router than me)

## Test plan

- When signed out I can see a list of public notebooks and open public notebooks
  - Going to `/notebooks/new` redirects to the notebooks list page
- When signed in I see my own notebooks, can open my own notebooks and can create new notebooks.

## App preview:

- [Web](https://sg-web-fkling-notebook-routes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
