### PR TITLE
Add sourcegraphAppMode flag to the JS context

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -51,6 +51,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         siteID: 'TestSiteID',
         siteGQLID: 'TestGQLSiteID',
         sourcegraphDotComMode: ENVIRONMENT_CONFIG.SOURCEGRAPHDOTCOM_MODE,
+        sourcegraphAppMode: false,
         userAgentIsBot: false,
         version: '0.0.0',
         xhrHeaders: {},

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -40,6 +40,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     siteID,
     siteGQLID,
     sourcegraphDotComMode: false,
+    sourcegraphAppMode: false,
     userAgentIsBot: false,
     version: '0.0.0',
     xhrHeaders: {},

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -52,6 +52,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     debug: boolean
 
     sourcegraphDotComMode: boolean
+    sourcegraphAppMode: boolean
 
     /**
      * siteID is the identifier of the Sourcegraph site.

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -81,6 +81,7 @@ type JSContext struct {
 	DeployType        string                   `json:"deployType"`
 
 	SourcegraphDotComMode bool `json:"sourcegraphDotComMode"`
+	SourcegraphAppMode    bool `json:"sourcegraphAppMode"`
 
 	BillingPublishableKey string `json:"billingPublishableKey,omitempty"`
 
@@ -221,6 +222,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		DeployType:        deploy.Type(),
 
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
+		SourcegraphAppMode:    deploy.IsDeployTypeSingleProgram(deploy.Type()),
 
 		BillingPublishableKey: BillingPublishableKey,
 


### PR DESCRIPTION
Add a boolean flag, `sourcegraphAppMode` that indicates whether we are in Sourcegraph App mode for the use in the frontend UI.

**Why**

The purpose is to have a flag available in the frontend which allows to define behaviours that are specific to Sourcegraph App mode.

Close #47921 

**Implementation notes**

On the backend, Sourcegraph App mode is enabled when `IsDeployTypeSingleProgram` return true.

The `sourcegraphAppMode` flag is accessible on `window.context.sourcegraphAppMode`, which mirrors the naming of `sourcegraphDotComMode` which is similarly also a boolean flag that affects the frontend UI behavior.

## Test plan

- Run in app mode and check that `window.context.sourcegraphAppMode` is true
- Run outside of app mode and check that `window.context.sourcegraphAppMode` is false

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
