### PR TITLE
oobmigration: Do not run deprecated migrations in worker (take 2)

### DIFF
--- a/cmd/worker/internal/migrations/init.go
+++ b/cmd/worker/internal/migrations/init.go
@@ -3,6 +3,10 @@ package migrations
 import (
 	"context"
 	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
@@ -10,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -56,7 +61,112 @@ func (m *migrator) Routines(startupCtx context.Context, observationCtx *observat
 		}
 	}
 
+	version, err := currentVersion(observationCtx.Logger)
+	if err != nil {
+		return nil, err
+	}
+
 	return []goroutine.BackgroundRoutine{
-		outOfBandMigrationRunner,
+		&outOfBandMigrationRunnerWrapper{Runner: outOfBandMigrationRunner, version: version},
 	}, nil
+}
+
+type outOfBandMigrationRunnerWrapper struct {
+	*oobmigration.Runner
+	version oobmigration.Version
+}
+
+func (w *outOfBandMigrationRunnerWrapper) Start() {
+	w.Runner.Start(w.version)
+}
+
+// currentVersion returns the version that should be given to the out of band migration runner.
+// In dev mode, we use the _next_ (unreleased) version so that we're always on the bleeding edge.
+// When running from a tagged release, we'll use the baked-in version string constant.
+func currentVersion(logger log.Logger) (oobmigration.Version, error) {
+	if rawVersion := version.Version(); !version.IsDev(rawVersion) {
+		version, ok := parseVersion(rawVersion)
+		if !ok {
+			return oobmigration.Version{}, errors.Newf("failed to parse current version: %q", rawVersion)
+		}
+
+		return version, nil
+	}
+
+	if rawVersion := os.Getenv("SRC_OOBMIGRATION_CURRENT_VERSION"); rawVersion != "" {
+		version, ok := oobmigration.NewVersionFromString(rawVersion)
+		if !ok {
+			return oobmigration.Version{}, errors.Newf("failed to parse force-supplied version: %q", rawVersion)
+		}
+
+		return version, nil
+	}
+
+	version, err := inferNextReleaseVersion()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	logger.Info("Using latest tag as current version", log.String("version", version.String()))
+	return version, nil
+}
+
+// parseVersion reads the Sourcegraph instance version set at build time. If the given string cannot
+// be parsed as one of the following formats, a false-valued flag is returned.
+//
+// Tagged release format: `v1.2.3`
+// Continuous release format: `(ef/feat_)?12345_2006-01-02-deadbeefbabe_1.2.2(_patch)?`
+func parseVersion(rawVersion string) (oobmigration.Version, bool) {
+	version, ok := oobmigration.NewVersionFromString(rawVersion)
+	if ok {
+		return version, true
+	}
+
+	parts := strings.Split(rawVersion, "_")
+	if len(parts) > 0 && parts[len(parts)-1] == "patch" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) > 0 {
+		return oobmigration.NewVersionFromString(parts[len(parts)-1])
+	}
+
+	return oobmigration.Version{}, false
+}
+
+// inferNextReleaseVersion returns the version AFTER the latest tagged release.
+func inferNextReleaseVersion() (oobmigration.Version, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	cmd := exec.Command("git", "tag", "--list", "v*")
+	cmd.Dir = wd
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	tagMap := map[string]struct{}{}
+	for _, tag := range strings.Split(string(output), "\n") {
+		tag = strings.Split(tag, "-")[0] // strip off rc suffix if it exists
+
+		if version, ok := oobmigration.NewVersionFromString(tag); ok {
+			tagMap[version.String()] = struct{}{}
+		}
+	}
+
+	versions := make([]oobmigration.Version, 0, len(tagMap))
+	for tag := range tagMap {
+		version, _ := oobmigration.NewVersionFromString(tag)
+		versions = append(versions, version)
+	}
+	oobmigration.SortVersions(versions)
+
+	if len(versions) == 0 {
+		return oobmigration.Version{}, errors.New("failed to find tagged version")
+	}
+
+	// Get highest release and bump by one
+	return versions[len(versions)-1].Next(), nil
 }

