### PR TITLE
fix pr body in changelog:cut command

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -243,7 +243,8 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
         argNames: ['changelogFile'],
         run: async (config, changelogFile = 'CHANGELOG.md') => {
             const upcoming = await getActiveRelease(config)
-            const prMessage = `changelog: cut sourcegraph@${upcoming.version.version}`
+            const commitMessage = `changelog: cut sourcegraph@${upcoming.version.version}`
+            const prBody = commitMessage + '\n\n ## Test plan\n\nN/A'
             const pullRequest = await createChangesets({
                 requiredCommands: [],
                 changes: [
@@ -252,8 +253,9 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                         repo: 'sourcegraph',
                         base: 'main',
                         head: `changelog-${upcoming.version.version}`,
-                        title: prMessage,
-                        commitMessage: prMessage + '\n\n ## Test plan\n\nn/a',
+                        title: commitMessage,
+                        commitMessage,
+                        body: prBody,
                         edits: [
                             (directory: string) => {
                                 console.log(`Updating '${changelogFile} for ${upcoming.version.format()}'`)
@@ -281,9 +283,9 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                         repo: 'deploy-sourcegraph-helm',
                         base: 'main',
                         head: `changelog-${upcoming.version.version}`,
-                        title: prMessage,
-                        commitMessage: prMessage,
-                        body: prMessage + '\n\n ## Test plan\n\nn/a',
+                        title: commitMessage,
+                        commitMessage,
+                        body: prBody,
                         edits: [
                             (directory: string) => {
                                 console.log(`Updating '${changelogFile} for ${upcoming.version.format()}'`)


### PR DESCRIPTION
The commit message was accidentally getting the commit body (including test plan)

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-fix-changelog-cut-prbody.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
