### PR TITLE
permissions-center: fix GraphQL types after renaming them in other commit.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -3,7 +3,7 @@ import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import { PermissionSyncJobReasonGroup, PermissionSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { PermissionsSyncJobReasonGroup, PermissionsSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -37,65 +37,65 @@ export const FiveSyncJobsFound: Story = () => (
                             },
                             result: {
                                 data: {
-                                    permissionSyncJobs: {
+                                    permissionsSyncJobs: {
                                         nodes: [
                                             createSyncJobMock(
                                                 '1',
-                                                PermissionSyncJobState.COMPLETED,
+                                                PermissionsSyncJobState.COMPLETED,
                                                 {
                                                     __typename: 'Repository',
                                                     name: 'sourcegraph/sourcegraph',
                                                 },
                                                 {
-                                                    group: PermissionSyncJobReasonGroup.WEBHOOK,
+                                                    group: PermissionsSyncJobReasonGroup.WEBHOOK,
                                                     message: 'REASON_GITHUB_REPO_EVENT',
                                                 }
                                             ),
                                             createSyncJobMock(
                                                 '2',
-                                                PermissionSyncJobState.ERRORED,
+                                                PermissionsSyncJobState.ERRORED,
                                                 {
                                                     __typename: 'User',
                                                     username: 'abdul',
                                                 },
                                                 {
-                                                    group: PermissionSyncJobReasonGroup.SOURCEGRAPH,
+                                                    group: PermissionsSyncJobReasonGroup.SOURCEGRAPH,
                                                     message: 'REASON_USER_EMAIL_VERIFIED',
                                                 }
                                             ),
                                             createSyncJobMock(
                                                 '3',
-                                                PermissionSyncJobState.FAILED,
+                                                PermissionsSyncJobState.FAILED,
                                                 {
                                                     __typename: 'Repository',
                                                     name: 'sourcegraph/hoursegraph',
                                                 },
                                                 {
-                                                    group: PermissionSyncJobReasonGroup.SCHEDULE,
+                                                    group: PermissionsSyncJobReasonGroup.SCHEDULE,
                                                     message: 'REASON_REPO_OUTDATED_PERMS',
                                                 }
                                             ),
                                             createSyncJobMock(
                                                 '4',
-                                                PermissionSyncJobState.PROCESSING,
+                                                PermissionsSyncJobState.PROCESSING,
                                                 {
                                                     __typename: 'User',
                                                     username: 'omar',
                                                 },
                                                 {
-                                                    group: PermissionSyncJobReasonGroup.MANUAL,
+                                                    group: PermissionsSyncJobReasonGroup.MANUAL,
                                                     message: 'REASON_MANUAL_USER_SYNC',
                                                 }
                                             ),
                                             createSyncJobMock(
                                                 '5',
-                                                PermissionSyncJobState.QUEUED,
+                                                PermissionsSyncJobState.QUEUED,
                                                 {
                                                     __typename: 'Repository',
                                                     name: 'sourcegraph/stillfunny',
                                                 },
                                                 {
-                                                    group: PermissionSyncJobReasonGroup.MANUAL,
+                                                    group: PermissionsSyncJobReasonGroup.MANUAL,
                                                     message: 'REASON_MANUAL_REPO_SYNC',
                                                 }
                                             ),
@@ -136,19 +136,19 @@ interface user {
 type subject = repo | user
 
 interface reason {
-    __typename?: 'PermissionSyncJobReason'
-    group: PermissionSyncJobReasonGroup
+    __typename?: 'PermissionsSyncJobReason'
+    group: PermissionsSyncJobReasonGroup
     message: string
 }
 
 function createSyncJobMock(
     id: string,
-    state: PermissionSyncJobState,
+    state: PermissionsSyncJobState,
     subject: subject,
     reason: reason
 ): PermissionsSyncJob {
     return {
-        __typename: 'PermissionSyncJob',
+        __typename: 'PermissionsSyncJob',
         id,
         state,
         subject,
@@ -157,9 +157,9 @@ function createSyncJobMock(
             username: 'super-site-admin',
         },
         queuedAt: formatRFC3339(TIMESTAMP_MOCK),
-        startedAt: state !== PermissionSyncJobState.QUEUED ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 1)) : null,
+        startedAt: state !== PermissionsSyncJobState.QUEUED ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 1)) : null,
         finishedAt:
-            state !== PermissionSyncJobState.QUEUED && state !== PermissionSyncJobState.PROCESSING
+            state !== PermissionsSyncJobState.QUEUED && state !== PermissionsSyncJobState.PROCESSING
                 ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 2))
                 : null,
         processAfter: null,

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -10,7 +10,7 @@ import {
     ConnectionList,
     ConnectionLoading,
 } from '../../components/FilteredConnection/ui'
-import { PermissionsSyncJob, PermissionSyncJobsResult, PermissionSyncJobsVariables } from '../../graphql-operations'
+import { PermissionsSyncJob, PermissionsSyncJobsResult, PermissionsSyncJobsVariables } from '../../graphql-operations'
 
 import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
 import { ChangesetCloseNode } from './PermissionsSyncJobsTableItem'
@@ -27,15 +27,15 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
     }, [telemetryService])
 
     const { connection, loading, error, refetch, ...paginationProps } = usePageSwitcherPagination<
-        PermissionSyncJobsResult,
-        PermissionSyncJobsVariables,
+        PermissionsSyncJobsResult,
+        PermissionsSyncJobsVariables,
         PermissionsSyncJob
     >({
         query: PERMISSIONS_SYNC_JOBS_QUERY,
         variables: {
             first: 20,
         },
-        getConnection: ({ data }) => data?.permissionSyncJobs || undefined,
+        getConnection: ({ data }) => data?.permissionsSyncJobs || undefined,
         options: { pollInterval: 5000 },
     })
 

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTableItem.tsx
@@ -5,7 +5,7 @@ import { mdiAccount, mdiCloudQuestion } from '@mdi/js'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { Badge, BADGE_VARIANTS, Icon, Text, Tooltip } from '@sourcegraph/wildcard'
 
-import { PermissionsSyncJob, PermissionSyncJobReasonGroup, PermissionSyncJobState } from '../../graphql-operations'
+import { PermissionsSyncJob, PermissionsSyncJobReasonGroup, PermissionsSyncJobState } from '../../graphql-operations'
 
 import styles from './PermissionsSyncJobsTableItem.module.scss'
 
@@ -19,7 +19,7 @@ interface JobStateMetadata {
     timeGetter: (job: PermissionsSyncJob) => string
 }
 
-const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadata> = {
+const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStateMetadata> = {
     QUEUED: {
         badgeVariant: 'secondary',
         temporalWording: 'Queued',
@@ -45,6 +45,11 @@ const JOB_STATE_METADATA_MAPPING: Record<PermissionSyncJobState, JobStateMetadat
         temporalWording: 'Failed',
         timeGetter: job => job.finishedAt ?? '',
     },
+    CANCELED: {
+        badgeVariant: 'outlineSecondary',
+        temporalWording: 'Canceled',
+        timeGetter: job => job.finishedAt ?? '',
+    },
 }
 
 export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren<ChangesetCloseNodeProps>> = ({
@@ -65,7 +70,7 @@ export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren
     </li>
 )
 
-const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionSyncJobState }> = ({ state }) => (
+const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionsSyncJobState }> = ({ state }) => (
     <Badge variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}>{state}</Badge>
 )
 
@@ -99,7 +104,7 @@ const PermissionsSyncJobReason: React.FunctionComponent<{ job: PermissionsSyncJo
         <div>{job.reason.group}</div>
         <Text className="mb-0 text-muted">
             <small>
-                {job.reason.group === PermissionSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
+                {job.reason.group === PermissionsSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
                     ? `by ${job.triggeredByUser.username}`
                     : job.reason.message}
             </small>

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -1,8 +1,7 @@
 import { gql } from '@sourcegraph/http-client'
 
-// TODO(sashaostrikov): move all properties to PermissionsSyncJob and make a storybook more elaborate
 export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
-    fragment PermissionsSyncJob on PermissionSyncJob {
+    fragment PermissionsSyncJob on PermissionsSyncJob {
         id
         state
         subject {
@@ -31,8 +30,8 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         permissionsFound
     }
 
-    query PermissionSyncJobs($first: Int, $last: Int, $after: String, $before: String) {
-        permissionSyncJobs(first: $first, last: $last, after: $after, before: $before) {
+    query PermissionsSyncJobs($first: Int, $last: Int, $after: String, $before: String) {
+        permissionsSyncJobs(first: $first, last: $last, after: $after, before: $before) {
             totalCount
             pageInfo {
                 hasNextPage


### PR DESCRIPTION
Test plan:
CI.
Storybook.

## App preview:

- [Web](https://sg-web-ao-fix-types.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
