### PR TITLE
Fix various CodeMirror related issues in the side blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed issues with propagating tracing configuration throughout the application. [#47428](https://github.com/sourcegraph/sourcegraph/pull/47428)
 - Enable `auto gc` on fetch when `SRC_ENABLE_GC_AUTO` is set to `true`. [#47852](https://github.com/sourcegraph/sourcegraph/pull/47852)
+- Fixes syntax highlighting and line number issues in the code preview rendered inside the references panel. [#48107](https://github.com/sourcegraph/sourcegraph/pull/48107)
 
 ### Removed
 

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -287,9 +287,8 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             staticExtensions,
             selectableLineNumbers({
                 onSelection,
-                navigate: navigateRef.current,
                 initialSelection: position.line !== undefined ? position : null,
-                navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
+                navigateToLineOnAnyClick: navigateToLineOnAnyClick ? navigateRef.current : null,
                 enableSelectionDrivenCodeNavigation,
             }),
             codeFoldingExtension(),

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { openSearchPanel } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
-import { EditorView, lineNumbers } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 import { isEqual } from 'lodash'
 import { createPath, NavigateFunction, useLocation, useNavigate, Location } from 'react-router-dom'
 

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { openSearchPanel } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
-import { EditorView } from '@codemirror/view'
+import { EditorView, lineNumbers } from '@codemirror/view'
 import { isEqual } from 'lodash'
 import { createPath, NavigateFunction, useLocation, useNavigate, Location } from 'react-router-dom'
 
@@ -287,6 +287,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             staticExtensions,
             selectableLineNumbers({
                 onSelection,
+                navigate: navigateRef.current,
                 initialSelection: position.line !== undefined ? position : null,
                 navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
                 enableSelectionDrivenCodeNavigation,

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -288,7 +288,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             selectableLineNumbers({
                 onSelection,
                 initialSelection: position.line !== undefined ? position : null,
-                navigateToLineOnAnyClick: navigateToLineOnAnyClick ? navigateRef.current : null,
+                navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
                 enableSelectionDrivenCodeNavigation,
             }),
             codeFoldingExtension(),

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -22,7 +22,6 @@ import {
     ViewUpdate,
 } from '@codemirror/view'
 import classNames from 'classnames'
-import { NavigateFunction } from 'react-router-dom'
 
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -22,6 +22,9 @@ import {
     ViewUpdate,
 } from '@codemirror/view'
 import classNames from 'classnames'
+import { NavigateFunction } from 'react-router-dom'
+
+import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { isValidLineRange, MOUSE_MAIN_BUTTON, preciseOffsetAtCoords } from './utils'
 
@@ -332,7 +335,7 @@ function selectOnClick({ onSelection }: SelectableLineNumbersConfig): Extension 
                 const clickedLine = view.state.doc.lineAt(offset)
                 if (offset === clickedLine.to) {
                     // If the offset is the same value as the end position of
-                    // the line then click happend after the last charcater.
+                    // the line then click happened after the last character.
                     selectedLine = clickedLine.number
                 } else if (offset === clickedLine.from && preciseOffsetAtCoords(view, event) === null) {
                     // `preciseOffsetAtCoords(...) === null` allows us to recognize clicks before the actual text content
@@ -356,6 +359,7 @@ function selectOnClick({ onSelection }: SelectableLineNumbersConfig): Extension 
 interface SelectableLineNumbersConfig {
     onSelection: (range: SelectedLineRange) => void
     initialSelection: SelectedLineRange | null
+    navigate: NavigateFunction
     navigateToLineOnAnyClick: boolean
     enableSelectionDrivenCodeNavigation?: boolean
 }
@@ -379,30 +383,47 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
         selectedLines.init(() => config.initialSelection),
         lineNumbers({
             domEventHandlers: {
+                mouseup(view, block, event) {
+                    if (!config.navigateToLineOnAnyClick) {
+                        return false
+                    }
+
+                    const mouseEvent = event as MouseEvent
+                    if (mouseEvent.button !== MOUSE_MAIN_BUTTON) {
+                        return true
+                    }
+
+                    const blobInfo = view.state.facet(blobPropsFacet).blobInfo
+                    const line = view.state.doc.lineAt(block.from).number
+                    const href = toPrettyBlobURL({
+                        ...blobInfo,
+                        position: { line, character: 0 },
+                    })
+                    config.navigate(href)
+
+                    return true
+                },
+
                 mousedown(view, block, event) {
-                    const mouseEvent = event as MouseEvent // make TypeScript happy
+                    if (config.navigateToLineOnAnyClick) {
+                        return true
+                    }
+
+                    const mouseEvent = event as MouseEvent
                     if (mouseEvent.button !== MOUSE_MAIN_BUTTON) {
                         return false
                     }
 
                     const line = view.state.doc.lineAt(block.from).number
-                    if (config.navigateToLineOnAnyClick) {
-                        // Only support single line selection when navigateToLineOnAnyClick is true.
-                        view.dispatch({
-                            effects: setSelectedLines.of({ line }),
-                            annotations: lineSelectionSource.of('gutter'),
-                        })
-                    } else {
-                        const range = view.state.field(selectedLines)
-                        view.dispatch({
-                            effects: mouseEvent.shiftKey
-                                ? setEndLine.of(line)
-                                : setSelectedLines.of(isSingleLine(range) && range?.line === line ? null : { line }),
-                            annotations: lineSelectionSource.of('gutter'),
-                            // Collapse/reset text selection
-                            selection: { anchor: view.state.selection.main.anchor },
-                        })
-                    }
+                    const range = view.state.field(selectedLines)
+                    view.dispatch({
+                        effects: mouseEvent.shiftKey
+                            ? setEndLine.of(line)
+                            : setSelectedLines.of(isSingleLine(range) && range?.line === line ? null : { line }),
+                        annotations: lineSelectionSource.of('gutter'),
+                        // Collapse/reset text selection
+                        selection: { anchor: view.state.selection.main.anchor },
+                    })
 
                     dragging = true
 

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -359,7 +359,7 @@ function selectOnClick({ onSelection }: SelectableLineNumbersConfig): Extension 
 interface SelectableLineNumbersConfig {
     onSelection: (range: SelectedLineRange) => void
     initialSelection: SelectedLineRange | null
-    navigateToLineOnAnyClick: NavigateFunction | null
+    navigateToLineOnAnyClick: boolean
     enableSelectionDrivenCodeNavigation?: boolean
 }
 
@@ -383,7 +383,7 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
         lineNumbers({
             domEventHandlers: {
                 mouseup(view, block, event) {
-                    if (config.navigateToLineOnAnyClick === null) {
+                    if (!config.navigateToLineOnAnyClick) {
                         return false
                     }
 
@@ -392,19 +392,19 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
                         return false
                     }
 
-                    const blobInfo = view.state.facet(blobPropsFacet).blobInfo
+                    const { blobInfo, navigate } = view.state.facet(blobPropsFacet)
                     const line = view.state.doc.lineAt(block.from).number
                     const href = toPrettyBlobURL({
                         ...blobInfo,
                         position: { line, character: 0 },
                     })
-                    config.navigateToLineOnAnyClick(href)
+                    navigate(href)
 
                     return true
                 },
 
                 mousedown(view, block, event) {
-                    if (config.navigateToLineOnAnyClick !== null) {
+                    if (config.navigateToLineOnAnyClick) {
                         return false
                     }
 

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -359,8 +359,7 @@ function selectOnClick({ onSelection }: SelectableLineNumbersConfig): Extension 
 interface SelectableLineNumbersConfig {
     onSelection: (range: SelectedLineRange) => void
     initialSelection: SelectedLineRange | null
-    navigate: NavigateFunction
-    navigateToLineOnAnyClick: boolean
+    navigateToLineOnAnyClick: NavigateFunction | null
     enableSelectionDrivenCodeNavigation?: boolean
 }
 
@@ -384,13 +383,13 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
         lineNumbers({
             domEventHandlers: {
                 mouseup(view, block, event) {
-                    if (!config.navigateToLineOnAnyClick) {
+                    if (config.navigateToLineOnAnyClick === null) {
                         return false
                     }
 
                     const mouseEvent = event as MouseEvent
                     if (mouseEvent.button !== MOUSE_MAIN_BUTTON) {
-                        return true
+                        return false
                     }
 
                     const blobInfo = view.state.facet(blobPropsFacet).blobInfo
@@ -399,14 +398,14 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
                         ...blobInfo,
                         position: { line, character: 0 },
                     })
-                    config.navigate(href)
+                    config.navigateToLineOnAnyClick(href)
 
                     return true
                 },
 
                 mousedown(view, block, event) {
-                    if (config.navigateToLineOnAnyClick) {
-                        return true
+                    if (config.navigateToLineOnAnyClick !== null) {
+                        return false
                     }
 
                     const mouseEvent = event as MouseEvent

--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -32,7 +32,7 @@ class LineLinkManager implements PluginValue {
                     Decoration.mark({
                         tagName: 'a',
                         attributes: { href, 'data-cm-line-link': '' },
-                        class: 'text-decoration-none',
+                        class: 'text-decoration-none text-inherit',
                     })
                 )
                 pos = line.to + 1

--- a/client/wildcard/src/global-styles/utilities/text.scss
+++ b/client/wildcard/src/global-styles/utilities/text.scss
@@ -74,6 +74,10 @@
     color: var(--white) !important;
 }
 
+.text-inherit {
+    color: inherit !important;
+}
+
 @each $color, $value in $theme-colors {
     .text-#{$color} {
         color: $value !important;


### PR DESCRIPTION
1) Fixes the issue where the syntax highlighting was sometimes showing invalid colors. This was caused by the inserted `<a>` tag to set a `color`. 
2) Greatly simplifies how we handle line numbers in the side blob which will now make it a very easy stupid link just like clicking on the content in the side blob

Paired on this with @taras-yemets 

## Test plan

Regarding 1:
<img width="1717" alt="Screenshot 2023-02-23 at 11 00 09" src="https://user-images.githubusercontent.com/458591/220893308-82b74265-e9fe-4b82-9908-0f037957eef5.png">

Regarding 2:

https://user-images.githubusercontent.com/458591/220893408-00543170-f4d3-48b4-a053-1084cf654ccc.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-various-codemirror-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
