### PR TITLE
fuzzy finder: fix summary spacing

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -47,7 +47,7 @@
 .summary {
     display: flex;
     align-items: center;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
     padding: 0 1rem;
 
     @media (--xs-breakpoint-down) {


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="329" alt="Screenshot 2023-02-22 at 14 46 09" src="https://user-images.githubusercontent.com/25318659/220623858-3cd3e9c0-b47e-4f53-becc-bbe7148b74f1.png">|<img width="329" alt="Screenshot 2023-02-22 at 14 45 52" src="https://user-images.githubusercontent.com/25318659/220623861-3df436f6-5251-425e-85e4-7f4e7dc0b62c.png">|

## Test plan
Tested manuall (screenshots attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
