### PR TITLE
feature flags: Clean up (and fix) deprectated search-related feature flags

### DIFF
--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -71,12 +71,7 @@ import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheP
 import { GLOBAL_SEARCH_CONTEXT_SPEC } from './SearchQueryStateObserver'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
-import {
-    setQueryStateFromSettings,
-    setExperimentalFeaturesFromSettings,
-    getExperimentalFeatures,
-    useNavbarQueryState,
-} from './stores'
+import { setQueryStateFromSettings, setExperimentalFeaturesFromSettings, useNavbarQueryState } from './stores'
 import { eventLogger } from './tracking/eventLogger'
 import type { UserAreaRoute } from './user/area/UserArea'
 import type { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
@@ -320,7 +315,7 @@ export class LegacySourcegraphWebApp extends React.Component<
                             telemetryService={eventLogger}
                             isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                             searchContextsEnabled={this.props.searchContextsEnabled}
-                            selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                            selectedSearchContextSpec={this.state.selectedSearchContextSpec}
                             setSelectedSearchContextSpec={this.setSelectedSearchContextSpec}
                             getUserSearchContextNamespaces={getUserSearchContextNamespaces}
                             fetchSearchContexts={fetchSearchContexts}
@@ -367,9 +362,6 @@ export class LegacySourcegraphWebApp extends React.Component<
             </ComponentsComposer>
         )
     }
-
-    private getSelectedSearchContextSpec = (): string | undefined =>
-        getExperimentalFeatures().showSearchContext ? this.state.selectedSearchContextSpec : undefined
 
     private setSelectedSearchContextSpecWithNoChecks = (spec: string): void => {
         this.setState({ selectedSearchContextSpec: spec })

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -71,12 +71,7 @@ import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheP
 import { GLOBAL_SEARCH_CONTEXT_SPEC } from './SearchQueryStateObserver'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
-import {
-    setQueryStateFromSettings,
-    setExperimentalFeaturesFromSettings,
-    getExperimentalFeatures,
-    useNavbarQueryState,
-} from './stores'
+import { setQueryStateFromSettings, setExperimentalFeaturesFromSettings, useNavbarQueryState } from './stores'
 import { useThemeProps } from './theme'
 import { eventLogger } from './tracking/eventLogger'
 import type { UserAreaRoute } from './user/area/UserArea'
@@ -134,7 +129,7 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
     const [graphqlClient, setGraphqlClient] = useState<GraphQLClient | null>(null)
     const [temporarySettingsStorage, setTemporarySettingsStorage] = useState<TemporarySettingsStorage | null>(null)
 
-    const [selectedSearchContextSpec, _setSelectedSearchContextSpec] = useState<string | null>(null)
+    const [selectedSearchContextSpec, _setSelectedSearchContextSpec] = useState<string | undefined>()
 
     // NOTE(2022-09-08) Inform the inlined code from
     // sourcegraph/code-intel-extensions about the change of search context.
@@ -213,11 +208,6 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
     useEffect(() => {
         selectedSearchContextSpecRef.current = selectedSearchContextSpec
     }, [selectedSearchContextSpec])
-    const getSelectedSearchContextSpec = useCallback(
-        (): string | undefined =>
-            getExperimentalFeatures().showSearchContext ? selectedSearchContextSpecRef.current ?? undefined : undefined,
-        []
-    )
 
     // TODO: Move all of this initialization outside React so we don't need to
     // handle the optional states everywhere
@@ -288,7 +278,7 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
             setSelectedSearchContextSpecToDefault()
         }
 
-        setWorkspaceSearchContext(selectedSearchContextSpec)
+        setWorkspaceSearchContext(selectedSearchContextSpec ?? null)
 
         userRepositoriesUpdates.next()
 
@@ -309,7 +299,7 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
         isMacPlatform: isMacPlatform(),
         telemetryService: eventLogger,
         isSourcegraphDotCom: window.context.sourcegraphDotComMode,
-        selectedSearchContextSpec: getSelectedSearchContextSpec(),
+        selectedSearchContextSpec,
         setSelectedSearchContextSpec,
         getUserSearchContextNamespaces,
         fetchSearchContexts,
@@ -382,7 +372,7 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
                     telemetryService={eventLogger}
                     isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                     searchContextsEnabled={props.searchContextsEnabled}
