### PR TITLE
Setup Wizard: add delete code host api to the wizard

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes } from 'react'
+import { FC, HTMLAttributes, useState } from 'react'
 
 import classNames from 'classnames'
 import { Routes, Route, matchPath, useLocation } from 'react-router-dom'
@@ -7,6 +7,7 @@ import { Container, Text } from '@sourcegraph/wildcard'
 
 import { CustomNextButton } from '../setup-steps'
 
+import { CodeHostDeleteModal, CodeHostToDelete } from './components/code-host-delete-modal'
 import { CodeHostsPicker } from './components/code-host-picker'
 import { CodeHostCreation, CodeHostEdit } from './components/code-hosts'
 import { CodeHostsNavigation } from './components/navigation'
@@ -19,6 +20,8 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
     const { className, ...attributes } = props
 
     const location = useLocation()
+    const [codeHostToDelete, setCodeHostToDelete] = useState<CodeHostToDelete | null>(null)
+
     const editConnectionRouteMatch = matchPath('/setup/remote-repositories/:codehostId/edit', location.pathname)
     const newConnectionRouteMatch = matchPath('/setup/remote-repositories/:codeHostType/create', location.pathname)
 
@@ -34,6 +37,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
                         activeConnectionId={editConnectionRouteMatch?.params?.codehostId}
                         createConnectionType={newConnectionRouteMatch?.params?.codeHostType}
                         className={styles.navigation}
+                        onCodeHostDelete={setCodeHostToDelete}
                     />
                 </Container>
 
@@ -41,12 +45,19 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
                     <Routes>
                         <Route index={true} element={<CodeHostsPicker />} />
                         <Route path=":codeHostType/create" element={<CodeHostCreation />} />
-                        <Route path=":codehostId/edit" element={<CodeHostEdit />} />
+                        <Route
+                            path=":codehostId/edit"
+                            element={<CodeHostEdit onCodeHostDelete={setCodeHostToDelete} />}
+                        />
                     </Routes>
                 </Container>
             </section>
 
             <CustomNextButton label="Custom next step label" disabled={true} />
+
+            {codeHostToDelete && (
+                <CodeHostDeleteModal codeHost={codeHostToDelete} onDismiss={() => setCodeHostToDelete(null)} />
+            )}
         </div>
     )
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.module.scss
@@ -1,0 +1,14 @@
+.root {
+    padding: 1rem;
+}
+
+.footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.seperator {
+    margin: 1rem -1rem;
+}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
@@ -40,7 +40,7 @@ export const CodeHostDeleteModal: FC<CodeHostDeleteModalProps> = props => {
 
         // We have to remove it from the cache after we remove it on the backend
         // and navigate user away from the edit UI (in case if this modal is used from
-        // edit UI) othewise clearing the cache will trigger query in edit UI for code host
+        // edit UI) otherwise clearing the cache will trigger query in edit UI for code host
         // which doesn't exist anymore
         removeDeletedHostFromCache(apolloClient.cache, codeHost.id)
         onDismiss()
@@ -90,7 +90,7 @@ export const CodeHostDeleteModal: FC<CodeHostDeleteModalProps> = props => {
     )
 }
 
