### PR TITLE
gRPC: return nil payload when LocalCodeIntel fails

### DIFF
--- a/cmd/symbols/internal/api/handler_cgo.go
+++ b/cmd/symbols/internal/api/handler_cgo.go
@@ -31,7 +31,11 @@ func (s *grpcService) LocalCodeIntel(ctx context.Context, request *proto.LocalCo
 
 	payload, err := squirrelService.LocalCodeIntel(ctx, args)
 	if err != nil {
-		return nil, err
+		// TODO(camdencheek): This ignores errors from LocalCodeIntel to match the behavior found here:
+		// https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a1631d58604815917096acc3356447c55baebf22/-/blob/cmd/symbols/squirrel/http_handlers.go?L57-57
+		//
+		// This is weird, and maybe not intentional, but things break if we return an error.
+		return nil, nil
 	}
 
 	var response proto.LocalCodeIntelResponse

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -324,8 +324,7 @@ func (c *Client) localCodeIntelGRPC(ctx context.Context, path types.RepoCommitPa
 		return nil, err
 	}
 
-	response := protoResponse.ToInternal()
-	return &response, nil
+	return protoResponse.ToInternal(), nil
 }
 
 func (c *Client) localCodeIntelJSON(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {

--- a/internal/symbols/v1/conversion.go
+++ b/internal/symbols/v1/conversion.go
@@ -174,14 +174,18 @@ func (x *LocalCodeIntelResponse) FromInternal(p *types.LocalCodeIntelPayload) {
 	}
 }
 
-func (x *LocalCodeIntelResponse) ToInternal() types.LocalCodeIntelPayload {
+func (x *LocalCodeIntelResponse) ToInternal() *types.LocalCodeIntelPayload {
+	if x == nil {
+		return nil
+	}
+
 	symbols := make([]types.Symbol, 0, len(x.GetSymbols()))
 
 	for _, s := range x.GetSymbols() {
 		symbols = append(symbols, s.ToInternal())
 	}
 
-	return types.LocalCodeIntelPayload{
+	return &types.LocalCodeIntelPayload{
 		Symbols: symbols,
 	}
 }

--- a/internal/symbols/v1/conversion_test.go
+++ b/internal/symbols/v1/conversion_test.go
@@ -127,7 +127,7 @@ func Test_Internal_Types_LocalCodeIntelPayload_ProtoRoundTrip(t *testing.T) {
 
 		converted := originalProto.ToInternal()
 
-		if diff = cmp.Diff(original, converted, cmpopts.EquateEmpty()); diff != "" {
+		if diff = cmp.Diff(&original, converted, cmpopts.EquateEmpty()); diff != "" {
 			return false
 		}
 


### PR DESCRIPTION
Our client code expects a nil payload when LocalCodeIntel fails. This seems to be used as a sentinel to fall back to search-based code intel in the client code. For the gRPC implementation, we propagated any errors we received, but this actually ends up breaking things because errors cause the client to not fall back to search-based code intel and instead throw the error.

@sourcegraph/code-intel, this feels like a hack. This probably isn't the best way to solve this, but I don't want to get distracted right now. Feel free to follow up with a less hacky fix. 

## Test plan

Tested locally that I would get RPC errors showing up in the client when the `grpc` flag was enabled, but applying this fix let the client fall back to search-based code intel.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
