### PR TITLE
app: remove redis dep from homebrew and linux packages

### DIFF
--- a/enterprise/dev/app/goreleaser.yaml
+++ b/enterprise/dev/app/goreleaser.yaml
@@ -96,7 +96,6 @@ nfpms:
       - rpm
     dependencies:
       - git
-      - redis
     vendor: "sourcegraph"
     homepage: "https://github.com/sourcegraph/sourcegraph"
     maintainer: "dev@sourcegraph.com"
@@ -121,7 +120,6 @@ brews:
       system "#{bin}/sourcegraph --help"
     dependencies:
       - name: git
-      - name: redis
       - name: sourcegraph/src-cli/src-cli
 
 announce:


### PR DESCRIPTION
This is no longer needed.

Test Plan: will rely on next goreleaser run.

Fixes #48099
