### PR TITLE
release-tool: auto save release config when prompting for input

### DIFF
--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -247,6 +247,7 @@ async function getScheduledReleaseWithInput(
         )
         scheduled = await newReleaseFromInput(releaseVersion)
         addScheduledRelease(config, scheduled)
+        saveReleaseConfig(config)
     }
     return scheduled
 }

--- a/dev/release/templates/patch_release_issue_template.md
+++ b/dev/release/templates/patch_release_issue_template.md
@@ -124,6 +124,6 @@ Create and test the first release candidate:
   pnpm run release release:close
 ```
 
-- [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://github.com/sourcegraph/sourcegraph/edit/main/dev/release/release-config.jsonc) after the auto-generated changes above.
+- [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://github.com/sourcegraph/sourcegraph/edit/main/dev/release/release-config.jsonc) after the auto-generated changes above if any.
 
 **Note:** If another patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md) be filled out and approved first.

--- a/dev/release/templates/release_issue_template.md
+++ b/dev/release/templates/release_issue_template.md
@@ -155,5 +155,4 @@ On the day of the release, confirm there are no more release-blocking issues (as
   ```
 - [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the auto-generated changes from above.
 
-
 **Note:** If a patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out and approved first.

--- a/dev/release/templates/release_issue_template.md
+++ b/dev/release/templates/release_issue_template.md
@@ -149,10 +149,11 @@ On the day of the release, confirm there are no more release-blocking issues (as
   pnpm run release tracking:issues
   pnpm run release tracking:timeline
   ```
-- [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the auto-generated changes from above.
 - [ ] Close the release.
   ```sh
   pnpm run release release:close
   ```
+- [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the auto-generated changes from above.
+
 
 **Note:** If a patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out and approved first.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48133

Auto save the release config when prompted for input of a new scheduled release. Also fixes a small ordering problem in the release guide template to push the changes to the config _after_ all the auto generation is done.

## Test plan

Ran locally adding 4.6.0:
```
{
  "metadata": {
    "teamEmail": "team@sourcegraph.com",
    "slackAnnounceChannel": "announce-engineering"
  },
  "scheduledReleases": {
    "4.5.0": {
      "codeFreezeDate": "2023-02-15T10:00:00.000-08:00",
      "securityApprovalDate": "2023-02-15T10:00:00.000-08:00",
      "releaseDate": "2023-02-22T10:00:00.000-08:00",
      "current": "4.5.0",
      "captainGitHubUsername": "coury-clark",
      "captainSlackUsername": "coury"
    },
    "4.6.0": {
      "codeFreezeDate": "2023-03-15T10:00:00.000-07:00",
      "securityApprovalDate": "2023-03-15T10:00:00.000-07:00",
      "releaseDate": "2023-03-22T10:00:00.000-07:00",
      "current": "4.6.0",
      "captainGitHubUsername": "coury-clark",
      "captainSlackUsername": "coury"
    }
  },
  "dryRun": {
    "tags": false,
    "changesets": false,
    "trackingIssues": false,
    "calendar": false,
    "slack": false
  },
  "in_progress": {
    "captainGitHubUsername": "coury-clark",
    "captainSlackUsername": "coury",
    "releases": [
      {
        "version": "4.5.0",
        "previous": "4.4.2"
      }
    ]
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-save-release-input.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

