### PR TITLE
own: fix: make search EventPersonMatch user field nullable

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -528,7 +528,7 @@ func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
 			Email:  v.Email,
 		}
 		if v.User != nil {
-			person.User = streamhttp.UserMetadata{
+			person.User = &streamhttp.UserMetadata{
 				Username:    v.User.Username,
 				DisplayName: v.User.DisplayName,
 				AvatarURL:   v.User.AvatarURL,

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -175,7 +175,7 @@ type EventPersonMatch struct {
 	Email  string `json:"email"`
 
 	// User will not be set if no user was matched.
-	User UserMetadata `json:"user,omitempty"`
+	User *UserMetadata `json:"user,omitempty"`
 }
 
 type UserMetadata struct {


### PR DESCRIPTION
address oversight as raised in https://github.com/sourcegraph/sourcegraph/pull/47745#discussion_r1112305508

## Test plan

```bash
curl \
  -H 'Authorization: token x' -H 'Accept: text/event-stream' --get --url 'https://sourcegraph.test:3443/.api/search/stream' --data-urlencode "q=repo:sourcegraph-test leo select:file.owners"
```

before:
```http
event: matches
data: [{"type":"person","handle":"notadmin","email":"","user":{"username":"notadmin","displayName":"","avatarURL":""}},{"type":"person","handle":"leonore","email":"","user":{"username":"","displayName":"","avatarURL":""}}]
``` 

after:
```http
event: matches
data: [{"type":"person","handle":"notadmin","email":"","user":{"username":"notadmin","displayName":"","avatarURL":""}},{"type":"person","handle":"leonore","email":""}]
```