### PR TITLE
app: open browser to url

### DIFF
--- a/cmd/frontend/internal/bg/app_ready.go
+++ b/cmd/frontend/internal/bg/app_ready.go
@@ -1,0 +1,21 @@
+package bg
+
+import (
+	"github.com/pkg/browser"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
+)
+
+// AppReady is called once the frontend has reported it is ready to serve
+// requests. It contains tasks related to Sourcegraph App (single binary).
+func AppReady(logger log.Logger) {
+	if !deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+		return
+	}
+
+	u := globals.ExternalURL().String()
+	if err := browser.OpenURL(u); err != nil {
+		logger.Error("failed to open browser", log.String("url", u), log.Error(err))
+	}
+}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -262,6 +262,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	logger.Info(fmt.Sprintf("✱ Sourcegraph is ready at: %s", globals.ExternalURL()))
 	ready()
 
+	// We only want to run this task once Sourcegraph is ready to serve user requests.
+	goroutine.Go(func() { bg.AppReady(logger) })
+
 	goroutine.MonitorBackgroundRoutines(context.Background(), routines...)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -438,7 +438,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
This reduces the friction of needing to copy paste the sourcegraph URL into your browser. When starting sourcegraph app we expect the users intention is to use it in the browser.

We introduce the AppReady background job to frontend for this logic. I believe this logic will be extended further for automatic account creation/etc which is why it lives here. Open to suggestions for a cleaner place.

Test Plan: sg start app and the browser is opened.

Fixes https://github.com/sourcegraph/sourcegraph/issues/47995
