### PR TITLE
Add hover tooltip for select:file.owners

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -165,6 +165,7 @@ export interface MetaSelector extends BaseMetaToken {
 export enum MetaSelectorKind {
     Repo = 'repo',
     File = 'file',
+    FileOwners = 'file.owners',
     Content = 'content',
     Symbol = 'symbol',
     Commit = 'commit',

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -146,6 +146,8 @@ const toSelectorHover = (token: MetaSelector): string => {
             return 'Select and display distinct repository paths from search results.'
         case MetaSelectorKind.File:
             return 'Select and display distinct file paths from search results.'
+        case MetaSelectorKind.FileOwners:
+            return 'Select and display distinct code owners from search results.'
         case MetaSelectorKind.Content:
             return 'Select and display only results matching content inside files.'
         case MetaSelectorKind.Commit:


### PR DESCRIPTION
We showed a small empty box on hover, this adds a proper description text.

## Test plan

Verified tooltip shows up.

## App preview:

- [Web](https://sg-web-es-select-tooltip.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
