### PR TITLE
the enterprise parts of client/web/ are not Apache 2-licensed

### DIFF
--- a/client/web/package.json
+++ b/client/web/package.json
@@ -3,7 +3,6 @@
   "name": "@sourcegraph/web",
   "version": "1.10.1",
   "description": "The Sourcegraph web app",
-  "license": "Apache-2.0",
   "scripts": {
     "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression integration",
     "task:mocha": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha",


### PR DESCRIPTION
## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-license-packagejson.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
