### PR TITLE
service: ensure we always call ready once

### DIFF
--- a/internal/service/servegit/service.go
+++ b/internal/service/servegit/service.go
@@ -50,12 +50,6 @@ func (s svc) Configure() (env.Config, []debugserver.Endpoint) {
 }
 
 func (s svc) Start(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, configI env.Config) (err error) {
-	defer func() {
-		if err == nil {
-			ready()
-		}
-	}()
-
 	config := configI.(*Config)
 
 	if config.ReposRoot == "" {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -26,9 +26,16 @@ type Service interface {
 	Configure() (env.Config, []debugserver.Endpoint)
 
 	// Start starts the service.
+	//
+	// When start returns or ready is called the service will be marked as
+	// ready.
+	//
 	// TODO(sqs): TODO(single-binary): make it monitorable with goroutine.Whatever interfaces.
-	Start(context.Context, *observation.Context, ReadyFunc, env.Config) error
+	Start(ctx context.Context, observationCtx *observation.Context, ready ReadyFunc, c env.Config) error
 }
 
-// ReadyFunc is called in (Service).Start when the service is ready to start serving clients.
+// ReadyFunc is called in (Service).Start to signal that the service is ready
+// to serve clients, even if Start has not returned. It is optional to call
+// ready, on Start returning the service will be marked as ready. It is safe
+// to call ready multiple times.
 type ReadyFunc func()


### PR DESCRIPTION
The interactions with ready seemed like a footgun. For example it is easy to forget to call ready which means we would never mark the process as ready. In fact the executor service never called ready. Alternatively you may accidently call ready twice leading to us marking the service as ready too soon.

Additionally I cleaned up a ready call that wasn't needed anymore and added documentation on the invariants we expect implementations to know.

Test Plan: go test. Additionally I audited each use of ready to ensure it was called before the Start function returned.