### PR TITLE
permissions-center: add first version of permissions sync jobs table.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.module.scss
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.module.scss
@@ -1,0 +1,8 @@
+.jobs {
+    &__grid {
+        display: grid;
+        grid-template-columns: [status] max-content [name] minmax(auto, 1fr) [reason] minmax(auto, 1fr) [added] min-content [removed] min-content [total] min-content;
+        column-gap: 1rem;
+        align-items: center;
+    }
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -1,14 +1,17 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
-import { WebStory } from '../../components/WebStory'
+import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { PermissionSyncJobReasonGroup, PermissionSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
-import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { WebStory } from '../../components/WebStory'
 import { PermissionsSyncJob } from '../../graphql-operations'
+
 import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
 import { PermissionsSyncJobsTable } from './PermissionsSyncJobsTable'
-import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
 
 const decorator: DecoratorFn = Story => <Story />
 
@@ -120,8 +123,10 @@ export const FiveSyncJobsFound: Story = () => (
 
 FiveSyncJobsFound.storyName = 'Five sync jobs'
 
-type subject = { __typename: 'Repository'; name: string } | { __typename: 'User'; username: string }
-type reason = { __typename?: 'PermissionSyncJobReason'; group: PermissionSyncJobReasonGroup; message: string }
+interface repo { __typename: 'Repository'; name: string }
+interface user { __typename: 'User'; username: string }
+type subject = repo | user
+interface reason { __typename?: 'PermissionSyncJobReason'; group: PermissionSyncJobReasonGroup; message: string }
 
 function createSyncJobMock(
     id: string,

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -1,0 +1,152 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { WebStory } from '../../components/WebStory'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+import { getDocumentNode } from '@sourcegraph/http-client'
+import { PermissionSyncJobReasonGroup, PermissionSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { PermissionsSyncJob } from '../../graphql-operations'
+import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
+import { PermissionsSyncJobsTable } from './PermissionsSyncJobsTable'
+import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
+
+const decorator: DecoratorFn = Story => <Story />
+
+const config: Meta = {
+    title: 'web/src/site-admin/permissions-center/PermissionsSyncJobsTable',
+    decorators: [decorator],
+}
+
+export default config
+
+const TIMESTAMP_MOCK = subMinutes(Date.now(), 5)
+
+export const FiveSyncJobsFound: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(PERMISSIONS_SYNC_JOBS_QUERY),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result: {
+                                data: {
+                                    permissionSyncJobs: {
+                                        nodes: [
+                                            createSyncJobMock(
+                                                '1',
+                                                PermissionSyncJobState.COMPLETED,
+                                                {
+                                                    __typename: 'Repository',
+                                                    name: 'sourcegraph/sourcegraph',
+                                                },
+                                                {
+                                                    group: PermissionSyncJobReasonGroup.WEBHOOK,
+                                                    message: 'REASON_GITHUB_REPO_EVENT',
+                                                }
+                                            ),
+                                            createSyncJobMock(
+                                                '2',
+                                                PermissionSyncJobState.ERRORED,
+                                                {
+                                                    __typename: 'User',
+                                                    username: 'abdul',
+                                                },
+                                                {
+                                                    group: PermissionSyncJobReasonGroup.SOURCEGRAPH,
+                                                    message: 'REASON_USER_EMAIL_VERIFIED',
+                                                }
+                                            ),
+                                            createSyncJobMock(
+                                                '3',
+                                                PermissionSyncJobState.FAILED,
+                                                {
+                                                    __typename: 'Repository',
+                                                    name: 'sourcegraph/hoursegraph',
+                                                },
+                                                {
+                                                    group: PermissionSyncJobReasonGroup.SCHEDULE,
+                                                    message: 'REASON_REPO_OUTDATED_PERMS',
+                                                }
+                                            ),
+                                            createSyncJobMock(
+                                                '4',
+                                                PermissionSyncJobState.PROCESSING,
+                                                {
+                                                    __typename: 'User',
+                                                    username: 'omar',
+                                                },
+                                                {
+                                                    group: PermissionSyncJobReasonGroup.MANUAL,
+                                                    message: 'REASON_MANUAL_USER_SYNC',
+                                                }
+                                            ),
+                                            createSyncJobMock(
+                                                '5',
+                                                PermissionSyncJobState.QUEUED,
+                                                {
+                                                    __typename: 'Repository',
+                                                    name: 'sourcegraph/stillfunny',
+                                                },
+                                                {
+                                                    group: PermissionSyncJobReasonGroup.MANUAL,
+                                                    message: 'REASON_MANUAL_REPO_SYNC',
+                                                }
+                                            ),
+                                        ],
+                                        totalCount: 5,
+                                        pageInfo: {
+                                            hasNextPage: true,
+                                            hasPreviousPage: false,
+                                            startCursor: null,
+                                            endCursor: null,
+                                        },
+                                    },
+                                },
+                            },
+                            nMatches: Number.POSITIVE_INFINITY,
+                        },
+                    ])
+                }
+            >
+                <PermissionsSyncJobsTable telemetryService={NOOP_TELEMETRY_SERVICE} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+FiveSyncJobsFound.storyName = 'Five sync jobs'
+
+type subject = { __typename: 'Repository'; name: string } | { __typename: 'User'; username: string }
+type reason = { __typename?: 'PermissionSyncJobReason'; group: PermissionSyncJobReasonGroup; message: string }
+
+function createSyncJobMock(
+    id: string,
+    state: PermissionSyncJobState,
+    subject: subject,
+    reason: reason
+): PermissionsSyncJob {
+    return {
+        __typename: 'PermissionSyncJob',
+        id,
+        state,
+        subject,
+        reason,
+        triggeredByUser: {
+            username: 'super-site-admin',
+        },
+        queuedAt: formatRFC3339(TIMESTAMP_MOCK),
+        startedAt: state !== PermissionSyncJobState.QUEUED ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 1)) : null,
+        finishedAt:
+            state !== PermissionSyncJobState.QUEUED && state !== PermissionSyncJobState.PROCESSING
+                ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 2))
+                : null,
+        processAfter: null,
+        permissionsAdded: 1337,
+        permissionsRemoved: 42,
+        permissionsFound: 1337 + 42,
+    }
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -123,10 +123,23 @@ export const FiveSyncJobsFound: Story = () => (
 
 FiveSyncJobsFound.storyName = 'Five sync jobs'
 
-interface repo { __typename: 'Repository'; name: string }
-interface user { __typename: 'User'; username: string }
+interface repo {
+    __typename: 'Repository'
+    name: string
+}
+
+interface user {
+    __typename: 'User'
+    username: string
+}
+
 type subject = repo | user
-interface reason { __typename?: 'PermissionSyncJobReason'; group: PermissionSyncJobReasonGroup; message: string }
+
+interface reason {
+    __typename?: 'PermissionSyncJobReason'
+    group: PermissionSyncJobReasonGroup
+    message: string
+}
 
 function createSyncJobMock(
     id: string,

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, H5, PageSwitcher } from '@sourcegraph/wildcard'
 
-
 import { usePageSwitcherPagination } from '../../components/FilteredConnection/hooks/usePageSwitcherPagination'
 import {
     ConnectionContainer,

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -41,7 +41,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
     })
 
     return (
-        <div className="site-admin-webhooks-page">
+        <div>
             <Container>
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect } from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Container, H5, PageSwitcher } from '@sourcegraph/wildcard'
+
+import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
+import { usePageSwitcherPagination } from '../../components/FilteredConnection/hooks/usePageSwitcherPagination'
+import { PermissionsSyncJob, PermissionSyncJobsResult, PermissionSyncJobsVariables } from '../../graphql-operations'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+} from '../../components/FilteredConnection/ui'
+
+import styles from './PermissionsSyncJobsTable.module.scss'
+import { ChangesetCloseNode } from './PermissionsSyncJobsTableItem'
+
+interface Props extends TelemetryProps {}
+
+export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryService,
+}) => {
+    useEffect(() => {
+        telemetryService.logPageView('PermissionsSyncJobsTable')
+    }, [telemetryService])
+
+    const { connection, loading, error, refetch, ...paginationProps } = usePageSwitcherPagination<
+        PermissionSyncJobsResult,
+        PermissionSyncJobsVariables,
+        PermissionsSyncJob
+    >({
+        query: PERMISSIONS_SYNC_JOBS_QUERY,
+        variables: {
+            first: 20,
+        },
+        getConnection: ({ data }) => data?.permissionSyncJobs || undefined,
+        options: { pollInterval: 5000 },
+    })
+
+    return (
+        <div className="site-admin-webhooks-page">
+            <Container>
+                <ConnectionContainer>
+                    {error && <ConnectionError errors={[error.message]} />}
+                    {loading && !connection && <ConnectionLoading />}
+                    <ConnectionList
+                        className={styles.jobsGrid}
+                        // className="list-group"
+                        aria-label="Permissions sync jobs"
+                    >
+                        {connection && connection.nodes?.length > 0 && <Header />}
+                        {connection?.nodes?.map(node => (
+                            <ChangesetCloseNode key={node.id} node={node} />
+                        ))}
+                    </ConnectionList>
+                </ConnectionContainer>
+                <PageSwitcher
+                    {...paginationProps}
+                    className="mt-4"
+                    totalCount={connection?.totalCount ?? null}
+                    totalLabel="permissions sync jobs"
+                />
+            </Container>
+        </div>
+    )
+}
+
+const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
+    <>
+        <H5 className="text-uppercase">Status</H5>
+        <H5 className="text-uppercase">Name</H5>
+        <H5 className="text-uppercase">Reason</H5>
+        <H5 className="text-uppercase">Added</H5>
+        <H5 className="text-uppercase">Removed</H5>
+        <H5 className="text-uppercase">Total</H5>
+    </>
+)

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -45,11 +45,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}
-                    <ConnectionList
-                        className={styles.jobsGrid}
-                        // className="list-group"
-                        aria-label="Permissions sync jobs"
-                    >
+                    <ConnectionList className={styles.jobsGrid} aria-label="Permissions sync jobs">
                         {connection && connection.nodes?.length > 0 && <Header />}
                         {connection?.nodes?.map(node => (
                             <ChangesetCloseNode key={node.id} node={node} />

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -3,18 +3,20 @@ import React, { useEffect } from 'react'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, H5, PageSwitcher } from '@sourcegraph/wildcard'
 
-import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
+
 import { usePageSwitcherPagination } from '../../components/FilteredConnection/hooks/usePageSwitcherPagination'
-import { PermissionsSyncJob, PermissionSyncJobsResult, PermissionSyncJobsVariables } from '../../graphql-operations'
 import {
     ConnectionContainer,
     ConnectionError,
     ConnectionList,
     ConnectionLoading,
 } from '../../components/FilteredConnection/ui'
+import { PermissionsSyncJob, PermissionSyncJobsResult, PermissionSyncJobsVariables } from '../../graphql-operations'
+
+import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
+import { ChangesetCloseNode } from './PermissionsSyncJobsTableItem'
 
 import styles from './PermissionsSyncJobsTable.module.scss'
-import { ChangesetCloseNode } from './PermissionsSyncJobsTableItem'
 
 interface Props extends TelemetryProps {}
 

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.module.scss
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.module.scss
@@ -1,0 +1,11 @@
+.job {
+    display: contents;
+
+    &__separator {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border-color-2);
+        margin-top: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { mdiAccount, mdiCloudQuestion } from '@mdi/js'
+
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { Badge, BADGE_VARIANTS, Icon, Text } from '@sourcegraph/wildcard'
 
@@ -15,7 +16,7 @@ export interface ChangesetCloseNodeProps {
 interface JobStateMetadata {
     badgeVariant: typeof BADGE_VARIANTS[number]
     temporalWording: string
-    timeGetter: (job: PermissionsSyncJob) => string | null
+    timeGetter: (job: PermissionsSyncJob) => string
 }
 
 const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadata> = {
@@ -27,44 +28,46 @@ const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadat
     PROCESSING: {
         badgeVariant: 'primary',
         temporalWording: 'Began processing',
-        timeGetter: job => job.startedAt,
+        timeGetter: job => job.startedAt ?? '',
     },
     COMPLETED: {
         badgeVariant: 'success',
         temporalWording: 'Completed',
-        timeGetter: job => job.finishedAt,
+        timeGetter: job => job.finishedAt ?? '',
     },
     ERRORED: {
         badgeVariant: 'danger',
         temporalWording: 'Errored',
-        timeGetter: job => job.finishedAt,
+        timeGetter: job => job.finishedAt ?? '',
     },
     FAILED: {
         badgeVariant: 'danger',
         temporalWording: 'Failed',
-        timeGetter: job => job.finishedAt,
+        timeGetter: job => job.finishedAt ?? '',
     },
 }
 
 export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren<ChangesetCloseNodeProps>> = ({
     node,
-}) => <li className={styles.job}>
-    <span className={styles.jobSeparator} />
-    <>
-        <PermissionsSyncJobStatusBadge state={node.state} />
-        <PermissionsSyncJobSubject job={node} />
-        <PermissionsSyncJobReason job={node} />
-        <div className="text-success">
-            ++<b>{node.permissionsAdded}</b>
-        </div>
-        <div className="text-danger">
-            --<b>{node.permissionsRemoved}</b>
-        </div>
-        <div className="text-secondary">
-            <b>{node.permissionsFound}</b>
-        </div>
-    </>
-</li>
+}) => (
+    <li className={styles.job}>
+        <span className={styles.jobSeparator} />
+        <>
+            <PermissionsSyncJobStatusBadge state={node.state} />
+            <PermissionsSyncJobSubject job={node} />
+            <PermissionsSyncJobReason job={node} />
+            <div className="text-success">
+                ++<b>{node.permissionsAdded}</b>
+            </div>
+            <div className="text-danger">
+                --<b>{node.permissionsRemoved}</b>
+            </div>
+            <div className="text-secondary">
+                <b>{node.permissionsFound}</b>
+            </div>
+        </>
+    </li>
+)
 
 const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionSyncJobState }> = ({ state }) => (
     <Badge variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}>{state}</Badge>
@@ -85,7 +88,7 @@ const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJ
                     </>
                 )}
             </div>
