### PR TITLE
batches: fix fork name migration progress

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -781,7 +781,12 @@ type ExternalChangesetResolver interface {
 	Body(context.Context) (*string, error)
 	Author() (*PersonResolver, error)
 	ExternalURL() (*externallink.Resolver, error)
+
+	// If the changeset is a fork, this corresponds to the namespace of the fork.
 	ForkNamespace() *string
+	// If the changeset is a fork, this corresponds to the name of the fork.
+	ForkName() *string
+
 	// ReviewState returns a value of type *btypes.ChangesetReviewState.
 	ReviewState(context.Context) *string
 	// CheckState returns a value of type *btypes.ChangesetCheckState.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -418,6 +418,10 @@ type ExternalChangeset implements Node & Changeset {
     host).
     """
     forkNamespace: String
+    """
+    If the changeset was opened from a fork, this is the name of the fork repository.
+    """
+    forkName: String
 
     """
     The review state of this changeset. This is only set once the changeset is published on the code host.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -140,6 +140,7 @@ type Changeset struct {
 	ExternalID         string
 	ExternalURL        ExternalURL
 	ForkNamespace      string
+	ForkName           string
 	ReviewState        string
 	CheckState         string
 	Events             ChangesetEventConnection

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -210,6 +210,7 @@ func TestChangesetResolver(t *testing.T) {
 		ExternalServiceType:   "github",
 		ExternalID:            "98765",
 		ExternalForkNamespace: "user",
+		ExternalForkName:      "my-fork",
 		PublicationState:      btypes.ChangesetPublicationStateUnpublished,
 		ReconcilerState:       btypes.ReconcilerStateQueued,
 	})
