### PR TITLE
own: Improve performance of FindOwners

### DIFF
--- a/internal/own/codeowners/v1/find_owners.go
+++ b/internal/own/codeowners/v1/find_owners.go
@@ -13,17 +13,19 @@ import (
 // Rules are evaluated in order: Returned owners come from the rule which pattern matches
 // given path, that is the furthest down the file.
 func (x *File) FindOwners(path string) []*Owner {
-	var owners []*Owner
-	for _, rule := range x.GetRule() {
+	rules := x.GetRule()
+	for i := len(rules) - 1; i >= 0; i-- {
+		rule := rules[i]
+
 		glob, err := compile(rule.GetPattern())
 		if err != nil {
 			continue
 		}
 		if glob.match(path) {
-			owners = rule.GetOwner()
+			return rule.GetOwner()
 		}
 	}
-	return owners
+	return nil
 }
 
 const separator = "/"


### PR DESCRIPTION
Since we always need to use the _last_ match in the file, we can just start finding a match from the last line upward, and return early if required.

## Test plan

Nothing seems to have broken, performance on a local instance is noticeably better.