### PR TITLE
web: Refactor useCodeMirror hook

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { closeCompletion, startCompletion } from '@codemirror/autocomplete'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
@@ -21,7 +21,12 @@ import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { useCodeMirror, createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
-import { EditorHint, QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
+import {
+    EditorHint,
+    QueryChangeSource,
+    type QueryState,
+    type SearchPatternTypeProps,
+} from '@sourcegraph/shared/src/search'
 import { Diagnostic, getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { Filter } from '@sourcegraph/shared/src/search/query/token'
@@ -116,7 +121,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
     // reference that doesn't change across renders (and some hooks should only
     // run when a prop changes, not the editor).
     const [editor, setEditor] = useState<EditorView | undefined>()
-    const editorReference = useRef<EditorView>()
+    const editorReference = useRef<EditorView | null>(null)
     const focusSearchBarShortcut = useKeyboardShortcut('focusSearch')
     const navigate = useNavigate()
 
@@ -126,7 +131,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
             editorReference.current = editor
             onEditorCreated?.(editor)
         },
-        [editorReference, onEditorCreated]
+        [onEditorCreated]
     )
 
     const autocompletion = useMemo(
@@ -252,37 +257,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
         }
     }, [editor, autoFocus])
 
-    // Update the editor's selection and cursor depending on how the search
-    // query was changed.
-    useEffect(() => {
-        if (!editor) {
-            return
-        }
-
-        if (queryState.changeSource === QueryChangeSource.userInput) {
-            // Don't react to user input
-            return
-        }
-
-        editor.dispatch({
-            selection: queryState.selectionRange
-                ? // Select the specified range (most of the time this will be a
-                  // placeholder filter value).
-                  EditorSelection.range(queryState.selectionRange.start, queryState.selectionRange.end)
-                : // Place the cursor at the end of the query.
-                  EditorSelection.cursor(editor.state.doc.length),
-            scrollIntoView: true,
-        })
-
-        if (queryState.hint) {
-            if ((queryState.hint & EditorHint.Focus) === EditorHint.Focus) {
-                editor.focus()
-            }
-            if ((queryState.hint & EditorHint.ShowSuggestions) === EditorHint.ShowSuggestions) {
-                startCompletion(editor)
-            }
-        }
-    }, [editor, queryState])
+    useUpdateEditorFromQueryState(editorReference, queryState, startCompletion)
 
     // It looks like <Shortcut ... /> needs a stable onMatch callback, hence we
     // are storing the editor in a ref so that `globalFocus` is stable.
