### PR TITLE
codemirror: Fix themes affecting other CodeMirror instances

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
@@ -140,8 +140,7 @@
     // .placeholder needs to explicilty have the same background color because it
     // appears to be placed outside of .focusedFilter rather than within it.
     .placeholder,
-    .focusedFilter,
-    :global(.sg-token-hover) {
+    .focusedFilter {
         background-color: var(--gray-02);
 
         :global(.theme-dark) & {

--- a/client/branded/src/search-ui/input/codemirror/loading-indicator.ts
+++ b/client/branded/src/search-ui/input/codemirror/loading-indicator.ts
@@ -31,7 +31,6 @@ export function loadingIndicator({ timeout = DEFAULT_TIMEOUT }: { timeout?: numb
                     // The container is used to add some padding between the
                     // document and the spinner
                     this.dom = document.createElement('div')
-                    this.dom.className = 'cm-sg-loading-spinner-container'
                     this.dom.append(spinner)
                     // The element is always takes part in the layout. This makes it
                     // easier to ensure that there is always enough space for the
@@ -78,10 +77,5 @@ export function loadingIndicator({ timeout = DEFAULT_TIMEOUT }: { timeout?: numb
                     }),
             }
         ),
-        EditorView.baseTheme({
-            'cm-sg-loading-spinner-container': {
-                marginLeft: '0.5rem',
-            },
-        }),
     ]
 }

--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -11,43 +11,54 @@ import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/util
 import { decoratedTokens, parsedQuery } from './parsedQuery'
 
 // Defines decorators for syntax highlighting
-const tokenHoverDecoration = Decoration.mark({ class: 'sg-token-hover' })
+const tokenHoverDecoration = Decoration.mark({ class: 'sg-decorated-token-hover' })
 
-// Overwrite styles for built-in hover element
-const hoverStyle = EditorView.baseTheme({
-    '.cm-tooltip': {
-        padding: '0.25rem',
-        color: 'var(--search-query-text-color)',
-        backgroundColor: 'var(--color-bg-1)',
-        border: '1px solid var(--border-color)',
-        borderRadius: 'var(--border-radius)',
-        boxShadow: 'var(--box-shadow)',
-        maxWidth: '50vw',
-    },
+const hoverStyle = [
+    // Overwrite styles for built-in hover element
+    EditorView.theme({
+        '.cm-tooltip': {
+            padding: '0.25rem',
+            color: 'var(--search-query-text-color)',
+            backgroundColor: 'var(--color-bg-1)',
+            border: '1px solid var(--border-color)',
+            borderRadius: 'var(--border-radius)',
+            boxShadow: 'var(--box-shadow)',
+            maxWidth: '50vw',
+        },
 
-    '.cm-tooltip p:last-child': {
-        marginBottom: 0,
-    },
+        '.cm-tooltip p:last-child': {
+            marginBottom: 0,
+        },
 
-    '.cm-tooltip code': {
-        backgroundColor: 'rgba(220, 220, 220, 0.4)',
-        borderRadius: 'var(--border-radius)',
-        padding: '0 0.4em',
-    },
+        '.cm-tooltip code': {
+            backgroundColor: 'rgba(220, 220, 220, 0.4)',
+            borderRadius: 'var(--border-radius)',
+            padding: '0 0.4em',
+        },
 
-    '.cm-tooltip-section': {
-        paddingBottom: '0.25rem',
-        borderTopColor: 'var(--border-color)',
-    },
+        '.cm-tooltip-section': {
+            paddingBottom: '0.25rem',
+            borderTopColor: 'var(--border-color)',
+        },
 
-    '.cm-tooltip-section:last-child': {
-        paddingTop: '0.25rem',
-        paddingBottom: 0,
-    },
-    '.cm-tooltip-section:last-child:first-child': {
-        padding: 0,
-    },
-})
+        '.cm-tooltip-section:last-child': {
+            paddingTop: '0.25rem',
+            paddingBottom: 0,
+        },
+        '.cm-tooltip-section:last-child:first-child': {
+            padding: 0,
+        },
+    }),
+    // Base style for custom classes
+    EditorView.baseTheme({
+        '.sg-decorated-token-hover': {
+            backgroundColor: 'var(--gray-02)',
+        },
+        '&dark .sg-decorated-token-hover': {
+            backgroundColor: 'var(--gray-08)',
+        },
+    }),
+]
 
 /**
  * Extension for providing token information. This includes showing a popover

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -181,7 +181,7 @@ function createEditor(
                 keymap.of(defaultKeymap),
                 codemirrorHistory(),
                 Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
-                EditorView.baseTheme({
+                EditorView.theme({
                     '&': {
                         flex: 1,
                         backgroundColor: 'var(--input-bg)',
@@ -211,12 +211,8 @@ function createEditor(
                     '.cm-line': {
                         padding: 0,
                     },
-                    '.sg-token-hover': {
-                        backgroundColor: 'var(--gray-02)',
+                    '.sg-decorated-token-hover': {
                         borderRadius: '3px',
-                    },
-                    '&dark .sg-token-hover': {
-                        backgroundColor: 'var(--gray-08)',
                     },
                 }),
                 querySettingsCompartment.of(queryExtensions),

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -7,32 +7,24 @@ import { isFilterOfType } from '@sourcegraph/shared/src/search/query/utils'
 
 import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
 
-const validFilter = Decoration.mark({ class: 'sg-filter' })
-const invalidFilter = Decoration.mark({ class: 'sg-filter sg-invalid-filter' })
-const contextFilter = Decoration.mark({ class: 'sg-context-filter', inclusiveEnd: false })
+const validFilter = Decoration.mark({ class: 'sg-query-token-filter' })
+const invalidFilter = Decoration.mark({ class: 'sg-query-token-filter sg-query-token-filter-invalid' })
+const contextFilter = Decoration.mark({ class: 'sg-query-token-filter-context', inclusiveEnd: false })
 
 export const filterHighlight = [
     EditorView.baseTheme({
-        '.sg-filter': {
+        '.sg-query-token-filter': {
             backgroundColor: 'var(--oc-blue-0)',
             borderRadius: '3px',
             padding: '0px',
         },
-        '.sg-invalid-filter': {
+        '.sg-query-token-filter-invalid': {
             backgroundColor: 'var(--oc-red-1)',
             borderColor: 'var(--oc-red-2)',
         },
-        '.sg-context-filter': {
+        '.sg-query-token-filter-context': {
             borderRadius: '3px',
             border: '1px solid var(--border-color)',
-        },
-        '.sg-clear-filter > button': {
-            border: 'none',
-            backgroundColor: 'transparent',
-            padding: 0,
-            width: 'var(--icon-inline-size)',
-            height: 'var(--icon-inline-size)',
-            color: 'var(--icon-color)',
         },
     }),
     EditorView.decorations.compute([decoratedTokens, 'selection'], state => {


### PR DESCRIPTION
Addresses https://sourcegraph.slack.com/archives/C04931KQVRC/p1677009186313629

PR #47940 included changes to style core CodeMirror classes in a certain way. However using `EditorView.baseTheme` seems to affect all CodeMirror instances.

This PR fixes this by using `EditorView.theme` where existing classes are being overwritting. To be honest I didn't know what exactly the effect of `baseTheme` is, but after reading more about it in the style example, it's supposed to be used for new classes/elements introduced by extensions.


## Test plan
- Opened the blob page and verified that hovercards look like before.
- Inspected the styling of tokens in the query input and verified that they look correct.

## App preview:

- [Web](https://sg-web-fkling-fix-codemirror-themes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
