### PR TITLE
batches: add `isCompleted` and `percentComplete` fields to `ChangesetsStats` resolver

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -52,7 +52,7 @@ const batchChangeDefaults: BatchChangeFields = {
         archived: 18,
         unpublished: 4,
         isCompleted: false,
-        percentComplete: 30
+        percentComplete: 30,
     },
     createdAt: subDays(now, 5).toISOString(),
     creator: {

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -51,6 +51,8 @@ const batchChangeDefaults: BatchChangeFields = {
         total: 29,
         archived: 18,
         unpublished: 4,
+        isCompleted: false,
+        percentComplete: 30
     },
     createdAt: subDays(now, 5).toISOString(),
     creator: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
@@ -30,6 +30,8 @@ export const MOCK_BATCH_CHANGE: BatchChangeFields = {
         archived: 5,
         total: 18,
         unpublished: 4,
+        isCompleted: false,
+        percentComplete: 25
     },
     createdAt: subDays(now, 5).toISOString(),
     creator: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
@@ -31,7 +31,7 @@ export const MOCK_BATCH_CHANGE: BatchChangeFields = {
         total: 18,
         unpublished: 4,
         isCompleted: false,
-        percentComplete: 25
+        percentComplete: 25,
     },
     createdAt: subDays(now, 5).toISOString(),
     creator: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -32,9 +32,8 @@ const calculatePercentComplete = <T extends MockStatsArgs>(stats: T, total: numb
     return ((stats.closed + stats.merged) / (total - stats.deleted - stats.archived)) * 100
 }
 
-const calculateTotal = <T extends MockStatsArgs>(stats: T): number => {
-    return stats.closed + stats.deleted + stats.merged + stats.draft + stats.open + stats.archived + stats.unpublished
-}
+const calculateTotal = <T extends MockStatsArgs>(stats: T): number =>
+    stats.closed + stats.deleted + stats.merged + stats.draft + stats.open + stats.archived + stats.unpublished
 
 export const Draft: Story<MockStatsArgs> = args => {
     const total = calculateTotal(args)

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -33,13 +33,7 @@ const calculatePercentComplete = <T extends MockStatsArgs>(stats: T, total: numb
 }
 
 const calculateTotal = <T extends MockStatsArgs>(stats: T): number => {
-    return stats.closed +
-        stats.deleted +
-        stats.merged +
-        stats.draft +
-        stats.open +
-        stats.archived +
-        stats.unpublished
+    return stats.closed + stats.deleted + stats.merged + stats.draft + stats.open + stats.archived + stats.unpublished
 }
 
 export const Draft: Story<MockStatsArgs> = args => {

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story, DecoratorFn } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
-import { BatchChangeState } from '../../../graphql-operations'
+import { BatchChangeState, ChangesetsStatsFields } from '../../../graphql-operations'
 
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 
@@ -14,7 +14,23 @@ const config: Meta = {
 
 export default config
 
-export const Draft: Story = () => (
+type MockStatsArgs = Omit<ChangesetsStatsFields, 'percentComplete' | '__typename' | 'isCompleted'>
+
+const calculateIsCompleted = <T extends MockStatsArgs>(stats: T): boolean => {
+    if (stats.total === 0) {
+        return false
+    }
+    return (stats.closed + stats.merged) === (stats.total - stats.deleted - stats.archived)
+}
+
+const calculatePercentComplete = <T extends MockStatsArgs>(stats: T): number => {
+    if (stats.total === 0) {
+        return 0
+    }
+    return ((stats.closed + stats.merged) / (stats.total - stats.deleted - stats.archived)) * 100
+}
+
+export const Draft: Story<MockStatsArgs> = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -22,14 +38,16 @@ export const Draft: Story = () => (
                 batchChange={{
                     changesetsStats: {
                         __typename: 'ChangesetsStats',
-                        deleted: 0,
-                        closed: 0,
-                        merged: 0,
-                        draft: 0,
-                        open: 0,
-                        archived: 0,
-                        total: 0,
-                        unpublished: 0,
+                        deleted: args.deleted,
+                        closed: args.closed,
+                        merged: args.merged,
+                        draft: args.draft,
+                        open: args.open,
+                        archived: args.archived,
+                        total: args.total,
+                        unpublished: args.unpublished,
+                        isCompleted: calculateIsCompleted(args),
+                        percentComplete: calculatePercentComplete(args),
                     },
                     diffStat: { added: 0, deleted: 0, __typename: 'DiffStat' },
                     state: BatchChangeState.DRAFT,
@@ -39,7 +57,42 @@ export const Draft: Story = () => (
     </WebStory>
 )
 
-export const Open: Story<OpenArgs> = args => (
+Draft.argTypes = {
+    closed: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    deleted: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    merged: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    draft: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    open: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    archived: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    unpublished: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    total: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    }
+}
+
+export const Open: Story<MockStatsArgs> = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -52,16 +105,11 @@ export const Open: Story<OpenArgs> = args => (
                         merged: args.merged,
                         draft: args.draft,
                         open: args.open,
-                        total:
-                            args.closed +
-                            args.deleted +
-                            args.merged +
-                            args.draft +
-                            args.open +
-                            args.archived +
-                            args.unpublished,
+                        total: args.total,
                         archived: args.archived,
                         unpublished: args.unpublished,
+                        isCompleted: calculateIsCompleted(args),
+                        percentComplete: calculatePercentComplete(args),
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
                     state: BatchChangeState.OPEN,
@@ -70,16 +118,6 @@ export const Open: Story<OpenArgs> = args => (
         )}
     </WebStory>
 )
-
-interface OpenArgs {
-    closed: number
-    deleted: number
-    merged: number
-    draft: number
-    open: number
-    archived: number
-    unpublished: number
-}
 
 Open.argTypes = {
     closed: {
@@ -110,9 +148,13 @@ Open.argTypes = {
         control: { type: 'number' },
         defaultValue: 55,
     },
+    total: {
+        control: { type: 'number' },
+        defaultValue: 118,
+    }
 }
 
-export const OpenAndComplete: Story = () => (
+export const OpenAndComplete: Story<MockStatsArgs> = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -120,14 +162,16 @@ export const OpenAndComplete: Story = () => (
                 batchChange={{
                     changesetsStats: {
                         __typename: 'ChangesetsStats',
-                        deleted: 10,
-                        closed: 10,
-                        merged: 80,
-                        draft: 0,
-                        open: 0,
-                        archived: 18,
-                        total: 118,
-                        unpublished: 0,
+                        deleted: args.deleted,
+                        closed: args.closed,
+                        merged: args.merged,
+                        draft: args.draft,
+                        open: args.open,
+                        archived: args.archived,
+                        total: args.total,
+                        unpublished: args.unpublished,
+                        isCompleted: calculateIsCompleted(args),
+                        percentComplete: calculatePercentComplete(args),
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
                     state: BatchChangeState.OPEN,
@@ -137,9 +181,44 @@ export const OpenAndComplete: Story = () => (
     </WebStory>
 )
 
+OpenAndComplete.argTypes = {
+    closed: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    deleted: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    merged: {
+        control: { type: 'number' },
+        defaultValue: 80,
+    },
+    draft: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    open: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    archived: {
+        control: { type: 'number' },
+        defaultValue: 18,
+    },
+    unpublished: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    total: {
+        control: { type: 'number' },
+        defaultValue: 118,
+    }
+}
+
 OpenAndComplete.storyName = 'open and complete'
 
-export const Closed: Story = () => (
+export const Closed: Story<MockStatsArgs> = args => (
     <WebStory>
         {props => (
             <BatchChangeStatsCard
@@ -147,14 +226,17 @@ export const Closed: Story = () => (
                 batchChange={{
                     changesetsStats: {
                         __typename: 'ChangesetsStats',
-                        closed: 10,
-                        deleted: 10,
-                        merged: 10,
-                        draft: 0,
-                        open: 10,
-                        archived: 18,
-                        total: 118,
-                        unpublished: 60,
+                        deleted: args.deleted,
+                        closed: args.closed,
+                        merged: args.merged,
+                        draft: args.draft,
+                        open: args.open,
+                        archived: args.archived,
+                        total: args.total,
+                        unpublished: args.unpublished,
+                        isCompleted: calculateIsCompleted(args),
+                        percentComplete: calculatePercentComplete(args),
+
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
                     state: BatchChangeState.CLOSED,
@@ -163,3 +245,38 @@ export const Closed: Story = () => (
         )}
     </WebStory>
 )
+
+Closed.argTypes = {
+    closed: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    deleted: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    merged: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    draft: {
+        control: { type: 'number' },
+        defaultValue: 0,
+    },
+    open: {
+        control: { type: 'number' },
+        defaultValue: 10,
+    },
+    archived: {
+        control: { type: 'number' },
+        defaultValue: 18,
+    },
+    unpublished: {
+        control: { type: 'number' },
+        defaultValue: 60,
+    },
+    total: {
+        control: { type: 'number' },
+        defaultValue: 118,
+    }
+}

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -20,7 +20,7 @@ const calculateIsCompleted = <T extends MockStatsArgs>(stats: T): boolean => {
     if (stats.total === 0) {
         return false
     }
-    return (stats.closed + stats.merged) === (stats.total - stats.deleted - stats.archived)
+    return stats.closed + stats.merged === stats.total - stats.deleted - stats.archived
 }
 
 const calculatePercentComplete = <T extends MockStatsArgs>(stats: T): number => {
@@ -89,7 +89,7 @@ Draft.argTypes = {
     total: {
         control: { type: 'number' },
         defaultValue: 0,
-    }
+    },
 }
 
 export const Open: Story<MockStatsArgs> = args => (
@@ -151,7 +151,7 @@ Open.argTypes = {
     total: {
         control: { type: 'number' },
         defaultValue: 118,
-    }
+    },
 }
 
 export const OpenAndComplete: Story<MockStatsArgs> = args => (
@@ -213,7 +213,7 @@ OpenAndComplete.argTypes = {
     total: {
         control: { type: 'number' },
         defaultValue: 118,
-    }
+    },
 }
 
 OpenAndComplete.storyName = 'open and complete'
@@ -236,7 +236,6 @@ export const Closed: Story<MockStatsArgs> = args => (
                         unpublished: args.unpublished,
                         isCompleted: calculateIsCompleted(args),
                         percentComplete: calculatePercentComplete(args),
-
                     },
                     diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
                     state: BatchChangeState.CLOSED,
@@ -278,5 +277,5 @@ Closed.argTypes = {
     total: {
         control: { type: 'number' },
         defaultValue: 118,
-    }
+    },
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -14,48 +14,63 @@ const config: Meta = {
 
 export default config
 
-type MockStatsArgs = Omit<ChangesetsStatsFields, 'percentComplete' | '__typename' | 'isCompleted'>
+type MockStatsArgs = Omit<ChangesetsStatsFields, 'percentComplete' | '__typename' | 'isCompleted' | 'total'>
 
-const calculateIsCompleted = <T extends MockStatsArgs>(stats: T): boolean => {
-    if (stats.total === 0) {
+// The methods (calculateIsCompleted & calculatePercentComplete) below are implemented on the backend,
+// we are duplicating the logic here to make them available for Storybook.
+const calculateIsCompleted = <T extends MockStatsArgs>(stats: T, total: number): boolean => {
+    if (total === 0) {
         return false
     }
-    return stats.closed + stats.merged === stats.total - stats.deleted - stats.archived
+    return stats.closed + stats.merged === total - stats.deleted - stats.archived
 }
 
-const calculatePercentComplete = <T extends MockStatsArgs>(stats: T): number => {
-    if (stats.total === 0) {
+const calculatePercentComplete = <T extends MockStatsArgs>(stats: T, total: number): number => {
+    if (total === 0) {
         return 0
     }
-    return ((stats.closed + stats.merged) / (stats.total - stats.deleted - stats.archived)) * 100
+    return ((stats.closed + stats.merged) / (total - stats.deleted - stats.archived)) * 100
 }
 
-export const Draft: Story<MockStatsArgs> = args => (
-    <WebStory>
-        {props => (
-            <BatchChangeStatsCard
-                {...props}
-                batchChange={{
-                    changesetsStats: {
-                        __typename: 'ChangesetsStats',
-                        deleted: args.deleted,
-                        closed: args.closed,
-                        merged: args.merged,
-                        draft: args.draft,
-                        open: args.open,
-                        archived: args.archived,
-                        total: args.total,
-                        unpublished: args.unpublished,
-                        isCompleted: calculateIsCompleted(args),
-                        percentComplete: calculatePercentComplete(args),
-                    },
-                    diffStat: { added: 0, deleted: 0, __typename: 'DiffStat' },
-                    state: BatchChangeState.DRAFT,
-                }}
-            />
-        )}
-    </WebStory>
-)
+const calculateTotal = <T extends MockStatsArgs>(stats: T): number => {
+    return stats.closed +
+        stats.deleted +
+        stats.merged +
+        stats.draft +
+        stats.open +
+        stats.archived +
+        stats.unpublished
+}
+
+export const Draft: Story<MockStatsArgs> = args => {
+    const total = calculateTotal(args)
+    return (
+        <WebStory>
+            {props => (
+                <BatchChangeStatsCard
+                    {...props}
+                    batchChange={{
+                        changesetsStats: {
+                            __typename: 'ChangesetsStats',
+                            deleted: args.deleted,
+                            closed: args.closed,
+                            merged: args.merged,
+                            draft: args.draft,
+                            open: args.open,
+                            archived: args.archived,
+                            total,
+                            unpublished: args.unpublished,
+                            isCompleted: calculateIsCompleted(args, total),
+                            percentComplete: calculatePercentComplete(args, total),
+                        },
+                        diffStat: { added: 0, deleted: 0, __typename: 'DiffStat' },
+                        state: BatchChangeState.DRAFT,
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
 
 Draft.argTypes = {
     closed: {
@@ -86,38 +101,37 @@ Draft.argTypes = {
         control: { type: 'number' },
         defaultValue: 0,
     },
-    total: {
-        control: { type: 'number' },
-        defaultValue: 0,
-    },
 }
 
-export const Open: Story<MockStatsArgs> = args => (
-    <WebStory>
-        {props => (
-            <BatchChangeStatsCard
-                {...props}
-                batchChange={{
-                    changesetsStats: {
-                        __typename: 'ChangesetsStats',
-                        closed: args.closed,
-                        deleted: args.deleted,
-                        merged: args.merged,
-                        draft: args.draft,
-                        open: args.open,
-                        total: args.total,
-                        archived: args.archived,
-                        unpublished: args.unpublished,
-                        isCompleted: calculateIsCompleted(args),
-                        percentComplete: calculatePercentComplete(args),
-                    },
-                    diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
-                    state: BatchChangeState.OPEN,
-                }}
-            />
-        )}
-    </WebStory>
-)
+export const Open: Story<MockStatsArgs> = args => {
+    const total = calculateTotal(args)
+    return (
+        <WebStory>
+            {props => (
+                <BatchChangeStatsCard
+                    {...props}
+                    batchChange={{
+                        changesetsStats: {
+                            __typename: 'ChangesetsStats',
+                            closed: args.closed,
+                            deleted: args.deleted,
+                            merged: args.merged,
+                            draft: args.draft,
+                            open: args.open,
+                            total,
+                            archived: args.archived,
+                            unpublished: args.unpublished,
+                            isCompleted: calculateIsCompleted(args, total),
+                            percentComplete: calculatePercentComplete(args, total),
+                        },
+                        diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
+                        state: BatchChangeState.OPEN,
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
 
 Open.argTypes = {
     closed: {
@@ -148,38 +162,37 @@ Open.argTypes = {
         control: { type: 'number' },
         defaultValue: 55,
     },
-    total: {
-        control: { type: 'number' },
-        defaultValue: 118,
-    },
 }
 
-export const OpenAndComplete: Story<MockStatsArgs> = args => (
-    <WebStory>
-        {props => (
-            <BatchChangeStatsCard
-                {...props}
-                batchChange={{
-                    changesetsStats: {
-                        __typename: 'ChangesetsStats',
-                        deleted: args.deleted,
-                        closed: args.closed,
-                        merged: args.merged,
-                        draft: args.draft,
-                        open: args.open,
-                        archived: args.archived,
-                        total: args.total,
-                        unpublished: args.unpublished,
-                        isCompleted: calculateIsCompleted(args),
-                        percentComplete: calculatePercentComplete(args),
-                    },
-                    diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
-                    state: BatchChangeState.OPEN,
-                }}
-            />
-        )}
-    </WebStory>
-)
+export const OpenAndComplete: Story<MockStatsArgs> = args => {
+    const total = calculateTotal(args)
+    return (
+        <WebStory>
+            {props => (
+                <BatchChangeStatsCard
+                    {...props}
+                    batchChange={{
+                        changesetsStats: {
+                            __typename: 'ChangesetsStats',
+                            deleted: args.deleted,
+                            closed: args.closed,
+                            merged: args.merged,
+                            draft: args.draft,
+                            open: args.open,
+                            archived: args.archived,
+                            total,
+                            unpublished: args.unpublished,
+                            isCompleted: calculateIsCompleted(args, total),
+                            percentComplete: calculatePercentComplete(args, total),
+                        },
+                        diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
+                        state: BatchChangeState.OPEN,
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
 
 OpenAndComplete.argTypes = {
     closed: {
@@ -210,40 +223,39 @@ OpenAndComplete.argTypes = {
         control: { type: 'number' },
         defaultValue: 0,
     },
-    total: {
-        control: { type: 'number' },
-        defaultValue: 118,
-    },
 }
 
 OpenAndComplete.storyName = 'open and complete'
 
-export const Closed: Story<MockStatsArgs> = args => (
-    <WebStory>
-        {props => (
-            <BatchChangeStatsCard
-                {...props}
-                batchChange={{
-                    changesetsStats: {
-                        __typename: 'ChangesetsStats',
-                        deleted: args.deleted,
-                        closed: args.closed,
-                        merged: args.merged,
-                        draft: args.draft,
-                        open: args.open,
-                        archived: args.archived,
-                        total: args.total,
-                        unpublished: args.unpublished,
-                        isCompleted: calculateIsCompleted(args),
-                        percentComplete: calculatePercentComplete(args),
-                    },
-                    diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
-                    state: BatchChangeState.CLOSED,
-                }}
-            />
-        )}
-    </WebStory>
-)
+export const Closed: Story<MockStatsArgs> = args => {
+    const total = calculateTotal(args)
+    return (
+        <WebStory>
+            {props => (
+                <BatchChangeStatsCard
+                    {...props}
+                    batchChange={{
+                        changesetsStats: {
+                            __typename: 'ChangesetsStats',
+                            deleted: args.deleted,
+                            closed: args.closed,
+                            merged: args.merged,
+                            draft: args.draft,
+                            open: args.open,
+                            archived: args.archived,
+                            total,
+                            unpublished: args.unpublished,
+                            isCompleted: calculateIsCompleted(args, total),
+                            percentComplete: calculatePercentComplete(args, total),
+                        },
+                        diffStat: { added: 3000, deleted: 3000, __typename: 'DiffStat' },
+                        state: BatchChangeState.CLOSED,
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
 
 Closed.argTypes = {
     closed: {
@@ -273,9 +285,5 @@ Closed.argTypes = {
     unpublished: {
         control: { type: 'number' },
         defaultValue: 60,
-    },
-    total: {
-        control: { type: 'number' },
-        defaultValue: 118,
     },
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -41,16 +41,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
     className,
 }) => {
     const { changesetsStats: stats, diffStat } = batchChange
-    // TODO: We should just compute this and `isCompleted` on the backend batch change resolver.
-    const percentComplete =
-        // We don't count archived or deleted changesets when computing the percentage.
-        stats.total === 0 ? 0 : ((stats.closed + stats.merged) / (stats.total - stats.archived - stats.deleted)) * 100
-    const isCompleted =
-        stats.total !== 0 && stats.closed + stats.merged === stats.total - stats.archived - stats.deleted
-    let BatchChangeStatusIcon = ProgressCheckIcon
-    if (isCompleted) {
-        BatchChangeStatusIcon = CheckCircleOutlineIcon
-    }
+    const BatchChangeStatusIcon = stats.isCompleted ? CheckCircleOutlineIcon : ProgressCheckIcon
     return (
         <div className={classNames(className)}>
             <div className="d-flex flex-wrap align-items-center flex-grow-1">
@@ -67,13 +58,13 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                 <div className="d-flex align-items-center">
                     <Heading as="h3" styleAs="h1" className="d-inline mb-0" aria-hidden="true">
                         <Icon
-                            className={classNames('mr-2', isCompleted ? 'text-success' : 'text-muted')}
+                            className={classNames('mr-2', stats.isCompleted ? 'text-success' : 'text-muted')}
                             as={BatchChangeStatusIcon}
                             aria-hidden={true}
                         />
                     </Heading>{' '}
                     <span className={classNames(styles.batchChangeStatsCardCompleteness, 'lead text-nowrap')}>
-                        {`${formatDisplayPercent(percentComplete)} complete`}
+                        {`${formatDisplayPercent(stats.percentComplete)} complete`}
                     </span>
                 </div>
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'd-none d-md-block mx-3')} />

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -61,6 +61,8 @@ const changesetsStatsFragment = gql`
         open
         unpublished
         archived
+        isCompleted
+        percentComplete
     }
 `
 

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -362,6 +362,8 @@ function mockCommonGraphQLResponses(
                     archived: 18,
                     unpublished: 3,
                     draft: 2,
+                    isCompleted: false,
+                    percentComplete: 27
                 },
                 state: BatchChangeState.OPEN,
                 closedAt: null,

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -363,7 +363,7 @@ function mockCommonGraphQLResponses(
                     unpublished: 3,
                     draft: 2,
                     isCompleted: false,
-                    percentComplete: 27
+                    percentComplete: 27,
                 },
                 state: BatchChangeState.OPEN,
                 closedAt: null,

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -731,6 +731,8 @@ type ChangesetsStatsResolver interface {
 	Processing() int32
 	Deleted() int32
 	Archived() int32
+	IsCompleted() bool
+	PercentComplete() int32
 }
 
 type ChangesetsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -523,7 +523,7 @@ type ChangesetsStats {
     """
     isCompleted: Boolean!
     """
-    The count of changesets that are complete (i.e in a merged or closed state).
+    The count of changesets that are complete (i.e in a merged or closed state) and not archived or deleted.
     """
     percentComplete: Int!
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -518,6 +518,14 @@ type ChangesetsStats {
     The count of all changesets.
     """
     total: Int!
+    """
+    If true, then all changesets are either merged or closed. This indicates that the batch change is completed.
+    """
+    isCompleted: Boolean!
+    """
+    The count of changesets that are complete (i.e in a merged or closed state).
+    """
+    percentComplete: Int!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats.go
@@ -49,7 +49,7 @@ func (r *changesetsStatsResolver) Total() int32 {
 }
 func (r *changesetsStatsResolver) IsCompleted() bool {
 	mergedAndClosedChangesets := r.stats.Closed + r.stats.Merged
-	// We don't count archived or deleted changesets when computing the percentage.
+	// We don't count archived or deleted changesets when computing `isCompleted`.
 	noOfIncludedChangesets := r.stats.Total - r.stats.Archived - r.stats.Deleted
 
 	return r.stats.Total != 0 && (mergedAndClosedChangesets == noOfIncludedChangesets)
@@ -59,11 +59,13 @@ func (r *changesetsStatsResolver) PercentComplete() int32 {
 		return 0
 	}
 
-	mergedAndClosed := r.stats.Merged + r.stats.Closed
-	// We don't count archived or deleted changesets when computing the percentage.
-	noOfIncludedChangesets := r.stats.Total - r.stats.Archived - r.stats.Deleted
-
-	return (mergedAndClosed / noOfIncludedChangesets) * 100
+	// We convert to float32 because the division of two integers will always return an integer, and the result
+	// is the largest integer value that is less than or equal to the actual quotient. In the case of percentages,
+	// it will always be between 0 and 1.
+	mergedAndClosed := float32(r.stats.Merged + r.stats.Closed)
+	// We don't count archived or deleted changesets when computing `percentComplete`.
+	noOfIncludedChangesets := float32(r.stats.Total - r.stats.Archived - r.stats.Deleted)
+	return int32((mergedAndClosed / noOfIncludedChangesets) * 100)
 }
 
 type repoChangesetsStatsResolver struct {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats.go
@@ -47,6 +47,24 @@ func (r *changesetsStatsResolver) Archived() int32 {
 func (r *changesetsStatsResolver) Total() int32 {
 	return r.stats.Total
 }
+func (r *changesetsStatsResolver) IsCompleted() bool {
+	mergedAndClosedChangesets := r.stats.Closed + r.stats.Merged
+	// We don't count archived or deleted changesets when computing the percentage.
+	noOfIncludedChangesets := r.stats.Total - r.stats.Archived - r.stats.Deleted
+
+	return r.stats.Total != 0 && (mergedAndClosedChangesets == noOfIncludedChangesets)
+}
+func (r *changesetsStatsResolver) PercentComplete() int32 {
+	if r.stats.Total == 0 {
+		return 0
+	}
+
+	mergedAndClosed := r.stats.Merged + r.stats.Closed
+	// We don't count archived or deleted changesets when computing the percentage.
+	noOfIncludedChangesets := r.stats.Total - r.stats.Archived - r.stats.Deleted
+
+	return (mergedAndClosed / noOfIncludedChangesets) * 100
+}
 
 type repoChangesetsStatsResolver struct {
 	stats btypes.RepoChangesetsStats

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changesets_stats_test.go
@@ -1,0 +1,71 @@
+package resolvers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+)
+
+func TestChangesetsStatsResolver(t *testing.T) {
+	t.Run("all changesets completed", func(t *testing.T) {
+		stats := btypes.ChangesetsStats{
+			CommonChangesetsStats: btypes.CommonChangesetsStats{
+				Unpublished: 0,
+				Draft:       0,
+				Open:        0,
+				Merged:      60,
+				Closed:      12,
+				Total:       118,
+			},
+			Deleted:  40,
+			Archived: 6,
+		}
+
+		r := changesetsStatsResolver{stats: stats}
+
+		require.Equal(t, r.IsCompleted(), true)
+		require.Equal(t, r.PercentComplete(), int32(100))
+	})
+
+	t.Run("empty changesets", func(t *testing.T) {
+		stats := btypes.ChangesetsStats{
+			CommonChangesetsStats: btypes.CommonChangesetsStats{
+				Unpublished: 0,
+				Draft:       0,
+				Open:        0,
+				Merged:      0,
+				Closed:      0,
+				Total:       0,
+			},
+			Deleted:  0,
+			Archived: 0,
+		}
+
+		r := changesetsStatsResolver{stats: stats}
+
+		require.Equal(t, r.IsCompleted(), false)
+		require.Equal(t, r.PercentComplete(), int32(0))
+	})
+
+	t.Run("incomplete changesets", func(t *testing.T) {
+		stats := btypes.ChangesetsStats{
+			CommonChangesetsStats: btypes.CommonChangesetsStats{
+				Unpublished: 55,
+				Draft:       5,
+				Open:        10,
+				Merged:      10,
+				Closed:      10,
+				Total:       118,
+			},
+			Deleted:  10,
+			Archived: 18,
+		}
+
+		r := changesetsStatsResolver{stats: stats}
+
+		require.Equal(t, r.IsCompleted(), false)
+		require.Equal(t, r.PercentComplete(), int32(22))
+	})
+}

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -1503,14 +1503,10 @@ SELECT
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'UNPUBLISHED') AS unpublished,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'CLOSED') AS closed,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'DRAFT') AS draft,
-
-	-- Archived merged changesets are included as part of the stats for changesets merged.
-	COUNT(*) FILTER (WHERE changesets.computed_state = 'MERGED') AS merged,
-
+	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'MERGED') AS merged,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'OPEN') AS open,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'DELETED') AS deleted,
-
-	COUNT(*) FILTER (WHERE %s AND changesets.computed_state <> 'MERGED') AS archived
+	COUNT(*) FILTER (WHERE %s) AS archived
 FROM changesets
 INNER JOIN repo on repo.id = changesets.repo_id
 WHERE

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -1503,10 +1503,14 @@ SELECT
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'UNPUBLISHED') AS unpublished,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'CLOSED') AS closed,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'DRAFT') AS draft,
-	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'MERGED') AS merged,
+
+	-- Archived merged changesets are included as part of the stats for changesets merged.
+	COUNT(*) FILTER (WHERE changesets.computed_state = 'MERGED') AS merged,
+
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'OPEN') AS open,
 	COUNT(*) FILTER (WHERE NOT %s AND changesets.computed_state = 'DELETED') AS deleted,
-	COUNT(*) FILTER (WHERE %s) AS archived
+
+	COUNT(*) FILTER (WHERE %s AND changesets.computed_state <> 'MERGED') AS archived
 FROM changesets
 INNER JOIN repo on repo.id = changesets.repo_id
 WHERE
@@ -1676,7 +1680,6 @@ func getChangesetsStatsQuery(batchChangeID int64) *sqlf.Query {
 		archived, archived,
 		archived, archived,
 		archived, archived,
-		archived,
 		sqlf.Join(preds, " AND "),
 	)
 }

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -1676,6 +1676,7 @@ func getChangesetsStatsQuery(batchChangeID int64) *sqlf.Query {
 		archived, archived,
 		archived, archived,
 		archived, archived,
+		archived,
 		sqlf.Join(preds, " AND "),
 	)
 }


### PR DESCRIPTION
While working on #47942 to include archived merged changesets in stats, I fixed the `TODO` item to move the `isCompleted` and `percentComplete` fields to the `ChangesetsStats` resolver. Pending when we agree on the best way forward for that edge case, I decided to move this into a separate PR so we can at least get that sorted.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested
* Add unit tests

![CleanShot 2023-02-23 at 07 52 39](https://user-images.githubusercontent.com/25608335/220838165-a4fb358d-297b-4a04-a234-2c6aeccdffe5.png)