--- a/cmd/worker/internal/migrations/init.go
+++ b/cmd/worker/internal/migrations/init.go
@@ -3,10 +3,6 @@ package migrations
 import (
 	"context"
 	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
@@ -14,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
-	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -78,95 +73,4 @@ type outOfBandMigrationRunnerWrapper struct {
 
 func (w *outOfBandMigrationRunnerWrapper) Start() {
 	w.Runner.Start(w.version)
-}
-
-// currentVersion returns the version that should be given to the out of band migration runner.
-// In dev mode, we use the _next_ (unreleased) version so that we're always on the bleeding edge.
-// When running from a tagged release, we'll use the baked-in version string constant.
-func currentVersion(logger log.Logger) (oobmigration.Version, error) {
-	if rawVersion := version.Version(); !version.IsDev(rawVersion) {
-		version, ok := parseVersion(rawVersion)
-		if !ok {
-			return oobmigration.Version{}, errors.Newf("failed to parse current version: %q", rawVersion)
-		}
-
-		return version, nil
-	}
-
-	if rawVersion := os.Getenv("SRC_OOBMIGRATION_CURRENT_VERSION"); rawVersion != "" {
-		version, ok := oobmigration.NewVersionFromString(rawVersion)
-		if !ok {
-			return oobmigration.Version{}, errors.Newf("failed to parse force-supplied version: %q", rawVersion)
-		}
-
-		return version, nil
-	}
-
-	version, err := inferNextReleaseVersion()
-	if err != nil {
-		return oobmigration.Version{}, err
-	}
-
-	logger.Info("Using latest tag as current version", log.String("version", version.String()))
-	return version, nil
-}
-
-// parseVersion reads the Sourcegraph instance version set at build time. If the given string cannot
-// be parsed as one of the following formats, a false-valued flag is returned.
-//
-// Tagged release format: `v1.2.3`
-// Continuous release format: `(ef/feat_)?12345_2006-01-02-deadbeefbabe_1.2.2(_patch)?`
-func parseVersion(rawVersion string) (oobmigration.Version, bool) {
-	version, ok := oobmigration.NewVersionFromString(rawVersion)
-	if ok {
-		return version, true
-	}
-
-	parts := strings.Split(rawVersion, "_")
-	if len(parts) > 0 && parts[len(parts)-1] == "patch" {
-		parts = parts[:len(parts)-1]
-	}
-	if len(parts) > 0 {
-		return oobmigration.NewVersionFromString(parts[len(parts)-1])
-	}
-
-	return oobmigration.Version{}, false
-}
-
-// inferNextReleaseVersion returns the version AFTER the latest tagged release.
-func inferNextReleaseVersion() (oobmigration.Version, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return oobmigration.Version{}, err
-	}
-
-	cmd := exec.Command("git", "tag", "--list", "v*")
-	cmd.Dir = wd
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return oobmigration.Version{}, err
-	}
-
-	tagMap := map[string]struct{}{}
-	for _, tag := range strings.Split(string(output), "\n") {
-		tag = strings.Split(tag, "-")[0] // strip off rc suffix if it exists
-
-		if version, ok := oobmigration.NewVersionFromString(tag); ok {
-			tagMap[version.String()] = struct{}{}
-		}
-	}
-
-	versions := make([]oobmigration.Version, 0, len(tagMap))
-	for tag := range tagMap {
-		version, _ := oobmigration.NewVersionFromString(tag)
-		versions = append(versions, version)
-	}
-	oobmigration.SortVersions(versions)
-
-	if len(versions) == 0 {
-		return oobmigration.Version{}, errors.New("failed to find tagged version")
-	}
-
-	// Get highest release and bump by one
-	return versions[len(versions)-1].Next(), nil
 }

--- a/cmd/worker/internal/migrations/init_test.go
+++ b/cmd/worker/internal/migrations/init_test.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+func TestParseVersion(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected oobmigration.Version
+	}{
+		{"v4.5.3", oobmigration.NewVersion(4, 5)},
+		{"201149_2023-02-23_4.5-dc8d16268c06", oobmigration.NewVersion(4, 5)},
+		{"201149_2023-02-23_4.5-dc8d16268c06_patch", oobmigration.NewVersion(4, 5)},
+		{"main-dry-run-ef-un-revert_201149_2023-02-23_4.5-dc8d16268c06", oobmigration.NewVersion(4, 5)},
+		{"main-dry-run-ef-un-revert_201149_2023-02-23_4.5-dc8d16268c06_patch", oobmigration.NewVersion(4, 5)},
+	}
+
+	for _, testCase := range testCases {
+		version, ok := parseVersion(testCase.input)
+		if !ok {
+			t.Errorf("unexpected unparseable version %q", testCase.input)
+		} else if version.String() != testCase.expected.String() {
+			t.Errorf("unexpected version for %q. want=%q have=%q", testCase.input, testCase.expected, version)
+		}
+	}
+}

