### PR TITLE
packages: remove reference to to-be-removed column in code and use default value instead

### DIFF
--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -355,8 +355,8 @@ CREATE TEMPORARY TABLE t_package_repo_versions (
 `
 
 const transferPackageRepoRefsQuery = `
-INSERT INTO lsif_dependency_repos (scheme, name, version)
-SELECT scheme, name, '👁️temporary_sentinel_value👁️'
+INSERT INTO lsif_dependency_repos (scheme, name)
+SELECT scheme, name
 FROM (
 	SELECT scheme, name
 	FROM t_package_repo_refs t

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -12474,7 +12474,7 @@
           "Index": 3,
           "TypeName": "text",
           "IsNullable": false,
-          "Default": "",
+          "Default": "'👁️temporary_sentinel_value👁️'::text",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
           "IdentityGeneration": "",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1770,7 +1770,7 @@ Foreign-key constraints:
 ---------+--------+-----------+----------+---------------------------------------------------
  id      | bigint |           | not null | nextval('lsif_dependency_repos_id_seq'::regclass)
  name    | text   |           | not null | 
- version | text   |           | not null | 
+ version | text   |           | not null | '👁️temporary_sentinel_value👁️'::text
  scheme  | text   |           | not null | 
 Indexes:
     "lsif_dependency_repos_pkey" PRIMARY KEY, btree (id)

--- a/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/down.sql
+++ b/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lsif_dependency_repos
+ALTER COLUMN version DROP DEFAULT;

--- a/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/metadata.yaml
+++ b/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/metadata.yaml
@@ -1,0 +1,2 @@
+name: package_repos_separate_versions_table_patch1
+parents: [1676584791]

--- a/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/up.sql
+++ b/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lsif_dependency_repos
+ALTER COLUMN version SET DEFAULT '👁️temporary_sentinel_value👁️';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2488,7 +2488,7 @@ ALTER SEQUENCE lsif_dependency_indexing_jobs_id_seq1 OWNED BY lsif_dependency_in
 CREATE TABLE lsif_dependency_repos (
     id bigint NOT NULL,
     name text NOT NULL,
-    version text NOT NULL,
+    version text DEFAULT '👁️temporary_sentinel_value👁️'::text NOT NULL,
     scheme text NOT NULL
 );
 


### PR DESCRIPTION
We should not be referencing the `version` column from `lsif_dependency_repos` if we plan to remove it in a later migration. Given we were only inserting a default value anyways, we should just use a default value in postgres instead. Then is safe :+1: 

## Test plan

Migration runs fine, no more references found in code, ran locally
