### PR TITLE
packages: optimize list + bulk insert queries

### DIFF
--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -338,10 +338,9 @@ func (s *vcsPackagesSyncer) versions(ctx context.Context, packageName reposource
 	}
 
 	listedPackages, _, err := s.svc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
-		Scheme:              s.scheme,
-		Name:                packageName,
-		ExactNameOnly:       true,
-		MostRecentlyUpdated: true,
+		Scheme:        s.scheme,
+		Name:          packageName,
+		ExactNameOnly: true,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list dependencies from db")

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -46,9 +46,6 @@ type ListDependencyReposOpts struct {
 	After int
 	// Limit limits the size of the results set to be returned.
 	Limit int
-	// MostRecentlyUpdated sorts by when a package was updated (either created or
-	// a new version added).
-	MostRecentlyUpdated bool
 }
 
 func (s *Service) ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (_ []PackageRepoReference, total int, err error) {
@@ -58,7 +55,6 @@ func (s *Service) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRe
 		log.Bool("exactOnly", opts.ExactNameOnly),
 		log.Int("after", opts.After),
 		log.Int("limit", opts.Limit),
-		log.Bool("mostRecentlyUpdated", opts.MostRecentlyUpdated),
 	}})
 	defer endObservation(1, observation.Args{})
 


### PR DESCRIPTION
## List (+ Count)

<details>
<summary>before</summary>

Somewhat less relevant, as this complexity was necessary at the time before migrations to collapse/reduce the table

```sql
EXPLAIN ANALYZE SELECT lr.id, lr.scheme, lr.name, prv.id, prv.package_id, prv.version
FROM (
	SELECT id, scheme, name
	FROM (
		SELECT id, scheme, name, ROW_NUMBER() OVER(
			PARTITION BY scheme, name
			ORDER BY id ASC
		) AS row_num
		FROM lsif_dependency_repos
        WHERE scheme = 'semanticdb'
		ORDER BY id ASC
	) AS single_entry
	WHERE row_num = 1
	-- ID based offset
    AND id > 43521
	-- limit results
	LIMIT 1000
) lr
JOIN package_repo_versions prv ON lr.id = prv.package_id
ORDER BY lr.id ASC;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
Sort  (cost=17266.41..17268.88 rows=988 width=56) (actual time=214.638..214.884 rows=3160 loops=1)
  Sort Key: single_entry.id
  Sort Method: quicksort  Memory: 548kB
  ->  Nested Loop  (cost=16319.26..17217.27 rows=988 width=56) (actual time=208.376..213.344 rows=3160 loops=1)
        ->  Limit  (cost=16318.83..16486.26 rows=47 width=33) (actual time=208.341..209.060 rows=1000 loops=1)
              ->  Subquery Scan on single_entry  (cost=16318.83..16486.26 rows=47 width=33) (actual time=208.340..208.913 rows=1000 loops=1)
                    Filter: ((single_entry.id > 43521) AND (single_entry.row_num = 1))
                    Rows Removed by Filter: 5061
                    ->  Sort  (cost=16318.83..16342.75 rows=9567 width=41) (actual time=207.078..207.699 rows=6061 loops=1)
                          Sort Key: lsif_dependency_repos.id
                          Sort Method: quicksort  Memory: 1705kB
                          ->  WindowAgg  (cost=15471.01..15686.27 rows=9567 width=41) (actual time=191.449..202.458 rows=9655 loops=1)
                                ->  Sort  (cost=15471.01..15494.93 rows=9567 width=33) (actual time=191.426..192.416 rows=9655 loops=1)
"                                      Sort Key: lsif_dependency_repos.name, lsif_dependency_repos.id"
                                      Sort Method: quicksort  Memory: 1580kB
                                      ->  Seq Scan on lsif_dependency_repos  (cost=0.00..14838.45 rows=9567 width=33) (actual time=0.011..70.235 rows=9655 loops=1)
                                            Filter: (scheme = 'semanticdb'::text)
                                            Rows Removed by Filter: 250723
        ->  Index Scan using package_repo_versions_fk_idx on package_repo_versions prv  (cost=0.43..15.33 rows=21 width=23) (actual time=0.002..0.003 rows=3 loops=1000)
              Index Cond: (package_id = single_entry.id)
Planning Time: 0.311 ms
Execution Time: 215.234 ms
```

