### PR TITLE
Add react router 6 error elements

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -13,7 +13,7 @@ import { FeedbackPrompt, LoadingSpinner, Panel } from '@sourcegraph/wildcard'
 
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
-import { ErrorBoundary, RouteError } from './components/ErrorBoundary'
+import { RouteError } from './components/ErrorBoundary'
 import { LazyFuzzyFinder } from './components/fuzzyFinder/LazyFuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
@@ -196,28 +196,26 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                 />
             )}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}
-            <ErrorBoundary location={location}>
-                <Suspense
-                    fallback={
-                        <div className="flex flex-1">
-                            <LoadingSpinner className="m-2" />
-                        </div>
-                    }
-                >
-                    <AppRouterContainer>
-                        <Routes>
-                            {props.routes.map(({ ...route }) => (
-                                <Route
-                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                    path={route.path}
-                                    element={route.element}
-                                    errorElement={<RouteError />}
-                                />
-                            ))}
-                        </Routes>
-                    </AppRouterContainer>
-                </Suspense>
-            </ErrorBoundary>
+            <Suspense
+                fallback={
+                    <div className="flex flex-1">
+                        <LoadingSpinner className="m-2" />
+                    </div>
+                }
+            >
+                <AppRouterContainer>
+                    <Routes>
+                        {props.routes.map(({ ...route }) => (
+                            <Route
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                path={route.path}
+                                element={route.element}
+                                errorElement={<RouteError />}
+                            />
+                        ))}
+                    </Routes>
+                </AppRouterContainer>
+            </Suspense>
             {parseQueryAndHash(location.search, location.hash).viewState && location.pathname !== PageRoutes.SignIn && (
                 <Panel
                     className={styles.panel}

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -13,7 +13,7 @@ import { FeedbackPrompt, LoadingSpinner, Panel } from '@sourcegraph/wildcard'
 
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
-import { ErrorBoundary } from './components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from './components/ErrorBoundary'
 import { LazyFuzzyFinder } from './components/fuzzyFinder/LazyFuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
@@ -211,6 +211,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                     path={route.path}
                                     element={route.element}
+                                    errorElement={<RouteError />}
                                 />
                             ))}
                         </Routes>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -35,7 +35,7 @@ import { FeedbackText, setLinkComponent, RouterLink, WildcardThemeContext, Wildc
 import { authenticatedUser as authenticatedUserSubject, AuthenticatedUser, authenticatedUserValue } from './auth'
 import { getWebGraphQLClient } from './backend/graphql'
 import { ComponentsComposer } from './components/ComponentsComposer'
-import { ErrorBoundary } from './components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from './components/ErrorBoundary'
 import { HeroPage } from './components/HeroPage'
 import { FeatureFlagsProvider } from './featureFlags/FeatureFlagsProvider'
 import { Layout } from './Layout'
@@ -279,6 +279,7 @@ export const SourcegraphWebApp: FC<StaticAppConfig> = props => {
             createBrowserRouter([
                 {
                     element: <LegacyRoute render={props => <Layout {...props} />} />,
+                    errorElement: <RouteError />,
                     children: props.routes.filter(isTruthy),
                 },
             ]),

--- a/client/web/src/components/ErrorBoundary.test.tsx
+++ b/client/web/src/components/ErrorBoundary.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
-import { ErrorBoundary, RouteError } from './ErrorBoundary'
+import { ErrorBoundary } from './ErrorBoundary'
 
 jest.mock('mdi-react/AlertCircleIcon', () => 'AlertCircleIcon')
 jest.mock('mdi-react/ReloadIcon', () => 'ReloadIcon')

--- a/client/web/src/components/ErrorBoundary.test.tsx
+++ b/client/web/src/components/ErrorBoundary.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
-import { ErrorBoundary } from './ErrorBoundary'
+import { ErrorBoundary, RouteError } from './ErrorBoundary'
 
 jest.mock('mdi-react/AlertCircleIcon', () => 'AlertCircleIcon')
 jest.mock('mdi-react/ReloadIcon', () => 'ReloadIcon')

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
 
 import { asError } from '@sourcegraph/common'
 import { Button, Code, Text } from '@sourcegraph/wildcard'
@@ -74,55 +75,91 @@ export class ErrorBoundary extends React.PureComponent<React.PropsWithChildren<P
 
     public render(): React.ReactNode | null {
         if (this.state.error !== undefined) {
-            if (isWebpackChunkError(this.state.error)) {
-                // "Loading chunk 123 failed" means that the JavaScript assets that correspond to the deploy
-                // version currently running are no longer available, likely because a redeploy occurred after the
-                // user initially loaded this page.
-                return (
-                    <HeroPage
-                        icon={ReloadIcon}
-                        title="Reload required"
-                        subtitle={
-                            <div className="container">
-                                <Text>A new version of Sourcegraph is available.</Text>
-                                <Button onClick={this.onReloadClick} variant="primary">
-                                    Reload to update
-                                </Button>
-                            </div>
-                        }
-                    />
-                )
-            }
-
-            if (this.props.render) {
-                return this.props.render(this.state.error)
-            }
-
             return (
-                <HeroPage
-                    icon={AlertCircleIcon}
-                    title="Error"
+                <ErrorBoundaryMessage
+                    error={this.state.error}
+                    extraContext={this.props.extraContext}
+                    render={this.props.render}
                     className={this.props.className}
-                    subtitle={
-                        <div className="container">
-                            <Text>
-                                Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it,
-                                contact your site admin or Sourcegraph support.
-                            </Text>
-                            <Text>
-                                <Code className="text-wrap">{this.state.error.message}</Code>
-                            </Text>
-                            {this.props.extraContext}
-                        </div>
-                    }
                 />
             )
         }
 
         return this.props.children
     }
+}
 
-    private onReloadClick: React.MouseEventHandler<HTMLElement> = () => {
-        window.location.reload() // hard page reload
+export const RouteError: React.FC = () => {
+    const routeError = useRouteError()
+    const error = useMemo(() => {
+        if (isRouteErrorResponse(routeError)) {
+            return new Error(routeError.data ? routeError.data : `${routeError.status} ${routeError.statusText}`)
+        }
+        return asError(routeError)
+    }, [routeError])
+    useEffect(() => {
+        if (typeof Sentry !== 'undefined') {
+            Sentry.captureException(error)
+        }
+    }, [error])
+    return <ErrorBoundaryMessage error={error} />
+}
+
+interface ErrorBoundaryMessageProps {
+    error: Error
+    // Extra context to aid with debugging
+    extraContext?: JSX.Element
+    // Custom render logic in place of <HeroPage>
+    render?: (error: Error) => JSX.Element
+    // className to pass to <HeroPage>
+    className?: string
+}
+const ErrorBoundaryMessage: React.FC<ErrorBoundaryMessageProps> = ({ error, extraContext, render, className }) => {
+    if (isWebpackChunkError(error)) {
+        // "Loading chunk 123 failed" means that the JavaScript assets that correspond to the deploy
+        // version currently running are no longer available, likely because a redeploy occurred after the
+        // user initially loaded this page.
+        return (
+            <HeroPage
+                icon={ReloadIcon}
+                title="Reload required"
+                subtitle={
+                    <div className="container">
+                        <Text>A new version of Sourcegraph is available.</Text>
+                        <Button onClick={hardReload} variant="primary">
+                            Reload to update
+                        </Button>
+                    </div>
+                }
+            />
+        )
     }
+
+    if (render) {
+        return render(error)
+    }
+
+    return (
+        <HeroPage
+            icon={AlertCircleIcon}
+            title="Error"
+            className={className}
+            subtitle={
+                <div className="container">
+                    <Text>
+                        Sourcegraph encountered an unexpected error. If reloading the page doesn't fix it, contact your
+                        site admin or Sourcegraph support.
+                    </Text>
+                    <Text>
+                        <Code className="text-wrap">{error.message}</Code>
+                    </Text>
+                    {extraContext}
+                </div>
+            }
+        />
+    )
+}
+
+function hardReload(): void {
+    window.location.reload()
 }

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -89,6 +89,10 @@ export class ErrorBoundary extends React.PureComponent<React.PropsWithChildren<P
     }
 }
 
