### PR TITLE
Search: fix some `repo:contains.path()` bugs

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -654,6 +654,10 @@ func (r *Resolver) filterRepoHasFileContent(
 					if err != nil {
 						if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, &gitdomain.BadCommitError{}) {
 							return false, err
+						} else if e := (&gitdomain.RevisionNotFoundError{}); errors.As(err, &e) && (rev == "HEAD" || rev == "") {
+							// In the case that we can't find HEAD, that means there are no commits, which means
+							// we can safely say this repo does not have the file being requested.
+							return false, nil
 						}
 
 						// For any other error, add this repo/rev pair to the set of missing repos

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -645,32 +645,33 @@ func (r *Resolver) filterRepoHasFileContent(
 	}
 
 	{ // Use searcher for unindexed revs
+
+		checkHasMatches := func(ctx context.Context, arg query.RepoHasFileContentArgs, repo types.MinimalRepo, rev string) (bool, error) {
+			commitID, err := r.gitserver.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, &gitdomain.BadCommitError{}) {
+					return false, err
+				} else if e := (&gitdomain.RevisionNotFoundError{}); errors.As(err, &e) && (rev == "HEAD" || rev == "") {
+					// In the case that we can't find HEAD, that means there are no commits, which means
+					// we can safely say this repo does not have the file being requested.
+					return false, nil
+				}
+
+				// For any other error, add this repo/rev pair to the set of missing repos
+				addMissing(RepoRevSpecs{Repo: repo, Revs: []query.RevisionSpecifier{{RevSpec: rev}}})
+				return false, nil
+			}
+
+			return r.repoHasFileContentAtCommit(ctx, repo, commitID, arg)
+		}
+
 		for _, repoRevs := range unindexed {
 			for _, rev := range repoRevs.Revs {
 				repo, rev := repoRevs.Repo, rev
 
-				checkHasMatches := func(ctx context.Context, arg query.RepoHasFileContentArgs) (bool, error) {
-					commitID, err := r.gitserver.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
-					if err != nil {
-						if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, &gitdomain.BadCommitError{}) {
-							return false, err
-						} else if e := (&gitdomain.RevisionNotFoundError{}); errors.As(err, &e) && (rev == "HEAD" || rev == "") {
-							// In the case that we can't find HEAD, that means there are no commits, which means
-							// we can safely say this repo does not have the file being requested.
-							return false, nil
-						}
-
-						// For any other error, add this repo/rev pair to the set of missing repos
-						addMissing(RepoRevSpecs{Repo: repo, Revs: []query.RevisionSpecifier{{RevSpec: rev}}})
-						return false, nil
-					}
-
-					return r.repoHasFileContentAtCommit(ctx, repo, commitID, arg)
-				}
-
 				p.Go(func(ctx context.Context) error {
 					for _, arg := range op.HasFileContent {
-						hasMatches, err := checkHasMatches(ctx, arg)
+						hasMatches, err := checkHasMatches(ctx, arg, repo, rev)
 						if err != nil {
 							return err
 						}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -474,6 +474,7 @@ func TestRepoHasFileContent(t *testing.T) {
 	repoB := types.MinimalRepo{ID: 2, Name: "example.com/2"}
 	repoC := types.MinimalRepo{ID: 3, Name: "example.com/3"}
 	repoD := types.MinimalRepo{ID: 4, Name: "example.com/4"}
+	repoE := types.MinimalRepo{ID: 5, Name: "example.com/5"}
 
 	mkHead := func(repo types.MinimalRepo) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
@@ -484,11 +485,19 @@ func TestRepoHasFileContent(t *testing.T) {
 
 	repos := database.NewMockRepoStore()
 	repos.ListMinimalReposFunc.SetDefaultHook(func(context.Context, database.ReposListOptions) ([]types.MinimalRepo, error) {
-		return []types.MinimalRepo{repoA, repoB, repoC, repoD}, nil
+		return []types.MinimalRepo{repoA, repoB, repoC, repoD, repoE}, nil
 	})
 
 	db := database.NewMockDB()
 	db.ReposFunc.SetDefaultReturn(repos)
+
+	mockGitserver := gitserver.NewMockClient()
+	mockGitserver.ResolveRevisionFunc.SetDefaultHook(func(_ context.Context, name api.RepoName, _ string, _ gitserver.ResolveRevisionOptions) (api.CommitID, error) {
+		if name == repoE.Name {
+			return "", &gitdomain.RevisionNotFoundError{}
+		}
+		return "", nil
+	})
 
 	unindexedCorpus := map[string]map[string]map[string]struct{}{
 		string(repoC.Name): {
@@ -535,6 +544,7 @@ func TestRepoHasFileContent(t *testing.T) {
 			mkHead(repoB),
 			mkHead(repoC),
 			mkHead(repoD),
+			mkHead(repoE),
 		},
 	}, {
 		name: "bad path",
@@ -576,6 +586,7 @@ func TestRepoHasFileContent(t *testing.T) {
 		matchingRepos: nil,
 		expected: []*search.RepositoryRevisions{
 			mkHead(repoD),
+			mkHead(repoE),
 		},
 	}, {
 		name: "path but no content",
@@ -616,7 +627,7 @@ func TestRepoHasFileContent(t *testing.T) {
 				Minimal: tc.matchingRepos,
 			}, nil)
 
-			res := NewResolver(logtest.Scoped(t), db, gitserver.NewMockClient(), endpoint.Static("test"), mockZoekt)
+			res := NewResolver(logtest.Scoped(t), db, mockGitserver, endpoint.Static("test"), mockZoekt)
 			resolved, err := res.Resolve(context.Background(), search.RepoOptions{
 				RepoFilters:    toParsedRepoFilters(".*"),
 				HasFileContent: tc.filters,

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -568,6 +568,16 @@ func TestRepoHasFileContent(t *testing.T) {
 			mkHead(repoC),
 		},
 	}, {
+		name: "one negated unindexed path",
+		filters: []query.RepoHasFileContentArgs{{
+			Path:    "pathC",
+			Negated: true,
+		}},
+		matchingRepos: nil,
+		expected: []*search.RepositoryRevisions{
+			mkHead(repoD),
+		},
+	}, {
 		name: "path but no content",
 		filters: []query.RepoHasFileContentArgs{{
 			Path:    "pathC",

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -110,10 +110,6 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 }
 
 func (rb *IndexedRepoRevs) BranchRepos() []zoektquery.BranchRepos {
-	if rb == nil {
-		// The zero-value of IndexedRepoRevs can be treated as an empty set of repo revs.
-		return nil
-	}
 	brs := make([]zoektquery.BranchRepos, 0, len(rb.branchRepos))
 	for _, br := range rb.branchRepos {
 		brs = append(brs, *br)
@@ -189,11 +185,11 @@ func PartitionRepos(
 ) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions, err error) {
 	// Fallback to Unindexed if the query contains valid ref-globs.
 	if containsRefGlobs {
-		return nil, repos, nil
+		return &IndexedRepoRevs{}, repos, nil
 	}
 	// Fallback to Unindexed if index:no
 	if useIndex == query.No {
-		return nil, repos, nil
+		return &IndexedRepoRevs{}, repos, nil
 	}
 
 	tr, ctx := trace.New(ctx, "PartitionRepos", string(typ))
@@ -224,7 +220,7 @@ func PartitionRepos(
 			logger.Warn("zoektIndexedRepos failed", log.Error(err))
 		}
 
-		return nil, repos, ctx.Err()
+		return &IndexedRepoRevs{}, repos, ctx.Err()
 	}
 
 	// Note: We do not need to handle list.Crashes since we will fallback to

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -110,6 +110,10 @@ func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.
 }
 
 func (rb *IndexedRepoRevs) BranchRepos() []zoektquery.BranchRepos {
+	if rb == nil {
+		// The zero-value of IndexedRepoRevs can be treated as an empty set of repo revs.
+		return nil
+	}
 	brs := make([]zoektquery.BranchRepos, 0, len(rb.branchRepos))
 	for _, br := range rb.branchRepos {
 		brs = append(brs, *br)


### PR DESCRIPTION
This PR is made up of three commits, each of which fixes a separate bug that I found while investigating the bug described [here](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1677226100924699). 

Commit 1 fixes a panic that only occurs when `index:no` is specified. This is an undocumented debugging parameter, so it is not a panic we've been seeing in production.

Commit 2 fixes support for negating `repo:contains.path()` and `repohasfile:` for unindexed repositories. When we added negation support to that predicate, we missed the codepath that is run for repositories that aren't indexed by Zoekt. Additionally, it extracts some logic to make the flow a bit more clear. 

Commit 3 adds a test for the fix in commit 2.

Commit 4 fixes the original issue, which is that we return "revision not found" alert for repositories that have no commits. If a repository has no commits, it definitely does not contain a file, so it's safe to ignore the error in that case. 

Commit 5 adds a test for the fix in commit 4.

## Test plan

Unit tests for fixes. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
