### PR TITLE
repos: exclude field for other

### DIFF
--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -209,6 +209,25 @@ func TestOther_ListRepos(t *testing.T) {
 			RepositoryPathPattern: "pre-{repo}",
 		},
 		Want: []string{"pre-a", "pre-b/c", "pre-d"},
+	}, {
+		Name: "src-expose/exclude",
+		Conn: &schema.OtherExternalServiceConnection{
+			Url:                   srcExpose.URL,
+			Repos:                 []string{"src-expose"},
+			Exclude:               []*schema.ExcludedOtherRepo{{Name: "not-exact"}, {Name: "exclude/exact"}, {Pattern: "exclude-dir"}},
+			RepositoryPathPattern: "pre-{repo}",
+		},
+		SrcExposeRepos: []string{"keep1", "not-exact/keep2", "exclude-dir/a", "exclude-dir/b", "exclude/exact", "keep3"},
+		Want:           []string{"keep1", "not-exact/keep2", "keep3"},
+	}, {
+		Name: "static/pattern",
+		Conn: &schema.OtherExternalServiceConnection{
+			Url:                   "http://test",
+			Repos:                 []string{"keep1", "not-exact/keep2", "exclude-dir/a", "exclude-dir/b", "exclude/exact", "keep3"},
+			Exclude:               []*schema.ExcludedOtherRepo{{Name: "not-exact"}, {Name: "exclude/exact"}, {Pattern: "exclude-dir"}},
+			RepositoryPathPattern: "{repo}",
+		},
+		Want: []string{"keep1", "not-exact/keep2", "keep3"},
 	}}
 
 	for _, tc := range cases {

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -34,6 +34,46 @@
       "type": "string",
       "default": "{base}/{repo}",
       "examples": ["pretty-host-name/{repo}"]
+    },
+    "exclude": {
+      "description": "A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({\"name\": \"myrepo\"}) or regular expression ({\"pattern\": \".*secret.*\"}).",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "ExcludedOtherRepo",
+        "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": ["name"]
+          },
+          {
+            "required": ["pattern"]
+          }
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of a Other repo (\"my-repo\") to exclude from mirroring.",
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "description": "Regular expression which matches against the name of a Other repo to exclude from mirroring.",
+            "type": "string",
+            "format": "regex"
+          }
+        }
+      },
+      "examples": [
+        [
+          {
+            "name": "myrepo"
+          },
+          {
+            "pattern": ".*secret.*"
+          }
+        ]
+      ]
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -684,6 +684,12 @@ type ExcludedGitoliteRepo struct {
 	// Pattern description: Regular expression which matches against the name of a Gitolite repo to exclude from mirroring.
 	Pattern string `json:"pattern,omitempty"`
 }
+type ExcludedOtherRepo struct {
+	// Name description: The name of a Other repo ("my-repo") to exclude from mirroring.
+	Name string `json:"name,omitempty"`
+	// Pattern description: Regular expression which matches against the name of a Other repo to exclude from mirroring.
+	Pattern string `json:"pattern,omitempty"`
+}
 type ExistingChangesetSpec struct {
 	// BaseRepository description: The GraphQL ID of the repository that contains the existing changeset on the code host.
 	BaseRepository string `json:"baseRepository"`
@@ -1590,7 +1596,9 @@ type OrganizationInvitations struct {
 
 // OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
 type OtherExternalServiceConnection struct {
-	Repos []string `json:"repos"`
+	// Exclude description: A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
+	Exclude []*ExcludedOtherRepo `json:"exclude,omitempty"`
+	Repos   []string             `json:"repos"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable "{base}" is replaced with the Git clone base URL host and path, and "{repo}" is replaced with the repository path taken from the `repos` field.
 	//
 	// For example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value "my/repo", then a repositoryPathPattern of "{base}/{repo}" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.


### PR DESCRIPTION
We add support for exclude names/patterns in the other external service following the same convention as in other external services. The motivation for this is when recursively adding repositories in App / Wizard we want a convenient way to exclude a repository.

Test Plan: added unit tests

Part of https://github.com/sourcegraph/sourcegraph/issues/47960

plz-review-url: https://plz.review/review/19565
