### PR TITLE
Search: make TestZoektSearchOptions more robust

### DIFF
--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -570,6 +570,11 @@ func TestZoektSearchOptions(t *testing.T) {
 				cfg := conf.Get()
 				cfg.ExperimentalFeatures.Ranking = tt.rankingFeatures
 				conf.Mock(cfg)
+
+				defer func() {
+					cfg.ExperimentalFeatures.Ranking = nil
+					conf.Mock(cfg)
+				}()
 			}
 
 			got := tt.options.ToSearch(tt.context)


### PR DESCRIPTION
The test modifies the global config, which can leak state to other tests. Now
we make sure to undo the config change.

## Test plan

This fixes failures I saw when running `go test -count=10 ./internal/search/...`