### PR TITLE
internal/database: avoid potential performance issue in db driver

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -141,16 +141,18 @@ func (d *extendedDriver) Open(str string) (driver.Conn, error) {
 		return nil, errors.New("sql driver is not a sqlhooks.Driver")
 	}
 
-	// Driver.Open() is called during after we first attempt to connect to the database
-	// during startup time in `dbconn.open()`, where the manager will persist the config internally,
-	// and also call the underlying pgx RegisterConnConfig() to register the config to pgx driver.
-	// Therefore, this should never be nil.
-	cfg := manager.getConfig(str)
-	if cfg == nil {
-		return nil, errors.Newf("no config found %q", str)
-	}
-
 	if pgConnectionUpdater != "" {
+		// Driver.Open() is called during after we first attempt to connect to the database
+		// during startup time in `dbconn.open()`, where the manager will persist the config internally,
+		// and also call the underlying pgx RegisterConnConfig() to register the config to pgx driver.
+		// Therefore, this should never be nil.
+		//
+		// We do not need this code path unless connection updater is enabled.
+		cfg := manager.getConfig(str)
+		if cfg == nil {
+			return nil, errors.Newf("no config found %q", str)
+		}
+
 		u, ok := connectionUpdaters[pgConnectionUpdater]
 		if !ok {
 			return nil, errors.Errorf("unknown connection updater %q", pgConnectionUpdater)


### PR DESCRIPTION
context: 

- https://sourcegraph.slack.com/archives/C03CSAER9LK/p1677236971974689
- https://github.com/sourcegraph/sourcegraph/pull/47585

we're not 100% this is the root cause, it's possible jsut due to the lowered db connection limit in s2

we've removed the limit and will monitor. then we can decide whether this PR is worth merging

## Test plan

s2 is not longer seeing database connection contention
