### PR TITLE
Fix space on subscription page

### DIFF
--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -89,8 +89,7 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                         >
                             Sourcegraph Enterprise
                         </Link>
-                        . See{' '}
-                        <Link to="https://about.sourcegraph.com/pricing">pricing</Link> for more information.
+                        . See <Link to="https://about.sourcegraph.com/pricing">pricing</Link> for more information.
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -89,7 +89,7 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                         >
                             Sourcegraph Enterprise
                         </Link>
-                        . See
+                        . See{' '}
                         <Link to="https://about.sourcegraph.com/pricing">pricing</Link> for more information.
                     </>
                 }


### PR DESCRIPTION
Add missing space to subscription page.

<img width="710" alt="Screenshot 2023-02-27 at 13 40 28" src="https://user-images.githubusercontent.com/7238650/221589605-ea28860d-e26d-4ac9-a030-77e8b13bb47c.png">


## Test plan

- [x] manual review
- [ ] tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vincent-fix-spacing-enterprise.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
