### PR TITLE
experimental search input: Correctly handle clicks on "Go to"

### DIFF
--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -82,10 +82,13 @@
 
                     > [role='gridcell'] {
                         padding: 0 0.5rem;
-                        border-left: 1px solid var(--border-color);
 
-                        &:first-child {
-                            border-left: 0;
+                        &:hover {
+                            text-decoration: underline;
+                        }
+
+                        + [role='gridcell'] {
+                            border-left: 1px solid var(--border-color-2);
                         }
                     }
                 }

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -7,7 +7,7 @@ import { isSafari } from '@sourcegraph/common'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { Icon, useWindowSize } from '@sourcegraph/wildcard'
 
-import { Action, CustomRenderer, Group, Option } from './suggestionsExtension'
+import type { Action, CustomRenderer, Group, Option } from './suggestionsExtension'
 
 import styles from './Suggestions.module.scss'
 
@@ -29,7 +29,7 @@ interface SuggesionsProps {
     results: Group[]
     activeRowIndex: number
     open?: boolean
-    onSelect(option: Option): void
+    onSelect(option: Option, action?: Action): void
 }
 
 export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
@@ -41,14 +41,24 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
 }) => {
     const [container, setContainer] = useState<HTMLDivElement | null>(null)
 
+    // Handles mouse clicks on suggestions. The corresponding option is determined by the extracting group and option
+    // indicies from the element ID.
     const handleSelection = useCallback(
         (event: MouseEvent) => {
-            const match = (event.target as HTMLElement).closest('li[role="row"]')?.id.match(/\d+x\d+/)
+            const target = event.target as HTMLElement
+            const match = target.closest('li[role="row"]')?.id.match(/\d+x\d+/)
             if (match) {
                 // Extracts the group and row index from the elements ID to pass
                 // the right option value to the callback.
-                const [group, option] = match[0].split('x')
-                onSelect(results[+group].options[+option])
+                const [groupIndex, optionIndex] = match[0].split('x')
+                const option = results[+groupIndex].options[+optionIndex]
+                // Determine which action was selected.
+                onSelect(
+                    option,
+                    target.closest<HTMLElement>('[data-action]')?.dataset?.action === 'secondary'
+                        ? option.alternativeAction
+                        : option.action
+                )
             }
         },
         [onSelect, results]
@@ -123,9 +133,13 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
                                         )}
                                     </div>
                                     <div className={styles.note}>
-                                        <div role="gridcell">{getActionName(option.action)}</div>
+                                        <div role="gridcell" data-action="primary">
+                                            {getActionName(option.action)}
+                                        </div>
                                         {option.alternativeAction && (
-                                            <div role="gridcell">{getActionName(option.alternativeAction)}</div>
+                                            <div role="gridcell" data-action="secondary">
+                                                {getActionName(option.alternativeAction)}
+                                            </div>
                                         )}
                                     </div>
                                 </li>

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -136,8 +136,8 @@ class SuggestionView {
     private container: HTMLDivElement
     private root: Root
 
-    private onSelect = (option: Option): void => {
-        applyAction(this.view, option.action, option)
+    private onSelect = (option: Option, action?: Action): void => {
+        applyAction(this.view, action ?? option.action, option)
         // Query input looses focus when option is selected via
         // mousedown/click. This is a necessary hack to re-focus the query
         // input.


### PR DESCRIPTION
Currently the "Got to" (or secondary) action is only "selectable" via keyboard shortcut. This commit updates the suggestions list implementation to recognize clicks on the "Go To" label.

I've considered whether those should actually be links or buttons, but I'm not sure it makes sense in this context because they are not actually focusable anyway (real focus always has to stay inside the text input), and keyboard events are handled by CodeMirror directly. I'll do a proper a11y evaluation later.

To make it clearer which "action" is taken I'm adding a text-decoration effect when hover over actions. I also tried to add the effect to the primary action when hovering elsewhere over the option, but I couldn't make it work properly.


https://user-images.githubusercontent.com/179026/220627628-992bb21f-59da-435d-9107-15b697c8d795.mp4


## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-search-input-mouse-go-to.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
