### PR TITLE
Fix line wrapping for git blame messages

### DIFF
--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -251,13 +251,15 @@ export const BlameDecoration: React.FunctionComponent<BlameDecorationProps> = ({
                                     as={SourceCommitIcon}
                                     className={classNames('mr-2 flex-shrink-0', styles.icon)}
                                 />
-                                <CommitMessageWithLinks
-                                    message={blameHunk.message}
-                                    to={blameHunk.displayInfo.linkURL}
-                                    className={styles.link}
-                                    onClick={logCommitClick}
-                                    externalURLs={externalURLs}
-                                />
+                                <div>
+                                    <CommitMessageWithLinks
+                                        message={blameHunk.message}
+                                        to={blameHunk.displayInfo.linkURL}
+                                        className={styles.link}
+                                        onClick={logCommitClick}
+                                        externalURLs={externalURLs}
+                                    />
+                                </div>
                             </div>
                             {blameHunk.commit.parents.length > 0 && (
                                 <>


### PR DESCRIPTION
When I extracted the GitHub issue linking in #47593 I accidentally removed a wrapping `<div>` in the Git blame view which causes the layout the be screwed up.

<img width="531" alt="Screenshot 2023-02-22 at 00 07 27" src="https://user-images.githubusercontent.com/458591/220479427-1e4492ed-769e-4dab-92d1-495c8a7e71c1.png">

Thanks @vovakulikov for noticing!

## Test plan

<img width="597" alt="Screenshot 2023-02-22 at 00 08 23" src="https://user-images.githubusercontent.com/458591/220479467-996fe3b8-c0eb-4d2c-a59f-7a6069853566.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-blame-message-with-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
