### PR TITLE
Bump rust version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -10,6 +10,6 @@ trivy 0.30.3
 kustomize 4.5.7
 awscli 2.4.7
 python system
-rust 1.62.0
+rust 1.63.0
 ruby 3.1.3
 pnpm 7.24.2


### PR DESCRIPTION
I got compile errors starting the dev stack because rust was too old for something, bumping it here fixes it.

## Test plan

sg start works again for me.