@@ -326,18 +301,33 @@ interface CodeMirrorQueryInputProps extends SearchPatternTypeProps {
  */
 export const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputProps> = React.memo(
     ({ onEditorCreated, patternType, interpretComments, value, className, extensions = EMPTY }) => {
-        // This is using state instead of a ref because `useRef` doesn't cause a
-        // re-render when the ref is attached, but we need that so that
-        // `useCodeMirror` is called again and the editor is actually created.
-        // See https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
-        const [container, setContainer] = useState<HTMLDivElement | null>(null)
+        const containerRef = useRef<HTMLDivElement | null>(null)
         const isLightTheme = useIsLightTheme()
-
         const externalExtensions = useMemo(() => new Compartment(), [])
         const themeExtension = useMemo(() => new Compartment(), [])
 
-        const editor = useCodeMirror(
-            container,
+        const editorRef = useRef<EditorView | null>(null)
+
+        // Update pattern type and/or interpretComments when changed
+        useEffect(() => {
+            editorRef.current?.dispatch({ effects: setQueryParseOptions.of({ patternType, interpretComments }) })
+        }, [patternType, interpretComments])
+
+        // Update theme if it changes
+        useEffect(() => {
+            editorRef.current?.dispatch({
+                effects: themeExtension.reconfigure(EditorView.darkTheme.of(isLightTheme === false)),
+            })
+        }, [themeExtension, isLightTheme])
+
+        // Update external extensions if they changed
+        useEffect(() => {
+            editorRef.current?.dispatch({ effects: externalExtensions.reconfigure(extensions) })
+        }, [externalExtensions, extensions])
+
+        useCodeMirror(
+            editorRef,
+            containerRef,
             value,
             useMemo(
                 () => [
@@ -376,32 +366,15 @@ export const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputP
         // having a reference to the editor allows other components to initiate
         // transactions.
         useEffect(() => {
-            if (editor) {
-                onEditorCreated?.(editor)
+            if (editorRef.current) {
+                onEditorCreated?.(editorRef.current)
             }
-        }, [editor, onEditorCreated])
-
-        // Update pattern type and/or interpretComments when changed
-        useEffect(() => {
-            editor?.dispatch({ effects: setQueryParseOptions.of({ patternType, interpretComments }) })
-        }, [editor, patternType, interpretComments])
-
-        // Update theme if it changes
-        useEffect(() => {
-            editor?.dispatch({
-                effects: themeExtension.reconfigure(EditorView.darkTheme.of(isLightTheme === false)),
-            })
-        }, [editor, themeExtension, isLightTheme])
-
-        // Update external extensions if they changed
-        useEffect(() => {
-            editor?.dispatch({ effects: externalExtensions.reconfigure(extensions) })
-        }, [editor, externalExtensions, extensions])
+        }, [onEditorCreated])
 
         return (
             <TraceSpanProvider name="CodeMirrorQueryInput">
                 <div
-                    ref={setContainer}
+                    ref={containerRef}
                     className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
                     data-editor="codemirror6"
                 />
@@ -409,6 +382,53 @@ export const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputP
         )
     }
 )
+CodeMirrorQueryInput.displayName = 'CodeMirrorQueryInput'
+
+/**
+ * Update the editor's selection and cursor depending on how the search
+ * query was changed.
+ */
+export function useUpdateEditorFromQueryState(
+    editorRef: RefObject<EditorView | null>,
+    queryState: QueryState,
+    startCompletion: (view: EditorView) => void
+): void {
+    const startCompletionRef = useRef(startCompletion)
+
+    useEffect(() => {
+        startCompletionRef.current = startCompletion
+    }, [startCompletion])
+
+    useEffect(() => {
+        if (!editorRef.current) {
+            return
+        }
+
+        if (queryState.changeSource === QueryChangeSource.userInput) {
+            // Don't react to user input
+            return
+        }
+
+        editorRef.current.dispatch({
+            selection: queryState.selectionRange
+                ? // Select the specified range (most of the time this will be a
+                  // placeholder filter value).
+                  EditorSelection.range(queryState.selectionRange.start, queryState.selectionRange.end)
+                : // Place the cursor at the end of the query.
+                  EditorSelection.cursor(editorRef.current.state.doc.length),
+            scrollIntoView: true,
+        })
+
+        if (queryState.hint) {
+            if ((queryState.hint & EditorHint.Focus) === EditorHint.Focus) {
+                editorRef.current.focus()
+            }
+            if ((queryState.hint & EditorHint.ShowSuggestions) === EditorHint.ShowSuggestions) {
+                startCompletionRef.current(editorRef.current)
+            }
+        }
+    }, [editorRef, queryState])
+}
 
 // The remainder of the file defines all the extensions that provide the query
 // editor behavior. Here is also a brief overview over CodeMirror's architecture

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -385,7 +385,7 @@ export const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputP
 CodeMirrorQueryInput.displayName = 'CodeMirrorQueryInput'
 
 /**
- * Update the editor's selection and cursor depending on how the search
+ * Update the editor's value, selection and cursor depending on how the search
  * query was changed.
  */
 export function useUpdateEditorFromQueryState(
@@ -400,7 +400,8 @@ export function useUpdateEditorFromQueryState(
     }, [startCompletion])
 
     useEffect(() => {
-        if (!editorRef.current) {
+        const editor = editorRef.current
+        if (!editor) {
             return
         }
 
@@ -409,22 +410,23 @@ export function useUpdateEditorFromQueryState(
             return
         }
 
-        editorRef.current.dispatch({
+        editor.dispatch({
+            changes: { from: 0, to: editor.state.doc.length, insert: queryState.query },
             selection: queryState.selectionRange
                 ? // Select the specified range (most of the time this will be a
                   // placeholder filter value).
                   EditorSelection.range(queryState.selectionRange.start, queryState.selectionRange.end)
                 : // Place the cursor at the end of the query.
-                  EditorSelection.cursor(editorRef.current.state.doc.length),
+                  EditorSelection.cursor(queryState.query.length),
             scrollIntoView: true,
         })
 
         if (queryState.hint) {
             if ((queryState.hint & EditorHint.Focus) === EditorHint.Focus) {
-                editorRef.current.focus()
+                editor.focus()
             }
             if ((queryState.hint & EditorHint.ShowSuggestions) === EditorHint.ShowSuggestions) {
-                startCompletionRef.current(editorRef.current)
+                startCompletionRef.current(editor)
             }
         }
     }, [editorRef, queryState])

--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jsdoc/check-indentation */
-import { useEffect, useMemo, useState } from 'react'
+import { MutableRefObject, RefObject, useEffect, useMemo } from 'react'
 
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import {
@@ -30,71 +30,47 @@ if (process.env.INTEGRATION_TESTS) {
  * Hook for rendering and updating a CodeMirror instance.
  */
 export function useCodeMirror(
-    container: HTMLDivElement | null,
+    editorRef: MutableRefObject<EditorView | null>,
+    containerRef: RefObject<HTMLDivElement | null>,
     value: string,
-    extensions?: EditorStateConfig['extensions'],
-    options?: {
-        /**
-         * When 'value' changes, trigger a transaction to update it. This is `true` by default.
-         * However, if other parts of the editor state should be changed when the value changes,
-         * you can set this to `false` and use the `replaceValue` function to update the value
-         * in a custom transaction.
-         */
-        updateValueOnChange?: boolean
-
-        /**
-         * When 'extension' changes, trigger a transaction to update it. This is `true` by default.
-         * Set this to  `false` to have more control over how to update the editor. This is
-         * useful for example when the caller wants to update the editor with `setState`.
-         */
-        updateOnExtensionChange?: boolean
-    }
-): EditorView | undefined {
-    const [view, setView] = useState<EditorView>()
-
-    useEffect(() => {
-        if (!container) {
-            return
-        }
-
-        const view = new EditorView({
-            state: EditorState.create({ doc: value, extensions }),
-            parent: container,
-        })
-        setView(view)
-        return () => {
-            setView(undefined)
-            view.destroy()
-        }
-        // Extensions and value are updated via transactions below
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [container])
-
+    extensions?: EditorStateConfig['extensions']
+): void {
     // Update editor value if necessary. This also sets the intial value of the
     // editor.
     useEffect(() => {
-        if (view && options?.updateValueOnChange !== false) {
-            const changes = replaceValue(view, value ?? '')
+        if (editorRef.current) {
+            const changes = replaceValue(editorRef.current, value ?? '')
 
             if (changes) {
-                view.dispatch({ changes })
+                editorRef.current.dispatch({ changes })
             }
         }
-        // View is not provided because this should only be triggered after the view
-        // was created.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value, options?.updateValueOnChange])
+    }, [editorRef, value])
 
     useEffect(() => {
-        if (view && extensions && options?.updateOnExtensionChange !== false) {
-            view.dispatch({ effects: StateEffect.reconfigure.of(extensions) })
+        if (editorRef.current && extensions) {
+            editorRef.current.dispatch({ effects: StateEffect.reconfigure.of(extensions) })
         }
-        // View is not provided because this should only be triggered after the view
-        // was created.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [extensions, options?.updateOnExtensionChange])
+    }, [editorRef, extensions])
 
-    return view
+    // Create editor if necessary
+    useEffect(() => {
+        if (!editorRef.current && containerRef.current) {
+            editorRef.current = new EditorView({
+                state: EditorState.create({ doc: value, extensions }),
+                parent: containerRef.current,
+            })
+        }
+    }, [editorRef, containerRef, value, extensions])
+
+    // Clean up editor on unmount
+    useEffect(
+        () => () => {
+            editorRef.current?.destroy()
+            editorRef.current = null
+        },
+        [editorRef]
+    )
 }
 
 /**

--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
@@ -10,11 +10,10 @@ import { mdiPlayCircleOutline, mdiPencil } from '@mdi/js'
 import classNames from 'classnames'
 
 import { changeListener } from '@sourcegraph/branded'
-import { useCodeMirror, editorHeight } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { CodeMirrorEditor, Editor, editorHeight } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { Icon, Markdown } from '@sourcegraph/wildcard'
 
 import { BlockProps, MarkdownBlock } from '../..'
-import { focusEditor } from '../../codemirror-utils'
 import { BlockMenuAction } from '../menu/NotebookBlockMenu'
 import { useCommonBlockMenuActions } from '../menu/useCommonBlockMenuActions'
 import { NotebookBlock } from '../NotebookBlock'
@@ -100,7 +99,7 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
             ...props
         }) => {
             const [isEditing, setIsEditing] = useState(!isReadOnly && input.initialFocusInput)
-            const containerRef = useRef<HTMLDivElement | null>(null)
+            const editorRef = useRef<Editor | null>(null)
 
             const runBlock = useCallback(() => {
                 onRunBlock(id)
@@ -120,7 +119,7 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
                 [id, onBlockInputChange]
             )
 
-            const extensions: Extension[] = useMemo(
+            const editorExtensions: Extension[] = useMemo(
                 () => [
                     keymap.of([
                         {
@@ -138,10 +137,6 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
                 [runBlock, onInputChange, newBlock]
             )
 
-            const editorRef = useRef<EditorView | null>(null)
-
-            useCodeMirror(editorRef, containerRef, input.text, extensions)
-
             const editMarkdown = useCallback(() => {
                 if (!isReadOnly) {
                     setIsEditing(true)
@@ -149,10 +144,8 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
             }, [isReadOnly, setIsEditing])
 
             useEffect(() => {
-                if (editorRef.current) {
-                    focusEditor(editorRef.current)
-                }
-            }, [isEditing, editorRef])
+                editorRef.current?.focus()
+            }, [isEditing])
 
             const commonMenuActions = useCommonBlockMenuActions({ id, isReadOnly, onNewBlock, ...props })
 
@@ -189,7 +182,7 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
                     'aria-label': 'Notebook markdown block',
                     isInputVisible: isEditing,
                     setIsInputVisible: setIsEditing,
-                    focusInput: () => editorRef.current && focusEditor(editorRef.current),
+                    focusInput: () => editorRef.current?.focus(),
                     ...props,
                 }),
                 [id, isEditing, isReadOnly, isSelected, menuActions, onBlockInputChange, onRunBlock, editorRef, props]
@@ -215,7 +208,7 @@ export const NotebookMarkdownBlock: React.FunctionComponent<React.PropsWithChild
                     className={classNames(styles.input, (isInputFocused || isSelected) && blockStyles.selected)}
                     {...notebookBlockProps}
                 >
-                    <div ref={containerRef} />
+                    <CodeMirrorEditor ref={editorRef} value={input.text} extensions={editorExtensions} />
                 </NotebookBlock>
             )
         }

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 
 import { json } from '@codemirror/lang-json'
 import { foldGutter } from '@codemirror/language'
@@ -37,10 +37,12 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
 
     const nonCriticalTelemetryDisabled = window.context.site.disableNonCriticalTelemetry === true
     const updatesDisabled = window.context.site['update.channel'] !== 'release'
-    const [jsonEditorContainer, setJSONEditorContainer] = useState<HTMLDivElement | null>(null)
+    const jsonEditorContainerRef = useRef<HTMLDivElement | null>(null)
+    const editorRef = useRef<EditorView | null>(null)
 
     useCodeMirror(
-        jsonEditorContainer,
+        editorRef,
+        jsonEditorContainerRef,
         useMemo(() => JSON.stringify(latestPing, undefined, 4), [latestPing]),
         useMemo(
             () => [
@@ -83,7 +85,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
             ) : isEmpty(latestPing) ? (
                 <Text>No recent ping data to display.</Text>
             ) : (
-                <div ref={setJSONEditorContainer} className="mb-1 border rounded" />
+                <div ref={jsonEditorContainerRef} className="mb-1 border rounded" />
             )}
             <H3>Critical telemetry</H3>
             <Text>


### PR DESCRIPTION
This was quite a journey: I set out to fix some issues with the new query input and wanted to switch to using the `useCodeMirror` hook for it at the same time... only to discover that the input was now broken in a different way! Somehow the way that `useState` and `useEffect` had been used didn't work as intended (specifically it was referencing the wrong extensions object). I tried various solutions to no avail...

In the end I found [this example in the new React docs](https://beta.reactjs.org/reference/react/useEffect#controlling-a-non-react-widget) and decided to model the hook in a similar way.

The `useCodeMirrorHook` now received two refs: One for the editor and one for the container DOM element. The editor ref can be used by the caller to reference the editor in callbacks and effects.

When a component that uses `useCodeMirror` is rendered the first time the following execution flows happens:
  - Component registers "editor update effects" (because they are listed before `useCodeMirror`). `useCodeMirror` is called with refs, initial value and initial extensions. The hook registers its own update effects and an editor creation effect.
  - React creates DOM nodes and sets container ref
  - React executes effects
    - "Editor update effects" are run but don't have any effect because the editor ref is still unset
    - Editor creation effect is run, with access to initial value and extensions. Creates editor and sets editor ref

This all worked great until I updated the `NotebookMarkdownBlock` component, which renders an editor conditionally. But because the container element is now passed as a ref, adding and removing the container won't trigger the editor to be created/destroyed anymore.

For this case I introduced a simple `CodeMirrorEditor` component that exposes a `focus` method. Being its own component, the editor gets properly created/destroyed on conditional renders.

Despite the conditional rendering issue, overall I think it's the more correct approach since it avoids unnecessary re-renders because the container node is not stored in state anymore. The editor should now be fully initialized in the first render pass. 

## Test plan

- Typing a regular expression into the query input (e.g. `foo.*bar`) and toggling the regexp button correctly updates the inputs syntax highlighting (indicating that extensions get properly updated).
- Selecting a different search context focuses the query input

- In the file view, clicking the blame button toggles the blame view

- In Notebooks, clicking the render/edit button of a Markdown block correctly switches between render and input mode.

## App preview:

- [Web](https://sg-web-fkling-refactor-codemirror-hook.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
