### PR TITLE
app: use embedded postgres for sg start app

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -842,7 +842,6 @@ commands:
       go build -gcflags="$GCFLAGS" -ldflags="-X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=single-program" -o .bin/sourcegraph github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph
     checkBinary: .bin/sourcegraph
     env:
-      USE_EMBEDDED_POSTGRESQL: false
       ENTERPRISE: 1
       SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
       SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
@@ -866,7 +865,6 @@ commands:
       go build -gcflags="$GCFLAGS" -ldflags="-X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=single-program" -o .bin/sourcegraph-oss github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss
     checkBinary: .bin/sourcegraph-oss
     env:
-      USE_EMBEDDED_POSTGRESQL: false
       WEBPACK_DEV_SERVER: 1
     watch:
       - cmd
@@ -1131,7 +1129,6 @@ commandsets:
     requiresDevPrivate: true
     checks:
       - docker
-      - postgres
       - git
     commands:
       - sourcegraph


### PR DESCRIPTION
Now that we clean up postgres properly, it should be safe to test the embedded postgres in dev. If someone wants to stick to there own postgres they can opt out with the USE_EMBEDDED_POSTGRESQL envvar on there own.

Test Plan: sg start app