@@ -372,6 +373,7 @@ func TestChangesetResolver(t *testing.T) {
 				Typename:      "ExternalChangeset",
 				ExternalID:    "98765",
 				ForkNamespace: "user",
+				ForkName:      "my-fork",
 				Repository:    apitest.Repository{Name: string(repo.Name)},
 				Labels:        []apitest.Label{},
 				State:         string(btypes.ChangesetStateProcessing),
@@ -432,6 +434,7 @@ query($changeset: ID!) {
 
       externalID
       forkNamespace
+	  forkName
       state
       reviewState
       checkState

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -25,6 +25,7 @@ type TestChangesetOpts struct {
 	ExternalID            string
 	ExternalBranch        string
 	ExternalForkNamespace string
+	ExternalForkName      string
 	ExternalState         btypes.ChangesetExternalState
 	ExternalReviewState   btypes.ChangesetReviewState
 	ExternalCheckState    btypes.ChangesetCheckState
@@ -113,6 +114,10 @@ func BuildChangeset(opts TestChangesetOpts) *btypes.Changeset {
 
 	if opts.ExternalForkNamespace != "" {
 		changeset.ExternalForkNamespace = opts.ExternalForkNamespace
+	}
+
+	if opts.ExternalForkName != "" {
+		changeset.ExternalForkName = opts.ExternalForkName
 	}
 
 	if opts.FailureMessage != "" {

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -426,3 +426,13 @@ func SetChangesetClosed(t *testing.T, ctx context.Context, s UpdateChangeseter, 
 		t.Fatalf("failed to update changeset: %s", err)
 	}
 }
+
+func DeleteChangeset(t *testing.T, ctx context.Context, s UpdateChangeseter, c *btypes.Changeset) {
+	t.Helper()
+
+	c.SetDeleted()
+
+	if err := s.UpdateChangeset(ctx, c); err != nil {
+		t.Fatalf("failed to delete changeset: %s", err)
+	}
+}

--- a/enterprise/internal/oobmigration/migrations/batches/external_fork_name_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/batches/external_fork_name_migrator.go
@@ -44,7 +44,7 @@ func (m *externalForkNameMigrator) Progress(ctx context.Context, _ bool) (float6
 // or Cloud.
 const externalForkNameMigratorProgressQuery = `
 SELECT
-	CASE migrated.count WHEN 0 THEN 0 ELSE
+	CASE total.count WHEN 0 THEN 1 ELSE
 		CAST(migrated.count AS float) / CAST(total.count AS float)
 	END
 FROM

--- a/enterprise/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
@@ -1,0 +1,232 @@
+package batches
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	bstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+
+	bbcs "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestExternalForkNameMigrator(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	s := bstore.New(db, &observation.TestContext, nil)
+
+	migrator := NewExternalForkNameMigrator(s.Store, 100)
+	progress, err := migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	if have, want := progress, 1.0; have != want {
+		t.Fatalf("got invalid progress with no DB entries, want=%f have=%f", want, have)
+	}
+
+	rs := database.ReposWith(logger, s)
+	es := database.ExternalServicesWith(logger, s)
+	ghrepo := bt.TestRepo(t, es, extsvc.KindGitHub)
+	glrepo := bt.TestRepo(t, es, extsvc.KindGitLab)
+	bbsrepo := bt.TestRepo(t, es, extsvc.KindBitbucketServer)
+	bbcrepo := bt.TestRepo(t, es, extsvc.KindBitbucketCloud)
+
+	if err := rs.Create(ctx, ghrepo, glrepo, bbsrepo, bbcrepo); err != nil {
+		t.Fatal(err)
+	}
+
+	testData := []struct {
+		extID            string
+		extSvcType       string
+		repoID           api.RepoID
+		extForkNamespace string
+		extForkName      string
+		extDeleted       bool
+		metadata         any
+		wantExtForkName  string
+	}{
+		// Changesets on GitHub/GitLab should not be migrated.
+		{
+			extID:            "gh1",
+			extSvcType:       extsvc.TypeGitHub,
+			repoID:           ghrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       false,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		{
+			extID:            "gl1",
+			extSvcType:       extsvc.TypeGitLab,
+			repoID:           glrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       false,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		// A changeset on Bitbucket Server/Cloud that is not on a fork should not be migrated.
+		{
+			extID:            "bbs1",
+			extSvcType:       extsvc.TypeBitbucketServer,
+			repoID:           bbsrepo.ID,
+			extForkNamespace: "",
+			extForkName:      "",
+			extDeleted:       true,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		{
+			extID:            "bbc1",
+			extSvcType:       extsvc.TypeBitbucketCloud,
+			repoID:           bbcrepo.ID,
+			extForkNamespace: "",
+			extForkName:      "",
+			extDeleted:       true,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		// A changeset on Bitbucket Server/Cloud that already has a fork name should not be migrated.
+		{
+			extID:            "bbs2",
+			extSvcType:       extsvc.TypeBitbucketServer,
+			repoID:           bbsrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "my-fork-name",
+			extDeleted:       false,
+			metadata:         nil,
+			wantExtForkName:  "my-fork-name",
+		},
+		{
+			extID:            "bbc2",
+			extSvcType:       extsvc.TypeBitbucketCloud,
+			repoID:           bbcrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "my-fork-name",
+			extDeleted:       false,
+			metadata:         nil,
+			wantExtForkName:  "my-fork-name",
+		},
+		// A changeset on Bitbucket Server/Cloud that was deleted on the code host should not be migrated.
+		{
+			extID:            "bbs3",
+			extSvcType:       extsvc.TypeBitbucketServer,
+			repoID:           bbsrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       true,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		{
+			extID:            "bbc3",
+			extSvcType:       extsvc.TypeBitbucketCloud,
+			repoID:           bbcrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       true,
+			metadata:         nil,
+			wantExtForkName:  "",
+		},
+		// A changeset on Bitbucket Server/Cloud that has a fork namespace and no fork name should be migrated.
+		{
+			extID:            "bbs4",
+			extSvcType:       extsvc.TypeBitbucketServer,
+			repoID:           bbsrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       false,
+			metadata: &bitbucketserver.PullRequest{
+				FromRef: bitbucketserver.Ref{Repository: bitbucketserver.RefRepository{Slug: "my-bbs-fork-name"}},
+			},
+			wantExtForkName: "my-bbs-fork-name",
+		},
+		{
+			extID:            "bbc4",
+			extSvcType:       extsvc.TypeBitbucketCloud,
+			repoID:           bbcrepo.ID,
+			extForkNamespace: "user",
+			extForkName:      "",
+			extDeleted:       false,
+			metadata: &bbcs.AnnotatedPullRequest{
+				PullRequest: &bitbucketcloud.PullRequest{
+					Source: bitbucketcloud.PullRequestEndpoint{Repo: bitbucketcloud.Repo{Name: "my-bbc-fork-name"}},
+				},
+			},
+			wantExtForkName: "my-bbc-fork-name",
+		},
+	}
+
+	for _, tc := range testData {
+		cs := bt.CreateChangeset(t, ctx, s, bt.TestChangesetOpts{
+			ExternalServiceType:   tc.extSvcType,
+			ExternalID:            tc.extID,
+			Repo:                  tc.repoID,
+			ExternalForkNamespace: tc.extForkNamespace,
+			ExternalForkName:      tc.extForkName,
+			Metadata:              tc.metadata,
+		})
+
+		if tc.extDeleted {
+			bt.DeleteChangeset(t, ctx, s, cs)
+		}
+	}
+
+	count, _, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf("SELECT count(*) FROM changesets")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 10 {
+		t.Fatalf("got %d changesets, want %d", count, 10)
+	}
+
+	progress, err = migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	// We expect to start with progress at 50% because 2 of the 4 changesets on forks on
+	// Bitbucket Server/Cloud already have a fork name set.
+	if have, want := progress, 0.5; have != want {
+		t.Fatalf("got invalid progress with unmigrated entries, want=%f have=%f", want, have)
+	}
+
+	if err := migrator.Up(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err = migrator.Progress(ctx, false)
+	assert.NoError(t, err)
+
+	if have, want := progress, 1.0; have != want {
+		t.Fatalf("got invalid progress after up migration, want=%f have=%f", want, have)
+	}
+
+	for _, tc := range testData {
+		// Check that we can find the empty spec with its new ID.
+		cs, err := s.GetChangeset(ctx, bstore.GetChangesetOpts{ExternalID: tc.extID, ExternalServiceType: tc.extSvcType})
+
+		fmt.Printf("changeset: %+v\n\n", cs)
+
+		if err != nil {
+			t.Fatalf("could not find changeset with external ID %s after migration", tc.extID)
+		}
+		if tc.wantExtForkName != "" && cs.ExternalForkName != tc.wantExtForkName {
+			t.Fatalf("changeset with external id %s has wrong fork name. got %q, want %q", tc.extID, cs.ExternalForkName, tc.wantExtForkName)
+		} else if tc.wantExtForkName == "" && cs.ExternalForkName != "" {
+			t.Fatalf("changeset with external id %s has wrong fork name. got %q, want empty string", tc.extID, cs.ExternalForkName)
+		}
+	}
+}


### PR DESCRIPTION
Cherry-picks commit for https://github.com/sourcegraph/sourcegraph/pull/47701 and one dependent commit (from https://github.com/sourcegraph/sourcegraph/pull/47911) into 4.5.

## Test plan

Will wait to ensure buildkite passes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
