### PR TITLE
sg: improve gen failure output and ignore vendor dir

### DIFF
--- a/dev/sg/internal/generate/golang/golang.go
+++ b/dev/sg/internal/generate/golang/golang.go
@@ -82,7 +82,8 @@ func findFilepathsWithGenerate(dir string) (map[string]struct{}, error) {
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
 
-		if entry.IsDir() {
+		// recurse in the directory, but skip the directory if it's a vendor dir
+		if entry.IsDir() && entry.Name() != "vendor" {
 			paths, err := findFilepathsWithGenerate(path)
 			if err != nil {
 				return nil, err
@@ -107,7 +108,7 @@ func findFilepathsWithGenerate(dir string) (map[string]struct{}, error) {
 			file.Close()
 
 			if err := scanner.Err(); err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "bufio.Scanner failed on file %q", path)
 			}
 		}
 	}


### PR DESCRIPTION
### The problem
If you have a vendor dir, sg would recurse into that directory and
somewhere on of the vendor dependencies will make bufio fail with the
following error:
```
Check "Go generate check" failed: bufio.Scanner: token too long
```

### The Fix
* ignore the vendor directory for go generate
* print the path bufio failed on

## Test plan
tested locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
