### PR TITLE
own: More precise email matching in CODEOWNERS

### DIFF
--- a/internal/own/codeowners/parse_test.go
+++ b/internal/own/codeowners/parse_test.go
@@ -266,8 +266,7 @@ README.md  @docs
 			Pattern: "LICENSE",
 			Owner: []*codeownerspb.Owner{
 				{Handle: "legal"},
-				// Note: To match GitLab parsing, we should not consider this as email.
-				{Email: "this_does_not_match"},
+				{Handle: "this_does_not_match"},
 				{Email: "janedoe@gitlab.com"},
 			},
 			LineNumber: 29,


### PR DESCRIPTION
This makes the handling of email vs handle more correct in the codeowners file. A simple regexp vs this library only adds minimal overhead, so I'm going with this more precise approach. The precision here will be required to correctly look up a user by username or email for resolving owners.

```
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/internal/own/codeowners
BenchmarkParseOwnerRegexp-10                     2179166               546.0 ns/op
BenchmarkParseOwnerRegexp-10                     2196027               544.2 ns/op
BenchmarkParseOwnerRegexp-10                     2187543               545.7 ns/op
BenchmarkParseOwnerRegexp-10                     2184733               548.0 ns/op
BenchmarkParseOwnerRegexp-10                     2186193               544.2 ns/op
BenchmarkParseOwnerRegexp-10                     2202376               543.4 ns/op
BenchmarkParseOwnerRegexp-10                     2190775               544.8 ns/op
BenchmarkParseOwnerRegexp-10                     2201841               544.5 ns/op
BenchmarkParseOwnerRegexp-10                     2192386               543.2 ns/op
BenchmarkParseOwnerRegexp-10                     2196045               546.7 ns/op
BenchmarkParseOwnerMailParseAddress-10           2033022               584.1 ns/op
BenchmarkParseOwnerMailParseAddress-10           2042937               591.0 ns/op
BenchmarkParseOwnerMailParseAddress-10           2001596               606.4 ns/op
BenchmarkParseOwnerMailParseAddress-10           2034459               585.0 ns/op
BenchmarkParseOwnerMailParseAddress-10           2051786               584.0 ns/op
BenchmarkParseOwnerMailParseAddress-10           2042914               586.1 ns/op
BenchmarkParseOwnerMailParseAddress-10           1996677               596.0 ns/op
BenchmarkParseOwnerMailParseAddress-10           2040442               598.4 ns/op
BenchmarkParseOwnerMailParseAddress-10           2037429               590.1 ns/op
BenchmarkParseOwnerMailParseAddress-10           2033472               603.6 ns/op
```



## Test plan

Tests still passed, and verified the performance implications of this.