### PR TITLE
Setup Experience: Fetch github organizations for remote github source

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -161,6 +161,11 @@ func (r *NodeResolver) ToExternalService() (*externalServiceResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToExternalServiceNamespace() (*externalServiceNamespaceResolver, bool) {
+	n, ok := r.Node.(*externalServiceNamespaceResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToGitRef() (*GitRefResolver, bool) {
 	n, ok := r.Node.(*GitRefResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1296,6 +1296,24 @@ type Query {
         after: String
     ): ExternalServiceConnection!
     """
+    Lists all namespaces for a given external service connection.
+    A namespace is an entity on the code host that repositories are assignable to.
+    """
+    queryExternalServiceNamespaces(
+        """
+        The kind of the external service.
+        """
+        kind: ExternalServiceKind!
+        """
+        The secret token value that is used to authenticate.
+        """
+        token: String!
+        """
+        The url of the external service.
+        """
+        url: String!
+    ): QueryExternalServiceNamespaceConnection!
+    """
     List all repositories.
     """
     repositories(
@@ -3127,6 +3145,48 @@ type ExternalServiceSyncJob implements Node {
     The number of existing repos whose metadata did not change during this sync job.
     """
     reposUnmodified: Int!
+}
+
+"""
+A list of namespaces available to an external service configuration.
+"""
+type QueryExternalServiceNamespaceConnection {
+    """
+    A list of namespaces available on the source.
+    Namespaces are used to organize which members and users can access repositories
+    and are defined by external service kind (e.g. Github organizations, Bitbucket projects, etc.)
+    """
+    nodes: [ExternalServiceNamespace!]!
+
+    """
+    The total number of source repos in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A namespace sourced from a defined external service (such as GitHub, GitLab, Phabricator, etc.) that can be discovered
+before any sync or mirror operations.
+"""
+type ExternalServiceNamespace implements Node {
+    """
+    The unique identifier of the external service namespace.
+    """
+    id: ID!
+    """
+    The name of the external service namespace.
+    """
+    name: String!
+    """
+    The Namespace's ID on the external service.
+    Example: For GitHub, this is the GitHub GraphQL API's node ID for the organization.
+    """
+    externalID: String!
 }
 """
 A list of repositories.

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -65,6 +66,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/sync-external-service", trace.WithRouteName("sync-external-service", s.handleExternalServiceSync))
 	mux.HandleFunc("/enqueue-changeset-sync", trace.WithRouteName("enqueue-changeset-sync", s.handleEnqueueChangesetSync))
 	mux.HandleFunc("/schedule-perms-sync", trace.WithRouteName("schedule-perms-sync", s.handleSchedulePermsSync))
+	mux.HandleFunc("/ext-svc-namespaces", trace.WithRouteName("ext-svc-namespaces", s.handleQueryExternalServiceNamespaces))
 	return mux
 }
 
@@ -164,15 +166,6 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	}
 	logger := s.Logger.With(log.Int64("ExternalServiceID", req.ExternalServiceID))
 
-	// We use the generic sourcer that doesn't have observability attached to it here because the way externalServiceValidate is set up,
-	// using the regular sourcer will cause a large dump of errors to be logged when it exits ListRepos prematurely.
-	var genericSourcer repos.Sourcer
-	sourcerLogger := logger.Scoped("repos.Sourcer", "repositories source")
-	db := database.NewDBWith(sourcerLogger.Scoped("db", "sourcer database"), s)
-	dependenciesService := dependencies.NewService(s.ObservationCtx, db)
-	cf := httpcli.NewExternalClientFactory(httpcli.NewLoggingMiddleware(sourcerLogger))
-	genericSourcer = repos.NewSourcer(sourcerLogger, db, cf, repos.WithDependenciesService(dependenciesService))
-
 	externalServiceID := req.ExternalServiceID
 
 	es, err := s.ExternalServiceStore().GetByID(ctx, externalServiceID)
@@ -185,6 +178,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	genericSourcer := s.NewGenericSourcer(logger)
 	genericSrc, err := genericSourcer(ctx, es)
 	if err != nil {
 		logger.Error("server.external-service-sync", log.Error(err))
@@ -405,4 +399,88 @@ func (s *Server) handleSchedulePermsSync(w http.ResponseWriter, r *http.Request)
 	s.PermsSyncer.ScheduleRepos(r.Context(), req.RepoIDs...)
 
 	s.respond(w, http.StatusOK, nil)
+}
+
+func (s *Server) handleQueryExternalServiceNamespaces(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	var req protocol.QueryExternalServiceNamespacesArgs
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	extsvc := &types.ExternalService{
+		Kind:   req.Kind,
+		Config: extsvc.NewUnencryptedConfig(req.Config),
+	}
+
+	logger := s.Logger.With(log.String("ExternalServiceKind", req.Kind))
+
+	genericSourcer := s.NewGenericSourcer(logger)
+	genericSrc, err := genericSourcer(ctx, extsvc)
+	if err != nil {
+		logger.Error("server.query-external-service-namespaces", log.Error(err))
+		return
+	}
+
+	var result *protocol.QueryExternalServiceNamespacesResult
+	if err = genericSrc.CheckConnection(ctx); err != nil {
+		result = &protocol.QueryExternalServiceNamespacesResult{Error: err.Error()}
+		s.respond(w, http.StatusUnauthorized, result)
+		return
+	}
+
+	var (
+		discoverableSrc repos.DiscoverableSource
+		discoverable    bool
+	)
+
+	if discoverableSrc, discoverable = genericSrc.(repos.DiscoverableSource); !discoverable {
+		result = &protocol.QueryExternalServiceNamespacesResult{Error: repos.UnimplementedDiscoverySource}
+		s.respond(w, http.StatusNotImplemented, result)
+		return
+	}
+
+	results := make(chan repos.SourceNamespaceResult)
+
+	go func() {
+		discoverableSrc.ListNamespaces(ctx, results)
+		close(results)
+	}()
+
+	var sourceErrs error
+	namespaces := make([]*types.ExternalServiceNamespace, 0)
+
+	for res := range results {
+		if res.Err != nil {
+			sourceErrs = errors.Append(sourceErrs, &repos.SourceError{Err: res.Err, ExtSvc: extsvc})
+			continue
+		}
+		namespaces = append(namespaces, res.Namespace)
+	}
+
+	if sourceErrs != nil {
+		result = &protocol.QueryExternalServiceNamespacesResult{Namespaces: namespaces, Error: sourceErrs.Error()}
+	} else {
+		result = &protocol.QueryExternalServiceNamespacesResult{Namespaces: namespaces}
+	}
+	s.respond(w, http.StatusOK, result)
+}
+
+var mockNewGenericSourcer func() repos.Sourcer
+
+func (s *Server) NewGenericSourcer(logger log.Logger) repos.Sourcer {
+	if mockNewGenericSourcer != nil {
+		return mockNewGenericSourcer()
+	}
+
+	// We use the generic sourcer that doesn't have observability attached to it here because the way externalServiceValidate is set up,
+	// using the regular sourcer will cause a large dump of errors to be logged when it exits ListRepos prematurely.
+	sourcerLogger := logger.Scoped("repos.Sourcer", "repositories source")
+	db := database.NewDBWith(sourcerLogger.Scoped("db", "sourcer database"), s)
+	dependenciesService := dependencies.NewService(s.ObservationCtx, db)
+	cf := httpcli.NewExternalClientFactory(httpcli.NewLoggingMiddleware(sourcerLogger))
+	return repos.NewSourcer(sourcerLogger, db, cf, repos.WithDependenciesService(dependenciesService))
 }

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -849,6 +849,119 @@ func TestExternalServiceValidate_ValidatesToken(t *testing.T) {
 	}
 }
 
+func TestServer_QueryExternalServiceNamespaces(t *testing.T) {
+	githubConnection := `
+{
+	"url": "https://github.com",
+	"token": "secret-token",
+}`
+
+	githubSource := types.ExternalService{
+		Kind:         extsvc.KindGitHub,
+		CloudDefault: true,
+		Config:       extsvc.NewUnencryptedConfig(githubConnection),
+	}
+
+	gitlabConnection := `
+	{
+	   "url": "https://gitlab.com",
+	   "token": "abc",
+	}`
+
+	gitlabSource := types.ExternalService{
+		Kind:         extsvc.KindGitLab,
+		CloudDefault: true,
+		Config:       extsvc.NewUnencryptedConfig(gitlabConnection),
+	}
+
+	githubOrg := &types.ExternalServiceNamespace{
+		ID:         1,
+		Name:       "sourcegraph",
+		ExternalID: "aaaaa",
+	}
+
+	testCases := []struct {
+		name   string
+		args   protocol.QueryExternalServiceNamespacesArgs
+		result *protocol.QueryExternalServiceNamespacesResult
+		src    repos.Source
+		assert typestest.ReposAssertion
+		err    string
+	}{
+		{
+			name: "discoverable source - github",
+			args: protocol.QueryExternalServiceNamespacesArgs{
+				Kind:   extsvc.KindGitHub,
+				Config: githubConnection,
+			},
+			src:    repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, &types.Repo{}), false, githubOrg),
+			result: &protocol.QueryExternalServiceNamespacesResult{Namespaces: []*types.ExternalServiceNamespace{githubOrg}, Error: ""},
+		},
+		{
+			name: "unavailable - github.com",
+			args: protocol.QueryExternalServiceNamespacesArgs{
+				Kind:   extsvc.KindGitHub,
+				Config: githubConnection,
+			},
+			src:    repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, &types.Repo{}), true, githubOrg),
+			result: &protocol.QueryExternalServiceNamespacesResult{Error: "fake source unavailable"},
+			err:    "fake source unavailable",
+		},
+		{
+			name: "discoverable source - github - empty namespaces result",
+			args: protocol.QueryExternalServiceNamespacesArgs{
+				Kind:   extsvc.KindGitHub,
+				Config: githubConnection,
+			},
+			src:    repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, &types.Repo{}), false),
+			result: &protocol.QueryExternalServiceNamespacesResult{Namespaces: []*types.ExternalServiceNamespace{}, Error: ""},
+		},
+		{
+			name: "source does not implement discoverable source",
+			args: protocol.QueryExternalServiceNamespacesArgs{
+				Kind:   extsvc.KindGitHub,
+				Config: gitlabConnection,
+			},
+			src:    repos.NewFakeSource(&gitlabSource, nil, &types.Repo{}),
+			result: &protocol.QueryExternalServiceNamespacesResult{Error: repos.UnimplementedDiscoverySource},
+			err:    repos.UnimplementedDiscoverySource,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			logger := logtest.Scoped(t)
+
+			s := &Server{
+				Logger: logger,
+			}
+
+			mockNewGenericSourcer = func() repos.Sourcer {
+				return repos.NewFakeSourcer(nil, tc.src)
+			}
+			defer func() { mockNewGenericSourcer = nil }()
+
+			srv := httptest.NewServer(s.Handler())
+			defer srv.Close()
+
+			cli := repoupdater.NewClient(srv.URL)
+
+			res, err := cli.QueryExternalServiceNamespaces(ctx, tc.args)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Fatalf("have err: %q, want: %q", have, want)
+			}
+
+			if diff := cmp.Diff(res, tc.result, cmpopts.IgnoreFields(protocol.RepoInfo{}, "ID")); diff != "" {
+				t.Fatalf("response mismatch(-have, +want): %s", diff)
+			}
+		})
+	}
+}
+
 type testSource struct {
 	fn func() error
 }

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1957,8 +1957,9 @@ type UserEmail struct {
 }
 
 type Org struct {
-	ID    int    `json:"id,omitempty"`
-	Login string `json:"login,omitempty"`
+	ID     int    `json:"id,omitempty"`
+	Login  string `json:"login,omitempty"`
+	NodeID string `json:"node_id,omitempty"`
 }
 
 // OrgDetails describes the more detailed Org data you can only get from the

