### PR TITLE
cmd/repo-updater/shared: s/syncScheduler/manageUnclonedRepos

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -174,7 +174,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		}
 	}()
 
-	go syncScheduler(ctx, logger, updateScheduler, store)
+	go manageUnclonedRepos(ctx, logger, updateScheduler, store)
 
 	if envvar.SourcegraphDotComMode() {
 		rateLimiter := ratelimit.NewInstrumentedLimiter("SyncReposWithLastErrors", rate.NewLimiter(.05, 1))
@@ -506,11 +506,11 @@ func getPrivateAddedOrModifiedRepos(diff repos.Diff) []api.RepoID {
 	return repoIDs
 }
 
-// syncScheduler will periodically list the uncloned repositories on gitserver
+// manageUnclonedRepos will periodically list the uncloned repositories on gitserver
 // and update the scheduler with the list. It also ensures that if any of our
 // indexable repos are missing from the cloned list they will be added for
 // cloning ASAP.
-func syncScheduler(ctx context.Context, logger log.Logger, sched *repos.UpdateScheduler, store repos.Store) {
+func manageUnclonedRepos(ctx context.Context, logger log.Logger, sched *repos.UpdateScheduler, store repos.Store) {
 	baseRepoStore := database.ReposWith(logger, store)
 
 	doSync := func() {


### PR DESCRIPTION
_If it walks like a duck and talks like a duck, name it a duck - Indradhanush Gupta, circa 2023_

The terms `sync`, `schedule` and `scheduler` are used and abused a lot in our repo-updater code making a lot of them sound similar.

I was reading this part of the code today and thought the name of this function should be more explicit, since it does one thing and does it well.



## Test plan

No functionality change. Just a rename.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
