### PR TITLE
Code Insights: Fix live preview refetch trigger

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/InsightRepoSection.tsx
@@ -129,7 +129,7 @@ function RepositoriesURLsPicker(props: RepositoriesURLsPickerProps): ReactElemen
     return (
         <RepositoriesField
             id="repositories-id"
-            description="Find and choose up to 1 repository to run insight"
+            description="Find and choose at least 1 repository to run insight"
             placeholder="Search repositories..."
             aria-labelledby={ariaLabelledby}
             aria-invalid={!!repositories.meta.error}

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -127,7 +127,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                     <Label htmlFor="repositories-id">Repositories</Label>
                     <RepositoriesField
                         id="repositories-id"
-                        description="Find and choose up to 1 repository to run insight"
+                        description="Find and choose at least 1 repository to run insight"
                         placeholder="Search repositories..."
                         {...getDefaultInputProps(repositories)}
                     />

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -35,7 +35,7 @@ interface CodeInsightExampleFormValues {
 }
 
 const INITIAL_INSIGHT_VALUES: CodeInsightExampleFormValues = {
-    repositories: ['github.com/sourcegraph/sourcegraph'],
+    repositories: [],
     query: 'TODO',
 }
 
@@ -126,7 +126,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
                 </Label>
                 <RepositoriesField
                     id="repositories-id"
-                    description="Find and choose up to 1 repository to run insight"
+                    description="Find and choose at least 1 repository to run insight"
                     placeholder="Search repositories..."
                     {...getDefaultInputProps(repositories)}
                 />


### PR DESCRIPTION
Reported in slack https://sourcegraph.slack.com/archives/C01RVEVPWLC/p1677232533873709

https://user-images.githubusercontent.com/18492575/221287823-74e15044-bc5a-4fca-89e6-b912d55236d4.mov


## Test plan
- Check insight creation UI live preview 
- Refresh button should refresh insight regardless it is in data or error state

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-live-preview-refetch.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
