### PR TITLE
Fix links in feature flags admin interface

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -201,7 +201,7 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<
                 }
                 className="mb-3"
                 actions={
-                    <ButtonLink variant="primary" to="./feature-flags/configuration/new">
+                    <ButtonLink variant="primary" to="./configuration/new">
                         Create feature flag
                     </ButtonLink>
                 }
@@ -273,7 +273,7 @@ const FeatureFlagNode: React.FunctionComponent<React.PropsWithChildren<FeatureFl
             </span>
 
             <span className={classNames(styles.button, 'd-none d-md-inline')}>
-                <Link to={`./feature-flags/configuration/${node.name}`} className="p-0">
+                <Link to={`./configuration/${node.name}`} className="p-0">
                     <Icon svgPath={mdiChevronRight} inline={false} aria-label="Configure" />
                 </Link>
             </span>


### PR DESCRIPTION
Some of the relative links where broken and included the `/feature-flags` folder twice.

## Test plan

Tested locally:

https://user-images.githubusercontent.com/458591/220382209-87407116-5391-46f7-86eb-346a1ef03c98.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-feature-flag-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
