### PR TITLE
experimental search input: Add back token hover information

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
@@ -66,41 +66,6 @@
             word-break: break-all;
         }
 
-        :global(.cm-tooltip) {
-            padding: 0.25rem;
-            color: var(--search-query-text-color);
-            background-color: var(--color-bg-1);
-            border: 1px solid var(--border-color);
-            border-radius: var(--border-radius);
-            box-shadow: var(--box-shadow);
-            max-width: 50vw;
-
-            p:last-child {
-                margin-bottom: 0;
-            }
-
-            code {
-                background-color: rgba(220, 220, 220, 0.4);
-                border-radius: var(--border-radius);
-                /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-                padding: 0 0.4em;
-            }
-
-            :global(.cm-tooltip-section) {
-                padding-bottom: 0.25rem;
-                border-top-color: var(--border-color);
-
-                &:last-child {
-                    padding-top: 0.25rem;
-                    padding-bottom: 0;
-                }
-
-                &:last-child:first-child {
-                    padding: 0;
-                }
-            }
-        }
-
         :global(.cm-tooltip-autocomplete) {
             /* Resets padding added above to .cm-tooltip */
             padding: 0;
@@ -171,16 +136,17 @@
             }
         }
     }
-}
 
-// .placeholder needs to explicilty have the same background color because it
-// appears to be placed outside of .focusedFilter rather than within it.
-.placeholder,
-.focusedFilter {
-    background-color: var(--gray-02);
+    // .placeholder needs to explicilty have the same background color because it
+    // appears to be placed outside of .focusedFilter rather than within it.
+    .placeholder,
+    .focusedFilter,
+    :global(.sg-token-hover) {
+        background-color: var(--gray-02);
 
-    :global(.theme-dark) & {
-        background-color: var(--gray-08);
+        :global(.theme-dark) & {
+            background-color: var(--gray-08);
+        }
     }
 }
 

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -3,17 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { closeCompletion, startCompletion } from '@codemirror/autocomplete'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { Diagnostic as CMDiagnostic, linter, LintSource } from '@codemirror/lint'
-import {
-    EditorSelection,
-    Extension,
-    StateEffect,
-    StateField,
-    Prec,
-    MapMode,
-    Compartment,
-    Range,
-    EditorState,
-} from '@codemirror/state'
+import { EditorSelection, Extension, Prec, Compartment, Range, EditorState } from '@codemirror/state'
 import {
     EditorView,
     ViewUpdate,
@@ -21,8 +11,6 @@ import {
     Decoration,
     placeholder as placeholderExtension,
     ViewPlugin,
-    hoverTooltip,
-    TooltipView,
     WidgetType,
 } from '@codemirror/view'
 import classNames from 'classnames'
@@ -34,12 +22,9 @@ import { useCodeMirror, createUpdateableField } from '@sourcegraph/shared/src/co
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { EditorHint, QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
-import { DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { Diagnostic, getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
-import { toHover } from '@sourcegraph/shared/src/search/query/hover'
-import { Node } from '@sourcegraph/shared/src/search/query/parser'
-import { Filter, KeywordKind } from '@sourcegraph/shared/src/search/query/token'
+import { Filter } from '@sourcegraph/shared/src/search/query/token'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
@@ -48,14 +33,9 @@ import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 import { createDefaultSuggestions, singleLine } from './codemirror'
 import { HISTORY_USER_EVENT, searchHistory as searchHistoryFacet } from './codemirror/history'
-import {
-    decoratedTokens,
-    queryTokens,
-    parseInputAsQuery,
-    setQueryParseOptions,
-    parsedQuery,
-} from './codemirror/parsedQuery'
+import { queryTokens, parseInputAsQuery, setQueryParseOptions } from './codemirror/parsedQuery'
 import { querySyntaxHighlighting } from './codemirror/syntax-highlighting'
+import { tokenInfo } from './codemirror/token-info'
 import { QueryInputProps } from './QueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
@@ -601,194 +581,6 @@ const highlightFocusedFilter = ViewPlugin.define(
     }
 )
 
-// Extension for providing token information. This includes showing a popover on
-// hover and highlighting the hovered token.
-function tokenInfo(): Extension {
-    const setHighlighedTokenPosition = StateEffect.define<number | null>()
-    const highlightedTokenPosition = StateField.define<number | null>({
-        create() {
-            return null
-        },
-        update(position, transaction) {
-            // Hide the highlight when the document changes. This replicates
-            // Monaco's behavior.
-            if (transaction.docChanged) {
-                return null
-            }
-            const effect = transaction.effects.find((effect): effect is StateEffect<number | null> =>
-                effect.is(setHighlighedTokenPosition)
-            )
-            if (effect) {
-                position = effect?.value
-            }
-            if (position !== null) {
-                // Mapping the position might not be necessary since we clear
-                // the highlight when the document changes anyway, but this is
-                // the safer way.
-                // MapMode.TrackDel causes mapPos to return null if content at
-                // this position was deleted (in which case we want to remove
-                // the highlight)
-                return transaction.changes.mapPos(position, 0, MapMode.TrackDel)
-            }
-            return position
-        },
-        provide(field) {
-            return EditorView.decorations.compute([field, decoratedTokens], state => {
-                const position = state.field(field)
-                if (!position) {
-                    return Decoration.none
-                }
-
-                const tooltipInfo = getTokensTooltipInformation(state.facet(decoratedTokens), position)
-                if (!tooltipInfo) {
-                    return Decoration.none
-                }
-                let { range } = tooltipInfo
-
-                const token = tooltipInfo.tokensAtCursor[0]
-                switch (token.type) {
-                    case 'keyword': {
-                        // Find operator (AND and OR are supported) and
-                        // highlight its operands too if possible
-                        const operator = findOperatorNode(position, state.facet(parsedQuery))
-                        if (operator) {
-                            range = operator.groupRange ?? operator.range
-                        }
-                        // Highlight operator keyword only
-                        break
-                    }
-                }
-
-                return Decoration.set([focusedFilterDeco.range(range.start, range.end)])
-            })
-        },
-    })
-
-    return [
-        highlightedTokenPosition,
-        // Highlights the hovered token
-        EditorView.domEventHandlers({
-            mousemove(event, view) {
-                const position = view.posAtCoords(event)
-                if (position && position !== view.state.field(highlightedTokenPosition)) {
-                    view.dispatch({ effects: setHighlighedTokenPosition.of(position) })
-                }
-            },
-            mouseleave(_event, view) {
-                if (view.state.field(highlightedTokenPosition) !== null) {
-                    view.dispatch({ effects: setHighlighedTokenPosition.of(null) })
-                }
-            },
-        }),
-        // Shows information about the hovered token
-        hoverTooltip(
-            (view, position) => {
-                const tooltipInfo = getTokensTooltipInformation(view.state.facet(decoratedTokens), position)
-                if (!tooltipInfo) {
-                    return null
-                }
-
-                return {
-                    pos: tooltipInfo.range.start,
-                    // tooltipInfo.range.end is exclusive, but this needs to be
-                    // inclusive to correctly hide the tooltip when the cursor
-                    // moves to the next token
-                    end: tooltipInfo.range.end - 1,
-                    // Show token info above the text by default to avoid
-                    // interfering with autcompletion (otherwise this could show
-                    // the token info *below* the autocompletion popover, which
-                    // looks bad)
-                    above: true,
-                    create(): TooltipView {
-                        const dom = document.createElement('div')
-                        dom.innerHTML = renderMarkdown(tooltipInfo.value)
-                        return {
-                            dom,
-                        }
-                    },
-                }
-            },
-            {
-                hoverTime: 100,
-                // Hiding the tooltip when the document changes replicates
-                // Monaco's behavior and also "feels right" because it removes
-                // "clutter" from the input.
-                hideOnChange: true,
-            }
-        ),
-    ]
-}
-
-function getTokensTooltipInformation(
-    tokens: readonly DecoratedToken[],
-    position: number
-): { tokensAtCursor: readonly DecoratedToken[]; range: { start: number; end: number }; value: string } | null {
-    const tokensAtCursor = tokens.filter(token => {
-        let { start, end } = token.range
-        switch (token.type) {
-            case 'field':
-                // +1 to include field separator :
-                end += 1
-                break
-        }
-        return start <= position && end > position
-    })
-
-    if (tokensAtCursor?.length === 0) {
-        return null
-    }
-    const values: string[] = []
-    let range: { start: number; end: number } | undefined
-
-    // Copied and adapted from getHoverResult (hover.ts)
-    for (const token of tokensAtCursor) {
-        switch (token.type) {
-            case 'field': {
-                const resolvedFilter = resolveFilter(token.value)
-                if (resolvedFilter) {
-                    values.push(
-                        'negated' in resolvedFilter
-                            ? resolvedFilter.definition.description(resolvedFilter.negated)
-                            : resolvedFilter.definition.description
-                    )
-                    // +1 to include field separator :
-                    range = { start: token.range.start, end: token.range.end + 1 }
-                }
-                break
-            }
-            case 'pattern':
-            case 'metaRevision':
-            case 'metaRepoRevisionSeparator':
-            case 'metaSelector':
-                values.push(toHover(token))
-                range = token.range
-                break
-            case 'metaRegexp':
-            case 'metaStructural':
-            case 'metaPredicate':
-                values.push(toHover(token))
-                range = token.groupRange ? token.groupRange : token.range
-                break
-            case 'keyword':
-                switch (token.kind) {
-                    case KeywordKind.And:
-                        values.push('Find results which match both the left and the right expression.')
-                        range = token.range
-                        break
-                    case KeywordKind.Or:
-                        values.push('Find results which match the left or the right expression.')
-                        range = token.range
-                        break
-                }
-        }
-    }
-
-    if (!range) {
-        return null
-    }
-    return { tokensAtCursor, range, value: values.join('') }
-}
-
 /**
  * Sets up client side query validation.
  */
@@ -867,17 +659,4 @@ function toCMDiagnostic(diagnostic: Diagnostic): CMDiagnostic {
             },
         })),
     }
