### PR TITLE
Fix click on blob line in references panel causing a full browser refresh

### DIFF
--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -31,7 +31,7 @@ class LineLinkManager implements PluginValue {
                     line.to,
                     Decoration.mark({
                         tagName: 'a',
-                        attributes: { href, 'data-line-link': '' },
+                        attributes: { href, 'data-cm-line-link': '' },
                         class: 'text-decoration-none',
                     })
                 )
@@ -50,11 +50,13 @@ export const navigateToLineOnAnyClickExtension: Extension = [
     EditorView.domEventHandlers({
         click(event, view) {
             const target = event.target as HTMLElement
-            // Check to see if the clicked target is a token link.
-            // If it is, push the link to the history stack.
-            if (target.matches('[data-line-link]')) {
+            const closest = target.closest('[data-cm-line-link]')
+
+            // Check to see if the clicked target is a or is inside a token link.
+            // If it is, navigate to the link.
+            if (closest) {
                 event.preventDefault()
-                const href = target.getAttribute('href')!
+                const href = closest.getAttribute('href')!
                 const props = view.state.facet(blobPropsFacet)
                 if (props.nav) {
                     props.nav(href)


### PR DESCRIPTION
I'm not sure since when this issue is around but the problem is that the `Event#target` is _not_ the `[data-cm-line-link]` but instead a children of it.

This uses `Element#closest()` to find the `[data-cm-line-link]` element and uses the react router navigate function to avoid a full refresh.

Thanks @vovakulikov for noticing!

## Test plan

Tested manually:


https://user-images.githubusercontent.com/458591/220393663-00b595f2-a4ae-4767-9366-b8c6873ff98c.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-references-panel-full.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
