### PR TITLE
display "README.MD" files properly

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -182,7 +182,10 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
     const readmeEntry = useMemo(() => {
         for (const entry of tree.entries) {
-            if (!entry.isDirectory && (entry.name === 'README.md' || entry.name === 'README')) {
+            if (
+                !entry.isDirectory &&
+                (entry.name.toLocaleLowerCase() === 'readme.md' || entry.name.toLocaleLowerCase() === 'readme')
+            ) {
                 return entry
             }
         }

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -29,7 +29,7 @@ type FileResolver interface {
 }
 
 func richHTML(content, ext string) (string, error) {
-	switch ext {
+	switch strings.ToLower(ext) {
 	case ".md", ".mdown", ".markdown", ".markdn":
 		break
 	default:


### PR DESCRIPTION
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/1646931/220259479-dfa3e04f-8639-4aa7-abb4-76fe9d6ed166.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/1646931/220259356-5894a88c-35be-4289-8b24-7a7afc59b06b.png">
</td>
</tr>
</table>

Before/After:
![image](https://user-images.githubusercontent.com/1646931/220262144-0f7cdb68-1245-46c5-b247-19d6da781b55.png)


## Test plan

Visual change. Tested locally.