### PR TITLE
Fix code intel hover navigation propagation issue

### DIFF
--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -625,7 +625,7 @@ export class HovercardView implements TooltipView {
         }
 
         root.render(
-            <CodeMirrorContainer onRender={() => repositionTooltips(this.view)}>
+            <CodeMirrorContainer navigate={props.navigate} onRender={() => repositionTooltips(this.view)}>
                 <div
                     className={classNames({
                         'cm-code-intel-hovercard': true,

--- a/client/web/src/repo/blob/codemirror/react-interop.tsx
+++ b/client/web/src/repo/blob/codemirror/react-interop.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, NavigateFunction, useLocation } from 'react-router-dom'
 
 import { WildcardThemeContext } from '@sourcegraph/wildcard'
 
 interface CodeMirrorContainerProps {
+    navigate: NavigateFunction
     onMount?: () => void
     onRender?: () => void
 }
@@ -14,6 +15,7 @@ interface CodeMirrorContainerProps {
  * CodeMirror.
  */
 export const CodeMirrorContainer: React.FunctionComponent<React.PropsWithChildren<CodeMirrorContainerProps>> = ({
+    navigate,
     onMount,
     onRender,
     children,
@@ -25,7 +27,26 @@ export const CodeMirrorContainer: React.FunctionComponent<React.PropsWithChildre
 
     return (
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
-            <BrowserRouter>{children}</BrowserRouter>
+            <BrowserRouter>
+                {children}
+                <SyncInnerRouterWithParent navigate={navigate} />
+            </BrowserRouter>
         </WildcardThemeContext.Provider>
     )
+}
+
+const SyncInnerRouterWithParent: React.FC<{ navigate: NavigateFunction }> = ({ navigate }) => {
+    const initialLocation = useState(useLocation())[0]
+    const location = useLocation()
+    useEffect(() => {
+        if (
+            location.hash === initialLocation.hash &&
+            location.pathname === initialLocation.pathname &&
+            location.search === initialLocation.search
+        ) {
+            return
+        }
+        navigate(location)
+    }, [location, navigate, initialLocation])
+    return null
 }

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -17,6 +17,7 @@ import { Compartment, Extension, StateEffect } from '@codemirror/state'
 import { EditorView, KeyBinding, keymap, Panel, runScopeHandlers, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { mdiChevronDown, mdiChevronUp, mdiFormatLetterCase, mdiInformationOutline, mdiRegex } from '@mdi/js'
 import { createRoot, Root } from 'react-dom/client'
+import { NavigateFunction } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
 import { debounceTime, distinctUntilChanged, startWith } from 'rxjs/operators'
 
@@ -30,6 +31,8 @@ import { Keybindings } from '../../../components/KeyboardShortcutsHelp/KeyboardS
 import { createElement } from '../../../util/dom'
 
 import { CodeMirrorContainer } from './react-interop'
+
+import { blobPropsFacet } from '.'
 
 const searchKeybinding = <Keybindings keybindings={[{ held: ['Mod'], ordered: ['F'] }]} />
 
@@ -63,12 +66,14 @@ class SearchPanel implements Panel {
     private input: HTMLInputElement | null = null
     private searchTerm = new Subject<string>()
     private subscriptions = new Subscription()
+    private navigate: NavigateFunction
 
     constructor(private view: EditorView) {
         this.dom = createElement('div', {
             className: 'cm-sg-search-container d-flex align-items-center',
             onkeydown: this.onkeydown,
         })
+        this.navigate = view.state.facet(blobPropsFacet).navigate
 
         this.state = {
             searchQuery: getSearchQuery(this.view.state),
@@ -141,6 +146,7 @@ class SearchPanel implements Panel {
 
         this.root.render(
             <CodeMirrorContainer
+                navigate={this.navigate}
                 onMount={() => {
                     this.input?.focus()
                     this.input?.select()


### PR DESCRIPTION
Fixes an issue on S2 that caused the references panel not to appear.

PR #47595 introduced an issue where link navigations inside the code mirror components are not propagated to the main React router context.

This is caused by the fact that these components are rendered into their own React roots which are wrapped with a custom router context that no longer communicates with the main context.

To fix this, I've added a small wrapper that listens for route changes in the parent and propagates it to the main router via the navigate function.

## Test plan

- Tested locally

https://user-images.githubusercontent.com/458591/220378367-39486721-08eb-49ec-b2cd-729a8f0c48d6.mov




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-code-intel-popover-router.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
