### PR TITLE
Mvu helm doc improvements

### DIFF
--- a/doc/admin/deploy/kubernetes/helm.md
+++ b/doc/admin/deploy/kubernetes/helm.md
@@ -933,10 +933,47 @@ A [multi-version upgrade](../../updates/index.md#multi-version-upgrades) is a do
 - Read our [update policy](../../updates/index.md#update-policy) to learn about Sourcegraph updates.
 - Find the entries that apply to the version range you're passing through in the [update notes for Sourcegraph with Kubernetes](../../updates/kubernetes.md#multi-version-upgrade-procedure).
 
-To perform a multi-version upgrade on a Sourcegraph instance running on Kubernetes with Helm:
+### Multi-version upgrade procedure
 
-1. Follow the steps to perform a [multi-version upgrade for Kubernetes](update.md#multi-version-upgrades).
-1. Follow the [standard upgrade for Kubernetes with Helm](#standard-upgrades) to upgrade the remaining infrastructure (e.g., `helm upgrade ...`).
+1. **Scale down `deployments` and `statefulSets` that access the database**, _this step prevents services from accessing the database while schema migrations are in process._ 
+  The following services must have their replicas scaled to 0:
+    - Deployments (e.g., `kubectl scale deployment <name> --replicas=0`)
+      - precise-code-intel-worker
+      - repo-updater
+      - searcher
+      - sourcegraph-frontend
+      - sourcegraph-frontend-internal
+      - symbols
+      - worker
+    - Stateful sets (e.g., `kubectl scale sts <name> --replicas=0`):
+      - gitserver
+      - indexed-search
+
+    The following convenience commands provide an example of scaling down the necessary services in a single command:
+
+    Deployments:
+    ```
+    kubectl get -n sourcegraph deploy --no-headers | awk '{print $1}' | xargs -n 1 -P 8 -I % kubectl -n sourcegraph scale deployment % --replicas=0
+    ```
+    StatefulSets: 
+    ```
+    kubectl -n sourcegraph get sts --selector 'app.kubernetes.io/component!=codeinsights-db,app.kubernetes.io/component!=codeintel-db,app.kubernetes.io/component!=pgsql' --no-headers | awk '{print $1}' | xargs -n 1 -P 8 -I % kubectl -n sourcegraph scale sts % --replicas=0
+    ```
+
+    > NOTE: The commands above use the `sourcegraph` namespace and are specific to the kubernetes-helm deployment.
+2. **Run the migrator `upgrade` command**
+  - The following command is the general template for running an upgrade
+    ```
+    helm upgrade --install -n <your namespace> --set "migrator.args={upgrade,--from=<current version>,--to=<version to upgrade to>}" sourcegraph-migrator sourcegraph/sourcegraph-migrator --version <migrator image version> 
+    ```
+    > NOTE: The command above is general and you'll need to substitute in your own namespace, target sourcegraph version, and desired migrator image version. In general run the most recent version of migrator.
+
+    You can learn more about running migrator operations in helm in the [migrator operations doc](../../how-to/manual_database_migrations.md#kubernetes).
+3. **Upgrade your instance via `helm upgrade`**
+  - Now that the databases have been migrated to the latest versions, services can be scaled up and upgrade via the [standard procedure](#standard-upgrades). For example:
+    ```
+    helm upgrade -n <your namespace> --install -f override.yaml --version <sourcegraph version> sourcegraph sourcegraph/sourcegraph
+    ```
 
 ### Rollback
 

--- a/doc/admin/deploy/kubernetes/helm.md
+++ b/doc/admin/deploy/kubernetes/helm.md
@@ -968,7 +968,7 @@ A [multi-version upgrade](../../updates/index.md#multi-version-upgrades) is a do
     ```
     > NOTE: The command above is general and you'll need to substitute in your own namespace, target sourcegraph version, and desired migrator image version. In general run the most recent version of migrator.
 
-    You can learn more about running migrator operations in helm in the [migrator operations doc](../../how-to/manual_database_migrations.md#kubernetes).
+    You can learn more about running migrator operations in helm in the [migrator operations doc](../../how-to/manual_database_migrations.md#helm-kubernetes).
 3. **Upgrade your instance via `helm upgrade`**
   - Now that the databases have been migrated to the latest versions, services can be scaled up and upgrade via the [standard procedure](#standard-upgrades). For example:
     ```

--- a/doc/admin/how-to/manual_database_migrations.md
+++ b/doc/admin/how-to/manual_database_migrations.md
@@ -317,6 +317,25 @@ job.batch/migrator condition met
 
 The log output of the `migrator` should include `INFO`-level logs and successfully terminate with `migrator exited with code 0`. If you see an error message or any of the databases have been flagged as "dirty", please follow ["How to troubleshoot a dirty database"](../../../admin/how-to/dirty_database.md). A dirty database will not affect your ability to use Sourcegraph however it will need to be resolved to upgrade further. If you are unable to resolve the issues, contact support at <mailto:support@sourcegraph.com> for further assistance. Otherwise, you are now safe to upgrade Sourcegraph.
 
+### Helm Kubernetes
+
+Running migrator operations in helm takes advantage of the [sourcegraph-migrator helm charts](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph-migrator). You can learn more about general operations and find some examples in the repo where the charts are defined.
+
+Generally the migrator is run via the `helm upgrade`, for example:
+```
+helm upgrade --install -n sourcegraph --set "migrator.args={drift,--db=frontend,--version=v3.39.1}" sourcegraph-migrator sourcegraph/sourcegraph-migrator --version 4.4.2
+```
+In the example above the `drift` operation is run with flags `-db` and `-version`. The migrator is run using image version `v4.4.2`.
+
+Arguments are set with the `--set "migrator.args={operation-arg,flag-arg-1,flag-arg-2}` portion of the command. Just like you would run commands in terminal, these are the args you are telling the migrator to run on initialization.
+
+In the most general form running operations follows this template:
+```
+helm upgrade --install -n <your namespace> --set "migrator.args={<arg1>,<arg2>,<arg3>}" sourcegraph-migrator sourcegraph/sourcegraph-migrator --version <migrator image version> 
+```
+
+> NOTE: You can troubleshoot a migrators operations with the command `kubectl -n sourcegraph logs -l job=migrator -f`. This will show you logs from the migrator jobs operation steps.
+
 ### Docker / Docker compose
 
 Run the following commands on your Docker host.

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -28,7 +28,11 @@ This release introduces a background job that will convert all LSIF data into SC
 
 ## v4.3 ➔ v4.4.1
 
-_No notes._
+- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process.
+
+  - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
+    - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 
+    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded with by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.2 ➔ v4.3.1
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -32,7 +32,7 @@ This release introduces a background job that will convert all LSIF data into SC
 
   - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
     - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 
-    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded with by providing migrator with the `--skip-drift-check` flag.
+    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.2 ➔ v4.3.1
 

--- a/doc/admin/updates/docker_compose.md
+++ b/doc/admin/updates/docker_compose.md
@@ -28,7 +28,7 @@ This release introduces a background job that will convert all LSIF data into SC
 
 ## v4.3 ➔ v4.4.1
 
-- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process.
+- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process. _This issue is fixed in patch v4.4.2_
 
   - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
     - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -32,11 +32,11 @@
 
 ## v4.3 ➔ v4.4.1
 
-- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process.
+- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process. _This issue is fixed in patch v4.4.2_
 
   - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
     - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 
-    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded with by providing migrator with the `--skip-drift-check` flag.
+    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.2 ➔ v4.3.1
 

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -32,7 +32,11 @@
 
 ## v4.3 ➔ v4.4.1
 
-_No notes._
+- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process.
+
+  - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
+    - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 
+    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded with by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.2 ➔ v4.3.1
 

--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -32,6 +32,11 @@ As a template, perform the same actions as the following diffs in your own deplo
 
 As a template, perform the same actions as the following diffs in your own deployment:
 - [`➔ v4.4.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/8cdeb7616b73e100aec41806b1118264fea0615d)
+- Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process. _This issue is fixed in patch v4.4.2_
+
+  - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`. 
+    - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`. 
+    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.2 ➔ v4.3.1
 


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/48013

This doc update mainly brings in operations currently found only in https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph-migrator. Additionally a note is added about the bug affecting those attempting to upgrade to v4.4.0

## Test plan
Tested with `sg run docsite`

An additional operations testing log may be found here: https://github.com/sourcegraph/deploy-sourcegraph-helm/issues/249
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
