### PR TITLE
gRPC: add Dial, DialContext, and NewServer to defaults package

### DIFF
--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
@@ -147,7 +146,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(int64(batchLogGlobalConcurrencyLimit)),
 	}
 
-	grpcServer := grpc.NewServer(defaults.ServerOptions(logger)...)
+	grpcServer := defaults.NewServer(logger)
 	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{
 		Server: &gitserver,
 	})

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -17,7 +17,6 @@ import (
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search"
@@ -29,7 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
-	grpcdefaults "github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
 	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	sharedsearch "github.com/sourcegraph/sourcegraph/internal/search"
@@ -182,7 +181,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	grpcServer := grpc.NewServer(grpcdefaults.ServerOptions(logger)...)
+	grpcServer := defaults.NewServer(logger)
 	reflection.Register(grpcServer)
 	grpcServer.RegisterService(&proto.SearcherService_ServiceDesc, &search.Server{
 		Service: sService,

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/go-ctags"
 	logger "github.com/sourcegraph/log"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
@@ -17,9 +18,6 @@ import (
 	proto "github.com/sourcegraph/sourcegraph/internal/symbols/v1"
 	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
 const maxNumSymbolResults = 500
@@ -95,9 +93,7 @@ func NewHandler(
 	rootLogger := logger.Scoped("symbolsServer", "symbols RPC server")
 
 	// Initialize the gRPC server
-	grpcServer := grpc.NewServer(
-		defaults.ServerOptions(rootLogger)...,
-	)
+	grpcServer := defaults.NewServer(rootLogger)
 	grpcServer.RegisterService(&proto.SymbolsService_ServiceDesc, &grpcService{
 		searchFunc:   searchFuncWrapper,
 		readFileFunc: readFileFunc,

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -37,7 +37,7 @@ func NewGitserverAddressesFromConf(cfg *conf.Unified) GitserverAddresses {
 func newTestGitserverConns(addrs []string) *GitserverConns {
 	conns := make(map[string]connAndErr)
 	for _, addr := range addrs {
-		conn, err := grpc.Dial(addr, defaults.DialOptions()...)
+		conn, err := defaults.Dial(addr)
 		conns[addr] = connAndErr{conn: conn, err: err}
 	}
 	return &GitserverConns{
@@ -141,7 +141,7 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 	// Open connections for each address
 	after.grpcConns = make(map[string]connAndErr, len(after.Addresses))
 	for _, addr := range after.Addresses {
-		conn, err := grpc.Dial(addr, defaults.DialOptions()...)
+		conn, err := defaults.Dial(addr)
 		after.grpcConns[addr] = connAndErr{conn: conn, err: err}
 	}
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -413,7 +412,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 		DB: db,
 	}
 
-	grpcServer := grpc.NewServer(defaults.ServerOptions(logtest.Scoped(t))...)
+	grpcServer := defaults.NewServer(logtest.Scoped(t))
 	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{Server: &s})
 
 	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"golang.org/x/sync/semaphore"
-	"google.golang.org/grpc"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -70,7 +69,7 @@ func InitGitserver() {
 		DB:                      db,
 	}
 
-	grpcServer := grpc.NewServer(defaults.ServerOptions(logger)...)
+	grpcServer := defaults.NewServer(logger)
 	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{Server: &s})
 	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
 

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -5,6 +5,7 @@
 package defaults
 
 import (
+	"context"
 	"strings"
 	"sync"
 
@@ -21,6 +22,16 @@ import (
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
+
+// Dial creates a client connection to the given target with the default options.
+func Dial(addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return DialContext(context.Background(), addr, additionalOpts...)
+}
+
+// DialContext creates a client connection to the given target with the default options.
+func DialContext(ctx context.Context, addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return grpc.DialContext(ctx, addr, append(DialOptions(), additionalOpts...)...)
+}
 
 // DialOptions is a set of default dial options that should be used for all
 // gRPC clients in Sourcegraph. The options can be extended with
@@ -47,6 +58,11 @@ func DialOptions() []grpc.DialOption {
 			otelgrpc.UnaryClientInterceptor(),
 		),
 	}
+}
+
+// NewServer creates a new *grpc.Server with the default options
+func NewServer(logger log.Logger, additionalOpts ...grpc.ServerOption) *grpc.Server {
+	return grpc.NewServer(append(ServerOptions(logger), additionalOpts...)...)
 }
 
 // ServerOptions is a set of default server options that should be used for all

--- a/internal/search/searcher/client_grpc.go
+++ b/internal/search/searcher/client_grpc.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -84,7 +83,7 @@ func SearchGRPC(
 			return false, errors.Wrap(err, "failed to parse URL")
 		}
 
-		clientConn, err := grpc.DialContext(ctx, parsed.Host, defaults.DialOptions()...)
+		clientConn, err := defaults.DialContext(ctx, parsed.Host)
 		if err != nil {
 			return false, err
 		}

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -520,7 +520,7 @@ func (c *Client) dialGRPC(ctx context.Context, repository api.RepoName) (*grpc.C
 		return nil, errors.Wrap(err, "parsing symbols service URL")
 	}
 
-	conn, err := grpc.DialContext(ctx, u.Host, defaults.DialOptions()...)
+	conn, err := defaults.DialContext(ctx, u.Host)
 	if err != nil {
 		return nil, errors.Wrap(err, "dialing symbols GRPC service")
 	}

--- a/internal/symbols/client_test.go
+++ b/internal/symbols/client_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
-	"google.golang.org/grpc"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -208,9 +207,7 @@ type mockSymbolsServer struct {
 }
 
 func (m *mockSymbolsServer) NewHandler(l log.Logger) (handler http.Handler, cleanup func()) {
-	grpcServer := grpc.NewServer(
-		defaults.ServerOptions(l)...,
-	)
+	grpcServer := defaults.NewServer(l)
 
 	grpcServer.RegisterService(&proto.SymbolsService_ServiceDesc, m)
 


### PR DESCRIPTION
This adds new functions for our gRPC operations that have the defaults already applied. This cuts a little boilerplate, but more importantly, removes the need to import `grpc` in most cases, which helps with package naming conflicts.

As a followup, I think we should consider renaming the `defaults` package to `grpcdefault` so that the imported package name has clear meaning. 

## Test plan

Existing tests. Pretty trivial change. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
