### PR TITLE
Fix wildcard tooltip making `<svg>` elements appear in tab order

### DIFF
--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -115,16 +115,22 @@ export const Tooltip: FC<TooltipProps> = props => {
             setOpen({ isOpen: false, reason: TooltipOpenChangeReason.TargetLeave })
         }
 
+        const preventFocusListeners = shouldPreventFocusListeners(target)
+
         target?.addEventListener('pointerenter', handleTargetPointerEnter)
         target?.addEventListener('pointerleave', handleTargetPointerLeave)
-        target?.addEventListener('focus', handleTargetPointerEnter, true)
-        target?.addEventListener('blur', handleTargetPointerLeave, true)
+        if (!preventFocusListeners) {
+            target?.addEventListener('focus', handleTargetPointerEnter, true)
+            target?.addEventListener('blur', handleTargetPointerLeave, true)
+        }
 
         return () => {
             target?.removeEventListener('pointerenter', handleTargetPointerEnter)
             target?.removeEventListener('pointerleave', handleTargetPointerLeave)
-            target?.removeEventListener('focus', handleTargetPointerEnter)
-            target?.removeEventListener('blur', handleTargetPointerLeave)
+            if (!preventFocusListeners) {
+                target?.removeEventListener('focus', handleTargetPointerEnter)
+                target?.removeEventListener('blur', handleTargetPointerLeave)
+            }
         }
     }, [target, setOpen])
 
@@ -215,3 +221,12 @@ const TooltipTarget = forwardRef<any, TooltipTargetProps>(function TooltipTarget
 
     return children
 })
+
+// We use this test to work around a Chromium bug that causes an `<svg>` element with a focus event
+// listener to appear in the tab-order. See https://bugs.chromium.org/p/chromium/issues/detail?id=445798
+function shouldPreventFocusListeners(target: HTMLElement | null): boolean {
+    return (
+        target?.tagName === 'svg' &&
+        (target.getAttribute('tabindex') === '-1' || target?.getAttribute('tabindex') === null)
+    )
+}


### PR DESCRIPTION
As part of #48035, we observed an issue that only reproduces in Chrome.

When an `<svg>` element that should not be focusable is getting a focus event listener attached, Chrome will _sometimes_ make it appear in the tab order.

To reproduce this issue, you can take a look at this JSBin example: https://jsbin.com/yucutapufi/edit?html,js,console,output

We found the respective bug report in the Chromium bug tracker: https://bugs.chromium.org/p/chromium/issues/detail?id=445798

For now, we decided that we value browser consistency and are fixing this by not attaching a focus event listener to `<svg>` elements that do not have an explicit tabIndex property set to a value other than -1.

This PR _might_ make it so that some tooltip targets are no longer accessible via tab navigation. However, these never were accessible in other browsers and we would need to fix them regardless. This will just make the problem more visible to us.

## Test plan

- Go to the symbol tab with the new accessible file tree feature flag enabled and observe that symbol icons no longer appear in the tab order
- Check that repo header icons still show the tooltip when tab-navigating

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-tooltip-making-svgs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
