### PR TITLE
dbtest: Fix missing parameter

### DIFF
--- a/internal/database/connections/test/connect.go
+++ b/internal/database/connections/test/connect.go
@@ -43,7 +43,7 @@ func NewTestDB(t testing.TB, logger log.Logger, dsn string, schemas ...*schemas.
 	}
 
 	migrationLogger := logtest.ScopedWith(t, logtest.LoggerOptions{Level: log.LevelError})
-	if err := runner.NewRunner(migrationLogger, newStoreFactoryMap(db, schemas)).Run(context.Background(), options); err != nil {
+	if err := runner.NewRunnerWithSchemas(migrationLogger, newStoreFactoryMap(db, schemas), schemas).Run(context.Background(), options); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We weren't passing the frozen schemas all the way down; we ended up just using the up-to-date ones.

## Test plan

Tested template dbs generated by dbtest package by hand.