### PR TITLE
client/web: Fix regression in connected accounts for ADO

### DIFF
--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -54,7 +54,13 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
         case 'azuredevops':
             accountConnection = (
                 <>
-                    {account.external?.displayName} (@{account.external?.login})
+                    {account.external?.displayName ? (
+                        <>
+                            {account.external.displayName} (@{account.external?.login})
+                        </>
+                    ) : (
+                        'Not connected'
+                    )}
                 </>
             )
             break


### PR DESCRIPTION
Missed this edge case when I was addressing code review comments in #47865.


## Test plan

- Tested locally

**Before**

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/2682729/221174260-7371f757-4ec5-4f16-92a5-e101e50026a9.png">


**After**

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/2682729/221174119-2ba5089e-ab76-4c46-ab1e-5b1024078386.png">

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/2682729/221174601-222efda3-a095-4e4a-a74f-8e640c7d7ad2.png">


- Builds should pass



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-ado-connected-account-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
