### PR TITLE
experimental search input: Support complex input updates

### DIFF
--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -349,7 +349,7 @@ class RegisteredSource {
                 )
             }
 
-            if (effect.is(startCompletion)) {
+            if (effect.is(startCompletionEffect)) {
                 source = source.query(transaction.state)
             }
         }
@@ -457,7 +457,7 @@ class SuggestionsState {
             if (effect.is(setSelectedEffect)) {
                 state = new SuggestionsState(state.source, state.open, effect.value)
             }
-            if (effect.is(hideCompletion)) {
+            if (effect.is(hideCompletionEffect)) {
                 state = new SuggestionsState(state.source, false, state.selectedOption)
             }
         }
@@ -490,8 +490,8 @@ const suggestionsConfig = Facet.define<Config, Config>({
 })
 
 const setSelectedEffect = StateEffect.define<number>()
-const startCompletion = StateEffect.define<void>()
-const hideCompletion = StateEffect.define<void>()
+const startCompletionEffect = StateEffect.define<void>()
+const hideCompletionEffect = StateEffect.define<void>()
 const updateResultEffect = StateEffect.define<{ source: RegisteredSource; result: SuggestionResult }>()
 const suggestionsStateField = StateField.define<SuggestionsState>({
     create() {
@@ -592,7 +592,7 @@ const defaultKeyboardBindings: KeyBinding[] = [
     {
         key: 'Mod-Space',
         run(view) {
-            view.dispatch({ effects: startCompletion.of() })
+            startCompletion(view)
             return true
         },
     },
@@ -621,7 +621,7 @@ const defaultKeyboardBindings: KeyBinding[] = [
         key: 'Escape',
         run(view) {
             if (view.state.field(suggestionsStateField).open) {
-                view.dispatch({ effects: hideCompletion.of() })
+                view.dispatch({ effects: hideCompletionEffect.of() })
                 return true
             }
             return false
@@ -639,7 +639,7 @@ export const suggestionSources = Facet.define<Source>({
                 update.view.hasFocus &&
                 update.view.state.field(suggestionsStateField).result.empty()
             ) {
-                update.view.dispatch({ effects: startCompletion.of() })
+                startCompletion(update.view)
             }
         }),
         Prec.highest(keymap.of(defaultKeyboardBindings)),
@@ -657,3 +657,10 @@ export const suggestions = ({ id, parent, source, historyOrNavigate }: ExternalC
     suggestionSources.of(source),
     ViewPlugin.define(view => new SuggestionView(id, view, parent)),
 ]
+
+/**
+ * Load and show suggestions.
+ */
+export function startCompletion(view: EditorView): void {
+    view.dispatch({ effects: startCompletionEffect.of() })
+}


### PR DESCRIPTION
Our current search input allows for some "complex" input updates: External places, like the search side bar or the example chips can update the query input and instruct it to e.g. focus itself or open completions.

Until now the new query input did not support this. This PR extracts the logic to perform these updates from the existing query input into a reusable hook.

While doing that I also updated the new search input to reuse some of functions I originally created for CodeMirror. And while doing _that_ I noticed an issue in the original implementation that caused the input value not to be updated (though I can't tell why).

But even with this fix in place I ran into problems with trying to initialize the editor fully on first render and only trigger extension reconfigurations when the extensions changed afterwards. In the end I had to initialize the editor partially and reconfigure the extensions when the editor becomes available and on extension changes.



## Test plan

- Clicking the example chips or entries in the search result sidebar update the input and focus it.
- Clicking certain entries in the search result sidebar update the input, focus it and show completions (e.g. search for repos).
- Submitting a search query on the homepage will open the search results page and correctly populate the query input (old and new version).
- Focusing the new input after a full page reload opens suggestions as expected.

## App preview:

- [Web](https://sg-web-fkling-search-input-fix-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

