### PR TITLE
gRPC: establish pattern of using generated register funcs

### DIFF
--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -146,7 +146,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	grpcServer := defaults.NewServer(logger)
-	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{
+	proto.RegisterGitserverServiceServer(grpcServer, &server.GRPCServer{
 		Server: &gitserver,
 	})
 

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -181,7 +181,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	defer cancel()
 
 	grpcServer := defaults.NewServer(logger)
-	grpcServer.RegisterService(&proto.SearcherService_ServiceDesc, &search.Server{
+	proto.RegisterSearcherServiceServer(grpcServer, &search.Server{
 		Service: sService,
 	})
 

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -93,7 +93,7 @@ func NewHandler(
 
 	// Initialize the gRPC server
 	grpcServer := defaults.NewServer(rootLogger)
-	grpcServer.RegisterService(&proto.SymbolsService_ServiceDesc, &grpcService{
+	proto.RegisterSymbolsServiceServer(grpcServer, &grpcService{
 		searchFunc:   searchFuncWrapper,
 		readFileFunc: readFileFunc,
 		ctagsBinary:  ctagsBinary,

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -413,7 +413,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 	}
 
 	grpcServer := defaults.NewServer(logtest.Scoped(t))
-	grpcServer.RegisterService(&proto.GitserverService_ServiceDesc, &server.GRPCServer{Server: &s})
+	proto.RegisterGitserverServiceServer(grpcServer, &server.GRPCServer{Server: &s})
 
 	handler := internalgrpc.MultiplexHandlers(grpcServer, s.Handler())
 	srv := httptest.NewServer(handler)

--- a/internal/symbols/client_test.go
+++ b/internal/symbols/client_test.go
@@ -208,8 +208,7 @@ type mockSymbolsServer struct {
 
 func (m *mockSymbolsServer) NewHandler(l log.Logger) (handler http.Handler, cleanup func()) {
 	grpcServer := defaults.NewServer(l)
-
-	grpcServer.RegisterService(&proto.SymbolsService_ServiceDesc, m)
+	proto.RegisterSymbolsServiceServer(grpcServer, m)
 
 	handler = internalgrpc.MultiplexHandlers(grpcServer, http.HandlerFunc(m.serveRestHandler))
 	cleanup = func() {


### PR DESCRIPTION
This replaces our calls of grpcServer.Register() with the registration functions generated with the services. These generated functions are more strongly typed, so will fail fast at compile time if you try to register the wrong kind of server.

Stacked on #48309 

## Test plan

It compiles.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
