### PR TITLE
repoupdater: use localhost if deploy type is app

### DIFF
--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -22,9 +23,21 @@ import (
 // DefaultClient is the default Client. Unless overwritten, it is
 // connected to the server specified by the REPO_UPDATER_URL
 // environment variable.
-var DefaultClient = NewClient(env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL"))
+var DefaultClient = NewClient(repoUpdaterURLDefault())
 
 var defaultDoer, _ = httpcli.NewInternalClientFactory("repoupdater").Doer()
+
+func repoUpdaterURLDefault() string {
+	if u := os.Getenv("REPO_UPDATER_URL"); u != "" {
+		return u
+	}
+
+	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+		return "http://127.0.0.1:3182"
+	}
+
+	return "http://repo-updater:3182"
+}
 
 // Client is a repoupdater client.
 type Client struct {

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -30,7 +30,6 @@ func Init(logger log.Logger) {
 
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")
 	setDefaultEnv(logger, "SEARCHER_URL", "http://127.0.0.1:3181")
-	setDefaultEnv(logger, "REPO_UPDATER_URL", "http://127.0.0.1:3182")
 	setDefaultEnv(logger, "BLOBSTORE_URL", "http://127.0.0.1:9000")
 
 	// The syntax-highlighter might not be running, but this is a better default than an internal


### PR DESCRIPTION
We use env.Get at init() time for the repo updater URL. This doesn't give enough time for app's setup to set the variable. So instead we switch to deciding the value based on deploy type. This is the same strategy used by gitserver, symbols, searcher and zoekt.

Test Plan: sg start app and CI