### PR TITLE
rbac: oob migration fix for role assignment (#47946)

### DIFF
--- a/internal/oobmigration/migrations/register.go
+++ b/internal/oobmigration/migrations/register.go
@@ -54,7 +54,7 @@ type migratorDependencies struct {
 func registerOSSMigrators(runner *oobmigration.Runner, noDelay bool, deps migratorDependencies) error {
 	return RegisterAll(runner, noDelay, []TaggedMigrator{
 		batches.NewExternalServiceWebhookMigratorWithDB(deps.store, deps.keyring.ExternalServiceKey, 50),
-		batches.NewUserRoleAssignmentMigrator(deps.store, 500),
+		batches.NewUserRoleAssignmentMigrator(deps.store, 250),
 	})
 }
 


### PR DESCRIPTION
Backporting to 4.5

Original PR:

Earlier today (or some days/ months ago depending on when you're reading this), I noticed that on S2 the OOB migration for assigning roles to existing users was at 99% for quite some time.

<img width="918" alt="CleanShot 2023-02-21 at 12 44 21@2x" src="https://user-images.githubusercontent.com/25608335/220336203-2fe406cb-e8bd-4c6b-9066-af14fd03d50a.png">

I did some digging to find out what happened, and I found out we had some site admins who weren't assigned the `USER` role. I confirmed they weren't newly created admins since the PR for assigning roles on creation merged pretty recently - they weren't. I suspect it's a case of the instance getting restarted when the OOB migration was in progress.

The existing logic for checking users that need to be assigned roles just checked the `user_roles` table to see if you had any record; we didn't check specifically for what roles were assigned.

```sql
SELECT
	id, site_admin
FROM users u
WHERE
	u.id NOT IN (SELECT user_id from user_roles)
```

This PR updates that query to check for the assigned roles and only sets what's needed. I also updated the test to test for this scenario.

## Test plan

<!-- All pull requests REQUIRE a test plan:
https://docs.sourcegraph.com/dev/background-information/testing_principles -->
The test added validates that the `Up` method checks for specific role assignments on a `USER` and `SITE_ADMINISTRATOR` level.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
