### PR TITLE
batches: hide unimplemented review state filters

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 
+import { reject } from 'lodash'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { Input, Form } from '@sourcegraph/wildcard'
@@ -123,7 +124,12 @@ export const ChangesetFilterRow: React.FunctionComponent<React.PropsWithChildren
                         <div className="w-100 d-block d-sm-none" />
                         <div className="col mb-2 ml-0 ml-sm-2">
                             <ChangesetFilter<ChangesetReviewState>
-                                values={Object.values(ChangesetReviewState)}
+                                values={reject(
+                                    Object.values(ChangesetReviewState),
+                                    state =>
+                                        state === ChangesetReviewState.COMMENTED ||
+                                        state === ChangesetReviewState.DISMISSED
+                                )}
                                 label="Review state"
                                 selected={reviewState}
                                 onChange={setReviewState}

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -425,6 +425,8 @@ type ExternalChangeset implements Node & Changeset {
 
     """
     The review state of this changeset. This is only set once the changeset is published on the code host.
+
+    Note: The COMMENTED and DISMISSED review states are not yet implemented.
     """
     reviewState: ChangesetReviewState
 
@@ -2683,6 +2685,8 @@ type BatchChange implements Node {
         onlyClosable: Boolean
         """
         Only include changesets with the given review state.
+
+        Note: The COMMENTED and DISMISSED review states are not yet implemented.
         """
         reviewState: ChangesetReviewState
         """


### PR DESCRIPTION
To reduce confusion, we ought not to surface the review state filters for review states that aren't currently implemented on the backend for changesets (commented, dismissed). This PR simply excludes them for the filters list. See https://github.com/sourcegraph/sourcegraph/issues/47360 for more context. 

<img width="269" alt="image" src="https://user-images.githubusercontent.com/8942601/220839400-2d866ed2-cc15-4c83-9dd3-ed04af838503.png">

## Test plan

Verified the two unimplemented states no longer appear in the dropdown for review filters, as shown above.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-hide-unimplemented-review.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
