### PR TITLE
Make team avatar inline correctly

### DIFF
--- a/client/web/src/team/TeamAvatar.tsx
+++ b/client/web/src/team/TeamAvatar.tsx
@@ -99,7 +99,7 @@ export const TeamAvatar = React.forwardRef(
         }
 
         if (inline) {
-            return <Icon ref={reference as React.ForwardedRef<SVGSVGElement>} as="div" aria-hidden={true} {...props} />
+            return <Icon ref={reference as React.ForwardedRef<SVGSVGElement>} as="span" aria-hidden={true} {...props} />
         }
 
         return <div ref={reference} {...props} />

--- a/client/web/src/team/area/TeamProfilePage.tsx
+++ b/client/web/src/team/area/TeamProfilePage.tsx
@@ -46,7 +46,7 @@ export const TeamProfilePage: React.FunctionComponent<TeamProfilePageProps> = ({
                 <div className="container">
                     <H3>Team name</H3>
                     <Text>
-                        <TeamAvatar team={team} className="mr-1" />
+                        <TeamAvatar team={team} inline={true} className="mr-1" />
                         {team.name}
                     </Text>
                     <H3>Display Name</H3>


### PR DESCRIPTION
Currently the avatar is a div inside a <p> tag on the profile page, which throws validation warnings. This fixes it. 

## Test plan

No more error in browser console. 

## App preview:

- [Web](https://sg-web-es-avatar-inline.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
