### PR TITLE
Search: disable ranking in hybrid search

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -167,9 +166,6 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 	opts := (&zoektutil.Options{
 		NumRepos:       1,
 		FileMatchLimit: int32(p.Limit),
-		Features: search.Features{
-			Ranking: true,
-		},
 	}).ToSearch(ctx)
 	if deadline, ok := ctx.Deadline(); ok {
 		opts.MaxWallTime = time.Until(deadline) - 100*time.Millisecond


### PR DESCRIPTION
This PR proposes reverting #44647 for now. At the moment, we always enable
search ranking for hybrid search -- it is not controlled by the
`search-ranking` feature flag. Recently, we had an incident with a new ranking
change, and we couldn't fully disable the feature because hybrid search
hardcodes the flag to 'true'. While we're still actively developing search
ranking (and while it's still disabled by default), I think we should disable
it in hybrid too.

## Test plan

Existing tests in CI