### PR TITLE
Disable telemetry (for now) in Sourcegraph App

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -747,7 +747,7 @@ func check(logger log.Logger, db database.DB) {
 // switched on/off at runtime.
 func isUpdateCheckCurrentlyEnabled() bool {
 	// Disabled when running in App mode.
-	// TODO: re-enable in App mode when authenticated.
+	// TODO(app): re-enable in App mode when a Sourcegraph.com account is connected.
 	return !deploy.IsDeployTypeSingleProgram(deploy.Type())
 }
 

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -743,6 +743,14 @@ func check(logger log.Logger, db database.DB) {
 	mu.Unlock()
 }
 
+// Check if update check is enabled, running at every interval so that it can be
+// switched on/off at runtime.
+func isUpdateCheckCurrentlyEnabled() bool {
+	// Disabled when running in App mode.
+	// TODO: re-enable in App mode when authenticated.
+	return !deploy.IsDeployTypeSingleProgram(deploy.Type())
+}
+
 var started bool
 
 // Start starts checking for software updates periodically.
@@ -759,7 +767,9 @@ func Start(logger log.Logger, db database.DB) {
 	const delay = 30 * time.Minute
 	scopedLog := logger.Scoped("updatecheck", "checks for updates of services and updates usage telemetry")
 	for {
-		check(scopedLog, db)
+		if isUpdateCheckCurrentlyEnabled() {
+			check(scopedLog, db)
+		}
 
 		// Randomize sleep to prevent thundering herds.
 		randomDelay := time.Duration(rand.Intn(600)) * time.Second


### PR DESCRIPTION
Disable telemetry ("update check" aka "pings") in Sourcegraph App for now.

The second part of this plan is to re-enable telemetry for opt-in users (where opt-in may be defined as "connected a Sourcegraph.com user")

## Test plan

- Run in App mode
- Check that no update check is being sent

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
