### PR TITLE
rbac: order columns for migration

### DIFF
--- a/migrations/frontend/1671543381_add_default_roles/up.sql
+++ b/migrations/frontend/1671543381_add_default_roles/up.sql
@@ -1,6 +1,6 @@
 -- system roles that come with every sourcegraph instance
 INSERT INTO
-    roles
+    roles (id, name, created_at, deleted_at, readonly)
 VALUES
     (1, 'USER', '2023-01-04 16:29:41.195966+00', NULL, TRUE),
     (2, 'SITE_ADMINISTRATOR', '2023-01-04 16:29:41.195966+00', NULL, TRUE)


### PR DESCRIPTION
Adds an explicit order to the columns for the roles insert statement to improve robustness when running migrations up and down.

## Test plan

Ran migrations down to well before `1671543381_add_default_roles` then back up successfully. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
