### PR TITLE
experimental search input: Fix history mode

### DIFF
--- a/client/branded/src/search-ui/input/experimental/codemirror/history.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/history.ts
@@ -1,4 +1,5 @@
 import type { Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
 import { mdiClockOutline } from '@mdi/js'
 import { formatDistanceToNow, parseISO } from 'date-fns'
 import { Fzf, type FzfOptions } from 'fzf'
@@ -6,7 +7,7 @@ import { Fzf, type FzfOptions } from 'fzf'
 import { pluralize } from '@sourcegraph/common'
 import { type RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 
-import { type ModeDefinition, modesFacet } from '../modes'
+import { type ModeDefinition, modesFacet, setMode } from '../modes'
 import { queryRenderer } from '../optionRenderer'
 import { type Source, suggestionSources, type Option } from '../suggestionsExtension'
 
@@ -24,7 +25,9 @@ function createHistorySuggestionSource(
     source: () => RecentSearch[],
     submitQuery: (query: string) => void
 ): Source['query'] {
-    const applySuggestion = (option: Option): void => {
+    const applySuggestion = (option: Option, view: EditorView): void => {
+        setMode(view, null)
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: option.label } })
         submitQuery(option.label)
     }
 

--- a/client/branded/src/search-ui/input/experimental/modes.ts
+++ b/client/branded/src/search-ui/input/experimental/modes.ts
@@ -125,7 +125,7 @@ export function getSelectedMode(state: EditorState): ModeDefinition | null {
     return state.field(selectedModeField, false)?.selectedMode ?? null
 }
 
-function setMode(view: EditorView, name: string | null | ((mode: string | null) => string | null)): boolean {
+export function setMode(view: EditorView, name: string | null | ((mode: string | null) => string | null)): boolean {
     const resolvedName = typeof name === 'function' ? name(getSelectedMode(view.state)?.name ?? null) : name
 
     if (resolvedName === null) {

--- a/client/shared/src/search/searchQueryState.tsx
+++ b/client/shared/src/search/searchQueryState.tsx
@@ -92,7 +92,7 @@ export interface SearchQueryState {
      * Note that this won't update `queryState` directly.
      */
     submitSearch: (
-        parameters: Omit<SubmitSearchParameters, 'query' | 'caseSensitive' | 'patternType'>,
+        parameters: Omit<SubmitSearchParameters, 'query' | 'caseSensitive' | 'patternType'> & { query?: string },
         updates?: QueryUpdate[]
     ) => void
 }

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -82,7 +82,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
-            const query = props.queryState.query
+            const query = parameters.query ?? props.queryState.query
 
             if (canSubmitSearch(query, props.selectedSearchContextSpec)) {
                 submitSearch({

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -45,11 +45,12 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
 
     submitSearch: (parameters, updates = []) => {
         const {
-            queryState: { query },
+            queryState,
             searchCaseSensitivity: caseSensitive,
             searchPatternType: patternType,
             searchMode: searchMode,
         } = get()
+        const query = parameters.query ?? queryState.query
         const updatedQuery = updateQuery(query, updates)
         if (canSubmitSearch(query, parameters.selectedSearchContextSpec)) {
             submitSearch({ ...parameters, query: updatedQuery, caseSensitive, patternType, searchMode })


### PR DESCRIPTION
Currently selecting a history entry from the search input when rendered in the navbar leaves the input in a broken state.

I didn't notice this because when I added the history mode the input was only rendered on the search home page. To make it work in other places I

- updated the extension to properly update the editor state (clear mode and set input)
- updated the global search query store to allow overwriting the query via parameters

I first attempted to remove the query parameter and instead relied on the fact that updating the input value will update the query state, but it seems due to effects this would try to submit the query before the query state was updated.
Allowing the query to be set on submission via parameters seems the safer solution.


Before/after video: 

https://user-images.githubusercontent.com/179026/221212334-7ae4a395-ad26-49ad-beb3-f9d3ba1599dd.mp4




## Test plan

See video. Selecting an entry from the history dropdown on the search homepage as well as the search results page work as expected.

## App preview:

- [Web](https://sg-web-fkling-fix-search-input-history.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