</details>

<details>
<summary>after</summary>

```sql
EXPLAIN ANALYZE SELECT lr.id, lr.scheme, lr.name, prv.id, prv.package_id, prv.version
FROM (
	SELECT id, scheme, name
	FROM lsif_dependency_repos
	WHERE scheme = 'semanticdb' AND id > 43521
	ORDER BY id ASC LIMIT 1000
) lr
JOIN package_repo_versions prv ON lr.id = prv.package_id -- optional join
ORDER BY lr.id ASC;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
Nested Loop  (cost=0.85..10182.06 rows=21024 width=56) (actual time=0.027..3.837 rows=3160 loops=1)
  ->  Limit  (cost=0.42..2184.26 rows=1000 width=33) (actual time=0.014..0.778 rows=1000 loops=1)
        ->  Index Scan using lsif_dependency_repos_pkey on lsif_dependency_repos  (cost=0.42..20543.79 rows=9407 width=33) (actual time=0.013..0.671 rows=1000 loops=1)
              Index Cond: (id > 43521)
              Filter: (scheme = 'semanticdb'::text)
  ->  Index Scan using package_repo_versions_fk_idx on package_repo_versions prv  (cost=0.43..7.78 rows=21 width=23) (actual time=0.001..0.002 rows=3 loops=1000)
        Index Cond: (package_id = lsif_dependency_repos.id)
Planning Time: 0.301 ms
Execution Time: 4.032 ms
```

</details>

## Bulk Insert (the juicy bits)

Results of these queries are fed into an `INSERT` statement, instead of using `ON CONFLICT DO NOTHING` as that consumes the primary key which we dont want to do here.

### Package Repo References

<details>
<summary>before</summary>

```sql
EXPLAIN ANALYZE SELECT scheme, name
FROM (
        SELECT scheme, name
        FROM t_package_repo_refs t
        -- we reduce all package repo refs before insert, so nothing in
        -- t_package_repo_refs to dedupe
        EXCEPT ALL
        (
                SELECT scheme, name
                FROM lsif_dependency_repos
        )
        -- we order by ID in list as we use ID-based pagination,
        -- but unit tests rely on name ordering when paginating
) diff
ORDER BY name;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=19480.12..19482.32 rows=880 width=64) (actual time=243.294..243.296 rows=2 loops=1)
   Sort Key: diff.name
   Sort Method: quicksort  Memory: 25kB
   ->  Subquery Scan on diff  (cost=0.00..19437.08 rows=880 width=64) (actual time=243.230..243.242 rows=2 loops=1)
         ->  HashSetOp Except All  (cost=0.00..19428.28 rows=880 width=68) (actual time=243.229..243.239 rows=2 loops=1)
               ->  Append  (cost=0.00..18122.90 rows=261076 width=68) (actual time=0.016..186.843 rows=260612 loops=1)
                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..27.60 rows=880 width=68) (actual time=0.015..0.178 rows=415 loops=1)
                           ->  Seq Scan on t_package_repo_refs t  (cost=0.00..18.80 rows=880 width=64) (actual time=0.011..0.075 rows=415 loops=1)
                     ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..16789.92 rows=260196 width=29) (actual time=0.043..153.976 rows=260197 loops=1)
                           ->  Seq Scan on lsif_dependency_repos  (cost=0.00..14187.96 rows=260196 width=25) (actual time=0.042..95.512 rows=260197 loops=1)
 Planning Time: 0.226 ms
 Execution Time: 243.400 ms
```

</details>

<details>
<summary>after</summary>

