### PR TITLE
web: remove `worker-loader` from the `web` package

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -9,7 +9,6 @@ import {
     STATIC_ASSETS_PATH,
     stylePlugin,
     packageResolutionPlugin,
-    workerPlugin,
     monacoPlugin,
     RXJS_RESOLUTIONS,
     buildMonaco,
@@ -43,7 +42,6 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     outdir: STATIC_ASSETS_PATH,
     plugins: [
         stylePlugin,
-        workerPlugin,
         manifestPlugin,
         packageResolutionPlugin({
             path: require.resolve('path-browserify'),

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -73,8 +73,6 @@ const hotLoadablePaths = ['branded', 'shared', 'web', 'wildcard'].map(workspace 
 const enterpriseDirectory = path.resolve(__dirname, 'src', 'enterprise')
 const styleLoader = IS_DEVELOPMENT ? 'style-loader' : MiniCssExtractPlugin.loader
 
-const extensionHostWorker = /main\.worker\.ts$/
-
 // Used to ensure that we include all initial chunks into the Webpack manifest.
 const initialChunkNames = {
   react: 'react',
@@ -254,7 +252,6 @@ const config = {
       {
         test: /\.[jt]sx?$/,
         include: hotLoadablePaths,
-        exclude: extensionHostWorker,
         use: [
           {
             loader: 'babel-loader',
@@ -267,7 +264,7 @@ const config = {
       },
       {
         test: /\.[jt]sx?$/,
-        exclude: [...hotLoadablePaths, extensionHostWorker],
+        exclude: hotLoadablePaths,
         use: [getBabelLoader()],
       },
       {
@@ -283,10 +280,6 @@ const config = {
       },
       getMonacoCSSRule(),
       getMonacoTTFRule(),
-      {
-        test: extensionHostWorker,
-        use: [{ loader: 'worker-loader', options: { inline: 'no-fallback' } }, getBabelLoader()],
-      },
       { test: /\.ya?ml$/, type: 'asset/source' },
       { test: /\.(png|woff2)$/, type: 'asset/resource' },
     ],


### PR DESCRIPTION
## Context

Thanks to [the PR](https://github.com/sourcegraph/sourcegraph/pull/47517) from @sqs, we can now remove worker loaders from the `web` package.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-remove-worker-loader-from-web.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