-function removeDeletedHostFromCache(cache: ApolloCache, codeHostId: string): void {
+function removeDeletedHostFromCache(cache: ApolloCache<any>, codeHostId: string): void {
     const deletedCodeHostId = cache.identify({
         __typename: 'ExternalService',
         id: codeHostId,

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
@@ -1,0 +1,101 @@
+import { FC } from 'react'
+
+import { useApolloClient } from '@apollo/client'
+import { ApolloCache } from '@apollo/client/cache'
+import { useNavigate } from 'react-router-dom'
+
+import { pluralize } from '@sourcegraph/common'
+import { useMutation } from '@sourcegraph/http-client'
+import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { Button, ErrorAlert, H2, Icon, Modal, Text } from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../../../../components/LoaderButton'
+import { getCodeHostIcon } from '../../helpers'
+import { DELETE_CODE_HOST } from '../../queries'
+
+import styles from './CodeHostDeleteModal.module.scss'
+
+export interface CodeHostToDelete {
+    id: string
+    kind: ExternalServiceKind
+    displayName: string
+    repoCount?: number
+}
+
+interface CodeHostDeleteModalProps {
+    codeHost: CodeHostToDelete
+    onDismiss: () => void
+}
+
+export const CodeHostDeleteModal: FC<CodeHostDeleteModalProps> = props => {
+    const { codeHost, onDismiss } = props
+
+    const navigate = useNavigate()
+    const apolloClient = useApolloClient()
+    const [deleteCode, { loading, error }] = useMutation(DELETE_CODE_HOST)
+
+    const handleDeleteConfirm = async (): Promise<void> => {
+        await deleteCode({ variables: { id: codeHost.id } })
+        navigate('/setup/remote-repositories')
+
+        // We have to remove it from the cache after we remove it on the backend
+        // and navigate user away from the edit UI (in case if this modal is used from
+        // edit UI) othewise clearing the cache will trigger query in edit UI for code host
+        // which doesn't exist anymore
+        removeDeletedHostFromCache(apolloClient.cache, codeHost.id)
+        onDismiss()
+    }
+
+    return (
+        <Modal
+            position="center"
+            aria-label="Delete external code host connection"
+            className={styles.root}
+            onDismiss={onDismiss}
+        >
+            <H2>
+                Remove connection with <Icon svgPath={getCodeHostIcon(codeHost.kind)} aria-hidden={true} /> '
+                {codeHost.displayName}'?
+            </H2>
+
+            <hr className={styles.seperator} />
+
+            <Text>
+                There are{' '}
+                <b>
+                    {codeHost.repoCount ?? 0} {pluralize('repository', codeHost.repoCount ?? 0, 'repositories')}
+                </b>{' '}
+                synced to Sourcegraph from '{codeHost.displayName}'. If the connection is removed, these repositories
+                will no longer be synced with Sourcegraph.
+            </Text>
+
+            <hr className={styles.seperator} />
+
+            {error && <ErrorAlert error={error} />}
+
+            <div className={styles.footer}>
+                <LoaderButton
+                    variant="danger"
+                    label="Yes, remove connection"
+                    loading={loading}
+                    disabled={loading}
+                    alwaysShowLabel={true}
+                    onClick={handleDeleteConfirm}
+                />
+                <Button variant="secondary" onClick={onDismiss}>
+                    Cancel
+                </Button>
+            </div>
+        </Modal>
+    )
+}
+
+function removeDeletedHostFromCache(cache: ApolloCache, codeHostId: string): void {
+    const deletedCodeHostId = cache.identify({
+        __typename: 'ExternalService',
+        id: codeHostId,
+    })
+
+    // Remove deleted code host from the apollo cache
+    cache.evict({ id: deletedCodeHostId })
+}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/index.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/index.ts
@@ -1,0 +1,2 @@
+export { CodeHostDeleteModal } from './CodeHostDeleteModal'
+export type { CodeHostToDelete } from './CodeHostDeleteModal'

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 
-import { gql, useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { useParams } from 'react-router-dom'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
@@ -8,37 +8,41 @@ import { Alert, Button, ErrorAlert, H4, Link, LoadingSpinner } from '@sourcegrap
 
 import { defaultExternalServices } from '../../../../../components/externalServices/externalServices'
 import { GetExternalServiceByIdResult, GetExternalServiceByIdVariables } from '../../../../../graphql-operations'
+import { GET_CODE_HOST_BY_ID } from '../../queries'
 
 import { CodeHostConnectFormFields, CodeHostJSONForm, CodeHostJSONFormState } from './common'
 import { GithubConnectView } from './github/GithubConnectView'
 
 import styles from './CodeHostCreation.module.scss'
 
-const GET_EXTERNAL_SERVICE_BY_ID = gql`
-    query GetExternalServiceById($id: ID!) {
-        node(id: $id) {
-            ... on ExternalService {
-                id
-                __typename
-                kind
-                displayName
-                config
-            }
-        }
-    }
-`
+/**
+ * Manually created type based on gql query schema, auto-generated tool can't infer
+ * proper type for ExternalServices (because of problems with gql schema itself, node
+ * type implementation problem that leads to have a massive union if when you use specific
+ * type fragment)
+ */
+interface EditableCodeHost {
+    __typename: 'ExternalService'
+    id: string
+    kind: ExternalServiceKind
+    displayName: string
+    config: string
+}
 
-interface CodeHostEditProps {}
+interface CodeHostEditProps {
+    onCodeHostDelete: (codeHost: EditableCodeHost) => void
+}
 
 /**
  * Renders edit UI for any supported code host type. (Github, Gitlab, ...)
  * Also performs edit, delete actions over opened code host connection
  */
-export const CodeHostEdit: FC<CodeHostEditProps> = () => {
+export const CodeHostEdit: FC<CodeHostEditProps> = props => {
+    const { onCodeHostDelete } = props
     const { codehostId } = useParams()
 
     const { data, loading, error, refetch } = useQuery<GetExternalServiceByIdResult, GetExternalServiceByIdVariables>(
-        GET_EXTERNAL_SERVICE_BY_ID,
+        GET_CODE_HOST_BY_ID,
         {
             fetchPolicy: 'cache-and-network',
             variables: { id: codehostId! },
@@ -86,7 +90,12 @@ export const CodeHostEdit: FC<CodeHostEditProps> = () => {
                         Update
                     </Button>
 
-                    <Button variant="danger" size="sm" type="submit">
+                    <Button
+                        variant="danger"
+                        size="sm"
+                        type="submit"
+                        onClick={() => onCodeHostDelete(data.node as EditableCodeHost)}
+                    >
                         Delete
                     </Button>
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 
 import { ErrorAlert, Icon, LoadingSpinner, Button, Tooltip, Link } from '@sourcegraph/wildcard'
 
-import { GetCodeHostsResult } from '../../../../../graphql-operations'
+import { CodeHost, GetCodeHostsResult } from '../../../../../graphql-operations'
 import { getCodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../../helpers'
 import { GET_CODE_HOSTS } from '../../queries'
 
@@ -16,10 +16,11 @@ interface CodeHostsNavigationProps {
     activeConnectionId: string | undefined
     createConnectionType: string | undefined
     className?: string
+    onCodeHostDelete: (codeHost: CodeHost) => void
 }
 
 export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
-    const { activeConnectionId, createConnectionType, className } = props
+    const { activeConnectionId, createConnectionType, className, onCodeHostDelete } = props
 
     const { data, loading, error, refetch } = useQuery<GetCodeHostsResult>(GET_CODE_HOSTS, {
         fetchPolicy: 'cache-and-network',
@@ -94,7 +95,7 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                     </Button>
 
                     <Tooltip content="Delete code host connection" placement="right" debounce={0}>
-                        <Button className={styles.deleteButton}>
+                        <Button className={styles.deleteButton} onClick={() => onCodeHostDelete(codeHost)}>
                             <Icon svgPath={mdiDelete} aria-label="Delete code host connection" />
                         </Button>
                     </Tooltip>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
@@ -24,6 +24,21 @@ export const GET_CODE_HOSTS = gql`
     ${CODE_HOST_FRAGMENT}
 `
 
+export const GET_CODE_HOST_BY_ID = gql`
+    query GetExternalServiceById($id: ID!) {
+        node(id: $id) {
+            ... on ExternalService {
+                id
+                __typename
+                kind
+                displayName
+                repoCount
+                config
+            }
+        }
+    }
+`
+
 export const ADD_CODE_HOST = gql`
     mutation AddRemoteCodeHost($input: AddExternalServiceInput!) {
         addExternalService(input: $input) {
@@ -32,4 +47,12 @@ export const ADD_CODE_HOST = gql`
     }
 
     ${CODE_HOST_FRAGMENT}
+`
+
+export const DELETE_CODE_HOST = gql`
+    mutation DeleteCodeHost($id: ID!) {
+        deleteExternalService(externalService: $id) {
+            alwaysNil
+        }
+    }
 `

--- a/client/wildcard/src/components/Typography/Text/Text.tsx
+++ b/client/wildcard/src/components/Typography/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import classNames from 'classnames'
 
@@ -11,6 +11,7 @@ import typographyStyles from '../Typography.module.scss'
 interface TextProps extends React.HTMLAttributes<HTMLParagraphElement>, TypographyProps {
     size?: typeof TYPOGRAPHY_SIZES[number]
     weight?: typeof TYPOGRAPHY_WEIGHTS[number]
+    children?: ReactNode | ReactNode[] | undefined
 }
 
 export const Text = React.forwardRef(function Text(


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47910

This PR just adds delete code host UI and connects it to the existing delete code host (external service) API. 

## Test plan
- Go to the setup wizard 
- Create some test external service (or skip it if you're already have it)
- Click deetel button in the aside menu or in the edit UI for code host 
- See that code host has been deleted and see that it disappeared in the aside navigation list

## App preview:

- [Web](https://sg-web-vk-add-delete-code-host-api-to.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
