### PR TITLE
app: specify platform for docker run ctags

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -153,6 +153,7 @@ const universalCtagsDevScript = `#!/usr/bin/env bash
 exec docker run --rm -i \
     -a stdin -a stdout -a stderr \
     --user guest \
+    --platform=linux/amd64 \
     --name=universal-ctags-$$ \
     --entrypoint /usr/local/bin/universal-ctags \
     slimsag/ctags:latest@sha256:dd21503a3ae51524ab96edd5c0d0b8326d4baaf99b4238dfe8ec0232050af3c7 "$@"


### PR DESCRIPTION
Spotted this warning from a devs log:

  WARNING: The requested image's platform (linux/amd64) does not match
  the detected host platform (linux/arm64/v8) and no specific platform
  was requested

I think this is the only place we do docker run for app.

Test Plan: yolo