### PR TITLE
Revert "remove enableLegacyExtensions and all now-unreachable code"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The Code insights "run over all repositories" mode has been replaced with search-powered repositories filed syntax. [#45687](https://github.com/sourcegraph/sourcegraph/pull/45687)
 - The settings `search.repositoryGroups`, `codeInsightsGqlApi`, `codeInsightsAllRepos`, `experimentalFeatures.copyQueryButton`,, `experimentalFeatures.showRepogroupHomepage`, `experimentalFeatures.showOnboardingTour`, `experimentalFeatures.showSearchContextManagement` and `codeIntelligence.autoIndexRepositoryGroups` have been removed as they were deprecated and unsued. [#47481](https://github.com/sourcegraph/sourcegraph/pull/47481)
-- The site config `enableLegacyExtensions` setting was removed. It is no longer possible to enable legacy Sourcegraph extension API functionality in this version.
 
 ## 4.4.2
 

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -102,6 +102,11 @@ describe('GitHub', () => {
                     siteAdmin: false,
                 },
             }),
+            EnableLegacyExtensions: () => ({
+                site: {
+                    enableLegacyExtensions: true,
+                },
+            }),
         })
 
         // Ensure that the same assets are requested in all environments.
@@ -150,7 +155,10 @@ describe('GitHub', () => {
     // it('shows hover tooltips when hovering a token and respects "Enable single click to go to definition" setting', async () => {
     //     mockUrls(['https://github.com/*path/find-definition'])
 
-    //     const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking()
+    //     const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
+    //         pollyServer: testContext.server,
+    //         sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
+    //     })
 
     //     const userSettings: Settings = {
     //         extensions: extensionSettings,
@@ -308,14 +316,16 @@ describe('GitHub', () => {
     // })
 
     describe('Pull request pages', () => {
-        // TODO(sqs): skipped because these have not been reimplemented after the extension API deprecation
-        describe.skip('Files Changed view', () => {
+        describe('Files Changed view', () => {
             // For each pull request test, set up a mock extension that verifies that the correct
             // file and revision info reach extensions.
             beforeEach(() => {
                 mockUrls(['https://github.com/*path/find-definition'])
 
-                const { mockExtension, extensionSettings } = setupExtensionMocking()
+                const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
+                    pollyServer: testContext.server,
+                    sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
+                })
 
                 const userSettings: Settings = {
                     extensions: extensionSettings,
@@ -340,6 +350,7 @@ describe('GitHub', () => {
                             merged: { contents: JSON.stringify(userSettings), messages: [] },
                         },
                     }),
+                    Extensions,
                     ResolveRev: ({ revision }) => ({
                         repository: {
                             mirrorInfo: { cloned: true },
@@ -628,8 +639,7 @@ describe('GitHub', () => {
             })
         })
 
-        // TODO(sqs): skipped because these have not been reimplemented after the extension API deprecation
-        describe.skip('Commit view', () => {
+        describe('Commit view', () => {
             beforeEach(() => {
                 mockUrls([
                     'https://github.com/*path/find-definition',
@@ -637,7 +647,10 @@ describe('GitHub', () => {
                     'https://github.com/commits/badges',
                 ])
 
-                const { mockExtension, extensionSettings } = setupExtensionMocking()
+                const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
+                    pollyServer: testContext.server,
+                    sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
+                })
 
                 const userSettings: Settings = {
                     extensions: extensionSettings,
@@ -678,6 +691,7 @@ describe('GitHub', () => {
                             },
                         },
                     }),
+                    Extensions,
                 })
 
                 // Serve a mock extension with a simple hover provider

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -91,6 +91,11 @@ describe('GitLab', () => {
                     hasCodeIntelligence: true,
                 },
             }),
+            EnableLegacyExtensions: () => ({
+                site: {
+                    enableLegacyExtensions: true,
+                },
+            }),
         })
 
         // Ensure that the same assets are requested in all environments.
@@ -141,9 +146,11 @@ describe('GitLab', () => {
         })
     })
 
-    // TODO(sqs): skipped because these have not been reimplemented after the extension API deprecation
-    it.skip('shows hover tooltips when hovering a token', async () => {
-        const { mockExtension, extensionSettings } = setupExtensionMocking()
+    it('shows hover tooltips when hovering a token', async () => {
+        const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
+            pollyServer: testContext.server,
+            sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
+        })
 
         const userSettings: Settings = {
             extensions: extensionSettings,
@@ -168,6 +175,7 @@ describe('GitLab', () => {
                     merged: { contents: JSON.stringify(userSettings), messages: [] },
                 },
             }),
+            Extensions,
         })
 
         // Serve a mock extension with a simple hover provider

--- a/client/browser/src/shared/platform/context.ts
+++ b/client/browser/src/shared/platform/context.ts
@@ -1,5 +1,5 @@
-import { combineLatest, ReplaySubject } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { combineLatest, ReplaySubject, of } from 'rxjs'
+import { map, switchMap } from 'rxjs/operators'
 
 import { asError } from '@sourcegraph/common'
 import { isHTTPAuthError } from '@sourcegraph/http-client'
@@ -8,11 +8,13 @@ import { mutateSettings, updateSettings } from '@sourcegraph/shared/src/settings
 import { EMPTY_SETTINGS_CASCADE, gqlToCascade, SettingsSubject } from '@sourcegraph/shared/src/settings/settings'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
+import { background } from '../../browser-extension/web-extension-api/runtime'
 import { createGraphQLHelpers } from '../backend/requestGraphQl'
 import { CodeHost } from '../code-hosts/shared/codeHost'
+import { isInPage } from '../context'
 
 import { createExtensionHost } from './extensionHost'
-import { getInlineExtensions } from './inlineExtensionsService'
+import { getInlineExtensions, shouldUseInlineExtensions } from './inlineExtensionsService'
 import { editClientSettings, fetchViewerSettings, mergeCascades, storageSettingsCascade } from './settings'
 
 export interface SourcegraphIntegrationURLs {
@@ -54,6 +56,8 @@ export function createPlatformContext(
         subjects: SettingsSubject[]
     }>(1)
     const { requestGraphQL, getBrowserGraphQLClient } = createGraphQLHelpers(sourcegraphURL, isExtension)
+
+    const shouldUseInlineExtensionsObservable = shouldUseInlineExtensions(requestGraphQL)
 
     const context: BrowserPlatformContext = {
         /**
@@ -116,6 +120,31 @@ export function createPlatformContext(
         requestGraphQL,
         getGraphQLClient: getBrowserGraphQLClient,
         createExtensionHost: () => createExtensionHost({ assetsURL }),
+        getScriptURLForExtension: () => {
+            if (isInPage) {
+                return undefined
+            }
+
+            return bundleURLs =>
+                shouldUseInlineExtensionsObservable.toPromise().then(shouldUseInlineExtensions => {
+                    if (shouldUseInlineExtensions) {
+                        // inline extensions have fixed scriptURLs
+                        return bundleURLs
+                    }
+
+                    // We need to import the extension's JavaScript file (in importScripts in the Web Worker) from a blob:
+                    // URI, not its original http:/https: URL, because Chrome extensions are not allowed to be published
+                    // with a CSP that allowlists https://* in script-src (see
+                    // https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-remote-script). (Firefox
+                    // add-ons have an even stricter restriction.)
+                    return Promise.allSettled(bundleURLs.map(bundleURL => background.createBlobURL(bundleURL))).then(
+                        results =>
+                            results.map(result =>
+                                result.status === 'rejected' ? asError(result.reason) : result.value
+                            )
+                    )
+                })
+        },
         urlToFile: ({ rawRepoName, ...target }, context) => {
             // We don't always resolve the rawRepoName, e.g. if there are multiple definitions.
             // Construct URL to file on code host, if possible.
@@ -127,7 +156,10 @@ export function createPlatformContext(
         },
         sourcegraphURL,
         clientApplication: 'other',
-        getStaticExtensions: () => getInlineExtensions(),
+        getStaticExtensions: () =>
+            shouldUseInlineExtensionsObservable.pipe(
+                switchMap(shouldUseInline => (shouldUseInline ? getInlineExtensions() : of(undefined)))
+            ),
     }
     return context
 }

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -1,10 +1,60 @@
 import { Observable, from } from 'rxjs'
+import { map } from 'rxjs/operators'
 
-import { checkOk } from '@sourcegraph/http-client'
+import { checkOk, isErrorGraphQLResult, gql } from '@sourcegraph/http-client'
 import { ExecutableExtension } from '@sourcegraph/shared/src/api/extension/activation'
 import { ExtensionManifest } from '@sourcegraph/shared/src/extensions/extensionManifest'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
 import extensions from '../../../code-intel-extensions.json'
+import { EnableLegacyExtensionsResult } from '../../graphql-operations'
+
+const DEFAULT_ENABLE_LEGACY_EXTENSIONS = false
+
+/**
+ * Determine which extensions should be loaded:
+ * - inline (bundled with the browser extension)
+ * - or from the extensions registry (if `enableLegacyExtensions` experimental feature value is set to `true`).
+ */
+export const shouldUseInlineExtensions = (requestGraphQL: PlatformContext['requestGraphQL']): Observable<boolean> =>
+    requestGraphQL<EnableLegacyExtensionsResult>({
+        request: gql`
+            query EnableLegacyExtensions {
+                site {
+                    enableLegacyExtensions
+                }
+            }
+        `,
+        variables: {},
+        mightContainPrivateInfo: false,
+    }).pipe(
+        map(result => {
+            if (isErrorGraphQLResult(result)) {
+                // EnableLegacyExtensions query resolver may not be implemented on older versions.
+                // Return `true` by default.
+                return true
+            }
+
+            try {
+                const enableLegacyExtensions = result.data.site.enableLegacyExtensions
+                return typeof enableLegacyExtensions === 'undefined'
+                    ? DEFAULT_ENABLE_LEGACY_EXTENSIONS
+                    : enableLegacyExtensions
+            } catch {
+                return DEFAULT_ENABLE_LEGACY_EXTENSIONS
+            }
+        }),
+        map(enableLegacyExtensions => {
+            // TODO: The Phabricator native extension is currently the only runtime that runs the
+            // browser extension code but does not use bundled extensions yet. We will fix this
+            // when we update the browser extensions to use the new code intel APIs (#42104).
+            if (window.SOURCEGRAPH_PHABRICATOR_EXTENSION === true) {
+                return false
+            }
+
+            return !enableLegacyExtensions
+        })
+    )
 
 /**
  * Get the manifest URL and script URL for a Sourcegraph extension which is inline (bundled with the browser add-on).

--- a/client/shared/src/api/client/connection.ts
+++ b/client/shared/src/api/client/connection.ts
@@ -44,7 +44,13 @@ export async function createExtensionHostClientConnection(
     initData: Omit<InitData, 'initialSettings'>,
     platformContext: Pick<
         PlatformContext,
-        'settings' | 'updateSettings' | 'getGraphQLClient' | 'requestGraphQL' | 'telemetryService' | 'clientApplication'
+        | 'settings'
+        | 'updateSettings'
+        | 'getGraphQLClient'
+        | 'requestGraphQL'
+        | 'telemetryService'
+        | 'getScriptURLForExtension'
+        | 'clientApplication'
     >
 ): Promise<{
     subscription: Unsubscribable

--- a/client/shared/src/api/client/enabledExtensions.ts
+++ b/client/shared/src/api/client/enabledExtensions.ts
@@ -1,0 +1,90 @@
+import { isEqual, once } from 'lodash'
+import { combineLatest, from, Observable, throwError } from 'rxjs'
+import { catchError, distinctUntilChanged, map, publishReplay, refCount, shareReplay, switchMap } from 'rxjs/operators'
+
+import { asError } from '@sourcegraph/common'
+
+import { ConfiguredExtension, extensionIDsFromSettings, isExtensionEnabled } from '../../extensions/extension'
+import { areExtensionsSame } from '../../extensions/extensions'
+import { queryConfiguredRegistryExtensions } from '../../extensions/helpers'
+import { PlatformContext } from '../../platform/context'
+import { isSettingsValid } from '../../settings/settings'
+
+/**
+ * @returns An observable that emits the list of extensions configured in the viewer's final settings upon
+ * subscription and each time it changes.
+ */
+function viewerConfiguredExtensions({
+    settings,
+    getGraphQLClient,
+}: Pick<PlatformContext, 'settings' | 'getGraphQLClient'>): Observable<ConfiguredExtension[]> {
+    return from(settings).pipe(
+        map(settings => extensionIDsFromSettings(settings)),
+        distinctUntilChanged((a, b) => isEqual(a, b)),
+        switchMap(extensionIDs => queryConfiguredRegistryExtensions({ getGraphQLClient }, extensionIDs)),
+        catchError(error => throwError(asError(error))),
+        // TODO: Restore reference counter after refactoring contributions service
+        // to not unsubscribe from existing entries when new entries are registered,
+        // in order to ensure that the source is unsubscribed from.
+        shareReplay(1)
+    )
+}
+
+/**
+ * List of extensions migrated to the core workflow.
+ */
+export const MIGRATED_TO_CORE_WORKFLOW_EXTENSION_IDS = new Set([
+    'sourcegraph/git-extras',
+    'sourcegraph/search-export',
+    'sourcegraph/open-in-editor',
+    'sourcegraph/open-in-vscode',
+    'dymka/open-in-webstorm',
+    'sourcegraph/open-in-atom',
+])
+
+/**
+ * Returns an Observable of extensions enabled for the user.
+ * Wrapped with the `once` function from lodash.
+ */
+export const getEnabledExtensions = once(
+    (
+        context: Pick<
+            PlatformContext,
+            'settings' | 'getGraphQLClient' | 'getScriptURLForExtension' | 'clientApplication'
+        >
+    ): Observable<ConfiguredExtension[]> =>
+        combineLatest([viewerConfiguredExtensions(context), context.settings]).pipe(
+            map(([configuredExtensions, settings]) => {
+                const enableGoImportsSearchQueryTransform =
+                    isSettingsValid(settings) &&
+                    settings.final.experimentalFeatures?.enableGoImportsSearchQueryTransform
+
+                return configuredExtensions.filter(extension => {
+                    const extensionsAsCoreFeatureMigratedExtension = MIGRATED_TO_CORE_WORKFLOW_EXTENSION_IDS.has(
+                        extension.id
+                    )
+                    // Ignore extensions migrated to the core workflow if the experimental feature is enabled
+                    if (context.clientApplication === 'sourcegraph' && extensionsAsCoreFeatureMigratedExtension) {
+                        return false
+                    }
+
+                    // Go import search query transform is enabled by default but can be disabled by the setting
+                    const enableGoImportsSearchQueryTransformMigratedExtension =
+                        (enableGoImportsSearchQueryTransform === undefined || enableGoImportsSearchQueryTransform) &&
+                        extension.id === 'go-imports-search'
+                    // Ignore loading the go-imports-search extension when the migrated go imports search is enabled
+                    if (
+                        context.clientApplication === 'sourcegraph' &&
+                        enableGoImportsSearchQueryTransformMigratedExtension
+                    ) {
+                        return false
+                    }
+
+                    return isExtensionEnabled(settings.final, extension.id)
+                })
+            }),
+            distinctUntilChanged((a, b) => areExtensionsSame(a, b)),
+            publishReplay(1),
+            refCount()
+        )
+)

--- a/client/shared/src/api/client/mainthread-api.test.ts
+++ b/client/shared/src/api/client/mainthread-api.test.ts
@@ -22,12 +22,18 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'getGraphQLClient' | 'requestGraphQL' | 'clientApplication'
+                | 'updateSettings'
+                | 'settings'
+                | 'getGraphQLClient'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'clientApplication'
             > = {
                 settings: EMPTY,
                 getGraphQLClient,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
+                getScriptURLForExtension: () => undefined,
                 clientApplication: 'other',
             }
 
@@ -55,12 +61,18 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'getGraphQLClient' | 'requestGraphQL' | 'clientApplication'
+                | 'updateSettings'
+                | 'settings'
+                | 'getGraphQLClient'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'clientApplication'
             > = {
                 settings: EMPTY,
                 getGraphQLClient,
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL,
+                getScriptURLForExtension: () => undefined,
                 clientApplication: 'other',
             }
 
@@ -81,7 +93,12 @@ describe('MainThreadAPI', () => {
             }
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'requestGraphQL' | 'getGraphQLClient' | 'clientApplication'
+                | 'updateSettings'
+                | 'settings'
+                | 'requestGraphQL'
+                | 'getGraphQLClient'
+                | 'getScriptURLForExtension'
+                | 'clientApplication'
             > = {
                 settings: of({
                     subjects: [
@@ -114,6 +131,7 @@ describe('MainThreadAPI', () => {
                 updateSettings,
                 getGraphQLClient,
                 requestGraphQL: () => EMPTY,
+                getScriptURLForExtension: () => undefined,
                 clientApplication: 'other',
             }
 
@@ -143,12 +161,18 @@ describe('MainThreadAPI', () => {
 
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'getGraphQLClient' | 'requestGraphQL' | 'clientApplication'
+                | 'updateSettings'
+                | 'settings'
+                | 'getGraphQLClient'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'clientApplication'
             > = {
                 getGraphQLClient,
                 settings: of(...values),
                 updateSettings: () => Promise.resolve(),
                 requestGraphQL: () => EMPTY,
+                getScriptURLForExtension: () => undefined,
                 clientApplication: 'other',
             }
 
@@ -169,12 +193,18 @@ describe('MainThreadAPI', () => {
             const values = new Subject<SettingsCascade<{ a: string }>>()
             const platformContext: Pick<
                 PlatformContext,
-                'updateSettings' | 'settings' | 'getGraphQLClient' | 'requestGraphQL' | 'clientApplication'
+                | 'updateSettings'
+                | 'settings'
+                | 'getGraphQLClient'
+                | 'requestGraphQL'
+                | 'getScriptURLForExtension'
+                | 'clientApplication'
             > = {
                 settings: values.asObservable(),
                 updateSettings: () => Promise.resolve(),
                 getGraphQLClient,
                 requestGraphQL: () => EMPTY,
+                getScriptURLForExtension: () => undefined,
                 clientApplication: 'other',
             }
             const passedToExtensionHost: SettingsCascade<object>[] = []

--- a/client/shared/src/api/client/search.ts
+++ b/client/shared/src/api/client/search.ts
@@ -1,18 +1,29 @@
 // For search-related extension API features, such as query transformers
 
-import { Observable, of } from 'rxjs'
+import { Remote } from 'comlink'
+import { from, Observable, of, TimeoutError } from 'rxjs'
+import { catchError, filter, first, switchMap, timeout } from 'rxjs/operators'
 
+import { logger } from '@sourcegraph/common'
+
+import { FlatExtensionHostAPI } from '../contract'
 import { SharedEventLogger } from '../sharedEventLogger'
+
+import { wrapRemoteObservable } from './api/common'
+
+const TRANSFORM_QUERY_TIMEOUT = 3000
 
 /**
  * Executes search query transformers contributed by Sourcegraph extensions.
  */
 export function transformSearchQuery({
     query,
+    extensionHostAPIPromise,
     enableGoImportsSearchQueryTransform,
     eventLogger,
 }: {
     query: string
+    extensionHostAPIPromise: null | Promise<Remote<FlatExtensionHostAPI>>
     enableGoImportsSearchQueryTransform: undefined | boolean
     eventLogger: SharedEventLogger
 }): Observable<string> {
@@ -22,7 +33,37 @@ export function transformSearchQuery({
         query = goImportsTransform(query, eventLogger)
     }
 
-    return of(query)
+    if (extensionHostAPIPromise === null) {
+        return of(query)
+    }
+
+    return from(extensionHostAPIPromise).pipe(
+        switchMap(extensionHostAPI =>
+            // Since we won't re-compute on subsequent extension activation, ensure that
+            // at least the initial set of extensions, which should include always-activated
+            // query-transforming extensions, have been loaded to ensure that the initial
+            // search query is transformed
+            wrapRemoteObservable(extensionHostAPI.haveInitialExtensionsLoaded()).pipe(
+                filter(haveLoaded => haveLoaded),
+                first(), // Ensure that it only emits once
+                switchMap(() =>
+                    wrapRemoteObservable(extensionHostAPI.transformSearchQuery(query)).pipe(
+                        first() // Ensure that it only emits once
+                    )
+                )
+            )
+        ),
+        // Timeout: if this is hanging due to any sort of extension bug, it may not result in a thrown error,
+        // but will degrade search UX.
+        // Wait up to 5 seconds and log to console for users to debug slow query transformer extensions
+        timeout(TRANSFORM_QUERY_TIMEOUT),
+        catchError(error => {
+            if (error instanceof TimeoutError) {
+                logger.error(`Extension query transformers took more than ${TRANSFORM_QUERY_TIMEOUT}ms`)
+            }
+            return of(query)
+        })
+    )
 }
 
 function goImportsTransform(query: string, eventLogger: SharedEventLogger): string {

--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -4,7 +4,7 @@ import { DocumentHighlight } from 'sourcegraph'
 
 import { Contributions, Evaluated, Raw, TextDocumentPositionParameters, HoverMerged } from '@sourcegraph/client-api'
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
-import { DeepReplace } from '@sourcegraph/common'
+import { DeepReplace, ErrorLike } from '@sourcegraph/common'
 import * as clientType from '@sourcegraph/extension-api-types'
 import { GraphQLResult } from '@sourcegraph/http-client'
 
@@ -195,6 +195,10 @@ export interface MainThreadAPI {
     // User interaction methods
     showMessage: (message: string) => Promise<void>
     showInputBox: (options?: InputBoxOptions) => Promise<string | undefined>
+
+    getScriptURLForExtension: () =>
+        | undefined
+        | (((bundleURLs: string[]) => Promise<(string | ErrorLike)[]>) & ProxyMarked)
 
     getEnabledExtensions: () => ProxySubscribable<(ConfiguredExtension | ExecutableExtension)[]>
 

--- a/client/shared/src/api/extension/test/activation.test.ts
+++ b/client/shared/src/api/extension/test/activation.test.ts
@@ -16,7 +16,8 @@ describe('Extension activation', () => {
         it('logs events for activated extensions', async () => {
             const logEvent = sinon.spy()
 
-            const mockMain = pretendRemote<Pick<MainThreadAPI, 'logEvent'>>({
+            const mockMain = pretendRemote<Pick<MainThreadAPI, 'getScriptURLForExtension' | 'logEvent'>>({
+                getScriptURLForExtension: () => undefined,
                 logEvent,
             })
 

--- a/client/shared/src/api/extension/test/extensionHost.configuration.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.configuration.test.ts
@@ -1,3 +1,4 @@
+import { proxy } from 'comlink'
 import { BehaviorSubject } from 'rxjs'
 
 import { SettingsCascade } from '../../../settings/settings'
@@ -23,6 +24,7 @@ describe('ExtensionHost: Configuration', () => {
                     sourcegraphURL: 'https://example.com/',
                 },
                 pretendRemote<ClientAPI>({
+                    getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
             )
@@ -42,6 +44,7 @@ describe('ExtensionHost: Configuration', () => {
                     sourcegraphURL: 'https://example.com/',
                 },
                 pretendRemote<ClientAPI>({
+                    getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
             )
@@ -59,6 +62,7 @@ describe('ExtensionHost: Configuration', () => {
                     sourcegraphURL: 'https://example.com/',
                 },
                 pretendRemote<ClientAPI>({
+                    getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
             )
@@ -78,6 +82,7 @@ describe('ExtensionHost: Configuration', () => {
                     sourcegraphURL: 'https://example.com/',
                 },
                 pretendRemote<ClientAPI>({
+                    getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
             )
@@ -100,6 +105,7 @@ describe('ExtensionHost: Configuration', () => {
                     sourcegraphURL: 'https://example.com/',
                 },
                 pretendRemote<ClientAPI>({
+                    getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                     applySettingsEdit: edit =>
                         Promise.resolve().then(() => {

--- a/client/shared/src/api/extension/test/extensionHost.documentHighlights.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.documentHighlights.test.ts
@@ -15,6 +15,7 @@ describe('getDocumentHighlights from ExtensionHost API, it aims to have more e2e
     // integration(ish) tests for scenarios not covered by providers tests
     const noopMain = pretendRemote<ClientAPI>({
         getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
+        getScriptURLForExtension: () => undefined,
     })
     const initialSettings: SettingsCascade<object> = {
         subjects: [],

--- a/client/shared/src/api/extension/test/extensionHost.hover.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.hover.test.ts
@@ -16,6 +16,7 @@ describe('getHover from ExtensionHost API, it aims to have more e2e feel', () =>
     // integration(ish) tests for scenarios not covered by providers tests
     const noopMain = pretendRemote<ClientAPI>({
         getEnabledExtensions: () => pretendProxySubscribable(of([])),
+        getScriptURLForExtension: () => undefined,
     })
     const initialSettings: SettingsCascade<object> = {
         subjects: [],

--- a/client/shared/src/api/extension/test/extensionHost.logging.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.logging.test.ts
@@ -11,6 +11,7 @@ import { initializeExtensionHostTest } from './test-helpers'
 
 const noopMain = pretendRemote<ClientAPI>({
     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
+    getScriptURLForExtension: () => undefined,
     logExtensionMessage: (...data) => logger.log(...data),
 })
 

--- a/client/shared/src/api/extension/test/extensionHost.search.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.search.test.ts
@@ -10,6 +10,7 @@ import { initializeExtensionHostTest } from './test-helpers'
 
 const noopMain = pretendRemote<ClientAPI>({
     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
+    getScriptURLForExtension: () => undefined,
 })
 const initialSettings: SettingsCascade<object> = { subjects: [], final: {} }
 

--- a/client/shared/src/backend/apolloCache.ts
+++ b/client/shared/src/backend/apolloCache.ts
@@ -5,6 +5,13 @@ import { TypedTypePolicies } from '../graphql-operations'
 // Defines how the Apollo cache interacts with our GraphQL schema.
 // See https://www.apollographql.com/docs/react/caching/cache-configuration/#typepolicy-fields
 const typePolicies: TypedTypePolicies = {
+    ExtensionRegistry: {
+        // Replace existing `ExtensionRegistry` with the incoming value.
+        // Required because of the missing `id` on the `ExtensionRegistry` field.
+        merge(existing, incoming) {
+            return incoming
+        },
+    },
     Person: {
         // Replace existing `Person` with the incoming value.
         // Required because of the missing `id` on the `Person` field.

--- a/client/shared/src/extensions/createLazyLoadedController.ts
+++ b/client/shared/src/extensions/createLazyLoadedController.ts
@@ -1,0 +1,66 @@
+import { from, Subscription } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+
+import type { InitData } from '../api/extension/extensionHost'
+import { syncPromiseSubscription } from '../api/util'
+import type { PlatformContext } from '../platform/context'
+
+import type { Controller } from './controller'
+
+/**
+ * Creates the controller, which handles all communication between the client application and extensions.
+ *
+ * There should only be a single controller for the entire client application. The controller's model represents
+ * all of the client application state that the client needs to know.
+ *
+ * The implementation (`createExtensionHostClientConnection`) is lazy loaded to avoid adding bytes when
+ * the extension system is disabled
+ */
+export function createController(
+    context: Pick<
+        PlatformContext,
+        | 'updateSettings'
+        | 'settings'
+        | 'getGraphQLClient'
+        | 'requestGraphQL'
+        | 'showMessage'
+        | 'showInputBox'
+        | 'getScriptURLForExtension'
+        | 'getStaticExtensions'
+        | 'telemetryService'
+        | 'clientApplication'
+        | 'sourcegraphURL'
+        | 'createExtensionHost'
+    >
+): Controller {
+    const subscriptions = new Subscription()
+    const initData: Omit<InitData, 'initialSettings'> = {
+        sourcegraphURL: context.sourcegraphURL,
+        clientApplication: context.clientApplication,
+    }
+    const extensionHostClientPromise = import('../api/client/connection').then(module =>
+        module.createExtensionHostClientConnection(context.createExtensionHost(), initData, context)
+    )
+
+    subscriptions.add(() => extensionHostClientPromise.then(({ subscription }) => subscription.unsubscribe()))
+
+    // TODO: Debug helpers, logging
+
+    return {
+        executeCommand: (parameters, suppressNotificationOnError) =>
+            extensionHostClientPromise.then(({ exposedToClient }) =>
+                exposedToClient.executeCommand(parameters, suppressNotificationOnError)
+            ),
+        commandErrors: from(extensionHostClientPromise).pipe(
+            switchMap(({ exposedToClient }) => exposedToClient.commandErrors)
+        ),
+        registerCommand: entryToRegister =>
+            syncPromiseSubscription(
+                extensionHostClientPromise.then(({ exposedToClient }) =>
+                    exposedToClient.registerCommand(entryToRegister)
+                )
+            ),
+        extHostAPI: extensionHostClientPromise.then(({ api }) => api),
+        unsubscribe: () => subscriptions.unsubscribe(),
+    }
+}

--- a/client/shared/src/extensions/createSyncLoadedController.ts
+++ b/client/shared/src/extensions/createSyncLoadedController.ts
@@ -26,6 +26,7 @@ export function createController(
         | 'requestGraphQL'
         | 'showMessage'
         | 'showInputBox'
+        | 'getScriptURLForExtension'
         | 'getStaticExtensions'
         | 'telemetryService'
         | 'clientApplication'

--- a/client/shared/src/extensions/extension.ts
+++ b/client/shared/src/extensions/extension.ts
@@ -8,7 +8,7 @@ import { ExtensionManifest } from './extensionManifest'
  * The default fields in the {@link ConfiguredExtension} manifest (i.e., the default value of the
  * `K` type parameter).
  */
-const CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS = ['contributes', 'activationEvents', 'url'] as const
+export const CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS = ['contributes', 'activationEvents', 'url'] as const
 export type ConfiguredExtensionManifestDefaultFields = typeof CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS[number]
 
 /**

--- a/client/shared/src/extensions/helpers.test.ts
+++ b/client/shared/src/extensions/helpers.test.ts
@@ -1,0 +1,32 @@
+import { createGraphQLClientGetter } from '../testing/apollo/createGraphQLClientGetter'
+
+import { ConfiguredExtension, ConfiguredExtensionManifestDefaultFields } from './extension'
+import { ExtensionManifest } from './extensionManifest'
+import { queryConfiguredRegistryExtensions } from './helpers'
+
+const TEST_MANIFEST: Pick<ExtensionManifest, ConfiguredExtensionManifestDefaultFields | 'publisher'> = {
+    publisher: 'a',
+    url: 'https://example.com',
+    activationEvents: [],
+}
+
+describe('queryConfiguredRegistryExtensions', () => {
+    it('gets extensions from GraphQL servers supporting extensions(extensionIDs)', done => {
+        const extensionsMock = {
+            data: {
+                extensionRegistry: {
+                    extensions: {
+                        nodes: [{ extensionID: 'a/b', manifest: { jsonFields: TEST_MANIFEST } }],
+                    },
+                },
+            },
+        }
+
+        const getGraphQLClient = createGraphQLClientGetter({ watchQueryMocks: [extensionsMock] })
+
+        queryConfiguredRegistryExtensions({ getGraphQLClient }, ['a/b']).subscribe(data => {
+            expect(data).toEqual([{ id: 'a/b', manifest: TEST_MANIFEST }] as ConfiguredExtension[])
+            done()
+        })
+    })
+})

--- a/client/shared/src/extensions/helpers.ts
+++ b/client/shared/src/extensions/helpers.ts
@@ -1,0 +1,87 @@
+import { Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { createAggregateError } from '@sourcegraph/common'
+import { fromObservableQueryPromise, getDocumentNode, gql } from '@sourcegraph/http-client'
+
+import { ExtensionsResult, ExtensionsVariables } from '../graphql-operations'
+import { PlatformContext } from '../platform/context'
+
+import {
+    ConfiguredExtension,
+    ConfiguredExtensionManifestDefaultFields,
+    CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS,
+} from './extension'
+import { ExtensionManifest } from './extensionManifest'
+
+const ExtensionsQuery = gql`
+    query Extensions($first: Int!, $extensionIDs: [String!]!, $extensionManifestFields: [String!]!) {
+        extensionRegistry {
+            extensions(first: $first, extensionIDs: $extensionIDs) {
+                nodes {
+                    id
+                    extensionID
+                    manifest {
+                        jsonFields(fields: $extensionManifestFields)
+                    }
+                }
+            }
+        }
+    }
+`
+
+/**
+ * Query the GraphQL API for registry metadata about the extensions given in {@link extensionIDs}.
+ *
+ * @returns An observable that emits once with the results.
+ */
+export function queryConfiguredRegistryExtensions(
+    // TODO(tj): can copy this over to extension host, just replace platformContext.requestGraphQL
+    // with mainThreadAPI.requestGraphQL
+    { getGraphQLClient }: Pick<PlatformContext, 'getGraphQLClient'>,
+    extensionIDs: string[]
+): Observable<ConfiguredExtension[]> {
+    if (extensionIDs.length === 0) {
+        return of([])
+    }
+
+    const queryObservablePromise = getGraphQLClient().then(client =>
+        client.watchQuery<ExtensionsResult, ExtensionsVariables>({
+            query: getDocumentNode(ExtensionsQuery),
+            variables: {
+                first: extensionIDs.length,
+                extensionIDs,
+                // Spread operator is required to avoid Typescript type error
+                // because of `readonly` type of `CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS`.
+                extensionManifestFields: [...CONFIGURED_EXTENSION_DEFAULT_MANIFEST_FIELDS],
+            },
+        })
+    )
+
+    return fromObservableQueryPromise(queryObservablePromise).pipe(
+        map(({ data, errors }) => {
+            if (!data?.extensionRegistry?.extensions?.nodes) {
+                throw createAggregateError(errors)
+            }
+
+            const { nodes } = data.extensionRegistry.extensions
+
+            return nodes
+                .filter(({ extensionID }) => extensionIDs.includes(extensionID))
+                .map(({ extensionID, manifest }) => {
+                    const getManifest = (value: typeof manifest): ConfiguredExtension['manifest'] => {
+                        if (!value) {
+                            return value
+                        }
+
+                        return value.jsonFields as Pick<ExtensionManifest, ConfiguredExtensionManifestDefaultFields>
+                    }
+
+                    return {
+                        id: extensionID,
+                        manifest: getManifest(manifest),
+                    }
+                })
+        })
+    )
+}

--- a/client/shared/src/hover/actions.ts
+++ b/client/shared/src/hover/actions.ts
@@ -488,45 +488,47 @@ export function registerHoverContributions({
             subscriptions.add(syncRemoteSubscription(referencesContributionPromise))
 
             let implementationsContributionPromise: Promise<unknown> = Promise.resolve()
-            const promise = extensionHostAPI.registerContributions({
-                actions: [
-                    ...languageSpecs.map(spec => ({
-                        actionItem: { label: 'Find implementations' },
-                        command: 'open',
-                        commandArguments: [
-                            "${get(context, 'implementations_" +
+            if (window.context?.enableLegacyExtensions === false) {
+                const promise = extensionHostAPI.registerContributions({
+                    actions: [
+                        ...languageSpecs.map(spec => ({
+                            actionItem: { label: 'Find implementations' },
+                            command: 'open',
+                            commandArguments: [
+                                "${get(context, 'implementations_" +
+                                    spec.languageID +
+                                    "') && get(context, 'panel.url') && sub(get(context, 'panel.url'), 'panelID', 'implementations_" +
+                                    spec.languageID +
+                                    "') || 'noop'}",
+                            ],
+                            id: 'findImplementations_' + spec.languageID,
+                            title: 'Find implementations',
+                        })),
+                    ],
+                    menus: {
+                        hover: languageSpecs.map(spec => ({
+                            action: 'findImplementations_' + spec.languageID,
+                            when:
+                                "resource.language == '" +
                                 spec.languageID +
-                                "') && get(context, 'panel.url') && sub(get(context, 'panel.url'), 'panelID', 'implementations_" +
-                                spec.languageID +
-                                "') || 'noop'}",
-                        ],
-                        id: 'findImplementations_' + spec.languageID,
-                        title: 'Find implementations',
-                    })),
-                ],
-                menus: {
-                    hover: languageSpecs.map(spec => ({
-                        action: 'findImplementations_' + spec.languageID,
-                        when:
-                            "resource.language == '" +
-                            spec.languageID +
-                            // eslint-disable-next-line no-template-curly-in-string
-                            "' && get(context, `implementations_${resource.language}`) && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)",
-                    })),
-                },
-            })
-            implementationsContributionPromise = promise
-            subscriptions.add(syncRemoteSubscription(promise))
-            for (const spec of languageSpecs) {
-                if (spec.textDocumentImplemenationSupport) {
-                    extensionHostAPI
-                        .updateContext({
-                            [`implementations_${spec.languageID}`]: true,
-                        })
-                        .then(
-                            () => {},
-                            () => {}
-                        )
+                                // eslint-disable-next-line no-template-curly-in-string
+                                "' && get(context, `implementations_${resource.language}`) && (goToDefinition.showLoading || goToDefinition.url || goToDefinition.error)",
+                        })),
+                    },
+                })
+                implementationsContributionPromise = promise
+                subscriptions.add(syncRemoteSubscription(promise))
+                for (const spec of languageSpecs) {
+                    if (spec.textDocumentImplemenationSupport) {
+                        extensionHostAPI
+                            .updateContext({
+                                [`implementations_${spec.languageID}`]: true,
+                            })
+                            .then(
+                                () => {},
+                                () => {}
+                            )
+                    }
                 }
             }
 

--- a/client/shared/src/notifications/NotificationItem.tsx
+++ b/client/shared/src/notifications/NotificationItem.tsx
@@ -5,7 +5,7 @@ import { from, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, scan, switchMap } from 'rxjs/operators'
 
 import { renderMarkdown } from '@sourcegraph/common'
-import { Alert } from '@sourcegraph/wildcard'
+import { Alert, AlertProps } from '@sourcegraph/wildcard'
 
 import type { NotificationType, Progress } from '../codeintel/legacy-extensions/api'
 
@@ -17,11 +17,21 @@ export interface UnbrandedNotificationItemStyleProps {
     notificationItemClassNames: Record<NotificationType, string>
 }
 
+export interface BrandedNotificationItemStyleProps {
+    notificationItemVariants: Record<NotificationType, AlertProps['variant']>
+}
+
+/**
+ * Note, we do not export this type because it is not intended to be used directly.
+ * Consumers should use either `UnbrandedNotificationItemStyleProps` or `BrandedNotificationItemStyleProps` when configuring this component.
+ */
+type NotificationItemStyleProps = UnbrandedNotificationItemStyleProps | BrandedNotificationItemStyleProps
+
 export interface NotificationItemProps {
     notification: Notification
     onDismiss: (notification: Notification) => void
     className?: string
-    notificationItemStyleProps: UnbrandedNotificationItemStyleProps
+    notificationItemStyleProps: NotificationItemStyleProps
 }
 
 interface NotificationItemState {
@@ -83,12 +93,18 @@ export class NotificationItem extends React.PureComponent<NotificationItemProps,
         const baseAlertClassName = classNames(styles.sourcegraphNotificationItem, this.props.className)
 
         const { notificationItemStyleProps } = this.props
-        const alertProps = {
-            className: classNames(
-                baseAlertClassName,
-                notificationItemStyleProps.notificationItemClassNames[this.props.notification.type]
-            ),
-        }
+        const alertProps =
+            'notificationItemVariants' in notificationItemStyleProps
+                ? {
+                      variant: notificationItemStyleProps.notificationItemVariants[this.props.notification.type],
+                      className: baseAlertClassName,
+                  }
+                : {
+                      className: classNames(
+                          baseAlertClassName,
+                          notificationItemStyleProps.notificationItemClassNames[this.props.notification.type]
+                      ),
+                  }
 
         return (
             <Alert {...alertProps}>

--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -3,7 +3,7 @@ import { isObject } from 'lodash'
 import { Observable, Subscribable, Subscription } from 'rxjs'
 
 import { DiffPart } from '@sourcegraph/codeintellify'
-import { hasProperty } from '@sourcegraph/common'
+import { ErrorLike, hasProperty } from '@sourcegraph/common'
 import { GraphQLClient, GraphQLResult } from '@sourcegraph/http-client'
 
 import { SettingsEdit } from '../api/client/services/settings'
@@ -129,6 +129,22 @@ export interface PlatformContext {
      * with the execution context (using, e.g., postMessage/onmessage) when it is ready.
      */
     createExtensionHost: () => Promise<ClosableEndpointPair>
+
+    /**
+     * Returns the script URL suitable for passing to importScripts for an extension's bundle.
+     *
+     * This is necessary because some platforms (such as Chrome extensions) use a script-src CSP
+     * that would prevent loading bundles from arbitrary URLs, which requires us to pass blob: URIs
+     * to importScripts.
+     *
+     * @param bundleURL The URL to the JavaScript bundle file specified in the extension manifest.
+     * @returns A script URL suitable for passing to importScripts, typically either the original
+     * https:// URL for the extension's bundle or a blob: URI for it.
+     *
+     * TODO(tj): If this doesn't return a getScriptURLForExtension function, the original bundleURL will be used.
+     * Also, make getScriptURL batched to minimize round trips between extension host and client application
+     */
+    getScriptURLForExtension: () => undefined | ((bundleURL: string[]) => Promise<(string | ErrorLike)[]>)
 
     /**
      * Constructs the URL (possibly relative or absolute) to the file with the specified options.

--- a/client/shared/src/testing/integration/mockExtension.ts
+++ b/client/shared/src/testing/integration/mockExtension.ts
@@ -1,4 +1,20 @@
+import { PollyServer } from '@pollyjs/core'
+
 import type { ExtensionContext } from '../../codeintel/legacy-extensions/api'
+import { ExtensionManifest } from '../../extensions/extensionManifest'
+import { ExtensionsResult, SharedGraphQlOperations } from '../../graphql-operations'
+import { Settings } from '../../settings/settings'
+
+interface ExtensionMockingInit {
+    /**
+     * The polly server object, used to intercept extension bundle requests.
+     */
+    pollyServer: PollyServer
+    /**
+     * The base Sourcegraph URL for the test instance, used to construst bundle URL.
+     */
+    sourcegraphBaseUrl: string
+}
 
 interface ExtensionMockingUtils {
     /**
@@ -8,16 +24,74 @@ interface ExtensionMockingUtils {
      */
     mockExtension: ({ id, bundle }: { id: string; bundle: () => void }) => void
     /**
+     * Use this as the `Extension` override for `TestContext#overrideGraphQL`.
+     */
+    Extensions: SharedGraphQlOperations['Extensions']
+    /**
      * Merge/replace your mock settings `extensions` property with this object.
      */
-    extensionSettings: {}
+    extensionSettings: Settings['extensions']
+}
+
+interface ExtensionsResultMock {
+    extensionRegistry: ExtensionsResult['extensionRegistry'] & {
+        __typename: 'ExtensionRegistry'
+    }
 }
 
 /**
  * Set up Sourcegraph extension mocking for an integration test.
  */
-export function setupExtensionMocking(): ExtensionMockingUtils {
-    throw new Error('not yet reimplemented after the extension API deprecation')
+export function setupExtensionMocking({
+    pollyServer,
+    sourcegraphBaseUrl,
+}: ExtensionMockingInit): ExtensionMockingUtils {
+    let internalID = 0
+
+    const extensionSettings: Settings['extensions'] = {}
+    const extensionsResult: ExtensionsResultMock = {
+        extensionRegistry: {
+            __typename: 'ExtensionRegistry',
+            extensions: {
+                nodes: [],
+            },
+        },
+    }
+
+    return {
+        mockExtension: ({ id, bundle }) => {
+            internalID++
+
+            /** The URL at which the manifest says the extension bundle is served. We should intercept requests to this URL. */
+            const bundleURL = new URL(
+                `/-/static/extension/00${internalID}-${id.replace(/\//g, '-')}.js?hash--${id.replace(/\//g, '-')}`,
+                sourcegraphBaseUrl
+            ).href
+
+            const extensionManifest: ExtensionManifest = {
+                url: bundleURL,
+                activationEvents: ['*'],
+            }
+
+            // Mutate mock data objects
+            extensionSettings[id] = true
+            extensionsResult.extensionRegistry.extensions.nodes.push({
+                id,
+                extensionID: id,
+                manifest: {
+                    jsonFields: extensionManifest,
+                },
+            })
+
+            pollyServer.get(bundleURL).intercept((request, response) => {
+                // Create an immediately-invoked function expression for the extensionBundle function
+                const extensionBundleString = `(${bundle.toString()})()`
+                response.type('application/javascript; charset=utf-8').send(extensionBundleString)
+            })
+        },
+        Extensions: () => extensionsResult,
+        extensionSettings,
+    }
 }
 
 // Commonly mocked extensions.

--- a/client/shared/src/testing/testHelpers.ts
+++ b/client/shared/src/testing/testHelpers.ts
@@ -44,6 +44,7 @@ interface Mocks
         | 'updateSettings'
         | 'getGraphQLClient'
         | 'requestGraphQL'
+        | 'getScriptURLForExtension'
         | 'clientApplication'
         | 'showMessage'
         | 'showInputBox'
@@ -54,6 +55,7 @@ const NOOP_MOCKS: Mocks = {
     updateSettings: () => Promise.reject(new Error('Mocks#updateSettings not implemented')),
     getGraphQLClient: () => Promise.reject(new Error('Mocks#getGraphQLClient not implemented')),
     requestGraphQL: () => throwError(new Error('Mocks#queryGraphQL not implemented')),
+    getScriptURLForExtension: () => undefined,
     clientApplication: 'sourcegraph',
 }
 

--- a/client/vscode/src/webview/platform/context.ts
+++ b/client/vscode/src/webview/platform/context.ts
@@ -26,6 +26,7 @@ export interface VSCodePlatformContext
         | 'getGraphQLClient'
         | 'showMessage'
         | 'showInputBox'
+        | 'getScriptURLForExtension'
         | 'getStaticExtensions'
         | 'telemetryService'
         | 'clientApplication'
@@ -59,6 +60,7 @@ export function createPlatformContext(extensionCoreAPI: Comlink.Remote<Extension
         updateSettings: () => Promise.resolve(),
         telemetryService: new EventLogger(extensionCoreAPI),
         clientApplication: 'other', // TODO add 'vscode-extension' to `clientApplication`,
+        getScriptURLForExtension: () => undefined,
         // TODO showInputBox
         // TODO showMessage
         getStaticExtensions: () => getInlineExtensions(),

--- a/client/vscode/tests/vsce.test.ts
+++ b/client/vscode/tests/vsce.test.ts
@@ -2,10 +2,13 @@ import { downloadAndUnzipVSCode } from '@vscode/test-electron'
 
 import { mixedSearchStreamEvents, highlightFileResult } from '@sourcegraph/shared/src/search/integration'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
+import { setupExtensionMocking } from '@sourcegraph/shared/src/testing/integration/mockExtension'
 
 import { createVSCodeIntegrationTestContext, VSCodeIntegrationTestContext } from './context'
 import { getVSCodeWebviewFrames } from './getWebview'
 import { launchVsCode, VSCodeTestDriver } from './launch'
+
+const sourcegraphBaseUrl = 'https://sourcegraph.com'
 
 describe('VS Code extension', () => {
     let vsCodeDriver: VSCodeTestDriver
@@ -36,11 +39,18 @@ describe('VS Code extension', () => {
     // fixing before we add more test cases to the suite.
 
     it('works', async () => {
+        const { Extensions } = setupExtensionMocking({
+            pollyServer: testContext.server,
+            sourcegraphBaseUrl,
+        })
+
         const userSettings: Settings = {
             extensions: {},
         }
 
         testContext.overrideGraphQL({
+            Extensions,
+
             ...highlightFileResult,
             ViewerSettings: () => ({
                 viewerSettings: {

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -67,6 +67,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         openTelemetry: {
             endpoint: ENVIRONMENT_CONFIG.CLIENT_OTEL_EXPORTER_OTLP_ENDPOINT,
         },
+        enableLegacyExtensions: false,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/dev/utils/get-api-proxy-settings.ts
+++ b/client/web/dev/utils/get-api-proxy-settings.ts
@@ -85,6 +85,9 @@ const jsContextChanges = `
         // Only username/password auth-provider provider is supported with the standalone server.
         authProviders: window.context.authProviders.filter(provider => provider.isBuiltin),
 
+        // For some reason, the standalone server crashes with legacy extensions enabled.
+        enableLegacyExtensions: false,
+
         // Sync externalURL with the development environment config.
         externalURL: '${HTTPS_WEB_SERVER_URL}',
 

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -197,6 +197,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
                     showFeedbackModal={showFeedbackModal}
+                    enableLegacyExtensions={window.context.enableLegacyExtensions}
                 />
             )}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -189,6 +189,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
                     showFeedbackModal={showFeedbackModal}
+                    enableLegacyExtensions={window.context.enableLegacyExtensions}
                 />
             )}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}

--- a/client/web/src/backend/persistenceMapper.test.ts
+++ b/client/web/src/backend/persistenceMapper.test.ts
@@ -25,6 +25,7 @@ describe('persistenceMapper', () => {
         const persistedString = await persistenceMapper(
             createStringifiedCache({
                 viewerSettings: { empty: null, data: true },
+                extensionRegistry: { data: true },
                 shouldNotBePersisted: {},
             })
         )

--- a/client/web/src/backend/persistenceMapper.ts
+++ b/client/web/src/backend/persistenceMapper.ts
@@ -5,7 +5,11 @@ import { QueryFieldPolicy } from '@sourcegraph/shared/src/graphql-operations'
  * After the implementation of the `persistLink` which will support `@persist` directive
  * hardcoded query names will be deprecated.
  */
-export const QUERIES_TO_PERSIST: (keyof QueryFieldPolicy)[] = ['viewerSettings', 'temporarySettings']
+export const QUERIES_TO_PERSIST: (keyof QueryFieldPolicy)[] = [
+    'viewerSettings',
+    'extensionRegistry',
+    'temporarySettings',
+]
 export const ROOT_QUERY_KEY = 'ROOT_QUERY'
 
 export interface CacheReference {

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.module.scss
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.module.scss
@@ -1,0 +1,21 @@
+.button {
+    color: var(--icon-color);
+    display: flex;
+    align-items: center;
+
+    &:hover {
+        // Required to overwrite .btn:hover styles with greater specificity.
+        color: var(--body-color) !important;
+    }
+}
+
+.action-item {
+    --link-color: var(--body-color);
+    --link-hover-color: var(--body-color);
+
+    display: block;
+    text-align: left;
+
+    /* Overwrite `ButtonLink` style */
+    text-decoration: none !important;
+}

--- a/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
+++ b/client/web/src/components/WebCommandListPopoverButton/WebCommandListPopoverButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import {
+    CommandListPopoverButton,
+    CommandListPopoverButtonProps,
+} from '@sourcegraph/shared/src/commandPalette/CommandList'
+import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
+import { Button } from '@sourcegraph/wildcard'
+
+import styles from './WebCommandListPopoverButton.module.scss'
+
+export const WebCommandListPopoverButton: React.FunctionComponent<
+    React.PropsWithChildren<CommandListPopoverButtonProps>
+> = props => {
+    const showCommandPaletteShortcut = useKeyboardShortcut('commandPalette')
+
+    return (
+        <CommandListPopoverButton
+            {...props}
+            as={Button}
+            variant="link"
+            buttonClassName={classNames('m-0 p-0', styles.button)}
+            formClassName="form p-2 bg-1 border-bottom"
+            inputClassName="form-control px-2 py-1"
+            listClassName="list-group list-group-flush list-unstyled pt-1"
+            actionItemClassName={classNames('list-group-item list-group-item-action p-2 border-0', styles.actionItem)}
+            selectedActionItemClassName="active border-primary"
+            noResultsClassName="list-group-item text-muted"
+            keyboardShortcutForShow={showCommandPaletteShortcut}
+        />
+    )
+}
+
+WebCommandListPopoverButton.displayName = 'WebCommandListPopoverButton'

--- a/client/web/src/components/WebCommandListPopoverButton/index.ts
+++ b/client/web/src/components/WebCommandListPopoverButton/index.ts
@@ -1,0 +1,1 @@
+export * from './WebCommandListPopoverButton'

--- a/client/web/src/components/shared.tsx
+++ b/client/web/src/components/shared.tsx
@@ -1,2 +1,3 @@
 // Components from shared with web-styling class names applied
 export { WebHoverOverlay } from './WebHoverOverlay'
+export { WebCommandListPopoverButton } from './WebCommandListPopoverButton'

--- a/client/web/src/components/useCarousel.ts
+++ b/client/web/src/components/useCarousel.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { isEqual } from 'lodash'
+import { Subscription } from 'rxjs'
+
+import { observeResize } from '@sourcegraph/common'
+
+interface CarouselOptions {
+    amountToScroll?: number
+    direction: CarouselDirection
+}
+
+type CarouselDirection = 'leftToRight' | 'topToBottom'
+
+interface CarouselState {
+    canScrollNegative: boolean
+    canScrollPositive: boolean
+    onNegativeClicked: () => void
+    onPositiveClicked: () => void
+    carouselReference: React.RefCallback<HTMLElement>
+}
+
+const defaultCarouselState = { canScrollNegative: false, canScrollPositive: false }
+
+const carouselScrollHandlers: Record<
+    CarouselDirection,
+    (carousel: HTMLElement) => Pick<CarouselState, 'canScrollNegative' | 'canScrollPositive'>
+> = {
+    leftToRight: carousel => ({
+        canScrollNegative: carousel.scrollLeft > 0,
+        canScrollPositive: carousel.scrollLeft + carousel.clientWidth < carousel.scrollWidth,
+    }),
+    topToBottom: carousel => ({
+        canScrollNegative: carousel.scrollTop > 0,
+        canScrollPositive: carousel.scrollTop + carousel.clientHeight < carousel.scrollHeight,
+    }),
+}
+
+const carouselClickHandlers: Record<
+    CarouselDirection,
+    (options: { carousel: HTMLElement; amountToScroll: number; sign: 'positive' | 'negative' }) => void
+> = {
+    leftToRight: ({ carousel, amountToScroll, sign }) => {
+        const width = carousel.clientWidth
+        carousel.scrollBy({
+            top: 0,
+            left: sign === 'positive' ? width * amountToScroll : -(width * amountToScroll),
+            behavior: 'smooth',
+        })
+    },
+    topToBottom: ({ carousel, amountToScroll, sign }) => {
+        const height = carousel.clientHeight
+        carousel.scrollBy({
+            top: sign === 'positive' ? height * amountToScroll : -(height * amountToScroll),
+            left: 0,
+            behavior: 'smooth',
+        })
+    },
+}
+
+export function useCarousel({ amountToScroll = 0.9, direction }: CarouselOptions): CarouselState {
+    const [carousel, setCarousel] = useState<HTMLElement | null>()
+    const nextCarousel = useCallback((carousel: HTMLElement) => {
+        setCarousel(carousel)
+    }, [])
+
+    const [scrollability, setScrollability] = useState(defaultCarouselState)
+
+    const scrollabilityReference = useRef(scrollability)
+    scrollabilityReference.current = scrollability
+
+    // Listen for UIEvents that can affect scrollability (e.g. scroll, resize)
+    useEffect(() => {
+        function onScroll(): void {
+            if (carousel) {
+                const newScrollability = carouselScrollHandlers[direction](carousel)
+                if (!isEqual(scrollabilityReference.current, newScrollability)) {
+                    setScrollability(newScrollability)
+                }
+            }
+        }
+
+        carousel?.addEventListener('scroll', onScroll)
+
+        let subscription: Subscription | undefined
+
+        if (carousel) {
+            subscription = observeResize(carousel).subscribe(() => {
+                const newScrollability = carouselScrollHandlers[direction](carousel)
+
+                if (!isEqual(scrollabilityReference.current, newScrollability)) {
+                    setScrollability(newScrollability)
+                }
+            })
+
+            // Check initial scroll state
+            const newScrollability = carouselScrollHandlers[direction](carousel)
+            if (!isEqual(scrollabilityReference.current, newScrollability)) {
+                setScrollability(newScrollability)
+            }
+        }
+
+        return () => {
+            carousel?.removeEventListener('scroll', onScroll)
+            subscription?.unsubscribe()
+        }
+    }, [carousel, direction])
+
+    // Handle negative and positive click events
+    const onNegativeClicked = useCallback(() => {
+        if (carousel) {
+            carouselClickHandlers[direction]({ sign: 'negative', amountToScroll, carousel })
+        }
+    }, [direction, amountToScroll, carousel])
+
+    const onPositiveClicked = useCallback(() => {
+        if (carousel) {
+            carouselClickHandlers[direction]({ sign: 'positive', amountToScroll, carousel })
+        }
+    }, [direction, amountToScroll, carousel])
+
+    return {
+        canScrollNegative: scrollability.canScrollNegative,
+        canScrollPositive: scrollability.canScrollPositive,
+        onNegativeClicked,
+        onPositiveClicked,
+        carouselReference: nextCarousel,
+    }
+}

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -20,7 +20,7 @@ export interface CodeInsightsRouterProps extends TelemetryProps {
 export const CodeInsightsRouter: FC<CodeInsightsRouterProps> = props => {
     const { authenticatedUser, telemetryService } = props
 
-    if (!window.context?.codeInsightsEnabled) {
+    if (!window.context.codeInsightsEnabled) {
         return (
             <CodeInsightsDotComGetStartedLazy
                 telemetryService={telemetryService}

--- a/client/web/src/extensions/components/ActionItemsBar.module.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.module.scss
@@ -1,0 +1,151 @@
+$default-icon-colors: --oc-grape-7, --oc-violet-7, --oc-cyan-9, --oc-indigo-7, --oc-pink-8;
+
+:root {
+    --action-item-width: 2.5rem;
+    --action-item-container-width: 2.5625rem; /* 2.5rem + 1px */
+}
+
+.bar {
+    flex: 0 0 auto;
+    width: var(--action-item-width);
+    background-color: var(--body-bg);
+    list-style: none;
+
+    &--collapsed {
+        width: 0.5rem;
+    }
+}
+
+.toggle-container {
+    width: var(--action-item-width);
+    background-color: var(--color-bg-2);
+    background-color: var(--body-bg);
+
+    &--open {
+        margin-bottom: -0.0625rem;
+    }
+}
+
+/* Used to visually separate action items bar sections. */
+.divider-horizontal {
+    height: 0.0625rem;
+    width: 1.25rem;
+    background-color: var(--border-color);
+    left: 0.625rem;
+}
+
+/* Used to visually separate action items bar toggle from repo header actions. */
+.divider-vertical {
+    height: 1.25rem;
+    width: 0.0625rem;
+    top: 0.75rem;
+    align-self: center;
+
+    border-radius: 2px;
+    background-color: var(--border-color);
+}
+
+.list {
+    overflow-y: auto;
+
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+.list-item {
+    user-select: none;
+
+    &:first-of-type {
+        margin-top: 0.375rem;
+    }
+
+    &:last-of-type {
+        margin-bottom: 0.375rem;
+    }
+}
+
+.action {
+    width: 2rem;
+    height: 2rem;
+    margin-left: 0.25rem;
+    border-radius: 0.1875rem;
+
+    &:hover {
+        background-color: var(--color-bg-2);
+    }
+
+    &--toggle {
+        height: auto;
+        padding: 0.25rem;
+    }
+
+    &--pressed {
+        color: var(--body-color);
+        background-color: var(--color-bg-3);
+
+        /* Override existing hover styles */
+        &:hover {
+            background-color: var(--color-bg-3);
+        }
+    }
+
+    &--inactive {
+        cursor: default;
+        filter: saturate(0%);
+        opacity: 0.7;
+    }
+
+    /* Default icon generated for extensions with no iconURL */
+    &--no-icon {
+        &::after {
+            color: var(--white);
+
+            /* Center letter */
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 1rem;
+            width: 1rem;
+            font-size: (10 / 16) + rem;
+            content: attr(data-content);
+            border-radius: (2 / 16) + rem;
+        }
+
+        &-inactive {
+            &::after {
+                background-color: var(--color-bg-3) !important;
+                color: var(--text-muted) !important;
+            }
+        }
+    }
+}
+
+.icon {
+    height: 1rem !important;
+    width: 1rem !important;
+
+    /* Default icon background color */
+    @for $i from 1 through length($default-icon-colors) {
+        &-#{$i} {
+            &::after {
+                background-color: var(nth($default-icon-colors, $i));
+            }
+        }
+    }
+}
+
+/* e.g. "close extensions panel", "add extensions" */
+.aux-icon {
+    color: var(--icon-color);
+}
+
+.scroll {
+    width: var(--action-item-width);
+
+    &:hover {
+        background-color: var(--color-bg-2);
+    }
+}

--- a/client/web/src/extensions/components/ActionItemsBar.story.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.story.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+
+import { DecoratorFn, Meta } from '@storybook/react'
+import { EMPTY, noop, of } from 'rxjs'
+
+import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
+import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { extensionsController, NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+
+import { AppRouterContainer } from '../../components/AppRouterContainer'
+import { WebStory } from '../../components/WebStory'
+import { SourcegraphContext } from '../../jscontext'
+
+import { ActionItemsBar, useWebActionItems } from './ActionItemsBar'
+
+const mockIconURL =
+    'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE2LjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHdpZHRoPSI5N3B4IiBoZWlnaHQ9Ijk3cHgiIHZpZXdCb3g9IjAgMCA5NyA5NyIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgOTcgOTciIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGZpbGw9IiNGMDUxMzMiIGQ9Ik05Mi43MSw0NC40MDhMNTIuNTkxLDQuMjkxYy0yLjMxLTIuMzExLTYuMDU3LTIuMzExLTguMzY5LDBsLTguMzMsOC4zMzJMNDYuNDU5LDIzLjE5CgkJYzIuNDU2LTAuODMsNS4yNzItMC4yNzMsNy4yMjksMS42ODVjMS45NjksMS45NywyLjUyMSw0LjgxLDEuNjcsNy4yNzVsMTAuMTg2LDEwLjE4NWMyLjQ2NS0wLjg1LDUuMzA3LTAuMyw3LjI3NSwxLjY3MQoJCWMyLjc1LDIuNzUsMi43NSw3LjIwNiwwLDkuOTU4Yy0yLjc1MiwyLjc1MS03LjIwOCwyLjc1MS05Ljk2MSwwYy0yLjA2OC0yLjA3LTIuNTgtNS4xMS0xLjUzMS03LjY1OGwtOS41LTkuNDk5djI0Ljk5NwoJCWMwLjY3LDAuMzMyLDEuMzAzLDAuNzc0LDEuODYxLDEuMzMyYzIuNzUsMi43NSwyLjc1LDcuMjA2LDAsOS45NTljLTIuNzUsMi43NDktNy4yMDksMi43NDktOS45NTcsMGMtMi43NS0yLjc1NC0yLjc1LTcuMjEsMC05Ljk1OQoJCWMwLjY4LTAuNjc5LDEuNDY3LTEuMTkzLDIuMzA3LTEuNTM3VjM2LjM2OWMtMC44NC0wLjM0NC0xLjYyNS0wLjg1My0yLjMwNy0xLjUzN2MtMi4wODMtMi4wODItMi41ODQtNS4xNC0xLjUxNi03LjY5OAoJCUwzMS43OTgsMTYuNzE1TDQuMjg4LDQ0LjIyMmMtMi4zMTEsMi4zMTMtMi4zMTEsNi4wNiwwLDguMzcxbDQwLjEyMSw0MC4xMThjMi4zMSwyLjMxMSw2LjA1NiwyLjMxMSw4LjM2OSwwTDkyLjcxLDUyLjc3OQoJCUM5NS4wMjEsNTAuNDY4LDk1LjAyMSw0Ni43MTksOTIuNzEsNDQuNDA4eiIvPgo8L2c+Cjwvc3ZnPgo='
+
+if (!window.context) {
+    window.context = { enableLegacyExtensions: false } as SourcegraphContext & Mocha.SuiteFunction
+}
+
+// eslint-disable-next-line id-length
+const mockActionItems = [...(new Array(10) as (number | undefined)[])].map((_, index) => `${index}`)
+const mockContributions: Evaluated<Contributions> = {
+    actions: mockActionItems.map((id, index) => ({
+        id,
+        actionItem: {
+            iconURL: mockIconURL,
+            label: 'Some label',
+            pressed: index < 2,
+            description: 'Some description',
+        },
+        command: 'open',
+        active: true,
+        category: 'Some category',
+        title: 'Some title',
+    })),
+    menus: {
+        [ContributableMenu.EditorTitle]: mockActionItems.map(id => ({
+            action: id,
+            alt: id,
+            when: true,
+        })),
+    },
+}
+
+const mockExtensionsController = {
+    ...extensionsController,
+    extHostAPI: Promise.resolve(
+        pretendRemote<FlatExtensionHostAPI>({
+            getContributions: () => pretendProxySubscribable(of(mockContributions)),
+            registerContributions: () => pretendProxySubscribable(EMPTY).subscribe(noop as any),
+            haveInitialExtensionsLoaded: () => pretendProxySubscribable(of(true)),
+        })
+    ),
+}
+
+const decorator: DecoratorFn = story => (
+    <WebStory
+        initialEntries={[
+            '/github.com/sourcegraph/sourcegraph/-/blob/client/browser/src/browser-extension/ThemeWrapper.tsx',
+        ]}
+    >
+        {() => (
+            <AppRouterContainer>
+                <div className="container mt-3">{story()}</div>
+            </AppRouterContainer>
+        )}
+    </WebStory>
+)
+
+const config: Meta = {
+    title: 'web/extensions/ActionItemsBar',
+    decorators: [decorator],
+    component: ActionItemsBar,
+    parameters: {
+        chromatic: {
+            enableDarkMode: true,
+            disableSnapshot: false,
+        },
+    },
+}
+
+export default config
+
+export const Default: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+    const { useActionItemsBar } = useWebActionItems()
+
+    return (
+        <ActionItemsBar
+            repo={undefined}
+            useActionItemsBar={useActionItemsBar}
+            extensionsController={mockExtensionsController}
+            platformContext={NOOP_PLATFORM_CONTEXT as any}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+        />
+    )
+}

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -1,0 +1,412 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiMenuDown, mdiMenuUp, mdiPuzzleOutline } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
+import classNames from 'classnames'
+import { head, last } from 'lodash'
+import { useLocation } from 'react-router-dom'
+import { BehaviorSubject, from, of } from 'rxjs'
+import { distinctUntilChanged, map } from 'rxjs/operators'
+import { focusable, FocusableElement } from 'tabbable'
+import { Key } from 'ts-key-enum'
+
+import { ContributableMenu } from '@sourcegraph/client-api'
+import { LocalStorageSubject } from '@sourcegraph/common'
+import { ActionItem } from '@sourcegraph/shared/src/actions/ActionItem'
+import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContainer'
+import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { isSettingsValid } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Button, ButtonLink, Icon, LoadingSpinner, Tooltip, useObservable } from '@sourcegraph/wildcard'
+
+import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { useCarousel } from '../../components/useCarousel'
+import { RepositoryFields } from '../../graphql-operations'
+import { OpenInEditorActionItem } from '../../open-in-editor/OpenInEditorActionItem'
+import { GoToCodeHostAction } from '../../repo/actions/GoToCodeHostAction'
+import { ToggleBlameAction } from '../../repo/actions/ToggleBlameAction'
+import { fetchFileExternalLinks } from '../../repo/backend'
+import { parseBrowserRepoURL } from '../../util/url'
+
+import styles from './ActionItemsBar.module.scss'
+
+const scrollButtonClassName = styles.scroll
+
+function getIconClassName(index: number): string | undefined {
+    return (styles as Record<string, string>)[`icon${index % 5}`]
+}
+
+function arrowable(element: HTMLElement): FocusableElement[] {
+    return focusable(element).filter(
+        elm => !elm.classList.contains('disabled') && !elm.classList.contains(scrollButtonClassName)
+    )
+}
+
+export function useWebActionItems(): Pick<ActionItemsBarProps, 'useActionItemsBar'> &
+    Pick<ActionItemsToggleProps, 'useActionItemsToggle'> {
+    const toggles = useMemo(() => new LocalStorageSubject('action-items-bar-expanded', true), [])
+
+    const [toggleReference, setToggleReference] = useState<HTMLElement | null>(null)
+    const nextToggleReference = useCallback((toggle: HTMLElement) => {
+        setToggleReference(toggle)
+    }, [])
+
+    const [barReference, setBarReference] = useState<HTMLElement | null>(null)
+    const nextBarReference = useCallback((bar: HTMLElement) => {
+        setBarReference(bar)
+    }, [])
+
+    // Set up keyboard navigation for distant toggle and bar. Remove previous event
+    // listeners whenever references change.
+    useEffect(() => {
+        function onKeyDownToggle(event: KeyboardEvent): void {
+            if (event.key === Key.ArrowDown && barReference) {
+                const firstBarArrowable = head(arrowable(barReference))
+                if (firstBarArrowable) {
+                    firstBarArrowable.focus()
+                    event.preventDefault()
+                }
+            }
+
+            if (event.key === Key.ArrowUp && barReference) {
+                const lastBarArrowable = last(arrowable(barReference))
+                if (lastBarArrowable) {
+                    lastBarArrowable.focus()
+                    event.preventDefault()
+                }
+            }
+        }
+
+        function onKeyDownBar(event: KeyboardEvent): void {
+            if (event.target instanceof HTMLElement && toggleReference && barReference) {
+                const arrowableChildren = arrowable(barReference)
+                const indexOfTarget = arrowableChildren.indexOf(event.target)
+
+                if (event.key === Key.ArrowDown) {
+                    // If this is the last arrowable element, go back to the toggle
+                    if (indexOfTarget === arrowableChildren.length - 1) {
+                        toggleReference.focus()
+                        event.preventDefault()
+                        return
+                    }
+
+                    const itemToFocus = arrowableChildren[indexOfTarget + 1]
+                    if (itemToFocus instanceof HTMLElement) {
+                        itemToFocus.focus()
+                        event.preventDefault()
+                        return
+                    }
+                }
+
+                if (event.key === Key.ArrowUp) {
+                    // If this is the first arrowable element, go back to the toggle
+                    if (indexOfTarget === 0) {
+                        toggleReference.focus()
+                        event.preventDefault()
+                        return
+                    }
+
+                    const itemToFocus = arrowableChildren[indexOfTarget - 1]
+                    if (itemToFocus instanceof HTMLElement) {
+                        itemToFocus.focus()
+                        event.preventDefault()
+                        return
+                    }
+                }
+            }
+        }
+
+        toggleReference?.addEventListener('keydown', onKeyDownToggle)
+        barReference?.addEventListener('keydown', onKeyDownBar)
+
+        return () => {
+            toggleReference?.removeEventListener('keydown', onKeyDownToggle)
+            toggleReference?.removeEventListener('keydown', onKeyDownBar)
+        }
+    }, [toggleReference, barReference])
+
+    const barsReferenceCounts = useMemo(() => new BehaviorSubject(0), [])
+
+    const useActionItemsBar = useCallback(() => {
+        // `useActionItemsBar` will be used as a hook
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const isOpen = useObservable(toggles)
+
+        // Let the toggle know it's on the page
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useEffect(() => {
+            // Use reference counter so that effect order doesn't matter
+            barsReferenceCounts.next(barsReferenceCounts.value + 1)
+
+            return () => barsReferenceCounts.next(barsReferenceCounts.value - 1)
+        }, [])
+
+        return { isOpen, barReference: nextBarReference }
+    }, [toggles, nextBarReference, barsReferenceCounts])
+
+    const useActionItemsToggle = useCallback(() => {
+        // `useActionItemsToggle` will be used as a hook
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const isOpen = useObservable(toggles)
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const toggle = useCallback(() => toggles.next(!isOpen), [isOpen])
+
+        // Only show the action items toggle when the <ActionItemsBar> component is on the page
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const barInPage = !!useObservable(
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            useMemo(
+                () =>
+                    barsReferenceCounts.pipe(
+                        map(count => count > 0),
+                        distinctUntilChanged()
+                    ),
+                []
+            )
+        )
+
+        return { isOpen, toggle, barInPage, toggleReference: nextToggleReference }
+    }, [toggles, nextToggleReference, barsReferenceCounts])
+
+    return {
+        useActionItemsBar,
+        useActionItemsToggle,
+    }
+}
+
+export interface ActionItemsBarProps extends ExtensionsControllerProps, TelemetryProps, PlatformContextProps {
+    repo?: RepositoryFields
+    useActionItemsBar: () => { isOpen: boolean | undefined; barReference: React.RefCallback<HTMLElement> }
+    source?: 'compare' | 'commit' | 'blob'
+}
+
+const actionItemClassName = classNames(
+    'd-flex justify-content-center align-items-center text-decoration-none',
+    styles.action
+)
+
+/**
+ * Renders extensions (both migrated to the core workflow and legacy) actions items in the sidebar.
+ */
+export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionItemsBar(props) {
+    const { extensionsController, source } = props
+
+    const location = useLocation()
+    const { isOpen, barReference } = props.useActionItemsBar()
+    const { repoName, rawRevision, filePath, commitRange, position, range } = parseBrowserRepoURL(
+        location.pathname + location.search + location.hash
+    )
+
+    const { carouselReference, canScrollNegative, canScrollPositive, onNegativeClicked, onPositiveClicked } =
+        useCarousel({ direction: 'topToBottom' })
+
+    const haveExtensionsLoaded = useObservable(
+        useMemo(
+            () =>
+                extensionsController !== null ? haveInitialExtensionsLoaded(extensionsController.extHostAPI) : of(true),
+            [extensionsController]
+        )
+    )
+
+    const settingsOrError = useObservable(
+        useMemo(() => from(props.platformContext.settings), [props.platformContext.settings])
+    )
+    const settings =
+        settingsOrError !== undefined && isSettingsValid(settingsOrError) ? settingsOrError.final : undefined
+    const perforceCodeHostUrlToSwarmUrlMap =
+        (settings?.['perforce.codeHostToSwarmMap'] as { [codeHost: string]: string } | undefined) || {}
+
+    if (!isOpen) {
+        return <div className={classNames(styles.bar, styles.barCollapsed)} />
+    }
+
+    return (
+        <div className={classNames('p-0 mr-2 position-relative d-flex flex-column', styles.bar)} ref={barReference}>
+            {/* To be clear to users that this isn't an error reported by extensions about e.g. the code they're viewing. */}
+            <ErrorBoundary location={location} render={error => <span>Component error: {error.message}</span>}>
+                <ActionItemsDivider />
+                {canScrollNegative && (
+                    <Button
+                        className={classNames('p-0 border-0', styles.scroll, styles.listItem)}
+                        onClick={onNegativeClicked}
+                        tabIndex={-1}
+                        variant="link"
+                        aria-label="Scroll up"
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiMenuUp} />
+                    </Button>
+                )}
+
+                {source !== 'compare' && source !== 'commit' && (
+                    <GoToCodeHostAction
+                        repo={props.repo}
+                        repoName={repoName}
+                        // We need a revision to generate code host URLs, if revision isn't available, we use the default branch or HEAD.
+                        revision={rawRevision || props.repo?.defaultBranch?.displayName || 'HEAD'}
+                        filePath={filePath}
+                        commitRange={commitRange}
+                        range={range}
+                        position={position}
+                        perforceCodeHostUrlToSwarmUrlMap={perforceCodeHostUrlToSwarmUrlMap}
+                        fetchFileExternalLinks={fetchFileExternalLinks}
+                        actionType="nav"
+                        source="actionItemsBar"
+                    />
+                )}
+
+                {source === 'blob' && (
+                    <>
+                        <ToggleBlameAction actionType="nav" source="actionItemsBar" />
+                        {window.context.isAuthenticatedUser && (
+                            <OpenInEditorActionItem
+                                platformContext={props.platformContext}
+                                externalServiceType={props.repo?.externalRepository?.serviceType}
+                                actionType="nav"
+                                source="actionItemsBar"
+                            />
+                        )}
+                    </>
+                )}
+
+                {extensionsController !== null ? (
+                    <ActionsContainer
+                        menu={ContributableMenu.EditorTitle}
+                        returnInactiveMenuItems={true}
+                        extensionsController={extensionsController}
+                        empty={null}
+                        location={location}
+                        platformContext={props.platformContext}
+                        telemetryService={props.telemetryService}
+                    >
+                        {items => (
+                            <ul className={classNames('list-unstyled m-0', styles.list)} ref={carouselReference}>
+                                {items.map((item, index) => {
+                                    const hasIconURL = !!item.action.actionItem?.iconURL
+                                    const className = classNames(
+                                        actionItemClassName,
+                                        !hasIconURL &&
+                                            classNames(styles.actionNoIcon, getIconClassName(index), 'text-sm')
+                                    )
+                                    const inactiveClassName = classNames(
+                                        styles.actionInactive,
+                                        !hasIconURL && styles.actionNoIconInactive
+                                    )
+                                    const listItemClassName = classNames(
+                                        styles.listItem,
+                                        index !== items.length - 1 && 'mb-1'
+                                    )
+
+                                    const dataContent = !hasIconURL ? item.action.category?.slice(0, 1) : undefined
+
+                                    return (
+                                        <li key={item.action.id} className={listItemClassName}>
+                                            <ActionItem
+                                                {...props}
+                                                {...item}
+                                                location={location}
+                                                extensionsController={extensionsController}
+                                                className={className}
+                                                dataContent={dataContent}
+                                                variant="actionItem"
+                                                iconClassName={styles.icon}
+                                                pressedClassName={styles.actionPressed}
+                                                inactiveClassName={inactiveClassName}
+                                                hideLabel={true}
+                                                tabIndex={-1}
+                                                hideExternalLinkIcon={true}
+                                                disabledDuringExecution={true}
+                                            />
+                                        </li>
+                                    )
+                                })}
+                            </ul>
+                        )}
+                    </ActionsContainer>
+                ) : null}
+                {canScrollPositive && (
+                    <Button
+                        className={classNames('p-0 border-0', styles.scroll, styles.listItem)}
+                        onClick={onPositiveClicked}
+                        tabIndex={-1}
+                        variant="link"
+                        aria-label="Scroll down"
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiMenuDown} />
+                    </Button>
+                )}
+                {haveExtensionsLoaded && <ActionItemsDivider />}
+            </ErrorBoundary>
+        </div>
+    )
+})
+
+export interface ActionItemsToggleProps extends ExtensionsControllerProps<'extHostAPI'> {
+    useActionItemsToggle: () => {
+        isOpen: boolean | undefined
+        toggle: () => void
+        toggleReference: React.RefCallback<HTMLElement>
+        barInPage: boolean
+    }
+    className?: string
+}
+
+export const ActionItemsToggle: React.FunctionComponent<React.PropsWithChildren<ActionItemsToggleProps>> = ({
+    useActionItemsToggle,
+    extensionsController,
+    className,
+}) => {
+    const panelName = extensionsController !== null && window.context.enableLegacyExtensions ? 'extensions' : 'actions'
+
+    const { isOpen, toggle, toggleReference, barInPage } = useActionItemsToggle()
+
+    const haveExtensionsLoaded = useObservable(
+        useMemo(
+            () =>
+                extensionsController !== null ? haveInitialExtensionsLoaded(extensionsController.extHostAPI) : of(true),
+            [extensionsController]
+        )
+    )
+
+    return barInPage ? (
+        <>
+            <li className={styles.dividerVertical} />
+            <li className={classNames('nav-item mr-2', className)}>
+                <div className={classNames(styles.toggleContainer, isOpen && styles.toggleContainerOpen)}>
+                    <Tooltip content={`${isOpen ? 'Close' : 'Open'} ${panelName} panel`}>
+                        <ButtonLink
+                            aria-label={
+                                isOpen
+                                    ? `Close ${panelName} panel. Press the down arrow key to enter the ${panelName} panel.`
+                                    : `Open ${panelName} panel`
+                            }
+                            className={classNames(actionItemClassName, styles.auxIcon, styles.actionToggle)}
+                            onSelect={toggle}
+                            ref={toggleReference}
+                        >
+                            {!haveExtensionsLoaded ? (
+                                <LoadingSpinner />
+                            ) : isOpen ? (
+                                <Icon aria-hidden={true} svgPath={mdiChevronDoubleUp} />
+                            ) : (
+                                <Icon
+                                    aria-hidden={true}
+                                    svgPath={
+                                        window.context.enableLegacyExtensions ? mdiPuzzleOutline : mdiChevronDoubleDown
+                                    }
+                                />
+                            )}
+                            {haveExtensionsLoaded && <VisuallyHidden>Down arrow to enter</VisuallyHidden>}
+                        </ButtonLink>
+                    </Tooltip>
+                </div>
+            </li>
+        </>
+    ) : null
+}
+
+const ActionItemsDivider: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => <div className={classNames('position-relative rounded-sm d-flex', styles.dividerHorizontal, className)} />

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -1,6 +1,10 @@
 import assert from 'assert'
 
+import type { ExtensionContext } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
+import { ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
+import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -14,6 +18,7 @@ import {
     createBlobContentResult,
 } from './graphQlResponseHelpers'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
+import { percySnapshotWithVariants } from './utils'
 
 describe('Blob viewer', () => {
     let driver: Driver
@@ -154,6 +159,368 @@ describe('Blob viewer', () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}#1-3`)
             await driver.page.waitForSelector('[data-testid="repo-blob"]')
             await driver.assertWindowLocation(`/${repositoryName}/-/blob/${fileName}?L1-3`)
+        })
+    })
+
+    // Describes the ways the blob viewer can be extended through Sourcegraph extensions.
+    describe('extensibility', () => {
+        beforeEach(() => {
+            const userSettings: Settings = {
+                extensions: {
+                    'test/test': true,
+                },
+            }
+            const extensionManifest: ExtensionManifest = {
+                url: new URL('/-/static/extension/0001-test-test.js?hash--test-test', driver.sourcegraphBaseUrl).href,
+                activationEvents: ['*'],
+            }
+            testContext.overrideGraphQL({
+                ...commonBlobGraphQlResults,
+                ViewerSettings: () => ({
+                    viewerSettings: {
+                        __typename: 'SettingsCascade',
+                        final: JSON.stringify(userSettings),
+                        subjects: [
+                            {
+                                __typename: 'User',
+                                displayName: 'Test User',
+                                id: 'TestUserSettingsID',
+                                latestSettings: {
+                                    id: 123,
+                                    contents: JSON.stringify(userSettings),
+                                },
+                                username: 'test',
+                                viewerCanAdminister: true,
+                                settingsURL: '/users/test/settings',
+                            },
+                        ],
+                    },
+                }),
+                Blob: () => ({
+                    repository: {
+                        commit: {
+                            blob: null,
+                            file: {
+                                __typename: 'VirtualFile',
+                                content: '// Log to console\nconsole.log("Hello world")',
+                                totalLines: 2,
+                                richHTML: '',
+                                highlight: {
+                                    aborted: false,
+                                    html:
+                                        // Note: whitespace in this string is significant.
+                                        '<table><tbody><tr>' +
+                                        '<td class="line" data-line="1"/>' +
+                                        '<td class="code"><span class="hl-source hl-js hl-react"><span class="hl-comment hl-line hl-double-slash hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-comment hl-js">//</span> ' +
+                                        'Log to console\n</span></span></td></tr>' +
+                                        '<tr><td class="line" data-line="2"/>' +
+                                        '<td class="code"><span class="hl-source hl-js hl-react"><span class="hl-meta hl-function-call hl-method hl-js">' +
+                                        '<span class="hl-support hl-type hl-object hl-console hl-js test-console-token">console</span>' +
+                                        '<span class="hl-punctuation hl-accessor hl-js">.</span>' +
+                                        '<span class="hl-support hl-function hl-console hl-js test-log-token">log</span>' +
+                                        '<span class="hl-meta hl-group hl-js"><span class="hl-punctuation hl-section hl-group hl-begin hl-js">(</span>' +
+                                        '<span class="hl-meta hl-string hl-js"><span class="hl-string hl-quoted hl-double hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-begin hl-js">&quot;</span>' +
+                                        'Hello world' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-end hl-js">&quot;</span></span></span>' +
+                                        '<span class="hl-punctuation hl-section hl-group hl-end hl-js">)</span></span>\n</span></span></td></tr></tbody></table>',
+                                    lsif: '',
+                                },
+                            },
+                        },
+                    },
+                }),
+                Extensions: () => ({
+                    extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
+                        extensions: {
+                            nodes: [
+                                {
+                                    id: 'test',
+                                    extensionID: 'test/test',
+                                    manifest: {
+                                        jsonFields: extensionManifest,
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                }),
+            })
+
+            // Serve a mock extension bundle with a simple hover provider
+            testContext.server
+                .get(new URL(extensionManifest.url, driver.sourcegraphBaseUrl).href)
+                .intercept((request, response) => {
+                    function extensionBundle(): void {
+                        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+                        const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
+
+                        function activate(context: ExtensionContext): void {
+                            context.subscriptions.add(
+                                sourcegraph.languages.registerHoverProvider([{ language: 'typescript' }], {
+                                    provideHover: () => ({
+                                        contents: {
+                                            kind: sourcegraph.MarkupKind.Markdown,
+                                            value: 'Test hover content',
+                                        },
+                                    }),
+                                })
+                            )
+                        }
+
+                        exports.activate = activate
+                    }
+                    // Create an immediately-invoked function expression for the extensionBundle function
+                    const extensionBundleString = `(${extensionBundle.toString()})()`
+                    response.type('application/javascript; charset=utf-8').send(extensionBundleString)
+                })
+        })
+        it('truncates long file paths properly', async () => {
+            await driver.page.goto(
+                `${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/this_is_a_long_file_path/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java`
+            )
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
+            await driver.page.waitForSelector('.test-breadcrumb')
+            // Uncomment this snapshot once https://github.com/sourcegraph/sourcegraph/issues/15126 is resolved
+            // await percySnapshot(driver.page, this.test!.fullTitle())
+        })
+
+        it.skip('shows a hover overlay from a hover provider when a token is hovered', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/${fileName}`)
+            await driver.page.waitForSelector('[data-testid="repo-blob"]')
+            // TODO
+        })
+
+        it.skip('gets displayed when navigating to a URL with a token position', async () => {
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/github.com/sourcegraph/test/-/test.ts#2:9`)
+            // TODO
+        })
+
+        // Disabled because it's flaky. See: https://github.com/sourcegraph/sourcegraph/issues/31806
+        it.skip('properly displays reference panel for URIs with spaces', async () => {
+            const repositoryName = 'github.com/sourcegraph/test%20repo'
+            const files = ['test.ts', 'test spaces.ts']
+            const commitID = '1234'
+            const userSettings: Settings = {
+                extensions: {
+                    'test/references': true,
+                },
+            }
+            const extensionManifest: ExtensionManifest = {
+                url: new URL(
+                    '/-/static/extension/0001-test-references.js?hash--test-references',
+                    driver.sourcegraphBaseUrl
+                ).href,
+                activationEvents: ['*'],
+            }
+            testContext.overrideGraphQL({
+                ...commonBlobGraphQlResults,
+                ViewerSettings: () => ({
+                    viewerSettings: {
+                        __typename: 'SettingsCascade',
+                        final: JSON.stringify(userSettings),
+                        subjects: [
+                            {
+                                __typename: 'User',
+                                displayName: 'Test User',
+                                id: 'TestUserSettingsID',
+                                latestSettings: {
+                                    id: 123,
+                                    contents: JSON.stringify(userSettings),
+                                },
+                                username: 'test',
+                                viewerCanAdminister: true,
+                                settingsURL: '/users/test/settings',
+                            },
+                        ],
+                    },
+                }),
+                Extensions: () => ({
+                    extensionRegistry: {
+                        __typename: 'ExtensionRegistry',
+                        extensions: {
+                            nodes: [
+                                {
+                                    id: 'test',
+                                    extensionID: 'test/references',
+                                    manifest: {
+                                        jsonFields: extensionManifest,
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                }),
+                Blob: ({ filePath }) => ({
+                    repository: {
+                        commit: {
+                            blob: null,
+                            file: {
+                                __typename: 'VirtualFile',
+                                content: `// file path: ${filePath}\nconsole.log("Hello world")`,
+                                totalLines: 2,
+                                richHTML: '',
+                                highlight: {
+                                    aborted: false,
+                                    html:
+                                        '<table><tbody><tr><td class="line" data-line="1"/><td class="code">' +
+                                        '<span class="hl-source hl-js hl-react"><span class="hl-comment hl-line hl-double-slash hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-comment hl-js">//</span>' +
+                                        ` file path: ${filePath}\n` +
+                                        '</span></span></td></tr>' +
+                                        '<tr><td class="line" data-line="2"/>' +
+                                        '<td class="code"><span class="hl-source hl-js hl-react">' +
+                                        '<span class="hl-meta hl-function-call hl-method hl-js">' +
+                                        '<span class="hl-support hl-type hl-object hl-console hl-js test-console-token">console</span>' +
+                                        '<span class="hl-punctuation hl-accessor hl-js">.</span>' +
+                                        '<span class="hl-support hl-function hl-console hl-js test-log-token">log</span>' +
+                                        '<span class="hl-meta hl-group hl-js"><span class="hl-punctuation hl-section hl-group hl-begin hl-js">(</span>' +
+                                        '<span class="hl-meta hl-string hl-js"><span class="hl-string hl-quoted hl-double hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-begin hl-js">&quot;</span>' +
+                                        'Hello world' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-end hl-js">&quot;</span></span></span>' +
+                                        '<span class="hl-punctuation hl-section hl-group hl-end hl-js">)</span></span>' +
+                                        '\n</span></span></td></tr></tbody></table>',
+                                    lsif: '',
+                                    lineRanges: [],
+                                },
+                            },
+                        },
+                    },
+                }),
+                TreeEntries: () => createTreeEntriesResult(repositorySourcegraphUrl, files),
+                ResolveRepoRev: () => createResolveRepoRevisionResult(repositorySourcegraphUrl, commitID),
+                HighlightedFile: ({ filePath }) => ({
+                    repository: {
+                        commit: {
+                            file: {
+                                isDirectory: false,
+                                richHTML: '',
+                                highlight: {
+                                    aborted: false,
+                                    html:
+                                        '<table><tbody><tr><td class="line" data-line="1"/><td class="code">' +
+                                        '<span class="hl-source hl-js hl-react"><span class="hl-comment hl-line hl-double-slash hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-comment hl-js">//</span>' +
+                                        ` file path: ${filePath}\n` +
+                                        '</span></span></td></tr>' +
+                                        '<tr><td class="line" data-line="2"/>' +
+                                        '<td class="code"><span class="hl-source hl-js hl-react">' +
+                                        '<span class="hl-meta hl-function-call hl-method hl-js">' +
+                                        '<span class="hl-support hl-type hl-object hl-console hl-js test-console-token">console</span>' +
+                                        '<span class="hl-punctuation hl-accessor hl-js">.</span>' +
+                                        '<span class="hl-support hl-function hl-console hl-js test-log-token">log</span>' +
+                                        '<span class="hl-meta hl-group hl-js"><span class="hl-punctuation hl-section hl-group hl-begin hl-js">(</span>' +
+                                        '<span class="hl-meta hl-string hl-js"><span class="hl-string hl-quoted hl-double hl-js">' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-begin hl-js">&quot;</span>' +
+                                        'Hello world' +
+                                        '<span class="hl-punctuation hl-definition hl-string hl-end hl-js">&quot;</span></span></span>' +
+                                        '<span class="hl-punctuation hl-section hl-group hl-end hl-js">)</span></span>' +
+                                        '\n</span></span></td></tr></tbody></table>',
+                                    lineRanges: [],
+                                },
+                            },
+                        },
+                    },
+                }),
+                FetchCommits: () => ({
+                    node: { __typename: 'GitCommit' },
+                }),
+                // Required for definition provider,
+                ResolveRawRepoName: () => ({
+                    repository: {
+                        mirrorInfo: {
+                            cloned: true,
+                        },
+                        uri: repositoryName,
+                    },
+                }),
+            })
+
+            // Serve a mock extension bundle with a simple reference provider
+            testContext.server
+                .get(new URL(extensionManifest.url, driver.sourcegraphBaseUrl).href)
+                .intercept((request, response) => {
+                    function extensionBundle(): void {
+                        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+                        const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
+
+                        function activate(context: ExtensionContext): void {
+                            context.subscriptions.add(
+                                sourcegraph.languages.registerReferenceProvider(['*'], {
+                                    provideReferences: () => [
+                                        new sourcegraph.Location(
+                                            new URL('git://github.com/sourcegraph/test%20repo?1234#test%20spaces.ts'),
+                                            new sourcegraph.Range(
+                                                new sourcegraph.Position(0, 0),
+                                                new sourcegraph.Position(1, 0)
+                                            )
+                                        ),
+                                    ],
+                                })
+                            )
+
+                            // We aren't testing definition providers in this test; we include a definition provider
+                            // because the "Find references" action isn't displayed unless a definition is found
+                            context.subscriptions.add(
+                                sourcegraph.languages.registerDefinitionProvider(['*'], {
+                                    provideDefinition: () =>
+                                        new sourcegraph.Location(
+                                            new URL('git://github.com/sourcegraph/test%20repo?1234#test%20spaces.ts'),
+                                            new sourcegraph.Range(
+                                                new sourcegraph.Position(0, 0),
+                                                new sourcegraph.Position(1, 0)
+                                            )
+                                        ),
+                                })
+                            )
+                        }
+
+                        exports.activate = activate
+                    }
+                    // Create an immediately-invoked function expression for the extensionBundle function
+                    const extensionBundleString = `(${extensionBundle.toString()})()`
+                    response.type('application/javascript; charset=utf-8').send(extensionBundleString)
+                })
+
+            // TEMPORARY: Mock `Date.now` to prevent temporary Firefox from rendering.
+            await driver.page.evaluateOnNewDocument(() => {
+                // Number of ms between Unix epoch and July 1, 2020 (outside of Firefox campaign range)
+                const mockMs = new Date('July 1, 2020 00:00:00 UTC').getTime()
+                Date.now = () => mockMs
+            })
+
+            await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/blob/test.ts`)
+
+            // Click on "log" in "console.log()" in line 2
+            await driver.page.waitForSelector('.test-log-token', { visible: true })
+            await driver.page.click('.test-log-token')
+
+            // Click 'Find references'
+            await driver.page.waitForSelector('.test-tooltip-find-references', { visible: true })
+            await driver.page.click('.test-tooltip-find-references')
+
+            await driver.page.waitForSelector('.test-file-match-children-item', { visible: true })
+
+            await percySnapshotWithVariants(driver.page, 'Blob Reference Panel', { waitForCodeHighlighting: true })
+            await accessibilityAudit(driver.page)
+            // Click on the first reference
+            await driver.page.click('.test-file-match-children-item')
+
+            // Assert that the first line of code has text content which contains: 'file path: test spaces.ts'
+            try {
+                await driver.page.waitForFunction(
+                    () =>
+                        document
+                            .querySelector('[data-testid="repo-blob"] [data-line="1"]')
+                            ?.nextElementSibling?.textContent?.includes('file path: test spaces.ts'),
+                    { timeout: 5000 }
+                )
+            } catch {
+                throw new Error('Expected to navigate to file after clicking on link in references panel')
+            }
         })
     })
 })

--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -2,8 +2,11 @@ import assert from 'assert'
 
 import { ElementHandle, MouseButton } from 'puppeteer'
 
+import type { ExtensionContext } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
 import { JsonDocument, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
+import { ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
+import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { Driver, createDriverForTest, percySnapshot } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -281,6 +284,136 @@ describe('CodeMirror blob view', () => {
         })
     })
 
+    // Describes the ways the blob viewer can be extended through Sourcegraph extensions.
+    describe('extensibility', () => {
+        beforeEach(() => {
+            testContext.overrideJsContext({ enableLegacyExtensions: true })
+        })
+
+        describe('hovercards', () => {
+            beforeEach(() => {
+                const {
+                    graphqlResults: extensionGraphQlResult,
+                    intercept,
+                    userSettings,
+                } = createExtensionData([
+                    {
+                        id: 'test',
+                        extensionID: 'test/test',
+                        extensionManifest: {
+                            url: new URL(
+                                '/-/static/extension/0001-test-test.js?hash--test-test',
+                                driver.sourcegraphBaseUrl
+                            ).href,
+                            activationEvents: ['*'],
+                        },
+                        bundle: function extensionBundle(): void {
+                            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+                            const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
+
+                            function activate(context: ExtensionContext): void {
+                                context.subscriptions.add(
+                                    sourcegraph.languages.registerHoverProvider([{ language: 'typescript' }], {
+                                        provideHover: () => ({
+                                            contents: {
+                                                kind: sourcegraph.MarkupKind.Markdown,
+                                                value: 'Test hover content',
+                                            },
+                                        }),
+                                    })
+                                )
+                            }
+
+                            exports.activate = activate
+                        },
+                    },
+                ])
+                testContext.overrideGraphQL({
+                    ...commonBlobGraphQlResults,
+                    ...createViewerSettingsGraphQLOverride({
+                        user: {
+                            ...userSettings,
+                            experimentalFeatures: {
+                                enableCodeMirrorFileView: true,
+                            },
+                        },
+                    }),
+                    ...extensionGraphQlResult,
+                })
+
+                // Serve a mock extension bundle with a simple hover provider
+                intercept(testContext, driver)
+            })
+
+            it('shows a hover overlay from a hover provider when a token is hovered', async () => {
+                await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
+                await waitForView()
+                await driver.page.hover(wordSelector)
+                await driver.page.waitForSelector('.cm-code-intel-hovercard')
+                assert.strictEqual(
+                    await driver.page.evaluate(
+                        (): string =>
+                            document.querySelector('[data-testid="hover-overlay-contents"]')?.textContent?.trim() ?? ''
+                    ),
+                    'Test hover content',
+                    'hovercard is visible with correct content'
+                )
+
+                await driver.page.hover(lineAt(5))
+                try {
+                    await driver.page.waitForSelector('.cm-code-intel-hovercard', { hidden: true })
+                } catch {
+                    throw new Error('Timeout waiting for hovercard to disappear')
+                }
+            })
+
+            it('pins a hovercard and unpins hovercards', async () => {
+                await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
+                await waitForView()
+                await driver.page.hover(wordSelector)
+                await driver.page.waitForSelector('.cm-code-intel-hovercard [data-testid="hover-copy-link"]')
+
+                await driver.page.click('.cm-code-intel-hovercard [data-testid="hover-copy-link"]')
+
+                // URL gets updated
+                await driver.assertWindowLocation(`${filePaths['test.ts']}?L1:1&popover=pinned`)
+
+                // Close button is visible
+                await driver.page.waitForSelector('.cm-code-intel-hovercard [aria-label="Close"]')
+
+                // Hovercard stay open when moving the mouse away
+                await driver.page.hover(lineAt(5))
+                await driver.page.waitForSelector('.cm-code-intel-hovercard')
+
+                // Closes hovercard when clicking on another line
+                await driver.page.click(lineAt(5))
+                try {
+                    await driver.page.waitForSelector('.cm-code-intel-hovercard', { hidden: true })
+                } catch {
+                    throw new Error('Timeout waiting for hovercard to close after selecting another line')
+                }
+
+                // Opens pinned hovecard when navigating back
+                await driver.page.goBack()
+                await driver.page.waitForSelector('.cm-code-intel-hovercard')
+
+                // Closes hover card when clicking the close button
+                await driver.page.click('.cm-code-intel-hovercard [aria-label="Close"]')
+                try {
+                    await driver.page.waitForSelector('.cm-code-intel-hovercard', { hidden: true })
+                } catch {
+                    throw new Error('Timeout waiting for hovercard to close after clicking close button')
+                }
+            })
+
+            it('opens a pinned hovercard on page load', async () => {
+                await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}?L1:1&popover=pinned`)
+                await waitForView()
+                await driver.page.waitForSelector('.cm-code-intel-hovercard')
+            })
+        })
+    })
+
     describe('in-document search', () => {
         const { graphqlResults: blobGraphqlResults, filePaths } = createBlobPageData({
             repoName,
@@ -442,6 +575,57 @@ function createBlobPageData<T extends BlobInfo>({
                     name: repoName,
                 },
             }),
+        },
+    }
+}
+
+interface MockExtension {
+    id: string
+    extensionID: string
+    extensionManifest: ExtensionManifest
+    /**
+     * A function whose body is a Sourcegraph extension.
+     *
+     * Bundle must import 'sourcegraph' (e.g. `const sourcegraph = require('sourcegraph')`)
+     * */
+    bundle: () => void
+}
+
+function createExtensionData(extensions: MockExtension[]): {
+    intercept: (testContext: WebIntegrationTestContext, driver: Driver) => void
+    graphqlResults: Pick<SharedGraphQlOperations, 'Extensions'>
+    userSettings: Required<Pick<Settings, 'extensions'>>
+} {
+    return {
+        intercept(testContext: WebIntegrationTestContext, driver: Driver) {
+            for (const extension of extensions) {
+                testContext.server
+                    .get(new URL(extension.extensionManifest.url, driver.sourcegraphBaseUrl).href)
+                    .intercept((_request, response) => {
+                        // Create an immediately-invoked function expression for the extensionBundle function
+                        const extensionBundleString = `(${extension.bundle.toString()})()`
+                        response.type('application/javascript; charset=utf-8').send(extensionBundleString)
+                    })
+            }
+        },
+        graphqlResults: {
+            Extensions: () => ({
+                extensionRegistry: {
+                    __typename: 'ExtensionRegistry',
+                    extensions: {
+                        nodes: extensions.map(extension => ({
+                            ...extension,
+                            manifest: { jsonFields: extension.extensionManifest },
+                        })),
+                    },
+                },
+            }),
+        },
+        userSettings: {
+            extensions: extensions.reduce((extensionsSettings: Record<string, boolean>, mockExtension) => {
+                extensionsSettings[mockExtension.extensionID] = true
+                return extensionsSettings
+            }, {}),
         },
     }
 }

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -49,4 +49,5 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     xhrHeaders: {},
     authProviders: [builtinAuthProvider],
     authMinPasswordLength: 12,
+    enableLegacyExtensions: false,
 })

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -201,6 +201,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the product research sign-up page is enabled on the site. */
     productResearchPageEnabled: boolean
 
+    /** Whether the use of extensions are enabled. (Doesn't affect code intel and git extras.) */
+    enableLegacyExtensions?: boolean
+
     /** Contains information about the product license. */
     licenseInfo?: {
         currentPlan: 'old-starter-0' | 'old-enterprise-0' | 'team-0' | 'enterprise-0' | 'business-0' | 'enterprise-1'

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -5,6 +5,7 @@ import {
     mockFetchSearchContexts,
     mockGetUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
+import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 import { Grid, H3 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -20,6 +21,7 @@ const defaultProps: GlobalNavbarProps = {
         final: null,
         subjects: null,
     },
+    extensionsController,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     globbing: false,
     platformContext: {} as any,
@@ -47,6 +49,7 @@ const allNavItemsProps: Partial<GlobalNavbarProps> = {
     batchChangesExecutionEnabled: true,
     batchChangesWebhookLogsEnabled: true,
     codeInsightsEnabled: true,
+    enableLegacyExtensions: true,
 }
 
 const allAuthenticatedNavItemsProps: Partial<GlobalNavbarProps> = {

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -5,7 +5,7 @@ import {
     mockFetchSearchContexts,
     mockGetUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
-import { NOOP_SETTINGS_CASCADE } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+import { extensionsController, NOOP_SETTINGS_CASCADE } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { GlobalNavbar } from './GlobalNavbar'
@@ -15,6 +15,7 @@ jest.mock('../components/branding/BrandLogo', () => ({ BrandLogo: 'BrandLogo' })
 
 const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     authenticatedUser: null,
+    extensionsController,
     isSourcegraphDotCom: false,
     isSourcegraphApp: false,
     platformContext: {} as any,
@@ -40,6 +41,16 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
 }
 
 describe('GlobalNavbar', () => {
+    const origContext = window.context
+    beforeEach(() => {
+        window.context = {
+            enableLegacyExtensions: false,
+        } as any
+    })
+    afterEach(() => {
+        window.context = origContext
+    })
+
     test('default', () => {
         const { asFragment } = renderWithBrandedContext(
             <MockedTestProvider>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -6,7 +6,9 @@ import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import { useLocation } from 'react-router-dom'
 
+import { ContributableMenu } from '@sourcegraph/client-api'
 import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
@@ -25,6 +27,7 @@ import { CodeMonitoringProps } from '../codeMonitoring'
 import { CodyIcon } from '../cody/CodyIcon'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { getFuzzyFinderFeatureFlags } from '../components/fuzzyFinder/FuzzyFinderFeatureFlag'
+import { WebCommandListPopoverButton } from '../components/shared'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { useRoutesMatch } from '../hooks'
 import { CodeInsightsProps } from '../insights/types'
@@ -47,6 +50,7 @@ import styles from './GlobalNavbar.module.scss'
 export interface GlobalNavbarProps
     extends SettingsCascadeProps<Settings>,
         PlatformContextProps,
+        ExtensionsControllerProps,
         TelemetryProps,
         SearchContextInputProps,
         CodeInsightsProps,
@@ -63,6 +67,7 @@ export interface GlobalNavbarProps
     globbing: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
+    enableLegacyExtensions?: boolean
     branding?: typeof window.context.branding
     showKeyboardShortcutsHelp: () => void
     showFeedbackModal: () => void
@@ -127,6 +132,8 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     searchContextsEnabled,
     codeMonitoringEnabled,
     notebooksEnabled,
+    extensionsController,
+    enableLegacyExtensions,
     showFeedbackModal,
     ...props
 }) => {
@@ -286,6 +293,16 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         </NavAction>
                     )}
                     {fuzzyFinderNavbar && FuzzyFinderNavItem(props.setFuzzyFinderIsVisible)}
+                    {props.authenticatedUser && extensionsController !== null && enableLegacyExtensions && (
+                        <NavAction>
+                            <WebCommandListPopoverButton
+                                {...props}
+                                extensionsController={extensionsController}
+                                location={location}
+                                menu={ContributableMenu.CommandPalette}
+                            />
+                        </NavAction>
+                    )}
                     {props.authenticatedUser?.siteAdmin && (
                         <NavAction>
                             <StatusMessagesNavItem />
@@ -308,7 +325,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                     >
                                         Sign in
                                     </Button>
-                                    {!isSourcegraphDotCom && window.context?.allowSignup && (
+                                    {!isSourcegraphDotCom && window.context.allowSignup && (
                                         <ButtonLink to="/sign-up" variant="primary" size="sm">
                                             Sign up
                                         </ButtonLink>

--- a/client/web/src/platform/context.ts
+++ b/client/web/src/platform/context.ts
@@ -71,10 +71,10 @@ export function createPlatformContext(): PlatformContext {
         },
         getGraphQLClient: getWebGraphQLClient,
         requestGraphQL: ({ request, variables }) => requestGraphQL(request, variables),
-        createExtensionHost: () => {
-            throw new Error('extensions are no longer supported in the web app')
-        },
+        createExtensionHost: async () =>
+            (await import('@sourcegraph/shared/src/api/extension/worker')).createExtensionHost(),
         urlToFile: toPrettyWebBlobURL,
+        getScriptURLForExtension: () => undefined,
         sourcegraphURL: window.context.externalURL,
         clientApplication: 'sourcegraph',
         telemetryService: eventLogger,

--- a/client/web/src/repo/RepoHeader.story.tsx
+++ b/client/web/src/repo/RepoHeader.story.tsx
@@ -8,6 +8,7 @@ import { Button, H1, H2, Icon, Link } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
 import { AuthenticatedUser } from '../auth'
+import { SourcegraphContext } from '../jscontext'
 
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
 import { FilePathBreadcrumbs } from './FilePathBreadcrumbs'
@@ -23,6 +24,10 @@ const mockUser = {
     emails: [{ email: 'user@me.com', isPrimary: true, verified: true }],
     siteAdmin: true,
 } as AuthenticatedUser
+
+if (!window.context) {
+    window.context = { enableLegacyExtensions: false } as SourcegraphContext & Mocha.SuiteFunction
+}
 
 const decorator: DecoratorFn = story => (
     <BrandedStory initialEntries={['/github.com/sourcegraph/sourcegraph/-/tree/']} styles={webStyles}>
@@ -65,6 +70,12 @@ export const Default: Story = () => (
         </div>
     </>
 )
+const useActionItemsToggle = () => ({
+    isOpen: false,
+    toggle: () => null,
+    toggleReference: () => null,
+    barInPage: false,
+})
 
 const onLifecyclePropsChange = (lifecycleProps: RepoHeaderContributionsLifecycleProps) => {
     lifecycleProps.repoHeaderContributionsLifecycleProps?.onRepoHeaderContributionAdd({
@@ -141,6 +152,7 @@ const createBreadcrumbs = (path: string) => [
 
 const createProps = (path: string, forceWrap: boolean = false): React.ComponentProps<typeof RepoHeader> => ({
     actionButtons: [],
+    useActionItemsToggle,
     breadcrumbs: createBreadcrumbs(path),
     repoName: 'sourcegraph/sourcegraph',
     revision: 'main',
@@ -148,6 +160,7 @@ const createProps = (path: string, forceWrap: boolean = false): React.ComponentP
     settingsCascade: EMPTY_SETTINGS_CASCADE,
     authenticatedUser: mockUser,
     platformContext: {} as any,
+    extensionsController: null,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     forceWrap,
 })

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -7,17 +7,21 @@ import { useLocation } from 'react-router-dom'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Menu, MenuList, Position, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { Breadcrumbs, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { ErrorBoundary } from '../components/ErrorBoundary'
+import type { ActionItemsToggleProps } from '../extensions/components/ActionItemsBar'
 import { ActionButtonDescriptor } from '../util/contributions'
 import { useBreakpoint } from '../util/dom'
 
 import { RepoHeaderActionDropdownToggle } from './components/RepoHeaderActions'
 
 import styles from './RepoHeader.module.scss'
+
+const ActionItemsToggle = lazyComponent(() => import('../extensions/components/ActionItemsBar'), 'ActionItemsToggle')
 
 /**
  * Stores the list of RepoHeaderContributions, manages addition/deletion, and ensures they are sorted.
@@ -117,7 +121,7 @@ export interface RepoHeaderContext {
 
 export interface RepoHeaderActionButton extends ActionButtonDescriptor<RepoHeaderContext> {}
 
-interface Props extends PlatformContextProps, TelemetryProps, BreadcrumbsProps {
+interface Props extends PlatformContextProps, TelemetryProps, BreadcrumbsProps, ActionItemsToggleProps {
     /**
      * An array of render functions for action buttons that can be configured *in addition* to action buttons
      * contributed through {@link RepoHeaderContributionsLifecycleProps} and through extensions.
@@ -247,6 +251,14 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                         </li>
                     </ul>
                 )}
+                {window.context.enableLegacyExtensions ? (
+                    <ul className="navbar-nav">
+                        <ActionItemsToggle
+                            useActionItemsToggle={props.useActionItemsToggle}
+                            extensionsController={props.extensionsController}
+                        />
+                    </ul>
+                ) : null}
             </ErrorBoundary>
         </nav>
     )

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -16,6 +16,7 @@ import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
 import { CodeIntelligenceProps } from '../codeintel'
 import { BreadcrumbSetters } from '../components/Breadcrumbs'
+import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 import { RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
 import { NotebookProps } from '../notebooks'
@@ -48,6 +49,7 @@ export interface RepoRevisionContainerContext
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
         RevisionSpec,
         BreadcrumbSetters,
+        ActionItemsBarProps,
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         BatchChangesProps,
@@ -79,6 +81,7 @@ interface RepoRevisionContainerProps
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
         RevisionSpec,
         BreadcrumbSetters,
+        ActionItemsBarProps,
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         CodeIntelligenceProps,

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -116,6 +116,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                 globbing={globbing}
                                 repo={repo}
                                 repoName={repoName}
+                                useActionItemsBar={context.useActionItemsBar}
                                 isSourcegraphDotCom={context.isSourcegraphDotCom}
                                 className={styles.pageContent}
                             />

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -363,33 +363,38 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, ..
     const alwaysRender = (
         <>
             <PageTitle title={getPageTitle()} />
-            {window.context.isAuthenticatedUser && (
-                <RepoHeaderContributionPortal
-                    position="right"
-                    priority={112}
-                    id="open-in-editor-action"
-                    repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
-                >
-                    {({ actionType }) => (
-                        <OpenInEditorActionItem
-                            platformContext={props.platformContext}
-                            externalServiceType={props.repoServiceType}
-                            actionType={actionType}
-                            source="repoHeader"
-                        />
+            {!window.context.enableLegacyExtensions ? (
+                <>
+                    {window.context.isAuthenticatedUser && (
+                        <RepoHeaderContributionPortal
+                            position="right"
+                            priority={112}
+                            id="open-in-editor-action"
+                            repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
+                        >
+                            {({ actionType }) => (
+                                <OpenInEditorActionItem
+                                    platformContext={props.platformContext}
+                                    externalServiceType={props.repoServiceType}
+                                    actionType={actionType}
+                                    source="repoHeader"
+                                />
+                            )}
+                        </RepoHeaderContributionPortal>
                     )}
-                </RepoHeaderContributionPortal>
-            )}
-            <RepoHeaderContributionPortal
-                position="right"
-                priority={111}
-                id="toggle-blame-action"
-                repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
-            >
-                {({ actionType }) => (
-                    <ToggleBlameAction actionType={actionType} source="repoHeader" renderMode={renderMode} />
-                )}
-            </RepoHeaderContributionPortal>
+                    <RepoHeaderContributionPortal
+                        position="right"
+                        priority={111}
+                        id="toggle-blame-action"
+                        repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
+                    >
+                        {({ actionType }) => (
+                            <ToggleBlameAction actionType={actionType} source="repoHeader" renderMode={renderMode} />
+                        )}
+                    </RepoHeaderContributionPortal>
+                </>
+            ) : null}
+
             <RepoHeaderContributionPortal
                 position="right"
                 priority={20}

--- a/client/web/src/repo/repoContainerRoutes.tsx
+++ b/client/web/src/repo/repoContainerRoutes.tsx
@@ -1,5 +1,7 @@
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
+import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
+
 import { RepoRevisionWrapper } from './components/RepoRevision'
 import { RepoContainerRoute } from './RepoContainer'
 
@@ -15,6 +17,10 @@ const RepositoryReleasesArea = lazyComponent(
 )
 const RepositoryCompareArea = lazyComponent(() => import('./compare/RepositoryCompareArea'), 'RepositoryCompareArea')
 const RepositoryStatsArea = lazyComponent(() => import('./stats/RepositoryStatsArea'), 'RepositoryStatsArea')
+const ActionItemsBar = lazyComponent<ActionItemsBarProps, 'ActionItemsBar'>(
+    () => import('../extensions/components/ActionItemsBar'),
+    'ActionItemsBar'
+)
 
 export const compareSpecPath = '/-/compare/*'
 
@@ -24,6 +30,15 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
         render: context => (
             <RepoRevisionWrapper>
                 <RepositoryCommitPage {...context} />
+                {window.context.enableLegacyExtensions && (
+                    <ActionItemsBar
+                        extensionsController={context.extensionsController}
+                        platformContext={context.platformContext}
+                        useActionItemsBar={context.useActionItemsBar}
+                        telemetryService={context.telemetryService}
+                        source="commit"
+                    />
+                )}
             </RepoRevisionWrapper>
         ),
     },
@@ -40,6 +55,15 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
         render: context => (
             <RepoRevisionWrapper>
                 <RepositoryCompareArea {...context} />
+                {window.context.enableLegacyExtensions && (
+                    <ActionItemsBar
+                        extensionsController={context.extensionsController}
+                        platformContext={context.platformContext}
+                        useActionItemsBar={context.useActionItemsBar}
+                        telemetryService={context.telemetryService}
+                        source="compare"
+                    />
+                )}
             </RepoRevisionWrapper>
         ),
     },

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -2,11 +2,18 @@ import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
+import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
+
 import { RepoRevisionContainerRoute } from './RepoRevisionContainer'
 
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
 
 const RepositoryFileTreePage = lazyComponent(() => import('./RepositoryFileTreePage'), 'RepositoryFileTreePage')
+
+const ActionItemsBar = lazyComponent<ActionItemsBarProps, 'ActionItemsBar'>(
+    () => import('../extensions/components/ActionItemsBar'),
+    'ActionItemsBar'
+)
 
 // Work around the issue that react router can not match nested splats when the URL contains spaces
 // by expanding the repo matcher to an optional path of up to 10 segments.
@@ -35,6 +42,16 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
         render: props => (
             <TraceSpanProvider name="RepositoryFileTreePage" attributes={{ objectType }}>
                 <RepositoryFileTreePage {...props} objectType={objectType} />
+                {window.context.enableLegacyExtensions && (
+                    <ActionItemsBar
+                        repo={props.repo}
+                        useActionItemsBar={props.useActionItemsBar}
+                        extensionsController={props.extensionsController}
+                        platformContext={props.platformContext}
+                        telemetryService={props.telemetryService}
+                        source={objectType === 'blob' ? 'blob' : undefined}
+                    />
+                )}
             </TraceSpanProvider>
         ),
     })),

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -35,6 +35,7 @@ import { RepoBatchChangesButton } from '../../batches/RepoBatchChangesButton'
 import { CodeIntelligenceProps } from '../../codeintel'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
+import { ActionItemsBarProps } from '../../extensions/components/ActionItemsBar'
 import { RepositoryFields } from '../../graphql-operations'
 import { basename } from '../../util/path'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
@@ -59,6 +60,7 @@ interface Props
     commitID: string
     revision: string
     globbing: boolean
+    useActionItemsBar: ActionItemsBarProps['useActionItemsBar']
     isSourcegraphDotCom: boolean
     className?: string
 }
@@ -83,6 +85,7 @@ export const TreePage: FC<Props> = ({
     useBreadcrumb,
     codeIntelligenceEnabled,
     batchChangesEnabled,
+    useActionItemsBar,
     isSourcegraphDotCom,
     className,
     ...props

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -43,7 +43,9 @@ interface SearchConsolePageProps
 export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<SearchConsolePageProps>> = props => {
     const location = useLocation()
     const navigate = useNavigate()
-    const { globbing, streamSearch, isSourcegraphDotCom } = props
+    const { globbing, streamSearch, extensionsController, isSourcegraphDotCom } = props
+    const extensionHostAPI =
+        extensionsController !== null && window.context.enableLegacyExtensions ? extensionsController.extHostAPI : null
     const enableGoImportsSearchQueryTransform = useExperimentalFeatures(
         features => features.enableGoImportsSearchQueryTransform
     )
@@ -70,10 +72,11 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
 
         return transformSearchQuery({
             query,
+            extensionHostAPIPromise: extensionHostAPI,
             enableGoImportsSearchQueryTransform,
             eventLogger,
         })
-    }, [location.search, enableGoImportsSearchQueryTransform])
+    }, [location.search, extensionHostAPI, enableGoImportsSearchQueryTransform])
 
     const autocompletion = useMemo(
         () =>

--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -5,6 +5,7 @@ import {
     mockFetchSearchContexts,
     mockGetUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
+import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
 import { WebStory } from '../../components/WebStory'
 import { MockedFeatureFlagsProvider } from '../../featureFlags/MockedFeatureFlagsProvider'
@@ -17,6 +18,7 @@ const defaultProps: SearchPageProps = {
         final: null,
         subjects: null,
     },
+    extensionsController,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     authenticatedUser: null,
     globbing: false,

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -4,6 +4,7 @@ import { mdiArrowRight } from '@mdi/js'
 import classNames from 'classnames'
 
 import { QueryExamples } from '@sourcegraph/branded/src/search-ui/components/QueryExamples'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { QueryState, SearchContextInputProps } from '@sourcegraph/shared/src/search'
@@ -29,6 +30,7 @@ import styles from './SearchPage.module.scss'
 export interface SearchPageProps
     extends SettingsCascadeProps<Settings>,
         TelemetryProps,
+        ExtensionsControllerProps<'extHostAPI' | 'executeCommand'>,
         PlatformContextProps<'settings' | 'sourcegraphURL' | 'updateSettings' | 'requestGraphQL'>,
         SearchContextInputProps,
         CodeInsightsProps {

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -3,6 +3,7 @@ import { NEVER } from 'rxjs'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { SearchPatternType } from '../../graphql-operations'
@@ -10,6 +11,7 @@ import { SearchPatternType } from '../../graphql-operations'
 import { SearchResultsInfoBar, SearchResultsInfoBarProps } from './SearchResultsInfoBar'
 
 const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
+    extensionsController,
     platformContext: { settings: NEVER, sourcegraphURL: 'https://sourcegraph.com' },
     authenticatedUser: {
         id: 'userID',
@@ -38,6 +40,12 @@ const renderSearchResultsInfoBar = (
     )
 
 describe('SearchResultsInfoBar', () => {
+    beforeAll(() => {
+        window.context = {
+            enableLegacyExtensions: false,
+        } as any
+    })
+
     test('code monitoring feature flag disabled', () => {
         expect(
             renderSearchResultsInfoBar({ query: 'foo type:diff', enableCodeMonitoring: false }).asFragment()

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -6,6 +6,7 @@ import { SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
+    extensionsController,
     HIGHLIGHTED_FILE_LINES_LONG_REQUEST,
     MULTIPLE_SEARCH_RESULT,
     REPO_MATCH_RESULTS_WITH_METADATA,
@@ -32,6 +33,7 @@ const streamingSearchResult: AggregateStreamingSearchResults = {
 }
 
 const defaultProps: StreamingSearchResultsProps = {
+    extensionsController,
     telemetryService: NOOP_TELEMETRY_SERVICE,
 
     authenticatedUser: {

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -13,6 +13,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
     COLLAPSABLE_SEARCH_RESULT,
+    extensionsController,
     HIGHLIGHTED_FILE_LINES_REQUEST,
     MULTIPLE_SEARCH_RESULT,
     REPO_MATCH_RESULT,
@@ -32,6 +33,7 @@ describe('StreamingSearchResults', () => {
     const streamingSearchResult = MULTIPLE_SEARCH_RESULT
 
     const defaultProps: StreamingSearchResultsProps = {
+        extensionsController,
         telemetryService: NOOP_TELEMETRY_SERVICE,
 
         authenticatedUser: null,
@@ -78,6 +80,9 @@ describe('StreamingSearchResults', () => {
             searchCaseSensitivity: false,
             searchQueryFromURL: 'r:golang/oauth2 test f:travis',
         })
+        window.context = {
+            enableLegacyExtensions: false,
+        } as any
     })
 
     it('should call streaming search API with the right parameters from URL', async () => {

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -19,6 +19,10 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         class="nav align-items-center"
       >
         <li
+          aria-hidden="true"
+          class="divider"
+        />
+        <li
           class="mr-2 navItem"
         >
           <button
@@ -92,6 +96,10 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
       <ul
         class="nav align-items-center"
       >
+        <li
+          aria-hidden="true"
+          class="divider"
+        />
         <li
           class="mr-2 navItem"
         >
@@ -167,6 +175,10 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         class="nav align-items-center"
       >
         <li
+          aria-hidden="true"
+          class="divider"
+        />
+        <li
           class="mr-2 navItem"
         >
           <button
@@ -241,6 +253,10 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         class="nav align-items-center"
       >
         <li
+          aria-hidden="true"
+          class="divider"
+        />
+        <li
           class="mr-2 navItem"
         >
           <button
@@ -314,6 +330,10 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
       <ul
         class="nav align-items-center"
       >
+        <li
+          aria-hidden="true"
+          class="divider"
+        />
         <li
           class="mr-2 navItem"
         >

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -265,6 +265,14 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
 
 function setDiagnosticsOptions(editor: typeof monaco, jsonSchema: JSONSchema | undefined): void {
     const schema = { ...settingsSchema, properties: { ...settingsSchema.properties } }
+    if (!window.context.enableLegacyExtensions) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties.extensions
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- we need to remove this key conditionally, but not from the schema
+        // @ts-ignore
+        delete schema.properties['extensions.activeLoggers']
+    }
     editor.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,
         allowComments: true,

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -2,24 +2,26 @@ import * as React from 'react'
 
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import { combineLatest, Observable, Subject, Subscription } from 'rxjs'
+import { combineLatest, Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 
 import { asError, createAggregateError, ErrorLike, isErrorLike, logger } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
+import { extensionIDsFromSettings } from '@sourcegraph/shared/src/extensions/extension'
+import { queryConfiguredRegistryExtensions } from '@sourcegraph/shared/src/extensions/helpers'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { SettingsCascadeProps, SettingsSubject } from '@sourcegraph/shared/src/settings/settings'
+import { gqlToCascade, SettingsCascadeProps, SettingsSubject } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, ErrorMessage } from '@sourcegraph/wildcard'
 
-import settingsSchemaJSON from '../../../../schema/settings.schema.json'
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { HeroPage } from '../components/HeroPage'
 import { SettingsCascadeResult } from '../graphql-operations'
 import { eventLogger } from '../tracking/eventLogger'
 
+import { mergeSettingsSchemas } from './configuration'
 import { SettingsPage } from './SettingsPage'
 
 /** Props shared by SettingsArea and its sub-pages. */
@@ -90,7 +92,11 @@ export class SettingsArea extends React.Component<Props, State> {
                 .pipe(
                     switchMap(([{ id }]) =>
                         fetchSettingsCascade(id).pipe(
-                            map(cascade => ({ subjects: cascade.subjects, settingsJSONSchema: settingsSchemaJSON })),
+                            switchMap(cascade =>
+                                this.getMergedSettingsJSONSchema(cascade).pipe(
+                                    map(settingsJSONSchema => ({ subjects: cascade.subjects, settingsJSONSchema }))
+                                )
+                            ),
                             catchError(error => [asError(error)]),
                             map(dataOrError => ({ dataOrError }))
                         )
@@ -171,6 +177,25 @@ export class SettingsArea extends React.Component<Props, State> {
     }
 
     private onUpdate = (): void => this.refreshRequests.next()
+
+    private getMergedSettingsJSONSchema(cascade: SettingsSubjects): Observable<{ $id: string }> {
+        return queryConfiguredRegistryExtensions(
+            this.props.platformContext,
+            extensionIDsFromSettings(gqlToCascade(cascade))
+        )
+            .pipe(
+                catchError(error => {
+                    logger.warn('Unable to get extension settings JSON Schemas for settings editor.', { error })
+                    return of([])
+                })
+            )
+            .pipe(
+                map(extensions => ({
+                    $id: 'mergedSettings.schema.json#',
+                    ...mergeSettingsSchemas(extensions),
+                }))
+            )
+    }
 }
 
 function fetchSettingsCascade(subject: Scalars['ID']): Observable<SettingsSubjects> {

--- a/client/web/src/settings/configuration.test.ts
+++ b/client/web/src/settings/configuration.test.ts
@@ -1,0 +1,66 @@
+import settingsSchemaJSON from '../../../../schema/settings.schema.json'
+
+import { mergeSettingsSchemas } from './configuration'
+
+describe('mergeSettingsSchemas', () => {
+    test('handles empty', () =>
+        expect(mergeSettingsSchemas([])).toEqual({
+            allOf: [{ $ref: settingsSchemaJSON.$id }],
+        }))
+
+    test('overwrites additionalProperties and required', () =>
+        expect(
+            mergeSettingsSchemas([
+                {
+                    manifest: {
+                        contributes: {
+                            configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
+                        },
+                    },
+                },
+                {
+                    manifest: {
+                        contributes: {
+                            configuration: { required: ['b'], properties: { b: { type: 'string' } } },
+                        },
+                    },
+                },
+            ])
+        ).toEqual({
+            allOf: [
+                { $ref: settingsSchemaJSON.$id },
+                { additionalProperties: true, required: [], properties: { a: { type: 'string' } } },
+                { additionalProperties: true, required: [], properties: { b: { type: 'string' } } },
+            ],
+        }))
+
+    test('handles error and null configuration', () =>
+        expect(
+            mergeSettingsSchemas([
+                {
+                    manifest: {
+                        contributes: {
+                            configuration: { additionalProperties: false, properties: { a: { type: 'string' } } },
+                        },
+                    },
+                },
+                {
+                    manifest: new Error('x'),
+                },
+                {
+                    manifest: null,
+                },
+                {
+                    manifest: {},
+                },
+                {
+                    manifest: { contributes: {} },
+                },
+            ])
+        ).toEqual({
+            allOf: [
+                { $ref: settingsSchemaJSON.$id },
+                { additionalProperties: true, required: [], properties: { a: { type: 'string' } } },
+            ],
+        }))
+})

--- a/client/web/src/settings/configuration.ts
+++ b/client/web/src/settings/configuration.ts
@@ -1,0 +1,54 @@
+import { isErrorLike } from '@sourcegraph/common'
+import { ConfiguredExtension } from '@sourcegraph/shared/src/extensions/extension'
+
+import settingsSchemaJSON from '../../../../schema/settings.schema.json'
+
+/**
+ * Merges settings schemas from base settings and all configured extensions.
+ *
+ * @param configuredExtensions
+ * @returns A JSON Schema that describes an instance of settings for a particular subject.
+ */
+export function mergeSettingsSchemas(configuredExtensions: Pick<ConfiguredExtension<'contributes'>, 'manifest'>[]): {
+    allOf: object
+} {
+    return {
+        allOf: [
+            { $ref: settingsSchemaJSON.$id },
+            ...(configuredExtensions || [])
+                .map(configuredExtension => {
+                    if (
+                        configuredExtension.manifest &&
+                        !isErrorLike(configuredExtension.manifest) &&
+                        configuredExtension.manifest.contributes?.configuration
+                    ) {
+                        // Adjust the schema to describe a valid instance of settings for a subject (instead of the
+                        // final, merged settings).
+                        //
+                        // This is necessary to avoid erroneous validation errors. For example, suppose an extension's
+                        // configuration schema declares that the property "x" is required. For the configuration to be
+                        // valid, "x" may be set in global, organization, or user settings. It is valid for user
+                        // settings to NOT contain "x" (if global or organization settings contains "x").
+                        //
+                        // The JSON Schema returned by mergeSettingsSchema is used for a single subject's settings
+                        // (e.g., for user settings in the above example). Therefore, we must allow additionalProperties
+                        // and set required to [] to avoid erroneous validation errors.
+                        return {
+                            ...configuredExtension.manifest.contributes.configuration,
+
+                            // Force allow additionalProperties to prevent any single extension's configuration schema
+                            // from invalidating all other extensions' configuration properties.
+                            additionalProperties: true,
+
+                            // Force no required properties because this instance is only the settings for a single
+                            // subject. It is possible that a required property is specified at a different subject in
+                            // the cascade, in which case we don't want to report this instance as invalid.
+                            required: [],
+                        }
+                    }
+                    return true // JSON Schema that matches everything
+                })
+                .filter(schema => schema !== true), // omit trivial JSON Schemas
+        ],
+    }
+}

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -9,6 +10,63 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
+
+var builtinExtensions = map[string]bool{
+	"sourcegraph/apex":       true,
+	"sourcegraph/clojure":    true,
+	"sourcegraph/cobol":      true,
+	"sourcegraph/cpp":        true,
+	"sourcegraph/csharp":     true,
+	"sourcegraph/cuda":       true,
+	"sourcegraph/dart":       true,
+	"sourcegraph/elixir":     true,
+	"sourcegraph/erlang":     true,
+	"sourcegraph/git-extras": true,
+	"sourcegraph/go":         true,
+	"sourcegraph/graphql":    true,
+	"sourcegraph/groovy":     true,
+	"sourcegraph/haskell":    true,
+	"sourcegraph/java":       true,
+	"sourcegraph/jsonnet":    true,
+	"sourcegraph/kotlin":     true,
+	"sourcegraph/lisp":       true,
+	"sourcegraph/lua":        true,
+	"sourcegraph/ocaml":      true,
+	"sourcegraph/pascal":     true,
+	"sourcegraph/perl":       true,
+	"sourcegraph/php":        true,
+	"sourcegraph/powershell": true,
+	"sourcegraph/protobuf":   true,
+	"sourcegraph/python":     true,
+	"sourcegraph/r":          true,
+	"sourcegraph/ruby":       true,
+	"sourcegraph/rust":       true,
+	"sourcegraph/scala":      true,
+	"sourcegraph/shell":      true,
+	"sourcegraph/starlark":   true,
+	"sourcegraph/swift":      true,
+	"sourcegraph/tcl":        true,
+	"sourcegraph/thrift":     true,
+	"sourcegraph/typescript": true,
+	"sourcegraph/verilog":    true,
+	"sourcegraph/vhdl":       true,
+}
+
+func defaultSettings() map[string]any {
+	extensionIDs := []string{}
+	for id := range builtinExtensions {
+		extensionIDs = append(extensionIDs, id)
+	}
+	extensions := map[string]bool{}
+	for _, id := range extensionIDs {
+		extensions[id] = true
+	}
+
+	return map[string]any{
+		"experimentalFeatures": map[string]any{},
+		"extensions":           extensions,
+	}
+}
 
 const singletonDefaultSettingsGQLID = "DefaultSettings"
 
@@ -24,7 +82,11 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: "{}"}
+	contents, err := json.Marshal(defaultSettings())
+	if err != nil {
+		return nil, err
+	}
+	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: string(contents)}
 	return &settingsResolver{r.db, &settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -1,0 +1,61 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var ErrExtensionsDisabled = errors.New("extensions are disabled in site configuration (contact the site admin to enable extensions)")
+
+func (r *schemaResolver) ExtensionRegistry(ctx context.Context) (ExtensionRegistryResolver, error) {
+	reg := ExtensionRegistry(r.db)
+	if conf.Extensions() == nil {
+		return nil, ErrExtensionsDisabled
+	}
+	return reg, nil
+}
+
+// ExtensionRegistry is the implementation of the GraphQL type ExtensionRegistry.
+var ExtensionRegistry func(db database.DB) ExtensionRegistryResolver
+
+// ExtensionRegistryResolver is the interface for the GraphQL type ExtensionRegistry.
+type ExtensionRegistryResolver interface {
+	Extensions(context.Context, *RegistryExtensionConnectionArgs) (RegistryExtensionConnection, error)
+}
+
+type RegistryExtensionConnectionArgs struct {
+	graphqlutil.ConnectionArgs
+	ExtensionIDs *[]string
+}
+
+// NodeToRegistryExtension is called to convert GraphQL node values to values of type
+// RegistryExtension. It is assigned at init time.
+var NodeToRegistryExtension func(any) (RegistryExtension, bool)
+
+// RegistryExtensionByID is called to look up values of GraphQL type RegistryExtension. It is
+// assigned at init time.
+var RegistryExtensionByID func(context.Context, database.DB, graphql.ID) (RegistryExtension, error)
+
+// RegistryExtension is the interface for the GraphQL type RegistryExtension.
+type RegistryExtension interface {
+	ID() graphql.ID
+	ExtensionID() string
+	Manifest(ctx context.Context) (ExtensionManifest, error)
+}
+
+// ExtensionManifest is the interface for the GraphQL type ExtensionManifest.
+type ExtensionManifest interface {
+	Raw() string
+	JSONFields(*struct{ Fields []string }) JSONValue
+}
+
+// RegistryExtensionConnection is the interface for the GraphQL type RegistryExtensionConnection.
+type RegistryExtensionConnection interface {
+	Nodes(context.Context) ([]RegistryExtension, error)
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -636,6 +636,9 @@ func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schema
 		"GitCommit": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return r.gitCommitByID(ctx, id)
 		},
+		"RegistryExtension": func(ctx context.Context, id graphql.ID) (Node, error) {
+			return RegistryExtensionByID(ctx, db, id)
+		},
 		"SavedSearch": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return r.savedSearchByID(ctx, id)
 		},

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -196,6 +196,13 @@ func (r *NodeResolver) ToGitCommit() (*GitCommitResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToRegistryExtension() (RegistryExtension, bool) {
+	if NodeToRegistryExtension == nil {
+		return nil, false
+	}
+	return NodeToRegistryExtension(r.Node)
+}
+
 func (r *NodeResolver) ToSavedSearch() (*savedSearchResolver, bool) {
 	n, ok := r.Node.(*savedSearchResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -245,6 +245,7 @@ type Mutation {
 
     - All user data (access tokens, email addresses, external account info, survey responses, etc)
     - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
+    - Sourcegraph extensions published by the user.
     - User, Organization, or Global settings authored by the user.
     """
     deleteUser(user: ID!, hard: Boolean): EmptyResponse
@@ -1597,6 +1598,10 @@ type Query {
         """
         first: Int
     ): SurveyResponseConnection!
+    """
+    The extension registry.
+    """
+    extensionRegistry: ExtensionRegistry!
     """
     FOR INTERNAL USE ONLY: Lists all status messages
     """
@@ -6905,6 +6910,11 @@ type Site implements SettingsSubject {
     the GLOBAL_SETTINGS_FILE environment variable, site settings edits cannot be made through the API.
     """
     allowSiteSettingsEdits: Boolean!
+    """
+    Whether to enable the extension registry and the use of extensions.
+    Reflects the site configuration `enableLegacyExtensions` experimental feature value.
+    """
+    enableLegacyExtensions: Boolean!
 
     """
     FOR INTERNAL USE ONLY: Returns information about instance upgrade readiness.
@@ -8010,6 +8020,75 @@ type ProductLicenseInfo {
     The date when this license expires.
     """
     expiresAt: DateTime!
+}
+
+"""
+An extension registry.
+"""
+type ExtensionRegistry {
+    """
+    A list of extensions published in the extension registry.
+    """
+    extensions(
+        """
+        Returns the first n extensions from the list.
+        """
+        first: Int
+        """
+        Returns only extensions with the given IDs.
+        """
+        extensionIDs: [String!]
+    ): RegistryExtensionConnection!
+}
+
+"""
+An extension's listing in the extension registry.
+"""
+type RegistryExtension implements Node {
+    """
+    The unique, opaque, permanent ID of the extension. Do not display this ID to the user; display
+    RegistryExtension.extensionID instead (it is friendlier and still unique, but it can be renamed).
+    """
+    id: ID!
+    """
+    The qualified, unique name that refers to this extension, consisting of the registry name (if non-default),
+    publisher's name, and the extension's name, all joined by "/" (for example, "acme-corp/my-extension-name").
+    """
+    extensionID: String!
+    """
+    The extension manifest, or null if none is set.
+    """
+    manifest: ExtensionManifest
+}
+
+"""
+A description of the extension, how to run or access it, and when to activate it.
+"""
+type ExtensionManifest {
+    """
+    The raw JSON (or JSONC) contents of the manifest. This value may be large (because many
+    manifests contain README and icon data), and it is JSONC (not strict JSON), which means
+    it must be parsed with a JSON parser that supports trailing commas and comments. Consider
+    using jsonFields instead.
+    """
+    raw: String!
+    """
+    The manifest as JSON (not JSONC, even if the raw manifest is JSONC) with only the
+    specified fields. This is useful for callers that only need certain fields and want
+    to avoid fetching a large amount of data (because many manifests contain README
+    and icon data).
+    """
+    jsonFields(fields: [String!]!): JSONValue!
+}
+
+"""
+A list of registry extensions.
+"""
+type RegistryExtensionConnection {
+    """
+    A list of registry extensions.
+    """
+    nodes: [RegistryExtension!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -230,6 +230,10 @@ func canUpdateSiteConfiguration() bool {
 	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
 }
 
+func (r *siteResolver) EnableLegacyExtensions() bool {
+	return conf.ExperimentalFeatures().EnableLegacyExtensions
+}
+
 func (r *siteResolver) UpgradeReadiness(ctx context.Context) (*upgradeReadinessResolver, error) {
 	// 🚨 SECURITY: Only site admins may view upgrade readiness information.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -164,6 +164,8 @@ type JSContext struct {
 
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
 
+	EnableLegacyExtensions bool `json:"enableLegacyExtensions"`
+
 	LicenseInfo *hooks.LicenseInfo `json:"licenseInfo"`
 
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit"`
@@ -306,6 +308,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		ProductResearchPageEnabled: conf.ProductResearchPageEnabled(),
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
+
+		EnableLegacyExtensions: conf.ExperimentalFeatures().EnableLegacyExtensions,
 
 		LicenseInfo: licenseInfo,
 

--- a/cmd/frontend/internal/app/ui/legacy_extensions_redirects.go
+++ b/cmd/frontend/internal/app/ui/legacy_extensions_redirects.go
@@ -1,0 +1,12 @@
+package ui
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+func ShouldRedirectLegacyExtensionEndpoints() bool {
+	if conf.ExperimentalFeatures().EnableLegacyExtensions {
+		return false
+	}
+	return true
+}

--- a/cmd/frontend/internal/app/ui/legacy_extensions_redirects_test.go
+++ b/cmd/frontend/internal/app/ui/legacy_extensions_redirects_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestLegacyExtensionsRedirects(t *testing.T) {
@@ -35,4 +37,40 @@ func TestLegacyExtensionsRedirects(t *testing.T) {
 			t.Errorf("%s: expected router to redirect to root page but got %s", oldURL, got)
 		}
 	}
+}
+
+func TestLegacyExtensionsRedirectsWithExtensionsEnabled(t *testing.T) {
+	enableLegacyExtensions()
+	defer conf.Mock(nil)
+
+	InitRouter(database.NewMockDB())
+	router := Router()
+
+	tests := []string{
+		"/extensions",
+		"/extensions/sourcegraph/codecov",
+		"/extensions/sourcegraph/codecov/-/manifest",
+		"/-/static/extension/13594-sourcegraph-codecov.js",
+	}
+	for i := range tests {
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", tests[i], nil)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		router.ServeHTTP(rw, req)
+
+		if got := rw.Header().Get("location"); got != "" {
+			t.Errorf("%s: expected router to not redirect to root page but got %s", tests[i], got)
+		}
+	}
+}
+
+func enableLegacyExtensions() {
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			EnableLegacyExtensions: true,
+		},
+	}})
 }

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -273,10 +273,12 @@ func initRouter(db database.DB, router *mux.Router) {
 	router.Get(routeSurvey).Handler(brandedNoIndex("Survey"))
 	router.Get(routeSurveyScore).Handler(brandedNoIndex("Survey"))
 	router.Get(routeRegistry).Handler(brandedNoIndex("Registry"))
-	if envvar.SourcegraphDotComMode() {
+	if ShouldRedirectLegacyExtensionEndpoints() {
 		router.Get(routeExtensions).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/", http.StatusMovedPermanently)
 		})
+	} else {
+		router.Get(routeExtensions).Handler(brandedIndex("Extensions"))
 	}
 	router.Get(routeHelp).HandlerFunc(serveHelp)
 	router.Get(routeSnippets).Handler(brandedNoIndex("Snippets"))

--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func (r *extensionRegistryResolver) Extensions(ctx context.Context, args *graphqlbackend.RegistryExtensionConnectionArgs) (graphqlbackend.RegistryExtensionConnection, error) {
+	return &registryExtensionConnectionResolver{
+		args:                         *args,
+		db:                           r.db,
+		listRemoteRegistryExtensions: listRemoteRegistryExtensions,
+	}, nil
+}
+
+// registryExtensionConnectionResolver resolves a list of registry extensions.
+type registryExtensionConnectionResolver struct {
+	args graphqlbackend.RegistryExtensionConnectionArgs
+
+	db                           database.DB
+	listRemoteRegistryExtensions func(_ context.Context, query string) ([]*registry.Extension, error)
+
+	// cache results because they are used by multiple fields
+	once               sync.Once
+	registryExtensions []graphqlbackend.RegistryExtension
+	err                error
+}
+
+func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.RegistryExtension, error) {
+	r.once.Do(func() {
+		args2 := r.args
+		if args2.First != nil {
+			tmp := *args2.First
+			tmp++ // so we can detect if there is a next page
+			args2.First = &tmp
+		}
+
+		// Query remote registry extensions, if filters would match any.
+		var remote []*registry.Extension
+		xs, err := r.listRemoteRegistryExtensions(ctx, "")
+		if err != nil {
+			// Continue execution even if r.err != nil so that partial (local) results are returned
+			// even when the remote registry is inaccessible.
+			r.err = err
+		}
+
+		if r.args.ExtensionIDs == nil {
+			remote = append(remote, xs...)
+		} else {
+			// The ExtensionIDs arg ("only include extensions specified by these IDs") is not
+			// applied at query time for remote extensions, so apply it here.
+			include := map[string]struct{}{}
+			for _, id := range *r.args.ExtensionIDs {
+				include[id] = struct{}{}
+			}
+			for _, x := range xs {
+				if _, ok := include[x.ExtensionID]; ok {
+					remote = append(remote, x)
+				}
+			}
+		}
+
+		r.registryExtensions = make([]graphqlbackend.RegistryExtension, len(remote))
+		for i, x := range remote {
+			r.registryExtensions[i] = &registryExtensionRemoteResolver{v: x}
+		}
+
+		sort.SliceStable(r.registryExtensions, func(i, j int) bool {
+			return r.registryExtensions[i].ExtensionID() < r.registryExtensions[j].ExtensionID()
+		})
+
+		allowedExtensions := ExtensionRegistryListAllowedExtensions()
+		if allowedExtensions != nil {
+			filteredExtensions := []graphqlbackend.RegistryExtension{}
+			for i := range r.registryExtensions {
+				ext := r.registryExtensions[i]
+				if _, ok := allowedExtensions[ext.ExtensionID()]; ok {
+					filteredExtensions = append(filteredExtensions, ext)
+				}
+			}
+			r.registryExtensions = filteredExtensions
+		}
+	})
+	return r.registryExtensions, r.err
+}
+
+func (r *registryExtensionConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.RegistryExtension, error) {
+	xs, _ := r.compute(ctx)
+	if r.args.First != nil && len(xs) > int(*r.args.First) {
+		xs = xs[:int(*r.args.First)]
+	}
+	return xs, nil
+}

--- a/cmd/frontend/registry/api/extension_connection_graphql_test.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+func TestRegistryExtensionConnectionResolver(t *testing.T) {
+	enableLegacyExtensions()
+	defer conf.Mock(nil)
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	stringSlicePtr := func(s []string) *[]string { return &s }
+	extensionIDs := func(xs []graphqlbackend.RegistryExtension) (ids []string) {
+		for _, x := range xs {
+			ids = append(ids, x.ExtensionID())
+		}
+		return ids
+	}
+
+	ctx := context.Background()
+
+	t.Run("extensionIDs", func(t *testing.T) {
+		r := registryExtensionConnectionResolver{
+			args: graphqlbackend.RegistryExtensionConnectionArgs{
+				ExtensionIDs: stringSlicePtr([]string{"a/a"}),
+			},
+			listRemoteRegistryExtensions: func(_ context.Context, query string) ([]*registry.Extension, error) {
+				return []*registry.Extension{
+					{ExtensionID: "a/b", Manifest: strptr(`{}`)},
+					{ExtensionID: "a/a", Manifest: strptr(`{}`)},
+				}, nil
+			},
+		}
+
+		nodes, err := r.Nodes(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ids, want := extensionIDs(nodes), []string{"a/a"}; !reflect.DeepEqual(ids, want) {
+			t.Errorf("got ids %v, want %v", ids, want)
+		}
+	})
+}
+
+func strptr(s string) *string { return &s }

--- a/cmd/frontend/registry/api/extension_graphql.go
+++ b/cmd/frontend/registry/api/extension_graphql.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func init() {
+	graphqlbackend.NodeToRegistryExtension = func(node any) (graphqlbackend.RegistryExtension, bool) {
+		n, ok := node.(*registryExtensionRemoteResolver)
+		return n, ok
+	}
+
+	graphqlbackend.RegistryExtensionByID = registryExtensionByID
+}
+
+// RegistryExtensionID identifies a registry extension.
+type RegistryExtensionID struct {
+	RemoteID *registryExtensionRemoteID `json:"r,omitempty"`
+}
+
+func MarshalRegistryExtensionID(id RegistryExtensionID) graphql.ID {
+	return relay.MarshalID("RegistryExtension", id)
+}
+
+func UnmarshalRegistryExtensionID(id graphql.ID) (registryExtensionID RegistryExtensionID, err error) {
+	err = relay.UnmarshalSpec(id, &registryExtensionID)
+	return
+}
+
+func registryExtensionByID(ctx context.Context, db database.DB, id graphql.ID) (graphqlbackend.RegistryExtension, error) {
+	registryExtensionID, err := UnmarshalRegistryExtensionID(id)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case registryExtensionID.RemoteID != nil:
+		x, err := getRemoteRegistryExtension(ctx, "uuid", registryExtensionID.RemoteID.UUID)
+		if err != nil {
+			return nil, err
+		}
+		return &registryExtensionRemoteResolver{v: x}, nil
+	default:
+		return nil, errors.New("invalid registry extension ID")
+	}
+}

--- a/cmd/frontend/registry/api/extension_manifest.go
+++ b/cmd/frontend/registry/api/extension_manifest.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+)
+
+// extensionManifest implements the GraphQL type ExtensionManifest.
+type extensionManifest struct {
+	raw string
+}
+
+// NewExtensionManifest creates a new resolver for the GraphQL type ExtensionManifest with the given
+// raw contents of an extension manifest.
+func NewExtensionManifest(raw *string) graphqlbackend.ExtensionManifest {
+	if raw == nil {
+		return nil
+	}
+	return &extensionManifest{raw: *raw}
+}
+
+func (r *extensionManifest) Raw() string { return r.raw }
+
+func (r *extensionManifest) JSONFields(args *struct{ Fields []string }) graphqlbackend.JSONValue {
+	return jsonValueWithFields(r.raw, args.Fields)
+}
+
+func jsonValueWithFields(jsoncStr string, fields []string) graphqlbackend.JSONValue {
+	o := map[string]json.RawMessage{}
+	jsonc.Unmarshal(jsoncStr, &o) // ignore error and treat as empty object
+
+	keepField := func(field string) bool {
+		for _, f := range fields {
+			if f == field {
+				return true
+			}
+		}
+		return false
+	}
+	for field := range o {
+		if !keepField(field) {
+			delete(o, field)
+		}
+	}
+	return graphqlbackend.JSONValue{Value: o}
+}

--- a/cmd/frontend/registry/api/extension_manifest_test.go
+++ b/cmd/frontend/registry/api/extension_manifest_test.go
@@ -1,0 +1,39 @@
+package api
+
+import "testing"
+
+func TestJSONValueWithFields(t *testing.T) {
+	tests := map[string]struct {
+		jsoncStr string
+		fields   []string
+		want     string
+	}{
+		"invalid json top-level": {
+			jsoncStr: `{`,
+			fields:   []string{"x"},
+			want:     `{}`,
+		},
+		"invalid json in field": {
+			jsoncStr: `{"a": {"b": }, "c": 3}`,
+			fields:   []string{"a", "c"},
+			want:     `{}`,
+		},
+		"subset of fields": {
+			jsoncStr: `{"a": 1, "b": {"c": 3,}, "d": true,}`,
+			fields:   []string{"d", "b", "x"},
+			want:     `{"b":{"c":3},"d":true}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := jsonValueWithFields(test.jsoncStr, test.fields)
+			got, err := v.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Errorf("got %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/frontend/registry/api/extension_remote_graphql.go
+++ b/cmd/frontend/registry/api/extension_remote_graphql.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+)
+
+// registryExtensionRemoteResolver implements the GraphQL type RegistryExtension with data from a
+// remote registry.
+type registryExtensionRemoteResolver struct {
+	v *registry.Extension
+}
+
+var _ graphqlbackend.RegistryExtension = &registryExtensionRemoteResolver{}
+
+func (r *registryExtensionRemoteResolver) ID() graphql.ID {
+	return MarshalRegistryExtensionID(RegistryExtensionID{
+		RemoteID: &registryExtensionRemoteID{Registry: r.v.RegistryURL, UUID: r.v.UUID},
+	})
+}
+
+// registryExtensionRemoteID identifies a registry extension on a remote registry. It is encoded in
+// RegistryExtensionID.
+type registryExtensionRemoteID struct {
+	Registry string `json:"r"`
+	UUID     string `json:"u"`
+}
+
+func (r *registryExtensionRemoteResolver) ExtensionID() string { return r.v.ExtensionID }
+
+func (r *registryExtensionRemoteResolver) Manifest(context.Context) (graphqlbackend.ExtensionManifest, error) {
+	return NewExtensionManifest(r.v.Manifest), nil
+}

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+// getRemoteRegistryURL returns the remote registry URL from site configuration, or nil if there is
+// none. If an error exists while parsing the value in site configuration, the error is returned.
+func getRemoteRegistryURL() (*url.URL, error) {
+	pc := conf.Extensions()
+	if pc == nil || pc.RemoteRegistryURL == "" {
+		return nil, nil
+	}
+	return url.Parse(pc.RemoteRegistryURL)
+}
+
+// IsRemoteExtensionAllowed reports whether to allow usage of the remote extension with the given
+// extension ID.
+//
+// It can be overridden to use custom logic.
+var IsRemoteExtensionAllowed = func(extensionID string) bool {
+	// By default, all remote extensions are allowed.
+	return true
+}
+
+// IsRemoteExtensionPublisherAllowed reports whether to allow usage of the remote extension created by
+// certain publisher by extension ID.
+//
+// It can be overridden to use custom logic.
+var IsRemoteExtensionPublisherAllowed = func(p registry.Publisher) bool {
+	// By default, all remote extensions are allowed.
+	return true
+}
+
+// getRemoteRegistryExtension gets the remote registry extension and rewrites its fields to be from
+// the frame-of-reference of this site. The field is either "uuid" or "extensionID".
+func getRemoteRegistryExtension(ctx context.Context, field, value string) (*registry.Extension, error) {
+	registryURL, err := getRemoteRegistryURL()
+	if registryURL == nil || err != nil {
+		return nil, err
+	}
+
+	var x *registry.Extension
+	switch field {
+	case "uuid":
+		x, err = registry.GetByUUID(ctx, registryURL, value)
+	case "extensionID":
+		x, err = registry.GetByExtensionID(ctx, registryURL, value)
+	default:
+		panic("unexpected field: " + field)
+	}
+	if x != nil {
+		x.RegistryURL = registryURL.String()
+	}
+
+	if x != nil && !IsRemoteExtensionAllowed(x.ExtensionID) {
+		return nil, errors.Errorf("extension is not allowed in site configuration: %q", x.ExtensionID)
+	}
+
+	if x != nil && !IsRemoteExtensionPublisherAllowed(x.Publisher) {
+		return nil, errors.Errorf("Only extensions authored by Sourcegraph are allowed in this site configuration")
+	}
+
+	return x, err
+}
+
+// listRemoteRegistryExtensions lists the remote registry extensions and rewrites their fields to be
+// from the frame-of-reference of this site.
+func listRemoteRegistryExtensions(ctx context.Context, query string) ([]*registry.Extension, error) {
+	registryURL, err := getRemoteRegistryURL()
+	if registryURL == nil || err != nil {
+		return nil, err
+	}
+
+	xs, err := registry.List(ctx, registryURL, query)
+	if err != nil {
+		return nil, err
+	}
+	for _, x := range xs {
+		x.RegistryURL = registryURL.String()
+	}
+	return xs, nil
+}

--- a/cmd/frontend/registry/api/extensions_test.go
+++ b/cmd/frontend/registry/api/extensions_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func enableLegacyExtensions() {
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			EnableLegacyExtensions: true,
+		},
+	}})
+}

--- a/cmd/frontend/registry/api/gating.go
+++ b/cmd/frontend/registry/api/gating.go
@@ -2,8 +2,51 @@ package api
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+// This list is different from the builtinExtensions since it only includes code
+// intel extensions.
+var codeIntelExtensions = map[string]bool{
+	"sourcegraph/apex":       true,
+	"sourcegraph/clojure":    true,
+	"sourcegraph/cobol":      true,
+	"sourcegraph/cpp":        true,
+	"sourcegraph/csharp":     true,
+	"sourcegraph/cuda":       true,
+	"sourcegraph/dart":       true,
+	"sourcegraph/elixir":     true,
+	"sourcegraph/erlang":     true,
+	"sourcegraph/go":         true,
+	"sourcegraph/graphql":    true,
+	"sourcegraph/groovy":     true,
+	"sourcegraph/haskell":    true,
+	"sourcegraph/java":       true,
+	"sourcegraph/jsonnet":    true,
+	"sourcegraph/kotlin":     true,
+	"sourcegraph/lisp":       true,
+	"sourcegraph/lua":        true,
+	"sourcegraph/ocaml":      true,
+	"sourcegraph/pascal":     true,
+	"sourcegraph/perl":       true,
+	"sourcegraph/php":        true,
+	"sourcegraph/powershell": true,
+	"sourcegraph/protobuf":   true,
+	"sourcegraph/python":     true,
+	"sourcegraph/r":          true,
+	"sourcegraph/ruby":       true,
+	"sourcegraph/rust":       true,
+	"sourcegraph/scala":      true,
+	"sourcegraph/shell":      true,
+	"sourcegraph/starlark":   true,
+	"sourcegraph/swift":      true,
+	"sourcegraph/tcl":        true,
+	"sourcegraph/thrift":     true,
+	"sourcegraph/typescript": true,
+	"sourcegraph/verilog":    true,
+	"sourcegraph/vhdl":       true,
+}
 
 func ExtensionRegistryReadEnabled() error {
 	// We need to allow read access to the extension registry of sourcegraph.com to allow instances
@@ -12,5 +55,34 @@ func ExtensionRegistryReadEnabled() error {
 		return nil
 	}
 
+	if conf.ExperimentalFeatures().EnableLegacyExtensions {
+		return nil
+	}
+
 	return errors.Errorf("extensions are disabled")
+}
+
+// The extensions list query (`extensionRegistry.extensions`) will be called by the native
+// integration, a deployment method where we do not have control over updating the client.
+//
+// An example for this is the GitLab native integration that ships with GitLab releases.
+// When enabled, it will make a GraphQL query to Sourcegraph to get a list of valid
+// extensions.
+//
+// Since we want to support code navigation in the native integrations after 4.0, we are
+// special-casing this API and make it return only code intel legacy extensions.
+//
+// Since the dotcom instance will be connected to from instances before 4.0, we'll need
+// to keep the behavior of being able to list all extensions there.
+//
+// This method returns nil if all extensions are allowed to be listed.
+func ExtensionRegistryListAllowedExtensions() map[string]bool {
+	err := ExtensionRegistryReadEnabled()
+
+	if err != nil {
+		return codeIntelExtensions
+	}
+
+	// nil means all extensions are allowed
+	return nil
 }

--- a/cmd/frontend/registry/api/registry_graphql.go
+++ b/cmd/frontend/registry/api/registry_graphql.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func init() {
+	graphqlbackend.ExtensionRegistry = func(db database.DB) graphqlbackend.ExtensionRegistryResolver {
+		ExtensionRegistry.db = db
+		return &ExtensionRegistry
+	}
+}
+
+// ExtensionRegistry is the implementation of the GraphQL type ExtensionRegistry.
+//
+// To supply implementations of extension registry functionality, use the fields on this value of
+// extensionRegistryResolver.
+var ExtensionRegistry extensionRegistryResolver
+
+// extensionRegistryResolver implements the GraphQL type ExtensionRegistry.
+type extensionRegistryResolver struct {
+	db database.DB
+}

--- a/internal/conf/platform.go
+++ b/internal/conf/platform.go
@@ -1,0 +1,57 @@
+package conf
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// PlatformConfiguration contains site configuration for the Sourcegraph platform.
+type PlatformConfiguration struct {
+	RemoteRegistryURL string
+}
+
+// DefaultRemoteRegistry is the default value for the site configuration property
+// "extensions"."remoteRegistry".
+//
+// It is intentionally not set in the OSS build.
+var DefaultRemoteRegistry string
+
+// Extensions returns the configuration for the Sourcegraph platform, or nil if it is disabled.
+func Extensions() *PlatformConfiguration {
+	cfg := Get()
+
+	x := cfg.Extensions
+	if x == nil {
+		if DefaultRemoteRegistry == "" {
+			// There is no reasonable default behavior for extensions given that there is no remote
+			// registry, so consider them disabled.
+			return nil
+		}
+
+		x = &schema.Extensions{}
+	}
+
+	if x.Disabled != nil && *x.Disabled {
+		return nil
+	}
+
+	var pc PlatformConfiguration
+
+	// If the "remoteRegistry" value is a string, use that. If false, then keep it empty. Otherwise
+	// use the default.
+	if s, ok := x.RemoteRegistry.(string); ok {
+		pc.RemoteRegistryURL = s
+	} else if b, ok := x.RemoteRegistry.(bool); ok && !b {
+		// Nothing to do.
+	} else {
+		pc.RemoteRegistryURL = DefaultRemoteRegistry
+	}
+
+	if v, _ := strconv.ParseBool(os.Getenv("OFFLINE")); v {
+		pc.RemoteRegistryURL = ""
+	}
+
+	return &pc
+}

--- a/internal/conf/platform_test.go
+++ b/internal/conf/platform_test.go
@@ -1,0 +1,76 @@
+package conf
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestExtensions(t *testing.T) {
+	check := func(t *testing.T, want *PlatformConfiguration) {
+		t.Helper()
+		got := Extensions()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	}
+
+	t.Run("no config and no DefaultRemoteRegistry", func(t *testing.T) {
+		DefaultRemoteRegistry = ""
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{}})
+		check(t, nil)
+	})
+
+	t.Run("no config but valid DefaultRemoteRegistry", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: "x"})
+	})
+
+	t.Run("empty config, valid DefaultRemoteRegistry", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{Extensions: &schema.Extensions{}}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: "x"})
+	})
+
+	t.Run("config extensions.disabled", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{Extensions: &schema.Extensions{Disabled: boolPtr(true)}}})
+		check(t, nil)
+	})
+
+	t.Run("config extensions.disabled false", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{Extensions: &schema.Extensions{Disabled: boolPtr(false)}}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: "x"})
+	})
+
+	t.Run("config extensions.remoteRegistry overrides DefaultRemoteRegistry", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{Extensions: &schema.Extensions{RemoteRegistry: "y"}}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: "y"})
+	})
+
+	t.Run("config extensions.remoteRegistry false", func(t *testing.T) {
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{Extensions: &schema.Extensions{RemoteRegistry: false}}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: ""})
+	})
+
+	t.Run("OFFLINE env var", func(t *testing.T) {
+		os.Setenv("OFFLINE", "1")
+		defer os.Unsetenv("OFFLINE")
+		DefaultRemoteRegistry = "x"
+		defer func() { DefaultRemoteRegistry = "" }()
+		Mock(&Unified{SiteConfiguration: schema.SiteConfiguration{}})
+		check(t, &PlatformConfiguration{RemoteRegistryURL: ""})
+	})
+}

--- a/internal/search/keyword/file_score.go
+++ b/internal/search/keyword/file_score.go
@@ -1,0 +1,14 @@
+package keyword
+
+import "strings"
+
+func getFileScore(filePath string, patterns []string) float64 {
+	filePathLowerCase := strings.ToLower(filePath)
+	count := 0
+	for _, pattern := range patterns {
+		if strings.Contains(filePathLowerCase, pattern) {
+			count += 1
+		}
+	}
+	return float64(count) / float64(len(patterns))
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -719,6 +719,8 @@ type ExperimentalFeatures struct {
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visibility of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
+	// EnableLegacyExtensions description: Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).
+	EnableLegacyExtensions bool `json:"enableLegacyExtensions,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code
@@ -808,6 +810,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")
 	delete(m, "enableGithubInternalRepoVisibility")
+	delete(m, "enableLegacyExtensions")
 	delete(m, "enablePermissionsWebhooks")
 	delete(m, "enablePostSignupFlow")
 	delete(m, "enableStorm")
@@ -852,6 +855,20 @@ type ExportUsageTelemetry struct {
 	TopicName string `json:"topicName,omitempty"`
 	// TopicProjectName description: GCP project name containing the usage data pubsub topic
 	TopicProjectName string `json:"topicProjectName,omitempty"`
+}
+
+// Extensions description: Configures Sourcegraph extensions.
+type Extensions struct {
+	// AllowOnlySourcegraphAuthoredExtensions description: Allow only Sourcegraph authored extensions from the default remote registry. If not set, all remote extensions may be used from the remote registry. If certain extensions are marked as allowed in `allowRemoteExtensions` field or `remoteRegistry` points to other than default registry, `allowOnlySourcegraphAuthoredExtensions` setting value will be ignored. To completely disable the remote registry, set `remoteRegistry` to `false`.
+	AllowOnlySourcegraphAuthoredExtensions bool `json:"allowOnlySourcegraphAuthoredExtensions,omitempty"`
+	// AllowRemoteExtensions description: Allow only the explicitly listed remote extensions (by extension ID, such as "alice/myextension") from the remote registry. If not set, all remote extensions may be used from the remote registry. To completely disable the remote registry, set `remoteRegistry` to `false`.
+	//
+	// Only available in Sourcegraph Enterprise.
+	AllowRemoteExtensions []string `json:"allowRemoteExtensions,omitempty"`
+	// Disabled description: Disable all usage of extensions.
+	Disabled *bool `json:"disabled,omitempty"`
+	// RemoteRegistry description: The remote extension registry URL, or `false` to not use a remote extension registry. If not set, the default remote extension registry URL is used.
+	RemoteRegistry any `json:"remoteRegistry,omitempty"`
 }
 type ExternalIdentity struct {
 	// AuthProviderID description: The value of the `configID` field of the targeted authentication provider.
@@ -1969,6 +1986,10 @@ type Settings struct {
 	CodeIntelligenceClickToGoToDefinition bool `json:"codeIntelligence.clickToGoToDefinition,omitempty"`
 	// ExperimentalFeatures description: Experimental features and settings.
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
+	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.
+	Extensions map[string]bool `json:"extensions,omitempty"`
+	// ExtensionsActiveLoggers description: The Sourcegraph extensions, by ID (e.g. `my/extension`), whose logs should be visible in the console.
+	ExtensionsActiveLoggers []string `json:"extensions.activeLoggers,omitempty"`
 	// FileSidebarVisibleByDefault description: Whether the sidebar on the repo view should be open by default.
 	FileSidebarVisibleByDefault bool `json:"fileSidebarVisibleByDefault,omitempty"`
 	// HistoryDefaultPageSize description: Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.
@@ -2067,6 +2088,8 @@ func (v *Settings) UnmarshalJSON(data []byte) error {
 	delete(m, "codeIntelligence.autoIndexPopularRepoLimit")
 	delete(m, "codeIntelligence.clickToGoToDefinition")
 	delete(m, "experimentalFeatures")
+	delete(m, "extensions")
+	delete(m, "extensions.activeLoggers")
 	delete(m, "fileSidebarVisibleByDefault")
 	delete(m, "history.defaultPageSize")
 	delete(m, "history.preferAbsoluteTimestamps")
@@ -2382,6 +2405,8 @@ type SiteConfiguration struct {
 	// ExperimentalFeatures description: Experimental features and settings.
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	ExportUsageTelemetry *ExportUsageTelemetry `json:"exportUsageTelemetry,omitempty"`
+	// Extensions description: Configures Sourcegraph extensions.
+	Extensions *Extensions `json:"extensions,omitempty"`
 	// ExternalServiceUserMode description: Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.
 	ExternalServiceUserMode string `json:"externalService.userMode,omitempty"`
 	// ExternalURL description: The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
@@ -2582,6 +2607,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "executors.srcCLIImageTag")
 	delete(m, "experimentalFeatures")
 	delete(m, "exportUsageTelemetry")
+	delete(m, "extensions")
 	delete(m, "externalService.userMode")
 	delete(m, "externalURL")
 	delete(m, "git.cloneURLToRepositoryName")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -570,6 +570,26 @@
       "enum": ["browser-extension", "native-integration"],
       "default": "browser-extension"
     },
+    "extensions": {
+      "description": "The Sourcegraph extensions to use. Enable an extension by adding a property `\"my/extension\": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "description": "A valid extension ID.",
+        "pattern": "^([^/]+/)?[^/]+/[^/]+$"
+      },
+      "additionalProperties": {
+        "type": "boolean",
+        "description": "`true` to enable the extension, `false` to disable the extension (if it was previously enabled)"
+      }
+    },
+    "extensions.activeLoggers": {
+      "description": "The Sourcegraph extensions, by ID (e.g. `my/extension`), whose logs should be visible in the console.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "codeHost.useNativeTooltips": {
       "description": "Whether to use the code host's native hover tooltips when they exist (GitHub's jump-to-definition tooltips, for example).",
       "type": "boolean",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -465,6 +465,11 @@
             }
           ]
         },
+        "enableLegacyExtensions": {
+          "description": "Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).",
+          "type": "boolean",
+          "default": false
+        },
         "insightsAlternateLoadingStrategy": {
           "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
           "type": "boolean",
@@ -1143,6 +1148,47 @@
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",
       "minLength": 20
+    },
+    "extensions": {
+      "description": "Configures Sourcegraph extensions.",
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "description": "Disable all usage of extensions.",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": true }
+        },
+        "remoteRegistry": {
+          "description": "The remote extension registry URL, or `false` to not use a remote extension registry. If not set, the default remote extension registry URL is used.",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "boolean", "const": false }
+          ]
+        },
+        "allowRemoteExtensions": {
+          "description": "Allow only the explicitly listed remote extensions (by extension ID, such as \"alice/myextension\") from the remote registry. If not set, all remote extensions may be used from the remote registry. To completely disable the remote registry, set `remoteRegistry` to `false`.\n\nOnly available in Sourcegraph Enterprise.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowOnlySourcegraphAuthoredExtensions": {
+          "description": "Allow only Sourcegraph authored extensions from the default remote registry. If not set, all remote extensions may be used from the remote registry. If certain extensions are marked as allowed in `allowRemoteExtensions` field or `remoteRegistry` points to other than default registry, `allowOnlySourcegraphAuthoredExtensions` setting value will be ignored. To completely disable the remote registry, set `remoteRegistry` to `false`.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "default": {
+        "remoteRegistry": "https://sourcegraph.com/.api/registry"
+      },
+      "examples": [
+        {
+          "remoteRegistry": "https://sourcegraph.com/.api/registry",
+          "allowRemoteExtensions": ["sourcegraph/java"]
+        }
+      ],
+      "group": "Extensions"
     },
     "auth.userOrgMap": {
       "description": "Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{\"*\": [\"org1\", \"org2\"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `\"*\"`.",


### PR DESCRIPTION
Backend integration tests are failing. This might be the cause.

This reverts commit e99c4145f74bab691ad60a65a4da2dcd3abf6f8a.

Test Plan: backend integration test on this PR passes.