### PR TITLE
Update SSL dependencies

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -36,5 +36,5 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' \
+RUN apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1t-r0' 'libssl1.1>=1.1.1t-r0' \
     'libxml2>=2.9.14-r2'  # CVE-2022-40303 CVE-2022-40304

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -45,8 +45,8 @@ RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_conf
 RUN apk add --upgrade --no-cache \
     'apk-tools>=2.12' \
     'krb5-libs>=1.18.4' \
-    'libssl1.1>=1.1.1l' \
-    'openssl>=1.1.1l' \
+    'libssl1.1>=1.1.1t-r0' \
+    'openssl>=1.1.1t-r0' \
     'busybox>=1.32.1' \
     'ncurses-libs>=6.2_p20210109-r1' \
     'ncurses-terminfo-base>=6.2_p20210109-r1' \

--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -45,8 +45,8 @@ RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_conf
 RUN apk add --upgrade --no-cache \
     'apk-tools>=2.12' \
     'krb5-libs>=1.18.4' \
-    'libssl1.1>=1.1.1t-r0' \
-    'openssl>=1.1.1t-r0' \
+    'libssl1.1>=1.1.1s-r0' \
+    'openssl>=1.1.1s-r0' \
     'busybox>=1.32.1' \
     'ncurses-libs>=6.2_p20210109-r1' \
     'ncurses-terminfo-base>=6.2_p20210109-r1' \

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1n-r0 libcrypto1.1>=1.1.1n-r0 busybox>=1.33.1-r6
+RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1t-r0 libcrypto1.1>=1.1.1t-r0 busybox>=1.33.1-r6
 
 
 USER redis

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
-
+# hadolint ignore=SC2261
 RUN apk --upgrade --no-cache add tini 'apk-tools>=2.12.7-r0' 'libssl1.1>=1.1.1t-r0' 'libcrypto1.1>=1.1.1t-r0' 'busybox>=1.33.1-r6'
 
 

--- a/docker-images/redis-cache/Dockerfile
+++ b/docker-images/redis-cache/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1t-r0 libcrypto1.1>=1.1.1t-r0 busybox>=1.33.1-r6
+RUN apk --upgrade --no-cache add tini 'apk-tools>=2.12.7-r0' 'libssl1.1>=1.1.1t-r0' 'libcrypto1.1>=1.1.1t-r0' 'busybox>=1.33.1-r6'
 
 
 USER redis

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1n-r0 libcrypto1.1>=1.1.1n-r0 busybox>=1.33.1-r6
+RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1t-r0 libcrypto1.1>=1.1.1t-r0 busybox>=1.33.1-r6
 
 USER redis
 COPY redis.conf /etc/redis/redis.conf

--- a/docker-images/redis-store/Dockerfile
+++ b/docker-images/redis-store/Dockerfile
@@ -5,7 +5,8 @@ RUN mkdir -p /redis-data && chown -R redis:redis /redis-data
 # @FIXME: Update redis image
 # Pin busybox=1.33.1-r6 https://github.com/sourcegraph/sourcegraph/issues/27965
 
-RUN apk --upgrade --no-cache add tini apk-tools>=2.12.7-r0 libssl1.1>=1.1.1t-r0 libcrypto1.1>=1.1.1t-r0 busybox>=1.33.1-r6
+# hadolint ignore=SC2261
+RUN apk --upgrade --no-cache add tini 'apk-tools>=2.12.7-r0' 'libssl1.1>=1.1.1t-r0' 'libcrypto1.1>=1.1.1t-r0' 'busybox>=1.33.1-r6'
 
 USER redis
 COPY redis.conf /etc/redis/redis.conf


### PR DESCRIPTION
We have some SSL issues that come up in container scans. Bumping up the version to resolve issues. Next PR will be to use the new base image for our image builds.


## Test plan

- [x] images build
- [x] images don't have SSL issues

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
