### PR TITLE
ci: Add latest tagged release to continuous build version

### DIFF
--- a/cmd/frontend/graphqlbackend/executor.go
+++ b/cmd/frontend/graphqlbackend/executor.go
@@ -15,7 +15,7 @@ import (
 
 const oneReleaseCycle = 35 * 24 * time.Hour
 
-var insiderBuildRegex = regexp.MustCompile(`^[\w-]+_(\d{4}-\d{2}-\d{2})_\w+`)
+var insiderBuildRegex = regexp.MustCompile(`^[\w-]+_(\d{4}-\d{2}-\d{2})_(\d+\.\d+-)?\w+`)
 
 func NewExecutorResolver(executor types.Executor) *ExecutorResolver {
 	return &ExecutorResolver{executor: executor}

--- a/cmd/frontend/graphqlbackend/executor_test.go
+++ b/cmd/frontend/graphqlbackend/executor_test.go
@@ -60,10 +60,17 @@ func TestExecutorResolver(t *testing.T) {
 			// The executor is not outdated when both sourcegraph and executor are the same (insiders).
 			{
 				executorVersion:    "executor-patch-notest-es-ignite-debug_168065_2022-08-25_e94e18c4ebcc_patch",
-				sourcegraphVersion: "169135_2022-08-25_a2b623dce148",
+				sourcegraphVersion: "169135_2022-08-25_4.4-a2b623dce148",
 				isActive:           true,
 				expected:           ExecutorCompatibilityUpToDate.ToGraphQL(),
 				description:        "executor and the sourcegraph instance are the same version (insiders)",
+			},
+			{
+				executorVersion:    "executor-patch-notest-es-ignite-debug_168065_2022-08-25_e94e18c4ebcc_patch",
+				sourcegraphVersion: "169135_2022-08-25_a2b623dce148",
+				isActive:           true,
+				expected:           ExecutorCompatibilityUpToDate.ToGraphQL(),
+				description:        "executor and the sourcegraph instance are the same version (insiders - old version)",
 			},
 			// The executor is outdated if the sourcegraph version is more than one version
 			// greater than the executor version (SEMVER).

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -461,7 +461,7 @@ type ParsedMainBranchImageTag struct {
 }
 
 // ParseMainBranchImageTag creates MainTag structs for tags created by
-// images.MainBranchImageTag.
+// images.BranchImageTag with a branch of "main".
 func ParseMainBranchImageTag(t string) (*ParsedMainBranchImageTag, error) {
 	s := ParsedMainBranchImageTag{}
 	t = strings.TrimSpace(t)

--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -41,7 +41,7 @@ func TestParseTag(t *testing.T) {
 		},
 		{
 			"from constructor",
-			images.MainBranchImageTag(mustTime(), "abcde", 1234),
+			images.BranchImageTag(mustTime(), "abcde", 1234, "main", ""),
 			&ParsedMainBranchImageTag{
 				Build:       1234,
 				Date:        "2006-01-02",

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -100,8 +100,23 @@ func CandidateImageTag(commit string, buildNumber int) string {
 	return fmt.Sprintf("%s_%d_candidate", commit, buildNumber)
 }
 
-// MainBranchImageTag provides the tag for all commits built on main, which are used for
-// continuous deployment.
-func MainBranchImageTag(now time.Time, commit string, buildNumber int) string {
-	return fmt.Sprintf("%05d_%10s_%.12s", buildNumber, now.Format("2006-01-02"), commit)
+// BranchImageTag provides the tag for all commits built outside of a tagged release.
+//
+// Example: `(ef/feat_)?12345_2006-01-02-1.2.2-deadbeefbabe(_patch)?`
+//
+// Notes:
+// - latest tag omitted if empty
+// - branch name omitted when `main`
+func BranchImageTag(now time.Time, commit string, buildNumber int, branchName, latestTag string) string {
+	commitSuffix := fmt.Sprintf("%.12s", commit)
+	if latestTag != "" {
+		commitSuffix = latestTag + "-" + commitSuffix
+	}
+
+	tag := fmt.Sprintf("%05d_%10s_%s", buildNumber, now.Format("2006-01-02"), commitSuffix)
+	if branchName != "main" {
+		tag = branchName + "_" + tag
+	}
+
+	return tag
 }

--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/ci/runtype"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/changed"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -101,26 +102,6 @@ func NewConfig(now time.Time) Config {
 		changedFiles = strings.Split(strings.TrimSpace(string(output)), "\n")
 	}
 
-	// special tag adjustments based on run type
-	switch {
-	case runType.Is(runtype.TaggedRelease):
-		// This tag is used for publishing versioned releases.
-		//
-		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
-		tag = strings.TrimPrefix(tag, "v")
-	case runType.Is(runtype.MainBranch):
-		// This tag is used for deploying continuously. Only ever generate this on the
-		// main branch.
-		tag = images.MainBranchImageTag(now, commit, buildNumber)
-	default:
-		// Encode branch inside build tag by default.
-		tag = fmt.Sprintf("%s_%05d_%10s_%.12s", sanitizeBranchForDockerTag(branch), buildNumber, now.Format("2006-01-02"), commit)
-	}
-	if runType.Is(runtype.ImagePatch, runtype.ImagePatchNoTest, runtype.ExecutorPatchNoTest) {
-		// Add additional patch suffix
-		tag = tag + "_patch"
-	}
-
 	diff, changedFilesByDiffType := changed.ParseDiff(changedFiles)
 
 	return Config{
@@ -128,7 +109,7 @@ func NewConfig(now time.Time) Config {
 
 		Time:              now,
 		Branch:            branch,
-		Version:           tag,
+		Version:           versionFromTag(runType, tag, commit, buildNumber, branch, now),
 		Commit:            commit,
 		MustIncludeCommit: mustIncludeCommits,
 		Diff:              diff,
@@ -143,6 +124,52 @@ func NewConfig(now time.Time) Config {
 			SlackToken: os.Getenv("SLACK_INTEGRATION_TOKEN"),
 		},
 	}
+}
+
+// versionFromTag constructs the Sourcegraph version from the given build state.
+func versionFromTag(runType runtype.RunType, tag string, commit string, buildNumber int, branch string, now time.Time) string {
+	if runType.Is(runtype.TaggedRelease) {
+		// This tag is used for publishing versioned releases.
+		//
+		// The Git tag "v1.2.3" should map to the Docker image "1.2.3" (without v prefix).
+		return strings.TrimPrefix(tag, "v")
+	}
+
+	// "main" branch is used for continuous deployment and has a special-case format
+	version := images.BranchImageTag(now, commit, buildNumber, sanitizeBranchForDockerTag(branch), tryGetLatestTag())
+
+	// Add additional patch suffix
+	if runType.Is(runtype.ImagePatch, runtype.ImagePatchNoTest, runtype.ExecutorPatchNoTest) {
+		version = version + "_patch"
+	}
+
+	return version
+}
+
+func tryGetLatestTag() string {
+	output, err := exec.Command("git", "tag", "--list", "v*").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+
+	tagMap := map[string]struct{}{}
+	for _, tag := range strings.Split(string(output), "\n") {
+		if version, ok := oobmigration.NewVersionFromString(tag); ok {
+			tagMap[version.String()] = struct{}{}
+		}
+	}
+	if len(tagMap) == 0 {
+		return ""
+	}
+
+	versions := make([]oobmigration.Version, 0, len(tagMap))
+	for tag := range tagMap {
+		version, _ := oobmigration.NewVersionFromString(tag)
+		versions = append(versions, version)
+	}
+	oobmigration.SortVersions(versions)
+
+	return versions[len(versions)-1].String()
 }
 
 func (c Config) shortCommit() string {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -2,6 +2,7 @@ package oobmigration
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -145,6 +146,17 @@ func CompareVersions(a, b Version) VersionOrder {
 	}
 
 	return VersionOrderEqual
+}
+
+// SortVersions sorts the given version slice in ascending order.
+func SortVersions(vs []Version) {
+	sort.Slice(vs, func(i, j int) bool {
+		if vs[i].Major == vs[j].Major {
+			return vs[i].Minor < vs[j].Minor
+		}
+
+		return vs[i].Major < vs[j].Major
+	})
 }
 
 // pointIntersectsInterval returns true if point falls within the interval [lower, upper].

--- a/lib/api/version_check.go
+++ b/lib/api/version_check.go
@@ -26,7 +26,7 @@ func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) 
 	// version string, we match on 7 or more characters. Currently, the Sourcegraph version
 	// is expected to return 12:
 	// https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/config.go?L96.
-	buildDate := regexp.MustCompile(`\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7,}(_patch)?$`)
+	buildDate := regexp.MustCompile(`\d+_(\d{4}-\d{2}-\d{2})_(\d+\.\d+-)?[a-z0-9]{7,}(_patch)?$`)
 	matches := buildDate.FindStringSubmatch(version)
 	if len(matches) > 1 {
 		return matches[1] >= minDate, nil

--- a/lib/api/version_check_test.go
+++ b/lib/api/version_check_test.go
@@ -87,6 +87,25 @@ func TestCheckSourcegraphVersion(t *testing.T) {
 			constraint:     ">= 0.0",
 			expected:       true,
 		},
+		// 12-character abbreviated hash with latest version tag
+		{
+			currentVersion: "54959_2020-01-29_4.4-925859585436",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_4.4-925859585436",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_4.4-925859585436",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
 		// Full 40-character hash, just for fun
 		{
 			currentVersion: "54959_2020-01-29_7db7d396346284fd0f8f79f130f38b16fb1d3d70",


### PR DESCRIPTION
**What:** This PR appends the most recently tagged release (major/minor pair) to insiders version strings in BuildKite.
**Why:** Currently oobmigrations are running past their deprecation period, and we need a reliable way to parse the version string to figure out in-bewteen which releases the build sits. See [this PR](https://github.com/sourcegraph/sourcegraph/pull/47964) as an example where we need to use this value.

**Considerations**: This changes our insiders version string, which I only saw one direct use of. Are there other places we need to be careful not to break the current convention?

Version string examples:

- `v1.2.3` (tagged)
- `12345_2006-01-02-deadbeefbabe` (old version from main)
- `12345_2006-01-02-1.2-deadbeefbabe` (new version from main)
- `ef_feat_12345_2006-01-02-deadbeefbabe` (old version from branch)
- `ef_feat_12345_2006-01-02-1.2-deadbeefbabe` (new version from branch)
- `ef_feat_12345_2006-01-02-1.2-deadbeefbabe_patch` (including patch)

Example from main-dry-run test:

```
docker.io/sourcegraph/worker:main-dry-run-ef-latest-tag_200901_2023-02-22_4.4-53e51fe979e9
                                                                          ^^^^ I did that :)
```

## Test plan

[Main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main-dry-run%2Fef%2Flatest-tag) on this branch.