### PR TITLE
backstage: add unit tests

### DIFF
--- a/client/backstage-backend/jest.config.js
+++ b/client/backstage-backend/jest.config.js
@@ -6,7 +6,7 @@ const config = require('../../jest.config.base')
 /** @type {import('@jest/types').Config.InitialOptions} */
 const exportedConfig = {
   ...config,
-  displayName: 'backstage-common',
+  displayName: 'backstage-backend',
   rootDir: __dirname,
   setupFiles: [...config.setupFiles],
 }

--- a/client/backstage-backend/package.json
+++ b/client/backstage-backend/package.json
@@ -19,7 +19,7 @@
     "dist": "ts-node --transpile-only ./scripts/esbuild.ts && pnpm types && cp package.dist.json dist/package.json",
     "types": "tsc -d -p tsconfig.json",
     "format": "prettier -w true .",
-    "test": "jest --testPathIgnorePatterns integration",
+    "test": "jest --testPathIgnorePatterns src/tests/integration/",
     "e2e": "jest --testPathPattern src/tests/integration/"
   },
   "devDependencies": {

--- a/client/backstage-backend/package.json
+++ b/client/backstage-backend/package.json
@@ -19,7 +19,8 @@
     "dist": "ts-node --transpile-only ./scripts/esbuild.ts && pnpm types && cp package.dist.json dist/package.json",
     "types": "tsc -d -p tsconfig.json",
     "format": "prettier -w true .",
-    "test": "jest"
+    "test": "jest --testPathIgnorePatterns integration",
+    "e2e": "jest --testPathPattern src/tests/integration/"
   },
   "devDependencies": {
     "@backstage/cli": "^0.22.1",

--- a/client/backstage-backend/src/client/Query.ts
+++ b/client/backstage-backend/src/client/Query.ts
@@ -2,22 +2,22 @@ import { gql } from '@apollo/client'
 import type { DocumentNode } from '@apollo/client'
 
 export interface Query<T> {
-  gql(): DocumentNode
-  vars(): string
-  marshal(data: any): T
+    gql(): DocumentNode
+    vars(): string
+    marshal(data: any): T
 }
 
 export type SearchResults = Array<SearchResult>
 export interface SearchResult {
-  readonly __typename?: string
-  readonly repository: string
-  readonly filename?: string
-  readonly fileContent?: string
+    readonly __typename?: string
+    readonly repository: string
+    readonly filename?: string
+    readonly fileContent?: string
 }
 
 export class SearchQuery implements Query<SearchResults> {
-  private readonly query: string
-  static gql: DocumentNode = gql(`
+    private readonly query: string
+    static raw: string = `
             query ($search: String!) {
                 search(query: $search) {
                     results {
@@ -36,44 +36,43 @@ export class SearchQuery implements Query<SearchResults> {
                     }
                 }
             }
-        `)
+        `
 
-
-  constructor(query: string) {
-    this.query = query
-  }
-
-  marshal(data: any): SearchResults {
-    const results = new Array<SearchResult>()
-    if (!data.search) {
-      return results
+    constructor(query: string) {
+        this.query = query
     }
 
-    for (const value of data.search.results.results) {
-      let filename = ""
-      let fileContent = ""
-      if ('file' in value) {
-        filename = value.file.name
-        fileContent = value.file.content
-      }
+    marshal(data: any): SearchResults {
+        const results = new Array<SearchResult>()
+        if (!data.search) {
+            return results
+        }
 
-      results.push({ repository: value.repository.name, filename: filename, fileContent: fileContent })
+        for (const value of data.search.results.results) {
+            let filename = ''
+            let fileContent = ''
+            if ('file' in value) {
+                filename = value.file.name
+                fileContent = value.file.content
+            }
+
+            results.push({ repository: value.repository.name, filename: filename, fileContent: fileContent })
+        }
+
+        return results
     }
 
-    return results
-  }
+    vars(): any {
+        return { search: this.query }
+    }
 
-  vars(): any {
-    return { search: this.query }
-  }
-
-  gql(): DocumentNode {
-    return SearchQuery.gql
-  }
+    gql(): DocumentNode {
+        return gql(SearchQuery.raw)
+    }
 }
 
 export class SearchRepoQuery extends SearchQuery {
-  static gql: DocumentNode = gql(`
+    static raw: string = `
             query ($search: String!) {
                 search(query: $search) {
                     results {
@@ -88,40 +87,39 @@ export class SearchRepoQuery extends SearchQuery {
                     }
                 }
             }
-        `)
+        `
 
+    constructor(query: string) {
+        super(query)
+    }
 
-  constructor(query: string) {
-    super(query)
-  }
-
-  gql(): DocumentNode {
-    return SearchRepoQuery.gql
-  }
+    gql(): DocumentNode {
+        return gql(SearchRepoQuery.raw)
+    }
 }
 
 export class UserQuery implements Query<string> {
-  static gql: DocumentNode = gql(`
+    static raw: string = `
             query {
                 currentUser {
                     username
                 }
             }
-        `)
+        `
 
-  vars(): any {
-    return {}
-  }
-
-  gql(): DocumentNode {
-    return UserQuery.gql
-  }
-
-  marshal(data: any): string {
-    if ('currentUser' in data) {
-      const { currentUser } = data
-      return currentUser.username
+    vars(): any {
+        return {}
     }
-    throw new Error('currentUser field missing')
-  }
+
+    gql(): DocumentNode {
+        return gql(UserQuery.raw)
+    }
+
+    marshal(data: any): string {
+        if ('currentUser' in data) {
+            const { currentUser } = data
+            return currentUser.username
+        }
+        throw new Error('currentUser field missing')
+    }
 }

--- a/client/backstage-backend/src/client/Query.ts
+++ b/client/backstage-backend/src/client/Query.ts
@@ -89,6 +89,7 @@ export class UserQuery implements Query<string> {
     marshal(data: any): string {
         if ('currentUser' in data) {
             const { currentUser } = data
+            console.log(currentUser.username)
             return currentUser.username
         }
         throw new Error('username not found')

--- a/client/backstage-backend/src/client/SourcegraphClient.test.ts
+++ b/client/backstage-backend/src/client/SourcegraphClient.test.ts
@@ -3,107 +3,110 @@ import { SourcegraphClient, SourcegraphService, BaseClient } from './Sourcegraph
 import { SearchQuery, SearchRepoQuery, SearchResult, UserQuery } from './Query'
 import { createMockClient } from '@apollo/client/testing'
 
-
 describe('SourcegraphService', () => {
-  test('current user query', async () => {
-    // setup
-    const data = {
-      currentUser: {
-        username: 'william',
-      },
-    }
-
-    const base = new BaseClient(createMockClient(data, UserQuery.gql))
-    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
-    // test
-    const username = await sourcegraphService.Users.currentUsername()
-    // verify
-    expect(username).toBe('william')
-  })
-  test('search query with 2 results', async () => {
-    // setup
-    const expected: SearchResult[] = [
-      { repository: 'repo 1', filename: 'filename-1', fileContent: 'logs of bogus content' },
-      { repository: 'repo 1', filename: 'filename-2', fileContent: 'logs of bogus content' },
-    ]
-    const data = {
-      search: {
-        results: {
-          results: [
-            {
-              __typename: "FileMatch",
-              repository: { name: expected[0].repository },
-              file: {
-                name: expected[0].filename,
-                content: expected[0].fileContent
-              },
+    test('current user query', async () => {
+        // setup
+        const data = {
+            currentUser: {
+                username: 'william',
             },
-            {
-              __typename: "FileMatch",
-              repository: { name: expected[1].repository },
-              file: {
-                name: expected[1].filename,
-                content: expected[1].fileContent
-              },
-            },
-          ]
         }
-      },
-    }
 
-    const query: SearchQuery = new SearchQuery('mock query')
-    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
-    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
-    // test
-    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
-    // verify
-    expect(results).toEqual(expected)
-  })
-  test('search query with 0 results', async () => {
-    // setup
-    const expected: SearchResult[] = []
-    const data = {
-      search: {
-        results: {
-          results: []
-        },
-      }
-    }
-
-    const query: SearchQuery = new SearchQuery('mock query')
-    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
-    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
-    // test
-    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
-    // verify
-    expect(results).toEqual(expected)
-  })
-  test('search query with only repository names', async () => {
-    // setup
-    const expected: SearchResult[] = [{ repository: "repo-1" }, { repository: "repo-2" }]
-    const data = {
-      search: {
-        results: {
-          results: [
-            {
-              __typename: "FileMatch",
-              repository: { name: "repo-1" },
+        const query: UserQuery = new UserQuery()
+        const base = new BaseClient(createMockClient(data, query.gql()))
+        let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+        // test
+        const username = await sourcegraphService.Users.currentUsername()
+        // verify
+        expect(username).toBe('william')
+    })
+    test('search query with 2 results', async () => {
+        // setup
+        const expected: SearchResult[] = [
+            { repository: 'repo 1', filename: 'filename-1', fileContent: 'logs of bogus content' },
+            { repository: 'repo 1', filename: 'filename-2', fileContent: 'logs of bogus content' },
+        ]
+        const data = {
+            search: {
+                results: {
+                    results: [
+                        {
+                            __typename: 'FileMatch',
+                            repository: { name: expected[0].repository },
+                            file: {
+                                name: expected[0].filename,
+                                content: expected[0].fileContent,
+                            },
+                        },
+                        {
+                            __typename: 'FileMatch',
+                            repository: { name: expected[1].repository },
+                            file: {
+                                name: expected[1].filename,
+                                content: expected[1].fileContent,
+                            },
+                        },
+                    ],
+                },
             },
-            {
-              __typename: "FileMatch",
-              repository: { name: "repo-2" },
-            }
-          ]
-        },
-      }
-    }
+        }
 
-    const query: SearchRepoQuery = new SearchRepoQuery('mock query')
-    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
-    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
-    // test
-    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
-    // verify
-    expect(results).toEqual(expected)
-  })
+        const query: SearchQuery = new SearchQuery('mock query')
+        const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+        let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+        // test
+        const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
+        // verify
+        expect(results).toEqual(expected)
+    })
+    test('search query with 0 results', async () => {
+        // setup
+        const expected: SearchResult[] = []
+        const data = {
+            search: {
+                results: {
+                    results: [],
+                },
+            },
+        }
+
+        const query: SearchQuery = new SearchQuery('mock query')
+        const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+        let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+        // test
+        const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
+        // verify
+        expect(results).toEqual(expected)
+    })
+    test('search query with only repository names', async () => {
+        // setup
+        const expected: SearchResult[] = [
+            { repository: 'repo-1', filename: '', fileContent: '' },
+            { repository: 'repo-2', filename: '', fileContent: '' },
+        ]
+        const data = {
+            search: {
+                results: {
+                    results: [
+                        {
+                            __typename: 'FileMatch',
+                            repository: { name: 'repo-1' },
+                        },
+                        {
+                            __typename: 'FileMatch',
+                            repository: { name: 'repo-2' },
+                        },
+                    ],
+                },
+            },
+        }
+
+        const query: SearchRepoQuery = new SearchRepoQuery('mock query')
+        const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+        let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+        // test
+        const results: SearchResult[] = await sourcegraphService.Search.doQuery(query)
+        // verify
+        expect(results).toEqual(expected)
+    })
 })

--- a/client/backstage-backend/src/client/SourcegraphClient.test.ts
+++ b/client/backstage-backend/src/client/SourcegraphClient.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, test } from '@jest/globals'
+import { describe, expect, test, jest } from '@jest/globals'
+import { SourcegraphClient, SourcegraphService, BaseClient } from './SourcegraphClient'
+import { Query } from './Query'
 
-describe('placeholder for SourcegraphClient tests', () => {
-    test('placeholder', () => expect('placeholder').toBeTruthy())
+let mockClient: BaseClient = new BaseClient('', '', '')
+
+let sourcegraphService: SourcegraphService = new SourcegraphClient(mockClient)
+
+describe('SourcegraphService', () => {
+    test('testquery', async () => {
+        // setup
+        jest.spyOn(mockClient, 'fetch').mockImplementationOnce(async () => {
+            console.log('hello from the mock impl')
+            return {
+                data: {
+                    currentUser: {
+                        username: 'william',
+                    },
+                },
+            }
+        })
+        // test
+        const username = await sourcegraphService.Users.currentUsername()
+        // verify
+        expect(username).toBe('william')
+    })
 })

--- a/client/backstage-backend/src/client/SourcegraphClient.test.ts
+++ b/client/backstage-backend/src/client/SourcegraphClient.test.ts
@@ -1,27 +1,109 @@
-import { describe, expect, test, jest } from '@jest/globals'
+import { describe, expect, test } from '@jest/globals'
 import { SourcegraphClient, SourcegraphService, BaseClient } from './SourcegraphClient'
-import { Query } from './Query'
+import { SearchQuery, SearchRepoQuery, SearchResult, UserQuery } from './Query'
+import { createMockClient } from '@apollo/client/testing'
 
-let mockClient: BaseClient = new BaseClient('', '', '')
-
-let sourcegraphService: SourcegraphService = new SourcegraphClient(mockClient)
 
 describe('SourcegraphService', () => {
-    test('testquery', async () => {
-        // setup
-        jest.spyOn(mockClient, 'fetch').mockImplementationOnce(async () => {
-            console.log('hello from the mock impl')
-            return {
-                data: {
-                    currentUser: {
-                        username: 'william',
-                    },
-                },
+  test('current user query', async () => {
+    // setup
+    const data = {
+      currentUser: {
+        username: 'william',
+      },
+    }
+
+    const base = new BaseClient(createMockClient(data, UserQuery.gql))
+    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+    // test
+    const username = await sourcegraphService.Users.currentUsername()
+    // verify
+    expect(username).toBe('william')
+  })
+  test('search query with 2 results', async () => {
+    // setup
+    const expected: SearchResult[] = [
+      { repository: 'repo 1', filename: 'filename-1', fileContent: 'logs of bogus content' },
+      { repository: 'repo 1', filename: 'filename-2', fileContent: 'logs of bogus content' },
+    ]
+    const data = {
+      search: {
+        results: {
+          results: [
+            {
+              __typename: "FileMatch",
+              repository: { name: expected[0].repository },
+              file: {
+                name: expected[0].filename,
+                content: expected[0].fileContent
+              },
+            },
+            {
+              __typename: "FileMatch",
+              repository: { name: expected[1].repository },
+              file: {
+                name: expected[1].filename,
+                content: expected[1].fileContent
+              },
+            },
+          ]
+        }
+      },
+    }
+
+    const query: SearchQuery = new SearchQuery('mock query')
+    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+    // test
+    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
+    // verify
+    expect(results).toEqual(expected)
+  })
+  test('search query with 0 results', async () => {
+    // setup
+    const expected: SearchResult[] = []
+    const data = {
+      search: {
+        results: {
+          results: []
+        },
+      }
+    }
+
+    const query: SearchQuery = new SearchQuery('mock query')
+    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+    // test
+    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
+    // verify
+    expect(results).toEqual(expected)
+  })
+  test('search query with only repository names', async () => {
+    // setup
+    const expected: SearchResult[] = [{ repository: "repo-1" }, { repository: "repo-2" }]
+    const data = {
+      search: {
+        results: {
+          results: [
+            {
+              __typename: "FileMatch",
+              repository: { name: "repo-1" },
+            },
+            {
+              __typename: "FileMatch",
+              repository: { name: "repo-2" },
             }
-        })
-        // test
-        const username = await sourcegraphService.Users.currentUsername()
-        // verify
-        expect(username).toBe('william')
-    })
+          ]
+        },
+      }
+    }
+
+    const query: SearchRepoQuery = new SearchRepoQuery('mock query')
+    const base = new BaseClient(createMockClient(data, query.gql(), query.vars()))
+    let sourcegraphService: SourcegraphService = new SourcegraphClient(base)
+    // test
+    const results: SearchResult[] = await sourcegraphService.Search.searchQuery('mock query')
+    // verify
+    expect(results).toEqual(expected)
+  })
 })

--- a/client/backstage-backend/src/client/SourcegraphClient.ts
+++ b/client/backstage-backend/src/client/SourcegraphClient.ts
@@ -1,102 +1,107 @@
 import { getGraphQLClient, GraphQLClient } from '@sourcegraph/http-client'
 import { generateCache } from '@sourcegraph/shared/src/backend/apolloCache'
-import { UserQuery, Query, AuthenticatedUser, AuthenticatedUserQuery, SearchQuery, SearchResult } from './Query'
+import { UserQuery, Query, SearchQuery, SearchResult, SearchResults } from './Query'
 
 export interface Config {
-    endpoint: string
-    token: string
-    sudoUsername?: string
+  endpoint: string
+  token: string
+  sudoUsername?: string
 }
 
 export interface UserService {
-    currentUsername(): Promise<string>
-    getAuthenticatedUser(): Promise<AuthenticatedUser>
+  currentUsername(): Promise<string>
 }
 
-export const createService = (config: Config): SourcegraphService => {
-    const { endpoint, token, sudoUsername } = config
-    const base = new BaseClient(endpoint, token, sudoUsername || '')
-    return new SourcegraphClient(base)
+export const createService = async (config: Config): Promise<SourcegraphService> => {
+  const { endpoint, token, sudoUsername } = config
+  const base = await BaseClient.create(endpoint, token, sudoUsername || '')
+  return new SourcegraphClient(base)
 }
 
 export const createDummySearch = (): SearchService => {
-    return {
-        searchQuery: async (_: string): Promise<SearchResult[]> => {
-            console.log('DummySearch not doing anything')
-            return []
-        },
-    }
+  return {
+    searchQuery: async (_: string): Promise<SearchResults> => {
+      console.log('DummySearch not doing anything')
+      return []
+    },
+    doQuery<T>: async (q: Query<T>): Promise<T> => { return Promise.resolve(q.marshal({}) },
+  }
 }
 
 export interface SearchService {
-    searchQuery(query: string): Promise<SearchResult[]>
+  searchQuery(query: string): Promise<SearchResults>
+  doQuery<T>(query: Query<T>): Promise<SearchResults>
 }
 
 export interface SourcegraphService {
-    Users: UserService
-    Search: SearchService
+  Users: UserService
+  Search: SearchService
 }
 
 export class SourcegraphClient implements SourcegraphService, UserService, SearchService {
-    private client: BaseClient
-    Users: UserService = this
-    Search: SearchService = this
+  private client: BaseClient
+  Users: UserService = this
+  Search: SearchService = this
 
-    constructor(client: BaseClient) {
-        this.client = client
-    }
+  constructor(client: BaseClient) {
+    this.client = client
+  }
 
-    async searchQuery(query: string): Promise<SearchResult[]> {
-        const q = new SearchQuery(query)
-        const results = await this.client.fetch(q)
+  async searchQuery(query: string): Promise<SearchResult[]> {
+    const q = new SearchQuery(query)
+    const results = await this.client.fetch(q)
 
-        return results
-    }
+    return results
+  }
 
-    async currentUsername(): Promise<string> {
-        const q = new UserQuery()
+  async doQuery<T>(query: Query<T>): Promise<T> {
+    return await this.client.fetch(query)
+  }
 
-        const result = await this.client.fetch(q)
-        return result
-    }
+  async currentUsername(): Promise<string> {
+    const q = new UserQuery()
 
-    async getAuthenticatedUser(): Promise<AuthenticatedUser> {
-        const q = new AuthenticatedUserQuery()
-        const result = await this.client.fetch(q)
-        return result
-    }
+    const result = await this.client.fetch(q)
+    return result
+  }
+
 }
 
 export class BaseClient {
-    private client?: GraphQLClient
-    constructor(baseUrl: string, token: string, sudoUsername: string) {
-        const authz =
-            sudoUsername?.length > 0 ? `token - sudo user = "${sudoUsername}", token = "${token}"` : `token ${token}`
-        const headers: RequestInit['headers'] = {
-            'X-Requested-With': `Sourcegraph - Backstage plugin DEV`,
-            Authorization: authz,
-        }
+  private client: GraphQLClient
 
-        if (!this.client) {
-            getGraphQLClient({
-                baseUrl: baseUrl,
-                headers: headers,
-                isAuthenticated: true,
-                cache: generateCache(),
-            }).then(client => {
-                this.client = client
-            })
-        }
+  static async create(baseUrl: string, token: string, sudoUsername: string): Promise<BaseClient> {
+    const authz =
+      sudoUsername?.length > 0 ? `token - sudo user = "${sudoUsername}", token = "${token}"` : `token ${token}`
+    const headers: RequestInit['headers'] = {
+      'X-Requested-With': `Sourcegraph - Backstage plugin DEV`,
+      Authorization: authz,
     }
 
-    async fetch<T>(query: Query<T>): Promise<T> {
-        const { data } = await this.client.query({
-            query: query.gql(),
-            variables: query.vars(),
-        })
-        if (!data) {
-            throw new Error('grapql request failed: no data')
-        }
-        return query.marshal(data)
+    try {
+      const client: GraphQLClient = await getGraphQLClient({
+        baseUrl: baseUrl,
+        headers: headers,
+        isAuthenticated: true,
+        cache: generateCache(),
+      })
+      return new BaseClient(client)
+    } catch (e) {
+      throw new Error(`failed to create graphsql client: ${e}`)
     }
+  }
+  constructor(client: GraphQLClient) {
+    this.client = client
+  }
+
+  async fetch<T>(query: Query<T>): Promise<T> {
+    const { data } = await this.client.query({
+      query: query.gql(),
+      variables: query.vars(),
+    })
+    if (!data) {
+      throw new Error('grapql request failed: no data')
+    }
+    return query.marshal(data)
+  }
 }

--- a/client/backstage-backend/src/client/SourcegraphClient.ts
+++ b/client/backstage-backend/src/client/SourcegraphClient.ts
@@ -3,105 +3,91 @@ import { generateCache } from '@sourcegraph/shared/src/backend/apolloCache'
 import { UserQuery, Query, SearchQuery, SearchResult, SearchResults } from './Query'
 
 export interface Config {
-  endpoint: string
-  token: string
-  sudoUsername?: string
+    endpoint: string
+    token: string
+    sudoUsername?: string
 }
 
 export interface UserService {
-  currentUsername(): Promise<string>
-}
-
-export const createService = async (config: Config): Promise<SourcegraphService> => {
-  const { endpoint, token, sudoUsername } = config
-  const base = await BaseClient.create(endpoint, token, sudoUsername || '')
-  return new SourcegraphClient(base)
-}
-
-export const createDummySearch = (): SearchService => {
-  return {
-    searchQuery: async (_: string): Promise<SearchResults> => {
-      console.log('DummySearch not doing anything')
-      return []
-    },
-    doQuery<T>: async (q: Query<T>): Promise<T> => { return Promise.resolve(q.marshal({}) },
-  }
+    currentUsername(): Promise<string>
 }
 
 export interface SearchService {
-  searchQuery(query: string): Promise<SearchResults>
-  doQuery<T>(query: Query<T>): Promise<SearchResults>
+    searchQuery(query: string): Promise<SearchResults>
+    doQuery<T>(query: Query<T>): Promise<T>
 }
 
 export interface SourcegraphService {
-  Users: UserService
-  Search: SearchService
+    Users: UserService
+    Search: SearchService
+}
+
+export const createService = async (config: Config): Promise<SourcegraphService> => {
+    const { endpoint, token, sudoUsername } = config
+    const base = await BaseClient.create(endpoint, token, sudoUsername || '')
+    return new SourcegraphClient(base)
 }
 
 export class SourcegraphClient implements SourcegraphService, UserService, SearchService {
-  private client: BaseClient
-  Users: UserService = this
-  Search: SearchService = this
+    private client: BaseClient
+    Users: UserService = this
+    Search: SearchService = this
 
-  constructor(client: BaseClient) {
-    this.client = client
-  }
+    constructor(client: BaseClient) {
+        this.client = client
+    }
 
-  async searchQuery(query: string): Promise<SearchResult[]> {
-    const q = new SearchQuery(query)
-    const results = await this.client.fetch(q)
+    async searchQuery(query: string): Promise<SearchResult[]> {
+        return await this.doQuery(new SearchQuery(query))
+    }
 
-    return results
-  }
+    async doQuery<T>(query: Query<T>): Promise<T> {
+        return await this.client.fetch(query)
+    }
 
-  async doQuery<T>(query: Query<T>): Promise<T> {
-    return await this.client.fetch(query)
-  }
+    async currentUsername(): Promise<string> {
+        const q = new UserQuery()
 
-  async currentUsername(): Promise<string> {
-    const q = new UserQuery()
-
-    const result = await this.client.fetch(q)
-    return result
-  }
-
+        const result = await this.client.fetch(q)
+        return result
+    }
 }
 
 export class BaseClient {
-  private client: GraphQLClient
+    private client: GraphQLClient
 
-  static async create(baseUrl: string, token: string, sudoUsername: string): Promise<BaseClient> {
-    const authz =
-      sudoUsername?.length > 0 ? `token - sudo user = "${sudoUsername}", token = "${token}"` : `token ${token}`
-    const headers: RequestInit['headers'] = {
-      'X-Requested-With': `Sourcegraph - Backstage plugin DEV`,
-      Authorization: authz,
+    static async create(baseUrl: string, token: string, sudoUsername: string): Promise<BaseClient> {
+        const authz =
+            sudoUsername?.length > 0 ? `token - sudo user = "${sudoUsername}", token = "${token}"` : `token ${token}`
+        const headers: RequestInit['headers'] = {
+            'X-Requested-With': `Sourcegraph - Backstage plugin DEV`,
+            Authorization: authz,
+        }
+
+        try {
+            const client: GraphQLClient = await getGraphQLClient({
+                baseUrl: baseUrl,
+                headers: headers,
+                isAuthenticated: true,
+                cache: generateCache(),
+            })
+            return new BaseClient(client)
+        } catch (e) {
+            throw new Error(`failed to create graphsql client: ${e}`)
+        }
+    }
+    constructor(client: GraphQLClient) {
+        this.client = client
     }
 
-    try {
-      const client: GraphQLClient = await getGraphQLClient({
-        baseUrl: baseUrl,
-        headers: headers,
-        isAuthenticated: true,
-        cache: generateCache(),
-      })
-      return new BaseClient(client)
-    } catch (e) {
-      throw new Error(`failed to create graphsql client: ${e}`)
+    async fetch<T>(query: Query<T>): Promise<T> {
+        const { data } = await this.client.query({
+            query: query.gql(),
+            variables: query.vars(),
+        })
+        if (!data) {
+            throw new Error('grapql request failed: no data')
+        }
+        return query.marshal(data)
     }
-  }
-  constructor(client: GraphQLClient) {
-    this.client = client
-  }
-
-  async fetch<T>(query: Query<T>): Promise<T> {
-    const { data } = await this.client.query({
-      query: query.gql(),
-      variables: query.vars(),
-    })
-    if (!data) {
-      throw new Error('grapql request failed: no data')
-    }
-    return query.marshal(data)
-  }
 }

--- a/client/backstage-backend/src/client/index.ts
+++ b/client/backstage-backend/src/client/index.ts
@@ -1,2 +1,2 @@
-export { SourcegraphService, SearchService, UserService } from './SourcegraphClient'
+export { SourcegraphService, createService, createDummySearch, SearchService, UserService } from './SourcegraphClient'
 export * from './Query'

--- a/client/backstage-backend/src/client/index.ts
+++ b/client/backstage-backend/src/client/index.ts
@@ -1,2 +1,2 @@
-export * from './SourcegraphClient'
+export { SourcegraphService, SearchService, UserService } from './SourcegraphClient'
 export * from './Query'

--- a/client/backstage-backend/src/providers/providers.ts
+++ b/client/backstage-backend/src/providers/providers.ts
@@ -6,80 +6,78 @@ import { EntityProvider, EntityProviderConnection } from '@backstage/plugin-cata
 export type EntityType = 'file' | 'grpc' | 'graphql'
 
 abstract class BaseEntityProvider implements EntityProvider {
-    private connection?: EntityProviderConnection
-    private readonly sourcegraph: SearchService
-    private query: string
-    private endpoint: string
-    private disabled: boolean = false
-    private readonly entityType: EntityType
-    private entityParseFn: ParserFunction
+  private connection?: EntityProviderConnection
+  private sourcegraph?: SearchService
+  private query: string
+  private endpoint: string
+  private disabled: boolean = false
+  private readonly entityType: EntityType
+  private entityParseFn: ParserFunction
 
-    protected constructor(config: Config, entityType: EntityType) {
-        const token = config.getString('sourcegraph.token')
-        const sudoUsername = config.getOptionalString('sourcegraph.sudoUsername')
-        const queryConfig = config.getConfig(`sourcegraph.${entityType}`)
+  protected constructor(config: Config, entityType: EntityType) {
+    const token = config.getString('sourcegraph.token')
+    const sudoUsername = config.getOptionalString('sourcegraph.sudoUsername')
+    const queryConfig = config.getConfig(`sourcegraph.${entityType}`)
 
-        this.endpoint = config.getString('sourcegraph.endpoint')
-        this.entityType = entityType
-        this.entityParseFn = parserForType(entityType)
-        this.query = queryConfig.getOptionalString('query') ?? ''
+    this.endpoint = config.getString('sourcegraph.endpoint')
+    this.entityType = entityType
+    this.entityParseFn = parserForType(entityType)
+    this.query = queryConfig.getOptionalString('query') ?? ''
 
-        // TODO(@burmudar): remove - only temporary
-        console.log(entityType, 'QUERY', this.query)
-        this.disabled = this.query == ''
-        if (this.disabled) {
-            this.sourcegraph = createDummySearch()
-        } else {
-            this.sourcegraph = createService({ endpoint: this.endpoint, token, sudoUsername }).Search
-        }
+    this.disabled = this.query == ''
+    if (this.disabled) {
+      this.sourcegraph = createDummySearch()
+    } else {
+      createService({ endpoint: this.endpoint, token, sudoUsername }).then((service) => this.sourcegraph = service.Search)
+    }
+  }
+
+  getProviderName(): string {
+    return `url: ${this.endpoint}/sourcegraph-${this.entityType}-entity-provider`
+  }
+
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection
+  }
+
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('connection not initialized')
     }
 
-    getProviderName(): string {
-        return `url: ${this.endpoint}/sourcegraph-${this.entityType}-entity-provider`
-    }
+    await this.fullMutation()
+  }
 
-    async connect(connection: EntityProviderConnection): Promise<void> {
-        this.connection = connection
-    }
+  async fullMutation() {
+    // TODO(@burmudar): remove - only temporary
+    console.log(`STARTING ${this.entityType} SEARCH ⌛`)
+    const results = await this.sourcegraph?.searchQuery(this.query)
+    console.log(`${results?.length} items matched query ${this.query}`)
+    console.log(`END ${this.entityType} SEARCH ⌛`)
 
-    async run(): Promise<void> {
-        if (!this.connection) {
-            throw new Error('connection not initialized')
-        }
+    const entities = this.entityParseFn(results ?? [], this.getProviderName())
 
-        await this.fullMutation()
-    }
-
-    async fullMutation() {
-        // TODO(@burmudar): remove - only temporary
-        console.log(`STARTING ${this.entityType} SEARCH ⌛`)
-        const results = await this.sourcegraph.searchQuery(this.query)
-        console.log(`${results.length} items matched query ${this.query}`)
-        console.log(`END ${this.entityType} SEARCH ⌛`)
-
-        const entities = this.entityParseFn(results, this.getProviderName())
-
-        await this.connection?.applyMutation({
-            type: 'full',
-            entities: entities,
-        })
-    }
+    await this.connection?.applyMutation({
+      type: 'full',
+      entities: entities,
+    })
+  }
 }
 
 export class GrpcEntityProvider extends BaseEntityProvider {
-    constructor(config: Config) {
-        super(config, 'grpc')
-    }
+  constructor(config: Config) {
+    super(config, 'grpc')
+  }
 }
 
 export class GraphQLEntityProvider extends BaseEntityProvider {
-    constructor(config: Config) {
-        super(config, 'graphql')
-    }
+  constructor(config: Config) {
+    super(config, 'graphql')
+  }
 }
 
 export class YamlFileEntityProvider extends BaseEntityProvider {
-    constructor(config: Config) {
-        super(config, 'file')
-    }
+  constructor(config: Config) {
+    super(config, 'file')
+  }
 }

--- a/client/backstage-backend/src/tests/integration/e2e.test.ts
+++ b/client/backstage-backend/src/tests/integration/e2e.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from '@jest/globals'
+import { createService, Config, SourcegraphService } from '../../client/SourcegraphClient'
+
+const sgConf: Config = {
+    endpoint: 'https://scaletesting.sgdev.org',
+    token: process.env.SG_TOKEN ?? '',
+}
+
+const sourcegraphService: SourcegraphService = createService(sgConf)
+
+describe('integration test against dotCom', () => {
+    console.log('using config', sgConf)
+    test('check current user', async () => {
+        const username: string = await sourcegraphService.Users.currentUsername()
+        console.log(username)
+        expect(username).toBe('burmudar')
+    })
+})

--- a/client/backstage-backend/src/tests/integration/e2e.test.ts
+++ b/client/backstage-backend/src/tests/integration/e2e.test.ts
@@ -2,17 +2,16 @@ import { describe, expect, test } from '@jest/globals'
 import { createService, Config, SourcegraphService } from '../../client/SourcegraphClient'
 
 const sgConf: Config = {
-    endpoint: 'https://scaletesting.sgdev.org',
-    token: process.env.SG_TOKEN ?? '',
+  endpoint: 'https://scaletesting.sgdev.org',
+  token: process.env.SG_TOKEN ?? '',
 }
 
-const sourcegraphService: SourcegraphService = createService(sgConf)
 
-describe('integration test against dotCom', () => {
-    console.log('using config', sgConf)
-    test('check current user', async () => {
-        const username: string = await sourcegraphService.Users.currentUsername()
-        console.log(username)
-        expect(username).toBe('burmudar')
-    })
+describe('integration test against dotCom', async () => {
+  const sourcegraphService: SourcegraphService = await createService(sgConf)
+  test('check current user', async () => {
+    const username: string = await sourcegraphService.Users.currentUsername()
+    console.log(username)
+    expect(username).toBe('burmudar')
+  })
 })

--- a/client/backstage-backend/src/tests/integration/e2e.test.ts
+++ b/client/backstage-backend/src/tests/integration/e2e.test.ts
@@ -2,16 +2,15 @@ import { describe, expect, test } from '@jest/globals'
 import { createService, Config, SourcegraphService } from '../../client/SourcegraphClient'
 
 const sgConf: Config = {
-  endpoint: 'https://scaletesting.sgdev.org',
-  token: process.env.SG_TOKEN ?? '',
+    endpoint: 'https://scaletesting.sgdev.org',
+    token: process.env.SG_TOKEN ?? '',
 }
 
-
 describe('integration test against dotCom', async () => {
-  const sourcegraphService: SourcegraphService = await createService(sgConf)
-  test('check current user', async () => {
-    const username: string = await sourcegraphService.Users.currentUsername()
-    console.log(username)
-    expect(username).toBe('burmudar')
-  })
+    const sourcegraphService: SourcegraphService = await createService(sgConf)
+    test('check current user', async () => {
+        const username: string = await sourcegraphService.Users.currentUsername()
+        console.log(username)
+        expect(username).toBe('burmudar')
+    })
 })


### PR DESCRIPTION
#### This adds unit tests for:
- Queries
- SourcegraphClient

#### Other things added
* Add SearchRepoQuery, which is a variation of the normal SearchQuery but only returns repos
* It also adds the beginning of integration tests

## Test plan
Unit tests
```
pnpm test

> @sourcegraph/backstage-backend@0.1.0 test /Users/william/code/sourcegraph/client/backstage-backend
> jest --testPathIgnorePatterns src/tests/integration/

 PASS   backstage-backend  src/client/SourcegraphClient.test.ts

Test Suites: 1 skipped, 1 passed, 1 of 2 total
Tests:       2 skipped, 4 passed, 6 total
Snapshots:   0 total
Time:        1.888 s, estimated 2 s
Ran all test suites.
```


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-wb-backstage-unit-tests.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
