### PR TITLE
Fuzzy finder: use case-insensitive casing instead of smart-search

### DIFF
--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
@@ -38,6 +38,7 @@ describe('case-insensitive fuzzy search', () => {
         ['batches/executor.go']
     )
     checkFuzzyMatches('exact-match', 'src/hello.ts', ['src/hello.ts', 'ignore.me'], ['src/hello.ts'])
+    checkFuzzyMatches('no-smart-case', 'getSlocEntry', ['getSLocEntry'], ['getSLocEntry'])
 
     // Buggy cache test. Previously, the cached list of candidates only included
     // results that had a fuzzy score above 0.2 causing the 'a' query to filter

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -40,6 +40,7 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
             selector: ({ text }) => text,
             limit: parameters.maxResults,
             match: extendedMatch,
+            casing: 'case-insensitive',
             tiebreakers,
         })
         const isEmpty = parameters.query === ''


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/C03CSAER9LK/p1677123675125939

Previously, the fuzzy finder only treated all lower-case queries are case insensitive. The query became case sensitive as soon as you added a single uppercase character. This resulted in surprising behavior where you got no matching results when you wrote a mixed-case query that got at least one character in the wrong case.

Now, the fuzzy finder is truly case-insensitive so even the query `getSlocentry` matches the symbol `getSLocEntry` in the llvm-project repo.



## Test plan

See new `no-smart-case` unit test, which I manually verified fails before this PR.

Also, manually tested with `getSlocentry` query in the llvm-project repo
<img width="1030" alt="CleanShot 2023-02-23 at 12 57 16@2x" src="https://user-images.githubusercontent.com/1408093/220899830-20dba87c-9094-48f1-8b79-73bded951052.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-symbols-case.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
