### PR TITLE
experimental search input: Fix overflow/line wrapping behavior

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -27,7 +27,7 @@
 
 .focus-container {
     display: flex;
-    background-color: var(--color-bg-1);
+    background-color: var(--input-bg);
     border-radius: 4px;
     margin: 0.75rem;
     border: 1px solid var(--border-color-2);
@@ -44,9 +44,9 @@
     }
 
     &:focus-within {
-        outline: 2px solid rgba(163, 208, 255, 1);
+        outline: 2px solid var(--primary-2);
         outline-offset: 0;
-        border-color: var(--border-active-color);
+        border-color: var(--primary-2);
 
         .hide-when-focused {
             display: none;
@@ -91,4 +91,29 @@
     height: 1.125rem;
     margin-right: 0.5rem;
     background-color: var(--border-color-2);
+}
+
+.mode-section {
+    display: flex;
+    align-items: center;
+    padding-right: 0.1875rem;
+    margin-right: 0.25rem;
+    border-right: 1px solid var(--border-color-2);
+    font-family: var(--code-font-family);
+    font-size: var(--code-font-size);
+    color: var(--text-muted);
+
+    button {
+        padding: 0.0625rem 0.125rem;
+
+        &:hover {
+            background-color: var(--color-bg-2);
+        }
+    }
+
+    &.active {
+        color: var(--logo-purple);
+        padding: 0;
+        border: 0;
+    }
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { defaultKeymap, historyKeymap, history as codemirrorHistory } from '@codemirror/commands'
 import { Compartment, EditorState, Extension, Prec } from '@codemirror/state'
 import { EditorView, keymap, drawSelection } from '@codemirror/view'
+import { mdiClockOutline } from '@mdi/js'
+import classNames from 'classnames'
 import inRange from 'lodash/inRange'
 import { useNavigate } from 'react-router-dom'
 import useResizeObserver from 'use-resize-observer'
@@ -13,6 +15,7 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { QueryChangeSource, QueryState } from '@sourcegraph/shared/src/search'
 import { getTokenLength } from '@sourcegraph/shared/src/search/query/utils'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { singleLine, placeholder as placeholderExtension } from '../codemirror'
 import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
@@ -20,7 +23,7 @@ import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
 
 import { filterHighlight } from './codemirror/syntax-highlighting'
-import { modeScope } from './modes'
+import { modeScope, useInputMode } from './modes'
 import { editorConfigFacet, Source, suggestions } from './suggestionsExtension'
 
 import styles from './CodeMirrorQueryInputWrapper.module.scss'
@@ -168,7 +171,6 @@ function createEditor(
             extensions: [
                 singleLine,
                 drawSelection(),
-                EditorView.lineWrapping,
                 EditorView.contentAttributes.of({
                     role: 'combobox',
                     'aria-controls': popoverID,
@@ -179,23 +181,32 @@ function createEditor(
                 keymap.of(defaultKeymap),
                 codemirrorHistory(),
                 Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
-                EditorView.theme({
+                EditorView.baseTheme({
                     '&': {
                         flex: 1,
                         backgroundColor: 'var(--input-bg)',
                         borderRadius: 'var(--border-radius)',
                         borderColor: 'var(--border-color)',
+                        // To ensure that the input doesn't overflow the parent
+                        minWidth: 0,
+                        marginRight: '0.5rem',
                     },
                     '&.cm-editor.cm-focused': {
                         outline: 'none',
                     },
+                    '.cm-scroller': {
+                        overflowX: 'hidden',
+                    },
                     '.cm-content': {
                         caretColor: 'var(--search-query-text-color)',
+                        color: 'var(--search-query-text-color)',
                         fontFamily: 'var(--code-font-family)',
                         fontSize: 'var(--code-font-size)',
-                        color: 'var(--search-query-text-color)',
                         padding: 0,
                         paddingLeft: '0.25rem',
+                    },
+                    '.cm-content.focus-visible': {
+                        boxShadow: 'none',
                     },
                     '.cm-line': {
                         padding: 0,
@@ -204,15 +215,10 @@ function createEditor(
                         backgroundColor: 'var(--gray-02)',
                         borderRadius: '3px',
                     },
-                }),
-                EditorView.theme(
-                    {
-                        '.sg-token-hover': {
-                            backgroundColor: 'var(--gray-08)',
-                        },
+                    '&dark .sg-token-hover': {
+                        backgroundColor: 'var(--gray-08)',
                     },
-                    { dark: true }
-                ),
+                }),
                 querySettingsCompartment.of(queryExtensions),
                 extensionsCompartment.of(extensions),
             ],
@@ -275,11 +281,14 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
     const focusContainerRef = useRef<HTMLDivElement | null>(null)
     const [suggestionsContainer, setSuggestionsContainer] = useState<HTMLDivElement | null>(null)
     const popoverID = useMemo(() => uuid.v4(), [])
+    const [mode, setMode, modeNotifierExtension] = useInputMode()
 
     // Wraps the onSubmit prop because that one changes whenever the input
     // value changes causing unnecessary reconfiguration of the extensions
     const onSubmitRef = useRef(onSubmit)
-    onSubmitRef.current = onSubmit
+    useEffect(() => {
+        onSubmitRef.current = onSubmit
+    }, [onSubmit])
     const hasSubmitHandler = !!onSubmit
 
     // Update extensions whenever any of these props change
@@ -296,6 +305,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
                 historyOrNavigate: navigate,
             }),
             externalExtensions,
+            modeNotifierExtension,
         ],
         [
             popoverID,
@@ -308,6 +318,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
             suggestionSource,
             navigate,
             externalExtensions,
+            modeNotifierExtension,
         ]
     )
 
@@ -325,7 +336,9 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
         [container]
     )
     const editorRef = useRef(editor)
-    editorRef.current = editor
+    useEffect(() => {
+        editorRef.current = editor
+    }, [editor])
     useEffect(() => () => editor?.destroy(), [editor])
 
     // Update editor content whenever query state changes
@@ -339,6 +352,13 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
         editorRef.current?.contentDOM.focus()
     }, [editorRef])
 
+    const toggleHistoryMode = useCallback(() => {
+        if (editorRef.current) {
+            setMode(editorRef.current, mode => (mode === 'History' ? null : 'History'))
+            editorRef.current.focus()
+        }
+    }, [setMode])
+
     const { ref: spacerRef, height: spacerHeight } = useResizeObserver({
         ref: focusContainerRef,
     })
@@ -349,6 +369,14 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
             <div className={styles.spacer} style={{ height: `${spacerHeight}px` }} />
             <div className={styles.root}>
                 <div ref={spacerRef} className={styles.focusContainer}>
+                    <div className={classNames(styles.modeSection, !!mode && styles.active)}>
+                        <Tooltip content="Recent searches">
+                            <Button variant="icon" onClick={toggleHistoryMode} aria-label="Open search history">
+                                <Icon svgPath={mdiClockOutline} aria-hidden="true" />
+                            </Button>
+                        </Tooltip>
+                        {mode && <span className="ml-1">{mode}:</span>}
+                    </div>
                     <div ref={setContainer} className="d-contents" />
                     {children}
                 </div>

--- a/client/branded/src/search-ui/input/experimental/codemirror/history.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/history.ts
@@ -1,86 +1,14 @@
-import { Extension, Prec } from '@codemirror/state'
-import { Decoration, EditorView, ViewPlugin, WidgetType } from '@codemirror/view'
+import type { Extension } from '@codemirror/state'
 import { mdiClockOutline } from '@mdi/js'
 import { formatDistanceToNow, parseISO } from 'date-fns'
-import { Fzf, FzfOptions } from 'fzf'
+import { Fzf, type FzfOptions } from 'fzf'
 
 import { pluralize } from '@sourcegraph/common'
-import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
-import { createSVGIcon } from '@sourcegraph/shared/src/util/dom'
+import { type RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 
-import { clearMode, getSelectedMode, ModeDefinition, modesFacet, setMode } from '../modes'
+import { type ModeDefinition, modesFacet } from '../modes'
 import { queryRenderer } from '../optionRenderer'
-import { Source, suggestionSources, Option } from '../suggestionsExtension'
-
-const theme = EditorView.theme({
-    '.sg-history-button': {
-        marginRight: '0.25rem',
-        paddingRight: '0.25rem',
-        borderRight: '1px solid var(--border-color-2)',
-        color: 'var(--icon-color)',
-    },
-    '.sg-history-button button': {
-        width: '1rem',
-        border: '0',
-        backgroundColor: 'transparent',
-        padding: 0,
-        color: 'inherit',
-    },
-    '.sg-history-button svg': {
-        display: 'inline-block',
-        width: 'var(--icon-inline-size)',
-        height: 'var(--icon-inline-size)',
-        // Setting this simplifies event handling for the history button widget
-        pointerEvents: 'none',
-    },
-    '.sg-mode-History .sg-history-button': {
-        color: 'var(--logo-purple)',
-        marginRight: '0',
-        border: '0',
-    },
-})
-
-function toggleHistoryMode(event: MouseEvent | KeyboardEvent, view: EditorView): void {
-    event.preventDefault()
-    const selectedMode = getSelectedMode(view.state)
-    if (selectedMode?.name === 'History') {
-        clearMode(view)
-    } else {
-        setMode(view, 'History')
-    }
-    view.focus()
-}
-
-/**
- * This ViewPlugin renders the history button at the beginning of the search
- * input.
- */
-const historyButton = ViewPlugin.define(
-    () => ({
-        decorations: Decoration.set(
-            Decoration.widget({
-                side: -1,
-                widget: new (class extends WidgetType {
-                    public toDOM(view: EditorView): HTMLElement {
-                        const container = document.createElement('span')
-                        container.className = 'sg-history-button'
-                        const button = document.createElement('button')
-                        button.type = 'button'
-                        const icon = createSVGIcon(mdiClockOutline)
-
-                        container.append(button)
-                        button.append(icon)
-                        button.addEventListener('click', event => toggleHistoryMode(event, view))
-                        return container
-                    }
-                })(),
-            }).range(0)
-        ),
-    }),
-    {
-        decorations: plugin => plugin.decorations,
-    }
-)
+import { type Source, suggestionSources, type Option } from '../suggestionsExtension'
 
 const fzfOptions: FzfOptions<RecentSearch> = {
     selector: search => search.query,
@@ -136,8 +64,6 @@ export function searchHistoryExtension(config: {
 }): Extension {
     return [
         modesFacet.of([config.mode]),
-        theme,
-        Prec.highest(historyButton),
         suggestionSources.of({
             query: createHistorySuggestionSource(config.source, config.submitQuery),
             mode: config.mode.name,

--- a/client/branded/src/search-ui/input/experimental/modes.ts
+++ b/client/branded/src/search-ui/input/experimental/modes.ts
@@ -1,14 +1,16 @@
+import { useMemo, useState } from 'react'
+
 import {
     Compartment,
     EditorState,
-    Extension,
+    type Extension,
     Facet,
     Prec,
     StateEffect,
     StateField,
-    Transaction,
+    type Transaction,
 } from '@codemirror/state'
-import { Decoration, EditorView, KeyBinding, keymap, WidgetType } from '@codemirror/view'
+import { EditorView, type KeyBinding, keymap } from '@codemirror/view'
 
 import { placeholderConfig } from '../codemirror/placeholder'
 
@@ -81,31 +83,6 @@ const selectedModeField = StateField.define<SelectedModeState>({
                     class: selectedMode ? `sg-mode-${selectedMode.name}` : '',
                 }
             }),
-            EditorView.theme({
-                '.sg-mode-marker': {
-                    color: 'var(--logo-purple)',
-                    paddingRight: '0.125rem',
-                },
-            }),
-            EditorView.decorations.compute([field], state => {
-                const selectedMode = state.field(field).selectedMode
-                if (!selectedMode) {
-                    return Decoration.none
-                }
-                return Decoration.set(
-                    Decoration.widget({
-                        widget: new (class extends WidgetType {
-                            public toDOM(): HTMLElement {
-                                const marker = document.createElement('span')
-                                marker.className = 'sg-mode-marker'
-                                marker.textContent = selectedMode.name + ':'
-                                return marker
-                            }
-                        })(),
-                        side: -1,
-                    }).range(0)
-                )
-            }),
         ]
     },
 })
@@ -148,9 +125,15 @@ export function getSelectedMode(state: EditorState): ModeDefinition | null {
     return state.field(selectedModeField, false)?.selectedMode ?? null
 }
 
-export function setMode(view: EditorView, name: string): boolean {
+function setMode(view: EditorView, name: string | null | ((mode: string | null) => string | null)): boolean {
+    const resolvedName = typeof name === 'function' ? name(getSelectedMode(view.state)?.name ?? null) : name
+
+    if (resolvedName === null) {
+        return clearMode(view)
+    }
+
     view.dispatch({
-        effects: setModeEffect.of(name),
+        effects: setModeEffect.of(resolvedName),
         // Clear input
         changes: { from: 0, to: view.state.doc.length, insert: '' },
         // It seems that setting the selection explicitly
@@ -160,7 +143,7 @@ export function setMode(view: EditorView, name: string): boolean {
     return true
 }
 
-export function clearMode(view: EditorView, restoreInput = true): boolean {
+function clearMode(view: EditorView, restoreInput = true): boolean {
     const state = view.state.field(selectedModeField, false)
     if (state?.selectedMode) {
         const changes = restoreInput
@@ -196,4 +179,31 @@ export function modeScope(extension: Extension, modes: (string | null)[]): Exten
             }
         }),
     ]
+}
+
+/**
+ * React hook to integrate with the input mode extension. The returned extension has to be passed
+ * to the CodeMirror instance when initialized. The hook works like `useState`: The first value
+ * is the currently enabled mode (or `null` if no mode is enabled), the second value is a setter
+ * for changing the mode.
+ */
+export function useInputMode(): [
+    string | null,
+    (view: EditorView, mode: string | null | ((mode: string | null) => string | null)) => void,
+    Extension
+] {
+    const [mode, set] = useState<string | null>(null)
+
+    const extension: Extension = useMemo(
+        () =>
+            EditorView.updateListener.of(update => {
+                const selectedMode = update.state.field(selectedModeField, false)?.selectedMode
+                if (selectedMode !== update.startState.field(selectedModeField, false)?.selectedMode) {
+                    set(selectedMode?.name ?? null)
+                }
+            }),
+        [set]
+    )
+
+    return [mode, setMode, extension]
 }


### PR DESCRIPTION
Currently the input wraps around for very long queries, but it doesn't look great because:
- The mode button + separator only cover the first line
- Lines have no padding and look "squished" togehter.

This PR changes the implementation to replicate the behavior of the current search input: scroll overflow with hidden scrollbar.

To make the scroll behavior work the mode button/indicator had to be reimplemented, otherwise it would have been scrolled out of view. The button is now implemented in React directly which has a couple of advantages:

- It's now in "tab order"
- We can use the Tooltip component from Wildcard

This PR also fixes some dark mode related issues (but not all of them). Specifically I misunderstood the purpose of the `{dark: true}` option passed to `EditorView.theme` (which causes the CodeMirror to think dark mode is active which also affects the text selection style). This change fixes that.

Before: 
<img width="813" alt="2023-02-21_20-17" src="https://user-images.githubusercontent.com/179026/220454179-456020b1-48d2-4546-be8d-8e245231ad5a.png">

After: 
<img width="844" alt="2023-02-21_20-24" src="https://user-images.githubusercontent.com/179026/220454225-b9ac8caa-854b-4e12-abc0-106dd3f28bde.png">



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-fkling-search-input-fix-overflow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
