### PR TITLE
[rank] add export ranking defs and refs background job

### DIFF
--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -112,6 +112,8 @@ type exportConfig struct {
 
 	RankingInterval    time.Duration
 	NumRankingRoutines int
+	RankingBatchSize   int
+	RankingJobsEnabled bool
 }
 
 var ConfigExportInst = &exportConfig{}
@@ -119,4 +121,6 @@ var ConfigExportInst = &exportConfig{}
 func (c *exportConfig) Load() {
 	c.RankingInterval = c.GetInterval("CODEINTEL_UPLOADS_RANKING_INTERVAL", "1s", "How frequently to serialize a batch of the code intel graph for ranking.")
 	c.NumRankingRoutines = c.GetInt("CODEINTEL_UPLOADS_RANKING_NUM_ROUTINES", "4", "The number of concurrent ranking graph serializer routines to run per worker instance.")
+	c.RankingBatchSize = c.GetInt("CODEINTEL_UPLOADS_RANKING_BATCH_SIZE", "10000", "The number of definitions and references to populate the ranking graph per batch.")
+	c.RankingJobsEnabled = c.GetBool("CODEINTEL_UPLOADS_RANKING_JOB_ENABLED", "false", "Whether or not to run the ranking job.")
 }

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -205,6 +205,8 @@ func NewGraphExporters(observationCtx *observation.Context, uploadSvc *Service) 
 			uploadSvc,
 			ConfigExportInst.NumRankingRoutines,
 			ConfigExportInst.RankingInterval,
+			ConfigExportInst.RankingBatchSize,
+			ConfigExportInst.RankingJobsEnabled,
 		),
 	}
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/iface.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/iface.go
@@ -20,7 +20,7 @@ import (
 )
 
 type UploadService interface {
-	ExportRankingGraph(ctx context.Context, numRankingRoutines int, numBatchSize int, rankingJobDisabled bool) error
+	ExportRankingGraph(ctx context.Context, numRankingRoutines int, numBatchSize int, rankingJobEnabled bool) error
 	VacuumRankingGraph(ctx context.Context) error
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/iface.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/iface.go
@@ -20,7 +20,7 @@ import (
 )
 
 type UploadService interface {
-	SerializeRankingGraph(ctx context.Context, numRankingRoutines int) error
+	ExportRankingGraph(ctx context.Context, numRankingRoutines int, numBatchSize int, rankingJobDisabled bool) error
 	VacuumRankingGraph(ctx context.Context) error
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -25,9 +25,10 @@ func NewRankingGraphExporter(
 				return err
 			}
 
-			if err := uploadsService.VacuumRankingGraph(ctx); err != nil {
-				return err
-			}
+			// Need to replace this pre-deployment
+			// if err := uploadsService.VacuumRankingGraph(ctx); err != nil {
+			// 	return err
+			// }
 
 			return nil
 		}))

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -13,13 +13,15 @@ func NewRankingGraphExporter(
 	uploadsService UploadService,
 	numRankingRoutines int,
 	interval time.Duration,
+	batchSize int,
+	rankingJobEnabled bool,
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
-		"pagerank.graph-exporter", "exports new and purges old code-intel data as CSV",
+		"rank.graph-exporter", "exports SCIP data to ranking defintions and reference tables",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
-			if err := uploadsService.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
+			if err := uploadsService.ExportRankingGraph(ctx, numRankingRoutines, batchSize, rankingJobEnabled); err != nil {
 				return err
 			}
 

--- a/enterprise/internal/codeintel/uploads/observability.go
+++ b/enterprise/internal/codeintel/uploads/observability.go
@@ -62,6 +62,9 @@ type operations struct {
 	// Tags
 	getListTags *observation.Operation
 
+	// Ranking
+	exportRankingGraph *observation.Operation
+
 	numUploadsRead         prometheus.Counter
 	numBytesUploaded       prometheus.Counter
 	numStaleRecordsDeleted prometheus.Counter
@@ -175,6 +178,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 		// Tags
 		getListTags: op("GetListTags"),
+
+		// Ranking
+		exportRankingGraph: op("ExportRankingGraph"),
 
 		numUploadsRead:         numUploadsRead,
 		numBytesUploaded:       numBytesUploaded,


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/sourcegraph/pull/47997

Adds the export definition and references background job.

## Test plan
Tested manually.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
