### PR TITLE
Allow to run GCP profiler in other instances

### DIFF
--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -11,16 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-// Init starts the Google Cloud Profiler when in sourcegraph.com mode in
-// production.  https://cloud.google.com/profiler/docs/profiling-go
-func Init() {
-	if !envvar.SourcegraphDotComMode() {
-		return
-	}
+var gcpProfilerEnabled = env.MustGetBool("GOOGLE_CLOUD_PROFILER_ENABLED", false, "If true, enable Google Cloud Profiler. See https://cloud.google.com/profiler/docs/profiling-go")
 
-	// SourcegraphDotComMode can be true in dev, so check we are in a k8s
-	// cluster.
-	if !deploy.IsDeployTypeKubernetes(deploy.Type()) {
+// Init starts the Google Cloud Profiler if configured.
+// Will enable when in sourcegraph.com mode in production, or when
+// GOOGLE_CLOUD_PROFILER_ENABLED is truthy.
+// See https://cloud.google.com/profiler/docs/profiling-go.
+func Init() {
+	if !shouldEnableProfiler() {
 		return
 	}
 
@@ -33,4 +31,19 @@ func Init() {
 	if err != nil {
 		log15.Error("profiler.Init google cloud profiler", "error", err)
 	}
+}
+
+func shouldEnableProfiler() bool {
+	// Force overwrite.
+	if gcpProfilerEnabled {
+		return true
+	}
+	if envvar.SourcegraphDotComMode() {
+		// SourcegraphDotComMode can be true in dev, so check we are in a k8s
+		// cluster.
+		if deploy.IsDeployTypeKubernetes(deploy.Type()) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
For MIs, this could also be helpful so allow to enable the profiler outside of dotcom, too with env var GOOGLE_CLOUD_PROFILER_ENABLED.

## Test plan

Code review and we'll see if we can get profiles on select cloud instances where required.