### PR TITLE
permissions-center: use consistent naming of permissions sync jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Experimental GraphQL query, `permissionsSyncJobs` is removed and substituted with new non-experimental `permissionSyncJobs` query (mind the singular form of permission) which provides full information about permission sync jobs stored in the database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
+- Experimental GraphQL query, `permissionsSyncJobs` is substituted with new non-experimental query which provides full information about permissions sync jobs stored in the database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
 - Renders `readme.txt` files in the repository page. [#47944](https://github.com/sourcegraph/sourcegraph/pull/47944)
 
 ### Fixed
@@ -33,7 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The LSIF upload endpoint is no longer supported and has been replaced by a diagnostic error page. src-cli v4.5+ will translate all local LSIF files to SCIP prior to upload. [#47547](https://github.com/sourcegraph/sourcegraph/pull/47547)
 - The experimental setting `authz.syncJobsRecordsLimit` has been removed. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
-- Storing permission sync jobs statuses in Redis has been removed as now all permission sync related data is stored in a database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
+- Storing permissions sync jobs statuses in Redis has been removed as now all permissions sync related data is stored in a database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
 
 ## 4.5.0
 

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -462,7 +462,7 @@ Please verify your email address on Sourcegraph ({{.Host}}) by clicking this lin
 
 // triggerPermissionsSync is a helper that attempts to schedule a new permissions
 // sync for the given user.
-func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32, reason database.PermissionSyncJobReason) {
+func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32, reason database.PermissionsSyncJobReason) {
 	permssync.SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{
 		UserIDs: []int32{userID},
 		Reason:  reason,

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -25,7 +25,7 @@ type AuthzResolver interface {
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
 	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
 	AuthzProviderTypes(ctx context.Context) ([]string, error)
-	PermissionSyncJobs(ctx context.Context, args ListPermissionSyncJobsArgs) (*graphqlutil.ConnectionResolver[PermissionSyncJobResolver], error)
+	PermissionsSyncJobs(ctx context.Context, args ListPermissionsSyncJobsArgs) (*graphqlutil.ConnectionResolver[PermissionsSyncJobResolver], error)
 
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -140,7 +140,7 @@ extend type Query {
     """
     Returns a list of recent permissions sync jobs for a given set of parameters.
     """
-    permissionSyncJobs(
+    permissionsSyncJobs(
         """
         Number of jobs returned. Maximum number of returned jobs is 500. Up to 100 jobs are returned by default.
         """
@@ -161,7 +161,7 @@ extend type Query {
         also used in conjunction with "last" to return the last N nodes.
         """
         before: String
-    ): PermissionSyncJobsConnection!
+    ): PermissionsSyncJobsConnection!
 
     """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
@@ -323,13 +323,13 @@ input FetchPermissionsOptions {
 }
 
 """
-Permission sync jobs.
+Permissions sync jobs.
 """
-type PermissionSyncJobsConnection implements Connection {
+type PermissionsSyncJobsConnection implements Connection {
     """
     Permission sync jobs.
     """
-    nodes: [PermissionSyncJob!]!
+    nodes: [PermissionsSyncJob!]!
     """
     The total number of jobs in the connection.
     """
@@ -343,7 +343,7 @@ type PermissionSyncJobsConnection implements Connection {
 """
 State types of permission sync jobs.
 """
-enum PermissionSyncJobState {
+enum PermissionsSyncJobState {
     QUEUED
     PROCESSING
     FAILED
@@ -356,11 +356,11 @@ Compound type for a permission sync job trigger reason.
 Consists of a reason group (PermissionSyncJobReasonGroup) and a message, providing details
 about why/how the sync was triggered.
 """
-type PermissionSyncJobReason {
+type PermissionsSyncJobReason {
     """
     PermissionSyncJobReasonGroup combines multiple permission sync job trigger reasons into groups with similar grounds.
     """
-    group: PermissionSyncJobReasonGroup!
+    group: PermissionsSyncJobReasonGroup!
     """
     Message with details about why/how the sync was triggered.
     """
@@ -370,7 +370,7 @@ type PermissionSyncJobReason {
 """
 State types of permission sync jobs.
 """
-enum PermissionSyncJobReasonGroup {
+enum PermissionsSyncJobReasonGroup {
     MANUAL
     WEBHOOK
     SCHEDULE
@@ -385,7 +385,7 @@ union PermissionSyncJobSubject = User | Repository
 """
 Permission sync job priority.
 """
-enum PermissionSyncJobPriority {
+enum PermissionsSyncJobPriority {
     LOW
     MEDIUM
     HIGH
@@ -416,7 +416,7 @@ type CodeHostState {
 """
 State of a permission sync job.
 """
-type PermissionSyncJob implements Node {
+type PermissionsSyncJob implements Node {
     """
     Unique node ID.
     """
@@ -424,7 +424,7 @@ type PermissionSyncJob implements Node {
     """
     State of a permission sync job.
     """
-    state: PermissionSyncJobState!
+    state: PermissionsSyncJobState!
     """
     Failure message for failed sync job.
     """
@@ -432,7 +432,7 @@ type PermissionSyncJob implements Node {
     """
     Reason for triggering a permission sync job.
     """
-    reason: PermissionSyncJobReason!
+    reason: PermissionsSyncJobReason!
     """
     Reason for cancellation of a given permission sync job.
     """
@@ -488,7 +488,7 @@ type PermissionSyncJob implements Node {
     """
     Priority of a permission sync job.
     """
-    priority: PermissionSyncJobPriority!
+    priority: PermissionsSyncJobPriority!
     """
     Flag showing that there are no permissions for a given repository/user.
     """

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -329,8 +329,8 @@ func (r *NodeResolver) ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, b
 	return n, ok
 }
 
-func (r *NodeResolver) ToPermissionSyncJob() (PermissionSyncJobResolver, bool) {
-	n, ok := r.Node.(PermissionSyncJobResolver)
+func (r *NodeResolver) ToPermissionsSyncJob() (PermissionsSyncJobResolver, bool) {
+	n, ok := r.Node.(PermissionsSyncJobResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -8,15 +8,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
-// PermissionSyncJobResolver is used to resolve permission sync jobs.
+// PermissionsSyncJobResolver is used to resolve permission sync jobs.
 //
-// TODO(sashaostrikov) add PermissionSyncJobProvider when it is persisted in the
+// TODO(sashaostrikov) add PermissionsSyncJobProvider when it is persisted in the
 // db.
-type PermissionSyncJobResolver interface {
+type PermissionsSyncJobResolver interface {
 	ID() graphql.ID
 	State() string
 	FailureMessage() *string
-	Reason() PermissionSyncJobReasonResolver
+	Reason() PermissionsSyncJobReasonResolver
 	CancellationReason() *string
 	TriggeredByUser(ctx context.Context) (*UserResolver, error)
 	QueuedAt() gqlutil.DateTime
@@ -29,7 +29,7 @@ type PermissionSyncJobResolver interface {
 	LastHeartbeatAt() *gqlutil.DateTime
 	WorkerHostname() string
 	Cancel() bool
-	Subject() PermissionSyncJobSubject
+	Subject() PermissionsSyncJobSubject
 	Priority() string
 	NoPerms() bool
 	InvalidateCaches() bool
@@ -39,7 +39,7 @@ type PermissionSyncJobResolver interface {
 	CodeHostStates() []CodeHostStateResolver
 }
 
-type PermissionSyncJobReasonResolver interface {
+type PermissionsSyncJobReasonResolver interface {
 	Group() string
 	Message() string
 }
@@ -51,11 +51,11 @@ type CodeHostStateResolver interface {
 	Message() string
 }
 
-type PermissionSyncJobSubject interface {
+type PermissionsSyncJobSubject interface {
 	ToRepository() (*RepositoryResolver, bool)
 	ToUser() (*UserResolver, bool)
 }
 
-type ListPermissionSyncJobsArgs struct {
+type ListPermissionsSyncJobsArgs struct {
 	graphqlutil.ConnectionResolverArgs
 }

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -64,7 +64,7 @@ type EnterpriseInit func(
 	keyring keyring.Ring,
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
-) (map[string]debugserver.Dumper, func(ctx context.Context, repo api.RepoID, syncReason database.PermissionSyncJobReason) error)
+) (map[string]debugserver.Dumper, func(ctx context.Context, repo api.RepoID, syncReason database.PermissionsSyncJobReason) error)
 
 type LazyDebugserverEndpoint struct {
 	repoUpdaterStateEndpoint     http.HandlerFunc
@@ -157,7 +157,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// All dependencies ready
 	debugDumpers := make(map[string]debugserver.Dumper)
-	var enqueueRepoPerms func(context.Context, api.RepoID, database.PermissionSyncJobReason) error
+	var enqueueRepoPerms func(context.Context, api.RepoID, database.PermissionsSyncJobReason) error
 	if enterpriseInit != nil {
 		debugDumpers, enqueueRepoPerms = enterpriseInit(observationCtx, db, store, keyring.Default(), cf, server)
 	}
@@ -450,7 +450,7 @@ func watchSyncer(
 	logger log.Logger,
 	syncer *repos.Syncer,
 	sched *repos.UpdateScheduler,
-	enqueueRepoPermsJob func(ctx context.Context, repo api.RepoID, syncReason database.PermissionSyncJobReason) error,
+	enqueueRepoPermsJob func(ctx context.Context, repo api.RepoID, syncReason database.PermissionsSyncJobReason) error,
 	changesetSyncer batches.UnarchivedChangesetSyncRegistry,
 ) {
 	logger.Debug("started new repo syncer updates scheduler relay thread")

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs_test.go
@@ -24,7 +24,7 @@ func TestPermissionSyncJobsResolver(t *testing.T) {
 
 		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
 
-		resolver, err := NewPermissionSyncJobsResolver(db, graphqlbackend.ListPermissionSyncJobsArgs{ConnectionResolverArgs: args})
+		resolver, err := NewPermissionsSyncJobsResolver(db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
 		require.NoError(t, err)
 		jobs, err := resolver.Nodes(ctx)
 		require.NoError(t, err)
@@ -42,11 +42,11 @@ func TestPermissionSyncJobsResolver(t *testing.T) {
 		db.PermissionSyncJobsFunc.SetDefaultReturn(jobsStore)
 		db.ReposFunc.SetDefaultReturn(repoStore)
 
-		resolver, err := NewPermissionSyncJobsResolver(db, graphqlbackend.ListPermissionSyncJobsArgs{ConnectionResolverArgs: args})
+		resolver, err := NewPermissionsSyncJobsResolver(db, graphqlbackend.ListPermissionsSyncJobsArgs{ConnectionResolverArgs: args})
 		require.NoError(t, err)
 		jobs, err := resolver.Nodes(ctx)
 		require.NoError(t, err)
 		require.Len(t, jobs, 1)
-		require.Equal(t, marshalPermissionSyncJobID(1), jobs[0].ID())
+		require.Equal(t, marshalPermissionsSyncJobID(1), jobs[0].ID())
 	})
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -617,11 +617,11 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 	}, nil
 }
 
-func (r *Resolver) PermissionSyncJobs(ctx context.Context, args graphqlbackend.ListPermissionSyncJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionSyncJobResolver], error) {
+func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args graphqlbackend.ListPermissionsSyncJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsSyncJobResolver], error) {
 	// 🚨 SECURITY: Only site admins can query sync jobs records.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
-	return NewPermissionSyncJobsResolver(r.db, args)
+	return NewPermissionsSyncJobsResolver(r.db, args)
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1765,7 +1765,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 		r := &Resolver{db: db}
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := r.PermissionSyncJobs(ctx, graphqlbackend.ListPermissionSyncJobsArgs{})
+		result, err := r.PermissionsSyncJobs(ctx, graphqlbackend.ListPermissionsSyncJobsArgs{})
 
 		require.ErrorIs(t, err, auth.ErrMustBeSiteAdmin)
 		require.Nil(t, result)
@@ -1803,7 +1803,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			NumFailures:        0,
 			WorkerHostname:     "worker.hostname",
 			Cancel:             false,
-			Priority:           database.HighPriorityPermissionSync,
+			Priority:           database.HighPriorityPermissionsSync,
 			NoPerms:            false,
 			InvalidateCaches:   false,
 			PermissionsAdded:   1337,
@@ -1820,7 +1820,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			StartedAt:        queuedAt,
 			WorkerHostname:   "worker.hostname",
 			Cancel:           false,
-			Priority:         database.HighPriorityPermissionSync,
+			Priority:         database.HighPriorityPermissionsSync,
 			NoPerms:          false,
 			InvalidateCaches: false,
 			CodeHostStates:   []database.PermissionSyncCodeHostState{},
@@ -1849,7 +1849,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			Schema:  parsedSchema,
 			Query: `
 query {
-  permissionSyncJobs(first:2) {
+  permissionsSyncJobs(first:2) {
 	totalCount
 	pageInfo { hasNextPage }
     nodes {
@@ -1894,10 +1894,10 @@ query {
 					`,
 			ExpectedResult: `
 {
-	"permissionSyncJobs": {
+	"permissionsSyncJobs": {
 		"nodes": [
 			{
-				"id": "UGVybWlzc2lvblN5bmNKb2I6Mw==",
+				"id": "UGVybWlzc2lvbnNTeW5jSm9iOjM=",
 				"state": "COMPLETED",
 				"failureMessage": null,
 				"reason": {
@@ -1930,7 +1930,7 @@ query {
 				"codeHostStates": []
 			},
 			{
-				"id": "UGVybWlzc2lvblN5bmNKb2I6NA==",
+				"id": "UGVybWlzc2lvbnNTeW5jSm9iOjQ=",
 				"state": "QUEUED",
 				"failureMessage": null,
 				"reason": {

--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -93,7 +93,7 @@ func (h *GitHubWebhook) handleRepositoryEvent(ctx context.Context, db database.D
 
 func (h *GitHubWebhook) handleMemberEvent(ctx context.Context, db database.DB, e *gh.MemberEvent, codeHostURN extsvc.CodeHostBaseURL) error {
 	action := e.GetAction()
-	var reason database.PermissionSyncJobReason
+	var reason database.PermissionsSyncJobReason
 	if action == "added" {
 		reason = database.ReasonGitHubUserAddedEvent
 	} else if action == "removed" {
@@ -109,7 +109,7 @@ func (h *GitHubWebhook) handleMemberEvent(ctx context.Context, db database.DB, e
 
 func (h *GitHubWebhook) handleOrganizationEvent(ctx context.Context, db database.DB, e *gh.OrganizationEvent, codeHostURN extsvc.CodeHostBaseURL) error {
 	action := e.GetAction()
-	var reason database.PermissionSyncJobReason
+	var reason database.PermissionsSyncJobReason
 	if action == "member_added" {
 		reason = database.ReasonGitHubOrgMemberAddedEvent
 	} else if action == "member_removed" {
@@ -125,7 +125,7 @@ func (h *GitHubWebhook) handleOrganizationEvent(ctx context.Context, db database
 
 func (h *GitHubWebhook) handleMembershipEvent(ctx context.Context, db database.DB, e *gh.MembershipEvent, codeHostURN extsvc.CodeHostBaseURL) error {
 	action := e.GetAction()
-	var reason database.PermissionSyncJobReason
+	var reason database.PermissionsSyncJobReason
 	if action == "added" {
 		reason = database.ReasonGitHubUserMembershipAddedEvent
 	} else if action == "removed" {
@@ -140,7 +140,7 @@ func (h *GitHubWebhook) handleMembershipEvent(ctx context.Context, db database.D
 
 func (h *GitHubWebhook) handleTeamEvent(ctx context.Context, e *gh.TeamEvent, db database.DB) error {
 	action := e.GetAction()
-	var reason database.PermissionSyncJobReason
+	var reason database.PermissionsSyncJobReason
 	if action == "added_to_repository" {
 		reason = database.ReasonGitHubTeamAddedToRepoEvent
 	} else if action == "removed_from_repository" {
@@ -152,7 +152,7 @@ func (h *GitHubWebhook) handleTeamEvent(ctx context.Context, e *gh.TeamEvent, db
 	return h.getRepoAndSyncPerms(ctx, db, e, reason)
 }
 
-func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB, user *gh.User, codeHostURN extsvc.CodeHostBaseURL, reason database.PermissionSyncJobReason) error {
+func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB, user *gh.User, codeHostURN extsvc.CodeHostBaseURL, reason database.PermissionsSyncJobReason) error {
 	externalAccounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
 		ServiceID:      codeHostURN.String(),
 		AccountID:      strconv.Itoa(int(user.GetID())),
@@ -175,7 +175,7 @@ func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB,
 	return err
 }
 
-func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB, e interface{ GetRepo() *gh.Repository }, reason database.PermissionSyncJobReason) error {
+func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB, e interface{ GetRepo() *gh.Repository }, reason database.PermissionsSyncJobReason) error {
 	ghRepo := e.GetRepo()
 
 	repo, err := db.Repos().GetFirstRepoByCloneURL(ctx, strings.TrimSuffix(ghRepo.GetCloneURL(), ".git"))

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_cleaner_test.go
@@ -71,7 +71,7 @@ func TestPermsSyncerWorkerCleaner(t *testing.T) {
 	cleanedJobsNumber, err = cleanJobs(ctx, db)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), cleanedJobsNumber)
-	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionSyncJobStateErrored)
+	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionsSyncJobStateErrored)
 
 	// Now let's make the history even shorter.
 	historySize = 0
@@ -79,8 +79,8 @@ func TestPermsSyncerWorkerCleaner(t *testing.T) {
 	cleanedJobsNumber, err = cleanJobs(ctx, db)
 	require.NoError(t, err)
 	require.Equal(t, int64(8), cleanedJobsNumber)
-	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionSyncJobStateFailed)
-	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionSyncJobStateCompleted)
+	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionsSyncJobStateFailed)
+	assertThereAreNoJobsWithState(t, ctx, store, database.PermissionsSyncJobStateCompleted)
 
 	// This way we should only have "queued" and "processing" jobs, let's check the
 	// number, we should have 8 now.
@@ -95,12 +95,12 @@ func TestPermsSyncerWorkerCleaner(t *testing.T) {
 	require.Equal(t, int64(0), cleanedJobsNumber)
 }
 
-var states = []database.PermissionSyncJobState{
-	database.PermissionSyncJobStateQueued,
-	database.PermissionSyncJobStateProcessing,
-	database.PermissionSyncJobStateErrored,
-	database.PermissionSyncJobStateFailed,
-	database.PermissionSyncJobStateCompleted,
+var states = []database.PermissionsSyncJobState{
+	database.PermissionsSyncJobStateQueued,
+	database.PermissionsSyncJobStateProcessing,
+	database.PermissionsSyncJobStateErrored,
+	database.PermissionsSyncJobStateFailed,
+	database.PermissionsSyncJobStateCompleted,
 }
 
 func addSyncJobs(t *testing.T, ctx context.Context, db database.DB, repoOrUser string, id int) {
@@ -117,20 +117,20 @@ func addSyncJobs(t *testing.T, ctx context.Context, db database.DB, repoOrUser s
 // Time is mapped to status, from oldest to newest: errored->failed->completed.
 //
 // Queued and processing jobs doesn't have a `finished_at` value, hence NULL.
-func getFinishedAt(state database.PermissionSyncJobState) string {
+func getFinishedAt(state database.PermissionsSyncJobState) string {
 	switch state {
-	case database.PermissionSyncJobStateErrored:
+	case database.PermissionsSyncJobStateErrored:
 		return "NOW() - INTERVAL '5 HOURS'"
-	case database.PermissionSyncJobStateFailed:
+	case database.PermissionsSyncJobStateFailed:
 		return "NOW() - INTERVAL '2 HOURS'"
-	case database.PermissionSyncJobStateCompleted:
+	case database.PermissionsSyncJobStateCompleted:
 		return "NOW() - INTERVAL '1 HOUR'"
 	default:
 		return "NULL"
 	}
 }
 
-func assertThereAreNoJobsWithState(t *testing.T, ctx context.Context, store database.PermissionSyncJobStore, state database.PermissionSyncJobState) {
+func assertThereAreNoJobsWithState(t *testing.T, ctx context.Context, store database.PermissionSyncJobStore, state database.PermissionsSyncJobState) {
 	t.Helper()
 	allSyncJobs, err := store.List(ctx, database.ListPermissionSyncJobOpts{})
 	require.NoError(t, err)

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -137,16 +137,16 @@ type schedule struct {
 
 // scheduledUser contains information for scheduling a user.
 type scheduledUser struct {
-	reason   database.PermissionSyncJobReason
-	priority database.PermissionSyncJobPriority
+	reason   database.PermissionsSyncJobReason
+	priority database.PermissionsSyncJobPriority
 	userID   int32
 	noPerms  bool
 }
 
 // scheduledRepo contains for scheduling a repository.
 type scheduledRepo struct {
-	reason   database.PermissionSyncJobReason
-	priority database.PermissionSyncJobPriority
+	reason   database.PermissionsSyncJobReason
+	priority database.PermissionsSyncJobPriority
 	repoID   api.RepoID
 	noPerms  bool
 }
@@ -201,7 +201,7 @@ func scheduleUsersWithNoPerms(ctx context.Context, store edb.PermsStore) ([]sche
 		users[i] = scheduledUser{
 			userID:   id,
 			reason:   database.ReasonUserNoPermissions,
-			priority: database.MediumPriorityPermissionSync,
+			priority: database.MediumPriorityPermissionsSync,
 			noPerms:  true,
 		}
 	}
@@ -221,7 +221,7 @@ func scheduleReposWithNoPerms(ctx context.Context, store edb.PermsStore) ([]sche
 		repositories[i] = scheduledRepo{
 			repoID:   id,
 			reason:   database.ReasonRepoNoPermissions,
-			priority: database.MediumPriorityPermissionSync,
+			priority: database.MediumPriorityPermissionsSync,
 			noPerms:  true,
 		}
 	}
@@ -241,7 +241,7 @@ func scheduleUsersWithOldestPerms(ctx context.Context, store edb.PermsStore, lim
 		users = append(users, scheduledUser{
 			userID:   id,
 			reason:   database.ReasonUserOutdatedPermissions,
-			priority: database.LowPriorityPermissionSync,
+			priority: database.LowPriorityPermissionsSync,
 		})
 	}
 	return users, nil
@@ -260,7 +260,7 @@ func scheduleReposWithOldestPerms(ctx context.Context, store edb.PermsStore, lim
 		repositories = append(repositories, scheduledRepo{
 			repoID:   id,
 			reason:   database.ReasonRepoOutdatedPermissions,
-			priority: database.LowPriorityPermissionSync,
+			priority: database.LowPriorityPermissionsSync,
 		})
 	}
 	return repositories, nil

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -62,14 +62,14 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 			UserID:       int(user1.ID),
 			RepositoryID: 0,
 			Reason:       database.ReasonUserNoPermissions,
-			Priority:     database.MediumPriorityPermissionSync,
+			Priority:     database.MediumPriorityPermissionsSync,
 			NoPerms:      true,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo1.ID),
 			Reason:       database.ReasonRepoNoPermissions,
-			Priority:     database.MediumPriorityPermissionSync,
+			Priority:     database.MediumPriorityPermissionsSync,
 			NoPerms:      true,
 		},
 	}
@@ -101,27 +101,27 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 			UserID:       int(user1.ID),
 			RepositoryID: 0,
 			Reason:       database.ReasonUserNoPermissions,
-			Priority:     database.MediumPriorityPermissionSync,
+			Priority:     database.MediumPriorityPermissionsSync,
 			NoPerms:      true,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo1.ID),
 			Reason:       database.ReasonRepoNoPermissions,
-			Priority:     database.MediumPriorityPermissionSync,
+			Priority:     database.MediumPriorityPermissionsSync,
 			NoPerms:      true,
 		},
 		{
 			UserID:       int(user2.ID),
 			RepositoryID: 0,
 			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo2.ID),
 			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 	}
 	runJobsTest(t, ctx, logger, db, store, wantJobs)
@@ -136,36 +136,36 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 			UserID:       int(user2.ID),
 			RepositoryID: 0,
 			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo2.ID),
 			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 		{
 			UserID:       int(user1.ID),
 			RepositoryID: 0,
 			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 		{
 			UserID:       0,
 			RepositoryID: int(repo1.ID),
 			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionSync,
+			Priority:     database.LowPriorityPermissionsSync,
 		},
 	}
 	runJobsTest(t, ctx, logger, db, store, wantJobs)
 }
 
 type testJob struct {
-	Reason       database.PermissionSyncJobReason
+	Reason       database.PermissionsSyncJobReason
 	ProcessAfter time.Time
 	RepositoryID int
 	UserID       int
-	Priority     database.PermissionSyncJobPriority
+	Priority     database.PermissionsSyncJobPriority
 	NoPerms      bool
 }
 
@@ -174,7 +174,7 @@ func runJobsTest(t *testing.T, ctx context.Context, logger log.Logger, db databa
 	require.NoError(t, err)
 	require.Equal(t, len(wantJobs), count)
 
-	jobs, err := store.List(ctx, database.ListPermissionSyncJobOpts{State: database.PermissionSyncJobStateQueued})
+	jobs, err := store.List(ctx, database.ListPermissionSyncJobOpts{State: database.PermissionsSyncJobStateQueued})
 	require.NoError(t, err)
 	require.Len(t, jobs, len(wantJobs))
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
@@ -26,9 +26,9 @@ const (
 )
 
 func MakePermsSyncerWorker(observationCtx *observation.Context, syncer permsSyncer, syncType syncType, jobsStore database.PermissionSyncJobStore) *permsSyncerWorker {
-	logger := observationCtx.Logger.Scoped("RepoPermsSyncerWorkerRepo", "Repository permission sync worker")
+	logger := observationCtx.Logger.Scoped("RepoPermsSyncerWorkerRepo", "Repository permissions sync worker")
 	if syncType == SyncTypeUser {
-		logger = observationCtx.Logger.Scoped("UserPermsSyncerWorker", "User permission sync worker")
+		logger = observationCtx.Logger.Scoped("UserPermsSyncerWorker", "User permissions sync worker")
 	}
 	return &permsSyncerWorker{
 		logger:    logger,
@@ -70,7 +70,7 @@ func (h *permsSyncerWorker) Handle(ctx context.Context, _ log.Logger, record *da
 	}
 
 	h.logger.Debug(
-		"Handling permission sync job",
+		"Handling permissions sync job",
 		log.String("type", reqType.String()),
 		log.Int32("id", reqID),
 		log.Int("priority", int(record.Priority)),
@@ -116,9 +116,9 @@ func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType request
 }
 
 func MakeStore(observationCtx *observation.Context, dbHandle basestore.TransactableHandle, syncType syncType) dbworkerstore.Store[*database.PermissionSyncJob] {
-	name := "repo_permission_sync_job_worker_store"
+	name := "repo_permissions_sync_job_worker_store"
 	if syncType == SyncTypeUser {
-		name = "user_permission_sync_job_worker_store"
+		name = "user_permissions_sync_job_worker_store"
 	}
 
 	return dbworkerstore.New(observationCtx, dbHandle, dbworkerstore.Options[*database.PermissionSyncJob]{
@@ -140,9 +140,9 @@ func MakeWorker(ctx context.Context, observationCtx *observation.Context, worker
 	handler := MakePermsSyncerWorker(observationCtx, permsSyncer, syncType, jobsStore)
 	// Number of handlers depends on a type of perms sync jobs this worker processes.
 	numHandlers := 1
-	name := "repo_permission_sync_job_worker"
+	name := "repo_permissions_sync_job_worker"
 	if syncType == SyncTypeUser {
-		name = "user_permission_sync_job_worker"
+		name = "user_permissions_sync_job_worker"
 		numHandlers = syncUsersMaxConcurrency()
 	}
 
@@ -157,8 +157,8 @@ func MakeWorker(ctx context.Context, observationCtx *observation.Context, worker
 
 func MakeResetter(observationCtx *observation.Context, workerStore dbworkerstore.Store[*database.PermissionSyncJob]) *dbworker.Resetter[*database.PermissionSyncJob] {
 	return dbworker.NewResetter(observationCtx.Logger, workerStore, dbworker.ResetterOptions{
-		Name:     "permission_sync_job_worker_resetter",
+		Name:     "permissions_sync_job_worker_resetter",
 		Interval: time.Second * 30, // Check for orphaned jobs every 30 seconds
-		Metrics:  dbworker.NewResetterMetrics(observationCtx, "permission_sync_job_worker"),
+		Metrics:  dbworker.NewResetterMetrics(observationCtx, "permissions_sync_job_worker"),
 	})
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
@@ -35,7 +35,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 			ID:               99,
 			UserID:           1234,
 			InvalidateCaches: true,
-			Priority:         database.HighPriorityPermissionSync,
+			Priority:         database.HighPriorityPermissionsSync,
 			NoPerms:          true,
 		})
 
@@ -57,7 +57,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 			ID:               777,
 			RepositoryID:     4567,
 			InvalidateCaches: false,
-			Priority:         database.LowPriorityPermissionSync,
+			Priority:         database.LowPriorityPermissionsSync,
 		})
 
 		wantRequest := combinedRequest{
@@ -105,18 +105,18 @@ func TestPermsSyncerWorker_RepoSyncJobs(t *testing.T) {
 	t.Cleanup(worker.Stop)
 
 	// Adding repo perms sync jobs.
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(2), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(2), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(3), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(3), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Adding user perms sync job, which should not be processed by current worker!
 	err = syncJobsStore.CreateUserSyncJob(ctx, user2.ID,
-		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
+		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, Priority: database.HighPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Wait for all jobs to be processed.
@@ -131,7 +131,7 @@ loop:
 		for _, job := range jobs {
 			// We don't check job with ID=4 because it is a user sync job which is not
 			// processed by current worker.
-			if job.ID != 4 && (job.State == database.PermissionSyncJobStateQueued || job.State == database.PermissionSyncJobStateProcessing) {
+			if job.ID != 4 && (job.State == database.PermissionsSyncJobStateQueued || job.State == database.PermissionsSyncJobStateProcessing) {
 				// wait and retry
 				time.Sleep(500 * time.Millisecond)
 				continue loop
@@ -172,7 +172,7 @@ loop:
 
 		// Check that repo sync job was completed and results were saved.
 		if jobID == 2 {
-			require.Equal(t, database.PermissionSyncJobStateCompleted, job.State)
+			require.Equal(t, database.PermissionsSyncJobStateCompleted, job.State)
 			require.Nil(t, job.FailureMessage)
 			require.Equal(t, 1, job.PermissionsAdded)
 			require.Equal(t, 2, job.PermissionsRemoved)
@@ -191,7 +191,7 @@ loop:
 
 		// Check that user sync job wasn't picked up by repo sync worker.
 		if jobID == 4 {
-			require.Equal(t, database.PermissionSyncJobStateQueued, job.State)
+			require.Equal(t, database.PermissionsSyncJobStateQueued, job.State)
 			require.Nil(t, job.FailureMessage)
 			require.Equal(t, 0, job.PermissionsAdded)
 			require.Equal(t, 0, job.PermissionsRemoved)
@@ -235,19 +235,19 @@ func TestPermsSyncerWorker_UserSyncJobs(t *testing.T) {
 
 	// Adding user perms sync jobs.
 	err = syncJobsStore.CreateUserSyncJob(ctx, user1.ID,
-		database.PermissionSyncJobOpts{Reason: database.ReasonUserOutdatedPermissions, Priority: database.LowPriorityPermissionSync})
+		database.PermissionSyncJobOpts{Reason: database.ReasonUserOutdatedPermissions, Priority: database.LowPriorityPermissionsSync})
 	require.NoError(t, err)
 
 	err = syncJobsStore.CreateUserSyncJob(ctx, user2.ID,
-		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, NoPerms: true, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
+		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, NoPerms: true, Priority: database.HighPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	err = syncJobsStore.CreateUserSyncJob(ctx, user3.ID,
-		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, NoPerms: true, Priority: database.HighPriorityPermissionSync, TriggeredByUserID: user1.ID})
+		database.PermissionSyncJobOpts{Reason: database.ReasonRepoNoPermissions, NoPerms: true, Priority: database.HighPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Adding repo perms sync job, which should not be processed by current worker!
-	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionSync, TriggeredByUserID: user1.ID})
+	err = syncJobsStore.CreateRepoSyncJob(ctx, api.RepoID(1), database.PermissionSyncJobOpts{Reason: database.ReasonManualRepoSync, Priority: database.MediumPriorityPermissionsSync, TriggeredByUserID: user1.ID})
 	require.NoError(t, err)
 
 	// Wait for all jobs to be processed.
@@ -262,7 +262,7 @@ loop:
 		for _, job := range jobs {
 			// We don't check job with ID=3 because it is a repo sync job which is not
 			// processed by current worker.
-			if job.ID != 4 && (job.State == database.PermissionSyncJobStateQueued || job.State == database.PermissionSyncJobStateProcessing) {
+			if job.ID != 4 && (job.State == database.PermissionsSyncJobStateQueued || job.State == database.PermissionsSyncJobStateProcessing) {
 				// wait and retry
 				time.Sleep(500 * time.Millisecond)
 				continue loop
@@ -302,7 +302,7 @@ loop:
 		}
 
 		if jobID == 2 {
-			require.Equal(t, database.PermissionSyncJobStateCompleted, job.State)
+			require.Equal(t, database.PermissionsSyncJobStateCompleted, job.State)
 			require.Nil(t, job.FailureMessage)
 			require.Equal(t, 1, job.PermissionsAdded)
 			require.Equal(t, 2, job.PermissionsRemoved)
@@ -322,7 +322,7 @@ loop:
 
 		// Check that repo sync job wasn't picked up by user sync worker.
 		if jobID == 4 {
-			require.Equal(t, database.PermissionSyncJobStateQueued, job.State)
+			require.Equal(t, database.PermissionsSyncJobStateQueued, job.State)
 			require.Nil(t, job.FailureMessage)
 			require.Equal(t, 0, job.PermissionsAdded)
 			require.Equal(t, 0, job.PermissionsRemoved)

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -36,7 +36,7 @@ func EnterpriseInit(
 	keyring keyring.Ring,
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
-) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID, ossDB.PermissionSyncJobReason) error) {
+) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID, ossDB.PermissionsSyncJobReason) error) {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		observationCtx.Logger.Info("enterprise edition")
@@ -58,14 +58,14 @@ func EnterpriseInit(
 	permsSyncer := authz.NewPermsSyncer(observationCtx.Logger.Scoped("PermsSyncer", "repository and user permissions syncer"), db, repoStore, permsStore, timeutil.Now, ratelimit.DefaultRegistry)
 
 	permsJobStore := db.PermissionSyncJobs()
-	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason ossDB.PermissionSyncJobReason) error {
+	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason ossDB.PermissionsSyncJobReason) error {
 		if authz.PermissionSyncingDisabled() {
 			return nil
 		}
 
 		// If the feature flag is enabled, create job...
 		if permssync.PermissionSyncWorkerEnabled(ctx, db, observationCtx.Logger) {
-			opts := ossDB.PermissionSyncJobOpts{Priority: ossDB.HighPriorityPermissionSync, Reason: reason}
+			opts := ossDB.PermissionSyncJobOpts{Priority: ossDB.HighPriorityPermissionsSync, Reason: reason}
 			return permsJobStore.CreateRepoSyncJob(ctx, repo, opts)
 		}
 		// ... otherwise, we just call the PermsSyncer

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -49,7 +49,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 	if PermissionSyncWorkerEnabled(ctx, db, logger) {
 		for _, userID := range req.UserIDs {
 			opts := database.PermissionSyncJobOpts{
-				Priority:          database.HighPriorityPermissionSync,
+				Priority:          database.HighPriorityPermissionsSync,
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
@@ -63,7 +63,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 
 		for _, repoID := range req.RepoIDs {
 			opts := database.PermissionSyncJobOpts{
-				Priority:          database.HighPriorityPermissionSync,
+				Priority:          database.HighPriorityPermissionsSync,
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -23,64 +23,64 @@ import (
 
 const CancellationReasonHigherPriority = "A job with higher priority was added."
 
-type PermissionSyncJobState string
+type PermissionsSyncJobState string
 
-// PermissionSyncJobState constants.
+// PermissionsSyncJobState constants.
 const (
-	PermissionSyncJobStateQueued     PermissionSyncJobState = "queued"
-	PermissionSyncJobStateProcessing PermissionSyncJobState = "processing"
-	PermissionSyncJobStateErrored    PermissionSyncJobState = "errored"
-	PermissionSyncJobStateFailed     PermissionSyncJobState = "failed"
-	PermissionSyncJobStateCompleted  PermissionSyncJobState = "completed"
+	PermissionsSyncJobStateQueued     PermissionsSyncJobState = "queued"
+	PermissionsSyncJobStateProcessing PermissionsSyncJobState = "processing"
+	PermissionsSyncJobStateErrored    PermissionsSyncJobState = "errored"
+	PermissionsSyncJobStateFailed     PermissionsSyncJobState = "failed"
+	PermissionsSyncJobStateCompleted  PermissionsSyncJobState = "completed"
 )
 
 // ToGraphQL returns the GraphQL representation of the worker state.
-func (s PermissionSyncJobState) ToGraphQL() string { return strings.ToUpper(string(s)) }
+func (s PermissionsSyncJobState) ToGraphQL() string { return strings.ToUpper(string(s)) }
 
-type PermissionSyncJobPriority int
+type PermissionsSyncJobPriority int
 
 const (
-	LowPriorityPermissionSync    PermissionSyncJobPriority = 0
-	MediumPriorityPermissionSync PermissionSyncJobPriority = 5
-	HighPriorityPermissionSync   PermissionSyncJobPriority = 10
+	LowPriorityPermissionsSync    PermissionsSyncJobPriority = 0
+	MediumPriorityPermissionsSync PermissionsSyncJobPriority = 5
+	HighPriorityPermissionsSync   PermissionsSyncJobPriority = 10
 )
 
-func (p PermissionSyncJobPriority) ToString() string {
+func (p PermissionsSyncJobPriority) ToString() string {
 	switch p {
-	case HighPriorityPermissionSync:
+	case HighPriorityPermissionsSync:
 		return "HIGH"
-	case MediumPriorityPermissionSync:
+	case MediumPriorityPermissionsSync:
 		return "MEDIUM"
-	case LowPriorityPermissionSync:
+	case LowPriorityPermissionsSync:
 		fallthrough
 	default:
 		return "LOW"
 	}
 }
 
-// PermissionSyncJobReasonGroup combines multiple permission sync job trigger
+// PermissionsSyncJobReasonGroup combines multiple permission sync job trigger
 // reasons into groups with similar grounds.
-type PermissionSyncJobReasonGroup string
+type PermissionsSyncJobReasonGroup string
 
-// PermissionSyncJobReasonGroup constants.
+// PermissionsSyncJobReasonGroup constants.
 const (
-	PermissionSyncJobReasonGroupManual      PermissionSyncJobReasonGroup = "MANUAL"
-	PermissionSyncJobReasonGroupWebhook     PermissionSyncJobReasonGroup = "WEBHOOK"
-	PermissionSyncJobReasonGroupSchedule    PermissionSyncJobReasonGroup = "SCHEDULE"
-	PermissionSyncJobReasonGroupSourcegraph PermissionSyncJobReasonGroup = "SOURCEGRAPH"
-	PermissionSyncJobReasonGroupUnknown     PermissionSyncJobReasonGroup = "UNKNOWN"
+	PermissionsSyncJobReasonGroupManual      PermissionsSyncJobReasonGroup = "MANUAL"
+	PermissionsSyncJobReasonGroupWebhook     PermissionsSyncJobReasonGroup = "WEBHOOK"
+	PermissionsSyncJobReasonGroupSchedule    PermissionsSyncJobReasonGroup = "SCHEDULE"
+	PermissionsSyncJobReasonGroupSourcegraph PermissionsSyncJobReasonGroup = "SOURCEGRAPH"
+	PermissionsSyncJobReasonGroupUnknown     PermissionsSyncJobReasonGroup = "UNKNOWN"
 )
 
-type PermissionSyncJobReason string
+type PermissionsSyncJobReason string
 
-// ResolveGroup returns a PermissionSyncJobReasonGroup for a given
-// PermissionSyncJobReason or PermissionSyncJobReasonGroupUnknown if the reason
+// ResolveGroup returns a PermissionsSyncJobReasonGroup for a given
+// PermissionsSyncJobReason or PermissionsSyncJobReasonGroupUnknown if the reason
 // doesn't belong to any of groups.
-func (r PermissionSyncJobReason) ResolveGroup() PermissionSyncJobReasonGroup {
+func (r PermissionsSyncJobReason) ResolveGroup() PermissionsSyncJobReasonGroup {
 	switch r {
 	case ReasonManualRepoSync,
 		ReasonManualUserSync:
-		return PermissionSyncJobReasonGroupManual
+		return PermissionsSyncJobReasonGroupManual
 	case ReasonGitHubUserEvent,
 		ReasonGitHubUserAddedEvent,
 		ReasonGitHubUserRemovedEvent,
@@ -92,66 +92,66 @@ func (r PermissionSyncJobReason) ResolveGroup() PermissionSyncJobReasonGroup {
 		ReasonGitHubOrgMemberRemovedEvent,
 		ReasonGitHubRepoEvent,
 		ReasonGitHubRepoMadePrivateEvent:
-		return PermissionSyncJobReasonGroupWebhook
+		return PermissionsSyncJobReasonGroupWebhook
 	case ReasonUserOutdatedPermissions,
 		ReasonUserNoPermissions,
 		ReasonRepoOutdatedPermissions,
 		ReasonRepoNoPermissions,
 		ReasonRepoUpdatedFromCodeHost:
-		return PermissionSyncJobReasonGroupSchedule
+		return PermissionsSyncJobReasonGroupSchedule
 	case ReasonUserEmailRemoved,
 		ReasonUserEmailVerified,
 		ReasonUserAddedToOrg,
 		ReasonUserRemovedFromOrg,
 		ReasonUserAcceptedOrgInvite:
-		return PermissionSyncJobReasonGroupSourcegraph
+		return PermissionsSyncJobReasonGroupSourcegraph
 	default:
-		return PermissionSyncJobReasonGroupUnknown
+		return PermissionsSyncJobReasonGroupUnknown
 	}
 }
 
 const (
 	// ReasonUserOutdatedPermissions and below are reasons of scheduled permission
 	// syncs.
-	ReasonUserOutdatedPermissions PermissionSyncJobReason = "REASON_USER_OUTDATED_PERMS"
-	ReasonUserNoPermissions       PermissionSyncJobReason = "REASON_USER_NO_PERMS"
-	ReasonRepoOutdatedPermissions PermissionSyncJobReason = "REASON_REPO_OUTDATED_PERMS"
-	ReasonRepoNoPermissions       PermissionSyncJobReason = "REASON_REPO_NO_PERMS"
-	ReasonRepoUpdatedFromCodeHost PermissionSyncJobReason = "REASON_REPO_UPDATED_FROM_CODE_HOST"
+	ReasonUserOutdatedPermissions PermissionsSyncJobReason = "REASON_USER_OUTDATED_PERMS"
+	ReasonUserNoPermissions       PermissionsSyncJobReason = "REASON_USER_NO_PERMS"
+	ReasonRepoOutdatedPermissions PermissionsSyncJobReason = "REASON_REPO_OUTDATED_PERMS"
+	ReasonRepoNoPermissions       PermissionsSyncJobReason = "REASON_REPO_NO_PERMS"
+	ReasonRepoUpdatedFromCodeHost PermissionsSyncJobReason = "REASON_REPO_UPDATED_FROM_CODE_HOST"
 
 	// ReasonUserEmailRemoved and below are reasons of permission syncs scheduled due
 	// to Sourcegraph internal events.
-	ReasonUserEmailRemoved      PermissionSyncJobReason = "REASON_USER_EMAIL_REMOVED"
-	ReasonUserEmailVerified     PermissionSyncJobReason = "REASON_USER_EMAIL_VERIFIED"
-	ReasonUserAddedToOrg        PermissionSyncJobReason = "REASON_USER_ADDED_TO_ORG"
-	ReasonUserRemovedFromOrg    PermissionSyncJobReason = "REASON_USER_REMOVED_FROM_ORG"
-	ReasonUserAcceptedOrgInvite PermissionSyncJobReason = "REASON_USER_ACCEPTED_ORG_INVITE"
+	ReasonUserEmailRemoved      PermissionsSyncJobReason = "REASON_USER_EMAIL_REMOVED"
+	ReasonUserEmailVerified     PermissionsSyncJobReason = "REASON_USER_EMAIL_VERIFIED"
+	ReasonUserAddedToOrg        PermissionsSyncJobReason = "REASON_USER_ADDED_TO_ORG"
+	ReasonUserRemovedFromOrg    PermissionsSyncJobReason = "REASON_USER_REMOVED_FROM_ORG"
+	ReasonUserAcceptedOrgInvite PermissionsSyncJobReason = "REASON_USER_ACCEPTED_ORG_INVITE"
 
 	// ReasonGitHubUserEvent and below are reasons of permission syncs triggered by
 	// webhook events.
-	ReasonGitHubUserEvent                  PermissionSyncJobReason = "REASON_GITHUB_USER_EVENT"
-	ReasonGitHubUserAddedEvent             PermissionSyncJobReason = "REASON_GITHUB_USER_ADDED_EVENT"
-	ReasonGitHubUserRemovedEvent           PermissionSyncJobReason = "REASON_GITHUB_USER_REMOVED_EVENT"
-	ReasonGitHubUserMembershipAddedEvent   PermissionSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_ADDED_EVENT"
-	ReasonGitHubUserMembershipRemovedEvent PermissionSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_REMOVED_EVENT"
-	ReasonGitHubTeamAddedToRepoEvent       PermissionSyncJobReason = "REASON_GITHUB_TEAM_ADDED_TO_REPO_EVENT"
-	ReasonGitHubTeamRemovedFromRepoEvent   PermissionSyncJobReason = "REASON_GITHUB_TEAM_REMOVED_FROM_REPO_EVENT"
-	ReasonGitHubOrgMemberAddedEvent        PermissionSyncJobReason = "REASON_GITHUB_ORG_MEMBER_ADDED_EVENT"
-	ReasonGitHubOrgMemberRemovedEvent      PermissionSyncJobReason = "REASON_GITHUB_ORG_MEMBER_REMOVED_EVENT"
-	ReasonGitHubRepoEvent                  PermissionSyncJobReason = "REASON_GITHUB_REPO_EVENT"
-	ReasonGitHubRepoMadePrivateEvent       PermissionSyncJobReason = "REASON_GITHUB_REPO_MADE_PRIVATE_EVENT"
+	ReasonGitHubUserEvent                  PermissionsSyncJobReason = "REASON_GITHUB_USER_EVENT"
+	ReasonGitHubUserAddedEvent             PermissionsSyncJobReason = "REASON_GITHUB_USER_ADDED_EVENT"
+	ReasonGitHubUserRemovedEvent           PermissionsSyncJobReason = "REASON_GITHUB_USER_REMOVED_EVENT"
+	ReasonGitHubUserMembershipAddedEvent   PermissionsSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_ADDED_EVENT"
+	ReasonGitHubUserMembershipRemovedEvent PermissionsSyncJobReason = "REASON_GITHUB_USER_MEMBERSHIP_REMOVED_EVENT"
+	ReasonGitHubTeamAddedToRepoEvent       PermissionsSyncJobReason = "REASON_GITHUB_TEAM_ADDED_TO_REPO_EVENT"
+	ReasonGitHubTeamRemovedFromRepoEvent   PermissionsSyncJobReason = "REASON_GITHUB_TEAM_REMOVED_FROM_REPO_EVENT"
+	ReasonGitHubOrgMemberAddedEvent        PermissionsSyncJobReason = "REASON_GITHUB_ORG_MEMBER_ADDED_EVENT"
+	ReasonGitHubOrgMemberRemovedEvent      PermissionsSyncJobReason = "REASON_GITHUB_ORG_MEMBER_REMOVED_EVENT"
+	ReasonGitHubRepoEvent                  PermissionsSyncJobReason = "REASON_GITHUB_REPO_EVENT"
+	ReasonGitHubRepoMadePrivateEvent       PermissionsSyncJobReason = "REASON_GITHUB_REPO_MADE_PRIVATE_EVENT"
 
 	// ReasonManualRepoSync and below are reasons of permission syncs triggered
 	// manually.
-	ReasonManualRepoSync PermissionSyncJobReason = "REASON_MANUAL_REPO_SYNC"
-	ReasonManualUserSync PermissionSyncJobReason = "REASON_MANUAL_USER_SYNC"
+	ReasonManualRepoSync PermissionsSyncJobReason = "REASON_MANUAL_REPO_SYNC"
+	ReasonManualUserSync PermissionsSyncJobReason = "REASON_MANUAL_USER_SYNC"
 )
 
 type PermissionSyncJobOpts struct {
-	Priority          PermissionSyncJobPriority
+	Priority          PermissionsSyncJobPriority
 	InvalidateCaches  bool
 	ProcessAfter      time.Time
-	Reason            PermissionSyncJobReason
+	Reason            PermissionsSyncJobReason
 	TriggeredByUserID int32
 	NoPerms           bool
 }
@@ -302,7 +302,7 @@ func (s *permissionSyncJobStore) checkDuplicateAndCreateSyncJob(ctx context.Cont
 	defer func() {
 		err = tx.Done(err)
 	}()
-	opts := ListPermissionSyncJobOpts{UserID: job.UserID, RepoID: job.RepositoryID, State: PermissionSyncJobStateQueued, NotCanceled: true, NullProcessAfter: true}
+	opts := ListPermissionSyncJobOpts{UserID: job.UserID, RepoID: job.RepositoryID, State: PermissionsSyncJobStateQueued, NotCanceled: true, NullProcessAfter: true}
 	syncJobs, err := tx.List(ctx, opts)
 	if err != nil {
 		return err
@@ -389,8 +389,8 @@ type ListPermissionSyncJobOpts struct {
 	ID                  int
 	UserID              int
 	RepoID              int
-	Reason              PermissionSyncJobReason
-	State               PermissionSyncJobState
+	Reason              PermissionsSyncJobReason
+	State               PermissionsSyncJobState
 	NullProcessAfter    bool
 	NotNullProcessAfter bool
 	NotCanceled         bool
@@ -497,9 +497,9 @@ func (s *permissionSyncJobStore) Count(ctx context.Context) (int, error) {
 
 type PermissionSyncJob struct {
 	ID                 int
-	State              PermissionSyncJobState
+	State              PermissionsSyncJobState
 	FailureMessage     *string
-	Reason             PermissionSyncJobReason
+	Reason             PermissionsSyncJobReason
 	CancellationReason *string
 	TriggeredByUserID  int32
 	QueuedAt           time.Time
@@ -516,7 +516,7 @@ type PermissionSyncJob struct {
 	RepositoryID int
 	UserID       int
 
-	Priority         PermissionSyncJobPriority
+	Priority         PermissionsSyncJobPriority
 	NoPerms          bool
 	InvalidateCaches bool
 

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -49,17 +49,17 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobs, 0, "jobs returned even though database is empty")
 
-	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, InvalidateCaches: true, Reason: ReasonUserNoPermissions, NoPerms: true, TriggeredByUserID: user.ID}
+	opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionsSync, InvalidateCaches: true, Reason: ReasonUserNoPermissions, NoPerms: true, TriggeredByUserID: user.ID}
 	err = store.CreateRepoSyncJob(ctx, repo1.ID, opts)
 	require.NoError(t, err)
 
 	processAfter := clock.Now().Add(5 * time.Minute)
-	opts = PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
+	opts = PermissionSyncJobOpts{Priority: MediumPriorityPermissionsSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 	err = store.CreateUserSyncJob(ctx, user1.ID, opts)
 	require.NoError(t, err)
 
 	processAfter = clock.Now().Add(5 * time.Minute)
-	opts = PermissionSyncJobOpts{Priority: LowPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
+	opts = PermissionSyncJobOpts{Priority: LowPriorityPermissionsSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 	err = store.CreateUserSyncJob(ctx, user2.ID, opts)
 	require.NoError(t, err)
 	codeHostStates := getSampleCodeHostStates()
@@ -77,9 +77,9 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	wantJobs := []*PermissionSyncJob{
 		{
 			ID:                jobs[0].ID,
-			State:             PermissionSyncJobStateQueued,
+			State:             PermissionsSyncJobStateQueued,
 			RepositoryID:      int(repo1.ID),
-			Priority:          HighPriorityPermissionSync,
+			Priority:          HighPriorityPermissionsSync,
 			InvalidateCaches:  true,
 			Reason:            ReasonUserNoPermissions,
 			NoPerms:           true,
@@ -87,18 +87,18 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		},
 		{
 			ID:               jobs[1].ID,
-			State:            PermissionSyncJobStateQueued,
+			State:            PermissionsSyncJobStateQueued,
 			UserID:           int(user1.ID),
-			Priority:         MediumPriorityPermissionSync,
+			Priority:         MediumPriorityPermissionsSync,
 			InvalidateCaches: true,
 			ProcessAfter:     processAfter,
 			Reason:           ReasonManualUserSync,
 		},
 		{
 			ID:                 jobs[2].ID,
-			State:              PermissionSyncJobStateQueued,
+			State:              PermissionsSyncJobStateQueued,
 			UserID:             int(user2.ID),
-			Priority:           LowPriorityPermissionSync,
+			Priority:           LowPriorityPermissionsSync,
 			InvalidateCaches:   true,
 			ProcessAfter:       processAfter,
 			Reason:             ReasonManualUserSync,
@@ -228,7 +228,7 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	require.Equal(t, allDelayedJobs[1].UserID, allDelayedJobs[1].ID-2)
 
 	// 5) Insert *medium* priority job without process_after for user1. Check that low priority job is canceled.
-	user1MediumPrioJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user1MediumPrioJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionsSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
 	err = store.CreateUserSyncJob(ctx, 1, user1MediumPrioJob)
 	require.NoError(t, err)
 
@@ -246,8 +246,8 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	}
 
 	// 6) Insert some medium priority jobs with process_after for both users. All of them should be inserted.
-	user1MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, ProcessAfter: fiveMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
-	user2MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, ProcessAfter: tenMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user1MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionsSync, ProcessAfter: fiveMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user2MediumPrioDelayedJob := PermissionSyncJobOpts{Priority: MediumPriorityPermissionsSync, ProcessAfter: tenMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
 
 	err = store.CreateUserSyncJob(ctx, 1, user1MediumPrioDelayedJob)
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	require.Equal(t, allDelayedJobs[3].UserID, allDelayedJobs[1].ID-2)
 
 	// 5) Insert *high* priority job without process_after for user1. Check that medium and low priority job is canceled.
-	user1HighPrioJob := PermissionSyncJobOpts{Priority: HighPriorityPermissionSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user1HighPrioJob := PermissionSyncJobOpts{Priority: HighPriorityPermissionsSync, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
 	err = store.CreateUserSyncJob(ctx, 1, user1HighPrioJob)
 	require.NoError(t, err)
 
@@ -576,7 +576,7 @@ func createSyncJobs(t *testing.T, ctx context.Context, userID int32, store Permi
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	for i := 0; i < 10; i++ {
 		processAfter := clock.Now().Add(5 * time.Minute)
-		opts := PermissionSyncJobOpts{Priority: MediumPriorityPermissionSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
+		opts := PermissionSyncJobOpts{Priority: MediumPriorityPermissionsSync, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 		err := store.CreateUserSyncJob(ctx, userID, opts)
 		require.NoError(t, err)
 	}

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -246,12 +246,12 @@ type ChangesetSyncResponse struct {
 // PermsSyncRequest is a request to sync permissions. The provided options are used to
 // sync all provided users and repos - to use different options, make a separate request.
 type PermsSyncRequest struct {
-	UserIDs           []int32                          `json:"user_ids"`
-	RepoIDs           []api.RepoID                     `json:"repo_ids"`
-	Options           authz.FetchPermsOptions          `json:"options"`
-	Reason            database.PermissionSyncJobReason `json:"reason"`
-	TriggeredByUserID int32                            `json:"triggered_by_user_id"`
-	ProcessAfter      time.Time                        `json:"process_after"`
+	UserIDs           []int32                           `json:"user_ids"`
+	RepoIDs           []api.RepoID                      `json:"repo_ids"`
+	Options           authz.FetchPermsOptions           `json:"options"`
+	Reason            database.PermissionsSyncJobReason `json:"reason"`
+	TriggeredByUserID int32                             `json:"triggered_by_user_id"`
+	ProcessAfter      time.Time                         `json:"process_after"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
**It's just a renaming PR**

Test plan:
CI.

Closes https://github.com/sourcegraph/sourcegraph/issues/48121