### PR TITLE
graphqlbackend: set experimentalFeatures to empty for default settings

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -24,7 +24,7 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
 func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: "{}"}
+	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: `{"experimentalFeatures": {}}`}
 	return &settingsResolver{r.db, &settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 


### PR DESCRIPTION
We stopped doing this when we removed extensions. I think not setting this unearthed some latent bugs in our code. In particular I think what is happening for our backend integration tests is that we now longer enable search contexts for some reason.

Test Plan: backend integration tests pass.