-            {JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job) && (
+            {JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job) != '' && (
                 <Text className="mb-0 text-muted">
                     <small>
                         {JOB_STATE_METADATA_MAPPING[job.state].temporalWording}{' '}
@@ -97,7 +100,7 @@ const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJ
     )
 }
 
-const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) =>
+const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => (
     <div>
         <div>{job.reason.group}</div>
         <Text className="mb-0 text-muted">
@@ -109,3 +112,4 @@ const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJo
             {/*    TODO(sashaostrikov) use pretty-printed message*/}
         </Text>
     </div>
+)

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 
-import styles from './PermissionsSyncJobsTableItem.module.scss'
-import { PermissionsSyncJob, PermissionSyncJobReasonGroup, PermissionSyncJobState } from '../../graphql-operations'
-import { Badge, BADGE_VARIANTS, Icon, Text } from '@sourcegraph/wildcard'
-import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { mdiAccount, mdiCloudQuestion } from '@mdi/js'
+import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import { Badge, BADGE_VARIANTS, Icon, Text } from '@sourcegraph/wildcard'
+
+import { PermissionsSyncJob, PermissionSyncJobReasonGroup, PermissionSyncJobState } from '../../graphql-operations'
+
+import styles from './PermissionsSyncJobsTableItem.module.scss'
 
 export interface ChangesetCloseNodeProps {
     node: PermissionsSyncJob
 }
 
