### PR TITLE
[rank] move SCIP compressor to shared directory

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/trie"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -159,8 +160,10 @@ type bufferedDocument struct {
 	payloadHash  []byte
 }
 
-const DocumentsBatchSize = 256
-const MaxBatchPayloadSum = 1024 * 1024 * 32
+const (
+	DocumentsBatchSize = 256
+	MaxBatchPayloadSum = 1024 * 1024 * 32
+)
 
 func (s *scipWriter) InsertDocument(ctx context.Context, path string, scipDocument *scip.Document) error {
 	if s.batchPayloadSum >= MaxBatchPayloadSum {
@@ -174,7 +177,7 @@ func (s *scipWriter) InsertDocument(ctx context.Context, path string, scipDocume
 		return err
 	}
 
-	compressedPayload, err := compressor.compress(bytes.NewReader(payload))
+	compressedPayload, err := shared.Compressor.Compress(bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/stream.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/stream.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -27,7 +28,7 @@ func (s *store) ScanDocuments(ctx context.Context, id int, f func(path string, d
 			return err
 		}
 
-		scipPayload, err := decompressor.decompress(bytes.NewReader(compressedSCIPPayload))
+		scipPayload, err := shared.Decompressor.Decompress(bytes.NewReader(compressedSCIPPayload))
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/codeintel/uploads/shared/scip_compressor.go
+++ b/enterprise/internal/codeintel/uploads/shared/scip_compressor.go
@@ -1,4 +1,4 @@
-package lsifstore
+package shared
 
 import (
 	"bytes"
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-var compressor = &gzipCompressor{
+var Compressor = &gzipCompressor{
 	writers: sync.Pool{
 		New: func() any { return gzip.NewWriter(nil) },
 	},
@@ -17,7 +17,7 @@ type gzipCompressor struct {
 	writers sync.Pool
 }
 
-func (c *gzipCompressor) compress(r io.Reader) ([]byte, error) {
+func (c *gzipCompressor) Compress(r io.Reader) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 	err := c.compressInto(r, buf)
 	return buf.Bytes(), err

--- a/enterprise/internal/codeintel/uploads/shared/scip_decompressor.go
+++ b/enterprise/internal/codeintel/uploads/shared/scip_decompressor.go
@@ -1,4 +1,4 @@
-package lsifstore
+package shared
 
 import (
 	"bytes"
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-var decompressor = &gzipDecompressor{
+var Decompressor = &gzipDecompressor{
 	readers: sync.Pool{
 		New: func() any { return new(gzip.Reader) },
 	},
@@ -17,7 +17,7 @@ type gzipDecompressor struct {
 	readers sync.Pool
 }
 
-func (c *gzipDecompressor) decompress(r io.Reader) ([]byte, error) {
+func (c *gzipDecompressor) Decompress(r io.Reader) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 	err := c.decompressInto(r, buf)
 	return buf.Bytes(), err


### PR DESCRIPTION
Move SCIP compressor and decompressor to shared directory since I will be needing it in the store here shortly.

## Test plan
Test manually
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
