### PR TITLE
ranking: Complete backend v1

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/uploads_graph_exporter.go
+++ b/enterprise/cmd/worker/internal/codeintel/uploads_graph_exporter.go
@@ -23,6 +23,7 @@ func (j *graphExporterJob) Description() string {
 
 func (j *graphExporterJob) Config() []env.Config {
 	return []env.Config{
+		uploads.RankingConfigInst,
 		uploads.ConfigExportInst,
 	}
 }

--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -6,6 +6,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
+type rankingConfig struct {
+	env.BaseConfig
+
+	Interval time.Duration
+}
+
+var RankingConfigInst = &rankingConfig{}
+
+func (c *rankingConfig) Load() {
+	c.Interval = c.GetInterval("CODEINTEL_RANKING_RECALCULATION_INTERVAL", "10s", "The maximum age of document reference count values used for ranking before being considered stale.")
+}
+
 type backfillConfig struct {
 	env.BaseConfig
 

--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -134,5 +134,5 @@ func (c *exportConfig) Load() {
 	c.RankingInterval = c.GetInterval("CODEINTEL_UPLOADS_RANKING_INTERVAL", "1s", "How frequently to serialize a batch of the code intel graph for ranking.")
 	c.NumRankingRoutines = c.GetInt("CODEINTEL_UPLOADS_RANKING_NUM_ROUTINES", "4", "The number of concurrent ranking graph serializer routines to run per worker instance.")
 	c.RankingBatchSize = c.GetInt("CODEINTEL_UPLOADS_RANKING_BATCH_SIZE", "10000", "The number of definitions and references to populate the ranking graph per batch.")
-	c.RankingJobsEnabled = c.GetBool("CODEINTEL_UPLOADS_RANKING_JOB_ENABLED", "true", "Whether or not to run the ranking job.")
+	c.RankingJobsEnabled = c.GetBool("CODEINTEL_UPLOADS_RANKING_JOB_ENABLED", "false", "Whether or not to run the ranking job.")
 }

--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -15,7 +15,7 @@ type rankingConfig struct {
 var RankingConfigInst = &rankingConfig{}
 
 func (c *rankingConfig) Load() {
-	c.Interval = c.GetInterval("CODEINTEL_RANKING_RECALCULATION_INTERVAL", "10s", "The maximum age of document reference count values used for ranking before being considered stale.")
+	c.Interval = c.GetInterval("CODEINTEL_RANKING_RECALCULATION_INTERVAL", "1h", "The maximum age of document reference count values used for ranking before being considered stale.")
 }
 
 type backfillConfig struct {

--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -15,7 +15,7 @@ type rankingConfig struct {
 var RankingConfigInst = &rankingConfig{}
 
 func (c *rankingConfig) Load() {
-	c.Interval = c.GetInterval("CODEINTEL_RANKING_RECALCULATION_INTERVAL", "1h", "The maximum age of document reference count values used for ranking before being considered stale.")
+	c.Interval = c.GetInterval("CODEINTEL_RANKING_RECALCULATION_INTERVAL", "72h", "The maximum age of document reference count values used for ranking before being considered stale.")
 }
 
 type backfillConfig struct {

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -78,7 +78,7 @@ func NewService(
 var (
 	bucketName                   = env.Get("CODEINTEL_UPLOADS_RANKING_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
 	rankingMapReduceBatchSize    = env.MustGetInt("CODEINTEL_UPLOADS_MAP_REDUCE_RANKING_BATCH_SIZE", 10000, "How many references, definitions, and path counts to map and reduce at once.")
-	rankingGraphKey              = env.Get("CODEINTEL_UPLOADS_RANKING_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new export in the configured bucket.")
+	rankingGraphKey              = env.Get("CODEINTEL_UPLOADS_RANKING_GRAPH_KEY", "dev", "Backdoor value used to restart the ranking export procedure.")
 	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_BATCH_SIZE", 16, "How many uploads to process at once.")
 	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_DELETE_BATCH_SIZE", 32, "How many stale uploads to delete at once.")
 	rankingBucketCredentialsFile = env.Get("CODEINTEL_UPLOADS_RANKING_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")

--- a/enterprise/internal/codeintel/uploads/internal/background/iface.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/iface.go
@@ -21,7 +21,7 @@ import (
 
 type UploadService interface {
 	ExportRankingGraph(ctx context.Context, numRankingRoutines int, numBatchSize int, rankingJobEnabled bool) error
-	MapRankingGraph(ctx context.Context, numRankingRoutines int, rankingJobEnabled bool) error
+	MapRankingGraph(ctx context.Context, numRankingRoutines int, rankingJobEnabled bool) (int, int, error)
 	ReduceRankingGraph(ctx context.Context, numRankingRoutines int, rankingJobEnabled bool) (float64, float64, error)
 	VacuumRankingGraph(ctx context.Context) error
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -18,14 +18,13 @@ func NewRankingGraphExporter(
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
-		"rank.graph-exporter", "exports SCIP data to ranking defintions and reference tables",
+		"rank.graph-exporter", "exports SCIP data to ranking definitions and reference tables",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
 			if err := uploadsService.ExportRankingGraph(ctx, numRankingRoutines, batchSize, rankingJobEnabled); err != nil {
 				return err
 			}
 
-			// Need to replace this pre-deployment
 			if err := uploadsService.VacuumRankingGraph(ctx); err != nil {
 				return err
 			}
@@ -75,7 +74,6 @@ func NewRankingGraphReducer(
 
 			operations.numPathCountsInputsRowsProcessed.Add(numPathCountsInputsProcessed)
 			operations.numPathRanksInserted.Add(numPathRanksInserted)
-
 			return nil
 		}),
 	)

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -2486,10 +2486,10 @@ type MockStore struct {
 	// mock function object controlling the behavior of the method
 	// InsertDefinitionsAndReferencesForDocument.
 	InsertDefinitionsAndReferencesForDocumentFunc *StoreInsertDefinitionsAndReferencesForDocumentFunc
-	// InsertDefintionsForRankingFunc is an instance of a mock function
+	// InsertDefinitionsForRankingFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// InsertDefintionsForRanking.
-	InsertDefintionsForRankingFunc *StoreInsertDefintionsForRankingFunc
+	// InsertDefinitionsForRanking.
+	InsertDefinitionsForRankingFunc *StoreInsertDefinitionsForRankingFunc
 	// InsertDependencySyncingJobFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// InsertDependencySyncingJob.
@@ -2579,6 +2579,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// UpdateUploadsVisibleToCommits.
 	UpdateUploadsVisibleToCommitsFunc *StoreUpdateUploadsVisibleToCommitsFunc
+	// VacuumStaleDefinitionsAndReferencesFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// VacuumStaleDefinitionsAndReferences.
+	VacuumStaleDefinitionsAndReferencesFunc *StoreVacuumStaleDefinitionsAndReferencesFunc
+	// VacuumStaleGraphsFunc is an instance of a mock function object
+	// controlling the behavior of the method VacuumStaleGraphs.
+	VacuumStaleGraphsFunc *StoreVacuumStaleGraphsFunc
 	// WorkerutilStoreFunc is an instance of a mock function object
 	// controlling the behavior of the method WorkerutilStore.
 	WorkerutilStoreFunc *StoreWorkerutilStoreFunc
@@ -2763,8 +2770,8 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared1.RankingDefintions) (r0 error) {
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: func(context.Context, string, int, []shared1.RankingDefinitions) (r0 error) {
 				return
 			},
 		},
@@ -2774,7 +2781,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		InsertPathCountInputsFunc: &StoreInsertPathCountInputsFunc{
-			defaultHook: func(context.Context, string, int) (r0 error) {
+			defaultHook: func(context.Context, string, int) (r0 int, r1 int, r2 error) {
 				return
 			},
 		},
@@ -2900,6 +2907,16 @@ func NewMockStore() *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: func(context.Context, int, *gitdomain.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) (r0 error) {
+				return
+			},
+		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: func(context.Context, string) (r0 int, r1 int, r2 error) {
+				return
+			},
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: func(context.Context, string) (r0 int, r1 int, r2 error) {
 				return
 			},
 		},
@@ -3090,9 +3107,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.InsertDefinitionsAndReferencesForDocument")
 			},
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared1.RankingDefintions) error {
-				panic("unexpected invocation of MockStore.InsertDefintionsForRanking")
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: func(context.Context, string, int, []shared1.RankingDefinitions) error {
+				panic("unexpected invocation of MockStore.InsertDefinitionsForRanking")
 			},
 		},
 		InsertDependencySyncingJobFunc: &StoreInsertDependencySyncingJobFunc{
@@ -3101,7 +3118,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		InsertPathCountInputsFunc: &StoreInsertPathCountInputsFunc{
-			defaultHook: func(context.Context, string, int) error {
+			defaultHook: func(context.Context, string, int) (int, int, error) {
 				panic("unexpected invocation of MockStore.InsertPathCountInputs")
 			},
 		},
@@ -3230,6 +3247,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateUploadsVisibleToCommits")
 			},
 		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: func(context.Context, string) (int, int, error) {
+				panic("unexpected invocation of MockStore.VacuumStaleDefinitionsAndReferences")
+			},
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: func(context.Context, string) (int, int, error) {
+				panic("unexpected invocation of MockStore.VacuumStaleGraphs")
+			},
+		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
 			defaultHook: func(*observation.Context) store1.Store[types.Upload] {
 				panic("unexpected invocation of MockStore.WorkerutilStore")
@@ -3347,8 +3374,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
 			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: i.InsertDefintionsForRanking,
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: i.InsertDefinitionsForRanking,
 		},
 		InsertDependencySyncingJobFunc: &StoreInsertDependencySyncingJobFunc{
 			defaultHook: i.InsertDependencySyncingJob,
@@ -3430,6 +3457,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: i.UpdateUploadsVisibleToCommits,
+		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: i.VacuumStaleDefinitionsAndReferences,
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: i.VacuumStaleGraphs,
 		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
 			defaultHook: i.WorkerutilStore,
@@ -7405,37 +7438,37 @@ func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []inte
 	return []interface{}{c.Result0}
 }
 
-// StoreInsertDefintionsForRankingFunc describes the behavior when the
-// InsertDefintionsForRanking method of the parent MockStore instance is
+// StoreInsertDefinitionsForRankingFunc describes the behavior when the
+// InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked.
-type StoreInsertDefintionsForRankingFunc struct {
-	defaultHook func(context.Context, string, int, []shared1.RankingDefintions) error
-	hooks       []func(context.Context, string, int, []shared1.RankingDefintions) error
-	history     []StoreInsertDefintionsForRankingFuncCall
+type StoreInsertDefinitionsForRankingFunc struct {
+	defaultHook func(context.Context, string, int, []shared1.RankingDefinitions) error
+	hooks       []func(context.Context, string, int, []shared1.RankingDefinitions) error
+	history     []StoreInsertDefinitionsForRankingFuncCall
 	mutex       sync.Mutex
 }
 
-// InsertDefintionsForRanking delegates to the next hook function in the
+// InsertDefinitionsForRanking delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertDefintionsForRanking(v0 context.Context, v1 string, v2 int, v3 []shared1.RankingDefintions) error {
-	r0 := m.InsertDefintionsForRankingFunc.nextHook()(v0, v1, v2, v3)
-	m.InsertDefintionsForRankingFunc.appendCall(StoreInsertDefintionsForRankingFuncCall{v0, v1, v2, v3, r0})
+func (m *MockStore) InsertDefinitionsForRanking(v0 context.Context, v1 string, v2 int, v3 []shared1.RankingDefinitions) error {
+	r0 := m.InsertDefinitionsForRankingFunc.nextHook()(v0, v1, v2, v3)
+	m.InsertDefinitionsForRankingFunc.appendCall(StoreInsertDefinitionsForRankingFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// InsertDefintionsForRanking method of the parent MockStore instance is
+// InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreInsertDefintionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, []shared1.RankingDefintions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, []shared1.RankingDefinitions) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertDefintionsForRanking method of the parent MockStore instance
+// InsertDefinitionsForRanking method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreInsertDefintionsForRankingFunc) PushHook(hook func(context.Context, string, int, []shared1.RankingDefintions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) PushHook(hook func(context.Context, string, int, []shared1.RankingDefinitions) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -7443,20 +7476,20 @@ func (f *StoreInsertDefintionsForRankingFunc) PushHook(hook func(context.Context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreInsertDefintionsForRankingFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, []shared1.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, int, []shared1.RankingDefinitions) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertDefintionsForRankingFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, []shared1.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, int, []shared1.RankingDefinitions) error {
 		return r0
 	})
 }
 
-func (f *StoreInsertDefintionsForRankingFunc) nextHook() func(context.Context, string, int, []shared1.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) nextHook() func(context.Context, string, int, []shared1.RankingDefinitions) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -7469,27 +7502,27 @@ func (f *StoreInsertDefintionsForRankingFunc) nextHook() func(context.Context, s
 	return hook
 }
 
-func (f *StoreInsertDefintionsForRankingFunc) appendCall(r0 StoreInsertDefintionsForRankingFuncCall) {
+func (f *StoreInsertDefinitionsForRankingFunc) appendCall(r0 StoreInsertDefinitionsForRankingFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreInsertDefintionsForRankingFuncCall
+// History returns a sequence of StoreInsertDefinitionsForRankingFuncCall
 // objects describing the invocations of this function.
-func (f *StoreInsertDefintionsForRankingFunc) History() []StoreInsertDefintionsForRankingFuncCall {
+func (f *StoreInsertDefinitionsForRankingFunc) History() []StoreInsertDefinitionsForRankingFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreInsertDefintionsForRankingFuncCall, len(f.history))
+	history := make([]StoreInsertDefinitionsForRankingFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreInsertDefintionsForRankingFuncCall is an object that describes an
-// invocation of method InsertDefintionsForRanking on an instance of
+// StoreInsertDefinitionsForRankingFuncCall is an object that describes an
+// invocation of method InsertDefinitionsForRanking on an instance of
 // MockStore.
-type StoreInsertDefintionsForRankingFuncCall struct {
+type StoreInsertDefinitionsForRankingFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -7501,7 +7534,7 @@ type StoreInsertDefintionsForRankingFuncCall struct {
 	Arg2 int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 []shared1.RankingDefintions
+	Arg3 []shared1.RankingDefinitions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -7509,13 +7542,13 @@ type StoreInsertDefintionsForRankingFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreInsertDefintionsForRankingFuncCall) Args() []interface{} {
+func (c StoreInsertDefinitionsForRankingFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreInsertDefintionsForRankingFuncCall) Results() []interface{} {
+func (c StoreInsertDefinitionsForRankingFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -7633,24 +7666,24 @@ func (c StoreInsertDependencySyncingJobFuncCall) Results() []interface{} {
 // StoreInsertPathCountInputsFunc describes the behavior when the
 // InsertPathCountInputs method of the parent MockStore instance is invoked.
 type StoreInsertPathCountInputsFunc struct {
-	defaultHook func(context.Context, string, int) error
-	hooks       []func(context.Context, string, int) error
+	defaultHook func(context.Context, string, int) (int, int, error)
+	hooks       []func(context.Context, string, int) (int, int, error)
 	history     []StoreInsertPathCountInputsFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertPathCountInputs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertPathCountInputs(v0 context.Context, v1 string, v2 int) error {
-	r0 := m.InsertPathCountInputsFunc.nextHook()(v0, v1, v2)
-	m.InsertPathCountInputsFunc.appendCall(StoreInsertPathCountInputsFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockStore) InsertPathCountInputs(v0 context.Context, v1 string, v2 int) (int, int, error) {
+	r0, r1, r2 := m.InsertPathCountInputsFunc.nextHook()(v0, v1, v2)
+	m.InsertPathCountInputsFunc.appendCall(StoreInsertPathCountInputsFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // InsertPathCountInputs method of the parent MockStore instance is invoked
 // and the hook queue is empty.
-func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Context, string, int) error) {
+func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Context, string, int) (int, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -7658,7 +7691,7 @@ func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Contex
 // InsertPathCountInputs method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, string, int) error) {
+func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, string, int) (int, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -7666,20 +7699,20 @@ func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreInsertPathCountInputsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int) error {
-		return r0
+func (f *StoreInsertPathCountInputsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, int) (int, int, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertPathCountInputsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int) error {
-		return r0
+func (f *StoreInsertPathCountInputsFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string, int) (int, int, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreInsertPathCountInputsFunc) nextHook() func(context.Context, string, int) error {
+func (f *StoreInsertPathCountInputsFunc) nextHook() func(context.Context, string, int) (int, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -7723,7 +7756,13 @@ type StoreInsertPathCountInputsFuncCall struct {
 	Arg2 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -7735,7 +7774,7 @@ func (c StoreInsertPathCountInputsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreInsertPathCountInputsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreInsertPathRanksFunc describes the behavior when the InsertPathRanks
@@ -10503,6 +10542,233 @@ func (c StoreUpdateUploadsVisibleToCommitsFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreUpdateUploadsVisibleToCommitsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreVacuumStaleDefinitionsAndReferencesFunc describes the behavior when
+// the VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance is invoked.
+type StoreVacuumStaleDefinitionsAndReferencesFunc struct {
+	defaultHook func(context.Context, string) (int, int, error)
+	hooks       []func(context.Context, string) (int, int, error)
+	history     []StoreVacuumStaleDefinitionsAndReferencesFuncCall
+	mutex       sync.Mutex
+}
+
+// VacuumStaleDefinitionsAndReferences delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) VacuumStaleDefinitionsAndReferences(v0 context.Context, v1 string) (int, int, error) {
+	r0, r1, r2 := m.VacuumStaleDefinitionsAndReferencesFunc.nextHook()(v0, v1)
+	m.VacuumStaleDefinitionsAndReferencesFunc.appendCall(StoreVacuumStaleDefinitionsAndReferencesFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance is invoked and the hook queue is empty.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) SetDefaultHook(hook func(context.Context, string) (int, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) PushHook(hook func(context.Context, string) (int, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) nextHook() func(context.Context, string) (int, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) appendCall(r0 StoreVacuumStaleDefinitionsAndReferencesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreVacuumStaleDefinitionsAndReferencesFuncCall objects describing the
+// invocations of this function.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) History() []StoreVacuumStaleDefinitionsAndReferencesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreVacuumStaleDefinitionsAndReferencesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreVacuumStaleDefinitionsAndReferencesFuncCall is an object that
+// describes an invocation of method VacuumStaleDefinitionsAndReferences on
+// an instance of MockStore.
+type StoreVacuumStaleDefinitionsAndReferencesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreVacuumStaleDefinitionsAndReferencesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreVacuumStaleDefinitionsAndReferencesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreVacuumStaleGraphsFunc describes the behavior when the
+// VacuumStaleGraphs method of the parent MockStore instance is invoked.
+type StoreVacuumStaleGraphsFunc struct {
+	defaultHook func(context.Context, string) (int, int, error)
+	hooks       []func(context.Context, string) (int, int, error)
+	history     []StoreVacuumStaleGraphsFuncCall
+	mutex       sync.Mutex
+}
+
+// VacuumStaleGraphs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) VacuumStaleGraphs(v0 context.Context, v1 string) (int, int, error) {
+	r0, r1, r2 := m.VacuumStaleGraphsFunc.nextHook()(v0, v1)
+	m.VacuumStaleGraphsFunc.appendCall(StoreVacuumStaleGraphsFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the VacuumStaleGraphs
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreVacuumStaleGraphsFunc) SetDefaultHook(hook func(context.Context, string) (int, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// VacuumStaleGraphs method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreVacuumStaleGraphsFunc) PushHook(hook func(context.Context, string) (int, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreVacuumStaleGraphsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreVacuumStaleGraphsFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *StoreVacuumStaleGraphsFunc) nextHook() func(context.Context, string) (int, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreVacuumStaleGraphsFunc) appendCall(r0 StoreVacuumStaleGraphsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreVacuumStaleGraphsFuncCall objects
+// describing the invocations of this function.
+func (f *StoreVacuumStaleGraphsFunc) History() []StoreVacuumStaleGraphsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreVacuumStaleGraphsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreVacuumStaleGraphsFuncCall is an object that describes an invocation
+// of method VacuumStaleGraphs on an instance of MockStore.
+type StoreVacuumStaleGraphsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreVacuumStaleGraphsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreVacuumStaleGraphsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreWorkerutilStoreFunc describes the behavior when the WorkerutilStore

--- a/enterprise/internal/codeintel/uploads/internal/background/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/observability.go
@@ -103,12 +103,43 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 }
 
-type rankingOperations struct {
+type rankMappingOperations struct {
+	numReferenceRecordsProcessed prometheus.Counter
+	numInputsInserted            prometheus.Counter
+}
+
+func newRankMappingOperations(observationCtx *observation.Context) *rankMappingOperations {
+	counter := func(name, help string) prometheus.Counter {
+		counter := prometheus.NewCounter(prometheus.CounterOpts{
+			Name: name,
+			Help: help,
+		})
+
+		observationCtx.Registerer.MustRegister(counter)
+		return counter
+	}
+
+	numReferenceRecordsProcessed := counter(
+		"src_codeintel_ranking_reference_records_processed_total",
+		"The number of reference rows processed.",
+	)
+	numInputsInserted := counter(
+		"src_codeintel_ranking_inputs_inserted_total",
+		"The number of input rows inserted.",
+	)
+
+	return &rankMappingOperations{
+		numReferenceRecordsProcessed: numReferenceRecordsProcessed,
+		numInputsInserted:            numInputsInserted,
+	}
+}
+
+type rankReducingOperations struct {
 	numPathCountsInputsRowsProcessed prometheus.Counter
 	numPathRanksInserted             prometheus.Counter
 }
 
-func newRankingOperations(observationCtx *observation.Context) *rankingOperations {
+func newRankReducingOperations(observationCtx *observation.Context) *rankReducingOperations {
 	counter := func(name, help string) prometheus.Counter {
 		counter := prometheus.NewCounter(prometheus.CounterOpts{
 			Name: name,
@@ -121,15 +152,14 @@ func newRankingOperations(observationCtx *observation.Context) *rankingOperation
 
 	numPathCountInputsRowsProcessed := counter(
 		"src_codeintel_ranking_path_count_inputs_rows_processed_total",
-		"The number of input row records merged into document scores for a single repo.",
+		"The number of input rows processed.",
 	)
-
 	numPathRanksInserted := counter(
 		"src_codeintel_ranking_path_ranks_inserted_total",
-		"The number of path ranks inserted and merged in for a single repo.",
+		"The number of path ranks inserted.",
 	)
 
-	return &rankingOperations{
+	return &rankReducingOperations{
 		numPathCountsInputsRowsProcessed: numPathCountInputsRowsProcessed,
 		numPathRanksInserted:             numPathRanksInserted,
 	}

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -85,7 +85,7 @@ type operations struct {
 	vacuumStaleDefinitionsAndReferences       *observation.Operation
 	vacuumStaleGraphs                         *observation.Operation
 	insertDefinitionsAndReferencesForDocument *observation.Operation
-	insertDefintionsForRanking                *observation.Operation
+	insertDefinitionsForRanking               *observation.Operation
 	insertReferencesForRanking                *observation.Operation
 	insertPathCountInputs                     *observation.Operation
 	insertPathRanks                           *observation.Operation
@@ -190,7 +190,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		vacuumStaleDefinitionsAndReferences:       op("VacuumStaleDefinitionsAndReferences"),
 		vacuumStaleGraphs:                         op("VacuumStaleGraphs"),
 		insertDefinitionsAndReferencesForDocument: op("InsertDefinitionsAndReferencesForDocument"),
-		insertDefintionsForRanking:                op("InsertDefintionsForRanking"),
+		insertDefinitionsForRanking:               op("InsertDefinitionsForRanking"),
 		insertReferencesForRanking:                op("InsertReferencesForRanking"),
 		insertPathCountInputs:                     op("InsertPathCountInputs"),
 		insertPathRanks:                           op("InsertPathRanks"),

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -82,6 +82,8 @@ type operations struct {
 	reindexUploadByID *observation.Operation
 
 	// Ranking
+	vacuumStaleDefinitionsAndReferences       *observation.Operation
+	vacuumStaleGraphs                         *observation.Operation
 	insertDefinitionsAndReferencesForDocument *observation.Operation
 	insertDefintionsForRanking                *observation.Operation
 	insertReferencesForRanking                *observation.Operation
@@ -185,6 +187,8 @@ func newOperations(observationCtx *observation.Context) *operations {
 		reindexUploadByID: op("ReindexUploadByID"),
 
 		// Ranking
+		vacuumStaleDefinitionsAndReferences:       op("VacuumStaleDefinitionsAndReferences"),
+		vacuumStaleGraphs:                         op("VacuumStaleGraphs"),
 		insertDefinitionsAndReferencesForDocument: op("InsertDefinitionsAndReferencesForDocument"),
 		insertDefintionsForRanking:                op("InsertDefintionsForRanking"),
 		insertReferencesForRanking:                op("InsertReferencesForRanking"),

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -125,7 +125,7 @@ type Store interface {
 	InsertDefinitionsAndReferencesForDocument(ctx context.Context, upload ExportedUpload, rankingGraphKey string, rankingBatchSize int, f func(ctx context.Context, upload ExportedUpload, rankingBatchSize int, rankingGraphKey, path string, document *scip.Document) error) (err error)
 	InsertDefintionsForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, defintions []shared.RankingDefintions) (err error)
 	InsertReferencesForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, references shared.RankingReferences) (err error)
-	InsertPathCountInputs(ctx context.Context, rankingGraphKey string, batchSize int) (err error)
+	InsertPathCountInputs(ctx context.Context, rankingGraphKey string, batchSize int) (numReferenceRecordsProcessed int, numInputsInserted int, err error)
 	InsertPathRanks(ctx context.Context, graphKey string, batchSize int) (numPathRanksInserted float64, numInputsProcessed float64, err error)
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -99,6 +99,12 @@ type Store interface {
 
 	GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) ([]ExportedUpload, error)
 
+	VacuumStaleGraphs(ctx context.Context, derivativeGraphKey string) (
+		metadataRecordsDeleted int,
+		inputRecordsDeleted int,
+		err error,
+	)
+
 	VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKey string) (
 		numStaleDefinitionRecordsDeleted int,
 		numStaleReferenceRecordsDeleted int,

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -99,6 +99,12 @@ type Store interface {
 
 	GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) ([]ExportedUpload, error)
 
+	VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKey string) (
+		numStaleDefinitionRecordsDeleted int,
+		numStaleReferenceRecordsDeleted int,
+		err error,
+	)
+
 	ProcessStaleExportedUploads(
 		ctx context.Context,
 		graphKey string,

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -123,7 +123,7 @@ type Store interface {
 
 	// Ranking
 	InsertDefinitionsAndReferencesForDocument(ctx context.Context, upload ExportedUpload, rankingGraphKey string, rankingBatchSize int, f func(ctx context.Context, upload ExportedUpload, rankingBatchSize int, rankingGraphKey, path string, document *scip.Document) error) (err error)
-	InsertDefintionsForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, defintions []shared.RankingDefintions) (err error)
+	InsertDefinitionsForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, definitions []shared.RankingDefinitions) (err error)
 	InsertReferencesForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, references shared.RankingReferences) (err error)
 	InsertPathCountInputs(ctx context.Context, rankingGraphKey string, batchSize int) (numReferenceRecordsProcessed int, numInputsInserted int, err error)
 	InsertPathRanks(ctx context.Context, graphKey string, batchSize int) (numPathRanksInserted float64, numInputsProcessed float64, err error)

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -24,7 +24,8 @@ func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKe
 	numStaleReferenceRecordsDeleted int,
 	err error,
 ) {
-	// TODO - observability
+	ctx, _, endObservation := s.operations.vacuumStaleDefinitionsAndReferences.With(ctx, &err, observation.Args{LogFields: []otlog.Field{}})
+	defer endObservation(1, observation.Args{})
 
 	rows, err := s.db.Query(ctx, sqlf.Sprintf(vacuumStaleDefinitionsAndReferencesQuery, graphKey, graphKey))
 	if err != nil {
@@ -85,7 +86,8 @@ func (s *store) VacuumStaleGraphs(ctx context.Context, derivativeGraphKey string
 	inputRecordsDeleted int,
 	err error,
 ) {
-	// TODO - observability
+	ctx, _, endObservation := s.operations.vacuumStaleGraphs.With(ctx, &err, observation.Args{LogFields: []otlog.Field{}})
+	defer endObservation(1, observation.Args{})
 
 	rows, err := s.db.Query(ctx, sqlf.Sprintf(vacuumStaleGraphsQuery, derivativeGraphKey, derivativeGraphKey))
 	if err != nil {

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -189,13 +189,13 @@ WHERE sid.upload_id = %s
 ORDER BY sid.document_path
 `
 
-func (s *store) InsertDefintionsForRanking(
+func (s *store) InsertDefinitionsForRanking(
 	ctx context.Context,
 	rankingGraphKey string,
 	rankingBatchNumber int,
-	defintions []shared.RankingDefintions,
+	definitions []shared.RankingDefinitions,
 ) (err error) {
-	ctx, _, endObservation := s.operations.insertDefintionsForRanking.With(
+	ctx, _, endObservation := s.operations.insertDefinitionsForRanking.With(
 		ctx,
 		&err,
 		observation.Args{},
@@ -209,15 +209,15 @@ func (s *store) InsertDefintionsForRanking(
 	defer func() { err = tx.Done(err) }()
 
 	inserter := func(inserter *batch.Inserter) error {
-		batchDefinitions := make([]shared.RankingDefintions, 0, rankingBatchNumber)
-		for _, def := range defintions {
+		batchDefinitions := make([]shared.RankingDefinitions, 0, rankingBatchNumber)
+		for _, def := range definitions {
 			batchDefinitions = append(batchDefinitions, def)
 
 			if len(batchDefinitions) == rankingBatchNumber {
 				if err := insertDefinitions(ctx, inserter, rankingGraphKey, batchDefinitions); err != nil {
 					return err
 				}
-				batchDefinitions = make([]shared.RankingDefintions, 0, rankingBatchNumber)
+				batchDefinitions = make([]shared.RankingDefinitions, 0, rankingBatchNumber)
 			}
 		}
 
@@ -254,7 +254,7 @@ func insertDefinitions(
 	ctx context.Context,
 	inserter *batch.Inserter,
 	rankingGraphKey string,
-	definitions []shared.RankingDefintions,
+	definitions []shared.RankingDefinitions,
 ) error {
 	for _, def := range definitions {
 		if err := inserter.Insert(

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// TODO - test
 func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKey string) (
 	numStaleDefinitionRecordsDeleted int,
 	numStaleReferenceRecordsDeleted int,
@@ -80,7 +79,6 @@ SELECT
 	(SELECT COUNT(*) FROM deleted_references)
 `
 
-// TODO - test
 func (s *store) VacuumStaleGraphs(ctx context.Context, derivativeGraphKey string) (
 	metadataRecordsDeleted int,
 	inputRecordsDeleted int,

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking_test.go
@@ -21,6 +21,14 @@ const (
 	mockRankingBatchNumber = 10
 )
 
+func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
+	// TODO
+}
+
+func TestVacuumStaleGraphs(t *testing.T) {
+	// TODO
+}
+
 func TestInsertReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
@@ -143,7 +151,7 @@ func TestInsertPathRanks(t *testing.T) {
 	}
 
 	// Test InsertPathCountInputs
-	if err := store.InsertPathCountInputs(ctx, mockRankingGraphKey, 1000); err != nil {
+	if _, _, err := store.InsertPathCountInputs(ctx, mockRankingGraphKey, 1000); err != nil {
 		t.Fatalf("unexpected error inserting path count inputs: %s", err)
 	}
 
@@ -216,7 +224,7 @@ func TestInsertPathCountInputs(t *testing.T) {
 	}
 
 	// Test InsertPathCountInputs
-	if err := store.InsertPathCountInputs(ctx, mockRankingGraphKey, 1000); err != nil {
+	if _, _, err := store.InsertPathCountInputs(ctx, mockRankingGraphKey, 1000); err != nil {
 		t.Fatalf("unexpected error inserting path count inputs: %s", err)
 	}
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/sourcegraph/log/logtest"
 
@@ -21,51 +22,14 @@ const (
 	mockRankingBatchNumber = 10
 )
 
-func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
-	// TODO
-}
-
-func TestVacuumStaleGraphs(t *testing.T) {
-	// TODO
-}
-
-func TestInsertReferences(t *testing.T) {
-	logger := logtest.Scoped(t)
-	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	store := New(&observation.TestContext, db)
-
-	// Insert references
-	mockReferences := []shared.RankingReferences{
-		{UploadID: 1, SymbolNames: []string{"foo", "bar", "baz"}},
-	}
-
-	for _, reference := range mockReferences {
-		// Test InsertReferencesForRanking
-		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, reference); err != nil {
-			t.Fatalf("unexpected error inserting references: %s", err)
-		}
-	}
-
-	// Test references where inserted
-	references, err := getRankingReferences(ctx, t, db, mockRankingGraphKey)
-	if err != nil {
-		t.Fatalf("unexpected error getting references: %s", err)
-	}
-
-	if diff := cmp.Diff(mockReferences, references); diff != "" {
-		t.Errorf("unexpected references (-want +got):\n%s", diff)
-	}
-}
-
 func TestInsertDefinition(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	// Insert defintions
-	mockDefinitions := []shared.RankingDefintions{
+	// Insert definitions
+	mockDefinitions := []shared.RankingDefinitions{
 		{
 			UploadID:     1,
 			SymbolName:   "foo",
@@ -87,11 +51,11 @@ func TestInsertDefinition(t *testing.T) {
 	}
 
 	// Test InsertDefinitionsForRanking
-	if err := store.InsertDefintionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
-	// Test definitions where inserted
+	// Test definitions were inserted
 	definitions, err := getRankingDefinitions(ctx, t, db, mockRankingGraphKey)
 	if err != nil {
 		t.Fatalf("unexpected error getting definitions: %s", err)
@@ -99,6 +63,35 @@ func TestInsertDefinition(t *testing.T) {
 
 	if diff := cmp.Diff(mockDefinitions, definitions); diff != "" {
 		t.Errorf("unexpected definitions (-want +got):\n%s", diff)
+	}
+}
+
+func TestInsertReferences(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	// Insert references
+	mockReferences := []shared.RankingReferences{
+		{UploadID: 1, SymbolNames: []string{"foo", "bar", "baz"}},
+	}
+
+	for _, reference := range mockReferences {
+		// Test InsertReferencesForRanking
+		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, reference); err != nil {
+			t.Fatalf("unexpected error inserting references: %s", err)
+		}
+	}
+
+	// Test references were inserted
+	references, err := getRankingReferences(ctx, t, db, mockRankingGraphKey)
+	if err != nil {
+		t.Fatalf("unexpected error getting references: %s", err)
+	}
+
+	if diff := cmp.Diff(mockReferences, references); diff != "" {
+		t.Errorf("unexpected references (-want +got):\n%s", diff)
 	}
 }
 
@@ -112,8 +105,8 @@ func TestInsertPathRanks(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	// Insert defintions
-	mockDefinitions := []shared.RankingDefintions{
+	// Insert definitions
+	mockDefinitions := []shared.RankingDefinitions{
 		{
 			UploadID:     1,
 			SymbolName:   "foo",
@@ -133,7 +126,7 @@ func TestInsertPathRanks(t *testing.T) {
 			DocumentPath: "foo.go",
 		},
 	}
-	if err := store.InsertDefintionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
@@ -185,8 +178,8 @@ func TestInsertPathCountInputs(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	// Insert defintions
-	mockDefinitions := []shared.RankingDefintions{
+	// Insert definitions
+	mockDefinitions := []shared.RankingDefinitions{
 		{
 			UploadID:     1,
 			SymbolName:   "foo",
@@ -206,7 +199,7 @@ func TestInsertPathCountInputs(t *testing.T) {
 			DocumentPath: "foo.go",
 		},
 	}
-	if err := store.InsertDefintionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
@@ -228,7 +221,7 @@ func TestInsertPathCountInputs(t *testing.T) {
 		t.Fatalf("unexpected error inserting path count inputs: %s", err)
 	}
 
-	// Test path count inputs where inserted
+	// Test path count inputs were inserted
 	repository, documentPath, count, err := getRankingPathCountsInputs(ctx, t, db, mockRankingGraphKey)
 	if err != nil {
 		t.Fatalf("unexpected error getting path count inputs: %s", err)
@@ -247,12 +240,159 @@ func TestInsertPathCountInputs(t *testing.T) {
 	}
 }
 
+func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	mockDefinitions := []shared.RankingDefinitions{
+		{UploadID: 1, SymbolName: "foo", Repository: "deadbeef", DocumentPath: "foo.go"},
+		{UploadID: 1, SymbolName: "bar", Repository: "deadbeef", DocumentPath: "bar.go"},
+		{UploadID: 2, SymbolName: "foo", Repository: "deadbeef", DocumentPath: "foo.go"},
+		{UploadID: 2, SymbolName: "bar", Repository: "deadbeef", DocumentPath: "bar.go"},
+		{UploadID: 3, SymbolName: "baz", Repository: "deadbeef", DocumentPath: "baz.go"},
+	}
+	mockReferences := []shared.RankingReferences{
+		{UploadID: 1, SymbolNames: []string{"foo"}},
+		{UploadID: 1, SymbolNames: []string{"bar"}},
+		{UploadID: 2, SymbolNames: []string{"foo"}},
+		{UploadID: 2, SymbolNames: []string{"bar"}},
+		{UploadID: 2, SymbolNames: []string{"baz"}},
+		{UploadID: 3, SymbolNames: []string{"bar"}},
+		{UploadID: 3, SymbolNames: []string{"baz"}},
+	}
+
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, mockDefinitions); err != nil {
+		t.Fatalf("unexpected error inserting definitions: %s", err)
+	}
+	for _, reference := range mockReferences {
+		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, reference); err != nil {
+			t.Fatalf("unexpected error inserting references: %s", err)
+		}
+	}
+
+	assertCounts := func(expectedNumDefinitions, expectedNumReferences int) {
+		definitions, err := getRankingDefinitions(ctx, t, db, mockRankingGraphKey)
+		if err != nil {
+			t.Fatalf("failed to get ranking definitions: %s", err)
+		}
+		if len(definitions) != expectedNumDefinitions {
+			t.Fatalf("unexpected number of definitions. want=%d have=%d", expectedNumDefinitions, len(definitions))
+		}
+
+		references, err := getRankingReferences(ctx, t, db, mockRankingGraphKey)
+		if err != nil {
+			t.Fatalf("failed to get ranking references: %s", err)
+		}
+		if len(references) != expectedNumReferences {
+			t.Fatalf("unexpected number of references. want=%d have=%d", expectedNumReferences, len(references))
+		}
+	}
+
+	// assert initial count
+	assertCounts(5, 7)
+
+	// make upload 2 visible at tip (1 and 3 are not)
+	insertVisibleAtTip(t, db, 50, 2)
+
+	// remove definitions and references for non-visible uploads
+	numStaleDefinitionRecordsDeleted, numStaleReferenceRecordsDeleted, err := store.VacuumStaleDefinitionsAndReferences(ctx, mockRankingGraphKey)
+	if err != nil {
+		t.Fatalf("unexpected error vacuuming stale definitions and references: %s", err)
+	}
+	if expected := 3; numStaleDefinitionRecordsDeleted != expected {
+		t.Fatalf("unexpected number of definition records deleted. want=%d have=%d", expected, numStaleDefinitionRecordsDeleted)
+	}
+	if expected := 4; numStaleReferenceRecordsDeleted != expected {
+		t.Fatalf("unexpected number of reference records deleted. want=%d have=%d", expected, numStaleReferenceRecordsDeleted)
+	}
+
+	// only upload 2's entries remain
+	assertCounts(2, 3)
+}
+
+func TestVacuumStaleGraphs(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	mockReferences := []shared.RankingReferences{
+		{UploadID: 1, SymbolNames: []string{"foo"}},
+		{UploadID: 1, SymbolNames: []string{"bar"}},
+		{UploadID: 2, SymbolNames: []string{"foo"}},
+		{UploadID: 2, SymbolNames: []string{"bar"}},
+		{UploadID: 2, SymbolNames: []string{"baz"}},
+		{UploadID: 3, SymbolNames: []string{"bar"}},
+		{UploadID: 3, SymbolNames: []string{"baz"}},
+	}
+	for _, reference := range mockReferences {
+		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchNumber, reference); err != nil {
+			t.Fatalf("unexpected error inserting references: %s", err)
+		}
+	}
+
+	for _, graphKey := range []string{mockRankingGraphKey + "-123", mockRankingGraphKey + "-456", mockRankingGraphKey + "-789"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO codeintel_ranking_references_processed (graph_key, codeintel_ranking_reference_id)
+			SELECT $1, id FROM codeintel_ranking_references
+	`, graphKey); err != nil {
+			t.Fatalf("failed to insert ranking references processed: %s", err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO codeintel_ranking_path_counts_inputs (repository, document_path, count, graph_key)
+			SELECT 50, '', 100, $1 FROM generate_series(1, 30)
+	`, graphKey); err != nil {
+			t.Fatalf("failed to insert ranking path count inputs: %s", err)
+		}
+	}
+
+	assertCounts := func(expectedMetadataRecords, expectedInputRecords int) {
+		store := basestore.NewWithHandle(db.Handle())
+
+		numMetadataRecords, _, err := basestore.ScanFirstInt(store.Query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM codeintel_ranking_references_processed`)))
+		if err != nil {
+			t.Fatalf("failed to count metadata records: %s", err)
+		}
+		if expectedMetadataRecords != numMetadataRecords {
+			t.Fatalf("unexpected number of metadata records. want=%d have=%d", expectedMetadataRecords, numMetadataRecords)
+		}
+
+		numInputRecords, _, err := basestore.ScanFirstInt(store.Query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM codeintel_ranking_path_counts_inputs`)))
+		if err != nil {
+			t.Fatalf("failed to count input records: %s", err)
+		}
+		if expectedInputRecords != numInputRecords {
+			t.Fatalf("unexpected number of input records. want=%d have=%d", expectedInputRecords, numInputRecords)
+		}
+	}
+
+	// assert initial count
+	assertCounts(3*7, 3*30)
+
+	// remove records associated with other ranking keys
+	metadataRecordsDeleted, inputRecordsDeleted, err := store.VacuumStaleGraphs(ctx, mockRankingGraphKey+"-456")
+	if err != nil {
+		t.Fatalf("unexpected error vacuuming stale graphs: %s", err)
+	}
+	if expected := 2 * 7; metadataRecordsDeleted != expected {
+		t.Fatalf("unexpected number of metadata records deleted. want=%d have=%d", expected, metadataRecordsDeleted)
+	}
+	if expected := 2 * 30; inputRecordsDeleted != expected {
+		t.Fatalf("unexpected number of input records deleted. want=%d have=%d", expected, inputRecordsDeleted)
+	}
+
+	// only the non-stale derivative graph key remains
+	assertCounts(1*7, 1*30)
+}
+
 func getRankingDefinitions(
 	ctx context.Context,
 	t *testing.T,
 	db database.DB,
 	graphKey string,
-) ([]shared.RankingDefintions, error) {
+) (_ []shared.RankingDefinitions, err error) {
 	query := fmt.Sprintf(
 		`SELECT upload_id, symbol_name, repository, document_path FROM codeintel_ranking_definitions WHERE graph_key = '%s'`,
 		graphKey,
@@ -261,8 +401,9 @@ func getRankingDefinitions(
 	if err != nil {
 		return nil, err
 	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
 
-	var definitions []shared.RankingDefintions
+	var definitions []shared.RankingDefinitions
 	for rows.Next() {
 		var uploadID int
 		var symbolName string
@@ -272,16 +413,13 @@ func getRankingDefinitions(
 		if err != nil {
 			return nil, err
 		}
-		definitions = append(definitions, shared.RankingDefintions{
+		definitions = append(definitions, shared.RankingDefinitions{
 			UploadID:     uploadID,
 			SymbolName:   symbolName,
 			Repository:   repository,
 			DocumentPath: documentPath,
 		})
 	}
-	defer func() {
-		err = basestore.CloseRows(rows, err)
-	}()
 
 	return definitions, nil
 }
@@ -291,7 +429,7 @@ func getRankingReferences(
 	t *testing.T,
 	db database.DB,
 	graphKey string,
-) ([]shared.RankingReferences, error) {
+) (_ []shared.RankingReferences, err error) {
 	query := fmt.Sprintf(
 		`SELECT upload_id, symbol_names FROM codeintel_ranking_references WHERE graph_key = '%s'`,
 		graphKey,
@@ -300,6 +438,7 @@ func getRankingReferences(
 	if err != nil {
 		return nil, err
 	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
 
 	var references []shared.RankingReferences
 	for rows.Next() {
@@ -314,9 +453,6 @@ func getRankingReferences(
 			SymbolNames: symbolNames,
 		})
 	}
-	defer func() {
-		err = basestore.CloseRows(rows, err)
-	}()
 
 	return references, nil
 }
@@ -335,6 +471,7 @@ func getRankingPathCountsInputs(
 	if err != nil {
 		return "", "", 0, err
 	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
 
 	for rows.Next() {
 		err = rows.Scan(&repository, &documentPath, &count)
@@ -342,9 +479,6 @@ func getRankingPathCountsInputs(
 			return "", "", 0, err
 		}
 	}
-	defer func() {
-		err = basestore.CloseRows(rows, err)
-	}()
 
 	return repository, documentPath, count, nil
 }

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -157,10 +157,10 @@ type MockStore struct {
 	// mock function object controlling the behavior of the method
 	// InsertDefinitionsAndReferencesForDocument.
 	InsertDefinitionsAndReferencesForDocumentFunc *StoreInsertDefinitionsAndReferencesForDocumentFunc
-	// InsertDefintionsForRankingFunc is an instance of a mock function
+	// InsertDefinitionsForRankingFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// InsertDefintionsForRanking.
-	InsertDefintionsForRankingFunc *StoreInsertDefintionsForRankingFunc
+	// InsertDefinitionsForRanking.
+	InsertDefinitionsForRankingFunc *StoreInsertDefinitionsForRankingFunc
 	// InsertDependencySyncingJobFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// InsertDependencySyncingJob.
@@ -250,6 +250,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// UpdateUploadsVisibleToCommits.
 	UpdateUploadsVisibleToCommitsFunc *StoreUpdateUploadsVisibleToCommitsFunc
+	// VacuumStaleDefinitionsAndReferencesFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// VacuumStaleDefinitionsAndReferences.
+	VacuumStaleDefinitionsAndReferencesFunc *StoreVacuumStaleDefinitionsAndReferencesFunc
+	// VacuumStaleGraphsFunc is an instance of a mock function object
+	// controlling the behavior of the method VacuumStaleGraphs.
+	VacuumStaleGraphsFunc *StoreVacuumStaleGraphsFunc
 	// WorkerutilStoreFunc is an instance of a mock function object
 	// controlling the behavior of the method WorkerutilStore.
 	WorkerutilStoreFunc *StoreWorkerutilStoreFunc
@@ -434,8 +441,8 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared.RankingDefintions) (r0 error) {
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: func(context.Context, string, int, []shared.RankingDefinitions) (r0 error) {
 				return
 			},
 		},
@@ -445,7 +452,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		InsertPathCountInputsFunc: &StoreInsertPathCountInputsFunc{
-			defaultHook: func(context.Context, string, int) (r0 error) {
+			defaultHook: func(context.Context, string, int) (r0 int, r1 int, r2 error) {
 				return
 			},
 		},
@@ -571,6 +578,16 @@ func NewMockStore() *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: func(context.Context, int, *gitdomain.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) (r0 error) {
+				return
+			},
+		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: func(context.Context, string) (r0 int, r1 int, r2 error) {
+				return
+			},
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: func(context.Context, string) (r0 int, r1 int, r2 error) {
 				return
 			},
 		},
@@ -761,9 +778,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.InsertDefinitionsAndReferencesForDocument")
 			},
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared.RankingDefintions) error {
-				panic("unexpected invocation of MockStore.InsertDefintionsForRanking")
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: func(context.Context, string, int, []shared.RankingDefinitions) error {
+				panic("unexpected invocation of MockStore.InsertDefinitionsForRanking")
 			},
 		},
 		InsertDependencySyncingJobFunc: &StoreInsertDependencySyncingJobFunc{
@@ -772,7 +789,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		InsertPathCountInputsFunc: &StoreInsertPathCountInputsFunc{
-			defaultHook: func(context.Context, string, int) error {
+			defaultHook: func(context.Context, string, int) (int, int, error) {
 				panic("unexpected invocation of MockStore.InsertPathCountInputs")
 			},
 		},
@@ -901,6 +918,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateUploadsVisibleToCommits")
 			},
 		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: func(context.Context, string) (int, int, error) {
+				panic("unexpected invocation of MockStore.VacuumStaleDefinitionsAndReferences")
+			},
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: func(context.Context, string) (int, int, error) {
+				panic("unexpected invocation of MockStore.VacuumStaleGraphs")
+			},
+		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
 			defaultHook: func(*observation.Context) store1.Store[types.Upload] {
 				panic("unexpected invocation of MockStore.WorkerutilStore")
@@ -1018,8 +1045,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
 			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
-		InsertDefintionsForRankingFunc: &StoreInsertDefintionsForRankingFunc{
-			defaultHook: i.InsertDefintionsForRanking,
+		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
+			defaultHook: i.InsertDefinitionsForRanking,
 		},
 		InsertDependencySyncingJobFunc: &StoreInsertDependencySyncingJobFunc{
 			defaultHook: i.InsertDependencySyncingJob,
@@ -1101,6 +1128,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: i.UpdateUploadsVisibleToCommits,
+		},
+		VacuumStaleDefinitionsAndReferencesFunc: &StoreVacuumStaleDefinitionsAndReferencesFunc{
+			defaultHook: i.VacuumStaleDefinitionsAndReferences,
+		},
+		VacuumStaleGraphsFunc: &StoreVacuumStaleGraphsFunc{
+			defaultHook: i.VacuumStaleGraphs,
 		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
 			defaultHook: i.WorkerutilStore,
@@ -5076,37 +5109,37 @@ func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []inte
 	return []interface{}{c.Result0}
 }
 
-// StoreInsertDefintionsForRankingFunc describes the behavior when the
-// InsertDefintionsForRanking method of the parent MockStore instance is
+// StoreInsertDefinitionsForRankingFunc describes the behavior when the
+// InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked.
-type StoreInsertDefintionsForRankingFunc struct {
-	defaultHook func(context.Context, string, int, []shared.RankingDefintions) error
-	hooks       []func(context.Context, string, int, []shared.RankingDefintions) error
-	history     []StoreInsertDefintionsForRankingFuncCall
+type StoreInsertDefinitionsForRankingFunc struct {
+	defaultHook func(context.Context, string, int, []shared.RankingDefinitions) error
+	hooks       []func(context.Context, string, int, []shared.RankingDefinitions) error
+	history     []StoreInsertDefinitionsForRankingFuncCall
 	mutex       sync.Mutex
 }
 
-// InsertDefintionsForRanking delegates to the next hook function in the
+// InsertDefinitionsForRanking delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertDefintionsForRanking(v0 context.Context, v1 string, v2 int, v3 []shared.RankingDefintions) error {
-	r0 := m.InsertDefintionsForRankingFunc.nextHook()(v0, v1, v2, v3)
-	m.InsertDefintionsForRankingFunc.appendCall(StoreInsertDefintionsForRankingFuncCall{v0, v1, v2, v3, r0})
+func (m *MockStore) InsertDefinitionsForRanking(v0 context.Context, v1 string, v2 int, v3 []shared.RankingDefinitions) error {
+	r0 := m.InsertDefinitionsForRankingFunc.nextHook()(v0, v1, v2, v3)
+	m.InsertDefinitionsForRankingFunc.appendCall(StoreInsertDefinitionsForRankingFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// InsertDefintionsForRanking method of the parent MockStore instance is
+// InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreInsertDefintionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, []shared.RankingDefintions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, []shared.RankingDefinitions) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertDefintionsForRanking method of the parent MockStore instance
+// InsertDefinitionsForRanking method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreInsertDefintionsForRankingFunc) PushHook(hook func(context.Context, string, int, []shared.RankingDefintions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) PushHook(hook func(context.Context, string, int, []shared.RankingDefinitions) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5114,20 +5147,20 @@ func (f *StoreInsertDefintionsForRankingFunc) PushHook(hook func(context.Context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreInsertDefintionsForRankingFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, []shared.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, int, []shared.RankingDefinitions) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertDefintionsForRankingFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, []shared.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, int, []shared.RankingDefinitions) error {
 		return r0
 	})
 }
 
-func (f *StoreInsertDefintionsForRankingFunc) nextHook() func(context.Context, string, int, []shared.RankingDefintions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) nextHook() func(context.Context, string, int, []shared.RankingDefinitions) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5140,27 +5173,27 @@ func (f *StoreInsertDefintionsForRankingFunc) nextHook() func(context.Context, s
 	return hook
 }
 
-func (f *StoreInsertDefintionsForRankingFunc) appendCall(r0 StoreInsertDefintionsForRankingFuncCall) {
+func (f *StoreInsertDefinitionsForRankingFunc) appendCall(r0 StoreInsertDefinitionsForRankingFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreInsertDefintionsForRankingFuncCall
+// History returns a sequence of StoreInsertDefinitionsForRankingFuncCall
 // objects describing the invocations of this function.
-func (f *StoreInsertDefintionsForRankingFunc) History() []StoreInsertDefintionsForRankingFuncCall {
+func (f *StoreInsertDefinitionsForRankingFunc) History() []StoreInsertDefinitionsForRankingFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreInsertDefintionsForRankingFuncCall, len(f.history))
+	history := make([]StoreInsertDefinitionsForRankingFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreInsertDefintionsForRankingFuncCall is an object that describes an
-// invocation of method InsertDefintionsForRanking on an instance of
+// StoreInsertDefinitionsForRankingFuncCall is an object that describes an
+// invocation of method InsertDefinitionsForRanking on an instance of
 // MockStore.
-type StoreInsertDefintionsForRankingFuncCall struct {
+type StoreInsertDefinitionsForRankingFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -5172,7 +5205,7 @@ type StoreInsertDefintionsForRankingFuncCall struct {
 	Arg2 int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 []shared.RankingDefintions
+	Arg3 []shared.RankingDefinitions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -5180,13 +5213,13 @@ type StoreInsertDefintionsForRankingFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreInsertDefintionsForRankingFuncCall) Args() []interface{} {
+func (c StoreInsertDefinitionsForRankingFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreInsertDefintionsForRankingFuncCall) Results() []interface{} {
+func (c StoreInsertDefinitionsForRankingFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -5304,24 +5337,24 @@ func (c StoreInsertDependencySyncingJobFuncCall) Results() []interface{} {
 // StoreInsertPathCountInputsFunc describes the behavior when the
 // InsertPathCountInputs method of the parent MockStore instance is invoked.
 type StoreInsertPathCountInputsFunc struct {
-	defaultHook func(context.Context, string, int) error
-	hooks       []func(context.Context, string, int) error
+	defaultHook func(context.Context, string, int) (int, int, error)
+	hooks       []func(context.Context, string, int) (int, int, error)
 	history     []StoreInsertPathCountInputsFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertPathCountInputs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertPathCountInputs(v0 context.Context, v1 string, v2 int) error {
-	r0 := m.InsertPathCountInputsFunc.nextHook()(v0, v1, v2)
-	m.InsertPathCountInputsFunc.appendCall(StoreInsertPathCountInputsFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockStore) InsertPathCountInputs(v0 context.Context, v1 string, v2 int) (int, int, error) {
+	r0, r1, r2 := m.InsertPathCountInputsFunc.nextHook()(v0, v1, v2)
+	m.InsertPathCountInputsFunc.appendCall(StoreInsertPathCountInputsFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // InsertPathCountInputs method of the parent MockStore instance is invoked
 // and the hook queue is empty.
-func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Context, string, int) error) {
+func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Context, string, int) (int, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -5329,7 +5362,7 @@ func (f *StoreInsertPathCountInputsFunc) SetDefaultHook(hook func(context.Contex
 // InsertPathCountInputs method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, string, int) error) {
+func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, string, int) (int, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5337,20 +5370,20 @@ func (f *StoreInsertPathCountInputsFunc) PushHook(hook func(context.Context, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreInsertPathCountInputsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int) error {
-		return r0
+func (f *StoreInsertPathCountInputsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string, int) (int, int, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertPathCountInputsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int) error {
-		return r0
+func (f *StoreInsertPathCountInputsFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string, int) (int, int, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *StoreInsertPathCountInputsFunc) nextHook() func(context.Context, string, int) error {
+func (f *StoreInsertPathCountInputsFunc) nextHook() func(context.Context, string, int) (int, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5394,7 +5427,13 @@ type StoreInsertPathCountInputsFuncCall struct {
 	Arg2 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -5406,7 +5445,7 @@ func (c StoreInsertPathCountInputsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreInsertPathCountInputsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreInsertPathRanksFunc describes the behavior when the InsertPathRanks
@@ -8174,6 +8213,233 @@ func (c StoreUpdateUploadsVisibleToCommitsFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreUpdateUploadsVisibleToCommitsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreVacuumStaleDefinitionsAndReferencesFunc describes the behavior when
+// the VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance is invoked.
+type StoreVacuumStaleDefinitionsAndReferencesFunc struct {
+	defaultHook func(context.Context, string) (int, int, error)
+	hooks       []func(context.Context, string) (int, int, error)
+	history     []StoreVacuumStaleDefinitionsAndReferencesFuncCall
+	mutex       sync.Mutex
+}
+
+// VacuumStaleDefinitionsAndReferences delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) VacuumStaleDefinitionsAndReferences(v0 context.Context, v1 string) (int, int, error) {
+	r0, r1, r2 := m.VacuumStaleDefinitionsAndReferencesFunc.nextHook()(v0, v1)
+	m.VacuumStaleDefinitionsAndReferencesFunc.appendCall(StoreVacuumStaleDefinitionsAndReferencesFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance is invoked and the hook queue is empty.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) SetDefaultHook(hook func(context.Context, string) (int, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// VacuumStaleDefinitionsAndReferences method of the parent MockStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) PushHook(hook func(context.Context, string) (int, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) nextHook() func(context.Context, string) (int, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) appendCall(r0 StoreVacuumStaleDefinitionsAndReferencesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreVacuumStaleDefinitionsAndReferencesFuncCall objects describing the
+// invocations of this function.
+func (f *StoreVacuumStaleDefinitionsAndReferencesFunc) History() []StoreVacuumStaleDefinitionsAndReferencesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreVacuumStaleDefinitionsAndReferencesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreVacuumStaleDefinitionsAndReferencesFuncCall is an object that
+// describes an invocation of method VacuumStaleDefinitionsAndReferences on
+// an instance of MockStore.
+type StoreVacuumStaleDefinitionsAndReferencesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreVacuumStaleDefinitionsAndReferencesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreVacuumStaleDefinitionsAndReferencesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreVacuumStaleGraphsFunc describes the behavior when the
+// VacuumStaleGraphs method of the parent MockStore instance is invoked.
+type StoreVacuumStaleGraphsFunc struct {
+	defaultHook func(context.Context, string) (int, int, error)
+	hooks       []func(context.Context, string) (int, int, error)
+	history     []StoreVacuumStaleGraphsFuncCall
+	mutex       sync.Mutex
+}
+
+// VacuumStaleGraphs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) VacuumStaleGraphs(v0 context.Context, v1 string) (int, int, error) {
+	r0, r1, r2 := m.VacuumStaleGraphsFunc.nextHook()(v0, v1)
+	m.VacuumStaleGraphsFunc.appendCall(StoreVacuumStaleGraphsFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the VacuumStaleGraphs
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreVacuumStaleGraphsFunc) SetDefaultHook(hook func(context.Context, string) (int, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// VacuumStaleGraphs method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreVacuumStaleGraphsFunc) PushHook(hook func(context.Context, string) (int, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreVacuumStaleGraphsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreVacuumStaleGraphsFunc) PushReturn(r0 int, r1 int, r2 error) {
+	f.PushHook(func(context.Context, string) (int, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *StoreVacuumStaleGraphsFunc) nextHook() func(context.Context, string) (int, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreVacuumStaleGraphsFunc) appendCall(r0 StoreVacuumStaleGraphsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreVacuumStaleGraphsFuncCall objects
+// describing the invocations of this function.
+func (f *StoreVacuumStaleGraphsFunc) History() []StoreVacuumStaleGraphsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreVacuumStaleGraphsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreVacuumStaleGraphsFuncCall is an object that describes an invocation
+// of method VacuumStaleGraphs on an instance of MockStore.
+type StoreVacuumStaleGraphsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreVacuumStaleGraphsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreVacuumStaleGraphsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreWorkerutilStoreFunc describes the behavior when the WorkerutilStore

--- a/enterprise/internal/codeintel/uploads/observability.go
+++ b/enterprise/internal/codeintel/uploads/observability.go
@@ -133,19 +133,19 @@ func newOperations(observationCtx *observation.Context) *operations {
 		"The number of stale upload records removed from GCS.",
 	)
 	numStaleDefinitionRecordsDeleted := counter(
-		"src_codeintel_uploads_num_stale_definition_records_deleted",
+		"src_codeintel_uploads_num_stale_definition_records_deleted_total",
 		"The number of stale definition records removed from Postgres.",
 	)
 	numStaleReferenceRecordsDeleted := counter(
-		"src_codeintel_uploads_num_stale_reference_records_deleted",
+		"src_codeintel_uploads_num_stale_reference_records_deleted_total",
 		"The number of stale reference records removed from Postgres.",
 	)
 	numMetadataRecordsDeleted := counter(
-		"src_codeintel_uploads_num_metadata_records_deleted",
+		"src_codeintel_uploads_num_metadata_records_deleted_total",
 		"The number of stale metadata records removed from Postgres.",
 	)
 	numInputRecordsDeleted := counter(
-		"src_codeintel_uploads_num_input_records_deleted",
+		"src_codeintel_uploads_num_input_records_deleted_total",
 		"The number of stale input records removed from Postgres.",
 	)
 	numBytesDeleted := counter(

--- a/enterprise/internal/codeintel/uploads/observability.go
+++ b/enterprise/internal/codeintel/uploads/observability.go
@@ -67,10 +67,12 @@ type operations struct {
 	mapRankingGraph    *observation.Operation
 	reduceRankingGraph *observation.Operation
 
-	numUploadsRead         prometheus.Counter
-	numBytesUploaded       prometheus.Counter
-	numStaleRecordsDeleted prometheus.Counter
-	numBytesDeleted        prometheus.Counter
+	numUploadsRead                   prometheus.Counter
+	numBytesUploaded                 prometheus.Counter
+	numStaleRecordsDeleted           prometheus.Counter
+	numStaleDefinitionRecordsDeleted prometheus.Counter
+	numStaleReferenceRecordsDeleted  prometheus.Counter
+	numBytesDeleted                  prometheus.Counter
 }
 
 var (
@@ -127,6 +129,14 @@ func newOperations(observationCtx *observation.Context) *operations {
 	numStaleRecordsDeleted := counter(
 		"src_codeintel_uploads_ranking_stale_uploads_removed_total",
 		"The number of stale upload records removed from GCS.",
+	)
+	numStaleDefinitionRecordsDeleted := counter(
+		"src_codeintel_uploads_num_stale_definition_records_deleted",
+		"The number of stale definition records removed from Postgres.",
+	)
+	numStaleReferenceRecordsDeleted := counter(
+		"src_codeintel_uploads_num_stale_reference_records_deleted",
+		"The number of stale reference records removed from Postgres.",
 	)
 	numBytesDeleted := counter(
 		"src_codeintel_uploads_ranking_bytes_deleted_total",
@@ -186,10 +196,12 @@ func newOperations(observationCtx *observation.Context) *operations {
 		mapRankingGraph:    op("MapRankingGraph"),
 		reduceRankingGraph: op("ReduceRankingGraph"),
 
-		numUploadsRead:         numUploadsRead,
-		numBytesUploaded:       numBytesUploaded,
-		numStaleRecordsDeleted: numStaleRecordsDeleted,
-		numBytesDeleted:        numBytesDeleted,
+		numUploadsRead:                   numUploadsRead,
+		numBytesUploaded:                 numBytesUploaded,
+		numStaleRecordsDeleted:           numStaleRecordsDeleted,
+		numStaleDefinitionRecordsDeleted: numStaleDefinitionRecordsDeleted,
+		numStaleReferenceRecordsDeleted:  numStaleReferenceRecordsDeleted,
+		numBytesDeleted:                  numBytesDeleted,
 	}
 }
 

--- a/enterprise/internal/codeintel/uploads/observability.go
+++ b/enterprise/internal/codeintel/uploads/observability.go
@@ -72,6 +72,8 @@ type operations struct {
 	numStaleRecordsDeleted           prometheus.Counter
 	numStaleDefinitionRecordsDeleted prometheus.Counter
 	numStaleReferenceRecordsDeleted  prometheus.Counter
+	numMetadataRecordsDeleted        prometheus.Counter
+	numInputRecordsDeleted           prometheus.Counter
 	numBytesDeleted                  prometheus.Counter
 }
 
@@ -138,6 +140,14 @@ func newOperations(observationCtx *observation.Context) *operations {
 		"src_codeintel_uploads_num_stale_reference_records_deleted",
 		"The number of stale reference records removed from Postgres.",
 	)
+	numMetadataRecordsDeleted := counter(
+		"src_codeintel_uploads_num_metadata_records_deleted",
+		"The number of stale metadata records removed from Postgres.",
+	)
+	numInputRecordsDeleted := counter(
+		"src_codeintel_uploads_num_input_records_deleted",
+		"The number of stale input records removed from Postgres.",
+	)
 	numBytesDeleted := counter(
 		"src_codeintel_uploads_ranking_bytes_deleted_total",
 		"The number of bytes deleted from GCS.",
@@ -201,6 +211,8 @@ func newOperations(observationCtx *observation.Context) *operations {
 		numStaleRecordsDeleted:           numStaleRecordsDeleted,
 		numStaleDefinitionRecordsDeleted: numStaleDefinitionRecordsDeleted,
 		numStaleReferenceRecordsDeleted:  numStaleReferenceRecordsDeleted,
+		numMetadataRecordsDeleted:        numMetadataRecordsDeleted,
+		numInputRecordsDeleted:           numInputRecordsDeleted,
 		numBytesDeleted:                  numBytesDeleted,
 	}
 }

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -249,5 +249,5 @@ func (s *Service) ReduceRankingGraph(
 // a fresh map/reduce job on a periodic cadence (equal to the bucket length). Changing the
 // parent graph key will also create a new map/reduce job (without switching buckets).
 func getCurrentGraphKey(now time.Time) string {
-	return fmt.Sprintf("%s-%d", rankingGraphKey, now.UTC().UnixNano()/RankingConfigInst.Interval.Nanoseconds())
+	return fmt.Sprintf("%s-%d", rankingGraphKey, now.UTC().Unix()/int64(RankingConfigInst.Interval.Seconds()))
 }

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -2,6 +2,7 @@ package uploads
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"cloud.google.com/go/storage"
@@ -133,7 +134,23 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 	return nil
 }
 
+// TODO - update grafana dashboards
+// TODO - update graph key generation for map/reduce
+// TODO - vacuum needs to cleanup map/reduce junk
+
 func (s *Service) VacuumRankingGraph(ctx context.Context) error {
+	// TODO - actually hit store
+
+	numStaleDefinitionRecordsDeleted := 0 // TODO
+	numStaleReferenceRecordsDeleted := 0  // TODO
+	fmt.Printf("NEED TO VACUUM RANKING GRAPH HERE\n")
+
+	s.operations.numStaleDefinitionRecordsDeleted.Add(float64(numStaleDefinitionRecordsDeleted))
+	s.operations.numStaleReferenceRecordsDeleted.Add(float64(numStaleReferenceRecordsDeleted))
+	return nil
+}
+
+func (s *Service) VacuumRankingGraphOld(ctx context.Context) error {
 	if s.rankingBucket == nil {
 		return nil
 	}

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -135,8 +135,6 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 	return nil
 }
 
-// TODO - update grafana dashboards
-
 func (s *Service) VacuumRankingGraph(ctx context.Context) error {
 	numStaleDefinitionRecordsDeleted, numStaleReferenceRecordsDeleted, err := s.store.VacuumStaleDefinitionsAndReferences(ctx, rankingGraphKey)
 	if err != nil {
@@ -238,8 +236,6 @@ func (s *Service) ReduceRankingGraph(
 
 	return numPathRanksInserted, numPathCountInputsProcessed, nil
 }
-
-// TODO - test
 
 // getCurrentGraphKey returns a derivative key from the configured parent used for exports
 // as well as the current "bucket" of time containing the current instant. Each bucket of

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -136,17 +136,22 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 }
 
 // TODO - update grafana dashboards
-// TODO - update graph key generation for map/reduce
-// TODO - vacuum needs to cleanup map/reduce junk
 
 func (s *Service) VacuumRankingGraph(ctx context.Context) error {
 	numStaleDefinitionRecordsDeleted, numStaleReferenceRecordsDeleted, err := s.store.VacuumStaleDefinitionsAndReferences(ctx, rankingGraphKey)
 	if err != nil {
 		return err
 	}
-
 	s.operations.numStaleDefinitionRecordsDeleted.Add(float64(numStaleDefinitionRecordsDeleted))
 	s.operations.numStaleReferenceRecordsDeleted.Add(float64(numStaleReferenceRecordsDeleted))
+
+	numMetadataRecordsDeleted, numInputRecordsDeleted, err := s.store.VacuumStaleGraphs(ctx, getCurrentGraphKey(time.Now()))
+	if err != nil {
+		return err
+	}
+	s.operations.numMetadataRecordsDeleted.Add(float64(numMetadataRecordsDeleted))
+	s.operations.numInputRecordsDeleted.Add(float64(numInputRecordsDeleted))
+
 	return nil
 }
 

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -234,9 +234,6 @@ func (s *Service) ReduceRankingGraph(
 	return numPathRanksInserted, numPathCountInputsProcessed, nil
 }
 
-// TODO - move this to config
-var interval = time.Second * 5
-
 // TODO - test
 
 // getCurrentGraphKey returns a derivative key from the configured parent used for exports
@@ -247,5 +244,5 @@ var interval = time.Second * 5
 // a fresh map/reduce job on a periodic cadence (equal to the bucket length). Changing the
 // parent graph key will also create a new map/reduce job (without switching buckets).
 func getCurrentGraphKey(now time.Time) string {
-	return fmt.Sprintf("%s-%d", rankingGraphKey, now.UTC().UnixNano()/interval.Nanoseconds())
+	return fmt.Sprintf("%s-%d", rankingGraphKey, now.UTC().UnixNano()/RankingConfigInst.Interval.Nanoseconds())
 }

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -2,7 +2,6 @@ package uploads
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"cloud.google.com/go/storage"
@@ -139,11 +138,10 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 // TODO - vacuum needs to cleanup map/reduce junk
 
 func (s *Service) VacuumRankingGraph(ctx context.Context) error {
-	// TODO - actually hit store
-
-	numStaleDefinitionRecordsDeleted := 0 // TODO
-	numStaleReferenceRecordsDeleted := 0  // TODO
-	fmt.Printf("NEED TO VACUUM RANKING GRAPH HERE\n")
+	numStaleDefinitionRecordsDeleted, numStaleReferenceRecordsDeleted, err := s.store.VacuumStaleDefinitionsAndReferences(ctx, rankingGraphKey)
+	if err != nil {
+		return err
+	}
 
 	s.operations.numStaleDefinitionRecordsDeleted.Add(float64(numStaleDefinitionRecordsDeleted))
 	s.operations.numStaleReferenceRecordsDeleted.Add(float64(numStaleReferenceRecordsDeleted))

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -86,14 +86,14 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 	document *scip.Document,
 ) error {
 	seenDefinitions := map[string]struct{}{}
-	definitions := []shared.RankingDefintions{}
+	definitions := []shared.RankingDefinitions{}
 	for _, occ := range document.Occurrences {
 		if occ.Symbol == "" || scip.IsLocalSymbol(occ.Symbol) {
 			continue
 		}
 
 		if scip.SymbolRole_Definition.Matches(occ) {
-			definitions = append(definitions, shared.RankingDefintions{
+			definitions = append(definitions, shared.RankingDefinitions{
 				UploadID:     upload.ID,
 				SymbolName:   occ.Symbol,
 				Repository:   upload.Repo,
@@ -118,7 +118,7 @@ func (s *Service) setDefinitionsAndReferencesForUpload(
 	}
 
 	if len(definitions) > 0 {
-		if err := s.store.InsertDefintionsForRanking(ctx, rankingGraphKey, rankingBatchNumber, definitions); err != nil {
+		if err := s.store.InsertDefinitionsForRanking(ctx, rankingGraphKey, rankingBatchNumber, definitions); err != nil {
 			return err
 		}
 	}

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -196,23 +196,23 @@ func (s *Service) VacuumRankingGraphOld(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) MapRankingGraph(ctx context.Context, numRankingRoutines int, rankingJobEnabled bool) (err error) {
+func (s *Service) MapRankingGraph(ctx context.Context, numRankingRoutines int, rankingJobEnabled bool) (
+	numReferenceRecordsProcessed int,
+	numInputsInserted int,
+	err error,
+) {
 	ctx, _, endObservation := s.operations.mapRankingGraph.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	if !rankingJobEnabled {
-		return nil
+		return 0, 0, nil
 	}
 
-	if err := s.store.InsertPathCountInputs(
+	return s.store.InsertPathCountInputs(
 		ctx,
 		getCurrentGraphKey(time.Now()),
 		rankingMapReduceBatchSize,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 func (s *Service) ReduceRankingGraph(

--- a/enterprise/internal/codeintel/uploads/shared/types.go
+++ b/enterprise/internal/codeintel/uploads/shared/types.go
@@ -205,7 +205,7 @@ type UploadLog struct {
 	Operation         string
 }
 
-type RankingDefintions struct {
+type RankingDefinitions struct {
 	UploadID     int
 	SymbolName   string
 	Repository   string

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -486,6 +486,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "codeintel_ranking_references_processed_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "configuration_policies_audit_logs_seq",
       "TypeName": "bigint",
       "StartValue": 1,
@@ -7724,19 +7733,6 @@
           "Comment": ""
         },
         {
-          "Name": "processed",
-          "Index": 5,
-          "TypeName": "boolean",
-          "IsNullable": false,
-          "Default": "false",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "symbol_names",
           "Index": 3,
           "TypeName": "text[]",
@@ -7786,6 +7782,83 @@
         }
       ],
       "Constraints": null,
+      "Triggers": []
+    },
+    {
+      "Name": "codeintel_ranking_references_processed",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "codeintel_ranking_reference_id",
+          "Index": 3,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "graph_key",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('codeintel_ranking_references_processed_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "codeintel_ranking_references_processed_graph_key_codeintel_rank",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_ranking_references_processed_graph_key_codeintel_rank ON codeintel_ranking_references_processed USING btree (graph_key, codeintel_ranking_reference_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "codeintel_ranking_references_processed_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_ranking_references_processed_pkey ON codeintel_ranking_references_processed USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "fk_codeintel_ranking_reference",
+          "ConstraintType": "f",
+          "RefTableName": "codeintel_ranking_references",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE"
+        }
+      ],
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -996,14 +996,30 @@ Indexes:
  upload_id    | integer |           | not null | 
  symbol_names | text[]  |           | not null | 
  graph_key    | text    |           | not null | 
- processed    | boolean |           | not null | false
 Indexes:
     "codeintel_ranking_references_pkey" PRIMARY KEY, btree (id)
     "codeintel_ranking_references_upload_id" btree (upload_id)
+Referenced by:
+    TABLE "codeintel_ranking_references_processed" CONSTRAINT "fk_codeintel_ranking_reference" FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE
 
 ```
 
 References for a given upload proceduced by background job consuming SCIP indexes.
+
+# Table "public.codeintel_ranking_references_processed"
+```
+             Column             |  Type   | Collation | Nullable |                              Default                               
+--------------------------------+---------+-----------+----------+--------------------------------------------------------------------
+ id                             | integer |           | not null | nextval('codeintel_ranking_references_processed_id_seq'::regclass)
+ graph_key                      | text    |           | not null | 
+ codeintel_ranking_reference_id | integer |           | not null | 
+Indexes:
+    "codeintel_ranking_references_processed_pkey" PRIMARY KEY, btree (id)
+    "codeintel_ranking_references_processed_graph_key_codeintel_rank" UNIQUE, btree (graph_key, codeintel_ranking_reference_id)
+Foreign-key constraints:
+    "fk_codeintel_ranking_reference" FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE
+
+```
 
 # Table "public.configuration_policies_audit_logs"
 ```

--- a/internal/types/codeintel.go
+++ b/internal/types/codeintel.go
@@ -7,7 +7,7 @@ import (
 
 // CodeIntelAggregatedEvent represents the total events and unique users within
 // the current week for a single event. The events are split again by language id
-// code intel action (e.g. defintions, references, hovers), and the code intel
+// code intel action (e.g. definitions, references, hovers), and the code intel
 // data source (e.g. precise, search).
 type CodeIntelAggregatedEvent struct {
 	Name        string

--- a/migrations/frontend/1677005673_add_codeintel_rank_defintions_and_references/metadata.yaml
+++ b/migrations/frontend/1677005673_add_codeintel_rank_defintions_and_references/metadata.yaml
@@ -1,2 +1,2 @@
-name: add_codeintel_rank_defintions_and_references
+name: add_codeintel_rank_definitions_and_references
 parents: [1676996650]

--- a/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/down.sql
+++ b/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS codeintel_ranking_references_processed;
+ALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS processed BOOLEAN NOT NULL DEFAULT false;

--- a/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/metadata.yaml
+++ b/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: Move processed flag out of references table
+parents: [1677008591, 1676584791]

--- a/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/up.sql
+++ b/migrations/frontend/1677104938_move_processed_flag_out_of_references_table/up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS processed;
+
+CREATE TABLE IF NOT EXISTS codeintel_ranking_references_processed (
+    id                              SERIAL PRIMARY KEY,
+    graph_key                       TEXT NOT NULL,
+    codeintel_ranking_reference_id  INT NOT NULL,
+
+    CONSTRAINT fk_codeintel_ranking_reference FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_ranking_references_processed_graph_key_codeintel_ranking_reference_id ON codeintel_ranking_references_processed(graph_key, codeintel_ranking_reference_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1751,8 +1751,7 @@ CREATE TABLE codeintel_ranking_references (
     id bigint NOT NULL,
     upload_id integer NOT NULL,
     symbol_names text[] NOT NULL,
-    graph_key text NOT NULL,
-    processed boolean DEFAULT false NOT NULL
+    graph_key text NOT NULL
 );
 
 COMMENT ON TABLE codeintel_ranking_references IS 'References for a given upload proceduced by background job consuming SCIP indexes.';
@@ -1765,6 +1764,22 @@ CREATE SEQUENCE codeintel_ranking_references_id_seq
     CACHE 1;
 
 ALTER SEQUENCE codeintel_ranking_references_id_seq OWNED BY codeintel_ranking_references.id;
+
+CREATE TABLE codeintel_ranking_references_processed (
+    id integer NOT NULL,
+    graph_key text NOT NULL,
+    codeintel_ranking_reference_id integer NOT NULL
+);
+
+CREATE SEQUENCE codeintel_ranking_references_processed_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE codeintel_ranking_references_processed_id_seq OWNED BY codeintel_ranking_references_processed.id;
 
 CREATE TABLE configuration_policies_audit_logs (
     log_timestamp timestamp with time zone DEFAULT clock_timestamp(),
@@ -4209,6 +4224,8 @@ ALTER TABLE ONLY codeintel_ranking_path_counts_inputs ALTER COLUMN id SET DEFAUL
 
 ALTER TABLE ONLY codeintel_ranking_references ALTER COLUMN id SET DEFAULT nextval('codeintel_ranking_references_id_seq'::regclass);
 
+ALTER TABLE ONLY codeintel_ranking_references_processed ALTER COLUMN id SET DEFAULT nextval('codeintel_ranking_references_processed_id_seq'::regclass);
+
 ALTER TABLE ONLY configuration_policies_audit_logs ALTER COLUMN sequence SET DEFAULT nextval('configuration_policies_audit_logs_seq'::regclass);
 
 ALTER TABLE ONLY critical_and_site_config ALTER COLUMN id SET DEFAULT nextval('critical_and_site_config_id_seq'::regclass);
@@ -4450,6 +4467,9 @@ ALTER TABLE ONLY codeintel_ranking_path_counts_inputs
 
 ALTER TABLE ONLY codeintel_ranking_references
     ADD CONSTRAINT codeintel_ranking_references_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY codeintel_ranking_references_processed
+    ADD CONSTRAINT codeintel_ranking_references_processed_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY critical_and_site_config
     ADD CONSTRAINT critical_and_site_config_pkey PRIMARY KEY (id);
@@ -4881,6 +4901,8 @@ CREATE INDEX codeintel_ranking_definitions_upload_id ON codeintel_ranking_defini
 CREATE UNIQUE INDEX codeintel_ranking_exports_graph_key_upload_id ON codeintel_ranking_exports USING btree (graph_key, upload_id);
 
 CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_and_repository ON codeintel_ranking_path_counts_inputs USING btree (graph_key, repository);
+
+CREATE UNIQUE INDEX codeintel_ranking_references_processed_graph_key_codeintel_rank ON codeintel_ranking_references_processed USING btree (graph_key, codeintel_ranking_reference_id);
 
 CREATE INDEX codeintel_ranking_references_upload_id ON codeintel_ranking_references USING btree (upload_id);
 
@@ -5482,6 +5504,9 @@ ALTER TABLE ONLY feature_flag_overrides
 
 ALTER TABLE ONLY feature_flag_overrides
     ADD CONSTRAINT feature_flag_overrides_namespace_user_id_fkey FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY codeintel_ranking_references_processed
+    ADD CONSTRAINT fk_codeintel_ranking_reference FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY gitserver_repos
     ADD CONSTRAINT gitserver_repos_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE;

--- a/monitoring/definitions/codeintel_ranking.go
+++ b/monitoring/definitions/codeintel_ranking.go
@@ -26,7 +26,7 @@ func CodeIntelRanking() *monitoring.Dashboard {
 		Groups: []monitoring.Group{
 			shared.CodeIntelligence.NewRankingServiceGroup("${source:regex}"),
 			shared.CodeIntelligence.NewRankingStoreGroup("${source:regex}"),
-			shared.CodeIntelligence.NewRankingGroup("${source:regexp}"),
+			shared.CodeIntelligence.NewRankingGroup("${source:regex}"),
 		},
 	}
 }

--- a/monitoring/definitions/codeintel_ranking.go
+++ b/monitoring/definitions/codeintel_ranking.go
@@ -26,7 +26,7 @@ func CodeIntelRanking() *monitoring.Dashboard {
 		Groups: []monitoring.Group{
 			shared.CodeIntelligence.NewRankingServiceGroup("${source:regex}"),
 			shared.CodeIntelligence.NewRankingStoreGroup("${source:regex}"),
-			shared.CodeIntelligence.NewRankingPageRankGroup("${source:regex}"),
+			shared.CodeIntelligence.NewRankingGroup("${source:regexp}"),
 		},
 	}
 }

--- a/monitoring/definitions/shared/codeintel_ranking.go
+++ b/monitoring/definitions/shared/codeintel_ranking.go
@@ -66,6 +66,82 @@ func (codeIntelligence) NewRankingStoreGroup(containerName string) monitoring.Gr
 	})
 }
 
+// src_codeintel_ranking_reference_records_processed_total
+// src_codeintel_ranking_inputs_inserted_total
+// src_codeintel_ranking_path_count_inputs_rows_processed_total
+// src_codeintel_ranking_path_ranks_inserted_total
+// src_codeintel_uploads_num_stale_definition_records_deleted_total
+// src_codeintel_uploads_num_stale_reference_records_deleted_total
+// src_codeintel_uploads_num_metadata_records_deleted_total
+// src_codeintel_uploads_num_input_records_deleted_total
+func (codeIntelligence) NewRankingGroup(containerName string) monitoring.Group {
+	return monitoring.Group{
+		Title:  "Codeintel: Ranking",
+		Hidden: false,
+		Rows: []monitoring.Row{
+			{
+				Standard.Count("reference rows processed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_ranking_reference_records_processed",
+					MetricDescriptionRoot: "reference rows processed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of reference rows processed.
+				`).Observable(),
+
+				Standard.Count("input rows inserted")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_ranking_inputs_inserted",
+					MetricDescriptionRoot: "input rows inserted",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of input rows inserted.
+				`).Observable(),
+
+				Standard.Count("input rows processed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_ranking_path_count_inputs_rows_processed",
+					MetricDescriptionRoot: "input rows processed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of input rows processed.
+				`).Observable(),
+
+				Standard.Count("path ranks updated")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_ranking_path_ranks_inserted",
+					MetricDescriptionRoot: "path ranks updated",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of path ranks inserted.
+				`).Observable(),
+			},
+
+			{
+				Standard.Count("stale definition records removed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_uploads_num_stale_definition_records_deleted",
+					MetricDescriptionRoot: "definition records removed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of stale definition records removed from Postgres.
+				`).Observable(),
+
+				Standard.Count("stale reference records removed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_uploads_num_stale_reference_records_deleted",
+					MetricDescriptionRoot: "reference records removed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of stale reference records removed from Postgres.
+				`).Observable(),
+
+				Standard.Count("stale metadata records removed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_uploads_num_metadata_records_deleted",
+					MetricDescriptionRoot: "metadata records removed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of stale metadata records removed from Postgres.
+				`).Observable(),
+
+				Standard.Count("stale input records removed")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_uploads_num_input_records_deleted",
+					MetricDescriptionRoot: "input records removed",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					The number of stale input records removed from Postgres.
+				`).Observable(),
+			},
+		},
+	}
+}
+
 // src_codeintel_uploads_ranking_uploads_read_total
 // src_codeintel_uploads_ranking_bytes_uploaded_total
 // src_codeintel_uploads_ranking_stale_uploads_removed_total


### PR DESCRIPTION
This PR ties up a few loose ends from recently merged work:

- Export metrics from `MapRankingGraph` via Prometheus
- Add `VacuumStaleGraphs` and `VacuumStaleDefinitionsAndReferences` to the store
- Call new `Vacuum*` methods from the exporter job
- Programmatically update the graph key for map/reduce jobs so that they periodically change
- Realized that using a different key will require us to move the `processed` flag out of the references table (and did so)
- Export metrics for the vacuum behaviors via Prometheus
- Updated Grafana dashboards to reflect new metrics (replacing PageRank groups)

## Test plan

Validated flow and metrics by hand, updated unit tests.