-                    selectedSearchContextSpec={getSelectedSearchContextSpec()}
+                    selectedSearchContextSpec={selectedSearchContextSpec}
                     setSelectedSearchContextSpec={setSelectedSearchContextSpec}
                     getUserSearchContextNamespaces={getUserSearchContextNamespaces}
                     fetchSearchContexts={fetchSearchContexts}

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { EMPTY, NEVER, Observable, of } from 'rxjs'
 
@@ -15,17 +15,11 @@ import { NOOP_SETTINGS_CASCADE } from '@sourcegraph/shared/src/testing/searchTes
 import { AuthenticatedUser } from '../auth'
 import { WebStory } from '../components/WebStory'
 import { SearchPatternType } from '../graphql-operations'
-import { useExperimentalFeatures } from '../stores'
 import { ThemePreference } from '../theme'
 
 import { cncf } from './cncf'
 import { CommunitySearchContextPage, CommunitySearchContextPageProps } from './CommunitySearchContextPage'
 import { temporal } from './Temporal'
-
-const decorator: DecoratorFn = Story => {
-    useExperimentalFeatures.setState({ showSearchContext: true })
-    return <Story />
-}
 
 const config: Meta = {
     title: 'web/CommunitySearchContextPage',
@@ -36,7 +30,6 @@ const config: Meta = {
         },
         chromatic: { viewports: [769, 1200] },
     },
-    decorators: [decorator],
 }
 
 export default config

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -1,7 +1,5 @@
 import { Navigate } from 'react-router-dom'
 
