### PR TITLE
flake: disable test for stream with file ranking: global text search: fork only

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -545,10 +545,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:  "regular expression without indexed search",
 				query: "index:no patterntype:regexp ^func.*$",
 			},
-			{
-				name:  "fork:only",
-				query: "fork:only router",
-			},
+			// Failing test: https://github.com/sourcegraph/sourcegraph/issues/48109
+			//{
+			//	name:  "fork:only",
+			//	query: "fork:only router",
+			//},
 			{
 				name:  "double-quoted pattern, nonzero result",
 				query: `"func main() {\n" patterntype:regexp type:file`,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -215,7 +215,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("execute search with search parameters", func(t *testing.T) {
+	t.Skip("execute search with search parameters", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:^github.com/sgtest/go-diff$ type:file file:.go -file:.md")
 		if err != nil {
 			t.Fatal(err)
@@ -229,7 +229,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("lang: filter", func(t *testing.T) {
+	t.Skip("lang: filter", func(t *testing.T) {
 		// On our test repositories, `function` has results for go, ts, python, html
 		results, err := client.SearchFiles("function lang:go")
 		if err != nil {
@@ -243,7 +243,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("excluding repositories", func(t *testing.T) {
+	t.Skip("excluding repositories", func(t *testing.T) {
 		results, err := client.SearchFiles("fmt.Sprintf -repo:jsonrpc2")
 		if err != nil {
 			t.Fatal(err)
@@ -260,7 +260,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("multiple revisions per repository", func(t *testing.T) {
+	t.Skip("multiple revisions per repository", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:sgtest/go-diff$@master:print-options:*refs/heads/ func NewHunksReader")
 		if err != nil {
 			t.Fatal(err)
@@ -288,7 +288,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("non fatal missing repo revs", func(t *testing.T) {
+	t.Skip("non fatal missing repo revs", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:sgtest rev:print-options NewHunksReader")
 		if err != nil {
 			t.Fatal(err)
@@ -504,7 +504,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("global text search", func(t *testing.T) {
+	t.Skip("global text search", func(t *testing.T) {
 		tests := []struct {
 			name          string
 			query         string
@@ -730,7 +730,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("structural search", func(t *testing.T) {
+	t.Skip("structural search", func(t *testing.T) {
 		tests := []struct {
 			name       string
 			query      string
@@ -781,7 +781,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("And/Or queries", func(t *testing.T) {
+	t.Skip("And/Or queries", func(t *testing.T) {
 		tests := []struct {
 			name       string
 			query      string
@@ -995,7 +995,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Run("And/Or search expression queries", func(t *testing.T) {
+	t.Skip("And/Or search expression queries", func(t *testing.T) {
 		tests := []struct {
 			name            string
 			query           string

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -215,7 +215,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("execute search with search parameters", func(t *testing.T) {
+	t.Run("execute search with search parameters", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:^github.com/sgtest/go-diff$ type:file file:.go -file:.md")
 		if err != nil {
 			t.Fatal(err)
@@ -229,7 +229,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("lang: filter", func(t *testing.T) {
+	t.Run("lang: filter", func(t *testing.T) {
 		// On our test repositories, `function` has results for go, ts, python, html
 		results, err := client.SearchFiles("function lang:go")
 		if err != nil {
@@ -243,7 +243,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("excluding repositories", func(t *testing.T) {
+	t.Run("excluding repositories", func(t *testing.T) {
 		results, err := client.SearchFiles("fmt.Sprintf -repo:jsonrpc2")
 		if err != nil {
 			t.Fatal(err)
@@ -260,7 +260,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("multiple revisions per repository", func(t *testing.T) {
+	t.Run("multiple revisions per repository", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:sgtest/go-diff$@master:print-options:*refs/heads/ func NewHunksReader")
 		if err != nil {
 			t.Fatal(err)
@@ -288,7 +288,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("non fatal missing repo revs", func(t *testing.T) {
+	t.Run("non fatal missing repo revs", func(t *testing.T) {
 		results, err := client.SearchFiles("repo:sgtest rev:print-options NewHunksReader")
 		if err != nil {
 			t.Fatal(err)
@@ -504,7 +504,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("global text search", func(t *testing.T) {
+	t.Run("global text search", func(t *testing.T) {
 		tests := []struct {
 			name          string
 			query         string
@@ -730,7 +730,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("structural search", func(t *testing.T) {
+	t.Run("structural search", func(t *testing.T) {
 		tests := []struct {
 			name       string
 			query      string
@@ -781,7 +781,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("And/Or queries", func(t *testing.T) {
+	t.Run("And/Or queries", func(t *testing.T) {
 		tests := []struct {
 			name       string
 			query      string
@@ -995,7 +995,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
-	t.Skip("And/Or search expression queries", func(t *testing.T) {
+	t.Run("And/Or search expression queries", func(t *testing.T) {
 		tests := []struct {
 			name            string
 			query           string


### PR DESCRIPTION
seeing consistent failure on latests builds, opened https://github.com/sourcegraph/sourcegraph/issues/48109 

```go
--- FAIL: TestSearch/stream_with_file_ranking (4.83s)
--
  | --- FAIL: TestSearch/stream_with_file_ranking/global_text_search (1.19s)
  | --- FAIL: TestSearch/stream_with_file_ranking/global_text_search/fork:only (0.02s)
  | search_test.go:709: malformed event, expected event: rpc error
```

## Test plan

test skip only, flake addition