### PR TITLE
batches: expose fork name changesets graphql

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -781,7 +781,12 @@ type ExternalChangesetResolver interface {
 	Body(context.Context) (*string, error)
 	Author() (*PersonResolver, error)
 	ExternalURL() (*externallink.Resolver, error)
+
+	// If the changeset is a fork, this corresponds to the namespace of the fork.
 	ForkNamespace() *string
+	// If the changeset is a fork, this corresponds to the name of the fork.
+	ForkName() *string
+
 	// ReviewState returns a value of type *btypes.ChangesetReviewState.
 	ReviewState(context.Context) *string
 	// CheckState returns a value of type *btypes.ChangesetCheckState.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -418,6 +418,10 @@ type ExternalChangeset implements Node & Changeset {
     host).
     """
     forkNamespace: String
+    """
+    If the changeset was opened from a fork, this is the name of the fork repository.
+    """
+    forkName: String
 
     """
     The review state of this changeset. This is only set once the changeset is published on the code host.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -140,6 +140,7 @@ type Changeset struct {
 	ExternalID         string
 	ExternalURL        ExternalURL
 	ForkNamespace      string
+	ForkName           string
 	ReviewState        string
 	CheckState         string
 	Events             ChangesetEventConnection

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -210,6 +210,7 @@ func TestChangesetResolver(t *testing.T) {
 		ExternalServiceType:   "github",
 		ExternalID:            "98765",
 		ExternalForkNamespace: "user",
+		ExternalForkName:      "user",
 		PublicationState:      btypes.ChangesetPublicationStateUnpublished,
 		ReconcilerState:       btypes.ReconcilerStateQueued,
 	})
@@ -372,6 +373,7 @@ func TestChangesetResolver(t *testing.T) {
 				Typename:      "ExternalChangeset",
 				ExternalID:    "98765",
 				ForkNamespace: "user",
+				ForkName:      "user",
 				Repository:    apitest.Repository{Name: string(repo.Name)},
 				Labels:        []apitest.Label{},
 				State:         string(btypes.ChangesetStateProcessing),
@@ -432,6 +434,7 @@ query($changeset: ID!) {
 
       externalID
       forkNamespace
+	  forkName
       state
       reviewState
       checkState

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -210,7 +210,7 @@ func TestChangesetResolver(t *testing.T) {
 		ExternalServiceType:   "github",
 		ExternalID:            "98765",
 		ExternalForkNamespace: "user",
-		ExternalForkName:      "user",
+		ExternalForkName:      "my-fork",
 		PublicationState:      btypes.ChangesetPublicationStateUnpublished,
 		ReconcilerState:       btypes.ReconcilerStateQueued,
 	})

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -373,7 +373,7 @@ func TestChangesetResolver(t *testing.T) {
 				Typename:      "ExternalChangeset",
 				ExternalID:    "98765",
 				ForkNamespace: "user",
-				ForkName:      "user",
+				ForkName:      "my-fork",
 				Repository:    apitest.Repository{Name: string(repo.Name)},
 				Labels:        []apitest.Label{},
 				State:         string(btypes.ChangesetStateProcessing),

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -25,6 +25,7 @@ type TestChangesetOpts struct {
 	ExternalID            string
 	ExternalBranch        string
 	ExternalForkNamespace string
+	ExternalForkName      string
 	ExternalState         btypes.ChangesetExternalState
 	ExternalReviewState   btypes.ChangesetReviewState
 	ExternalCheckState    btypes.ChangesetCheckState
@@ -113,6 +114,10 @@ func BuildChangeset(opts TestChangesetOpts) *btypes.Changeset {
 
 	if opts.ExternalForkNamespace != "" {
 		changeset.ExternalForkNamespace = opts.ExternalForkNamespace
+	}
+
+	if opts.ExternalForkName != "" {
+		changeset.ExternalForkName = opts.ExternalForkName
 	}
 
 	if opts.FailureMessage != "" {


### PR DESCRIPTION
This is a part of #46967. `ForkName` is one of the fields on the webhook payload for a changeset, we don't currently expose `ForkName` via the GraphQL API, this PR fixes that. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Update unit tests for forked changesets

<img width="1199" alt="CleanShot 2023-02-20 at 19 30 43@2x" src="https://user-images.githubusercontent.com/25608335/220178496-7f7a19b6-4c85-4714-8f13-2aceab9cc1dc.png">
