### PR TITLE
ranking: Move SCIP export method from store to lsifstore

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -2482,10 +2482,6 @@ type MockStore struct {
 	// HasRepositoryFunc is an instance of a mock function object
 	// controlling the behavior of the method HasRepository.
 	HasRepositoryFunc *StoreHasRepositoryFunc
-	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// InsertDefinitionsAndReferencesForDocument.
-	InsertDefinitionsAndReferencesForDocumentFunc *StoreInsertDefinitionsAndReferencesForDocumentFunc
 	// InsertDefinitionsForRankingFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// InsertDefinitionsForRanking.
@@ -2741,7 +2737,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
-			defaultHook: func(context.Context, string, string, int) (r0 []store.ExportedUpload, r1 error) {
+			defaultHook: func(context.Context, string, string, int) (r0 []shared1.ExportedUpload, r1 error) {
 				return
 			},
 		},
@@ -2762,11 +2758,6 @@ func NewMockStore() *MockStore {
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
-				return
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -3078,7 +3069,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
-			defaultHook: func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+			defaultHook: func(context.Context, string, string, int) ([]shared1.ExportedUpload, error) {
 				panic("unexpected invocation of MockStore.GetUploadsForRanking")
 			},
 		},
@@ -3100,11 +3091,6 @@ func NewStrictMockStore() *MockStore {
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: func(context.Context, int) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-				panic("unexpected invocation of MockStore.InsertDefinitionsAndReferencesForDocument")
 			},
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
@@ -3370,9 +3356,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: i.HasRepository,
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
 			defaultHook: i.InsertDefinitionsForRanking,
@@ -6751,15 +6734,15 @@ func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Results() []interface{} {
 // StoreGetUploadsForRankingFunc describes the behavior when the
 // GetUploadsForRanking method of the parent MockStore instance is invoked.
 type StoreGetUploadsForRankingFunc struct {
-	defaultHook func(context.Context, string, string, int) ([]store.ExportedUpload, error)
-	hooks       []func(context.Context, string, string, int) ([]store.ExportedUpload, error)
+	defaultHook func(context.Context, string, string, int) ([]shared1.ExportedUpload, error)
+	hooks       []func(context.Context, string, string, int) ([]shared1.ExportedUpload, error)
 	history     []StoreGetUploadsForRankingFuncCall
 	mutex       sync.Mutex
 }
 
 // GetUploadsForRanking delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 string, v3 int) ([]store.ExportedUpload, error) {
+func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 string, v3 int) ([]shared1.ExportedUpload, error) {
 	r0, r1 := m.GetUploadsForRankingFunc.nextHook()(v0, v1, v2, v3)
 	m.GetUploadsForRankingFunc.appendCall(StoreGetUploadsForRankingFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -6768,7 +6751,7 @@ func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 strin
 // SetDefaultHook sets function that is called when the GetUploadsForRanking
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context, string, string, int) ([]store.ExportedUpload, error)) {
+func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context, string, string, int) ([]shared1.ExportedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -6776,7 +6759,7 @@ func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context
 // GetUploadsForRanking method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, string, string, int) ([]store.ExportedUpload, error)) {
+func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, string, string, int) ([]shared1.ExportedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -6784,20 +6767,20 @@ func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, stri
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetUploadsForRankingFunc) SetDefaultReturn(r0 []store.ExportedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) SetDefaultReturn(r0 []shared1.ExportedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int) ([]shared1.ExportedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetUploadsForRankingFunc) PushReturn(r0 []store.ExportedUpload, r1 error) {
-	f.PushHook(func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) PushReturn(r0 []shared1.ExportedUpload, r1 error) {
+	f.PushHook(func(context.Context, string, string, int) ([]shared1.ExportedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetUploadsForRankingFunc) nextHook() func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) nextHook() func(context.Context, string, string, int) ([]shared1.ExportedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -6844,7 +6827,7 @@ type StoreGetUploadsForRankingFuncCall struct {
 	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []store.ExportedUpload
+	Result0 []shared1.ExportedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -7317,125 +7300,6 @@ func (c StoreHasRepositoryFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreHasRepositoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreInsertDefinitionsAndReferencesForDocumentFunc describes the behavior
-// when the InsertDefinitionsAndReferencesForDocument method of the parent
-// MockStore instance is invoked.
-type StoreInsertDefinitionsAndReferencesForDocumentFunc struct {
-	defaultHook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
-	hooks       []func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
-	history     []StoreInsertDefinitionsAndReferencesForDocumentFuncCall
-	mutex       sync.Mutex
-}
-
-// InsertDefinitionsAndReferencesForDocument delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 store.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-	r0 := m.InsertDefinitionsAndReferencesForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(StoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the
-// InsertDefinitionsAndReferencesForDocument method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertDefinitionsAndReferencesForDocument method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-		return r0
-	})
-}
-
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 StoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreInsertDefinitionsAndReferencesForDocumentFuncCall objects describing
-// the invocations of this function.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) History() []StoreInsertDefinitionsAndReferencesForDocumentFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object that
-// describes an invocation of method
-// InsertDefinitionsAndReferencesForDocument on an instance of MockStore.
-type StoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 store.ExportedUpload
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 int
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreInsertDefinitionsForRankingFunc describes the behavior when the
@@ -11173,6 +11037,10 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// InsertDefinitionsAndReferencesForDocument.
+	InsertDefinitionsAndReferencesForDocumentFunc *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LsifStoreInsertMetadataFunc
@@ -11216,6 +11084,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -11276,6 +11149,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
 			},
 		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+				panic("unexpected invocation of MockLsifStore.InsertDefinitionsAndReferencesForDocument")
+			},
+		},
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
 				panic("unexpected invocation of MockLsifStore.InsertMetadata")