```sql
EXPLAIN ANALYZE SELECT scheme, name
FROM t_package_repo_refs t
WHERE NOT EXISTS (
        SELECT scheme, name
        FROM lsif_dependency_repos
        WHERE scheme = t.scheme AND
        name = t.name
)
ORDER BY name;
                                                                                   QUERY PLAN                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=2276.11..2277.76 rows=660 width=64) (actual time=3.410..3.411 rows=2 loops=1)
   Sort Key: t.name
   Sort Method: quicksort  Memory: 25kB
   ->  Nested Loop Anti Join  (cost=0.42..2245.20 rows=660 width=64) (actual time=3.394..3.403 rows=2 loops=1)
         ->  Seq Scan on t_package_repo_refs t  (cost=0.00..18.80 rows=880 width=64) (actual time=0.009..0.062 rows=415 loops=1)
         ->  Index Scan using lsif_dependency_repos_name_idx on lsif_dependency_repos  (cost=0.42..2.52 rows=1 width=25) (actual time=0.008..0.008 rows=1 loops=415)
               Index Cond: (name = t.name)
               Filter: (scheme = t.scheme)
 Planning Time: 0.111 ms
 Execution Time: 3.432 ms
```

</details>

### Package Repo Reference Versions

<details>
<summary>before</summary>

```sql
EXPLAIN ANALYZE SELECT package_id, version
FROM t_package_repo_versions
EXCEPT
(
        SELECT package_id, version
        FROM package_repo_versions
)
ORDER BY package_id, version;
                                                                        QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=47452.29..47452.79 rows=200 width=44) (actual time=776.035..776.038 rows=3 loops=1)
   Sort Key: "*SELECT* 1".package_id, "*SELECT* 1".version
   Sort Method: quicksort  Memory: 25kB
   ->  HashSetOp Except  (cost=0.00..47444.65 rows=200 width=44) (actual time=776.017..776.022 rows=3 loops=1)
         ->  Append  (cost=0.00..40953.38 rows=1298255 width=44) (actual time=0.009..626.162 rows=1299484 loops=1)
               ->  Subquery Scan on "*SELECT* 1"  (cost=0.00..34.00 rows=1200 width=44) (actual time=0.009..0.032 rows=73 loops=1)
                     ->  Seq Scan on t_package_repo_versions  (cost=0.00..22.00 rows=1200 width=40) (actual time=0.007..0.015 rows=73 loops=1)
               ->  Subquery Scan on "*SELECT* 2"  (cost=0.00..34428.10 rows=1297055 width=19) (actual time=0.007..489.285 rows=1299411 loops=1)
                     ->  Seq Scan on package_repo_versions  (cost=0.00..21457.55 rows=1297055 width=15) (actual time=0.006..245.464 rows=1299411 loops=1)
 Planning Time: 0.084 ms
 Execution Time: 776.080 ms
```

</details>

<details>
<summary>after</summary>

```sql
EXPLAIN ANALYZE SELECT DISTINCT package_id, version
FROM t_package_repo_versions t
WHERE NOT EXISTS (
        SELECT package_id, version
        FROM package_repo_versions
        WHERE package_id = t.package_id AND
        version = t.version
)
ORDER BY package_id, version;
                                                                                           QUERY PLAN                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1801.54..1802.04 rows=200 width=40) (actual time=0.358..0.359 rows=3 loops=1)
   Sort Key: t.package_id, t.version
   Sort Method: quicksort  Memory: 25kB
   ->  HashAggregate  (cost=1791.90..1793.90 rows=200 width=40) (actual time=0.348..0.350 rows=3 loops=1)
         Group Key: t.package_id, t.version
         ->  Nested Loop Anti Join  (cost=0.43..1787.40 rows=900 width=40) (actual time=0.335..0.343 rows=4 loops=1)
               ->  Seq Scan on t_package_repo_versions t  (cost=0.00..22.00 rows=1200 width=40) (actual time=0.010..0.018 rows=73 loops=1)
               ->  Index Only Scan using package_repo_versions_unique_version_per_package on package_repo_versions  (cost=0.43..1.47 rows=1 width=15) (actual time=0.004..0.004 rows=1 loops=73)
                     Index Cond: ((package_id = t.package_id) AND (version = t.version))
                     Heap Fetches: 0
 Planning Time: 0.230 ms
 Execution Time: 0.409 ms
```

</details>

## Test plan

Covered by existing unit tests and a number of manual tests with dotcom data
