### PR TITLE
Remove `searchStats` feature flag and update docs

### DIFF
--- a/doc/code_search/explanations/index.md
+++ b/doc/code_search/explanations/index.md
@@ -11,6 +11,5 @@
   - Search for repositories, symbols and files using the [Fuzzy finder](features.md#fuzzy-search).
   - Curate [saved searches](features.md#saved-searches) for yourself or your org.
   - Use [code monitoring](../../code_monitoring/index.md) to set up notifications for code changes that match a query.
-  - View [language statistics](features.md#statistics) for search results.
 - [Search details](search_details.md)
 - [Search tips](tips.md)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2169,8 +2169,6 @@ type SettingsExperimentalFeatures struct {
 	SearchQueryInput *string `json:"searchQueryInput,omitempty"`
 	// SearchResultsAggregations description: Display aggregations for your search results on the search screen.
 	SearchResultsAggregations *bool `json:"searchResultsAggregations,omitempty"`
-	// SearchStats description: Enables a button on the search results page that shows language statistics about the results for a search query.
-	SearchStats *bool `json:"searchStats,omitempty"`
 	// SetupWizard description: Experimental setup wizard
 	SetupWizard *bool `json:"setupWizard,omitempty"`
 	// ShowCodeMonitoringLogs description: Shows code monitoring logs tab.
@@ -2241,7 +2239,6 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "searchContextsQuery")
 	delete(m, "searchQueryInput")
 	delete(m, "searchResultsAggregations")
-	delete(m, "searchStats")
 	delete(m, "setupWizard")
 	delete(m, "showCodeMonitoringLogs")
 	delete(m, "showMultilineSearchConsole")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -55,14 +55,6 @@
             "pointer": true
           }
         },
-        "searchStats": {
-          "description": "Enables a button on the search results page that shows language statistics about the results for a search query.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "showMultilineSearchConsole": {
           "description": "Enables the multiline search console at search/console",
           "type": "boolean",


### PR DESCRIPTION
This flag had been removed in #46045 but (accidentally?) added back in #45705. The feature (search stats) itself been removed in #45996. Documentation about it has already been removed in #30564. The link removed in this PR has been dead since then.

## Test plan

`grep`ped the code for references to the flag and used sourcegraph to find the commits that made changes to the related code and documentation.
