### PR TITLE
jscontext: add `__typename` to returned user.

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -76,6 +76,7 @@ type UserSession struct {
 }
 
 type CurrentUser struct {
+	GraphQLTypename     string     `json:"__typename"`
 	ID                  graphql.ID `json:"id"`
 	DatabaseID          int32      `json:"databaseID"`
 	Username            string     `json:"username"`
@@ -346,6 +347,7 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 	}
 
 	return &CurrentUser{
+		GraphQLTypename:     "User",
 		AvatarURL:           userResolver.AvatarURL(),
 		Session:             &UserSession{session.CanSignOut()},
 		DatabaseID:          userResolver.DatabaseID(),


### PR DESCRIPTION
Test plan:
Local sg run and check.

followup/fix to https://github.com/sourcegraph/sourcegraph/pull/47010

Logging the user now returns `__typename`:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/94846361/221550096-526dd518-5d29-43bc-abf7-19859a751a4f.png">
