### PR TITLE
sg: fix `live` command after ci build version update

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -80,12 +80,14 @@ func printDeployedVersion(e environment, commits int) error {
 
 	buildDate := elems[1]
 
-	// split the release tag from the commit Sha
+	// attempt to split the release tag from the commit Sha if there
+	var buildSha string
 	versionTag := strings.Split(elems[2], "-")
 	if len(versionTag) != 2 {
-		return errors.Errorf("unknown format of /__version tag: %q", elems[2])
+		buildSha = elems[2]
+	} else {
+		buildSha = versionTag[1]
 	}
-	buildSha := versionTag[1]
 
 	pending = std.Out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
 	_, err = run.GitCmd("fetch", "-q")

--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -72,13 +72,20 @@ func printDeployedVersion(e environment, commits int) error {
 		))
 		return nil
 	}
+	// format: id_date_releasetag-sha
 	elems := strings.Split(bodyStr, "_")
 	if len(elems) != 3 {
 		return errors.Errorf("unknown format of /__version response: %q", body)
 	}
 
 	buildDate := elems[1]
-	buildSha := elems[2]
+
+	// split the release tag from the commit Sha
+	versionTag := strings.Split(elems[2], "-")
+	if len(versionTag) != 2 {
+		return errors.Errorf("unknown format of /__version tag: %q", elems[2])
+	}
+	buildSha := versionTag[1]
 
 	pending = std.Out.Pending(output.Line("", output.StylePending, "Running 'git fetch' to update list of commits..."))
 	_, err = run.GitCmd("fetch", "-q")


### PR DESCRIPTION
I think [this](https://github.com/sourcegraph/sourcegraph/pull/48050) broke `sg live` parsing, as it adds a release tag to the `__version` output afaict. 

## Test plan

```bash
$ cd dev/sg

$ go run . live s2
✅ Fetched deployed version
✅ Done updating list of commits

💡 Live on "s2": ff45c0f95a51 (built on 2023-02-23)

$ go run . live scaletesting
✅ Fetched deployed version
✅ Done updating list of commits

💡 Live on "scaletesting": 4cd778cfb5ab (built on 2023-02-15)

❗️ Deployed SHA 4cd778cfb5ab not found in last 20 commits on origin/main :(
```