### PR TITLE
web: improve tree page

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -286,9 +286,9 @@ export const TreePage: FC<Props> = ({
     return (
         <div className={classNames(styles.treePage, className)}>
             <Container className={styles.container}>
-                <PageTitle title={getPageTitle()} />
-
                 <div className={classNames(styles.header)}>
+                    <PageTitle title={getPageTitle()} />
+
                     <header className="mb-3">
                         {isRoot ? (
                             <RootHeaderSection />
@@ -300,30 +300,30 @@ export const TreePage: FC<Props> = ({
                             </PageHeader>
                         )}
                     </header>
-                </div>
 
-                {treeOrError === undefined || repo === undefined ? (
-                    <div>
-                        <LoadingSpinner /> Loading files and directories
-                    </div>
-                ) : isErrorLike(treeOrError) ? (
-                    // If the tree is actually a blob, be helpful and redirect to the blob page.
-                    // We don't have error names on GraphQL errors.
-                    /not a directory/i.test(treeOrError.message) ? (
-                        <Navigate to={toPrettyBlobURL({ repoName, revision, commitID, filePath })} replace={true} />
+                    {treeOrError === undefined || repo === undefined ? (
+                        <div>
+                            <LoadingSpinner /> Loading files and directories
+                        </div>
+                    ) : isErrorLike(treeOrError) ? (
+                        // If the tree is actually a blob, be helpful and redirect to the blob page.
+                        // We don't have error names on GraphQL errors.
+                        /not a directory/i.test(treeOrError.message) ? (
+                            <Navigate to={toPrettyBlobURL({ repoName, revision, commitID, filePath })} replace={true} />
+                        ) : (
+                            <ErrorAlert error={treeOrError} />
+                        )
                     ) : (
-                        <ErrorAlert error={treeOrError} />
-                    )
-                ) : (
-                    <TreePageContent
-                        filePath={filePath}
-                        tree={treeOrError}
-                        repo={repo}
-                        revision={revision}
-                        commitID={commitID}
-                        {...props}
-                    />
-                )}
+                        <TreePageContent
+                            filePath={filePath}
+                            tree={treeOrError}
+                            repo={repo}
+                            revision={revision}
+                            commitID={commitID}
+                            {...props}
+                        />
+                    )}
+                </div>
             </Container>
         </div>
     )

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react'
+import React, { useMemo, useEffect, FC } from 'react'
 
 import { mdiBrain, mdiCog, mdiFolder, mdiHistory, mdiSourceBranch, mdiSourceRepository, mdiTag } from '@mdi/js'
 import classNames from 'classnames'
@@ -75,7 +75,7 @@ export const treePageRepositoryFragment = gql`
     }
 `
 
-export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+export const TreePage: FC<Props> = ({
     repo,
     repoName,
     commitID,
@@ -90,19 +90,22 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
     className,
     ...props
 }) => {
+    const isRoot = filePath === ''
+
     useEffect(() => {
-        if (filePath === '') {
+        if (isRoot) {
             props.telemetryService.logViewEvent('Repository')
         } else {
             props.telemetryService.logViewEvent('Tree')
         }
-    }, [filePath, props.telemetryService])
+    }, [isRoot, props.telemetryService])
 
     useBreadcrumb(
         useMemo(() => {
-            if (!filePath) {
+            if (isRoot) {
                 return
             }
+
             return {
                 key: 'treePath',
                 className: 'flex-shrink-past-contents',
@@ -117,7 +120,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     />
                 ),
             }
-        }, [filePath, repoName, revision, props.telemetryService])
+        }, [isRoot, filePath, repoName, revision, props.telemetryService])
     )
 
     const treeOrError = useObservable(
@@ -182,112 +185,123 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
         return `${repoString}`
     }
 
-    const [showPageTitle] = useState(true)
-
     const RootHeaderSection = (): React.ReactElement => (
-        <>
-            <div className="d-flex flex-wrap justify-content-between px-0">
-                <div className={styles.header}>
-                    <PageHeader className="mb-3 test-tree-page-title">
-                        <PageHeader.Heading as="h2" styleAs="h1">
-                            <PageHeader.Breadcrumb icon={mdiSourceRepository}>
-                                {displayRepoName(repo?.name || '')}
-                            </PageHeader.Breadcrumb>
-                        </PageHeader.Heading>
-                    </PageHeader>
-                    {repo?.description && <Text>{repo.description}</Text>}
-                </div>
-                <div className={styles.menu}>
-                    <ButtonGroup>
-                        <Tooltip content="Branches">
-                            <Button
-                                className="flex-shrink-0"
-                                to={`/${encodeURIPathComponent(repoName)}/-/branches`}
-                                variant="secondary"
-                                outline={true}
-                                as={Link}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiSourceBranch} />{' '}
-                                <span className={styles.text}>Branches</span>
-                            </Button>
-                        </Tooltip>
-                        <Tooltip content="Tags">
-                            <Button
-                                className="flex-shrink-0"
-                                to={`/${encodeURIPathComponent(repoName)}/-/tags`}
-                                variant="secondary"
-                                outline={true}
-                                as={Link}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiTag} /> <span className={styles.text}>Tags</span>
-                            </Button>
-                        </Tooltip>
-                        <Tooltip content="Compare">
-                            <Button
-                                className="flex-shrink-0"
-                                to={
-                                    revision
-                                        ? `/${encodeURIPathComponent(repoName)}/-/compare/...${encodeURIComponent(
-                                              revision
-                                          )}`
-                                        : `/${encodeURIPathComponent(repoName)}/-/compare`
-                                }
-                                variant="secondary"
-                                outline={true}
-                                as={Link}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiHistory} />{' '}
-                                <span className={styles.text}>Compare</span>
-                            </Button>
-                        </Tooltip>
-                        {codeIntelligenceEnabled && (
-                            <Tooltip content="Code graph data">
-                                <Button
-                                    className="flex-shrink-0"
-                                    to={`/${encodeURIPathComponent(repoName)}/-/code-graph`}
-                                    variant="secondary"
-                                    outline={true}
-                                    as={Link}
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiBrain} />{' '}
-                                    <span className={styles.text}>Code graph data</span>
-                                </Button>
-                            </Tooltip>
-                        )}
-                        {batchChangesEnabled && (
-                            <Tooltip content="Batch changes">
-                                <RepoBatchChangesButton
-                                    className="flex-shrink-0"
-                                    textClassName={styles.text}
-                                    repoName={repoName}
-                                />
-                            </Tooltip>
-                        )}
-                        {repo?.viewerCanAdminister && (
-                            <Tooltip content="Settings">
-                                <Button
-                                    className="flex-shrink-0"
-                                    to={`/${encodeURIPathComponent(repoName)}/-/settings`}
-                                    variant="secondary"
-                                    outline={true}
-                                    as={Link}
-                                    aria-label="Repository settings"
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiCog} />
-                                    <span className={styles.text}>Settings</span>
-                                </Button>
-                            </Tooltip>
-                        )}
-                    </ButtonGroup>
-                </div>
+        <div className="d-flex flex-wrap justify-content-between px-0">
+            <div className={styles.header}>
+                <PageHeader className="mb-3 test-tree-page-title">
+                    <PageHeader.Heading as="h2" styleAs="h1">
+                        <PageHeader.Breadcrumb icon={mdiSourceRepository}>
+                            {displayRepoName(repo?.name || '')}
+                        </PageHeader.Breadcrumb>
+                    </PageHeader.Heading>
+                </PageHeader>
+                {repo?.description && <Text>{repo.description}</Text>}
             </div>
