### PR TITLE
bzl: avoid running test with external network reqs

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -15,7 +16,8 @@ import (
 )
 
 func TestLatestDockerVersionPushed(t *testing.T) {
-	if testing.Short() {
+	// We cannot perform external network requests in Bazel tests, it breaks the sandbox.
+	if testing.Short() || os.Getenv("BAZEL_TEST") == "1" {
 		t.Skip("Skipping due to network request against dockerhub")
 	}
 
@@ -33,7 +35,8 @@ func TestLatestDockerVersionPushed(t *testing.T) {
 }
 
 func TestLatestKubernetesVersionPushed(t *testing.T) {
-	if testing.Short() {
+	// We cannot perform external network requests in Bazel tests, it breaks the sandbox.
+	if testing.Short() || os.Getenv("BAZEL_TEST") == "1" {
 		t.Skip("Skipping due to network request")
 	}
 
@@ -49,7 +52,8 @@ func TestLatestKubernetesVersionPushed(t *testing.T) {
 }
 
 func TestLatestDockerComposeOrPureDockerVersionPushed(t *testing.T) {
-	if testing.Short() {
+	// We cannot perform external network requests in Bazel tests, it breaks the sandbox.
+	if testing.Short() || os.Getenv("BAZEL_TEST") == "1" {
 		t.Skip("Skipping due to network request")
 	}
 


### PR DESCRIPTION
External HTTP requests are not compatible with running tests fully sandboxed as bazel expects them. This PR add a quick check to avoid running them when Bazel is the test runner.

On the long term, I might consider adding a bunch a helpers to deal with this as we progress through various edge cases.

For now that will do.

Test plan: tests passed with Bazel, locally.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
