### PR TITLE
gRPC: translate errors to context.Canceled

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -551,7 +551,9 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, errRe
 		}
 		r := streamio.NewReader(func() ([]byte, error) {
 			msg, err := stream.Recv()
-			if err != nil {
+			if status.Code(err) == codes.Canceled {
+				return nil, context.Canceled
+			} else if err != nil {
 				return nil, err
 			}
 			return msg.GetData(), nil

--- a/internal/search/searcher/client_grpc.go
+++ b/internal/search/searcher/client_grpc.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -98,6 +100,8 @@ func SearchGRPC(
 			msg, err := resp.Recv()
 			if errors.Is(err, io.EOF) {
 				return false, nil
+			} else if status.Code(err) == codes.Canceled {
+				return false, context.Canceled
 			} else if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
The search pipeline has special treatment for `context.Canceled` errors. However, the gRPC error returned when a context canceled does _not_ respond to `errors.Is(err, context.Canceled)`. This means that our special treatment fails, and the error gets returned, causing the test to fail.

A real fix here will be to add interceptors to our gRPC clients that translates these automatically.

## Test plan

Running backend integration tests that were previously failing consistently.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
