### PR TITLE
Ranking: fix nil deference in flush collect sender

### DIFF
--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -163,11 +163,9 @@ func (f *flushCollectSender) Send(endpoint string, event *zoekt.SearchResult) {
 
 		if len(f.firstEvent) == 0 {
 			f.stopCollectingAndFlush(zoekt.FlushReasonTimerExpired)
-		}
-
-		// Protect against too large aggregates. This should be the exception and only
-		// happen for queries yielding an extreme number of results.
-		if f.maxSizeBytes >= 0 && f.collectSender.sizeBytes > uint64(f.maxSizeBytes) {
+		} else if f.maxSizeBytes >= 0 && f.collectSender.sizeBytes > uint64(f.maxSizeBytes) {
+			// Protect against too large aggregates. This should be the exception and only
+			// happen for queries yielding an extreme number of results.
 			f.stopCollectingAndFlush(zoekt.FlushReasonMaxSize)
 		}
 	} else {

--- a/internal/search/backend/aggregate_test.go
+++ b/internal/search/backend/aggregate_test.go
@@ -160,7 +160,7 @@ func TestFlushCollectSenderMaxSize(t *testing.T) {
 
 	opts := zoekt.SearchOptions{
 		UseDocumentRanks: true,
-		FlushWallTime:    100000000 * time.Millisecond,
+		FlushWallTime:    100 * time.Millisecond,
 	}
 
 	// Collect all search results in order they were sent to stream


### PR DESCRIPTION
The previous PR #47931 introduced a bug where we could try to reference
collectSender even after it's been set to nil. This fixes it and adds a test
covering the case.

## Test plan

Added new test case