### PR TITLE
use types.ExternalServiceRepository instead of types.Repo

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -519,14 +519,7 @@ func (r *externalServiceRepositoryConnectionResolver) compute(ctx context.Contex
 			return
 		}
 
-		for _, repo := range res.Repos {
-			node := &types.ExternalServiceRepository{
-				ID:         repo.ID,
-				Name:       repo.Name,
-				ExternalID: repo.ExternalRepo.ID,
-			}
-			r.nodes = append(r.nodes, node)
-		}
+		r.nodes = res.Repos
 	})
 
 	return r.nodes, r.err

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -1280,7 +1280,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 	res1 := singleResult(graphqlID1, repoName1, externalID1)
 	res2 := singleResult(graphqlID2, repoName2, externalID2)
 
-	mockExternalServiceRepos := func(t *testing.T, repos []*types.Repo, err error) {
+	mockExternalServiceRepos := func(t *testing.T, repos []*types.ExternalServiceRepository, err error) {
 		t.Helper()
 
 		errStr := ""
@@ -1305,7 +1305,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		mockExternalServiceRepos(t, []*types.Repo{&repo1, &repo2}, nil)
+		mockExternalServiceRepos(t, []*types.ExternalServiceRepository{repo1.ToExternalServiceRepository(), repo2.ToExternalServiceRepository()}, nil)
 
 		RunTest(t, &Test{
 			Schema: mustParseGraphQLSchema(t, db),
@@ -1332,7 +1332,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		mockExternalServiceRepos(t, []*types.Repo{&repo1, &repo2}, nil)
+		mockExternalServiceRepos(t, []*types.ExternalServiceRepository{repo1.ToExternalServiceRepository(), repo2.ToExternalServiceRepository()}, nil)
 
 		RunTest(t, &Test{
 			Schema:         mustParseGraphQLSchema(t, db),
@@ -1362,7 +1362,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		mockExternalServiceRepos(t, []*types.Repo{&repo1, &repo2}, nil)
+		mockExternalServiceRepos(t, []*types.ExternalServiceRepository{repo1.ToExternalServiceRepository(), repo2.ToExternalServiceRepository()}, nil)
 
 		RunTest(t, &Test{
 			Schema: mustParseGraphQLSchema(t, db),
@@ -1389,7 +1389,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		mockExternalServiceRepos(t, []*types.Repo{&repo1, &repo2}, nil)
+		mockExternalServiceRepos(t, []*types.ExternalServiceRepository{repo1.ToExternalServiceRepository(), repo2.ToExternalServiceRepository()}, nil)
 
 		RunTest(t, &Test{
 			Schema: mustParseGraphQLSchema(t, db),
@@ -1445,7 +1445,7 @@ func TestExternalServiceRepositories(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		mockExternalServiceRepos(t, []*types.Repo{&repo1, &repo2}, nil)
+		mockExternalServiceRepos(t, []*types.ExternalServiceRepository{repo1.ToExternalServiceRepository(), repo2.ToExternalServiceRepository()}, nil)
 
 		RunTest(t, &Test{
 			Schema:         mustParseGraphQLSchema(t, db),

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -524,14 +524,14 @@ func (s *Server) handleExternalServiceRepositories(w http.ResponseWriter, r *htt
 	}()
 
 	var sourceErrs error
-	repositories := make([]*types.Repo, 0)
+	repositories := make([]*types.ExternalServiceRepository, 0)
 
 	for res := range results {
 		if res.Err != nil {
 			sourceErrs = errors.Append(sourceErrs, &repos.SourceError{Err: res.Err, ExtSvc: externalSvc})
 			continue
 		}
-		repositories = append(repositories, res.Repo)
+		repositories = append(repositories, res.Repo.ToExternalServiceRepository())
 	}
 
 	if sourceErrs != nil {

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -1043,7 +1043,7 @@ func TestServer_ExternalServiceRepositories(t *testing.T) {
 			first:        5,
 			excludeRepos: []string{},
 			src:          repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, githubRepository), false),
-			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.Repo{githubRepository}, Error: ""},
+			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.ExternalServiceRepository{githubRepository.ToExternalServiceRepository()}, Error: ""},
 		},
 		{
 			name:         "discoverable source - github - non empty query string",
@@ -1053,7 +1053,7 @@ func TestServer_ExternalServiceRepositories(t *testing.T) {
 			first:        5,
 			excludeRepos: []string{},
 			src:          repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, githubRepository), false),
-			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.Repo{githubRepository}, Error: ""},
+			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.ExternalServiceRepository{githubRepository.ToExternalServiceRepository()}, Error: ""},
 		},
 		{
 			name:         "discoverable source - github - non empty excludeRepos",
@@ -1063,7 +1063,7 @@ func TestServer_ExternalServiceRepositories(t *testing.T) {
 			first:        5,
 			excludeRepos: []string{"org1/repo1", "owner2/repo2"},
 			src:          repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil, githubRepository), false),
-			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.Repo{githubRepository}, Error: ""},
+			result:       &protocol.ExternalServiceRepositoriesResult{Repos: []*types.ExternalServiceRepository{githubRepository.ToExternalServiceRepository()}, Error: ""},
 		},
 		{
 			name:   "unavailable - github.com",
@@ -1078,7 +1078,7 @@ func TestServer_ExternalServiceRepositories(t *testing.T) {
 			kind:   extsvc.KindGitHub,
 			config: githubConnection,
 			src:    repos.NewFakeDiscoverableSource(repos.NewFakeSource(&githubSource, nil), false),
-			result: &protocol.ExternalServiceRepositoriesResult{Repos: []*types.Repo{}, Error: ""},
+			result: &protocol.ExternalServiceRepositoriesResult{Repos: []*types.ExternalServiceRepository{}, Error: ""},
 		},
 		{
 			name:   "source does not implement discoverable source",

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -292,6 +292,6 @@ type ExternalServiceRepositoriesArgs struct {
 }
 
 type ExternalServiceRepositoriesResult struct {
-	Repos []*types.Repo
+	Repos []*types.ExternalServiceRepository
 	Error string
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -137,6 +137,14 @@ func (r *Repo) ExternalServiceIDs() []int64 {
 	return ids
 }
 
+func (r *Repo) ToExternalServiceRepository() *ExternalServiceRepository {
+	return &ExternalServiceRepository{
+		ID:         r.ID,
+		Name:       r.Name,
+		ExternalID: r.ExternalRepo.ID,
+	}
+}
+
 // BlockedRepoError is returned by a Repo IsBlocked method.
 type BlockedRepoError struct {
 	Name   api.RepoName


### PR DESCRIPTION
Followup from https://github.com/sourcegraph/sourcegraph/pull/48096

This changes the ExternalServiceRepositories response to return types.ExternalServiceRepository instead of types.Repo. We do not actually use all the fields of types.Repo, and always convert it to a types.ExternalServiceRepository. Additionally, a types.Repo cannot be safely serialized to JSON because it loses the type information in the Metadata field, so we don't want to have invalid types.Repo values floating around.

This is blocking adding a gRPC implementation of these new RPCs because I don't want to implement an incorrect protobuf encoding of `types.Repo`. 

## Test plan

Existing tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
