### PR TITLE
Setup Wizard: Improve setup wizard layout and UI api 

### DIFF
--- a/client/web/src/setup-wizard/Setup.module.scss
+++ b/client/web/src/setup-wizard/Setup.module.scss
@@ -22,6 +22,15 @@
     flex-direction: column;
 }
 
+.content {
+    flex-grow: 1;
+    overflow: auto;
+}
+
+.footer {
+    flex-shrink: 0;
+}
+
 .header {
     background: var(--header-gradient);
     background: radial-gradient(

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -8,7 +8,7 @@ import { PageTitle } from '../components/PageTitle'
 import { SiteAdminRepositoriesContainer } from '../site-admin/SiteAdminRepositoriesContainer'
 
 import { RemoteRepositoriesStep } from './components/remote-repositories-step'
-import { SetupStepsRoot, StepConfiguration } from './components/setup-steps'
+import { SetupStepsRoot, SetupStepsContent, SetupStepsFooter, StepConfiguration } from './components/setup-steps'
 
 import styles from './Setup.module.scss'
 
@@ -50,15 +50,21 @@ export const SetupWizard: FC = () => {
     return (
         <div className={styles.root}>
             <PageTitle title="Setup" />
-            <header className={styles.header}>
-                <BrandLogo variant="logo" isLightTheme={false} className={styles.logo} />
+            <SetupStepsRoot initialStepId={activeStepId} steps={SETUP_STEPS} onStepChange={handleStepChange}>
+                <div className={styles.content}>
+                    <header className={styles.header}>
+                        <BrandLogo variant="logo" isLightTheme={false} className={styles.logo} />
 
-                <H2 as={H1} className="font-weight-normal text-white mt-3 mb-4">
-                    Welcome to Sourcegraph! Let's get started.
-                </H2>
-            </header>
+                        <H2 as={H1} className="font-weight-normal text-white mt-3 mb-4">
+                            Welcome to Sourcegraph! Let's get started.
+                        </H2>
+                    </header>
 
-            <SetupStepsRoot initialStepId={activeStepId} steps={SETUP_STEPS} onStepChange={handleStepChange} />
+                    <SetupStepsContent />
+                </div>
+
+                <SetupStepsFooter className={styles.footer} />
+            </SetupStepsRoot>
         </div>
     )
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -5,7 +5,7 @@ import { Routes, Route, matchPath, useLocation } from 'react-router-dom'
 
 import { Container, Text } from '@sourcegraph/wildcard'
 
-import { CustomNextButton } from '../setup-steps'
+import { FooterWidget, CustomNextButton } from '../setup-steps'
 
 import { CodeHostDeleteModal, CodeHostToDelete } from './components/code-host-delete-modal'
 import { CodeHostsPicker } from './components/code-host-picker'
@@ -53,6 +53,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
                 </Container>
             </section>
 
+            <FooterWidget>Hello custom content in the footer</FooterWidget>
             <CustomNextButton label="Custom next step label" disabled={true} />
 
             {codeHostToDelete && (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.module.scss
@@ -11,9 +11,7 @@
     gap: 0.5rem;
     align-items: center;
     position: sticky;
-    // Calculated value since we already have sticky footer element for
-    // the core wizard UI.
-    bottom: 51px;
+    bottom: 0;
     margin-top: auto;
     padding: 0.5rem 1rem;
     background-color: var(--color-bg-1);

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.module.scss
@@ -8,9 +8,7 @@
 .footer {
     margin: auto -1rem -1rem;
     position: sticky;
-    // Calculated value since we already have sticky footer element for
-    // the core wizard UI.
-    bottom: 51px;
+    bottom: 0;
 }
 
 .configuration-group {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -26,6 +26,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
+    min-height: 100%;
 }
 
 .delete-button {
@@ -60,9 +61,9 @@
     &--with-more-link {
         border-top: 1px solid var(--border-color);
         position: sticky;
-        bottom: 51px;
+        bottom: 0;
         background-color: var(--light-text);
-        margin-top: 0.5rem;
+        margin-top: auto;
         margin-bottom: -1rem;
         margin-left: -1rem;
         margin-right: -1rem;

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
@@ -93,25 +93,50 @@
     width: 100%;
 }
 
-.navigation {
+.footer {
     display: flex;
+    flex-direction: column;
     position: sticky;
     bottom: 0;
-    background-color: var(--gray-02);
-    border-top: 1px solid var(--border-color);
+
+    $self: &;
 
     :global(.theme-dark) & {
         background-color: var(--color-bg-2);
     }
 
-    &-inner {
+    &-navigation {
+        display: flex;
+        background-color: var(--gray-02);
+        border-top: 1px solid var(--border-color);
+    }
+
+    &-inner-navigation {
         display: flex;
         flex-grow: 1;
         gap: 0.5rem;
+        padding: 0.5rem;
         width: 100%;
         max-width: 55rem;
         margin: auto;
-        padding: 0.5rem;
+    }
+
+    &-widget {
+        display: flex;
+        width: 100%;
+        background-color: var(--color-bg-1);
+        border-top: 1px solid var(--border-color);
+
+        &:has(> #{$self}-inner-widget:empty) {
+            display: none;
+        }
+    }
+
+    &-inner-widget {
+        max-width: 55rem;
+        margin: auto;
+        flex-grow: 1;
+        padding: 0.25rem 0.5rem;
     }
 
     // Hide default next button if the custom button is rendered

--- a/client/web/src/setup-wizard/components/setup-steps/index.ts
+++ b/client/web/src/setup-wizard/components/setup-steps/index.ts
@@ -1,2 +1,2 @@
-export { SetupStepsRoot, SetupStepsContent, SetupStepsFooter, CustomNextButton } from './SetupSteps'
+export { SetupStepsRoot, SetupStepsContent, SetupStepsFooter, FooterWidget, CustomNextButton } from './SetupSteps'
 export type { StepConfiguration } from './SetupSteps'

--- a/client/web/src/setup-wizard/components/setup-steps/index.ts
+++ b/client/web/src/setup-wizard/components/setup-steps/index.ts
@@ -1,2 +1,2 @@
-export { SetupStepsRoot, CustomNextButton } from './SetupSteps'
+export { SetupStepsRoot, SetupStepsContent, SetupStepsFooter, CustomNextButton } from './SetupSteps'
 export type { StepConfiguration } from './SetupSteps'


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47909

This PR adds new layout to the setup wizard component that allows rendering generic element from individual setup step UI in the shared footer component; this is needed functionality to render progress bar from the step react tree in the outside (outside of the step component DOM) footer DOM element 

## TODO
- [x] Add new layout (avoid having hardcoede value for the bottom coordinate in sticky elements 
- [x] Add portal API in order to render genetic content in the footer DOM from the individual steap react component 

## Test plan
- CI is passing and has green status

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-re-layout-setup-wizard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
