### PR TITLE
Fix settings editor not correctly marking as dirty

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -79,7 +79,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
     }
 
     private get effectiveValue(): string {
-        return this.props.value
+        return this.state.value === undefined ? this.props.value : this.state.value
     }
 
     private get isDirty(): boolean {


### PR DESCRIPTION
This was introduced in https://github.com/sourcegraph/sourcegraph/commit/fd4fd0e370530f29af04bd40bdfd7d4564eb86d2, reverting to the previous behavior.

## Test plan

Verified editor works again.

## App preview:

- [Web](https://sg-web-es-fix-settings-editor.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
