### PR TITLE
Return correct result counts for ownership search

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -39,11 +40,16 @@ func LowercaseFieldNames(nodes []Node) []Node {
 	})
 }
 
+const CountAllLimit = 99999999
+
+var countAllLimitStr = strconv.Itoa(CountAllLimit)
+
 // SubstituteCountAll replaces count:all with count:99999999.
 func SubstituteCountAll(nodes []Node) []Node {
 	return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 		if field == FieldCount && strings.ToLower(value) == "all" {
-			return Parameter{Field: field, Value: "99999999", Negated: negated, Annotation: annotation}
+			c := countAllLimitStr
+			return Parameter{Field: field, Value: c, Negated: negated, Annotation: annotation}
 		}
 		return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 	})


### PR DESCRIPTION
Ownership search is implemented as a post-filter so we might drop results. Search usually expects every result to be returned, so we only request `N | count:N` results from each search backend. With filtering in place, though, we might not return the correct result count. As a temporary fix, we're overwriting the result limit for search backends to `count:all`, then filter the results, and then rely on the limit job to correctly cut the stream once enough results were collected.

We will want to revisit this temporary fixup after starship in a more general effort to improve ownership search performance, but this should get us to some usable experience for Starship.

Closes https://github.com/sourcegraph/sourcegraph/issues/47280

## Test plan

Verified result counts look okay now. 