### PR TITLE
rbac: make pagination optional for. permissions 

### DIFF
--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -22,7 +22,9 @@ func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 		permissionStore := tx.Permissions()
 		rolePermissionStore := tx.RolePermissions()
 
-		dbPerms, err := permissionStore.FetchAll(ctx)
+		dbPerms, err := permissionStore.List(ctx, database.PermissionListOpts{
+			PaginationArgs: &database.PaginationArgs{},
+		})
 		if err != nil {
 			return errors.Wrap(err, "fetching permissions from database")
 		}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permission_connection_store.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permission_connection_store.go
@@ -47,6 +47,9 @@ func (pcs *permisionConnectionStore) ComputeTotal(ctx context.Context) (*int32, 
 }
 
 func (pcs *permisionConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]gql.PermissionResolver, error) {
+	if args == nil {
+		args = &database.PaginationArgs{}
+	}
 	permissions, err := pcs.db.Permissions().List(ctx, database.PermissionListOpts{
 		PaginationArgs: args,
 		RoleID:         pcs.roleID,

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permission_connection_store.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permission_connection_store.go
@@ -47,9 +47,6 @@ func (pcs *permisionConnectionStore) ComputeTotal(ctx context.Context) (*int32, 
 }
 
 func (pcs *permisionConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]gql.PermissionResolver, error) {
-	if args == nil {
-		args = &database.PaginationArgs{}
-	}
 	permissions, err := pcs.db.Permissions().List(ctx, database.PermissionListOpts{
 		PaginationArgs: args,
 		RoleID:         pcs.roleID,

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -82,6 +82,7 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 			OrderBy: database.OrderBy{
 				{Field: "permissions.id"},
 			},
+			AllowNoLimit: true,
 		},
 	)
 }

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/permissions.go
@@ -82,6 +82,11 @@ func (r *Resolver) Permissions(ctx context.Context, args *gql.ListPermissionArgs
 			OrderBy: database.OrderBy{
 				{Field: "permissions.id"},
 			},
+			// We want to be able to retrieve all permissions belonging to a user at once on startup,
+			// hence we are removing pagination from this resolver. Ideally, we shouldn't have performance
+			// issues since permissions aren't created by users, and it'd take a while before we start having
+			// thousands of permissions in a database, so we are able to get by with disabling pagination
+			// for the permissions resolver.
 			AllowNoLimit: true,
 		},
 	)

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -35466,9 +35466,6 @@ type MockPermissionStore struct {
 	// DeleteFunc is an instance of a mock function object controlling the
 	// behavior of the method Delete.
 	DeleteFunc *PermissionStoreDeleteFunc
-	// FetchAllFunc is an instance of a mock function object controlling the
-	// behavior of the method FetchAll.
-	FetchAllFunc *PermissionStoreFetchAllFunc
 	// GetByIDFunc is an instance of a mock function object controlling the
 	// behavior of the method GetByID.
 	GetByIDFunc *PermissionStoreGetByIDFunc
@@ -35510,11 +35507,6 @@ func NewMockPermissionStore() *MockPermissionStore {
 		},
 		DeleteFunc: &PermissionStoreDeleteFunc{
 			defaultHook: func(context.Context, DeletePermissionOpts) (r0 error) {
-				return
-			},
-		},
-		FetchAllFunc: &PermissionStoreFetchAllFunc{
-			defaultHook: func(context.Context) (r0 []*types.Permission, r1 error) {
 				return
 			},
 		},
@@ -35570,11 +35562,6 @@ func NewStrictMockPermissionStore() *MockPermissionStore {
 				panic("unexpected invocation of MockPermissionStore.Delete")
 			},
 		},
-		FetchAllFunc: &PermissionStoreFetchAllFunc{
-			defaultHook: func(context.Context) ([]*types.Permission, error) {
-				panic("unexpected invocation of MockPermissionStore.FetchAll")
-			},
-		},
 		GetByIDFunc: &PermissionStoreGetByIDFunc{
 			defaultHook: func(context.Context, GetPermissionOpts) (*types.Permission, error) {
 				panic("unexpected invocation of MockPermissionStore.GetByID")
@@ -35617,9 +35604,6 @@ func NewMockPermissionStoreFrom(i PermissionStore) *MockPermissionStore {
 		},
 		DeleteFunc: &PermissionStoreDeleteFunc{
 			defaultHook: i.Delete,
-		},
-		FetchAllFunc: &PermissionStoreFetchAllFunc{
-			defaultHook: i.FetchAll,
 		},
 		GetByIDFunc: &PermissionStoreGetByIDFunc{
 			defaultHook: i.GetByID,
@@ -36168,111 +36152,6 @@ func (c PermissionStoreDeleteFuncCall) Args() []interface{} {
 // invocation.
 func (c PermissionStoreDeleteFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// PermissionStoreFetchAllFunc describes the behavior when the FetchAll
-// method of the parent MockPermissionStore instance is invoked.
-type PermissionStoreFetchAllFunc struct {
-	defaultHook func(context.Context) ([]*types.Permission, error)
-	hooks       []func(context.Context) ([]*types.Permission, error)
-	history     []PermissionStoreFetchAllFuncCall
-	mutex       sync.Mutex
-}
-
-// FetchAll delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockPermissionStore) FetchAll(v0 context.Context) ([]*types.Permission, error) {
-	r0, r1 := m.FetchAllFunc.nextHook()(v0)
-	m.FetchAllFunc.appendCall(PermissionStoreFetchAllFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the FetchAll method of
-// the parent MockPermissionStore instance is invoked and the hook queue is
-// empty.
-func (f *PermissionStoreFetchAllFunc) SetDefaultHook(hook func(context.Context) ([]*types.Permission, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// FetchAll method of the parent MockPermissionStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *PermissionStoreFetchAllFunc) PushHook(hook func(context.Context) ([]*types.Permission, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *PermissionStoreFetchAllFunc) SetDefaultReturn(r0 []*types.Permission, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]*types.Permission, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *PermissionStoreFetchAllFunc) PushReturn(r0 []*types.Permission, r1 error) {
-	f.PushHook(func(context.Context) ([]*types.Permission, error) {
-		return r0, r1
-	})
-}
-
-func (f *PermissionStoreFetchAllFunc) nextHook() func(context.Context) ([]*types.Permission, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *PermissionStoreFetchAllFunc) appendCall(r0 PermissionStoreFetchAllFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of PermissionStoreFetchAllFuncCall objects
-// describing the invocations of this function.
-func (f *PermissionStoreFetchAllFunc) History() []PermissionStoreFetchAllFuncCall {
-	f.mutex.Lock()
-	history := make([]PermissionStoreFetchAllFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// PermissionStoreFetchAllFuncCall is an object that describes an invocation
-// of method FetchAll on an instance of MockPermissionStore.
-type PermissionStoreFetchAllFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*types.Permission
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c PermissionStoreFetchAllFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c PermissionStoreFetchAllFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // PermissionStoreGetByIDFunc describes the behavior when the GetByID method

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -41,8 +41,6 @@ type PermissionStore interface {
 	Create(ctx context.Context, opts CreatePermissionOpts) (*types.Permission, error)
 	// Delete deletes a permission with the provided ID
 	Delete(ctx context.Context, opts DeletePermissionOpts) error
-	// FetchAll returns all permissions in the database. This list is not paginated and is meant for internal use only.
-	FetchAll(ctx context.Context) ([]*types.Permission, error)
 	// GetByID returns the permission matching the given ID, or PermissionNotFoundErr if no such record exists.
 	GetByID(ctx context.Context, opts GetPermissionOpts) (*types.Permission, error)
 	// List returns all the permissions in the database that matches the options.
@@ -257,32 +255,6 @@ func (p *permissionStore) GetByID(ctx context.Context, opts GetPermissionOpts) (
 	}
 
 	return permission, nil
-}
-
-func (p *permissionStore) FetchAll(ctx context.Context) ([]*types.Permission, error) {
-	query := sqlf.Sprintf(
-		"SELECT %s FROM permissions",
-		sqlf.Join(permissionColumns, ", "),
-	)
-
-	rows, err := p.Query(ctx, query)
-	if err != nil {
-		return nil, errors.Wrap(err, "error running query")
-	}
-
-	defer rows.Close()
-
-	var permissions []*types.Permission
-	for rows.Next() {
-		permission, err := scanPermission(rows)
-		if err != nil {
-			return nil, errors.Wrap(err, "scanning permission")
-		}
-
-		permissions = append(permissions, permission)
-	}
-
-	return permissions, rows.Err()
 }
 
 const permissionListQueryFmtStr = `

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -328,20 +328,6 @@ func TestPermissionCount(t *testing.T) {
 	})
 }
 
-func TestPermissionFetchAll(t *testing.T) {
-	ctx := context.Background()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
-	store := db.Permissions()
-
-	_, _, totalPerms := seedPermissionDataForList(ctx, t, store, db)
-
-	perms, err := store.FetchAll(ctx)
-
-	require.NoError(t, err)
-	require.Len(t, perms, totalPerms)
-}
-
 func seedPermissionDataForList(ctx context.Context, t *testing.T, store PermissionStore, db DB) (*types.Role, *types.User, int) {
 	t.Helper()
 


### PR DESCRIPTION
This PR makes pagination optional for the permissions resolver. We need to be able to fetch a user's or role's permission in one query for the following reasons:

* so that the background job for updating permissions can make just one query to the database to fetch all permissions to compare. We previously had a different method, `FetchAll`, but I removed it because it duplicated the logic for `List` on the permission store.
* We need to be able to fetch a user's permission at startup to figure out what aspects of the UI they have access to or should not have access to

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing.
![CleanShot 2023-02-23 at 15 26 14](https://user-images.githubusercontent.com/25608335/220935318-0c31ba38-0905-4073-80e6-272306c48216.png)