-        </>
+            <div className={styles.menu}>
+                <ButtonGroup>
+                    <Tooltip content="Branches">
+                        <Button
+                            className="flex-shrink-0"
+                            to={`/${encodeURIPathComponent(repoName)}/-/branches`}
+                            variant="secondary"
+                            outline={true}
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiSourceBranch} />{' '}
+                            <span className={styles.text}>Branches</span>
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Tags">
+                        <Button
+                            className="flex-shrink-0"
+                            to={`/${encodeURIPathComponent(repoName)}/-/tags`}
+                            variant="secondary"
+                            outline={true}
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiTag} /> <span className={styles.text}>Tags</span>
+                        </Button>
+                    </Tooltip>
+                    <Tooltip content="Compare">
+                        <Button
+                            className="flex-shrink-0"
+                            to={
+                                revision
+                                    ? `/${encodeURIPathComponent(repoName)}/-/compare/...${encodeURIComponent(
+                                          revision
+                                      )}`
+                                    : `/${encodeURIPathComponent(repoName)}/-/compare`
+                            }
+                            variant="secondary"
+                            outline={true}
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiHistory} />{' '}
+                            <span className={styles.text}>Compare</span>
+                        </Button>
+                    </Tooltip>
+                    {codeIntelligenceEnabled && (
+                        <Tooltip content="Code graph data">
+                            <Button
+                                className="flex-shrink-0"
+                                to={`/${encodeURIPathComponent(repoName)}/-/code-graph`}
+                                variant="secondary"
+                                outline={true}
+                                as={Link}
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiBrain} />{' '}
+                                <span className={styles.text}>Code graph data</span>
+                            </Button>
+                        </Tooltip>
+                    )}
+                    {batchChangesEnabled && (
+                        <Tooltip content="Batch changes">
+                            <RepoBatchChangesButton
+                                className="flex-shrink-0"
+                                textClassName={styles.text}
+                                repoName={repoName}
+                            />
+                        </Tooltip>
+                    )}
+                    {repo?.viewerCanAdminister && (
+                        <Tooltip content="Settings">
+                            <Button
+                                className="flex-shrink-0"
+                                to={`/${encodeURIPathComponent(repoName)}/-/settings`}
+                                variant="secondary"
+                                outline={true}
+                                as={Link}
+                                aria-label="Repository settings"
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiCog} />
+                                <span className={styles.text}>Settings</span>
+                            </Button>
+                        </Tooltip>
+                    )}
+                </ButtonGroup>
+            </div>
+        </div>
     )
 
     return (
         <div className={classNames(styles.treePage, className)}>
             <Container className={styles.container}>
-                {!showPageTitle && <PageTitle title={getPageTitle()} />}
+                <PageTitle title={getPageTitle()} />
+
+                <div className={classNames(styles.header)}>
+                    <header className="mb-3">
+                        {isRoot ? (
+                            <RootHeaderSection />
+                        ) : (
+                            <PageHeader className="mb-3 mr-2 test-tree-page-title">
+                                <PageHeader.Heading as="h2" styleAs="h1">
+                                    <PageHeader.Breadcrumb icon={mdiFolder}>{filePath}</PageHeader.Breadcrumb>
+                                </PageHeader.Heading>
+                            </PageHeader>
+                        )}
+                    </header>
+                </div>
+
                 {treeOrError === undefined || repo === undefined ? (
                     <div>
                         <LoadingSpinner /> Loading files and directories
@@ -301,28 +315,14 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                         <ErrorAlert error={treeOrError} />
                     )
                 ) : (
-                    <div className={classNames(styles.header)}>
-                        <header className="mb-3">
-                            {treeOrError.isRoot ? (
-                                <RootHeaderSection />
-                            ) : (
-                                <PageHeader className="mb-3 mr-2 test-tree-page-title">
-                                    <PageHeader.Heading as="h2" styleAs="h1">
-                                        <PageHeader.Breadcrumb icon={mdiFolder}>{filePath}</PageHeader.Breadcrumb>
-                                    </PageHeader.Heading>
-                                </PageHeader>
-                            )}
-                        </header>
-
-                        <TreePageContent
-                            filePath={filePath}
-                            tree={treeOrError}
-                            repo={repo}
-                            revision={revision}
-                            commitID={commitID}
-                            {...props}
-                        />
-                    </div>
+                    <TreePageContent
+                        filePath={filePath}
+                        tree={treeOrError}
+                        repo={repo}
+                        revision={revision}
+                        commitID={commitID}
+                        {...props}
+                    />
                 )}
             </Container>
         </div>


### PR DESCRIPTION
## Context

Improvement based on [the Slack report](https://sourcegraph.slack.com/files/U01SD823C9W/F04QS1E1RHT/screen_recording_2023-02-22_at_18.17.14.mov). With this PR we no longer hide the page title when we navigate between folders/files on the tree page. This removes extra flickering of the content.

## Test plan

1. Open the tree view and navigate between folders/files.
2. Notice that the page title is always displayed and doesn't disappear when we wait for the next batch of data from the API.

## App preview:

- [Web](https://sg-web-vb-improve-tree-page.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
