### PR TITLE
graphqlbackend: check requireed OOB migrations against latest version

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	migratorshared "github.com/sourcegraph/sourcegraph/cmd/migrator/shared"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -323,9 +324,13 @@ func isRequiredOutOfBandMigration(version oobmigration.Version, m oobmigration.M
 }
 
 func (r *upgradeReadinessResolver) RequiredOutOfBandMigrations(ctx context.Context) ([]*outOfBandMigrationResolver, error) {
-	_, version, _, err := r.init(ctx)
-	if err != nil {
-		return nil, err
+	updateStatus := updatecheck.Last()
+	if updateStatus == nil || !updateStatus.HasUpdate() {
+		return nil, errors.New("No latest update version available (reload in a few seconds)")
+	}
+	version, _, ok := oobmigration.NewVersionAndPatchFromString(updateStatus.UpdateVersion)
+	if !ok {
+		return nil, errors.Errorf("invalid latest update version %q", updateStatus.UpdateVersion)
 	}
 
 	migrations, err := oobmigration.NewStoreWithDB(r.db).List(ctx)

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -326,7 +326,7 @@ func isRequiredOutOfBandMigration(version oobmigration.Version, m oobmigration.M
 func (r *upgradeReadinessResolver) RequiredOutOfBandMigrations(ctx context.Context) ([]*outOfBandMigrationResolver, error) {
 	updateStatus := updatecheck.Last()
 	if updateStatus == nil || !updateStatus.HasUpdate() {
-		return nil, errors.New("No latest update version available (reload in a few seconds)")
+		return nil, errors.New("no latest update version available (reload in a few seconds)")
 	}
 	version, _, ok := oobmigration.NewVersionAndPatchFromString(updateStatus.UpdateVersion)
 	if !ok {

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -8093,7 +8093,7 @@
 			{
 				"ID": 1671543381,
 				"Name": "add_default_roles",
-				"UpQuery": "-- system roles that come with every sourcegraph instance\nINSERT INTO\n    roles\nVALUES\n    (1, 'USER', '2023-01-04 16:29:41.195966+00', NULL, TRUE),\n    (2, 'SITE_ADMINISTRATOR', '2023-01-04 16:29:41.195966+00', NULL, TRUE)\nON CONFLICT (id) DO NOTHING;\n\nSELECT pg_catalog.setval('roles_id_seq', 3, true);",
+				"UpQuery": "-- system roles that come with every sourcegraph instance\nINSERT INTO\n    roles (id, name, created_at, deleted_at, readonly)\nVALUES\n    (1, 'USER', '2023-01-04 16:29:41.195966+00', NULL, TRUE),\n    (2, 'SITE_ADMINISTRATOR', '2023-01-04 16:29:41.195966+00', NULL, TRUE)\nON CONFLICT (id) DO NOTHING;\n\nSELECT pg_catalog.setval('roles_id_seq', 3, true);",
 				"DownQuery": "DELETE FROM roles WHERE id IN (1, 2);",
 				"Privileged": false,
 				"NonIdempotent": false,


### PR DESCRIPTION
Previously, we were checking agsinst the current running version for required OOB migrations, which is incorrect as pointed out in https://github.com/sourcegraph/sourcegraph/pull/48046#discussion_r1114467855 because if an unfinished OOBM is already deprecated at the current running version the instance won't even start.

Instead, we should be checking against the latest version, (reasonably) taking the assumption that the site admin always wants to upgrade from the current to the latest version (i.e. what's multi-version upgrade is for).

## Test plan

> **Note**: The latest version at the time of the screenshot is 4.4.1.

Randomly setting the progress some deprecated OOBM to 0.

<img width="1285" alt="CleanShot 2023-02-22 at 23 55 22@2x" src="https://user-images.githubusercontent.com/2946214/220680055-ebab6316-0677-467b-ba51-5d3a8647f670.png">

