### PR TITLE
perforce: expose changelist and file revision data via GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4794,6 +4794,10 @@ type GitCommit implements Node {
     """
     abbreviatedOID: String!
     """
+    The changelist number in the Perforce depot submitted with this commit.
+    """
+    changelist: Int
+    """
     This commit's author.
     """
     author: Signature!
@@ -5567,6 +5571,10 @@ type GitBlob implements TreeEntry & File2 {
     The Git commit containing this blob.
     """
     commit: GitCommit!
+    """
+    The file revision at this commit on Perforce.
+    """
+    revision: Int
     """
     The repository containing this Git blob.
     """


### PR DESCRIPTION
Exposes changelist and file revision data for Perforce repos (depots).

## Test plan
TODO

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