--- a/cmd/worker/internal/migrations/version.go
+++ b/cmd/worker/internal/migrations/version.go
@@ -1,0 +1,104 @@
+package migrations
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// currentVersion returns the version that should be given to the out of band migration runner.
+// In dev mode, we use the _next_ (unreleased) version so that we're always on the bleeding edge.
+// When running from a tagged release, we'll use the baked-in version string constant.
+func currentVersion(logger log.Logger) (oobmigration.Version, error) {
+	if rawVersion := version.Version(); !version.IsDev(rawVersion) {
+		version, ok := parseVersion(rawVersion)
+		if !ok {
+			return oobmigration.Version{}, errors.Newf("failed to parse current version: %q", rawVersion)
+		}
+
+		return version, nil
+	}
+
+	if rawVersion := os.Getenv("SRC_OOBMIGRATION_CURRENT_VERSION"); rawVersion != "" {
+		version, ok := oobmigration.NewVersionFromString(rawVersion)
+		if !ok {
+			return oobmigration.Version{}, errors.Newf("failed to parse force-supplied version: %q", rawVersion)
+		}
+
+		return version, nil
+	}
+
+	version, err := inferNextReleaseVersion()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	logger.Info("Using latest tag as current version", log.String("version", version.String()))
+	return version, nil
+}
+
+// parseVersion reads the Sourcegraph instance version set at build time. If the given string cannot
+// be parsed as one of the following formats, a false-valued flag is returned.
+//
+// Tagged release format: `v1.2.3`
+// Continuous release format: `(ef-feat_)?12345_2006-01-02-1.2-deadbeefbabe(_patch)?`
+func parseVersion(rawVersion string) (oobmigration.Version, bool) {
+	version, ok := oobmigration.NewVersionFromString(rawVersion)
+	if ok {
+		return version, true
+	}
+
+	parts := strings.Split(rawVersion, "_")
+	if len(parts) > 0 && parts[len(parts)-1] == "patch" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) > 0 {
+		return oobmigration.NewVersionFromString(strings.Split(parts[len(parts)-1], "-")[0])
+	}
+
+	return oobmigration.Version{}, false
+}
+
+// inferNextReleaseVersion returns the version AFTER the latest tagged release.
+func inferNextReleaseVersion() (oobmigration.Version, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	cmd := exec.Command("git", "tag", "--list", "v*")
+	cmd.Dir = wd
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return oobmigration.Version{}, err
+	}
+
+	tagMap := map[string]struct{}{}
+	for _, tag := range strings.Split(string(output), "\n") {
+		tag = strings.Split(tag, "-")[0] // strip off rc suffix if it exists
+
+		if version, ok := oobmigration.NewVersionFromString(tag); ok {
+			tagMap[version.String()] = struct{}{}
+		}
+	}
+
+	versions := make([]oobmigration.Version, 0, len(tagMap))
+	for tag := range tagMap {
+		version, _ := oobmigration.NewVersionFromString(tag)
+		versions = append(versions, version)
+	}
+	oobmigration.SortVersions(versions)
+
+	if len(versions) == 0 {
+		return oobmigration.Version{}, errors.New("failed to find tagged version")
+	}
+
+	// Get highest release and bump by one
+	return versions[len(versions)-1].Next(), nil
+}

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -102,7 +102,7 @@ func CandidateImageTag(commit string, buildNumber int) string {
 
 // BranchImageTag provides the tag for all commits built outside of a tagged release.
 //
-// Example: `(ef/feat_)?12345_2006-01-02-1.2.2-deadbeefbabe(_patch)?`
+// Example: `(ef-feat_)?12345_2006-01-02-1.2-deadbeefbabe`
 //
 // Notes:
 // - latest tag omitted if empty

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -37,8 +36,6 @@ type migratorAndOption struct {
 	Migrator
 	migratorOptions
 }
-
-var _ goroutine.BackgroundRoutine = &Runner{}
 
 func NewRunnerWithDB(observationCtx *observation.Context, db database.DB, refreshInterval time.Duration) *Runner {
 	return NewRunner(observationCtx, NewStoreWithDB(db), refreshInterval)
@@ -198,8 +195,16 @@ func (r *Runner) UpdateDirection(ctx context.Context, ids []int, applyReverse bo
 
 // Start runs registered migrators on a loop until they complete. This method will periodically
 // re-read from the database in order to refresh its current view of the migrations.
-func (r *Runner) Start() {
-	r.StartPartial(nil)
+func (r *Runner) Start(currentVersion Version) {
+	r.startInternal(func(migration Migration) bool {
+		if CompareVersions(currentVersion, migration.Introduced) == VersionOrderBefore {
+			// current version before migration introduction
+			return false
+		}
+
+		// migration not yet deprecated or current version is before deprecated version
+		return migration.Deprecated == nil || CompareVersions(currentVersion, *migration.Deprecated) == VersionOrderBefore
+	})
 }
 
 // StartPartial runs registered migrators matching one of the given identifiers on a loop until
@@ -207,31 +212,38 @@ func (r *Runner) Start() {
 // current view of the migrations. When the given set of identifiers is empty, all migrations in
 // the database with a registered migrator will be considered active.
 func (r *Runner) StartPartial(ids []int) {
+	idMap := make(map[int]struct{}, len(ids))
+	for _, id := range ids {
+		idMap[id] = struct{}{}
+	}
+
+	r.startInternal(func(m Migration) bool {
+		_, ok := idMap[m.ID]
+		return ok
+	})
+}
+
+func (r *Runner) startInternal(shouldRunMigration func(m Migration) bool) {
 	defer close(r.finished)
 
 	ctx := r.ctx
 	var wg sync.WaitGroup
 	migrationProcesses := map[int]chan Migration{}
 
-	idMap := make(map[int]struct{}, len(ids))
-	for _, id := range ids {
-		idMap[id] = struct{}{}
-	}
-
 	// Periodically read the complete set of out-of-band migrations from the database
 	for migrations := range r.listMigrations(ctx) {
 		for i := range migrations {
-			id := migrations[i].ID
-			migrator, ok := r.migrators[id]
+			migration := migrations[i]
+			migrator, ok := r.migrators[migration.ID]
 			if !ok {
 				continue
 			}
-			if _, ok := idMap[id]; !ok && len(ids) != 0 {
+			if !shouldRunMigration(migration) {
 				continue
 			}
 
 			// Ensure we have a migration routine running for this migration
-			r.ensureProcessorIsRunning(&wg, migrationProcesses, id, func(ch <-chan Migration) {
+			r.ensureProcessorIsRunning(&wg, migrationProcesses, migration.ID, func(ch <-chan Migration) {
 				runMigrator(ctx, r.store, migrator.Migrator, ch, migrator.migratorOptions, r.logger, r.operations)
 			})
 
@@ -248,9 +260,9 @@ func (r *Runner) StartPartial(ids []int) {
 		loop:
 			for {
 				select {
-				case migrationProcesses[id] <- migrations[i]:
+				case migrationProcesses[migration.ID] <- migrations[i]:
 					break loop
-				case <-migrationProcesses[id]:
+				case <-migrationProcesses[migration.ID]:
 				}
 			}
 		}
@@ -280,12 +292,12 @@ func (r *Runner) listMigrations(ctx context.Context) <-chan []Migration {
 				if !errors.Is(err, ctx.Err()) {
 					r.logger.Error("Failed to list out-of-band migrations", log.Error(err))
 				}
-			}
-
-			select {
-			case ch <- migrations:
-			case <-ctx.Done():
-				return
+			} else {
+				select {
+				case ch <- migrations:
+				case <-ctx.Done():
+					return
+				}
 			}
 
 			select {


### PR DESCRIPTION
This reverts commit 334e47e5dc55ad08aa8545f2c672d1335eea2ed2 that reverted the original PR #47964.

## Test plan

Main-dry-run.