-type JobStateMetadata = {
+interface JobStateMetadata {
     badgeVariant: typeof BADGE_VARIANTS[number]
     temporalWording: string
     timeGetter: (job: PermissionsSyncJob) => string | null
@@ -46,25 +48,23 @@ const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadat
 
 export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren<ChangesetCloseNodeProps>> = ({
     node,
-}) => (
-    <li className={styles.job}>
-        <span className={styles.jobSeparator} />
-        <>
-            <PermissionsSyncJobStatusBadge state={node.state} />
-            <PermissionsSyncJobSubject job={node} />
-            <PermissionsSyncJobReason job={node} />
-            <div className="text-success">
-                ++<b>{node.permissionsAdded}</b>
-            </div>
-            <div className="text-danger">
-                --<b>{node.permissionsRemoved}</b>
-            </div>
-            <div className="text-secondary">
-                <b>{node.permissionsFound}</b>
-            </div>
-        </>
-    </li>
-)
+}) => <li className={styles.job}>
+    <span className={styles.jobSeparator} />
+    <>
+        <PermissionsSyncJobStatusBadge state={node.state} />
+        <PermissionsSyncJobSubject job={node} />
+        <PermissionsSyncJobReason job={node} />
+        <div className="text-success">
+            ++<b>{node.permissionsAdded}</b>
+        </div>
+        <div className="text-danger">
+            --<b>{node.permissionsRemoved}</b>
+        </div>
+        <div className="text-secondary">
+            <b>{node.permissionsFound}</b>
+        </div>
+    </>
+</li>
 
 const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionSyncJobState }> = ({ state }) => (
     <Badge variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}>{state}</Badge>
