### PR TITLE
permissions-center: add forgotten `canceled` sync job state.

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -349,6 +349,7 @@ enum PermissionsSyncJobState {
     FAILED
     ERRORED
     COMPLETED
+    CANCELED
 }
 
 """

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -32,6 +32,7 @@ const (
 	PermissionsSyncJobStateErrored    PermissionsSyncJobState = "errored"
 	PermissionsSyncJobStateFailed     PermissionsSyncJobState = "failed"
 	PermissionsSyncJobStateCompleted  PermissionsSyncJobState = "completed"
+	PermissionsSyncJobStateCanceled   PermissionsSyncJobState = "canceled"
 )
 
 // ToGraphQL returns the GraphQL representation of the worker state.

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -240,6 +240,7 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	for _, job := range allUser1Jobs {
 		if job.ID == 1 {
 			require.True(t, job.Cancel)
+			require.Equal(t, PermissionsSyncJobStateCanceled, job.State)
 		} else {
 			require.False(t, job.Cancel)
 		}


### PR DESCRIPTION
Test plan:
Unit test updated.

Based off another feature branch, should be merged after this [PR](https://github.com/sourcegraph/sourcegraph/pull/48123).