-}
-
-function findOperatorNode(position: number, node: Node | null): Extract<Node, { type: 'operator' }> | null {
-    if (!node || node.type !== 'operator' || node.range.start >= position || node.range.end <= position) {
-        return null
-    }
-    for (const operand of node.operands) {
-        const result = findOperatorNode(position, operand)
-        if (result) {
-            return result
-        }
-    }
-    return node
 }

--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -1,0 +1,254 @@
+import { Extension, MapMode, StateEffect, StateField } from '@codemirror/state'
+import { Decoration, EditorView, hoverTooltip, TooltipView } from '@codemirror/view'
+
+import { renderMarkdown } from '@sourcegraph/common'
+import type { DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { toHover } from '@sourcegraph/shared/src/search/query/hover'
+import { Node } from '@sourcegraph/shared/src/search/query/parser'
+import { KeywordKind } from '@sourcegraph/shared/src/search/query/token'
+import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
+
+import { decoratedTokens, parsedQuery } from './parsedQuery'
+
+// Defines decorators for syntax highlighting
+const tokenHoverDecoration = Decoration.mark({ class: 'sg-token-hover' })
+
+// Overwrite styles for built-in hover element
+const hoverStyle = EditorView.baseTheme({
+    '.cm-tooltip': {
+        padding: '0.25rem',
+        color: 'var(--search-query-text-color)',
+        backgroundColor: 'var(--color-bg-1)',
+        border: '1px solid var(--border-color)',
+        borderRadius: 'var(--border-radius)',
+        boxShadow: 'var(--box-shadow)',
+        maxWidth: '50vw',
+    },
+
+    '.cm-tooltip p:last-child': {
+        marginBottom: 0,
+    },
+
+    '.cm-tooltip code': {
+        backgroundColor: 'rgba(220, 220, 220, 0.4)',
+        borderRadius: 'var(--border-radius)',
+        padding: '0 0.4em',
+    },
+
+    '.cm-tooltip-section': {
+        paddingBottom: '0.25rem',
+        borderTopColor: 'var(--border-color)',
+    },
+
+    '.cm-tooltip-section:last-child': {
+        paddingTop: '0.25rem',
+        paddingBottom: 0,
+    },
+    '.cm-tooltip-section:last-child:first-child': {
+        padding: 0,
+    },
+})
+
+/**
+ * Extension for providing token information. This includes showing a popover
+ * on hover and highlighting the hovered token.
+ */
+export function tokenInfo(): Extension {
+    const setHighlighedTokenPosition = StateEffect.define<number | null>()
+    const highlightedTokenPosition = StateField.define<number | null>({
+        create() {
+            return null
+        },
+        update(position, transaction) {
+            // Hide the highlight when the document changes. This replicates
+            // Monaco's behavior.
+            if (transaction.docChanged) {
+                return null
+            }
+            const effect = transaction.effects.find((effect): effect is StateEffect<number | null> =>
+                effect.is(setHighlighedTokenPosition)
+            )
+            if (effect) {
+                position = effect?.value
+            }
+            if (position !== null) {
+                // Mapping the position might not be necessary since we clear
+                // the highlight when the document changes anyway, but this is
+                // the safer way.
+                // MapMode.TrackDel causes mapPos to return null if content at
+                // this position was deleted (in which case we want to remove
+                // the highlight)
+                return transaction.changes.mapPos(position, 0, MapMode.TrackDel)
+            }
+            return position
+        },
+        provide(field) {
+            return EditorView.decorations.compute([field, decoratedTokens], state => {
+                const position = state.field(field)
+                if (!position) {
+                    return Decoration.none
+                }
+
+                const tooltipInfo = getTokensTooltipInformation(state.facet(decoratedTokens), position)
+                if (!tooltipInfo) {
+                    return Decoration.none
+                }
+                let { range } = tooltipInfo
+
+                const token = tooltipInfo.tokensAtCursor[0]
+                switch (token.type) {
+                    case 'keyword': {
+                        // Find operator (AND and OR are supported) and
+                        // highlight its operands too if possible
+                        const operator = findOperatorNode(position, state.facet(parsedQuery))
+                        if (operator) {
+                            range = operator.groupRange ?? operator.range
+                        }
+                        // Highlight operator keyword only
+                        break
+                    }
+                }
+
+                return Decoration.set([tokenHoverDecoration.range(range.start, range.end)])
+            })
+        },
+    })
+
+    return [
+        hoverStyle,
+        highlightedTokenPosition,
+        // Highlights the hovered token
+        EditorView.domEventHandlers({
+            mousemove(event, view) {
+                const position = view.posAtCoords(event)
+                if (position && position !== view.state.field(highlightedTokenPosition)) {
+                    view.dispatch({ effects: setHighlighedTokenPosition.of(position) })
+                }
+            },
+            mouseleave(_event, view) {
+                if (view.state.field(highlightedTokenPosition) !== null) {
+                    view.dispatch({ effects: setHighlighedTokenPosition.of(null) })
+                }
+            },
+        }),
+        // Shows information about the hovered token
+        hoverTooltip(
+            (view, position) => {
+                const tooltipInfo = getTokensTooltipInformation(view.state.facet(decoratedTokens), position)
+                if (!tooltipInfo) {
+                    return null
+                }
+
+                return {
+                    pos: tooltipInfo.range.start,
+                    // tooltipInfo.range.end is exclusive, but this needs to be
+                    // inclusive to correctly hide the tooltip when the cursor
+                    // moves to the next token
+                    end: tooltipInfo.range.end - 1,
+                    // Show token info above the text by default to avoid
+                    // interfering with autcompletion (otherwise this could show
+                    // the token info *below* the autocompletion popover, which
+                    // looks bad)
+                    above: true,
+                    create(): TooltipView {
+                        const dom = document.createElement('div')
+                        dom.innerHTML = renderMarkdown(tooltipInfo.value)
+                        return {
+                            dom,
+                        }
+                    },
+                }
+            },
+            {
+                hoverTime: 100,
+                // Hiding the tooltip when the document changes replicates
+                // Monaco's behavior and also "feels right" because it removes
+                // "clutter" from the input.
+                hideOnChange: true,
+            }
+        ),
+    ]
+}
+
+function getTokensTooltipInformation(
+    tokens: readonly DecoratedToken[],
+    position: number
+): { tokensAtCursor: readonly DecoratedToken[]; range: { start: number; end: number }; value: string } | null {
+    const tokensAtCursor = tokens.filter(token => {
+        let { start, end } = token.range
+        switch (token.type) {
+            case 'field':
+                // +1 to include field separator :
+                end += 1
+                break
+        }
+        return start <= position && end > position
+    })
+
+    if (tokensAtCursor?.length === 0) {
+        return null
+    }
+    const values: string[] = []
+    let range: { start: number; end: number } | undefined
+
+    // Copied and adapted from getHoverResult (hover.ts)
+    for (const token of tokensAtCursor) {
+        switch (token.type) {
+            case 'field': {
+                const resolvedFilter = resolveFilterMemoized(token.value)
+                if (resolvedFilter) {
+                    values.push(
+                        'negated' in resolvedFilter
+                            ? resolvedFilter.definition.description(resolvedFilter.negated)
+                            : resolvedFilter.definition.description
+                    )
+                    // +1 to include field separator :
+                    range = { start: token.range.start, end: token.range.end + 1 }
+                }
+                break
+            }
+            case 'pattern':
+            case 'metaRevision':
+            case 'metaRepoRevisionSeparator':
+            case 'metaSelector':
+                values.push(toHover(token))
+                range = token.range
+                break
+            case 'metaRegexp':
+            case 'metaStructural':
+            case 'metaPredicate':
+                values.push(toHover(token))
+                range = token.groupRange ? token.groupRange : token.range
+                break
+            case 'keyword':
+                switch (token.kind) {
+                    case KeywordKind.And:
+                        values.push('Find results which match both the left and the right expression.')
+                        range = token.range
+                        break
+                    case KeywordKind.Or:
+                        values.push('Find results which match the left or the right expression.')
+                        range = token.range
+                        break
+                }
+        }
+    }
+
+    if (!range) {
+        return null
+    }
+    return { tokensAtCursor, range, value: values.join('') }
+}
+
+function findOperatorNode(position: number, node: Node | null): Extract<Node, { type: 'operator' }> | null {
+    if (!node || node.type !== 'operator' || node.range.start >= position || node.range.end <= position) {
+        return null
+    }
+    for (const operand of node.operands) {
+        const result = findOperatorNode(position, operand)
+        if (result) {
+            return result
+        }
+    }
+    return node
+}

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -17,6 +17,7 @@ import { getTokenLength } from '@sourcegraph/shared/src/search/query/utils'
 import { singleLine, placeholder as placeholderExtension } from '../codemirror'
 import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
 import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
+import { tokenInfo } from '../codemirror/token-info'
 
 import { filterHighlight } from './codemirror/syntax-highlighting'
 import { modeScope } from './modes'
@@ -84,7 +85,6 @@ function configureExtensions({
     historyOrNavigate,
 }: ExtensionConfig): Extension {
     const extensions = [
-        singleLine,
         EditorView.darkTheme.of(isLightTheme === false),
         EditorView.updateListener.of(update => {
             if (update.docChanged) {
@@ -166,6 +166,7 @@ function createEditor(
             doc: queryState.query,
             selection: { anchor: queryState.query.length },
             extensions: [
+                singleLine,
                 drawSelection(),
                 EditorView.lineWrapping,
                 EditorView.contentAttributes.of({
@@ -177,7 +178,7 @@ function createEditor(
                 keymap.of(historyKeymap),
                 keymap.of(defaultKeymap),
                 codemirrorHistory(),
-                Prec.low([querySyntaxHighlighting, modeScope(filterHighlight, [null])]),
+                Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
                 EditorView.theme({
                     '&': {
                         flex: 1,
@@ -199,7 +200,19 @@ function createEditor(
                     '.cm-line': {
                         padding: 0,
                     },
+                    '.sg-token-hover': {
+                        backgroundColor: 'var(--gray-02)',
+                        borderRadius: '3px',
+                    },
                 }),
+                EditorView.theme(
+                    {
+                        '.sg-token-hover': {
+                            backgroundColor: 'var(--gray-08)',
+                        },
+                    },
+                    { dark: true }
+                ),
                 querySettingsCompartment.of(queryExtensions),
                 extensionsCompartment.of(extensions),
             ],


### PR DESCRIPTION
This PR extracts the token hover information extension into its own module (including styles) to make it reusable and includes it in the experimental search input.

<img width="842" alt="2023-02-21_09-18" src="https://user-images.githubusercontent.com/179026/220305815-18bf75ae-4bbd-4229-b13b-979dd48626d0.png">


## Test plan

Hovered over tokens in the current and the experimental search input.

## App preview:

- [Web](https://sg-web-fkling-search-input-hover.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
