### PR TITLE
web: review and better document the app shell context fields

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -2,27 +2,15 @@ import React, { Suspense, useCallback, useLayoutEffect, useState } from 'react'
 
 import classNames from 'classnames'
 import { Outlet, useLocation, Navigate, useMatches } from 'react-router-dom'
-import { Observable } from 'rxjs'
 
 import { TabbedPanelContent } from '@sourcegraph/branded/src/components/panel/TabbedPanelContent'
-import { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
-import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SearchContextProps } from '@sourcegraph/shared/src/search'
-import { SettingsCascadeProps, SettingsSubjectCommonFields } from '@sourcegraph/shared/src/settings/settings'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useTheme, Theme } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 import { FeedbackPrompt, LoadingSpinner, Panel } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from './auth'
-import type { BatchChangesProps } from './batches'
-import type { CodeIntelligenceProps } from './codeintel'
-import { CodeMonitoringProps } from './codeMonitoring'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -33,11 +21,11 @@ import { useUserHistory } from './components/useUserHistory'
 import { useFeatureFlag } from './featureFlags/useFeatureFlag'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { useHandleSubmitFeedback } from './hooks'
+import { LegacyLayoutRouteContext } from './LegacyRouteContext'
 import { SurveyToast } from './marketing/toast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
-import type { NotebookProps } from './notebooks'
 import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
-import { parseSearchURLQuery, SearchAggregationProps, SearchStreamingProps } from './search'
+import { parseSearchURLQuery } from './search'
 import { NotepadContainer } from './search/Notepad'
 import { SearchQueryStateObserver } from './SearchQueryStateObserver'
 import { useExperimentalFeatures } from './stores'
@@ -48,33 +36,10 @@ import styles from './Layout.module.scss'
 
 const LazySetupWizard = lazyComponent(() => import('./setup-wizard'), 'SetupWizard')
 
