### PR TITLE
Use curl from edge/main

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,7 @@ RUN apk update && apk add --no-cache \
     'bind-tools>=9.16.33-r0' \
     busybox \
     ca-certificates \
-    'curl>=7.79.1-r4' \
+    'curl>=7.88.1-r1' --repository='https://dl-cdn.alpinelinux.org/alpine/edge/main' \
     mailcap \
     tini \
     wget


### PR DESCRIPTION
Alpine 3.14 does not contain latest updates for `curl`. It indicates our version as 'possibly vulnerable', for multiple issues. Snyk picks this up as definitely vulnerable. But our internal scanners don't. We will now use `curl` from the edge repository to always be on the latest.

https://security.alpinelinux.org/vuln/CVE-2022-42915


## Test plan
build and scan container.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
