### PR TITLE
Render GitHub pull requests everywhere we render git commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Experimental GraphQL query, `permissionsSyncJobs` is substituted with new non-experimental query which provides full information about permissions sync jobs stored in the database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
 - Renders `readme.txt` files in the repository page. [#47944](https://github.com/sourcegraph/sourcegraph/pull/47944)
-- Renders GitHub pull request references in all places where a commit message is referenced. [#](https://github.com/sourcegraph/sourcegraph/pull/)
+- Renders GitHub pull request references in all places where a commit message is referenced. [#48183](https://github.com/sourcegraph/sourcegraph/pull/48183)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Experimental GraphQL query, `permissionsSyncJobs` is substituted with new non-experimental query which provides full information about permissions sync jobs stored in the database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
 - Renders `readme.txt` files in the repository page. [#47944](https://github.com/sourcegraph/sourcegraph/pull/47944)
+- Renders GitHub pull request references in all places where a commit message is referenced. [#](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ### Fixed
 

--- a/client/web/src/repo/commit/CommitMessageWithLinks.tsx
+++ b/client/web/src/repo/commit/CommitMessageWithLinks.tsx
@@ -31,14 +31,13 @@ export const CommitMessageWithLinks = ({
         'data-testid': 'git-commit-node-message-subject',
         className,
         onClick,
-        rel: 'noreferrer noopener',
-        target: '_blank',
         to,
     }
 
     const github = externalURLs ? externalURLs.find(url => url.serviceKind === ExternalServiceKind.GITHUB) : null
     const matches = [...message.matchAll(GH_ISSUE_NUMBER_IN_COMMIT)]
     if (github && matches.length > 0) {
+        const url = githubRepoUrl(github.url)
         let remainingMessage = message
         let skippedCharacters = 0
         const linkSegments: React.ReactNode[] = []
@@ -57,7 +56,12 @@ export const CommitMessageWithLinks = ({
                 </Link>
             )
             linkSegments.push(
-                <Link key={linkSegments.length} to={`${github.url}/pull/${issueNumber.replace('#', '')}`}>
+                <Link
+                    target="blank"
+                    rel="noreferrer noopener"
+                    key={linkSegments.length}
+                    to={`${url}/pull/${issueNumber.replace('#', '')}`}
+                >
                     {issueNumber}
                 </Link>
             )
@@ -77,4 +81,19 @@ export const CommitMessageWithLinks = ({
     }
 
     return <Link {...commitLinkProps}>{message}</Link>
+}
+
+// Some places return an URL to objects within a repo, e.g.:
+//
+// https://github.com/sourcegraph/sourcegraph/commit/ad1ea519e5a31bb868be947107bcf43f4f9fc672
+//
+// This function removes those unwanted parts
+const GITHUB_URL_SCHEMA = /^(https?:\/\/[^/]+\/[^/]+\/[^/]+)(.+)$/
+function githubRepoUrl(url: string): string {
+    const match = url.match(GITHUB_URL_SCHEMA)
+    if (match?.[1]) {
+        return match[1]
+    }
+
+    return url
 }

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -8,7 +8,7 @@ import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
 import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
-import { ExternalServiceKind, GitCommitFields } from '../../graphql-operations'
+import { GitCommitFields } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { DiffModeSelector } from '../commit/DiffModeSelector'
@@ -58,8 +58,6 @@ export interface GitCommitNodeProps {
      * Tracking issue to migrate away from this component: https://github.com/sourcegraph/sourcegraph/issues/23157
      * */
     wrapperElement?: 'div' | 'li'
-
-    externalURLs?: { url: string; serviceKind: ExternalServiceKind | null }[] | undefined
 }
 
 /** Displays a Git commit. */
@@ -76,7 +74,6 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     diffMode,
     onHandleDiffMode,
     wrapperElement: WrapperElement = 'div',
-    externalURLs,
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
@@ -107,7 +104,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     to={node.canonicalURL}
                     className={classNames(messageSubjectClassName, styles.messageLink)}
                     message={node.subject}
-                    externalURLs={externalURLs}
+                    externalURLs={node.externalURLs}
                 />
             </span>
 

--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -24,14 +24,7 @@ export const GitCommitNodeTableRow: React.FC<
         | 'onHandleDiffMode'
         | 'diffMode'
     >
-> = ({
-    node,
-    className,
-    expandCommitMessageBody,
-    hideExpandCommitMessageBody,
-    messageSubjectClassName,
-    externalURLs,
-}) => {
+> = ({ node, className, expandCommitMessageBody, hideExpandCommitMessageBody, messageSubjectClassName }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
 
     const toggleShowCommitMessageBody = useCallback((): void => {
@@ -46,7 +39,7 @@ export const GitCommitNodeTableRow: React.FC<
                     to={node.canonicalURL}
                     className={classNames(messageSubjectClassName, styles.messageLink)}
                     message={node.subject}
-                    externalURLs={externalURLs}
+                    externalURLs={node.externalURLs}
                 />
             </span>
             {node.body && !hideExpandCommitMessageBody && !expandCommitMessageBody && (

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -152,8 +152,6 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
             useAlternateAfterCursor: true,
         },
     })
-    const node = data?.node
-    const externalURLs = node && node.__typename === 'Repository' ? node.externalURLs : undefined
 
     useEffect(() => {
         eventLogger.logPageView('RepositoryCommits')
@@ -223,13 +221,7 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
                     {error && <ErrorAlert error={error} className="w-100 mb-0" />}
                     <ConnectionList className="list-group list-group-flush w-100">
                         {connection?.nodes.map(node => (
-                            <GitCommitNode
-                                key={node.id}
-                                className="list-group-item"
-                                wrapperElement="li"
-                                node={node}
-                                externalURLs={externalURLs}
-                            />
+                            <GitCommitNode key={node.id} className="list-group-item" wrapperElement="li" node={node} />
                         ))}
                     </ConnectionList>
                     {loading && <ConnectionLoading />}

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -121,7 +121,7 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
     const location = useLocation()
     const { filePath = '' } = parseBrowserRepoURL(location.pathname)
 
-    const { connection, error, loading, hasNextPage, fetchMore, data } = useShowMorePagination<
+    const { connection, error, loading, hasNextPage, fetchMore } = useShowMorePagination<
         RepositoryGitCommitsResult,
         RepositoryGitCommitsVariables,
         GitCommitFields

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -445,7 +445,6 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
     })
 
     const node = data?.node && data?.node.__typename === 'Repository' ? data.node : null
-    const externalURLs = node?.externalURLs
     const connection = node?.commit?.ancestors
 
     return (
@@ -461,7 +460,6 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
                                 className={styles.gitCommitNode}
                                 messageSubjectClassName={styles.gitCommitNodeMessageSubject}
                                 compact={true}
-                                externalURLs={externalURLs}
                             />
                         ))}
                     </tbody>


### PR DESCRIPTION
Fixed some leftover places that didn't show the git commit messages yet. Thank you for the [feedback](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1677224937394609), @mrnugget. 

It turns out this is evne easier because the `node` already had `externalURLs` so I can even delete code!

## Test plan

<img width="1540" alt="Screenshot 2023-02-24 at 12 43 59" src="https://user-images.githubusercontent.com/458591/221174314-ef9c06bc-1dbb-4bd8-9a23-ec02806eed0a.png">
<img width="1196" alt="Screenshot 2023-02-24 at 12 43 38" src="https://user-images.githubusercontent.com/458591/221174325-d5c82c05-bb35-4296-81c3-2cc26e952455.png">
<img width="730" alt="Screenshot 2023-02-24 at 12 43 09" src="https://user-images.githubusercontent.com/458591/221174330-ed07e318-7ad8-4a2f-b16f-26c05a0e363e.png">

Update: The screenshots are slightly outdated, the URLs are fixed now!

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
