### PR TITLE
Fix contributions console error after React router update

### DIFF
--- a/client/web/src/contributions.ts
+++ b/client/web/src/contributions.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { useLocation, useNavigate } from 'react-router-dom'
+import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom'
 import { Subscription } from 'rxjs'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -19,12 +19,15 @@ export function GlobalContributions(props: Props): null {
     const location = useLocation()
     const navigate = useNavigate()
 
-    // Location may be used by the hover contributions after they are
-    // initialized. To avoid stale location, we need to keep it in a ref.
+    // Location and navigate may be used by the hover contributions after they
+    // are initialized and closed over. To avoid stale data, we keep them in
+    // refs.
     const locationRef = useRef(location)
+    const navigateRef = useRef(navigate)
     useEffect(() => {
         locationRef.current = location
-    }, [location])
+        navigateRef.current = navigate
+    }, [location, navigate])
 
     const [error, setError] = useState<null | Error>(null)
 
@@ -38,10 +41,12 @@ export function GlobalContributions(props: Props): null {
     useEffect(() => {
         const subscriptions = new Subscription()
         if (extensionsController !== null) {
+            const historyOrNavigate: NavigateFunction = (to: any, options: any): void =>
+                navigateRef.current?.(to, options) as any
             subscriptions.add(
                 registerHoverContributions({
                     platformContext,
-                    historyOrNavigate: navigate,
+                    historyOrNavigate,
                     getLocation: () => locationRef.current,
                     extensionsController,
                     locationAssign: globalThis.location.assign.bind(globalThis.location),
@@ -49,7 +54,7 @@ export function GlobalContributions(props: Props): null {
             )
         }
         return () => subscriptions.unsubscribe()
-    }, [extensionsController, navigate, platformContext])
+    }, [extensionsController, platformContext])
 
     // Throw error to the <ErrorBoundary />
     if (error) {

--- a/client/web/src/contributions.ts
+++ b/client/web/src/contributions.ts
@@ -41,8 +41,8 @@ export function GlobalContributions(props: Props): null {
     useEffect(() => {
         const subscriptions = new Subscription()
         if (extensionsController !== null) {
-            const historyOrNavigate: NavigateFunction = (to: any, options: any): void =>
-                navigateRef.current?.(to, options) as any
+            const historyOrNavigate: NavigateFunction = ((to: any, options: any): void =>
+                navigateRef.current?.(to, options)) as any
             subscriptions.add(
                 registerHoverContributions({
                     platformContext,


### PR DESCRIPTION
@valerybugakov: We talked about the root issue before: Right now, we recreate the React router config whenever the state of `SourcegraphWebApp` (or `LegacySourcegraphWebApp`) changes. This causes the contributions part of the code to initialize multiple times (because the `navigate` function changes)

This is a temporary fix that removes the console errors by not closing over `navigate` and using a ref instead.

Luckily, the new code path doesn't need these contributions anymore  

## Test plan

- Tested locally, the errors are gone
- Verified via `console.log` that `registerHoverContributions` is not called a second time.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-contributions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
