### PR TITLE
keyword: expand query with stems

### DIFF
--- a/internal/search/keyword/query_transformer_test.go
+++ b/internal/search/keyword/query_transformer_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestTransformPattern(t *testing.T) {
 	patterns := []string{
+		"compute",
 		"K",
 		"Means",
 		"Clustering",
@@ -23,19 +24,28 @@ func TestTransformPattern(t *testing.T) {
 		"using",
 		"a",
 		"timer",
+		"computing",
 	}
 	wantPatterns := []string{
+		"compute",
+		"comput",
 		"k",
+		"means",
 		"mean",
+		"clustering",
 		"cluster",
 		"convert",
 		"int",
 		"string",
+		"finding",
 		"find",
 		"time",
+		"elapsed",
 		"elaps",
 		"using",
+		"use",
 		"timer",
+		"computing",
 	}
 
 	gotPatterns := transformPatterns(patterns)
@@ -65,8 +75,8 @@ func TestQueryStringToKeywordQuery(t *testing.T) {
 		},
 		{
 			query:        "K MEANS CLUSTERING in python",
-			wantQuery:    autogold.Expect("count:99999999 type:file lang:Python (k OR mean OR cluster)"),
-			wantPatterns: autogold.Expect([]string{"k", "mean", "cluster"}),
+			wantQuery:    autogold.Expect("count:99999999 type:file lang:Python (k OR means OR mean OR clustering OR cluster)"),
+			wantPatterns: autogold.Expect([]string{"k", "means", "mean", "clustering", "cluster"}),
 		},
 	}
 


### PR DESCRIPTION
Instead of replacing the original keywords with their stems, we keep both.

Example:

**Before:**
Zoekt can compute quickly -> zoekt comput quickly ("can" is a stop word)

**After:**
Zoekt can compute quickly -> zoekt compute comput quickli quickly

This has 2 advantages:

1. More matches: The stem might not match, but the original keyword might and vice versa.

2. Matching symbols: If a user query contains a symbol name, we want to make sure that we match it extactly and give it a proper boost.

The change makes the query more expensive, however this is probably fine, because we limit keyword queries to a single repo for now.

### Test plan:
- updated unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
