### PR TITLE
Gitserver: centralize address resolution in `GitserverAddresses`

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -173,7 +173,7 @@ const reposStatsName = "repos-stats.json"
 // 10. Perform sg-maintenance
 // 11. Git prune
 // 12. Only during first run: Set sizes of repos which don't have it in a database.
-func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.GitServerAddresses) {
+func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.GitserverAddresses) {
 	janitorRunning.Set(1)
 	janitorStart := time.Now()
 	defer func() {

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -86,7 +86,7 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos(actor.WithInternalActor(context.Background()), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(actor.WithInternalActor(context.Background()), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), api.RepoID(i))
@@ -151,7 +151,7 @@ func TestCleanupInactive(t *testing.T) {
 		DB:             database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
 		t.Error("expected repoA not to be removed")
@@ -186,7 +186,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "does-not-exist"
-		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
+		s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -219,7 +219,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "gitserver-0"
-		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}})
+		s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -252,7 +252,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		wrongShardReposDeleteLimit = -1
-		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
+		s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); os.IsNotExist(err) {
 			t.Error("expected repoA not to be removed")
@@ -320,7 +320,7 @@ func TestGitGCAuto(t *testing.T) {
 		DB:             database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	// Verify that there are no more GC-able objects in the repository.
 	if !strings.Contains(countObjects(), "count: 0") {
@@ -442,7 +442,7 @@ func TestCleanupExpired(t *testing.T) {
 		DB: database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	// repos that shouldn't be re-cloned
 	if repoNewTime.Before(modTime(repoNew)) {
@@ -548,7 +548,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		s.testSetup(t)
 		s.DB = mockDB
 
-		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+		s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 		// nothing should happen if test env not declared to true
 		if _, err := os.Stat(repoExists); err != nil {
@@ -568,7 +568,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		s.testSetup(t)
 		s.DB = mockDB
 
-		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+		s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 		if _, err := os.Stat(repoNotExists); err == nil {
 			t.Fatal("repo not existing in DB was not removed")
@@ -710,7 +710,7 @@ func TestCleanupOldLocks(t *testing.T) {
 
 	s := &Server{ReposDir: root, Logger: logtest.Scoped(t), ObservationCtx: observation.TestContextTB(t), DB: database.NewMockDB()}
 	s.testSetup(t)
-	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	isRemoved := func(path string) bool {
 		_, err := os.Stat(path)
@@ -1571,7 +1571,7 @@ update gitserver_repos set repo_size_bytes = 228 where repo_id = 1;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -627,7 +627,7 @@ func (s *Server) Handler() http.Handler {
 // background goroutine.
 func (s *Server) Janitor(ctx context.Context, interval time.Duration) {
 	for {
-		gitserverAddrs := currentGitserverAddresses()
+		gitserverAddrs := gitserver.NewGitserverAddressesFromConf()
 		s.cleanupRepos(actor.WithInternalActor(ctx), gitserverAddrs)
 		time.Sleep(interval)
 	}
@@ -641,7 +641,7 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 	var previousAddrs string
 	var previousPinned string
 	for {
-		gitServerAddrs := currentGitserverAddresses()
+		gitServerAddrs := gitserver.NewGitserverAddressesFromConf()
 		addrs := gitServerAddrs.Addresses
 		// We turn addrs into a string here for easy comparison and storage of previous
 		// addresses since we'd need to take a copy of the slice anyway.
@@ -670,18 +670,6 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 
 func (s *Server) addrForRepo(repoName api.RepoName, gitServerAddrs gitserver.GitServerAddresses) string {
 	return gitServerAddrs.AddrForRepo(filepath.Base(os.Args[0]), repoName)
-}
-
-func currentGitserverAddresses() gitserver.GitServerAddresses {
-	cfg := conf.Get()
-	gitServerAddrs := gitserver.GitServerAddresses{
-		Addresses: cfg.ServiceConnectionConfig.GitServers,
-	}
-	if cfg.ExperimentalFeatures != nil {
-		gitServerAddrs.PinnedServers = cfg.ExperimentalFeatures.GitServerPinnedRepos
-	}
-
-	return gitServerAddrs
 }
 
 // StartClonePipeline clones repos asynchronously. It creates a producer-consumer

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -668,7 +668,7 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 	}
 }
 
-func (s *Server) addrForRepo(repoName api.RepoName, gitServerAddrs gitserver.GitServerAddresses) string {
+func (s *Server) addrForRepo(repoName api.RepoName, gitServerAddrs gitserver.GitserverAddresses) string {
 	return gitServerAddrs.AddrForRepo(filepath.Base(os.Args[0]), repoName)
 }
 
@@ -783,7 +783,7 @@ var (
 	})
 )
 
-func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batchSize, perSecond int, fullSync bool) error {
+func (s *Server) syncRepoState(gitServerAddrs gitserver.GitserverAddresses, batchSize, perSecond int, fullSync bool) error {
 	s.Logger.Debug("starting syncRepoState", log.Bool("fullSync", fullSync))
 	addrs := gitServerAddrs.Addresses
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -669,7 +669,7 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 }
 
 func (s *Server) addrForRepo(repoName api.RepoName, gitServerAddrs gitserver.GitServerAddresses) string {
-	return gitserver.AddrForRepo(filepath.Base(os.Args[0]), repoName, gitServerAddrs)
+	return gitServerAddrs.AddrForRepo(filepath.Base(os.Args[0]), repoName)
 }
 
 func currentGitserverAddresses() gitserver.GitServerAddresses {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -1407,7 +1407,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.syncRepoState(gitserver.GitServerAddresses{Addresses: []string{hostname}}, 10, 10, true)
+	err = s.syncRepoState(gitserver.GitserverAddresses{Addresses: []string{hostname}}, 10, 10, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1432,7 +1432,7 @@ func TestSyncRepoState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = s.syncRepoState(gitserver.GitServerAddresses{Addresses: []string{hostname}}, 10, 10, true)
+		err = s.syncRepoState(gitserver.GitserverAddresses{Addresses: []string{hostname}}, 10, 10, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -34,7 +34,12 @@ func newTestGitserverAddresses(addrs []string) GitServerAddresses {
 }
 
 type GitServerAddresses struct {
-	Addresses     []string
+	// The current list of gitserver addresses
+	Addresses []string
+
+	// A list of overrides to pin a repo to a specific gitserver instance. This
+	// ensures that, even if the number of gitservers changes, these repos will
+	// not be moved.
 	PinnedServers map[string]string
 }
 

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -1,0 +1,184 @@
+package gitserver
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"google.golang.org/grpc"
+)
+
+var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "src_gitserver_addr_for_repo_invoked",
+	Help: "Number of times gitserver.AddrForRepo was invoked",
+}, []string{"user_agent"})
+
+type GitServerAddresses struct {
+	Addresses     []string
+	PinnedServers map[string]string
+}
+
+func (g *GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
+	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
+	rs := string(repo)
+
+	if pinnedAddr, ok := g.PinnedServers[rs]; ok {
+		return pinnedAddr
+	}
+
+	return addrForKey(rs, g.Addresses)
+}
+
+func newConfPicker() addrPicker {
+	cp := &atomicPicker{}
+	conf.Watch(func() {
+		cp.update(conf.Get())
+	})
+	return cp
+}
+
+func newTestPicker(addrs []string) addrPicker {
+	cp := &atomicPicker{}
+
+	errTest := errors.New("grpc connections not available in test picker")
+	conns := make(map[string]connErr, len(addrs))
+	for _, addr := range addrs {
+		conns[addr] = connErr{err: errTest}
+	}
+
+	cp.cur.Store(&addrsAndConns{
+		GitServerAddresses: GitServerAddresses{
+			Addresses:     addrs,
+			PinnedServers: nil,
+		},
+		conns: conns,
+	})
+
+	return cp
+}
+
+type addrPicker interface {
+	addrs() []string
+	addrForRepo(userAgent string, repo api.RepoName) string
+	connForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error)
+}
+
+type atomicPicker struct {
+	cur atomic.Pointer[addrsAndConns]
+}
+
+type addrsAndConns struct {
+	GitServerAddresses
+
+	// invariant: exactly one connection per addr
+	conns map[string]connErr
+}
+
+type connErr struct {
+	conn *grpc.ClientConn
+	err  error
+}
+
+func (c *atomicPicker) addrs() []string {
+	return c.cur.Load().Addresses
+}
+
+func (c *atomicPicker) addrForRepo(userAgent string, repo api.RepoName) string {
+	set := c.cur.Load()
+	return set.AddrForRepo(userAgent, repo)
+}
+
+func (c *atomicPicker) connForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
+	set := c.cur.Load()
+
+	addr := set.AddrForRepo(userAgent, repo)
+	ce := set.conns[addr]
+	return ce.conn, ce.err
+}
+
+func (c *atomicPicker) update(cfg *conf.Unified) {
+	newAddrs := cfg.ServiceConnections().GitServers
+	newPinned := map[string]string(nil)
+	if cfg.ExperimentalFeatures != nil {
+		newPinned = cfg.ExperimentalFeatures.GitServerPinnedRepos
+	}
+
+	oldAddrSet := c.cur.Load()
+
+	// Diff the old and new addresses
+	added, removed, unchanged := diffStrings(oldAddrSet.Addresses, newAddrs)
+	newConns := make(map[string]connErr, len(newAddrs))
+
+	// For each address that hasn't changed, reuse the gRPC connection
+	for _, addr := range unchanged {
+		newConns[addr] = oldAddrSet.conns[addr]
+	}
+
+	// For each new address, open a new gRPC connection
+	for _, addr := range added {
+		conn, err := grpc.Dial(addr, defaults.DialOptions()...)
+		newConns[addr] = connErr{conn: conn, err: err}
+	}
+
+	if len(newAddrs) != len(newConns) {
+		panic("violated invariant: addrs is not the same size as conns")
+	}
+
+	// Store the updated set of addrs in the picker
+	newSet := addrsAndConns{
+		GitServerAddresses: GitServerAddresses{
+			Addresses:     newAddrs,
+			PinnedServers: newPinned,
+		},
+		conns: newConns,
+	}
+	c.cur.Store(&newSet)
+
+	// After storing the updated value, close the old connections
+	for _, addr := range removed {
+		c := oldAddrSet.conns[addr]
+		if c.err != nil {
+			// Skip the connection if opening it failed
+			continue
+		}
+		c.conn.Close()
+	}
+}
+
+func diffStrings(before, after []string) (added, removed, unchanged []string) {
+	beforeSet := make(map[string]struct{})
+	for _, addr := range before {
+		beforeSet[addr] = struct{}{}
+	}
+
+	for _, addr := range after {
+		_, ok := beforeSet[addr]
+		if ok {
+			unchanged = append(unchanged, addr)
+			delete(beforeSet, addr)
+		} else {
+			added = append(added, addr)
+		}
+	}
+
+	for addr := range beforeSet {
+		removed = append(removed, addr)
+	}
+
+	return added, removed, unchanged
+}
+
+// addrForKey returns the gitserver address to use for the given string key,
+// which is hashed for sharding purposes.
+func addrForKey(key string, addrs []string) string {
+	sum := md5.Sum([]byte(key))
+	serverIndex := binary.BigEndian.Uint64(sum[:]) % uint64(len(addrs))
+	return addrs[serverIndex]
+}

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -18,9 +18,9 @@ var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 
 // NewGitserverAddressesFromConf fetches the current set of gitserver addresses
 // and pinned repos for gitserver.
-func NewGitserverAddressesFromConf() GitServerAddresses {
+func NewGitserverAddressesFromConf() GitserverAddresses {
 	cfg := conf.Get()
-	addrs := GitServerAddresses{
+	addrs := GitserverAddresses{
 		Addresses: cfg.ServiceConnectionConfig.GitServers,
 	}
 	if cfg.ExperimentalFeatures != nil {
@@ -29,13 +29,13 @@ func NewGitserverAddressesFromConf() GitServerAddresses {
 	return addrs
 }
 
-func newTestGitserverAddresses(addrs []string) GitServerAddresses {
-	return GitServerAddresses{
+func newTestGitserverAddresses(addrs []string) GitserverAddresses {
+	return GitserverAddresses{
 		Addresses: addrs,
 	}
 }
 
-type GitServerAddresses struct {
+type GitserverAddresses struct {
 	// The current list of gitserver addresses
 	Addresses []string
 
@@ -46,7 +46,7 @@ type GitServerAddresses struct {
 }
 
 // AddrForRepo returns the gitserver address to use for the given repo name.
-func (g GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
+func (g GitserverAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
 	addrForRepoInvoked.WithLabelValues(userAgent).Inc()
 
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -3,16 +3,12 @@ package gitserver
 import (
 	"crypto/md5"
 	"encoding/binary"
-	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"google.golang.org/grpc"
 )
 
 var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -20,12 +16,29 @@ var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Number of times gitserver.AddrForRepo was invoked",
 }, []string{"user_agent"})
 
+func NewGitserverAddressesFromConf() GitServerAddresses {
+	cfg := conf.Get()
+	addrs := GitServerAddresses{
+		Addresses: cfg.ServiceConnectionConfig.GitServers,
+	}
+	if cfg.ExperimentalFeatures != nil {
+		addrs.PinnedServers = cfg.ExperimentalFeatures.GitServerPinnedRepos
+	}
+	return addrs
+}
+
+func newTestGitserverAddresses(addrs []string) GitServerAddresses {
+	return GitServerAddresses{
+		Addresses: addrs,
+	}
+}
+
 type GitServerAddresses struct {
 	Addresses     []string
 	PinnedServers map[string]string
 }
 
-func (g *GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
+func (g GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
 	rs := string(repo)
 
@@ -34,145 +47,6 @@ func (g *GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) st
 	}
 
 	return addrForKey(rs, g.Addresses)
-}
-
-func newConfPicker() addrPicker {
-	cp := &atomicPicker{}
-	conf.Watch(func() {
-		cp.update(conf.Get())
-	})
-	return cp
-}
-
-func newTestPicker(addrs []string) addrPicker {
-	cp := &atomicPicker{}
-
-	errTest := errors.New("grpc connections not available in test picker")
-	conns := make(map[string]connErr, len(addrs))
-	for _, addr := range addrs {
-		conns[addr] = connErr{err: errTest}
-	}
-
-	cp.cur.Store(&addrsAndConns{
-		GitServerAddresses: GitServerAddresses{
-			Addresses:     addrs,
-			PinnedServers: nil,
-		},
-		conns: conns,
-	})
-
-	return cp
-}
-
-type addrPicker interface {
-	addrs() []string
-	addrForRepo(userAgent string, repo api.RepoName) string
-	connForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error)
-}
-
-type atomicPicker struct {
-	cur atomic.Pointer[addrsAndConns]
-}
-
-type addrsAndConns struct {
-	GitServerAddresses
-
-	// invariant: exactly one connection per addr
-	conns map[string]connErr
-}
-
-type connErr struct {
-	conn *grpc.ClientConn
-	err  error
-}
-
-func (c *atomicPicker) addrs() []string {
-	return c.cur.Load().Addresses
-}
-
-func (c *atomicPicker) addrForRepo(userAgent string, repo api.RepoName) string {
-	set := c.cur.Load()
-	return set.AddrForRepo(userAgent, repo)
-}
-
-func (c *atomicPicker) connForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
-	set := c.cur.Load()
-
-	addr := set.AddrForRepo(userAgent, repo)
-	ce := set.conns[addr]
-	return ce.conn, ce.err
-}
-
-func (c *atomicPicker) update(cfg *conf.Unified) {
-	newAddrs := cfg.ServiceConnections().GitServers
-	newPinned := map[string]string(nil)
-	if cfg.ExperimentalFeatures != nil {
-		newPinned = cfg.ExperimentalFeatures.GitServerPinnedRepos
-	}
-
-	oldAddrSet := c.cur.Load()
-
-	// Diff the old and new addresses
-	added, removed, unchanged := diffStrings(oldAddrSet.Addresses, newAddrs)
-	newConns := make(map[string]connErr, len(newAddrs))
-
-	// For each address that hasn't changed, reuse the gRPC connection
-	for _, addr := range unchanged {
-		newConns[addr] = oldAddrSet.conns[addr]
-	}
-
-	// For each new address, open a new gRPC connection
-	for _, addr := range added {
-		conn, err := grpc.Dial(addr, defaults.DialOptions()...)
-		newConns[addr] = connErr{conn: conn, err: err}
-	}
-
-	if len(newAddrs) != len(newConns) {
-		panic("violated invariant: addrs is not the same size as conns")
-	}
-
-	// Store the updated set of addrs in the picker
-	newSet := addrsAndConns{
-		GitServerAddresses: GitServerAddresses{
-			Addresses:     newAddrs,
-			PinnedServers: newPinned,
-		},
-		conns: newConns,
-	}
-	c.cur.Store(&newSet)
-
-	// After storing the updated value, close the old connections
-	for _, addr := range removed {
-		c := oldAddrSet.conns[addr]
-		if c.err != nil {
-			// Skip the connection if opening it failed
-			continue
-		}
-		c.conn.Close()
-	}
-}
-
-func diffStrings(before, after []string) (added, removed, unchanged []string) {
-	beforeSet := make(map[string]struct{})
-	for _, addr := range before {
-		beforeSet[addr] = struct{}{}
-	}
-
-	for _, addr := range after {
-		_, ok := beforeSet[addr]
-		if ok {
-			unchanged = append(unchanged, addr)
-			delete(beforeSet, addr)
-		} else {
-			added = append(added, addr)
-		}
-	}
-
-	for addr := range beforeSet {
-		removed = append(removed, addr)
-	}
-
-	return added, removed, unchanged
 }
 
 // addrForKey returns the gitserver address to use for the given string key,

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -16,6 +16,8 @@ var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Number of times gitserver.AddrForRepo was invoked",
 }, []string{"user_agent"})
 
+// NewGitserverAddressesFromConf fetches the current set of gitserver addresses
+// and pinned repos for gitserver.
 func NewGitserverAddressesFromConf() GitServerAddresses {
 	cfg := conf.Get()
 	addrs := GitServerAddresses{
@@ -43,6 +45,7 @@ type GitServerAddresses struct {
 	PinnedServers map[string]string
 }
 
+// AddrForRepo returns the gitserver address to use for the given repo name.
 func (g GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
 	rs := string(repo)

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -47,6 +47,8 @@ type GitServerAddresses struct {
 
 // AddrForRepo returns the gitserver address to use for the given repo name.
 func (g GitServerAddresses) AddrForRepo(userAgent string, repo api.RepoName) string {
+	addrForRepoInvoked.WithLabelValues(userAgent).Inc()
+
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
 	rs := string(repo)
 

--- a/internal/gitserver/addrs_test.go
+++ b/internal/gitserver/addrs_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAddrForRepo(t *testing.T) {
-	ga := GitServerAddresses{
+	ga := GitserverAddresses{
 		Addresses: []string{"gitserver-1", "gitserver-2", "gitserver-3"},
 		PinnedServers: map[string]string{
 			"repo2": "gitserver-1",

--- a/internal/gitserver/addrs_test.go
+++ b/internal/gitserver/addrs_test.go
@@ -1,0 +1,52 @@
+package gitserver
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestAddrForRepo(t *testing.T) {
+	ga := GitServerAddresses{
+		Addresses: []string{"gitserver-1", "gitserver-2", "gitserver-3"},
+		PinnedServers: map[string]string{
+			"repo2": "gitserver-1",
+		},
+	}
+
+	testCases := []struct {
+		name string
+		repo api.RepoName
+		want string
+	}{
+		{
+			name: "repo1",
+			repo: api.RepoName("repo1"),
+			want: "gitserver-3",
+		},
+		{
+			name: "check we normalise",
+			repo: api.RepoName("repo1.git"),
+			want: "gitserver-3",
+		},
+		{
+			name: "another repo",
+			repo: api.RepoName("github.com/sourcegraph/sourcegraph.git"),
+			want: "gitserver-2",
+		},
+		{
+			name: "pinned repo", // different server address that the hashing function would normally yield
+			repo: api.RepoName("repo2"),
+			want: "gitserver-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ga.AddrForRepo("gitserver", tc.repo)
+			if got != tc.want {
+				t.Fatalf("Want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -189,7 +189,8 @@ type clientImplementor struct {
 	// logger is used for all logging and logger creation
 	logger sglog.Logger
 
-	// addrs is a function that returns the current set of gitserver addresses
+	// addrs is a function that returns the current set of gitserver addresses.
+	// It is called each time a request is made. It must be safe for concurrent use.
 	addrs func() GitServerAddresses
 
 	// operations are used for internal observability

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -92,7 +92,7 @@ func NewTestClient(cli httpcli.Doer, addrs []string) Client {
 	logger := sglog.Scoped("NewTestClient", "Test New client")
 	return &clientImplementor{
 		logger:      logger,
-		addrs:       func() GitServerAddresses { return newTestGitserverAddresses(addrs) },
+		addrs:       func() GitserverAddresses { return newTestGitserverAddresses(addrs) },
 		httpClient:  cli,
 		HTTPLimiter: parallel.NewRun(500),
 		// Use the binary name for userAgent. This should effectively identify
@@ -191,7 +191,7 @@ type clientImplementor struct {
 
 	// addrs is a function that returns the current set of gitserver addresses.
 	// It is called each time a request is made. It must be safe for concurrent use.
-	addrs func() GitServerAddresses
+	addrs func() GitserverAddresses
 
 	// operations are used for internal observability
 	operations *operations

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -282,9 +282,11 @@ func createSimpleGitRepo(t *testing.T, root string) string {
 }
 
 func TestAddrForRepo(t *testing.T) {
-	addrs := []string{"gitserver-1", "gitserver-2", "gitserver-3"}
-	pinned := map[string]string{
-		"repo2": "gitserver-1",
+	ga := gitserver.GitServerAddresses{
+		Addresses: []string{"gitserver-1", "gitserver-2", "gitserver-3"},
+		PinnedServers: map[string]string{
+			"repo2": "gitserver-1",
+		},
 	}
 
 	testCases := []struct {
@@ -316,10 +318,7 @@ func TestAddrForRepo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := gitserver.AddrForRepo("gitserver", tc.repo, gitserver.GitServerAddresses{
-				Addresses:     addrs,
-				PinnedServers: pinned,
-			})
+			got := ga.AddrForRepo("gitserver", tc.repo)
 			if got != tc.want {
 				t.Fatalf("Want %q, got %q", tc.want, got)
 			}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -281,51 +281,6 @@ func createSimpleGitRepo(t *testing.T, root string) string {
 	return dir
 }
 
-func TestAddrForRepo(t *testing.T) {
-	ga := gitserver.GitServerAddresses{
-		Addresses: []string{"gitserver-1", "gitserver-2", "gitserver-3"},
-		PinnedServers: map[string]string{
-			"repo2": "gitserver-1",
-		},
-	}
-
-	testCases := []struct {
-		name string
-		repo api.RepoName
-		want string
-	}{
-		{
-			name: "repo1",
-			repo: api.RepoName("repo1"),
-			want: "gitserver-3",
-		},
-		{
-			name: "check we normalise",
-			repo: api.RepoName("repo1.git"),
-			want: "gitserver-3",
-		},
-		{
-			name: "another repo",
-			repo: api.RepoName("github.com/sourcegraph/sourcegraph.git"),
-			want: "gitserver-2",
-		},
-		{
-			name: "pinned repo", // different server address that the hashing function would normally yield
-			repo: api.RepoName("repo2"),
-			want: "gitserver-1",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := ga.AddrForRepo("gitserver", tc.repo)
-			if got != tc.want {
-				t.Fatalf("Want %q, got %q", tc.want, got)
-			}
-		})
-	}
-}
-
 func TestClient_P4Exec(t *testing.T) {
 	_ = gitserver.CreateRepoDir(t)
 	tests := []struct {


### PR DESCRIPTION
This is some more setup for gRPC so we can have avoid opening a connection per RPC call.

Previously, a gitserver client had a dependency on two different closures: one to fetch the list of gitserver addresses, and one to fetch the set of repos that are pinned to a specific gitserver instance. We had quite a few methods and functions that expose this information (with some duplication on the server side), and no place that we could atomically swap out a set of associated gRPC connections.

This centralizes the address resolution interface around `GitServerAddresses`, which already existed, but was not broadly used. This will allow us to open a global set of gRPC connections so we no longer have open connections per-RPC.

Buidling off https://github.com/sourcegraph/sourcegraph/pull/47920
For more on where this is going, see [this draft](https://github.com/sourcegraph/sourcegraph/pull/47927)

## Test plan

Updated tests. No behavior change, so I'm relying on existing tests here.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
