### PR TITLE
packages: fix parent migration number for patch migration

### DIFF
--- a/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/metadata.yaml
+++ b/migrations/frontend/1676996650_package_repos_separate_versions_table_patch1/metadata.yaml
@@ -1,2 +1,2 @@
 name: package_repos_separate_versions_table_patch1
-parents: [1676584791]
+parents: [1675962678]


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/47988. 1675962678 is the latest migration on branch 4.5

## Test plan

Ran up migration :+1: minimal impact anyway
