### PR TITLE
experimental search input: Fix query example and search sidebar integration

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -11,6 +11,7 @@ import useResizeObserver from 'use-resize-observer'
 import * as uuid from 'uuid'
 
 import { HistoryOrNavigate } from '@sourcegraph/common'
+import { useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { QueryChangeSource, QueryState } from '@sourcegraph/shared/src/search'
@@ -21,10 +22,11 @@ import { singleLine, placeholder as placeholderExtension } from '../codemirror'
 import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
 import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
+import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
 import { filterHighlight } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
-import { editorConfigFacet, Source, suggestions } from './suggestionsExtension'
+import { editorConfigFacet, Source, suggestions, startCompletion } from './suggestionsExtension'
 
 import styles from './CodeMirrorQueryInputWrapper.module.scss'
 
@@ -157,70 +159,56 @@ function configureQueryExtensions({
     return parseInputAsQuery({ patternType, interpretComments })
 }
 
-function createEditor(
-    parent: HTMLDivElement,
-    popoverID: string,
-    queryState: QueryState,
-    extensions: Extension,
-    queryExtensions: Extension
-): EditorView {
-    return new EditorView({
-        state: EditorState.create({
-            doc: queryState.query,
-            selection: { anchor: queryState.query.length },
-            extensions: [
-                singleLine,
-                drawSelection(),
-                EditorView.contentAttributes.of({
-                    role: 'combobox',
-                    'aria-controls': popoverID,
-                    'aria-owns': popoverID,
-                    'aria-haspopup': 'grid',
-                }),
-                keymap.of(historyKeymap),
-                keymap.of(defaultKeymap),
-                codemirrorHistory(),
-                Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
-                EditorView.theme({
-                    '&': {
-                        flex: 1,
-                        backgroundColor: 'var(--input-bg)',
-                        borderRadius: 'var(--border-radius)',
-                        borderColor: 'var(--border-color)',
-                        // To ensure that the input doesn't overflow the parent
-                        minWidth: 0,
-                        marginRight: '0.5rem',
-                    },
-                    '&.cm-editor.cm-focused': {
-                        outline: 'none',
-                    },
-                    '.cm-scroller': {
-                        overflowX: 'hidden',
-                    },
-                    '.cm-content': {
-                        caretColor: 'var(--search-query-text-color)',
-                        color: 'var(--search-query-text-color)',
-                        fontFamily: 'var(--code-font-family)',
-                        fontSize: 'var(--code-font-size)',
-                        padding: 0,
-                        paddingLeft: '0.25rem',
-                    },
-                    '.cm-content.focus-visible': {
-                        boxShadow: 'none',
-                    },
-                    '.cm-line': {
-                        padding: 0,
-                    },
-                    '.sg-decorated-token-hover': {
-                        borderRadius: '3px',
-                    },
-                }),
-                querySettingsCompartment.of(queryExtensions),
-                extensionsCompartment.of(extensions),
-            ],
+// Creates extensions that don't depend on props
+function createStaticExtensions({ popoverID }: { popoverID: string }): Extension {
+    return [
+        singleLine,
+        drawSelection(),
+        EditorView.contentAttributes.of({
+            role: 'combobox',
+            'aria-controls': popoverID,
+            'aria-owns': popoverID,
+            'aria-haspopup': 'grid',
         }),
-        parent,
-    })
+        keymap.of(historyKeymap),
+        keymap.of(defaultKeymap),
+        codemirrorHistory(),
+        Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
+        EditorView.theme({
+            '&': {
+                flex: 1,
+                backgroundColor: 'var(--input-bg)',
+                borderRadius: 'var(--border-radius)',
+                borderColor: 'var(--border-color)',
+                // To ensure that the input doesn't overflow the parent
+                minWidth: 0,
+                marginRight: '0.5rem',
+            },
+            '&.cm-editor.cm-focused': {
+                outline: 'none',
+            },
+            '.cm-scroller': {
+                overflowX: 'hidden',
+            },
+            '.cm-content': {
+                caretColor: 'var(--search-query-text-color)',
+                color: 'var(--search-query-text-color)',
+                fontFamily: 'var(--code-font-family)',
+                fontSize: 'var(--code-font-size)',
+                padding: 0,
+                paddingLeft: '0.25rem',
+            },
+            '.cm-content.focus-visible': {
+                boxShadow: 'none',
+            },
+            '.cm-line': {
+                padding: 0,
+            },
+            '.sg-decorated-token-hover': {
+                borderRadius: '3px',
+            },
+        }),
+    ]
 }
 
 function updateExtensions(editor: EditorView | null, extensions: Extension): void {
@@ -232,15 +220,6 @@ function updateExtensions(editor: EditorView | null, extensions: Extension): voi
 function updateQueryExtensions(editor: EditorView | null, extensions: Extension): void {
     if (editor) {
         editor.dispatch({ effects: querySettingsCompartment.reconfigure(extensions) })
-    }
-}
-
-function updateValueIfNecessary(editor: EditorView | null, queryState: QueryState): void {
-    if (editor && queryState.changeSource !== QueryChangeSource.userInput) {
-        editor.dispatch({
-            changes: { from: 0, to: editor.state.doc.length, insert: queryState.query },
-            selection: { anchor: queryState.query.length },
-        })
     }
 }
 
@@ -273,7 +252,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
     children,
 }) => {
     const navigate = useNavigate()
-    const [container, setContainer] = useState<HTMLDivElement | null>(null)
+    const editorContainerRef = useRef<HTMLDivElement | null>(null)
     const focusContainerRef = useRef<HTMLDivElement | null>(null)
     const [suggestionsContainer, setSuggestionsContainer] = useState<HTMLDivElement | null>(null)
     const popoverID = useMemo(() => uuid.v4(), [])
@@ -287,8 +266,9 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
     }, [onSubmit])
     const hasSubmitHandler = !!onSubmit
 
+    const staticExtensions = useMemo(() => createStaticExtensions({ popoverID }), [popoverID])
     // Update extensions whenever any of these props change
-    const extensions = useMemo(
+    const dynamicExtensions = useMemo(
         () => [
             configureExtensions({
                 popoverID,
@@ -324,25 +304,32 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
         [patternType, interpretComments]
     )
 
-    const editor = useMemo(
-        () => (container ? createEditor(container, popoverID, queryState, extensions, queryExtensions) : null),
-        // Should only run once when the component is created, not when
-        // extensions for state update (this is handled in separate hooks)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [container]
-    )
-    const editorRef = useRef(editor)
-    useEffect(() => {
-        editorRef.current = editor
-    }, [editor])
-    useEffect(() => () => editor?.destroy(), [editor])
+    const editorRef = useRef<EditorView | null>(null)
 
-    // Update editor content whenever query state changes
-    useEffect(() => updateValueIfNecessary(editorRef.current, queryState), [queryState])
+    // Update editor state whenever query state changes
+    useUpdateEditorFromQueryState(editorRef, queryState, startCompletion)
 
     // Update editor configuration whenever extensions change
-    useEffect(() => updateExtensions(editorRef.current, extensions), [extensions])
+    useEffect(() => updateExtensions(editorRef.current, dynamicExtensions), [dynamicExtensions])
     useEffect(() => updateQueryExtensions(editorRef.current, queryExtensions), [queryExtensions])
+
+    // Create editor
+    useCodeMirror(
+        editorRef,
+        editorContainerRef,
+        queryState.query,
+        useMemo(
+            () => [
+                staticExtensions,
+                extensionsCompartment.of(dynamicExtensions),
+                querySettingsCompartment.of(queryExtensions),
+            ],
+            // Only set extensions during initialization. dynamicExtensions and queryExtensions
+            // are updated separately.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            []
+        )
+    )
 
     const focus = useCallback(() => {
         editorRef.current?.contentDOM.focus()
@@ -373,7 +360,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
                         </Tooltip>
                         {mode && <span className="ml-1">{mode}:</span>}
                     </div>
-                    <div ref={setContainer} className="d-contents" />
+                    <div ref={editorContainerRef} className="d-contents" />
                     {children}
                 </div>
                 <div ref={setSuggestionsContainer} className={styles.suggestions} />

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -349,7 +349,7 @@ class RegisteredSource {
                 )
             }
 
-            if (effect.is(startCompletion)) {
+            if (effect.is(startCompletionEffect)) {
                 source = source.query(transaction.state)
             }
         }
@@ -457,7 +457,7 @@ class SuggestionsState {
             if (effect.is(setSelectedEffect)) {
                 state = new SuggestionsState(state.source, state.open, effect.value)
             }
-            if (effect.is(hideCompletion)) {
+            if (effect.is(hideCompletionEffect)) {
                 state = new SuggestionsState(state.source, false, state.selectedOption)
             }
         }
@@ -490,8 +490,8 @@ const suggestionsConfig = Facet.define<Config, Config>({
 })
 
 const setSelectedEffect = StateEffect.define<number>()
-const startCompletion = StateEffect.define<void>()
-const hideCompletion = StateEffect.define<void>()
+const startCompletionEffect = StateEffect.define<void>()
+const hideCompletionEffect = StateEffect.define<void>()
 const updateResultEffect = StateEffect.define<{ source: RegisteredSource; result: SuggestionResult }>()
 const suggestionsStateField = StateField.define<SuggestionsState>({
     create() {
@@ -592,7 +592,7 @@ const defaultKeyboardBindings: KeyBinding[] = [
     {
         key: 'Mod-Space',
         run(view) {
-            view.dispatch({ effects: startCompletion.of() })
+            startCompletion(view)
             return true
         },
     },
@@ -621,7 +621,7 @@ const defaultKeyboardBindings: KeyBinding[] = [
         key: 'Escape',
         run(view) {
             if (view.state.field(suggestionsStateField).open) {
-                view.dispatch({ effects: hideCompletion.of() })
+                view.dispatch({ effects: hideCompletionEffect.of() })
                 return true
             }
             return false
@@ -639,7 +639,7 @@ export const suggestionSources = Facet.define<Source>({
                 update.view.hasFocus &&
                 update.view.state.field(suggestionsStateField).result.empty()
             ) {
-                update.view.dispatch({ effects: startCompletion.of() })
+                startCompletion(update.view)
             }
         }),
         Prec.highest(keymap.of(defaultKeyboardBindings)),
@@ -657,3 +657,10 @@ export const suggestions = ({ id, parent, source, historyOrNavigate }: ExternalC
     suggestionSources.of(source),
     ViewPlugin.define(view => new SuggestionView(id, view, parent)),
 ]
+
+/**
+ * Load and show suggestions.
+ */
+export function startCompletion(view: EditorView): void {
+    view.dispatch({ effects: startCompletionEffect.of() })
+}


### PR DESCRIPTION
Depends on #48193

We have some interaction patterns that externally update the query input, including giving hints to the input for how behave (focus, show suggestions, etc)

The experimental query input did not support these yet. This commit updates the component to reuse existing functions to add this support (specifically `useUpdateEditorFromQueryState`).



## Test plan

- Clicking on search examples on the search homepage updates the input and focuses it.
- Selecting a filter from the search reference in the search sidebar updates the query input, focuses it and shows suggestions.

## App preview:

- [Web](https://sg-web-fkling-fix-search-input-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
