### PR TITLE
fix typo in the setting of clientSecret

### DIFF
--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -51,7 +51,7 @@ async function authorize(credentials: OAuth2ClientOptions): Promise<OAuth2Client
         const { port } = server.address() as AddressInfo
         const oauth2Client = new OAuth2Client({
             clientId: credentials.installed.client_id,
-            clientSecret: credentials.installed.client_id,
+            clientSecret: credentials.installed.client_secret,
             redirectUri: `http://localhost:${port}`,
         })
 


### PR DESCRIPTION
clientSecret was accidentally set to clientId, I switched in back to be set to clientSecret so that calendar auth can work
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
ran `pnpm run release tracking:timeline`    and no longer got auth issue

## App preview:

- [Web](https://sg-web-mucles-calendar-auth-typo-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
