### PR TITLE
Search: do not write after starting stream

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -81,7 +81,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		eventWriter.Error(err)
 		tr.SetError(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }


### PR DESCRIPTION
After we make our first write to the stream, setting the HTTP status code has no effect. Additionally, clients expects the response to be an SSE-formatted stream, and writing the error message to the stream breaks that expectation, giving us garbage errors. 

This just removes the HTTP error status and depends on writing the error to the stream as an event.

This fixes the cryptic error [here](https://buildkite.com/sourcegraph/sourcegraph/builds/201118#01867e12-21a6-4203-84d0-a36d90c0b475)

## Test plan

Tested locally that integration tests no longer fail with a cryptic error.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