-import { isErrorLike } from '@sourcegraph/common'
-import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { isCodeInsightsEnabled } from '../insights/utils/is-code-insights-enabled'
@@ -33,9 +31,6 @@ const EditSearchContextPage = lazyComponent(
 const SearchContextPage = lazyComponent(() => import('./searchContexts/SearchContextPage'), 'SearchContextPage')
 const GlobalCodyArea = lazyComponent(() => import('./cody/GlobalCodyArea'), 'GlobalCodyArea')
 
-const isSearchContextsManagementEnabled = (settingsCascade: SettingsCascadeOrError): boolean =>
-    !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.showSearchContext !== false
-
 export const enterpriseRoutes: readonly LayoutRouteProps[] = [
     {
         path: EnterprisePageRoutes.BatchChanges,
@@ -57,22 +52,18 @@ export const enterpriseRoutes: readonly LayoutRouteProps[] = [
     {
         path: EnterprisePageRoutes.Contexts,
         render: props => <SearchContextsListPage {...props} />,
-        condition: props => isSearchContextsManagementEnabled(props.settingsCascade),
     },
     {
         path: EnterprisePageRoutes.CreateContext,
         render: props => <CreateSearchContextPage {...props} />,
-        condition: props => isSearchContextsManagementEnabled(props.settingsCascade),
     },
     {
         path: EnterprisePageRoutes.EditContext,
         render: props => <EditSearchContextPage {...props} />,
-        condition: props => isSearchContextsManagementEnabled(props.settingsCascade),
     },
     {
         path: EnterprisePageRoutes.Context,
         render: props => <SearchContextPage {...props} />,
-        condition: props => isSearchContextsManagementEnabled(props.settingsCascade),
     },
     {
         path: EnterprisePageRoutes.SearchNotebook,

--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -1,4 +1,4 @@
-import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { Meta, Story } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
@@ -10,7 +10,6 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { WebStory } from '../../components/WebStory'
 import { MockedFeatureFlagsProvider } from '../../featureFlags/MockedFeatureFlagsProvider'
-import { useExperimentalFeatures } from '../../stores'
 import { ThemePreference } from '../../theme'
 
 import { SearchPage, SearchPageProps } from './SearchPage'
@@ -38,14 +37,8 @@ const defaultProps = (props: ThemeProps): SearchPageProps => ({
 
 window.context.allowSignup = true
 
-const decorator: DecoratorFn = Story => {
-    useExperimentalFeatures.setState({ showSearchContext: false })
-    return <Story />
-}
-
 const config: Meta = {
     title: 'web/search/home/SearchPage',
-    decorators: [decorator],
     parameters: {
         design: {
             type: 'figma',

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -10,7 +10,6 @@ const defaultSettings: SettingsExperimentalFeatures = {
      * Whether we show the multiline editor at /search/console
      */
     showMultilineSearchConsole: false,
-    showSearchContext: true,
     codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
     codeInsightsCompute: false,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2163,24 +2163,18 @@ type SettingsExperimentalFeatures struct {
 	PreloadGoToDefinition bool `json:"preloadGoToDefinition,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
-	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
-	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchQueryInput description: Specify which version of the search query input to use
 	SearchQueryInput *string `json:"searchQueryInput,omitempty"`
 	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.
 	SearchResultsAggregations *bool `json:"searchResultsAggregations,omitempty"`
 	// SearchStats description: Enables a button on the search results page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
-	// SearchStreaming description: DEPRECATED: This feature is now permanently enabled. Enables streaming search support.
-	SearchStreaming *bool `json:"searchStreaming,omitempty"`
 	// SetupWizard description: Experimental setup wizard
 	SetupWizard *bool `json:"setupWizard,omitempty"`
 	// ShowCodeMonitoringLogs description: Shows code monitoring logs tab.
 	ShowCodeMonitoringLogs *bool `json:"showCodeMonitoringLogs,omitempty"`
 	// ShowMultilineSearchConsole description: Enables the multiline search console at search/console
 	ShowMultilineSearchConsole *bool `json:"showMultilineSearchConsole,omitempty"`
-	// ShowSearchContext description: Enables the search context dropdown.
-	ShowSearchContext *bool `json:"showSearchContext,omitempty"`
 	// SymbolKindTags description: Show the initial letter of the symbol kind instead of icons.
 	SymbolKindTags bool           `json:"symbolKindTags,omitempty"`
 	Additional     map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
@@ -2242,15 +2236,12 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "goCodeCheckerTemplates")
 	delete(m, "preloadGoToDefinition")
 	delete(m, "proactiveSearchResultsAggregations")
-	delete(m, "searchContextsQuery")
 	delete(m, "searchQueryInput")
 	delete(m, "searchResultsAggregations")
 	delete(m, "searchStats")
-	delete(m, "searchStreaming")
 	delete(m, "setupWizard")
 	delete(m, "showCodeMonitoringLogs")
 	delete(m, "showMultilineSearchConsole")
-	delete(m, "showSearchContext")
 	delete(m, "symbolKindTags")
 	if len(m) > 0 {
 		v.Additional = make(map[string]any, len(m))

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2163,6 +2163,8 @@ type SettingsExperimentalFeatures struct {
 	PreloadGoToDefinition bool `json:"preloadGoToDefinition,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
+	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
+	SearchContextsQuery *bool `json:"searchContextsQuery,omitempty"`
 	// SearchQueryInput description: Specify which version of the search query input to use
 	SearchQueryInput *string `json:"searchQueryInput,omitempty"`
 	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.
@@ -2236,6 +2238,7 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "goCodeCheckerTemplates")
 	delete(m, "preloadGoToDefinition")
 	delete(m, "proactiveSearchResultsAggregations")
+	delete(m, "searchContextsQuery")
 	delete(m, "searchQueryInput")
 	delete(m, "searchResultsAggregations")
 	delete(m, "searchStats")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -47,32 +47,8 @@
             "pointer": true
           }
         },
-        "searchContextsQuery": {
-          "description": "DEPRECATED: This feature is now permanently enabled. Enables query based search contexts",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "searchStats": {
           "description": "Enables a button on the search results page that shows language statistics about the results for a search query.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
-        "searchStreaming": {
-          "description": "DEPRECATED: This feature is now permanently enabled. Enables streaming search support.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
-        "showSearchContext": {
-          "description": "Enables the search context dropdown.",
           "type": "boolean",
           "default": false,
           "!go": {

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -47,6 +47,14 @@
             "pointer": true
           }
         },
+        "searchContextsQuery": {
+          "description": "DEPRECATED: This feature is now permanently enabled. Enables query based search contexts",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "searchStats": {
           "description": "Enables a button on the search results page that shows language statistics about the results for a search query.",
           "type": "boolean",


### PR DESCRIPTION
These flags have been removed in #46086 and #46045 but were accidentally(merge conflict?) added back to the schema in #46086.

Furthermore the `showSearchContext` flag was still accessed in a couple of places, resulting in a broken experience if it was set to `false`:

<img width="640" alt="2023-02-21_13-43" src="https://user-images.githubusercontent.com/179026/220369826-6592db71-604c-4aeb-9a17-334439f1e604.png">


This PR removes the flags and removes all uses of `showSearchContext` flag.




## Test plan

`grepped` for the removed flags (`showSearchContext` is still used as props in various places though).
Opened web app and verified that the context dropdown is properly populated.