-export interface LegacyLayoutProps
-    extends SettingsCascadeProps<Settings>,
-        PlatformContextProps,
-        ExtensionsControllerProps,
-        TelemetryProps,
-        SearchContextProps,
-        SearchStreamingProps,
-        CodeIntelligenceProps,
-        BatchChangesProps,
-        NotebookProps,
-        CodeMonitoringProps,
-        SearchAggregationProps {
-    authenticatedUser: AuthenticatedUser | null
-
-    /**
-     * The subject GraphQL node ID of the viewer, which is used to look up the viewer's settings. This is either
-     * the site's GraphQL node ID (for anonymous users) or the authenticated user's GraphQL node ID.
-     */
-    viewerSubject: SettingsSubjectCommonFields
-
-    // Search
-    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
-
-    globbing: boolean
-    isSourcegraphDotCom: boolean
-    isSourcegraphApp: boolean
+export interface LegacyLayoutProps extends LegacyLayoutRouteContext {
+    children?: never
 }
+
 /**
  * Syntax highlighting changes for WCAG 2.1 contrast compliance (currently behind feature flag)
  * https://github.com/sourcegraph/sourcegraph/issues/36251

--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useCallback } from 'react'
+import { FC, PropsWithChildren, createContext, useContext, useCallback } from 'react'
 
 import { Observable } from 'rxjs'
 
@@ -14,37 +14,90 @@ import {
     updateSearchContext,
     deleteSearchContext,
     isSearchContextSpecAvailable,
+    SearchContextProps,
 } from '@sourcegraph/shared/src/search'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
 
-import { BatchChangesProps, isBatchChangesExecutionEnabled } from './batches'
-import { CodeIntelligenceProps } from './codeintel'
-import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './components/Breadcrumbs'
-import type { LegacyLayoutProps } from './LegacyLayout'
+import { isBatchChangesExecutionEnabled } from './batches'
+import { useBreadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from './components/Breadcrumbs'
+import { SearchStreamingProps } from './search'
+import { StaticSourcegraphWebAppContext, DynamicSourcegraphWebAppContext } from './SourcegraphWebApp'
+import { StaticAppConfig } from './staticAppConfig'
 import { eventLogger } from './tracking/eventLogger'
 
-export interface LegacyLayoutRouteComponentProps
-    extends Omit<LegacyLayoutProps, 'match'>,
-        BreadcrumbsProps,
-        BreadcrumbSetters,
-        CodeIntelligenceProps,
-        BatchChangesProps {
-    isSourcegraphDotCom: boolean
-    isSourcegraphApp: boolean
+export interface StaticLegacyRouteContext extends LegacyRouteComputedContext, LegacyRouteStaticInjections {}
+
+/**
+ * Static values we compute in the `<LegacyRoute /> component.
+ *
+ * Static in the sense that there are no other ways to change
+ * these values except by refetching the entire original value (settingsCascade)
+ */
+export interface LegacyRouteComputedContext {
+    /**
+     * TODO: expose these fields in the new `useSettings()` hook, calculate next to source.
+     */
+    globbing: boolean
+    batchChangesExecutionEnabled: boolean
+
+    /**
+     * TODO: remove from the context and repalce with isMacPlatform() calls
+     */
     isMacPlatform: boolean
 }
 
-interface Props {
-    render: (props: LegacyLayoutRouteComponentProps) => JSX.Element
-    condition?: (props: LegacyLayoutRouteComponentProps) => boolean
+/**
+ * Non-primitive values (components, objects) we inject in the <LegacyRoute /> component.
+ *
+ * TODO: consolidate all static intejections in one place or get rid of them is possible.
+ */
+export interface LegacyRouteStaticInjections
+    extends Pick<TelemetryProps, 'telemetryService'>,
+        Pick<
+            SearchContextProps,
+            | 'getUserSearchContextNamespaces'
+            | 'fetchSearchContexts'
+            | 'fetchSearchContextBySpec'
+            | 'fetchSearchContext'
+            | 'createSearchContext'
+            | 'updateSearchContext'
+            | 'deleteSearchContext'
+            | 'isSearchContextSpecAvailable'
+        >,
+        Pick<SearchStreamingProps, 'streamSearch'>,
+        Pick<BreadcrumbsProps, 'breadcrumbs'>,
+        Pick<BreadcrumbSetters, 'useBreadcrumb' | 'setBreadcrumb'> {
+    // Search
+    fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+}
+
+/**
+ * LegacyRoute component props consist of fours parts:
+ * 1. StaticAppConfig — injected at the tip of the React tree.
+ * 2. StaticSourcegraphWebAppContext — injected by the `SourcegraphWebApp` component.
+ * 3. DynamicSourcegraphWebAppContext — injected by the `SourcegraphWebApp` component.
+ * 4. StaticLegacyRouteContext — injected by the `StaticLegacyRouteContext` component
+ *
+ * All these fields are static except for `DynamicSourcegraphWebAppContext`.
+ */
+export interface LegacyLayoutRouteContext
+    extends StaticAppConfig,
+        StaticSourcegraphWebAppContext,
+        DynamicSourcegraphWebAppContext,
+        StaticLegacyRouteContext {}
+
+interface LegacyRouteProps {
+    render: (props: LegacyLayoutRouteContext) => JSX.Element
+    condition?: (props: LegacyLayoutRouteContext) => boolean
 }
 
 /**
  * A wrapper component for React router route entrypoints that still need access to the legacy
  * route context and prop drilling.
  */
-export const LegacyRoute = ({ render, condition }: Props): JSX.Element | null => {
+export const LegacyRoute: FC<LegacyRouteProps> = ({ render, condition }) => {
     const context = useContext(LegacyRouteContext)
     if (!context) {
         throw new Error('LegacyRoute must be used inside a LegacyRouteContext.Provider')
@@ -56,6 +109,65 @@ export const LegacyRoute = ({ render, condition }: Props): JSX.Element | null =>
 
     return render(context)
 }
+
+export interface LegacyRouteContextProviderProps {
+    context: StaticAppConfig & StaticSourcegraphWebAppContext & DynamicSourcegraphWebAppContext
+}
+
+export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContextProviderProps>> = props => {
+    const { children, context } = props
+    const { settingsCascade, platformContext } = context
+
+    const _fetchHighlightedFileLineRanges = useCallback(
+        (parameters: FetchFileParameters, force?: boolean | undefined): Observable<string[][]> =>
+            fetchHighlightedFileLineRanges({ ...parameters, platformContext }, force),
+        [platformContext]
+    )
+
+    const breadcrumbProps = useBreadcrumbs()
+
+    const injections = {
+        /**
+         * Search context props
+         */
+        getUserSearchContextNamespaces,
+        fetchSearchContexts,
+        fetchSearchContextBySpec,
+        fetchSearchContext,
+        createSearchContext,
+        updateSearchContext,
+        deleteSearchContext,
+        isSearchContextSpecAvailable,
+
+        /**
+         * Other injections from static imports
+         */
+        streamSearch: aggregateStreamingSearch,
+        fetchHighlightedFileLineRanges: _fetchHighlightedFileLineRanges,
+        telemetryService: eventLogger,
+
+        /**
+         * Breadcrumb props
+         */
+        ...breadcrumbProps,
+    } satisfies LegacyRouteStaticInjections
+
+    const derivedFromSettings = {
+        globbing: globbingEnabledFromSettings(settingsCascade),
+        batchChangesExecutionEnabled: isBatchChangesExecutionEnabled(settingsCascade),
+        isMacPlatform: isMacPlatform(),
+    } satisfies LegacyRouteComputedContext
+
+    const legacyContext = {
+        ...context,
+        ...injections,
+        ...derivedFromSettings,
+    } satisfies LegacyLayoutRouteContext
+
+    return <LegacyRouteContext.Provider value={legacyContext}>{children}</LegacyRouteContext.Provider>
+}
+
+export const LegacyRouteContext = createContext<LegacyLayoutRouteContext | null>(null)
 
 /**
  * A convenience hook to return the platform context.
@@ -70,68 +182,3 @@ export const useLegacyPlatformContext = (): PlatformContext => {
     }
     return context.platformContext
 }
-
-export interface LegacyRouteContextProviderProps {
-    context: Omit<
-        LegacyLayoutRouteComponentProps,
-        | 'isMacPlatform'
-        | 'isSourcegraphDotCom'
-        | 'isSourcegraphApp'
-        | 'getUserSearchContextNamespaces'
-        | 'fetchSearchContexts'
-        | 'fetchSearchContextBySpec'
-        | 'fetchSearchContext'
-        | 'createSearchContext'
-        | 'updateSearchContext'
-        | 'deleteSearchContext'
-        | 'isSearchContextSpecAvailable'
-        | 'globbing'
-        | 'streamSearch'
-        | 'batchChangesExecutionEnabled'
-        | 'fetchHighlightedFileLineRanges'
-        | 'batchChangesWebhookLogsEnabled'
-        | 'breadcrumbs'
-        | 'useBreadcrumb'
-        | 'setBreadcrumb'
-        | 'telemetryService'
-    >
-}
-export const LegacyRouteContextProvider: React.FC<React.PropsWithChildren<LegacyRouteContextProviderProps>> = ({
-    children,
-    context,
-}) => {
-    const { settingsCascade, platformContext } = context
-
-    const _fetchHighlightedFileLineRanges = useCallback(
-        (parameters: FetchFileParameters, force?: boolean | undefined): Observable<string[][]> =>
-            fetchHighlightedFileLineRanges({ ...parameters, platformContext }, force),
-        [platformContext]
-    )
-
-    const breadcrumbProps = useBreadcrumbs()
-
-    const legacyContext = {
-        ...context,
-        ...breadcrumbProps,
-        isMacPlatform: isMacPlatform(),
-        isSourcegraphDotCom: window.context.sourcegraphDotComMode,
-        isSourcegraphApp: window.context.sourcegraphAppMode,
-        getUserSearchContextNamespaces,
-        fetchSearchContexts,
-        fetchSearchContextBySpec,
-        fetchSearchContext,
-        createSearchContext,
-        updateSearchContext,
-        deleteSearchContext,
-        isSearchContextSpecAvailable,
-        globbing: globbingEnabledFromSettings(settingsCascade),
-        streamSearch: aggregateStreamingSearch,
-        batchChangesExecutionEnabled: isBatchChangesExecutionEnabled(settingsCascade),
-        fetchHighlightedFileLineRanges: _fetchHighlightedFileLineRanges,
-        batchChangesWebhookLogsEnabled: window.context.batchChangesWebhookLogsEnabled,
-        telemetryService: eventLogger,
-    } satisfies LegacyLayoutRouteComponentProps
-
-    return <LegacyRouteContext.Provider value={legacyContext}>{children}</LegacyRouteContext.Provider>
-}
-export const LegacyRouteContext = createContext<LegacyLayoutRouteComponentProps | null>(null)

--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -152,7 +152,7 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
         ...breadcrumbProps,
     } satisfies LegacyRouteStaticInjections
 
-    const derivedFromSettings = {
+    const computedContextFields = {
         globbing: globbingEnabledFromSettings(settingsCascade),
         batchChangesExecutionEnabled: isBatchChangesExecutionEnabled(settingsCascade),
         isMacPlatform: isMacPlatform(),
@@ -161,7 +161,7 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
     const legacyContext = {
         ...context,
         ...injections,
-        ...derivedFromSettings,
+        ...computedContextFields,
     } satisfies LegacyLayoutRouteContext
 
     return <LegacyRouteContext.Provider value={legacyContext}>{children}</LegacyRouteContext.Provider>

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { ApolloProvider } from '@apollo/client'
 import ServerIcon from 'mdi-react/ServerIcon'
 import { RouterProvider, createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom'
-import { combineLatest, from, Subscription, fromEvent, Subject, Observable } from 'rxjs'
+import { combineLatest, from, Subscription, fromEvent, Observable } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
 import { GraphQLClient, HTTPStatusError } from '@sourcegraph/http-client'
@@ -22,7 +22,6 @@ import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { ShortcutProvider } from '@sourcegraph/shared/src/react-shortcuts'
 import {
     getUserSearchContextNamespaces,
-    SearchContextProps,
     fetchSearchContexts,
     fetchSearchContext,
     fetchSearchContextBySpec,
@@ -48,70 +47,24 @@ import { FeedbackText, setLinkComponent, RouterLink, WildcardThemeContext, Wildc
 
 import { authenticatedUser as authenticatedUserSubject, AuthenticatedUser, authenticatedUserValue } from './auth'
 import { getWebGraphQLClient } from './backend/graphql'
-import { BatchChangesProps, isBatchChangesExecutionEnabled } from './batches'
-import type { CodeIntelligenceProps } from './codeintel'
-import { CodeMonitoringProps } from './codeMonitoring'
+import { isBatchChangesExecutionEnabled } from './batches'
 import { ComponentsComposer } from './components/ComponentsComposer'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { HeroPage } from './components/HeroPage'
 import { FeatureFlagsProvider } from './featureFlags/FeatureFlagsProvider'
-import type { CodeInsightsProps } from './insights/types'
 import { LegacyLayout, LegacyLayoutProps } from './LegacyLayout'
 import { LegacyRouteContextProvider } from './LegacyRouteContext'
-import { NotebookProps } from './notebooks'
-import type { OrgAreaRoute } from './org/area/OrgArea'
-import type { OrgAreaHeaderNavItem } from './org/area/OrgHeader'
-import type { OrgSettingsAreaRoute } from './org/settings/OrgSettingsArea'
-import type { OrgSettingsSidebarItems } from './org/settings/OrgSettingsSidebar'
 import { createPlatformContext } from './platform/context'
-import type { RepoContainerRoute } from './repo/RepoContainer'
-import type { RepoHeaderActionButton } from './repo/RepoHeader'
-import type { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
-import type { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
-import type { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
-import type { LayoutRouteProps } from './routes'
-import { parseSearchURL, SearchAggregationProps } from './search'
+import { parseSearchURL } from './search'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
 import { GLOBAL_SEARCH_CONTEXT_SPEC } from './SearchQueryStateObserver'
-import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
-import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
+import { StaticAppConfig } from './staticAppConfig'
 import { setQueryStateFromSettings, setExperimentalFeaturesFromSettings, useNavbarQueryState } from './stores'
 import { eventLogger } from './tracking/eventLogger'
-import type { UserAreaRoute } from './user/area/UserArea'
-import type { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
-import type { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
-import type { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
 import { UserSessionStores } from './UserSessionStores'
 import { siteSubjectNoAdmin, viewerSubjectFromSettings } from './util/settings'
 
 import styles from './LegacySourcegraphWebApp.module.scss'
-
-export interface LegacySourcegraphWebAppProps
-    extends CodeIntelligenceProps,
-        CodeInsightsProps,
-        Pick<BatchChangesProps, 'batchChangesEnabled'>,
-        Pick<SearchContextProps, 'searchContextsEnabled'>,
-        NotebookProps,
-        CodeMonitoringProps,
-        SearchAggregationProps {
-    siteAdminAreaRoutes: readonly SiteAdminAreaRoute[]
-    siteAdminSideBarGroups: SiteAdminSideBarGroups
-    siteAdminOverviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]
-    userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[]
-    userAreaRoutes: readonly UserAreaRoute[]
-    userSettingsSideBarItems: UserSettingsSidebarItems
-    userSettingsAreaRoutes: readonly UserSettingsAreaRoute[]
-    orgSettingsSideBarItems: OrgSettingsSidebarItems
-    orgSettingsAreaRoutes: readonly OrgSettingsAreaRoute[]
-    orgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[]
-    orgAreaRoutes: readonly OrgAreaRoute[]
-    repoContainerRoutes: readonly RepoContainerRoute[]
-    repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[]
-    repoHeaderActionButtons: readonly RepoHeaderActionButton[]
-    repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
-    repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
-    routes: readonly LayoutRouteProps[]
-}
 
 interface LegacySourcegraphWebAppState extends SettingsCascadeProps {
     error?: Error
@@ -157,18 +110,14 @@ setLinkComponent(RouterLink)
 /**
  * The root component.
  */
-export class LegacySourcegraphWebApp extends React.Component<
-    LegacySourcegraphWebAppProps,
-    LegacySourcegraphWebAppState
-> {
+export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, LegacySourcegraphWebAppState> {
     private readonly subscriptions = new Subscription()
-    private readonly userRepositoriesUpdates = new Subject<void>()
     private readonly platformContext: PlatformContext = createPlatformContext()
     private readonly extensionsController: ExtensionsController | null = window.context.enableLegacyExtensions
         ? createExtensionsController(this.platformContext)
         : createNoopController(this.platformContext)
 
-    constructor(props: LegacySourcegraphWebAppProps) {
+    constructor(props: StaticAppConfig) {
         super(props)
 
         if (this.extensionsController !== null) {
@@ -251,8 +200,6 @@ export class LegacySourcegraphWebApp extends React.Component<
         this.setWorkspaceSearchContext(this.state.selectedSearchContextSpec).catch(error => {
             logger.error('Error sending search context to extensions!', error)
         })
-
-        this.userRepositoriesUpdates.next()
     }
 
     public componentWillUnmount(): void {

--- a/client/web/src/OpenSourceWebApp.tsx
+++ b/client/web/src/OpenSourceWebApp.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC } from 'react'
 
 import './SourcegraphWebApp.scss'
 import { LegacySourcegraphWebApp } from './LegacySourcegraphWebApp'
@@ -14,37 +14,54 @@ import { repoSettingsSideBarGroups } from './repo/settings/sidebaritems'
 import { routes } from './routes'
 import { siteAdminAreaRoutes } from './site-admin/routes'
 import { siteAdminSidebarGroups } from './site-admin/sidebaritems'
+import {
+    StaticAppConfig,
+    StaticHardcodedAppConfig,
+    StaticInjectedAppConfig,
+    windowContextConfig,
+} from './staticAppConfig'
 import { userAreaHeaderNavItems } from './user/area/navitems'
 import { userAreaRoutes } from './user/area/routes'
 import { userSettingsAreaRoutes } from './user/settings/routes'
 import { userSettingsSideBarItems } from './user/settings/sidebaritems'
 
+const injectedValuesConfig = {
+    /**
+     * Routes and nav links
+     */
+    siteAdminAreaRoutes,
+    siteAdminSideBarGroups: siteAdminSidebarGroups,
+    siteAdminOverviewComponents: [],
+    userAreaRoutes,
+    userAreaHeaderNavItems,
+    userSettingsSideBarItems,
+    userSettingsAreaRoutes,
+    orgSettingsSideBarItems,
+    orgSettingsAreaRoutes,
+    orgAreaRoutes,
+    orgAreaHeaderNavItems,
+    repoContainerRoutes,
+    repoRevisionContainerRoutes,
+    repoHeaderActionButtons,
+    repoSettingsAreaRoutes,
+    repoSettingsSidebarGroups: repoSettingsSideBarGroups,
+    routes,
+} satisfies StaticInjectedAppConfig
+
+const hardcodedConfig = {
+    codeIntelligenceEnabled: false,
+    searchContextsEnabled: false,
+    notebooksEnabled: false,
+    codeMonitoringEnabled: false,
+    searchAggregationEnabled: false,
+} satisfies StaticHardcodedAppConfig
+
+const staticAppConfig = {
+    ...injectedValuesConfig,
+    ...windowContextConfig,
+    ...hardcodedConfig,
+} satisfies StaticAppConfig
+
 // Entry point for the app without enterprise functionality.
 // For more info see: https://docs.sourcegraph.com/admin/subscriptions#paid-subscriptions-for-sourcegraph-enterprise
-export const OpenSourceWebApp: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <LegacySourcegraphWebApp
-        siteAdminAreaRoutes={siteAdminAreaRoutes}
-        siteAdminSideBarGroups={siteAdminSidebarGroups}
-        siteAdminOverviewComponents={[]}
-        userAreaRoutes={userAreaRoutes}
-        userAreaHeaderNavItems={userAreaHeaderNavItems}
-        userSettingsSideBarItems={userSettingsSideBarItems}
-        userSettingsAreaRoutes={userSettingsAreaRoutes}
-        orgSettingsSideBarItems={orgSettingsSideBarItems}
-        orgSettingsAreaRoutes={orgSettingsAreaRoutes}
-        orgAreaRoutes={orgAreaRoutes}
-        orgAreaHeaderNavItems={orgAreaHeaderNavItems}
-        repoContainerRoutes={repoContainerRoutes}
-        repoRevisionContainerRoutes={repoRevisionContainerRoutes}
-        repoHeaderActionButtons={repoHeaderActionButtons}
-        repoSettingsAreaRoutes={repoSettingsAreaRoutes}
-        repoSettingsSidebarGroups={repoSettingsSideBarGroups}
-        routes={routes}
-        codeIntelligenceEnabled={false}
-        batchChangesEnabled={false}
-        searchContextsEnabled={false}
-        notebooksEnabled={false}
-        codeMonitoringEnabled={false}
-        searchAggregationEnabled={false}
-    />
-)
+export const OpenSourceWebApp: FC = () => <LegacySourcegraphWebApp {...staticAppConfig} />

--- a/client/web/src/enterprise/EnterpriseWebApp.tsx
+++ b/client/web/src/enterprise/EnterpriseWebApp.tsx
@@ -1,9 +1,15 @@
-import React from 'react'
+import { FC } from 'react'
 
 import '../SourcegraphWebApp.scss'
 
 import { LegacySourcegraphWebApp } from '../LegacySourcegraphWebApp'
 import { SourcegraphWebApp } from '../SourcegraphWebApp'
+import {
+    StaticAppConfig,
+    StaticHardcodedAppConfig,
+    StaticInjectedAppConfig,
+    windowContextConfig,
+} from '../staticAppConfig'
 
 import { CodeIntelligenceBadgeContent } from './codeintel/badge/components/CodeIntelligenceBadgeContent'
 import { CodeIntelligenceBadgeMenu } from './codeintel/badge/components/CodeIntelligenceBadgeMenu'
@@ -26,73 +32,58 @@ import { enterpriseUserAreaRoutes } from './user/routes'
 import { enterpriseUserSettingsAreaRoutes } from './user/settings/routes'
 import { enterpriseUserSettingsSideBarItems } from './user/settings/sidebaritems'
 
-export const EnterpriseWebApp: React.FC = () => {
+const injectedValuesConfig = {
+    /**
+     * Routes and nav links
+     */
+    siteAdminAreaRoutes: enterpriseSiteAdminAreaRoutes,
+    siteAdminSideBarGroups: enterpriseSiteAdminSidebarGroups,
+    siteAdminOverviewComponents: enterpriseSiteAdminOverviewComponents,
+    userAreaHeaderNavItems: enterpriseUserAreaHeaderNavItems,
+    userAreaRoutes: enterpriseUserAreaRoutes,
+    userSettingsSideBarItems: enterpriseUserSettingsSideBarItems,
+    userSettingsAreaRoutes: enterpriseUserSettingsAreaRoutes,
+    orgSettingsSideBarItems: enterpriseOrgSettingsSideBarItems,
+    orgSettingsAreaRoutes: enterpriseOrgSettingsAreaRoutes,
+    orgAreaRoutes: enterpriseOrganizationAreaRoutes,
+    orgAreaHeaderNavItems: enterpriseOrgAreaHeaderNavItems,
+    repoContainerRoutes: enterpriseRepoContainerRoutes,
+    repoRevisionContainerRoutes: enterpriseRepoRevisionContainerRoutes,
+    repoHeaderActionButtons: enterpriseRepoHeaderActionButtons,
+    repoSettingsAreaRoutes: enterpriseRepoSettingsAreaRoutes,
+    repoSettingsSidebarGroups: enterpriseRepoSettingsSidebarGroups,
+    routes: enterpriseRoutes,
+
+    /**
+     * Per feature injections
+     */
+    useCodeIntel,
+    codeIntelligenceBadgeMenu: CodeIntelligenceBadgeMenu,
+    codeIntelligenceBadgeContent: CodeIntelligenceBadgeContent,
+} satisfies StaticInjectedAppConfig
+
+const hardcodedConfig = {
+    codeIntelligenceEnabled: true,
+    codeInsightsEnabled: true,
+    searchContextsEnabled: true,
+    notebooksEnabled: true,
+    codeMonitoringEnabled: true,
+    searchAggregationEnabled: true,
+} satisfies StaticHardcodedAppConfig
+
+const staticAppConfig = {
+    ...injectedValuesConfig,
+    ...windowContextConfig,
+    ...hardcodedConfig,
+} satisfies StaticAppConfig
+
+export const EnterpriseWebApp: FC = () => {
     if (window.context.experimentalFeatures.enableStorm) {
         // eslint-disable-next-line no-console
         console.log('Storm 🌪️ is enabled for this page load.')
 
-        return (
-            <SourcegraphWebApp
-                siteAdminAreaRoutes={enterpriseSiteAdminAreaRoutes}
-                siteAdminSideBarGroups={enterpriseSiteAdminSidebarGroups}
-                siteAdminOverviewComponents={enterpriseSiteAdminOverviewComponents}
-                userAreaHeaderNavItems={enterpriseUserAreaHeaderNavItems}
-                userAreaRoutes={enterpriseUserAreaRoutes}
-                userSettingsSideBarItems={enterpriseUserSettingsSideBarItems}
-                userSettingsAreaRoutes={enterpriseUserSettingsAreaRoutes}
-                orgSettingsSideBarItems={enterpriseOrgSettingsSideBarItems}
-                orgSettingsAreaRoutes={enterpriseOrgSettingsAreaRoutes}
-                orgAreaRoutes={enterpriseOrganizationAreaRoutes}
-                orgAreaHeaderNavItems={enterpriseOrgAreaHeaderNavItems}
-                repoContainerRoutes={enterpriseRepoContainerRoutes}
-                repoRevisionContainerRoutes={enterpriseRepoRevisionContainerRoutes}
-                repoHeaderActionButtons={enterpriseRepoHeaderActionButtons}
-                repoSettingsAreaRoutes={enterpriseRepoSettingsAreaRoutes}
-                repoSettingsSidebarGroups={enterpriseRepoSettingsSidebarGroups}
-                routes={enterpriseRoutes}
-                codeIntelligenceEnabled={true}
-                codeIntelligenceBadgeMenu={CodeIntelligenceBadgeMenu}
-                codeIntelligenceBadgeContent={CodeIntelligenceBadgeContent}
-                useCodeIntel={useCodeIntel}
-                codeInsightsEnabled={true}
-                batchChangesEnabled={window.context.batchChangesEnabled}
-                searchContextsEnabled={true}
-                notebooksEnabled={true}
-                codeMonitoringEnabled={true}
-                searchAggregationEnabled={true}
-            />
-        )
+        return <SourcegraphWebApp {...staticAppConfig} />
     }
 
-    return (
-        <LegacySourcegraphWebApp
-            siteAdminAreaRoutes={enterpriseSiteAdminAreaRoutes}
-            siteAdminSideBarGroups={enterpriseSiteAdminSidebarGroups}
-            siteAdminOverviewComponents={enterpriseSiteAdminOverviewComponents}
-            userAreaHeaderNavItems={enterpriseUserAreaHeaderNavItems}
-            userAreaRoutes={enterpriseUserAreaRoutes}
-            userSettingsSideBarItems={enterpriseUserSettingsSideBarItems}
-            userSettingsAreaRoutes={enterpriseUserSettingsAreaRoutes}
-            orgSettingsSideBarItems={enterpriseOrgSettingsSideBarItems}
-            orgSettingsAreaRoutes={enterpriseOrgSettingsAreaRoutes}
-            orgAreaRoutes={enterpriseOrganizationAreaRoutes}
-            orgAreaHeaderNavItems={enterpriseOrgAreaHeaderNavItems}
-            repoContainerRoutes={enterpriseRepoContainerRoutes}
-            repoRevisionContainerRoutes={enterpriseRepoRevisionContainerRoutes}
-            repoHeaderActionButtons={enterpriseRepoHeaderActionButtons}
-            repoSettingsAreaRoutes={enterpriseRepoSettingsAreaRoutes}
-            repoSettingsSidebarGroups={enterpriseRepoSettingsSidebarGroups}
-            routes={enterpriseRoutes}
-            codeIntelligenceEnabled={true}
-            codeIntelligenceBadgeMenu={CodeIntelligenceBadgeMenu}
-            codeIntelligenceBadgeContent={CodeIntelligenceBadgeContent}
-            useCodeIntel={useCodeIntel}
-            codeInsightsEnabled={true}
-            batchChangesEnabled={window.context.batchChangesEnabled}
-            searchContextsEnabled={true}
-            notebooksEnabled={true}
-            codeMonitoringEnabled={true}
-            searchAggregationEnabled={true}
-        />
-    )
+    return <LegacySourcegraphWebApp {...staticAppConfig} />
 }

--- a/client/web/src/enterprise/cody/GlobalCodyArea.tsx
+++ b/client/web/src/enterprise/cody/GlobalCodyArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { Routes, Route } from 'react-router-dom'
 
@@ -13,8 +13,9 @@ import { CodyPage } from './CodyPage'
  * For Sourcegraph team members only. For instructions, see
  * https://docs.google.com/document/d/1u7HYPmJFtDANtBgczzmAR0BmhM86drwDXCqx-F2jTEE/edit#.
  */
-export const GlobalCodyArea: React.FunctionComponent = ({ ...outerProps }) => {
+export const GlobalCodyArea: FC = props => {
     const [codyEnabled] = useFeatureFlag('cody')
+
     if (!codyEnabled) {
         return <Page>Cody is not enabled.</Page>
     }
@@ -23,7 +24,7 @@ export const GlobalCodyArea: React.FunctionComponent = ({ ...outerProps }) => {
         <div className="w-100">
             <Page>
                 <Routes>
-                    <Route path="" element={<CodyPage {...outerProps} />} />
+                    <Route path="" element={<CodyPage {...props} />} />
                 </Routes>
             </Page>
         </div>

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -84,7 +84,7 @@ export const enterpriseRoutes: readonly LayoutRouteProps[] = [
     },
     {
         path: EnterprisePageRoutes.Cody,
-        element: <LegacyRoute render={props => <GlobalCodyArea {...props} />} />,
+        element: <LegacyRoute render={props => <GlobalCodyArea />} />,
     },
     ...routes,
 ]

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
-import { LegacyLayoutRouteComponentProps } from '../LegacyRouteContext'
+import { LegacyLayoutRouteContext } from '../LegacyRouteContext'
 
 import { parseSearchURLQuery } from '.'
 
@@ -16,9 +16,7 @@ const StreamingSearchResults = lazyComponent(() => import('./results/StreamingSe
  * Renders the Search home page or Search results depending on whether a query
  * was submitted (present in the URL) or not.
  */
-export const SearchPageWrapper: React.FunctionComponent<
-    React.PropsWithChildren<LegacyLayoutRouteComponentProps>
-> = props => {
+export const SearchPageWrapper: FC<LegacyLayoutRouteContext> = props => {
     const location = useLocation()
     const hasSearchQuery = parseSearchURLQuery(location.search)
 

--- a/client/web/src/staticAppConfig.ts
+++ b/client/web/src/staticAppConfig.ts
@@ -1,0 +1,87 @@
+import { SearchContextProps } from '@sourcegraph/shared/src/search'
+
+import { BatchChangesProps } from './batches'
+import type { CodeIntelligenceProps } from './codeintel'
+import { CodeMonitoringProps } from './codeMonitoring'
+import type { CodeInsightsProps } from './insights/types'
+import { NotebookProps } from './notebooks'
+import type { OrgAreaRoute } from './org/area/OrgArea'
+import type { OrgAreaHeaderNavItem } from './org/area/OrgHeader'
+import type { OrgSettingsAreaRoute } from './org/settings/OrgSettingsArea'
+import type { OrgSettingsSidebarItems } from './org/settings/OrgSettingsSidebar'
+import type { RepoContainerRoute } from './repo/RepoContainer'
+import type { RepoHeaderActionButton } from './repo/RepoHeader'
+import type { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
+import type { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
+import type { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
+import type { LayoutRouteProps } from './routes'
+import { SearchAggregationProps } from './search'
+import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
+import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
+import type { UserAreaRoute } from './user/area/UserArea'
+import type { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
+import type { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
+import type { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
+
+export interface StaticAppConfig
+    extends StaticHardcodedAppConfig,
+        StaticInjectedAppConfig,
+        StaticWindowContextComputedAppConfig {}
+
+/**
+ * Primitive configuration values we hardcode at the tip of the React tree.
+ */
+export interface StaticHardcodedAppConfig
+    extends Pick<SearchAggregationProps, 'searchAggregationEnabled'>,
+        Pick<CodeMonitoringProps, 'codeMonitoringEnabled'>,
+        Pick<NotebookProps, 'notebooksEnabled'>,
+        Pick<SearchContextProps, 'searchContextsEnabled'>,
+        Pick<CodeInsightsProps, 'codeInsightsEnabled'>,
+        Pick<CodeIntelligenceProps, 'codeIntelligenceEnabled'> {}
+
+/**
+ * Non-primitive values (components, objects) we inject at the tip of the React tree.
+ */
+export interface StaticInjectedAppConfig
+    extends Pick<CodeIntelligenceProps, 'codeIntelligenceBadgeContent' | 'useCodeIntel' | 'codeIntelligenceBadgeMenu'> {
+    siteAdminAreaRoutes: readonly SiteAdminAreaRoute[]
+    siteAdminSideBarGroups: SiteAdminSideBarGroups
+    siteAdminOverviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]
+    userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[]
+    userAreaRoutes: readonly UserAreaRoute[]
+    userSettingsSideBarItems: UserSettingsSidebarItems
+    userSettingsAreaRoutes: readonly UserSettingsAreaRoute[]
+    orgSettingsSideBarItems: OrgSettingsSidebarItems
+    orgSettingsAreaRoutes: readonly OrgSettingsAreaRoute[]
+    orgAreaHeaderNavItems: readonly OrgAreaHeaderNavItem[]
+    orgAreaRoutes: readonly OrgAreaRoute[]
+    repoContainerRoutes: readonly RepoContainerRoute[]
+    repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[]
+    repoHeaderActionButtons: readonly RepoHeaderActionButton[]
+    repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
+    repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
+    routes: readonly LayoutRouteProps[]
+}
+
+/**
+ * Static values we compute based on the `window.context`.
+ *
+ * Static in the sense that there are no other ways to change
+ * these values except by refetching the entire original value (window.contexxt)
+ */
+export interface StaticWindowContextComputedAppConfig extends Pick<BatchChangesProps, 'batchChangesEnabled'> {
+    isSourcegraphDotCom: boolean
+    isSourcegraphApp: boolean
+    batchChangesWebhookLogsEnabled: boolean
+}
+
+/**
+ * This configuration object is universal for both versions of the app:
+ * enterprise and open source.
+ */
+export const windowContextConfig = {
+    isSourcegraphDotCom: window.context.sourcegraphDotComMode,
+    isSourcegraphApp: window.context.sourcegraphAppMode,
+    batchChangesWebhookLogsEnabled: window.context.batchChangesWebhookLogsEnabled,
+    batchChangesEnabled: window.context.batchChangesEnabled,
+} satisfies StaticWindowContextComputedAppConfig


### PR DESCRIPTION
## Context

We have many fields coming from the tip of the React tree. It's hard for me to understand where they come from because all of them are defined in one huge interface. Understanding these fields' nature is essential because we must consolidate all dynamic fields on one layer and update them together to avoid redundant content layout shifts. 

We also need to define guidelines for new application configuration fields to make them predictable and easy to find. With this PR, I went over all the fields in the application shell and split them into dynamic and static categories. I also documented ideas on what we can do to remove most of the dynamic fields from the application shell. 

## Test plan

CI should be green. This PR doesn't contain any functional changes. Only comments and Typescript types updates. 

## App preview:

- [Web](https://sg-web-vb-review-app-shell-context-fields.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
