### PR TITLE
batches: expose owning batch change for changesets

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -756,6 +756,7 @@ type ChangesetResolver interface {
 	// State returns a value of type *btypes.ChangesetState.
 	State() string
 	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
+	OwnedByBatchChange() *graphql.ID
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)
 	ToHiddenExternalChangeset() (HiddenExternalChangesetResolver, bool)

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -756,7 +756,6 @@ type ChangesetResolver interface {
 	// State returns a value of type *btypes.ChangesetState.
 	State() string
 	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
-	OwnedByBatchChange() *graphql.ID
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)
 	ToHiddenExternalChangeset() (HiddenExternalChangesetResolver, bool)
@@ -782,6 +781,8 @@ type ExternalChangesetResolver interface {
 	Body(context.Context) (*string, error)
 	Author() (*PersonResolver, error)
 	ExternalURL() (*externallink.Resolver, error)
+
+	OwnedByBatchChange() *graphql.ID
 
 	// If the changeset is a fork, this corresponds to the namespace of the fork.
 	ForkNamespace() *string

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -355,6 +355,11 @@ type ExternalChangeset implements Node & Changeset {
     ): BatchChangeConnection!
 
     """
+    The batch change that "owns" this changeset: If this is null, it is imported/tracked by a batch change.
+    """
+    ownedByBatchChange: ID
+
+    """
     The events belonging to this changeset.
     """
     events(first: Int = 50, after: String): ChangesetEventConnection!

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -125,10 +125,13 @@ type ExternalURL struct {
 }
 
 type Changeset struct {
-	Typename           string `json:"__typename"`
-	ID                 string
-	Repository         Repository
+	Typename   string `json:"__typename"`
+	ID         string
+	Repository Repository
+
 	BatchChanges       BatchChangeConnection
+	OwnedByBatchChange *string
+
 	CreatedAt          string
 	UpdatedAt          string
 	NextSyncAt         string

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -194,7 +194,7 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 
 // This points to the Batch Change that can close or open this changeset on its codehost. If this is nil,
 // then the changeset is imported.
-func (r *changesetResolver) OwnedByBatchChange(ctx context.Context) *graphql.ID {
+func (r *changesetResolver) OwnedByBatchChange() *graphql.ID {
 	if batchChangeID := r.changeset.OwnedByBatchChangeID; batchChangeID != 0 {
 		bcID := bgql.MarshalBatchChangeID(batchChangeID)
 		return &bcID

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -192,6 +192,16 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 	return &batchChangesConnectionResolver{store: r.store, gitserverClient: r.gitserverClient, opts: opts}, nil
 }
 
+// This points to the Batch Change that can close or open this changeset on its codehost. If this is nil,
+// then the changeset is imported.
+func (r *changesetResolver) OwnedByBatchChange(ctx context.Context) *graphql.ID {
+	if batchChangeID := r.changeset.OwnedByBatchChangeID; batchChangeID != 0 {
+		bcID := bgql.MarshalBatchChangeID(batchChangeID)
+		return &bcID
+	}
+	return nil
+}
+
 func (r *changesetResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.changeset.CreatedAt}
 }

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -19,6 +19,7 @@ type TestChangesetOpts struct {
 	BatchChange  int64
 	CurrentSpec  int64
 	PreviousSpec int64
+
 	BatchChanges []btypes.BatchChangeAssoc
 
 	ExternalServiceType   string


### PR DESCRIPTION
This is also a part of https://github.com/sourcegraph/sourcegraph/pull/46967. We need to expose the id of the batch change that owns a changeset.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Add unit tests