### PR TITLE
Add useSetting hook

### DIFF
--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -1,10 +1,11 @@
+import { createContext, useContext, useMemo } from 'react'
+
 import { cloneDeep, isFunction } from 'lodash'
 
 import { createAggregateError, ErrorLike, isErrorLike, parseJSONCOrError } from '@sourcegraph/common'
 
 import { DefaultSettingFields, OrgSettingFields, SiteSettingFields, UserSettingFields } from '../graphql-operations'
 import { Settings as GeneratedSettingsType } from '../schema/settings.schema'
-import { createContext, useContext, useMemo } from 'react'
 
 /**
  * A dummy type to represent the "subject" for client settings (i.e., settings stored in the client application,
@@ -236,6 +237,7 @@ export function isSettingsValid<S extends Settings>(
 
 /**
  * React partial props for components needing the settings cascade.
+ *
  * @deprecated Use useSettings() or useSettingsCascade() instead.
  */
 export interface SettingsCascadeProps<S extends Settings = Settings> {
@@ -261,6 +263,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren<SettingsProvider
 
 /**
  * Access the underlying settings cascade directly.
+ *
  * @deprecated Use useSettings() instead.
  */
 export const useSettingsCascade = (): SettingsCascadeOrError => {

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -37,7 +37,11 @@ import {
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
-import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import {
+    EMPTY_SETTINGS_CASCADE,
+    SettingsCascadeProps,
+    SettingsProvider,
+} from '@sourcegraph/shared/src/settings/settings'
 import { TemporarySettingsProvider } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsProvider'
 import { TemporarySettingsStorage } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsStorage'
 import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
@@ -345,6 +349,7 @@ export class LegacySourcegraphWebApp extends React.Component<
                     /* eslint-disable react/no-children-prop, react/jsx-key */
                     <ApolloProvider client={graphqlClient} children={undefined} />,
                     <WildcardThemeContext.Provider value={WILDCARD_THEME} />,
+                    <SettingsProvider settingsCascade={this.state.settingsCascade} />,
                     <ErrorBoundary location={null} />,
                     <TraceSpanProvider name={SharedSpanName.AppMount} />,
                     <FeatureFlagsProvider />,

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -35,6 +35,7 @@ import {
     EMPTY_SETTINGS_CASCADE,
     Settings,
     SettingsCascadeOrError,
+    SettingsProvider,
     SettingsSubjectCommonFields,
 } from '@sourcegraph/shared/src/settings/settings'
 import { TemporarySettingsProvider } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsProvider'
@@ -420,6 +421,7 @@ export const SourcegraphWebApp: React.FC<SourcegraphWebAppProps> = props => {
                 /* eslint-disable react/no-children-prop, react/jsx-key */
                 <ApolloProvider client={graphqlClient} children={undefined} />,
                 <WildcardThemeContext.Provider value={WILDCARD_THEME} />,
+                <SettingsProvider settingsCascade={settingsCascade} />,
                 <ErrorBoundary location={null} />,
                 <TraceSpanProvider name={SharedSpanName.AppMount} />,
                 <FeatureFlagsProvider />,


### PR DESCRIPTION
Inspired by Vova's #47864, this adds a new `useSettings()` hook to replace the existing `SettingsCascadeProps` prop drilling.

I decided to _not_ replace all of the props drilling just yet to avoid a massive merge conflict when Vova's PR ships. I also really want to focus on cleaning up the app shell instead and I need this particularly for one use case: Cleaning up `globbing` which, as it turns out, is just a computed value from the setting instead.

With this new settings API in place, I want to start trimming the shared props mess in a follow-up PR. This will then already remove the needs to pass the settings cascade around naturally and we will end up with a few smaller issues instead of a high change of breaking things.

I've also marked the existing settings APIs (including access to the `SettingsCascade` object directly) as deprecated. `useSettings()` should be used when possible. I don't think we need to validate the settings in every caller manually. 😅 

## Test plan

- Add `console.log(useSettings())` to a route
- See the settings resolve. Wow. Magic!
<img width="1307" alt="Screenshot 2023-02-21 at 18 34 44" src="https://user-images.githubusercontent.com/458591/220418472-ec05ba30-c39f-4337-bdeb-d8a8c33dc80a.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-settings-context.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
