### PR TITLE
zoekt: update to sourcegraph/zoekt@b65e3e6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -276,7 +276,7 @@ replace (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20230222090137-23121817690d
+	github.com/sourcegraph/zoekt v0.0.0-20230222091349-b65e3e6bceef
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2108,8 +2108,8 @@ github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef h1:fWPxLkDObzzK
 github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230222090137-23121817690d h1:u9gx6Mqp17u0X/KRYp//MXzIfdCFIvPKxc5LwL1ghFo=
-github.com/sourcegraph/zoekt v0.0.0-20230222090137-23121817690d/go.mod h1:pYHdTfl7eBIQOALuugYItJp9gZXDR0Cx7v1Kr7GGwz4=
+github.com/sourcegraph/zoekt v0.0.0-20230222091349-b65e3e6bceef h1:8m3KmiPFserdWGG0D/VjKprze+AV+yOvjR4WBgNYAWg=
+github.com/sourcegraph/zoekt v0.0.0-20230222091349-b65e3e6bceef/go.mod h1:pYHdTfl7eBIQOALuugYItJp9gZXDR0Cx7v1Kr7GGwz4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
The automatic sync PR (#47829) I merged earlier today did not sync to the rev it advertised in the PR description 🤷 

includes:

- b65e3e6bce scoring: score files based on absolute number of atoms

### Test plan
tested by Zoekt CI