@@ -74,7 +74,7 @@ const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJ
     return (
         <div>
             <div>
-                {job.subject.__typename == 'Repository' ? (
+                {job.subject.__typename === 'Repository' ? (
                     <>
                         <Icon aria-hidden={true} svgPath={mdiCloudQuestion} /> {job.subject.name}
                         {/*    TODO(sashaostrikov) use code host related icons after GQL API is updated*/}
@@ -89,7 +89,7 @@ const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJ
                 <Text className="mb-0 text-muted">
                     <small>
                         {JOB_STATE_METADATA_MAPPING[job.state].temporalWording}{' '}
-                        <Timestamp date={JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job)!!} />
+                        <Timestamp date={JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job)} />
                     </small>
                 </Text>
             )}
@@ -97,18 +97,15 @@ const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJ
     )
 }
 
-const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
-    return (
-        <div>
-            <div>{job.reason.group}</div>
-            <Text className="mb-0 text-muted">
-                <small>
-                    {job.reason.group === PermissionSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
-                        ? `by ${job.triggeredByUser.username}`
-                        : job.reason.message}
-                </small>
-                {/*    TODO(sashaostrikov) use pretty-printed message*/}
-            </Text>
-        </div>
-    )
-}
+const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) =>
+    <div>
+        <div>{job.reason.group}</div>
+        <Text className="mb-0 text-muted">
+            <small>
+                {job.reason.group === PermissionSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
+                    ? `by ${job.triggeredByUser.username}`
+                    : job.reason.message}
+            </small>
+            {/*    TODO(sashaostrikov) use pretty-printed message*/}
+        </Text>
+    </div>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+
+import styles from './PermissionsSyncJobsTableItem.module.scss'
+import { PermissionsSyncJob, PermissionSyncJobReasonGroup, PermissionSyncJobState } from '../../graphql-operations'
+import { Badge, BADGE_VARIANTS, Icon, Text } from '@sourcegraph/wildcard'
+import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import { mdiAccount, mdiCloudQuestion } from '@mdi/js'
+
+export interface ChangesetCloseNodeProps {
+    node: PermissionsSyncJob
+}
+
+type JobStateMetadata = {
+    badgeVariant: typeof BADGE_VARIANTS[number]
+    temporalWording: string
+    timeGetter: (job: PermissionsSyncJob) => string | null
+}
+
+const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadata> = {
+    QUEUED: {
+        badgeVariant: 'secondary',
+        temporalWording: 'Queued',
+        timeGetter: job => job.queuedAt,
+    },
+    PROCESSING: {
+        badgeVariant: 'primary',
+        temporalWording: 'Began processing',
+        timeGetter: job => job.startedAt,
+    },
+    COMPLETED: {
+        badgeVariant: 'success',
+        temporalWording: 'Completed',
+        timeGetter: job => job.finishedAt,
+    },
+    ERRORED: {
+        badgeVariant: 'danger',
+        temporalWording: 'Errored',
+        timeGetter: job => job.finishedAt,
+    },
+    FAILED: {
+        badgeVariant: 'danger',
+        temporalWording: 'Failed',
+        timeGetter: job => job.finishedAt,
+    },
+}
+
+export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren<ChangesetCloseNodeProps>> = ({
+    node,
+}) => (
+    <li className={styles.job}>
+        <span className={styles.jobSeparator} />
+        <>
+            <PermissionsSyncJobStatusBadge state={node.state} />
+            <PermissionsSyncJobSubject job={node} />
+            <PermissionsSyncJobReason job={node} />
+            <div className="text-success">
+                ++<b>{node.permissionsAdded}</b>
+            </div>
+            <div className="text-danger">
+                --<b>{node.permissionsRemoved}</b>
+            </div>
+            <div className="text-secondary">
+                <b>{node.permissionsFound}</b>
+            </div>
+        </>
+    </li>
+)
+
+const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionSyncJobState }> = ({ state }) => (
+    <Badge variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}>{state}</Badge>
+)
+
+const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
+    return (
+        <div>
+            <div>
+                {job.subject.__typename == 'Repository' ? (
+                    <>
+                        <Icon aria-hidden={true} svgPath={mdiCloudQuestion} /> {job.subject.name}
+                        {/*    TODO(sashaostrikov) use code host related icons after GQL API is updated*/}
+                    </>
+                ) : (
+                    <>
+                        <Icon aria-hidden={true} svgPath={mdiAccount} /> {job.subject.username}
+                    </>
+                )}
+            </div>
+            {JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job) && (
+                <Text className="mb-0 text-muted">
+                    <small>
+                        {JOB_STATE_METADATA_MAPPING[job.state].temporalWording}{' '}
+                        <Timestamp date={JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job)!!} />
+                    </small>
+                </Text>
+            )}
+        </div>
+    )
+}
+
+const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
+    return (
+        <div>
+            <div>{job.reason.group}</div>
+            <Text className="mb-0 text-muted">
+                <small>
+                    {job.reason.group === PermissionSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
+                        ? `by ${job.triggeredByUser.username}`
+                        : job.reason.message}
+                </small>
+                {/*    TODO(sashaostrikov) use pretty-printed message*/}
+            </Text>
+        </div>
+    )
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -73,32 +73,30 @@ const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: Permission
     <Badge variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}>{state}</Badge>
 )
 