@@ -11322,6 +11200,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
@@ -11898,6 +11779,126 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFunc describes the
+// behavior when the InsertDefinitionsAndReferencesForDocument method of the
+// parent MockLsifStore instance is invoked.
+type LsifStoreInsertDefinitionsAndReferencesForDocumentFunc struct {
+	defaultHook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
+	hooks       []func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
+	history     []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertDefinitionsAndReferencesForDocument delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockLsifStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 shared1.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+	r0 := m.InsertDefinitionsAndReferencesForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// InsertDefinitionsAndReferencesForDocument method of the parent
+// MockLsifStore instance is invoked and the hook queue is empty.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertDefinitionsAndReferencesForDocument method of the parent
+// MockLsifStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+		return r0
+	})
+}
+
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) History() []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object
+// that describes an invocation of method
+// InsertDefinitionsAndReferencesForDocument on an instance of
+// MockLsifStore.
+type LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 shared1.ExportedUpload
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // LsifStoreInsertMetadataFunc describes the behavior when the

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -27,6 +28,7 @@ type LsifStore interface {
 
 	// Stream
 	ScanDocuments(ctx context.Context, id int, f func(path string, document *scip.Document) error) (err error)
+	InsertDefinitionsAndReferencesForDocument(ctx context.Context, upload shared.ExportedUpload, rankingGraphKey string, rankingBatchSize int, f func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey, path string, document *scip.Document) error) (err error)
 }
 
 type SCIPWriter interface {

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_ranking.go
@@ -1,0 +1,68 @@
+package lsifstore
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func (s *store) InsertDefinitionsAndReferencesForDocument(
+	ctx context.Context,
+	upload shared.ExportedUpload,
+	rankingGraphKey string,
+	rankingBatchNumber int,
+	setDefsAndRefs func(ctx context.Context, upload shared.ExportedUpload, rankingBatchNumber int, rankingGraphKey, path string, document *scip.Document) error,
+) (err error) {
+	ctx, _, endObservation := s.operations.insertDefinitionsAndReferencesForDocument.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.Int("id", upload.ID),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	rows, err := s.db.Query(ctx, sqlf.Sprintf(getDocumentsByUploadIDQuery, upload.ID))
+	if err != nil {
+		return err
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		var path string
+		var compressedSCIPPayload []byte
+		if err := rows.Scan(&path, &compressedSCIPPayload); err != nil {
+			return err
+		}
+
+		scipPayload, err := shared.Decompressor.Decompress(bytes.NewReader(compressedSCIPPayload))
+		if err != nil {
+			return err
+		}
+
+		var document scip.Document
+		if err := proto.Unmarshal(scipPayload, &document); err != nil {
+			return err
+		}
+		err = setDefsAndRefs(ctx, upload, rankingBatchNumber, rankingGraphKey, path, &document)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const getDocumentsByUploadIDQuery = `
+SELECT
+	sid.document_path,
+	sd.raw_scip_payload
+FROM codeintel_scip_document_lookup sid
+JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
+WHERE sid.upload_id = %s
+ORDER BY sid.document_path
+`

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -8,13 +8,14 @@ import (
 )
 
 type operations struct {
-	deleteLsifDataByUploadIds   *observation.Operation
-	idsWithMeta                 *observation.Operation
-	reconcileCandidates         *observation.Operation
-	getUploadDocumentsForPath   *observation.Operation
-	scanDocuments               *observation.Operation
-	insertMetadata              *observation.Operation
-	deleteUnreferencedDocuments *observation.Operation
+	deleteLsifDataByUploadIds                 *observation.Operation
+	idsWithMeta                               *observation.Operation
+	reconcileCandidates                       *observation.Operation
+	getUploadDocumentsForPath                 *observation.Operation
+	scanDocuments                             *observation.Operation
+	insertMetadata                            *observation.Operation
+	deleteUnreferencedDocuments               *observation.Operation
+	insertDefinitionsAndReferencesForDocument *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -38,12 +39,13 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		deleteLsifDataByUploadIds:   op("DeleteLsifDataByUploadIds"),
-		idsWithMeta:                 op("IDsWithMeta"),
-		reconcileCandidates:         op("ReconcileCandidates"),
-		getUploadDocumentsForPath:   op("GetUploadDocumentsForPath"),
-		scanDocuments:               op("ScanDocuments"),
-		insertMetadata:              op("InsertMetadata"),
-		deleteUnreferencedDocuments: op("DeleteUnreferencedDocuments"),
+		deleteLsifDataByUploadIds:                 op("DeleteLsifDataByUploadIds"),
+		idsWithMeta:                               op("IDsWithMeta"),
+		reconcileCandidates:                       op("ReconcileCandidates"),
+		getUploadDocumentsForPath:                 op("GetUploadDocumentsForPath"),
+		scanDocuments:                             op("ScanDocuments"),
+		insertMetadata:                            op("InsertMetadata"),
+		deleteUnreferencedDocuments:               op("DeleteUnreferencedDocuments"),
+		insertDefinitionsAndReferencesForDocument: op("InsertDefinitionsAndReferencesForDocument"),
 	}
 }

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	logger "github.com/sourcegraph/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
@@ -97,7 +96,7 @@ type Store interface {
 
 	ReconcileCandidates(ctx context.Context, batchSize int) (_ []int, err error)
 
-	GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) ([]ExportedUpload, error)
+	GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) ([]shared.ExportedUpload, error)
 
 	VacuumStaleGraphs(ctx context.Context, derivativeGraphKey string) (
 		metadataRecordsDeleted int,
@@ -122,7 +121,6 @@ type Store interface {
 	ReindexUploadByID(ctx context.Context, id int) error
 
 	// Ranking
-	InsertDefinitionsAndReferencesForDocument(ctx context.Context, upload ExportedUpload, rankingGraphKey string, rankingBatchSize int, f func(ctx context.Context, upload ExportedUpload, rankingBatchSize int, rankingGraphKey, path string, document *scip.Document) error) (err error)
 	InsertDefinitionsForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, definitions []shared.RankingDefinitions) (err error)
 	InsertReferencesForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, references shared.RankingReferences) (err error)
 	InsertPathCountInputs(ctx context.Context, rankingGraphKey string, batchSize int) (numReferenceRecordsProcessed int, numInputsInserted int, err error)

--- a/enterprise/internal/codeintel/uploads/internal/store/store_export.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_export.go
@@ -6,23 +6,17 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-type ExportedUpload struct {
-	ID           int
-	Repo         string
-	Root         string
-	ObjectPrefix string
-}
-
-var scanUploads = basestore.NewSliceScanner(func(s dbutil.Scanner) (u ExportedUpload, _ error) {
+var scanUploads = basestore.NewSliceScanner(func(s dbutil.Scanner) (u shared.ExportedUpload, _ error) {
 	err := s.Scan(&u.ID, &u.Repo, &u.Root, &u.ObjectPrefix)
 	return u, err
 })
 
-func (s *store) GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) (_ []ExportedUpload, err error) {
+func (s *store) GetUploadsForRanking(ctx context.Context, graphKey, objectPrefix string, batchSize int) (_ []shared.ExportedUpload, err error) {
 	return scanUploads(s.db.Query(ctx, sqlf.Sprintf(
 		getUploadsForRankingQuery,
 		graphKey,

--- a/enterprise/internal/codeintel/uploads/internal/store/store_export_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -46,7 +47,7 @@ func TestGetUploadsForRanking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting uploads for ranking: %s", err)
 	}
-	expectedUploads := []ExportedUpload{
+	expectedUploads := []shared.ExportedUpload{
 		{ID: 102, Repo: "bar", ObjectPrefix: "ranking/test/102"},
 		{ID: 103, Repo: "baz", ObjectPrefix: "ranking/test/103"},
 	}
@@ -59,7 +60,7 @@ func TestGetUploadsForRanking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting uploads for ranking: %s", err)
 	}
-	expectedUploads = []ExportedUpload{
+	expectedUploads = []shared.ExportedUpload{
 		{ID: 100, Repo: "foo", ObjectPrefix: "ranking/test/100"},
 	}
 	if diff := cmp.Diff(expectedUploads, uploads); diff != "" {
@@ -99,7 +100,7 @@ func TestProcessStaleExportedUploads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting uploads for ranking: %s", err)
 	}
-	expectedUploads := []ExportedUpload{
+	expectedUploads := []shared.ExportedUpload{
 		{ID: 100, Repo: "foo", ObjectPrefix: "ranking/test/100"}, // shadowed by upload 102
 		{ID: 103, Repo: "bar", ObjectPrefix: "ranking/test/103"}, // repo gets deleted
 		{ID: 105, Repo: "baz", ObjectPrefix: "ranking/test/105"}, // upload gets deleted

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -1,15 +1,12 @@
 package store
 
 import (
-	"bytes"
 	"context"
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -17,59 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func (s *store) InsertDefinitionsAndReferencesForDocument(
-	ctx context.Context,
-	upload ExportedUpload,
-	rankingGraphKey string,
-	rankingBatchNumber int,
-	setDefsAndRefs func(ctx context.Context, upload ExportedUpload, rankingBatchNumber int, rankingGraphKey, path string, document *scip.Document) error,
-) (err error) {
-	ctx, _, endObservation := s.operations.insertDefinitionsAndReferencesForDocument.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.Int("id", upload.ID),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	rows, err := s.db.Query(ctx, sqlf.Sprintf(getDocumentsByUploadIDQuery, upload.ID))
-	if err != nil {
-		return err
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var path string
-		var compressedSCIPPayload []byte
-		if err := rows.Scan(&path, &compressedSCIPPayload); err != nil {
-			return err
-		}
-
-		scipPayload, err := shared.Decompressor.Decompress(bytes.NewReader(compressedSCIPPayload))
-		if err != nil {
-			return err
-		}
-
-		var document scip.Document
-		if err := proto.Unmarshal(scipPayload, &document); err != nil {
-			return err
-		}
-		err = setDefsAndRefs(ctx, upload, rankingBatchNumber, rankingGraphKey, path, &document)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-const getDocumentsByUploadIDQuery = `
-SELECT
-	sid.document_path,
-	sd.raw_scip_payload
-FROM codeintel_scip_document_lookup sid
-JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
-WHERE sid.upload_id = %s
-ORDER BY sid.document_path
-`
 
 func (s *store) InsertDefinitionsForRanking(
 	ctx context.Context,

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -153,10 +153,6 @@ type MockStore struct {
 	// HasRepositoryFunc is an instance of a mock function object
 	// controlling the behavior of the method HasRepository.
 	HasRepositoryFunc *StoreHasRepositoryFunc
-	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// InsertDefinitionsAndReferencesForDocument.
-	InsertDefinitionsAndReferencesForDocumentFunc *StoreInsertDefinitionsAndReferencesForDocumentFunc
 	// InsertDefinitionsForRankingFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// InsertDefinitionsForRanking.
@@ -412,7 +408,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
-			defaultHook: func(context.Context, string, string, int) (r0 []store.ExportedUpload, r1 error) {
+			defaultHook: func(context.Context, string, string, int) (r0 []shared.ExportedUpload, r1 error) {
 				return
 			},
 		},
@@ -433,11 +429,6 @@ func NewMockStore() *MockStore {
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
-				return
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -749,7 +740,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
-			defaultHook: func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+			defaultHook: func(context.Context, string, string, int) ([]shared.ExportedUpload, error) {
 				panic("unexpected invocation of MockStore.GetUploadsForRanking")
 			},
 		},
@@ -771,11 +762,6 @@ func NewStrictMockStore() *MockStore {
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: func(context.Context, int) (bool, error) {
 				panic("unexpected invocation of MockStore.HasRepository")
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-				panic("unexpected invocation of MockStore.InsertDefinitionsAndReferencesForDocument")
 			},
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
@@ -1041,9 +1027,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		HasRepositoryFunc: &StoreHasRepositoryFunc{
 			defaultHook: i.HasRepository,
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &StoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
 			defaultHook: i.InsertDefinitionsForRanking,
@@ -4422,15 +4405,15 @@ func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Results() []interface{} {
 // StoreGetUploadsForRankingFunc describes the behavior when the
 // GetUploadsForRanking method of the parent MockStore instance is invoked.
 type StoreGetUploadsForRankingFunc struct {
-	defaultHook func(context.Context, string, string, int) ([]store.ExportedUpload, error)
-	hooks       []func(context.Context, string, string, int) ([]store.ExportedUpload, error)
+	defaultHook func(context.Context, string, string, int) ([]shared.ExportedUpload, error)
+	hooks       []func(context.Context, string, string, int) ([]shared.ExportedUpload, error)
 	history     []StoreGetUploadsForRankingFuncCall
 	mutex       sync.Mutex
 }
 
 // GetUploadsForRanking delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 string, v3 int) ([]store.ExportedUpload, error) {
+func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 string, v3 int) ([]shared.ExportedUpload, error) {
 	r0, r1 := m.GetUploadsForRankingFunc.nextHook()(v0, v1, v2, v3)
 	m.GetUploadsForRankingFunc.appendCall(StoreGetUploadsForRankingFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -4439,7 +4422,7 @@ func (m *MockStore) GetUploadsForRanking(v0 context.Context, v1 string, v2 strin
 // SetDefaultHook sets function that is called when the GetUploadsForRanking
 // method of the parent MockStore instance is invoked and the hook queue is
 // empty.
-func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context, string, string, int) ([]store.ExportedUpload, error)) {
+func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context, string, string, int) ([]shared.ExportedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -4447,7 +4430,7 @@ func (f *StoreGetUploadsForRankingFunc) SetDefaultHook(hook func(context.Context
 // GetUploadsForRanking method of the parent MockStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, string, string, int) ([]store.ExportedUpload, error)) {
+func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, string, string, int) ([]shared.ExportedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4455,20 +4438,20 @@ func (f *StoreGetUploadsForRankingFunc) PushHook(hook func(context.Context, stri
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetUploadsForRankingFunc) SetDefaultReturn(r0 []store.ExportedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) SetDefaultReturn(r0 []shared.ExportedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string, int) ([]shared.ExportedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetUploadsForRankingFunc) PushReturn(r0 []store.ExportedUpload, r1 error) {
-	f.PushHook(func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) PushReturn(r0 []shared.ExportedUpload, r1 error) {
+	f.PushHook(func(context.Context, string, string, int) ([]shared.ExportedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetUploadsForRankingFunc) nextHook() func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
+func (f *StoreGetUploadsForRankingFunc) nextHook() func(context.Context, string, string, int) ([]shared.ExportedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4515,7 +4498,7 @@ type StoreGetUploadsForRankingFuncCall struct {
 	Arg3 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []store.ExportedUpload
+	Result0 []shared.ExportedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4988,125 +4971,6 @@ func (c StoreHasRepositoryFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreHasRepositoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreInsertDefinitionsAndReferencesForDocumentFunc describes the behavior
-// when the InsertDefinitionsAndReferencesForDocument method of the parent
-// MockStore instance is invoked.
-type StoreInsertDefinitionsAndReferencesForDocumentFunc struct {
-	defaultHook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
-	hooks       []func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
-	history     []StoreInsertDefinitionsAndReferencesForDocumentFuncCall
-	mutex       sync.Mutex
-}
-
-// InsertDefinitionsAndReferencesForDocument delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 store.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-	r0 := m.InsertDefinitionsAndReferencesForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(StoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the
-// InsertDefinitionsAndReferencesForDocument method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertDefinitionsAndReferencesForDocument method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-		return r0
-	})
-}
-
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, store.ExportedUpload, string, int, func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 StoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreInsertDefinitionsAndReferencesForDocumentFuncCall objects describing
-// the invocations of this function.
-func (f *StoreInsertDefinitionsAndReferencesForDocumentFunc) History() []StoreInsertDefinitionsAndReferencesForDocumentFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object that
-// describes an invocation of method
-// InsertDefinitionsAndReferencesForDocument on an instance of MockStore.
-type StoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 store.ExportedUpload
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 int
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 func(ctx context.Context, upload store.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreInsertDefinitionsForRankingFunc describes the behavior when the
@@ -8844,6 +8708,10 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// InsertDefinitionsAndReferencesForDocument.
+	InsertDefinitionsAndReferencesForDocumentFunc *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LsifStoreInsertMetadataFunc
@@ -8887,6 +8755,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -8947,6 +8820,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
 			},
 		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+				panic("unexpected invocation of MockLsifStore.InsertDefinitionsAndReferencesForDocument")
+			},
+		},
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
 				panic("unexpected invocation of MockLsifStore.InsertMetadata")
@@ -8993,6 +8871,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
 		},
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
@@ -9569,6 +9450,126 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFunc describes the
+// behavior when the InsertDefinitionsAndReferencesForDocument method of the
+// parent MockLsifStore instance is invoked.
+type LsifStoreInsertDefinitionsAndReferencesForDocumentFunc struct {
+	defaultHook func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
+	hooks       []func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
+	history     []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertDefinitionsAndReferencesForDocument delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockLsifStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 shared.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+	r0 := m.InsertDefinitionsAndReferencesForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// InsertDefinitionsAndReferencesForDocument method of the parent
+// MockLsifStore instance is invoked and the hook queue is empty.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertDefinitionsAndReferencesForDocument method of the parent
+// MockLsifStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+		return r0
+	})
+}
+
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, shared.ExportedUpload, string, int, func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) History() []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object
+// that describes an invocation of method
+// InsertDefinitionsAndReferencesForDocument on an instance of
+// MockLsifStore.
+type LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 shared.ExportedUpload
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(ctx context.Context, upload shared.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // LsifStoreInsertMetadataFunc describes the behavior when the

--- a/enterprise/internal/codeintel/uploads/shared/types.go
+++ b/enterprise/internal/codeintel/uploads/shared/types.go
@@ -216,3 +216,10 @@ type RankingReferences struct {
 	UploadID    int
 	SymbolNames []string
 }
+
+type ExportedUpload struct {
+	ID           int
+	Repo         string
+	Root         string
+	ObjectPrefix string
+}


### PR DESCRIPTION
Move the methods that target non-frontend-schema into the lsifstore (soon to be renamed) package, which targets the codeintel-db.

## Test plan

Tested locally.