### PR TITLE
experimental search input: Add toggle to enable/disable new search input

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -52,6 +52,9 @@ export interface TemporarySettingsSchema {
     'search.results.collapseSmartSearch': boolean
     'search.input.recentSearches': RecentSearch[]
     'search.input.usedInlineHistory': boolean
+    // This is a temporary (no pun intended) setting to allow users to easily
+    // switch been the current and the new search input. It's only used when
+    // the feature flag `"searchQueryInput": "experimental"` is set.
     'search.input.experimental': boolean
     // TODO #41002: Remove this temporary setting.
     // This temporary setting is now turned on by default with no UI to toggle it off.

--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -52,6 +52,7 @@ export interface TemporarySettingsSchema {
     'search.results.collapseSmartSearch': boolean
     'search.input.recentSearches': RecentSearch[]
     'search.input.usedInlineHistory': boolean
+    'search.input.experimental': boolean
     // TODO #41002: Remove this temporary setting.
     // This temporary setting is now turned on by default with no UI to toggle it off.
     'coreWorkflowImprovements.enabled_deprecated': boolean

--- a/client/web/src/SearchQueryStateObserver.tsx
+++ b/client/web/src/SearchQueryStateObserver.tsx
@@ -65,6 +65,7 @@ export const SearchQueryStateObserver: FC<SearchQueryStateObserverProps> = props
                     setSelectedSearchContextSpec(parsedSearchURLAndContext.searchContextSpec.spec)
                 }
 
+                // TODO (#48103): Remove/simplify when new search input is released
                 const processedQuery =
                     !enableExperimentalSearchInput &&
                     parsedSearchURLAndContext.searchContextSpec &&

--- a/client/web/src/SearchQueryStateObserver.tsx
+++ b/client/web/src/SearchQueryStateObserver.tsx
@@ -9,7 +9,7 @@ import { isSearchContextSpecAvailable } from '@sourcegraph/shared/src/search'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 
 import { getQueryStateFromLocation } from './search'
-import { useExperimentalFeatures } from './stores'
+import { useExperimentalQueryInput } from './search/useExperimentalSearchInput'
 import { setQueryStateFromURL } from './stores/navbarSearchQueryState'
 
 export const GLOBAL_SEARCH_CONTEXT_SPEC = 'global'
@@ -30,16 +30,10 @@ export const SearchQueryStateObserver: FC<SearchQueryStateObserverProps> = props
     const selectedSearchContextSpecRef = useRef(selectedSearchContextSpec)
     selectedSearchContextSpecRef.current = selectedSearchContextSpec
 
-    const { searchQueryInput, isInitialized } = useExperimentalFeatures()
-
-    // This ensures that the query stays unmodified until we know
-    // whether the feature flag is set or not.
-    const enableExperimentalSearchInput = isInitialized ? searchQueryInput === 'experimental' : true
-    const enableExperimentalSearchInputRef = useRef(enableExperimentalSearchInput)
-    enableExperimentalSearchInputRef.current = enableExperimentalSearchInput
+    const [enableExperimentalSearchInput] = useExperimentalQueryInput()
 
     // Create `locationSubject` once on mount. New values are provided in the `useEffect` hook.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
     const [locationSubject] = useState(() => new BehaviorSubject<Location>(location))
 
     useEffect(() => {
@@ -72,7 +66,7 @@ export const SearchQueryStateObserver: FC<SearchQueryStateObserverProps> = props
                 }
 
                 const processedQuery =
-                    !enableExperimentalSearchInputRef.current &&
+                    !enableExperimentalSearchInput &&
                     parsedSearchURLAndContext.searchContextSpec &&
                     searchContextsEnabled
                         ? omitFilter(
@@ -91,7 +85,7 @@ export const SearchQueryStateObserver: FC<SearchQueryStateObserverProps> = props
         platformContext,
         searchContextsEnabled,
         selectedSearchContextSpecRef,
-        enableExperimentalSearchInputRef,
+        enableExperimentalSearchInput,
         setSelectedSearchContextSpec,
     ])
 

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -3,8 +3,8 @@ import { useCallback, useMemo, ChangeEventHandler, FC } from 'react'
 import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { useTheme, ThemeSetting } from '@sourcegraph/shared/src/theme'
@@ -157,7 +157,8 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 <div className="px-2 py-1">
                                     <div className="d-flex align-items-center justify-content-between">
                                         <div className="mr-2">
-                                            New Search Input <ProductStatusBadge status="beta" className="ml-1" />
+                                            New Search Input{' '}
+                                            <ProductStatusBadge status="experimental" className="ml-1" />
                                         </div>
                                         <Toggle
                                             value={experimentalQueryInputEnabled}

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -4,6 +4,7 @@ import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { useTheme, ThemeSetting } from '@sourcegraph/shared/src/theme'
@@ -20,9 +21,12 @@ import {
     AnchorLink,
     Select,
     Icon,
+    ProductStatusBadge,
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
+import { useExperimentalQueryInput } from '../search/useExperimentalSearchInput'
+import { useExperimentalFeatures } from '../stores'
 
 import styles from './UserNavItem.module.scss'
 
@@ -76,6 +80,8 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
     }, [setThemeSetting, themeSetting])
 
     const organizations = authenticatedUser.organizations.nodes