-const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
-    return (
+const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => (
+    <div>
         <div>
-            <div>
-                {job.subject.__typename === 'Repository' ? (
-                    <>
-                        <Icon aria-hidden={true} svgPath={mdiCloudQuestion} /> {job.subject.name}
-                        {/*    TODO(sashaostrikov) use code host related icons after GQL API is updated*/}
-                    </>
-                ) : (
-                    <>
-                        <Icon aria-hidden={true} svgPath={mdiAccount} /> {job.subject.username}
-                    </>
-                )}
-            </div>
-            {JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job) != '' && (
-                <Text className="mb-0 text-muted">
-                    <small>
-                        {JOB_STATE_METADATA_MAPPING[job.state].temporalWording}{' '}
-                        <Timestamp date={JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job)} />
-                    </small>
-                </Text>
+            {job.subject.__typename === 'Repository' ? (
+                <>
+                    <Icon aria-hidden={true} svgPath={mdiCloudQuestion} /> {job.subject.name}
+                    {/*    TODO(sashaostrikov) use code host related icons after GQL API is updated*/}
+                </>
+            ) : (
+                <>
+                    <Icon aria-hidden={true} svgPath={mdiAccount} /> {job.subject.username}
+                </>
             )}
         </div>
-    )
-}
+        {JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job) !== '' && (
+            <Text className="mb-0 text-muted">
+                <small>
+                    {JOB_STATE_METADATA_MAPPING[job.state].temporalWording}{' '}
+                    <Timestamp date={JOB_STATE_METADATA_MAPPING[job.state].timeGetter(job)} />
+                </small>
+            </Text>
+        )}
+    </div>
+)
 
 const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => (
     <div>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiAccount, mdiCloudQuestion } from '@mdi/js'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
