### PR TITLE
Remove repo loading state tooltip

### DIFF
--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -30,7 +30,7 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     onClick,
 }) => {
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
-    const unformattedNumber = `${value}`
+    const unformattedNumber = typeof value === 'object' ? '' : `${value}`
     const location = useLocation()
 
     const searchParams = useMemo(() => {

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -13,6 +13,7 @@ import styles from './index.module.scss'
 interface ValueLegendItemProps {
     color?: string
     description: string
+    // Value is a number or LoadingSpinner
     value: number | string | ReactNode
     tooltip?: string
     className?: string
@@ -30,7 +31,7 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     onClick,
 }) => {
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
-    const unformattedNumber = typeof value === 'object' ? '' : `${value}`
+    const unformattedNumber = `${value}`
     const location = useLocation()
 
     const searchParams = useMemo(() => {
@@ -42,7 +43,7 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     }, [filter, location.search])
 
     const tooltipOnNumber =
-        formattedNumber !== unformattedNumber
+        formattedNumber !== unformattedNumber && typeof value !== 'object'
             ? isNaN(parseFloat(unformattedNumber))
                 ? unformattedNumber
                 : Intl.NumberFormat('en').format(parseFloat(unformattedNumber))


### PR DESCRIPTION
**BEFORE**
![image](https://user-images.githubusercontent.com/59381432/221622667-1c575eac-80ae-40ee-b383-6e0a645340a8.png)

**AFTER**
![Screenshot 2023-02-27 at 9 30 58 AM](https://user-images.githubusercontent.com/59381432/221622686-a325b311-da41-400c-a1de-2cebbe6e82fb.png)

## Test plan
- Test on site admin repo page, ensure loading state has no tooltip value

## App preview:

- [Web](https://sg-web-becca-rm-repo-loading-state.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
