### PR TITLE
Fix integration test for list users

### DIFF
--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -296,16 +296,6 @@ mutation {
 	}
 }`,
 			}, {
-				name: "users",
-				query: `
-{
-	users {
-		nodes {
-			id
-		}
-	}
-}`,
-			}, {
 				name: "surveyResponses",
 				query: `
 {


### PR DESCRIPTION
Not a site-admin protected route anymore, so we have to remove this test! See https://github.com/sourcegraph/sourcegraph/pull/48237 for context on this change.



## Test plan

Just a test that doesn't apply anymore.