+    const searchQueryInputFeature = useExperimentalFeatures(features => features.searchQueryInput)
+    const [experimentalQueryInputEnabled, setExperimentalQueryInputEnabled] = useExperimentalQueryInput()
 
     return (
         <>
@@ -147,6 +153,20 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     </div>
                                 )}
                             </div>
+                            {searchQueryInputFeature === 'experimental' && (
+                                <div className="px-2 py-1">
+                                    <div className="d-flex align-items-center justify-content-between">
+                                        <div className="mr-2">
+                                            New Search Input <ProductStatusBadge status="beta" className="ml-1" />
+                                        </div>
+                                        <Toggle
+                                            value={experimentalQueryInputEnabled}
+                                            onToggle={setExperimentalQueryInputEnabled}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+
                             {organizations.length > 0 && (
                                 <>
                                     <MenuDivider className={styles.dropdownDivider} />

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -8,6 +8,8 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { QueryState, SearchContextInputProps } from '@sourcegraph/shared/src/search'
+import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
+import { appendContextFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
@@ -17,8 +19,8 @@ import { AuthenticatedUser } from '../../auth'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { CodeInsightsProps } from '../../insights/types'
 import { AddCodeHostWidget, useShouldShowAddCodeHostWidget } from '../../onboarding/AddCodeHostWidget'
-import { useExperimentalFeatures } from '../../stores'
 import { eventLogger } from '../../tracking/eventLogger'
+import { useExperimentalQueryInput } from '../useExperimentalSearchInput'
 
 import { SearchPageFooter } from './SearchPageFooter'
 import { SearchPageInput } from './SearchPageInput'
@@ -47,7 +49,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
     const { width } = useWindowSize()
     const isLightTheme = useIsLightTheme()
     const shouldShowAddCodeHostWidget = useShouldShowAddCodeHostWidget(props.authenticatedUser)
-    const experimentalQueryInput = useExperimentalFeatures(features => features.searchQueryInput === 'experimental')
+    const [experimentalQueryInput] = useExperimentalQueryInput()
 
     /** The value entered by the user in the query input */
     const [queryState, setQueryState] = useState<QueryState>({
@@ -55,10 +57,17 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
     })
 
     useEffect(() => {
-        if (experimentalQueryInput && props.selectedSearchContextSpec) {
-            setQueryState(state =>
-                state.query === '' ? { query: `context:${props.selectedSearchContextSpec} ` } : state
-            )
+        if (props.selectedSearchContextSpec) {
+            setQueryState(state => {
+                if (experimentalQueryInput) {
+                    return { query: appendContextFilter(state.query, props.selectedSearchContextSpec) }
+                }
+                const contextFilter = getGlobalSearchContextFilter(state.query)?.filter
+                if (contextFilter) {
+                    return { query: omitFilter(state.query, contextFilter) }
+                }
+                return state
+            })
         }
     }, [experimentalQueryInput, props.selectedSearchContextSpec])
 

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -57,6 +57,9 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
     })
 
     useEffect(() => {
+        // TODO (#48103): Remove/simplify when new search input is released
+        // Because the current and the new search input handle the context: selector differently
+        // we need properly "translate" the queries when switching between the both versions
         if (props.selectedSearchContextSpec) {
             setQueryState(state => {
                 if (experimentalQueryInput) {

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -155,6 +155,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         submitSearchOnChangeRef
     )
 
+    // TODO (#48103): Remove/simplify when new search input is released
     const input = experimentalQueryInput ? (
         <LazyCodeMirrorQueryInput
             patternType={patternType}

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -38,6 +38,7 @@ import {
 import { submitSearch } from '../helpers'
 import { useLazyCreateSuggestions, useLazyHistoryExtension } from '../input/lazy'
 import { useRecentSearches } from '../input/useRecentSearches'
+import { useExperimentalQueryInput } from '../useExperimentalSearchInput'
 
 import styles from './SearchPageInput.module.scss'
 
@@ -71,7 +72,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const isLightTheme = useIsLightTheme()
     const { caseSensitive, patternType, searchMode } = useNavbarQueryState(queryStateSelector, shallow)
-    const experimentalQueryInput = useExperimentalFeatures(features => features.searchQueryInput === 'experimental')
+    const [experimentalQueryInput] = useExperimentalQueryInput()
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -113,6 +113,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
         submitSearchOnChangeRef
     )
 
+    // TODO (#48103): Remove/simplify when new search input is released
     if (experimentalQueryInput) {
         return (
             <Form

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -16,6 +16,7 @@ import { Form } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../../auth'
 import { useExperimentalFeatures, useNavbarQueryState, setSearchCaseSensitivity } from '../../stores'
 import { NavbarQueryState, setSearchMode, setSearchPatternType } from '../../stores/navbarSearchQueryState'
+import { useExperimentalQueryInput } from '../useExperimentalSearchInput'
 
 import { useLazyCreateSuggestions, useLazyHistoryExtension } from './lazy'
 import { useRecentSearches } from './useRecentSearches'
@@ -55,9 +56,9 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
     const { queryState, setQueryState, submitSearch, searchCaseSensitivity, searchPatternType, searchMode } =
         useNavbarQueryState(selectQueryState, shallow)
 
+    const [experimentalQueryInput] = useExperimentalQueryInput()
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-    const experimentalQueryInput = useExperimentalFeatures(features => features.searchQueryInput === 'experimental')
 
     const { recentSearches } = useRecentSearches()
     const recentSearchesRef = useRef(recentSearches)

--- a/client/web/src/search/input/lazy.ts
+++ b/client/web/src/search/input/lazy.ts
@@ -11,6 +11,10 @@ import { useObservable } from '@sourcegraph/wildcard'
 
 import type { SuggestionsSourceConfig } from './suggestions'
 
+// TODO (#48103): Remove/simplify when new search input is released
+/**
+ * Helper hook to load depedencies for the new search input on demand.
+ */
 export function useLazyCreateSuggestions(enabled: boolean, parameters: SuggestionsSourceConfig): Source | undefined {
     const suggestionsModule = useObservable(
         useMemo(() => (enabled ? from(import('./suggestions')) : of(undefined)), [enabled])
@@ -22,6 +26,10 @@ export function useLazyCreateSuggestions(enabled: boolean, parameters: Suggestio
     )
 }
 
+// TODO (#48103): Remove/simplify when new search input is released
+/**
+ * Helper hook to load depedencies for the new search input on demand.
+ */
 export function useLazyHistoryExtension(
     enabled: boolean,
     recentSearchesRef: RefObject<RecentSearch[] | undefined>,

--- a/client/web/src/search/useExperimentalSearchInput.ts
+++ b/client/web/src/search/useExperimentalSearchInput.ts
@@ -4,7 +4,7 @@ import { useExperimentalFeatures } from '../stores'
 
 /**
  * Whether or not to use the experimental search input. Defaults to true if the experimental
- * feature flag is set. The user can ovewrite the value via temporary settings. While temporary
+ * feature flag is set. The user can override the value via temporary settings. While temporary
  * settings are loading the settings also defaults to true.
  */
 export function useExperimentalQueryInput(): [boolean, UseTemporarySettingsReturnType<'search.input.experimental'>[1]] {

--- a/client/web/src/search/useExperimentalSearchInput.ts
+++ b/client/web/src/search/useExperimentalSearchInput.ts
@@ -1,0 +1,17 @@
+import { useTemporarySetting, UseTemporarySettingsReturnType } from '@sourcegraph/shared/src/settings/temporary'
+
+import { useExperimentalFeatures } from '../stores'
+
+/**
+ * Whether or not to use the experimental search input. Defaults to true if the experimental
+ * feature flag is set. The user can ovewrite the value via temporary settings. While temporary
+ * settings are loading the settings also defaults to true.
+ */
+export function useExperimentalQueryInput(): [boolean, UseTemporarySettingsReturnType<'search.input.experimental'>[1]] {
+    const experimentalSearchInputEnabled = useExperimentalFeatures(
+        features => features.searchQueryInput === 'experimental'
+    )
+    const [userSettingEnabled, setUserSetting] = useTemporarySetting('search.input.experimental', true)
+
+    return [experimentalSearchInputEnabled && (userSettingEnabled ?? true), setUserSetting]
+}


### PR DESCRIPTION
This PR adds a toggle button to the user menu to enable/disable the new search input, similar what we had for the simple UI changes.

This changes the purpose of the experimental feature flag: If it's set to `experimental` then the toggle button will be shown and the new search input will be enabled by default.

The user can then enable/disable the new input via the toggle. This setting is stored in temporary settings.

When the experimental feature flag is *not* set, neither the new search input nor the toggle button will be available.

In order to roll out this change to customers we need to set the experimental feature flag to `experimental` by default.

There is the caveat that if the user disabled the new search input it will still be rendered briefly until the temporary settings have been loaded. Not sure if there is a good way around this without blocking rendering of the search input until the data is available (but I guess we could do that if we wanted to).


https://user-images.githubusercontent.com/179026/220654248-95b3b440-4e7c-401b-a52c-7092fcd516cb.mp4

<img width="230" alt="2023-02-23_09-36" src="https://user-images.githubusercontent.com/179026/220875042-881d850b-0e63-4a46-ba91-200e72a8eb68.png">



## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-search-input-toggle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
