### PR TITLE
gRPC: register the reflection service by default

### DIFF
--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -150,7 +149,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{
 		Server: &gitserver,
 	})
-	reflection.Register(grpcServer)
 
 	gitserver.RegisterMetrics(observationCtx, db)
 

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -17,7 +17,6 @@ import (
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -182,7 +181,6 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	defer cancel()
 
 	grpcServer := defaults.NewServer(logger)
-	reflection.Register(grpcServer)
 	grpcServer.RegisterService(&proto.SearcherService_ServiceDesc, &search.Server{
 		Service: sService,
 	})

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/go-ctags"
 	logger "github.com/sourcegraph/log"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
@@ -100,8 +99,6 @@ func NewHandler(
 		ctagsBinary:  ctagsBinary,
 		logger:       rootLogger.Scoped("grpc", "grpc server implementation"),
 	})
-
-	reflection.Register(grpcServer)
 
 	jsonLogger := rootLogger.Scoped("jsonrpc", "json server implementation")
 

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"sync"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -62,7 +62,9 @@ func DialOptions() []grpc.DialOption {
 
 // NewServer creates a new *grpc.Server with the default options
 func NewServer(logger log.Logger, additionalOpts ...grpc.ServerOption) *grpc.Server {
-	return grpc.NewServer(append(ServerOptions(logger), additionalOpts...)...)
+	s := grpc.NewServer(append(ServerOptions(logger), additionalOpts...)...)
+	reflection.Register(s)
+	return s
 }
 
 // ServerOptions is a set of default server options that should be used for all


### PR DESCRIPTION
The current pattern is to create a server with `defaults.NewServer()` then immediately register the reflection service on it. Instead, let's just automatically register the reflection service and remove one more import. 

## Test plan

Checked that the debug endpoints that rely on reflection still work

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
