### PR TITLE
Use Prettier/TS for import order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -223,6 +223,7 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
         schema: 'always',
       },
     ],
+    'import/order': 'off',
   },
   overrides: [
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,9 +50,7 @@
   "eslint.packageManager": "pnpm",
   "eslint.lintTask.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": true
-  },
+  "editor.codeActionsOnSave": {},
   "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": { "cache": true },
   "eslint.workingDirectories": ["./dev/release", "./client/*"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,7 +50,9 @@
   "eslint.packageManager": "pnpm",
   "eslint.lintTask.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
-  "editor.codeActionsOnSave": {},
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
   "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": { "cache": true },
   "eslint.workingDirectories": ["./dev/release", "./client/*"],

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "postcss-focus-visible": "^5.0.0",
     "postcss-loader": "^7.0.2",
     "prettier": "2.8.1",
+    "prettier-plugin-organize-imports": "^3.2.2",
     "prettier-plugin-svelte": "^2.9.0",
     "process": "^0.11.10",
     "punycode": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,7 @@ importers:
       postcss-inset: ^1.0.0
       postcss-loader: ^7.0.2
       prettier: 2.8.1
+      prettier-plugin-organize-imports: ^3.2.2
       prettier-plugin-svelte: ^2.9.0
       pretty-bytes: ^5.3.0
       process: ^0.11.10
@@ -735,6 +736,7 @@ importers:
       postcss-focus-visible: 5.0.0
       postcss-loader: 7.0.2_6jdsrmfenkuhhw3gx4zvjlznce
       prettier: 2.8.1
+      prettier-plugin-organize-imports: 3.2.2_qihnrdemp6oz4j3nop6rl7uloy
       prettier-plugin-svelte: 2.9.0_4h247imu46srxjbpsfob5j3nnq
       process: 0.11.10
       punycode: 2.1.1
@@ -27149,6 +27151,23 @@ packages:
   /prepend-http/2.0.0:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /prettier-plugin-organize-imports/3.2.2_qihnrdemp6oz4j3nop6rl7uloy:
+    resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
+    peerDependencies:
+      '@volar/vue-language-plugin-pug': ^1.0.4
+      '@volar/vue-typescript': ^1.0.4
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+    peerDependenciesMeta:
+      '@volar/vue-language-plugin-pug':
+        optional: true
+      '@volar/vue-typescript':
+        optional: true
+    dependencies:
+      prettier: 2.8.1
+      typescript: 4.9.5
     dev: true
 
   /prettier-plugin-svelte/2.9.0_4h247imu46srxjbpsfob5j3nnq:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,6 @@
-module.exports = require('@sourcegraph/prettierrc')
+const baseConfig = require('@sourcegraph/prettierrc')
+
+module.exports = {
+  ...baseConfig,
+  plugins: [...(baseConfig.plugins || []), 'prettier-plugin-organize-imports'],
+}


### PR DESCRIPTION
## Description

Disables `import/order`

Adds TS import ordering
 
## Test plan

N/A - Config change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-use-ts-for-import-order.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