+/**
+ * A React component that can be used within a react router errorElement callback. It extracts the
+ * route error and displays it nicely on the page.
+ */
 export const RouteError: React.FC = () => {
     const routeError = useRouteError()
     const error = useMemo(() => {

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -18,7 +18,7 @@ import { AuthenticatedUser } from '../../auth'
 import { requestGraphQL } from '../../backend/graphql'
 import { BatchChangesProps } from '../../batches'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
+import { RouteError } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { Page } from '../../components/Page'
 import { OrganizationResult, OrganizationVariables, OrgAreaOrganizationFields } from '../../graphql-operations'
@@ -253,38 +253,36 @@ export class OrgArea extends React.Component<OrgAreaProps> {
         }
 
         return (
-            <ErrorBoundary location={this.props.location}>
-                <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                    <Routes>
-                        {this.props.orgAreaRoutes.map(
-                            ({ path, render, condition = () => true, fullPage }) =>
-                                condition(context) && (
-                                    <Route
-                                        path={path}
-                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                        errorElement={<RouteError />}
-                                        element={
-                                            fullPage ? (
-                                                render(context)
-                                            ) : (
-                                                <Page className="org-area">
-                                                    <OrgHeader
-                                                        {...this.props}
-                                                        {...context}
-                                                        navItems={this.props.orgAreaHeaderNavItems}
-                                                        className="mb-3"
-                                                    />
-                                                    <div className="container">{render(context)}</div>
-                                                </Page>
-                                            )
-                                        }
-                                    />
-                                )
-                        )}
-                        <Route element={<NotFoundPage />} />
-                    </Routes>
-                </React.Suspense>
-            </ErrorBoundary>
+            <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+                <Routes>
+                    {this.props.orgAreaRoutes.map(
+                        ({ path, render, condition = () => true, fullPage }) =>
+                            condition(context) && (
+                                <Route
+                                    path={path}
+                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    errorElement={<RouteError />}
+                                    element={
+                                        fullPage ? (
+                                            render(context)
+                                        ) : (
+                                            <Page className="org-area">
+                                                <OrgHeader
+                                                    {...this.props}
+                                                    {...context}
+                                                    navItems={this.props.orgAreaHeaderNavItems}
+                                                    className="mb-3"
+                                                />
+                                                <div className="container">{render(context)}</div>
+                                            </Page>
+                                        )
+                                    }
+                                />
+                            )
+                    )}
+                    <Route element={<NotFoundPage />} />
+                </Routes>
+            </React.Suspense>
         )
     }
 

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -18,7 +18,7 @@ import { AuthenticatedUser } from '../../auth'
 import { requestGraphQL } from '../../backend/graphql'
 import { BatchChangesProps } from '../../batches'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { Page } from '../../components/Page'
 import { OrganizationResult, OrganizationVariables, OrgAreaOrganizationFields } from '../../graphql-operations'
@@ -262,6 +262,7 @@ export class OrgArea extends React.Component<OrgAreaProps> {
                                     <Route
                                         path={path}
                                         key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                        errorElement={<RouteError />}
                                         element={
                                             fullPage ? (
                                                 render(context)

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
+import { RouteError } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import {
     OrgAreaOrganizationFields,
@@ -48,7 +48,6 @@ export interface OrgSettingsAreaRouteContext extends OrgSettingsAreaProps {
  * an organization's settings.
  */
 export const AuthenticatedOrgSettingsArea: FC<OrgSettingsAreaProps> = props => {
-    const location = useLocation()
     const orgDeletionFlag = useQuery<OrgFeatureFlagValueResult, OrgFeatureFlagValueVariables>(
         GET_ORG_FEATURE_FLAG_VALUE,
         {
@@ -67,24 +66,22 @@ export const AuthenticatedOrgSettingsArea: FC<OrgSettingsAreaProps> = props => {
         <div className="d-flex flex-column flex-sm-row">
             <OrgSettingsSidebar items={props.sideBarItems} {...context} className="flex-0 mr-3 mb-4" />
             <div className="flex-1">
-                <ErrorBoundary location={location}>
-                    <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                        <Routes>
-                            {props.routes.map(
-                                ({ path, render, condition = () => true }) =>
-                                    condition(context) && (
-                                        <Route
-                                            element={render(context)}
-                                            errorElement={<RouteError />}
-                                            path={path}
-                                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                        />
-                                    )
-                            )}
-                            <Route element={<NotFoundPage />} />
-                        </Routes>
-                    </React.Suspense>
-                </ErrorBoundary>
+                <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+                    <Routes>
+                        {props.routes.map(
+                            ({ path, render, condition = () => true }) =>
+                                condition(context) && (
+                                    <Route
+                                        element={render(context)}
+                                        errorElement={<RouteError />}
+                                        path={path}
+                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                    />
+                                )
+                        )}
+                        <Route element={<NotFoundPage />} />
+                    </Routes>
+                </React.Suspense>
             </div>
         </div>
     )

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -8,7 +8,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import {
     OrgAreaOrganizationFields,
@@ -75,6 +75,7 @@ export const AuthenticatedOrgSettingsArea: FC<OrgSettingsAreaProps> = props => {
                                     condition(context) && (
                                         <Route
                                             element={render(context)}
+                                            errorElement={<RouteError />}
                                             path={path}
                                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                         />

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -31,7 +31,7 @@ import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
 import { CodeIntelligenceProps } from '../codeintel'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
-import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
+import { RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
@@ -382,53 +382,51 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                 </RepoHeaderContributionPortal>
             )}
 
-            <ErrorBoundary location={location}>
-                <Suspense fallback={null}>
-                    <Routes>
-                        {repoContainerRoutes.map(({ path, render, condition = () => true }) => (
-                            <Route
-                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                path={repoSplat + path}
-                                errorElement={<RouteError />}
-                                element={
-                                    /**
-                                     * `repoContainerRoutes` depend on `repo`. We render these routes only when
-                                     * the `repo` value is resolved. If repo resolves to error due to empty repository
-                                     * then we return Empty Repository.
-                                     */
-                                    repo && condition({ ...repoContainerContext, repo }) ? (
-                                        render({ ...repoContainerContext, repo })
-                                    ) : isEmptyRepo ? (
-                                        <EmptyRepo />
-                                    ) : null
-                                }
-                            />
-                        ))}
-                        <Route
-                            path={repoSplat + repoSettingsAreaPath}
-                            errorElement={<RouteError />}
-                            // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
-                            element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
-                        />
+            <Suspense fallback={null}>
+                <Routes>
+                    {repoContainerRoutes.map(({ path, render, condition = () => true }) => (
                         <Route
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            path="*"
+                            path={repoSplat + path}
                             errorElement={<RouteError />}
                             element={
-                                isEmptyRepo ? (
+                                /**
+                                 * `repoContainerRoutes` depend on `repo`. We render these routes only when
+                                 * the `repo` value is resolved. If repo resolves to error due to empty repository
+                                 * then we return Empty Repository.
+                                 */
+                                repo && condition({ ...repoContainerContext, repo }) ? (
+                                    render({ ...repoContainerContext, repo })
+                                ) : isEmptyRepo ? (
                                     <EmptyRepo />
-                                ) : (
-                                    <RepoRevisionContainer
-                                        {...repoRevisionContainerContext}
-                                        {...childBreadcrumbSetters}
-                                        routes={props.repoRevisionContainerRoutes}
-                                    />
-                                )
+                                ) : null
                             }
                         />
-                    </Routes>
-                </Suspense>
-            </ErrorBoundary>
+                    ))}
+                    <Route
+                        path={repoSplat + repoSettingsAreaPath}
+                        errorElement={<RouteError />}
+                        // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
+                        element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
+                    />
+                    <Route
+                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                        path="*"
+                        errorElement={<RouteError />}
+                        element={
+                            isEmptyRepo ? (
+                                <EmptyRepo />
+                            ) : (
+                                <RepoRevisionContainer
+                                    {...repoRevisionContainerContext}
+                                    {...childBreadcrumbSetters}
+                                    routes={props.repoRevisionContainerRoutes}
+                                />
+                            )
+                        }
+                    />
+                </Routes>
+            </Suspense>
         </div>
     )
 }

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -31,7 +31,7 @@ import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
 import { CodeIntelligenceProps } from '../codeintel'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
-import { ErrorBoundary } from '../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { ExternalLinkFields, RepositoryFields } from '../graphql-operations'
 import { CodeInsightsProps } from '../insights/types'
@@ -389,6 +389,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                             <Route
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                 path={repoSplat + path}
+                                errorElement={<RouteError />}
                                 element={
                                     /**
                                      * `repoContainerRoutes` depend on `repo`. We render these routes only when
@@ -405,12 +406,14 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         ))}
                         <Route
                             path={repoSplat + repoSettingsAreaPath}
+                            errorElement={<RouteError />}
                             // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
                             element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
                         />
                         <Route
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                             path="*"
+                            errorElement={<RouteError />}
                             element={
                                 isEmptyRepo ? (
                                     <EmptyRepo />

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -13,7 +13,7 @@ import { PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 import { BatchChangesProps } from '../batches'
-import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
+import { RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { Page } from '../components/Page'
 import { RouteV6Descriptor } from '../util/contributions'
@@ -96,25 +96,23 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                     batchChangesWebhookLogsEnabled={props.batchChangesWebhookLogsEnabled}
                 />
                 <div className="flex-bounded">
-                    <ErrorBoundary location={location}>
-                        <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                            <Routes>
-                                {props.routes.map(
-                                    ({ render, path, condition = () => true }) =>
-                                        condition(context) && (
-                                            <Route
-                                                // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                                key="hardcoded-key"
-                                                errorElement={<RouteError />}
-                                                path={path}
-                                                element={render(context)}
-                                            />
-                                        )
-                                )}
-                                <Route path="*" element={<NotFoundPage />} />
-                            </Routes>
-                        </React.Suspense>
-                    </ErrorBoundary>
+                    <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+                        <Routes>
+                            {props.routes.map(
+                                ({ render, path, condition = () => true }) =>
+                                    condition(context) && (
+                                        <Route
+                                            // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                            key="hardcoded-key"
+                                            errorElement={<RouteError />}
+                                            path={path}
+                                            element={render(context)}
+                                        />
+                                    )
+                            )}
+                            <Route path="*" element={<NotFoundPage />} />
+                        </Routes>
+                    </React.Suspense>
                 </div>
             </div>
         </Page>

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -13,7 +13,7 @@ import { PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 import { BatchChangesProps } from '../batches'
-import { ErrorBoundary } from '../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
 import { Page } from '../components/Page'
 import { RouteV6Descriptor } from '../util/contributions'
@@ -105,6 +105,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                                             <Route
                                                 // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                                 key="hardcoded-key"
+                                                errorElement={<RouteError />}
                                                 path={path}
                                                 element={render(context)}
                                             />

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { useLocation, Routes, Route } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 
 import { SiteSettingFields } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -59,7 +59,6 @@ interface SiteAdminAreaProps extends PlatformContextProps, SettingsCascadeProps,
 
 const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildren<SiteAdminAreaProps>> = props => {
     const reference = useRef<HTMLDivElement>(null)
-    const location = useLocation()
 
     // If not site admin, redirect to sign in.
     if (!props.authenticatedUser.siteAdmin) {

--- a/client/web/src/team/TeamsArea.tsx
+++ b/client/web/src/team/TeamsArea.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
-import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
+import { RouteError } from '../components/ErrorBoundary'
 import { NotFoundPage } from '../components/HeroPage'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
@@ -32,23 +32,20 @@ export interface Props {
  */
 const AuthenticatedTeamsArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     const [enableTeams] = useFeatureFlag('search-ownership')
-    const location = useLocation()
 
     // No teams on sourcegraph.com
     if (!enableTeams || props.isSourcegraphDotCom) {
         return <NotFoundPage pageType="team" />
     }
     return (
-        <ErrorBoundary location={location}>
-            <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                <Routes>
-                    <Route path="new" element={<NewTeamPage />} errorElement={<RouteError />} />
-                    <Route path="" element={<TeamListPage {...props} />} errorElement={<RouteError />} />
-                    <Route path=":teamName/*" element={<TeamArea {...props} />} errorElement={<RouteError />} />
-                    <Route element={<NotFoundPage pageType="team" />} errorElement={<RouteError />} />
-                </Routes>
-            </React.Suspense>
-        </ErrorBoundary>
+        <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+            <Routes>
+                <Route path="new" element={<NewTeamPage />} errorElement={<RouteError />} />
+                <Route path="" element={<TeamListPage {...props} />} errorElement={<RouteError />} />
+                <Route path=":teamName/*" element={<TeamArea {...props} />} errorElement={<RouteError />} />
+                <Route element={<NotFoundPage pageType="team" />} errorElement={<RouteError />} />
+            </Routes>
+        </React.Suspense>
     )
 }
 

--- a/client/web/src/team/TeamsArea.tsx
+++ b/client/web/src/team/TeamsArea.tsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
-import { ErrorBoundary } from '../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../components/ErrorBoundary'
 import { NotFoundPage } from '../components/HeroPage'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
@@ -42,10 +42,10 @@ const AuthenticatedTeamsArea: React.FunctionComponent<React.PropsWithChildren<Pr
         <ErrorBoundary location={location}>
             <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
                 <Routes>
-                    <Route path="new" element={<NewTeamPage />} />
-                    <Route path="" element={<TeamListPage {...props} />} />
-                    <Route path=":teamName/*" element={<TeamArea {...props} />} />
-                    <Route element={<NotFoundPage pageType="team" />} />
+                    <Route path="new" element={<NewTeamPage />} errorElement={<RouteError />} />
+                    <Route path="" element={<TeamListPage {...props} />} errorElement={<RouteError />} />
+                    <Route path=":teamName/*" element={<TeamArea {...props} />} errorElement={<RouteError />} />
+                    <Route element={<NotFoundPage pageType="team" />} errorElement={<RouteError />} />
                 </Routes>
             </React.Suspense>
         </ErrorBoundary>

--- a/client/web/src/team/area/TeamArea.tsx
+++ b/client/web/src/team/area/TeamArea.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Route, Routes, useLocation, useParams } from 'react-router-dom'
+import { Route, Routes, useParams } from 'react-router-dom'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner, ErrorMessage } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { RouteError } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { TeamAreaTeamFields } from '../../graphql-operations'
 import { RouteV6Descriptor } from '../../util/contributions'
@@ -61,8 +61,6 @@ export interface TeamAreaRouteContext {
 export const TeamArea: React.FunctionComponent<TeamAreaProps> = ({ authenticatedUser }) => {
     const { teamName } = useParams<{ teamName: string }>()
 
-    const location = useLocation()
-
     const { data, loading, error, refetch } = useTeam(teamName!)
 
     if (loading) {
@@ -89,19 +87,13 @@ export const TeamArea: React.FunctionComponent<TeamAreaProps> = ({ authenticated
     }
 
     return (
-        <ErrorBoundary location={location}>
-            <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                <Routes>
-                    <Route path="" element={<TeamProfilePage {...context} />} errorElement={<RouteError />} />
-                    <Route path="members" element={<TeamMembersPage {...context} />} errorElement={<RouteError />} />
-                    <Route
-                        path="child-teams"
-                        element={<TeamChildTeamsPage {...context} />}
-                        errorElement={<RouteError />}
-                    />
-                    <Route element={<NotFoundPage />} />
-                </Routes>
-            </React.Suspense>
-        </ErrorBoundary>
+        <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+            <Routes>
+                <Route path="" element={<TeamProfilePage {...context} />} errorElement={<RouteError />} />
+                <Route path="members" element={<TeamMembersPage {...context} />} errorElement={<RouteError />} />
+                <Route path="child-teams" element={<TeamChildTeamsPage {...context} />} errorElement={<RouteError />} />
+                <Route element={<NotFoundPage />} />
+            </Routes>
+        </React.Suspense>
     )
 }

--- a/client/web/src/team/area/TeamArea.tsx
+++ b/client/web/src/team/area/TeamArea.tsx
@@ -92,9 +92,13 @@ export const TeamArea: React.FunctionComponent<TeamAreaProps> = ({ authenticated
         <ErrorBoundary location={location}>
             <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
                 <Routes>
-                    <Route path="" element={<TeamProfilePage {...context} />} />
-                    <Route path="members" element={<TeamMembersPage {...context} />} />
-                    <Route path="child-teams" element={<TeamChildTeamsPage {...context} />} />
+                    <Route path="" element={<TeamProfilePage {...context} />} errorElement={<RouteError />} />
+                    <Route path="members" element={<TeamMembersPage {...context} />} errorElement={<RouteError />} />
+                    <Route
+                        path="child-teams"
+                        element={<TeamChildTeamsPage {...context} />}
+                        errorElement={<RouteError />}
+                    />
                     <Route element={<NotFoundPage />} />
                 </Routes>
             </React.Suspense>

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -11,7 +11,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../../auth'
 import { BatchChangesProps } from '../../batches'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
 import { NotFoundPage } from '../../components/HeroPage'
 import { Page } from '../../components/Page'
 import { UserAreaUserFields, UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../../graphql-operations'
@@ -187,6 +187,7 @@ export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, isS
                         ({ path, render, condition = () => true, fullPage }) =>
                             condition(context) && (
                                 <Route
+                                    errorElement={<RouteError />}
                                     element={
                                         fullPage ? (
                                             render(context)

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo, Suspense } from 'react'
 
-import { useParams, useLocation, Routes, Route } from 'react-router-dom'
+import { useParams, Routes, Route } from 'react-router-dom'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -11,7 +11,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../../auth'
 import { BatchChangesProps } from '../../batches'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
+import { RouteError } from '../../components/ErrorBoundary'
 import { NotFoundPage } from '../../components/HeroPage'
 import { Page } from '../../components/Page'
 import { UserAreaUserFields, UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../../graphql-operations'
@@ -121,7 +121,6 @@ export interface UserAreaRouteContext
  * A user's public profile area.
  */
 export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, isSourcegraphDotCom, ...props }) => {
-    const location = useLocation()
     const { username } = useParams()
     const userAreaMainUrl = `/users/${username}`
 
@@ -174,43 +173,41 @@ export const UserArea: FC<UserAreaProps> = ({ useBreadcrumb, userAreaRoutes, isS
     }
 
     return (
-        <ErrorBoundary location={location}>
-            <Suspense
-                fallback={
-                    <div className="w-100 text-center">
-                        <LoadingSpinner className="m-2" />
-                    </div>
-                }
-            >
-                <Routes>
-                    {userAreaRoutes.map(
-                        ({ path, render, condition = () => true, fullPage }) =>
-                            condition(context) && (
-                                <Route
-                                    errorElement={<RouteError />}
-                                    element={
-                                        fullPage ? (
-                                            render(context)
-                                        ) : (
-                                            <Page>
-                                                <UserAreaHeader
-                                                    {...props}
-                                                    {...context}
-                                                    className="mb-3"
-                                                    navItems={props.userAreaHeaderNavItems}
-                                                />
-                                                <div className="container">{render(context)}</div>
-                                            </Page>
-                                        )
-                                    }
-                                    path={path}
-                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                />
-                            )
-                    )}
-                    <Route element={<NotFoundPage pageType="user" />} />
-                </Routes>
-            </Suspense>
-        </ErrorBoundary>
+        <Suspense
+            fallback={
+                <div className="w-100 text-center">
+                    <LoadingSpinner className="m-2" />
+                </div>
+            }
+        >
+            <Routes>
+                {userAreaRoutes.map(
+                    ({ path, render, condition = () => true, fullPage }) =>
+                        condition(context) && (
+                            <Route
+                                errorElement={<RouteError />}
+                                element={
+                                    fullPage ? (
+                                        render(context)
+                                    ) : (
+                                        <Page>
+                                            <UserAreaHeader
+                                                {...props}
+                                                {...context}
+                                                className="mb-3"
+                                                navItems={props.userAreaHeaderNavItems}
+                                            />
+                                            <div className="container">{render(context)}</div>
+                                        </Page>
+                                    )
+                                }
+                                path={path}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                            />
+                        )
+                )}
+                <Route element={<NotFoundPage pageType="user" />} />
+            </Routes>
+        </Suspense>
     )
 }

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
-import { Route, Routes, useLocation } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -10,7 +10,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
+import { RouteError } from '../../components/ErrorBoundary'
 import { HeroPage, NotFoundPage } from '../../components/HeroPage'
 import {
     UserAreaUserFields,
@@ -89,7 +89,6 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
     React.PropsWithChildren<UserSettingsAreaProps>
 > = props => {
     const { authenticatedUser, sideBarItems } = props
-    const location = useLocation()
 
     const { data, error, loading, previousData } = useQuery<
         UserSettingsAreaUserProfileResult,
@@ -151,24 +150,22 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
                     className={classNames('flex-0 mr-3 mb-4', styles.userSettingsSidebar)}
                 />
                 <div className="flex-1">
-                    <ErrorBoundary location={location}>
-                        <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
-                            <Routes>
-                                {props.routes.map(
-                                    ({ path, render, condition = () => true }) =>
-                                        condition(context) && (
-                                            <Route
-                                                errorElement={<RouteError />}
-                                                element={render(context)}
-                                                path={path}
-                                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                            />
-                                        )
-                                )}
-                                <Route element={<NotFoundPage pageType="settings" />} />
-                            </Routes>
-                        </React.Suspense>
-                    </ErrorBoundary>
+                    <React.Suspense fallback={<LoadingSpinner className="m-2" />}>
+                        <Routes>
+                            {props.routes.map(
+                                ({ path, render, condition = () => true }) =>
+                                    condition(context) && (
+                                        <Route
+                                            errorElement={<RouteError />}
+                                            element={render(context)}
+                                            path={path}
+                                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                        />
+                                    )
+                            )}
+                            <Route element={<NotFoundPage pageType="settings" />} />
+                        </Routes>
+                    </React.Suspense>
                 </div>
             </div>
         </>

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -10,7 +10,7 @@ import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { ErrorBoundary, RouteError } from '../../components/ErrorBoundary'
 import { HeroPage, NotFoundPage } from '../../components/HeroPage'
 import {
     UserAreaUserFields,
@@ -158,6 +158,7 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
                                     ({ path, render, condition = () => true }) =>
                                         condition(context) && (
                                             <Route
+                                                errorElement={<RouteError />}
                                                 element={render(context)}
                                                 path={path}
                                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490


### PR DESCRIPTION
I was looking into why the error boundaries are no longer working as expeced.

It turns out that RR6 no longer bubbles errors through to the React error boundary but instead using their own [`errorElement` API](https://reactrouter.com/en/main/route/error-element). 🙃  

To reproduce the previous behavior, this PR manually defines an `errorElement` for all Routes that are mounted in the same file that also mounts an `<ErrorBoundary />`. This way, the error does not unintentionally bubble to the root of the React router.

## Test plan

Tested manually, here's an error that bubbles to the top:

<img width="1200" alt="Screenshot 2023-02-27 at 16 41 39" src="https://user-images.githubusercontent.com/458591/221612438-818f7a2a-af4e-4881-8b13-c4f00c303d67.png">

And here an error inside the user area:

<img width="1239" alt="Screenshot 2023-02-27 at 16 51 22" src="https://user-images.githubusercontent.com/458591/221612473-a8d0a311-7a0a-4ac9-b7ee-09089c26d168.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-rr6-error-handling.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
