### PR TITLE
Revert "Don't load full codeowners file into memory (#48240)"

### DIFF
--- a/internal/own/service_test.go
+++ b/internal/own/service_test.go
@@ -1,9 +1,7 @@
 package own_test
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"os"
 	"sort"
 	"testing"
@@ -31,12 +29,12 @@ type repoPath struct {
 // repoFiles is a fake git client mapping a file
 type repoFiles map[repoPath]string
 
-func (fs repoFiles) NewFileReader(_ context.Context, _ authz.SubRepoPermissionChecker, repoName api.RepoName, commitID api.CommitID, file string) (io.ReadCloser, error) {
+func (fs repoFiles) ReadFile(_ context.Context, _ authz.SubRepoPermissionChecker, repoName api.RepoName, commitID api.CommitID, file string) ([]byte, error) {
 	content, ok := fs[repoPath{Repo: repoName, CommitID: commitID, Path: file}]
 	if !ok {
 		return nil, os.ErrNotExist
 	}
-	return io.NopCloser(bytes.NewReader([]byte(content))), nil
+	return []byte(content), nil
 }
 
 func TestOwnersServesFilesAtVariousLocations(t *testing.T) {
@@ -55,7 +53,7 @@ func TestOwnersServesFilesAtVariousLocations(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			git := gitserver.NewMockClient()
-			git.NewFileReaderFunc.SetDefaultHook(repo.NewFileReader)
+			git.ReadFileFunc.SetDefaultHook(repo.ReadFile)
 			got, err := own.NewService(git, database.NewMockDB()).OwnersFile(context.Background(), "repo", "SHA")
 			require.NoError(t, err)
 			assert.Equal(t, codeownersText, got.Repr())
@@ -76,7 +74,7 @@ func TestOwnersCannotFindFile(t *testing.T) {
 		{"repo", "SHA", "notCODEOWNERS"}: codeownersFile.Repr(),
 	}
 	git := gitserver.NewMockClient()
-	git.NewFileReaderFunc.SetDefaultHook(repo.NewFileReader)
+	git.ReadFileFunc.SetDefaultHook(repo.ReadFile)
 	got, err := own.NewService(git, database.NewMockDB()).OwnersFile(context.Background(), "repo", "SHA")
 	require.NoError(t, err)
 	assert.Nil(t, got)

--- a/internal/search/codeownership/filter_job_test.go
+++ b/internal/search/codeownership/filter_job_test.go
@@ -1,9 +1,7 @@
 package codeownership
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"io/fs"
 	"strings"
 	"testing"
@@ -271,12 +269,12 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 			ctx := context.Background()
 
 			gitserverClient := gitserver.NewMockClient()
-			gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
+			gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
 				content, ok := tt.args.repoContent[file]
 				if !ok {
 					return nil, fs.ErrNotExist
 				}
-				return io.NopCloser(bytes.NewReader([]byte(content))), nil
+				return []byte(content), nil
 			})
 
 			rules := NewRulesCache(gitserverClient, database.NewMockDB())

--- a/internal/search/codeownership/select_job_test.go
+++ b/internal/search/codeownership/select_job_test.go
@@ -1,9 +1,7 @@
 package codeownership
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"io/fs"
 	"sort"
 	"testing"
@@ -25,7 +23,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
+		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
 			return nil, fs.ErrNotExist
 		})
 		db := database.NewMockDB()
@@ -48,9 +46,9 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
+		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
 			// return a codeowner path for no which doesn't match the path of the match below.
-			return io.NopCloser(bytes.NewReader([]byte("NO.md @test\n"))), nil
+			return []byte("NO.md @test\n"), nil
 		})
 		db := database.NewMockDB()
 		rules := NewRulesCache(gitserverClient, db)
@@ -72,10 +70,10 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		ctx := context.Background()
 
 		gitserverClient := gitserver.NewMockClient()
-		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) (io.ReadCloser, error) {
+		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, file string) ([]byte, error) {
 			// README is owned by a user and a team.
 			// code.go is owner by another user and an unknown entity.
-			return io.NopCloser(bytes.NewReader([]byte("README.md @testUserHandle @testTeamHandle\ncode.go user@email.com @unknown"))), nil
+			return []byte("README.md @testUserHandle @testTeamHandle\ncode.go user@email.com @unknown"), nil
 		})
 		mockUserStore := database.NewMockUserStore()
 		mockTeamStore := database.NewMockTeamStore()


### PR DESCRIPTION
This reverts commit 2cc22f8cbf2ab478ac919e09d9a75e78732b924c.

Broke the logic, as it returns the notfounderr from the stream now and not the `NewFileReader`

## Test plan

Reverts a change that broke main. Verified it works again. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
