### PR TITLE
permissions-center: expose perms sync jobs filtering.

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -161,6 +161,14 @@ extend type Query {
         also used in conjunction with "last" to return the last N nodes.
         """
         before: String
+        """
+        Optional filter for PermissionsSyncJobReasonGroup.
+        """
+        reasonGroup: PermissionsSyncJobReasonGroup
+        """
+        Optional filter for PermissionsSyncJobState.
+        """
+        state: PermissionsSyncJobState
     ): PermissionsSyncJobsConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
@@ -58,4 +59,6 @@ type PermissionsSyncJobSubject interface {
 
 type ListPermissionsSyncJobsArgs struct {
 	graphqlutil.ConnectionResolverArgs
+	ReasonGroup *database.PermissionsSyncJobReasonGroup
+	State       *database.PermissionsSyncJobState
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -28,7 +28,7 @@ type permissionsSyncJobConnectionStore struct {
 }
 
 func (s *permissionsSyncJobConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {
-	count, err := s.db.PermissionSyncJobs().Count(ctx)
+	count, err := s.db.PermissionSyncJobs().Count(ctx, s.getListArgs(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (s *permissionsSyncJobConnectionStore) ComputeTotal(ctx context.Context) (*
 }
 
 func (s *permissionsSyncJobConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]graphqlbackend.PermissionsSyncJobResolver, error) {
-	jobs, err := s.db.PermissionSyncJobs().List(ctx, database.ListPermissionSyncJobOpts{PaginationArgs: args})
+	jobs, err := s.db.PermissionSyncJobs().List(ctx, s.getListArgs(args))
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +92,20 @@ func (s *permissionsSyncJobConnectionStore) MarshalCursor(node graphqlbackend.Pe
 
 func (s *permissionsSyncJobConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
 	return &cursor, nil
+}
+
+func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.PaginationArgs) database.ListPermissionSyncJobOpts {
+	opts := database.ListPermissionSyncJobOpts{}
+	if pageArgs != nil {
+		opts.PaginationArgs = pageArgs
+	}
+	if s.args.ReasonGroup != nil {
+		opts.ReasonGroup = *s.args.ReasonGroup
+	}
+	if s.args.State != nil {
+		opts.State = *s.args.State
+	}
+	return opts
 }
 
 type permissionsSyncJobResolver struct {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -37873,7 +37873,7 @@ func NewMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 			},
 		},
 		CountFunc: &PermissionSyncJobStoreCountFunc{
-			defaultHook: func(context.Context) (r0 int, r1 error) {
+			defaultHook: func(context.Context, ListPermissionSyncJobOpts) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -37931,7 +37931,7 @@ func NewStrictMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 			},
 		},
 		CountFunc: &PermissionSyncJobStoreCountFunc{
-			defaultHook: func(context.Context) (int, error) {
+			defaultHook: func(context.Context, ListPermissionSyncJobOpts) (int, error) {
 				panic("unexpected invocation of MockPermissionSyncJobStore.Count")
 			},
 		},
@@ -38131,24 +38131,24 @@ func (c PermissionSyncJobStoreCancelQueuedJobFuncCall) Results() []interface{} {
 // PermissionSyncJobStoreCountFunc describes the behavior when the Count
 // method of the parent MockPermissionSyncJobStore instance is invoked.
 type PermissionSyncJobStoreCountFunc struct {
-	defaultHook func(context.Context) (int, error)
-	hooks       []func(context.Context) (int, error)
+	defaultHook func(context.Context, ListPermissionSyncJobOpts) (int, error)
+	hooks       []func(context.Context, ListPermissionSyncJobOpts) (int, error)
 	history     []PermissionSyncJobStoreCountFuncCall
 	mutex       sync.Mutex
 }
 
 // Count delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPermissionSyncJobStore) Count(v0 context.Context) (int, error) {
-	r0, r1 := m.CountFunc.nextHook()(v0)
-	m.CountFunc.appendCall(PermissionSyncJobStoreCountFuncCall{v0, r0, r1})
+func (m *MockPermissionSyncJobStore) Count(v0 context.Context, v1 ListPermissionSyncJobOpts) (int, error) {
+	r0, r1 := m.CountFunc.nextHook()(v0, v1)
+	m.CountFunc.appendCall(PermissionSyncJobStoreCountFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Count method of the
 // parent MockPermissionSyncJobStore instance is invoked and the hook queue
 // is empty.
-func (f *PermissionSyncJobStoreCountFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
+func (f *PermissionSyncJobStoreCountFunc) SetDefaultHook(hook func(context.Context, ListPermissionSyncJobOpts) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -38156,7 +38156,7 @@ func (f *PermissionSyncJobStoreCountFunc) SetDefaultHook(hook func(context.Conte
 // Count method of the parent MockPermissionSyncJobStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *PermissionSyncJobStoreCountFunc) PushHook(hook func(context.Context) (int, error)) {
+func (f *PermissionSyncJobStoreCountFunc) PushHook(hook func(context.Context, ListPermissionSyncJobOpts) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -38165,19 +38165,19 @@ func (f *PermissionSyncJobStoreCountFunc) PushHook(hook func(context.Context) (i
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermissionSyncJobStoreCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context) (int, error) {
+	f.SetDefaultHook(func(context.Context, ListPermissionSyncJobOpts) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermissionSyncJobStoreCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context) (int, error) {
+	f.PushHook(func(context.Context, ListPermissionSyncJobOpts) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *PermissionSyncJobStoreCountFunc) nextHook() func(context.Context) (int, error) {
+func (f *PermissionSyncJobStoreCountFunc) nextHook() func(context.Context, ListPermissionSyncJobOpts) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -38213,6 +38213,9 @@ type PermissionSyncJobStoreCountFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ListPermissionSyncJobOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -38224,7 +38227,7 @@ type PermissionSyncJobStoreCountFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermissionSyncJobStoreCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -508,11 +508,9 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 		conds = append(conds, pagination.Where)
 	}
 
-	var whereClause *sqlf.Query
-	if len(conds) != 0 {
+	whereClause := sqlf.Sprintf("")
+	if len(conds) > 0 {
 		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(conds, "\n AND "))
-	} else {
-		whereClause = sqlf.Sprintf("")
 	}
 
 	q := sqlf.Sprintf(
@@ -550,11 +548,9 @@ FROM permission_sync_jobs
 func (s *permissionSyncJobStore) Count(ctx context.Context, opts ListPermissionSyncJobOpts) (int, error) {
 	conds := opts.sqlConds()
 
-	var whereClause *sqlf.Query
-	if len(conds) != 0 {
+	whereClause := sqlf.Sprintf("")
+	if len(conds) > 0 {
 		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(conds, "\n AND "))
-	} else {
-		whereClause = sqlf.Sprintf("")
 	}
 
 	q := sqlf.Sprintf(countPermissionSyncJobsQuery, whereClause)

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -219,7 +219,7 @@ type PermissionSyncJobStore interface {
 	CreateRepoSyncJob(ctx context.Context, repo api.RepoID, opts PermissionSyncJobOpts) error
 
 	List(ctx context.Context, opts ListPermissionSyncJobOpts) ([]*PermissionSyncJob, error)
-	Count(ctx context.Context) (int, error)
+	Count(ctx context.Context, opts ListPermissionSyncJobOpts) (int, error)
 	CancelQueuedJob(ctx context.Context, reason string, id int) error
 	SaveSyncResult(ctx context.Context, id int, result *SetPermissionsResult, codeHostStatuses CodeHostStatusesSet) error
 }
@@ -544,10 +544,20 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 const countPermissionSyncJobsQuery = `
 SELECT COUNT(*)
 FROM permission_sync_jobs
+%s -- whereClause
 `
 
-func (s *permissionSyncJobStore) Count(ctx context.Context) (int, error) {
-	q := sqlf.Sprintf(countPermissionSyncJobsQuery)
+func (s *permissionSyncJobStore) Count(ctx context.Context, opts ListPermissionSyncJobOpts) (int, error) {
+	conds := opts.sqlConds()
+
+	var whereClause *sqlf.Query
+	if len(conds) != 0 {
+		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(conds, "\n AND "))
+	} else {
+		whereClause = sqlf.Sprintf("")
+	}
+
+	q := sqlf.Sprintf(countPermissionSyncJobsQuery, whereClause)
 	var count int
 	if err := s.QueryRow(ctx, q).Scan(&count); err != nil {
 		return 0, err


### PR DESCRIPTION
This commit adds 2 arguments to `permissionsSyncJobs` query: `reasonGroup` and `state` which can be used to filter permissions sync jobs.

Test plan:
Tests added.

Closes https://github.com/sourcegraph/sourcegraph/issues/48245