### PR TITLE
Allow to list users on non-dotcom

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -143,8 +143,8 @@ func (o *OrgResolver) Members(ctx context.Context, args struct {
 	graphqlutil.ConnectionResolverArgs
 	Query *string
 }) (*graphqlutil.ConnectionResolver[*UserResolver], error) {
-	// 🚨 SECURITY: Only org members can list other org members.
-	if err := checkMembersAccess(ctx, o.db, o.org.ID); err != nil {
+	// 🚨 SECURITY: Verify listing users is allowed.
+	if err := checkMembersAccess(ctx, o.db); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
As discussed here, there is no security benefit of guarding this method on customer instances and we will be able to provide auto-completion for adding members to teams after this change.

> We do not allow regular users to call the ListUsers endpoint in the GraphQL API. However, we do allow to get a user by their ID. Since IDs are sequential, this is no protection against exfiltrating all the users from the instance (and if you go to their profile by username, you can also see them and the fields that are readable by non-site-admins).

I made sure we still don't allow this on dotcom.

Context: https://sourcegraph.slack.com/archives/C1JH2BEHZ/p1677379256496279

Closes https://github.com/sourcegraph/sourcegraph/issues/48235.

## Test plan

Can now successfully list users as a non-admin.