### PR TITLE
Code Insights: Fix export insight data tooltip

### DIFF
--- a/client/web/src/components/LoaderButton.tsx
+++ b/client/web/src/components/LoaderButton.tsx
@@ -1,35 +1,37 @@
-import React from 'react'
+import { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
 import { LoadingSpinner, Button, ButtonProps } from '@sourcegraph/wildcard'
 
 export interface LoaderButtonProps extends ButtonProps {
-    loading: boolean
-    label: string
-    alwaysShowLabel: boolean
+    loading?: boolean
+    label?: string
+    alwaysShowLabel?: boolean
     icon?: JSX.Element
 }
 
-export const LoaderButton: React.FunctionComponent<React.PropsWithChildren<Partial<LoaderButtonProps>>> = ({
-    icon,
-    loading,
-    label,
-    alwaysShowLabel,
-    ...props
-}) => (
-    <Button {...props} className={classNames(props.className, 'd-flex justify-content-center align-items-center')}>
-        {loading ? (
-            <>
-                <LoadingSpinner />
-                {alwaysShowLabel && <span className="ml-1">{label}</span>}
-            </>
-        ) : icon ? (
-            <>
-                {icon}&nbsp;{label}
-            </>
-        ) : (
-            label
-        )}
-    </Button>
-)
+export const LoaderButton = forwardRef<HTMLButtonElement, LoaderButtonProps>((props, ref) => {
+    const { loading, label, alwaysShowLabel, icon, ...otherProps } = props
+
+    return (
+        <Button
+            ref={ref}
+            {...otherProps}
+            className={classNames(props.className, 'd-flex justify-content-center align-items-center')}
+        >
+            {loading ? (
+                <>
+                    <LoadingSpinner />
+                    {alwaysShowLabel && <span className="ml-1">{label}</span>}
+                </>
+            ) : icon ? (
+                <>
+                    {icon}&nbsp;{label}
+                </>
+            ) : (
+                label
+            )}
+        </Button>
+    )
+})

--- a/client/web/src/enterprise/insights/components/DownloadFileButton.tsx
+++ b/client/web/src/enterprise/insights/components/DownloadFileButton.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, useState } from 'react'
+import { forwardRef, MouseEvent, useState } from 'react'
 
 import { ButtonProps } from '@sourcegraph/wildcard'
 
@@ -10,7 +10,7 @@ interface DownloadFileButtonProps extends ButtonProps {
     children?: string
 }
 
-export const DownloadFileButton: FC<DownloadFileButtonProps> = props => {
+export const DownloadFileButton = forwardRef<HTMLButtonElement, DownloadFileButtonProps>((props, ref) => {
     const { fileUrl, fileName, children, onClick, ...attributes } = props
 
     const [isLoading, setLoading] = useState(false)
@@ -35,6 +35,7 @@ export const DownloadFileButton: FC<DownloadFileButtonProps> = props => {
 
     return (
         <LoaderButton
+            ref={ref}
             {...attributes}
             label={children}
             loading={isLoading}
@@ -42,7 +43,7 @@ export const DownloadFileButton: FC<DownloadFileButtonProps> = props => {
             onClick={handleClick}
         />
     )
-}
+})
 
 function syntheticDownload(url: string, name: string): void {
     const element = document.createElement('a')


### PR DESCRIPTION

## Test plan
- Go to the insight standalone page
- Hover or focus the export data
- You should see tooltip with export insight information 
  
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-export-tooltip-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
