### PR TITLE
Connect setup wizard to the external services API

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -110,11 +110,13 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
             )
         }
 
-        const { className, ...otherProps } = this.props
+        const { className, blockNavigationIfDirty, ...otherProps } = this.props
 
         return (
             <div className={className || ''}>
-                <BeforeUnloadPrompt when={this.props.loading || this.isDirty} message="Discard changes?" />
+                {blockNavigationIfDirty && (
+                    <BeforeUnloadPrompt when={this.props.loading || this.isDirty} message="Discard changes?" />
+                )}
                 {this.props.actions && (
                     <EditorActionsGroup actions={this.props.actions} onClick={this.runAction.bind(this)} />
                 )}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -1,12 +1,20 @@
 import { FC, ReactNode } from 'react'
 
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
+import { useMutation } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 import { Alert, H4, Link, Button } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../../../components/externalServices/externalServices'
+import { LoaderButton } from '../../../../../components/LoaderButton'
+import {
+    AddExternalServiceInput,
+    AddRemoteCodeHostResult,
+    AddRemoteCodeHostVariables,
+} from '../../../../../graphql-operations'
 import { getCodeHostKindFromURLParam } from '../../helpers'
+import { ADD_CODE_HOST, CODE_HOST_FRAGMENT } from '../../queries'
 
 import { CodeHostJSONForm, CodeHostJSONFormState } from './common'
 import { GithubConnectView } from './github/GithubConnectView'
@@ -36,9 +44,15 @@ export const CodeHostCreation: FC = () => {
         <CodeHostCreationView codeHostKind={codeHostKind}>
             {state => (
                 <footer className={styles.footer}>
-                    <Button variant="primary" size="sm" type="submit">
-                        Connect
-                    </Button>
+                    <LoaderButton
+                        type="submit"
+                        variant="primary"
+                        size="sm"
+                        label={state.submitting ? 'Connecting' : 'Connect'}
+                        alwaysShowLabel={true}
+                        loading={state.submitting}
+                        disabled={state.submitting}
+                    />
                     <Button as={Link} size="sm" to="/setup/remote-repositories" variant="secondary">
                         Cancel
                     </Button>
@@ -61,9 +75,38 @@ interface CodeHostCreationFormProps {
 const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
     const { codeHostKind, children } = props
 
-    const handleSubmit = async (): Promise<void> => {
-        // TODO connect API handler
-        await Promise.resolve()
+    const navigate = useNavigate()
+    const [addRemoteCodeHost] = useMutation<AddRemoteCodeHostResult, AddRemoteCodeHostVariables>(ADD_CODE_HOST)
+
+    const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
+        await addRemoteCodeHost({
+            variables: { input },
+            update: (cache, result) => {
+                const { data } = result
+
+                if (!data) {
+                    return
+                }
+
+                cache.modify({
+                    fields: {
+                        externalServices(codeHosts) {
+                            const newCodeHost = cache.writeFragment({
+                                data: data.addExternalService,
+                                fragment: CODE_HOST_FRAGMENT,
+                            })
+
+                            // Update local cache and put newly created/connected code host
+                            // to the beginning of code hosts list
+                            return { nodes: [newCodeHost, ...codeHosts.nodes] }
+                        },
+                    },
+                })
+            },
+        })
+
+        navigate('/setup/remote-repositories')
+        // TODO show notification UI that code host has been added successfully
     }
 
     if (codeHostKind === ExternalServiceKind.GITHUB) {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -116,7 +116,7 @@ const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
 
     const initialValues: CodeHostConnectFormFields = {
         displayName,
-        configuration,
+        config: configuration,
     }
 
     if (codeHostKind === ExternalServiceKind.GITHUB) {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
@@ -18,16 +18,19 @@ import {
     useField,
     useFieldAPI,
     useForm,
+    ErrorAlert,
+    FORM_ERROR,
 } from '@sourcegraph/wildcard'
 
 import { AddExternalServiceOptions } from '../../../../../../components/externalServices/externalServices'
+import { AddExternalServiceInput } from '../../../../../../graphql-operations'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../../../../../settings/DynamicallyImportedMonacoSettingsEditor'
 
 import styles from './CodeHostConnection.module.scss'
 
 export interface CodeHostConnectFormFields {
     displayName: string
-    configuration: string
+    config: string
 }
 
 export interface CodeHostJSONFormState {
@@ -39,7 +42,7 @@ interface CodeHostJSONFormProps {
     externalServiceOptions: AddExternalServiceOptions
     initialValues?: CodeHostConnectFormFields
     children: (state: CodeHostJSONFormState) => ReactNode
-    onSubmit: (values: CodeHostConnectFormFields) => Promise<void>
+    onSubmit: (values: AddExternalServiceInput) => Promise<void>
 }
 
 export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
@@ -49,13 +52,13 @@ export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
         `${externalServiceOptions.kind}-connect-form`,
         {
             displayName: externalServiceOptions.defaultDisplayName,
-            configuration: externalServiceOptions.defaultConfig,
+            config: externalServiceOptions.defaultConfig,
         }
     )
 
     const form = useForm<CodeHostConnectFormFields>({
         initialValues: initialValues ?? localValues,
-        onSubmit,
+        onSubmit: values => onSubmit({ ...values, kind: externalServiceOptions.kind }),
         onChange: event => setLocalValues(event.values),
     })
 
@@ -67,7 +70,7 @@ export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
 
     const configuration = useField({
         formApi: form.formAPI,
-        name: 'configuration',
+        name: 'config',
     })
 
     return (
@@ -78,6 +81,12 @@ export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
                 configurationField={configuration}
                 externalServiceOptions={externalServiceOptions}
             />
+
+            <>
+                {form.formAPI.submitErrors && (
+                    <ErrorAlert className="w-100" error={form.formAPI.submitErrors[FORM_ERROR]} />
+                )}
+            </>
 
             <div className={styles.footer}>{children(form.formAPI)}</div>
         </form>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -20,6 +20,8 @@ import {
     getDefaultInputProps,
     useFieldAPI,
     useControlledField,
+    ErrorAlert,
+    FORM_ERROR,
 } from '@sourcegraph/wildcard'
 
 import { codeHostExternalServices } from '../../../../../../components/externalServices/externalServices'
@@ -32,7 +34,7 @@ import styles from './GithubConnectView.module.scss'
 
 const DEFAULT_FORM_VALUES: CodeHostConnectFormFields = {
     displayName: codeHostExternalServices.github.defaultDisplayName,
-    configuration: `
+    config: `
 {
     "url": "https://github.com",
     "token": ""
@@ -67,7 +69,7 @@ export const GithubConnectView: FC<GithubConnectViewProps> = props => {
             await onSubmit({
                 kind: ExternalServiceKind.GITHUB,
                 displayName: values.displayName,
-                config: values.configuration,
+                config: values.config,
             })
 
             // Reset initial values after successful connect action
@@ -121,7 +123,7 @@ export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
 
     const configuration = useField({
         formApi: form.formAPI,
-        name: 'configuration',
+        name: 'config',
     })
 
     return (
@@ -160,6 +162,11 @@ export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
                         externalServiceOptions={codeHostExternalServices.github}
                     />
                 </TabPanel>
+                <>
+                    {form.formAPI.submitErrors && (
+                        <ErrorAlert className="w-100 mt-4" error={form.formAPI.submitErrors[FORM_ERROR]} />
+                    )}
+                </>
             </TabPanels>
 
             {children(form.formAPI)}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactElement } from 'react'
 
-import { gql, useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { mdiInformationOutline, mdiDelete, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 
@@ -8,24 +8,9 @@ import { ErrorAlert, Icon, LoadingSpinner, Button, Tooltip, Link } from '@source
 
 import { GetCodeHostsResult } from '../../../../../graphql-operations'
 import { getCodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../../helpers'
+import { GET_CODE_HOSTS } from '../../queries'
 
 import styles from './CodeHostsNavigation.module.scss'
-
-const GET_CODE_HOSTS = gql`
-    query GetCodeHosts {
-        externalServices {
-            nodes {
-                __typename
-                id
-                kind
-                repoCount
-                displayName
-                lastSyncAt
-                nextSyncAt
-            }
-        }
-    }
-`
 
 interface CodeHostsNavigationProps {
     activeConnectionId: string | undefined

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
@@ -1,4 +1,4 @@
-import { mdiBitbucket, mdiGithub, mdiGitlab, mdiAws } from '@mdi/js'
+import { mdiBitbucket, mdiGithub, mdiGitlab, mdiAws, mdiGit } from '@mdi/js'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -12,7 +12,10 @@ export const getCodeHostIcon = (codeHostType: ExternalServiceKind | null): strin
             return mdiBitbucket
         case ExternalServiceKind.AWSCODECOMMIT:
             return mdiAws
-
+        case ExternalServiceKind.AZUREDEVOPS:
+            return mdiGit
+        case ExternalServiceKind.BITBUCKETSERVER:
+            return mdiBitbucket
         default:
             // TODO: Add support for other code host
             return ''

--- a/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
@@ -1,0 +1,35 @@
+import { gql } from '@apollo/client'
+
+export const CODE_HOST_FRAGMENT = gql`
+    fragment CodeHost on ExternalService {
+        __typename
+        id
+        kind
+        repoCount
+        displayName
+        lastSyncAt
+        nextSyncAt
+    }
+`
+
+export const GET_CODE_HOSTS = gql`
+    query GetCodeHosts {
+        externalServices {
+            nodes {
+                ...CodeHost
+            }
+        }
+    }
+
+    ${CODE_HOST_FRAGMENT}
+`
+
+export const ADD_CODE_HOST = gql`
+    mutation AddRemoteCodeHost($input: AddExternalServiceInput!) {
+        addExternalService(input: $input) {
+            ...CodeHost
+        }
+    }
+
+    ${CODE_HOST_FRAGMENT}
+`


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47237

This PR connects "connection UI" to the code host (external services API), note that token validation and pickers will be connected later (as soon as we merge BE PRs about new queries for this form)

## Test plan
- Go to the `/setup/remote-repositories` URL
- Try to connect GIthub or any other code host 
- Right after creation you should see them in the aside navigation block 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-connect-code-host-api-wizard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