--- a/internal/repos/sources_discoverable.go
+++ b/internal/repos/sources_discoverable.go
@@ -1,0 +1,28 @@
+package repos
+
+import (
+	"context"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+const UnimplementedDiscoverySource = "External Service type does not support discovery of repositories and namespaces."
+
+// A DiscoverableSource yields metadata for remote entities (e.g. repositories, namespaces) on a readable external service
+// that Sourcegraph may or may not have setup for mirror/sync operations
+type DiscoverableSource interface {
+	// ListNamespaces returns the namespaces available on the source.
+	// Namespaces are used to organize which members and users can access repositories
+	// and are defined by external service kind (e.g. Github organizations, Bitbucket projects, etc.)
+	ListNamespaces(context.Context, chan SourceNamespaceResult)
+}
+
+// A SourceNamespaceResult is sent by a Source over a channel for each namespace it
+// yields when listing namespace entities
+type SourceNamespaceResult struct {
+	// Source points to the Source that produced this result
+	Source Source
+	// Namespace is the external service namespace that was listed by the Source
+	Namespace *types.ExternalServiceNamespace
+	// Err is only set in case the Source ran into an error when listing namespaces
+	Err error
+}

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -90,3 +90,33 @@ func (s *FakeSource) GetRepo(ctx context.Context, name string) (*types.Repo, err
 func (s *FakeSource) ExternalServices() types.ExternalServices {
 	return types.ExternalServices{s.svc}
 }
+
+func (s *FakeDiscoverableSource) ListNamespaces(ctx context.Context, results chan SourceNamespaceResult) {
+	if s.lockChan != nil {
+		s.lockChan <- struct{}{}
+		<-s.lockChan
+	}
+
+	if s.err != nil {
+		results <- SourceNamespaceResult{Source: s, Err: s.err}
+		return
+	}
+
+	for _, n := range s.namespaces {
+		results <- SourceNamespaceResult{Source: s, Namespace: &types.ExternalServiceNamespace{ID: n.ID, Name: n.Name, ExternalID: n.ExternalID}}
+	}
+}
+
+// FakeDiscoverableSource is a fake implementation of DiscoverableSource to be used in tests.
+type FakeDiscoverableSource struct {
+	*FakeSource
+	namespaces []*types.ExternalServiceNamespace
+}
+
+// NewFakeDiscoverableSource returns an instance of FakeDiscoverableSource with the given namespaces.
+func NewFakeDiscoverableSource(fs *FakeSource, connectionErr bool, ns ...*types.ExternalServiceNamespace) *FakeDiscoverableSource {
+	if connectionErr {
+		fs.Unavailable()
+	}
+	return &FakeDiscoverableSource{FakeSource: fs, namespaces: ns}
+}

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -272,3 +272,13 @@ type ExternalServiceSyncRequest struct {
 type ExternalServiceSyncResult struct {
 	Error string
 }
+
+type QueryExternalServiceNamespacesArgs struct {
+	Kind   string
+	Config string
+}
+
+type QueryExternalServiceNamespacesResult struct {
+	Namespaces []*types.ExternalServiceNamespace
+	Error      string
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -622,6 +622,13 @@ type ExternalServiceSyncJob struct {
 	ReposUnmodified int32
 }
 
+// ExternalServiceNamespace represents a namespace on an external service that can have ownership over repositories
+type ExternalServiceNamespace struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	ExternalID string `json:"external_id"`
+}
+
 // URN returns a unique resource identifier of this external service,
 // used as the key in a repo's Sources map as well as the SourceInfo ID.
 func (e *ExternalService) URN() string {


### PR DESCRIPTION
The current setup of a code host connection of type Github expects the user to explicitly define relevant organizations whose repositories should be included for mirroring/sync'ing with sourcegraph.  

The setup experience effort (see PRFAQ) will fetch a list of github organizations affiliated with the given token so that user can view this list of organizations and select which should be included in the code host connection configuration. This fetch can take place before or after the code host connection is saved to sourcegraphs External Services data store.

This PR provides the backend work to support this:

- GraphQL resolver which accepts the token and will return affiliated organizations
- repoupdater client and server changes to complete the actual request to github

There is a second PR coming soon that will implement a similar changeset but for fetch repsitories.

[PRFAQ](https://docs.google.com/document/d/1Wjkm6q9JMprINAZ3Yz58MhlmRWTxAGLi8dAxaEVZXSE/edit#heading=h.ioaref7nlstg)
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- repoupdater server tests
- external services graphql tests (TBD?)
- sg start -> api console to test queries
