### PR TITLE
Adjust repo badge alignment

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -5,7 +5,7 @@
 }
 
 .badge-wrapper {
-    min-width: 100px;
+    min-width: 90px;
 }
 
 .alert-content {

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -62,9 +62,9 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
         >
             <div className="d-flex align-items-center justify-content-between">
                 <div className="d-flex col-7 pl-0">
-                    <div className={classNames('d-flex col-2 px-0 justify-content-between h-100', styles.badgeWrapper)}>
+                    <div className={classNames('col-2 px-0 my-auto h-100', styles.badgeWrapper)}>
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
-                        {node.mirrorInfo.cloneInProgress && <LoadingSpinner />}
+                        {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}
                     </div>
 
                     <div className="d-flex flex-column ml-2">


### PR DESCRIPTION
[Relevant thread](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1677075289337339)
<img width="951" alt="image" src="https://user-images.githubusercontent.com/59381432/220991607-be15703b-f7ab-4861-8572-4e14c9cb5a2c.png">

## Test plan
- Nav to `/site-admin/repositories?status=needs-index` for a good view of different repo statuses side by side
- Account for needed gap between badge & repo for loading state
- Or use the filters to view other repo status'

## App preview:

- [Web](https://sg-web-becca-repo-badge-ui-alignment.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
