### PR TITLE
Don't load full codeowners file into memory

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -316,7 +316,7 @@ type Client interface {
 	ReadDir(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error)
 
 	// NewFileReader returns an io.ReadCloser reading from the named file at commit.
-	// The caller should always close the reader after use
+	// The caller should always close the reader after use.
 	NewFileReader(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error)
 
 	// DiffSymbols performs a diff command which is expected to be parsed by our symbols package

--- a/internal/search/codeownership/filter_job_test.go
+++ b/internal/search/codeownership/filter_job_test.go
@@ -1,7 +1,9 @@
 package codeownership
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"io/fs"
 	"strings"
 	"testing"
@@ -269,12 +271,12 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 			ctx := context.Background()
 
 			gitserverClient := gitserver.NewMockClient()
-			gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
+			gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
 				content, ok := tt.args.repoContent[file]
 				if !ok {
 					return nil, fs.ErrNotExist
 				}
-				return []byte(content), nil
+				return io.NopCloser(bytes.NewReader([]byte(content))), nil
 			})
 
 			rules := NewRulesCache(gitserverClient, database.NewMockDB())

--- a/internal/search/codeownership/select_job_test.go
+++ b/internal/search/codeownership/select_job_test.go
@@ -1,7 +1,9 @@
 package codeownership
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"io/fs"
 	"sort"
 	"testing"
@@ -23,7 +25,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
+		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
 			return nil, fs.ErrNotExist
 		})
 		db := database.NewMockDB()
@@ -46,9 +48,9 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
+		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
 			// return a codeowner path for no which doesn't match the path of the match below.
-			return []byte("NO.md @test\n"), nil
+			return io.NopCloser(bytes.NewReader([]byte("NO.md @test\n"))), nil
 		})
 		db := database.NewMockDB()
 		rules := NewRulesCache(gitserverClient, db)
@@ -70,10 +72,10 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
+		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
 			// README is owned by a user and a team.
 			// code.go is owner by another user and an unknown entity.
-			return []byte("README.md @testUserHandle @testTeamHandle\ncode.go user@email.com @unknown"), nil
+			return io.NopCloser(bytes.NewReader([]byte("README.md @testUserHandle @testTeamHandle\ncode.go user@email.com @unknown"))), nil
 		})
 		mockUserStore := database.NewMockUserStore()
 		mockTeamStore := database.NewMockTeamStore()


### PR DESCRIPTION
We convert to a reader right after, so we can skip this step.

## Test plan

Things still seem to work. 