### PR TITLE
saved searches: bring back user menu item

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -122,6 +122,9 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             <MenuLink as={Link} to={authenticatedUser.settingsURL!}>
                                 Settings
                             </MenuLink>
+                            <MenuLink as={Link} to={`/users/${props.authenticatedUser.username}/searches`}>
+                                Saved searches
+                            </MenuLink>
                             {enableTeams && !isSourcegraphDotCom && (
                                 <MenuLink as={Link} to="/teams">
                                     Teams


### PR DESCRIPTION
Reverts https://github.com/sourcegraph/sourcegraph/pull/47859 based on [conversations with the CE team](https://sourcegraph.slack.com/archives/CU93UDUBV/p1677111089934889) that this feature is used a lot more than we initially thought.

## Test plan

Verify "saved searches" menu item is shown again.

## App preview:

- [Web](https://sg-web-jp-savedsearchesmenu.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