-import { Badge, BADGE_VARIANTS, Icon, Text } from '@sourcegraph/wildcard'
+import { Badge, BADGE_VARIANTS, Icon, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { PermissionsSyncJob, PermissionSyncJobReasonGroup, PermissionSyncJobState } from '../../graphql-operations'
 
@@ -56,12 +56,8 @@ export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren
             <PermissionsSyncJobStatusBadge state={node.state} />
             <PermissionsSyncJobSubject job={node} />
             <PermissionsSyncJobReason job={node} />
-            <div className="text-success">
-                ++<b>{node.permissionsAdded}</b>
-            </div>
-            <div className="text-danger">
-                --<b>{node.permissionsRemoved}</b>
-            </div>
+            <PermissionsSyncJobNumbers job={node} added={true} />
+            <PermissionsSyncJobNumbers job={node} added={false} />
             <div className="text-secondary">
                 <b>{node.permissionsFound}</b>
             </div>
@@ -111,3 +107,30 @@ const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJo
         </Text>
     </div>
 )
+
+// added/removed access for X repositories/users
+const PermissionsSyncJobNumbers: React.FunctionComponent<{ job: PermissionsSyncJob; added: boolean }> = ({
+    job,
+    added,
+}) =>
+    added ? (
+        <Tooltip
+            content={`Added access for ${job.permissionsAdded} ${
+                job.subject.__typename === 'Repository' ? 'users' : 'repositories'
+            }.`}
+        >
+            <div className="text-success">
+                +<b>{job.permissionsAdded}</b>
+            </div>
+        </Tooltip>
+    ) : (
+        <Tooltip
+            content={`Removed access for ${job.permissionsRemoved} ${
+                job.subject.__typename === 'Repository' ? 'users' : 'repositories'
+            }.`}
+        >
+            <div className="text-danger">
+                -<b>{job.permissionsRemoved}</b>
+            </div>
+        </Tooltip>
+    )

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -1,0 +1,62 @@
+import { gql } from '@sourcegraph/http-client'
+
+// TODO(sashaostrikov): move all properties to PermissionsSyncJob and make a storybook more elaborate
+export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
+    fragment PermissionsSyncJob on PermissionSyncJob {
+        id
+        state
+        subject {
+            ... on Repository {
+                __typename
+                name
+            }
+            ... on User {
+                __typename
+                username
+            }
+        }
+        triggeredByUser {
+            username
+        }
+        reason {
+            group
+            message
+        }
+        queuedAt
+        startedAt
+        finishedAt
+        processAfter
+        permissionsAdded
+        permissionsRemoved
+        permissionsFound
+    }
+
+    query PermissionSyncJobs($first: Int, $last: Int, $after: String, $before: String) {
+        permissionSyncJobs(first: $first, last: $last, after: $after, before: $before) {
+            totalCount
+            pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+            }
+            nodes {
+                ...PermissionsSyncJob
+                failureMessage
+                cancellationReason
+                ranForMs
+                numResets
+                numFailures
+                lastHeartbeatAt
+                workerHostname
+                cancel
+                priority
+                noPerms
+                invalidateCaches
+                codeHostStates {
+                    providerID
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -1,8 +1,8 @@
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { isPackagesEnabled } from './flags'
-import { SiteAdminAreaRoute } from './SiteAdminArea'
 import { PermissionsSyncJobsTable } from './permissions-center/PermissionsSyncJobsTable'
+import { SiteAdminAreaRoute } from './SiteAdminArea'
 
 const AnalyticsOverviewPage = lazyComponent(() => import('./analytics/AnalyticsOverviewPage'), 'AnalyticsOverviewPage')
 const AnalyticsSearchPage = lazyComponent(() => import('./analytics/AnalyticsSearchPage'), 'AnalyticsSearchPage')

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -2,6 +2,7 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { isPackagesEnabled } from './flags'
 import { SiteAdminAreaRoute } from './SiteAdminArea'
+import { PermissionsSyncJobsTable } from './permissions-center/PermissionsSyncJobsTable'
 
 const AnalyticsOverviewPage = lazyComponent(() => import('./analytics/AnalyticsOverviewPage'), 'AnalyticsOverviewPage')
 const AnalyticsSearchPage = lazyComponent(() => import('./analytics/AnalyticsSearchPage'), 'AnalyticsSearchPage')
@@ -226,5 +227,9 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         path: '/packages',
         render: props => <SiteAdminPackagesPage {...props} />,
         condition: isPackagesEnabled,
+    },
+    {
+        path: '/permissions-syncs',
+        render: props => <PermissionsSyncJobsTable {...props} />,
     },
 ]


### PR DESCRIPTION
Test plan:
Storybook.
Local sg run and visual check.

### Quicc demo

https://user-images.githubusercontent.com/94846361/220935742-af35374d-85fe-4686-9f5c-dd7026dc567b.mp4

### Storybook screenshot for those unimpressed by demo
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/94846361/220936187-096b2e24-0805-48e5-ba64-cad85096faaa.png">

#### There are still a couple of TODOs which I'll address shortly, hence...

Part of https://github.com/sourcegraph/sourcegraph/issues/47868


## App preview:

- [Web](https://sg-web-ao-ui-pc-perms-sync-table.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
