### PR TITLE
Setup Wizard: Prepare first setup wizard UI prototype

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -144,7 +144,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
                     </div>
                 }
             >
-                <LazySetupWizard />
+                <LazySetupWizard isSourcegraphApp={props.isSourcegraphApp} />
             </Suspense>
         )
     }

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -137,7 +137,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     </div>
                 }
             >
-                <LazySetupWizard isSourcegraphApp={props.isSourcegraphApp}/>
+                <LazySetupWizard isSourcegraphApp={props.isSourcegraphApp} />
             </Suspense>
         )
     }

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -137,7 +137,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     </div>
                 }
             >
-                <LazySetupWizard />
+                <LazySetupWizard isSourcegraphApp={props.isSourcegraphApp}/>
             </Suspense>
         )
     }

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useCallback } from 'react'
+import { FC, ReactElement, useCallback, useMemo } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { H1, H2, Text } from '@sourcegraph/wildcard'
@@ -12,29 +12,40 @@ import { SetupStepsRoot, SetupStepsContent, SetupStepsFooter, StepConfiguration 
 
 import styles from './Setup.module.scss'
 
-const SETUP_STEPS: StepConfiguration[] = [
+const CORE_STEPS: StepConfiguration[] = [
     {
-        id: '001',
-        name: 'Add local repositories',
-        path: '/setup/local-repositories',
-        component: LocalRepositoriesStep,
-    },
-    {
-        id: '002',
+        id: 'remote-repositoires',
         name: 'Add remote repositories',
         path: '/setup/remote-repositories',
         component: RemoteRepositoriesStep,
     },
     {
-        id: '003',
+        id: 'sync-repositories',
         name: 'Sync repositories',
         path: '/setup/sync-repositories',
         component: SyncRepositoriesStep,
     },
 ]
 
-export const SetupWizard: FC = () => {
+const SOURCEGRAPH_STEPS = [
+    {
+        id: 'local-repositories',
+        name: 'Add local repositories',
+        path: '/setup/local-repositories',
+        component: LocalRepositoriesStep,
+    },
+    ...CORE_STEPS
+]
+
+interface SetupWizardProps {
+    isSourcegraphApp: boolean
+}
+
+export const SetupWizard: FC<SetupWizardProps> = props => {
+    const { isSourcegraphApp } = props
+
     const [activeStepId, setStepId, status] = useTemporarySetting('setup.activeStepId')
+    const steps = useMemo(() => isSourcegraphApp ? SOURCEGRAPH_STEPS : CORE_STEPS, [isSourcegraphApp])
 
     const handleStepChange = useCallback(
         (step: StepConfiguration): void => {
@@ -50,7 +61,7 @@ export const SetupWizard: FC = () => {
     return (
         <div className={styles.root}>
             <PageTitle title="Setup" />
-            <SetupStepsRoot initialStepId={activeStepId} steps={SETUP_STEPS} onStepChange={handleStepChange}>
+            <SetupStepsRoot initialStepId={activeStepId} steps={steps} onStepChange={handleStepChange}>
                 <div className={styles.content}>
                     <header className={styles.header}>
                         <BrandLogo variant="logo" isLightTheme={false} className={styles.logo} />

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -27,7 +27,7 @@ const CORE_STEPS: StepConfiguration[] = [
     },
 ]
 
-const SOURCEGRAPH_STEPS = [
+const SOURCEGRAPH_APP_STEPS = [
     {
         id: 'local-repositories',
         name: 'Add local repositories',
@@ -45,7 +45,7 @@ export const SetupWizard: FC<SetupWizardProps> = props => {
     const { isSourcegraphApp } = props
 
     const [activeStepId, setStepId, status] = useTemporarySetting('setup.activeStepId')
-    const steps = useMemo(() => (isSourcegraphApp ? SOURCEGRAPH_STEPS : CORE_STEPS), [isSourcegraphApp])
+    const steps = useMemo(() => (isSourcegraphApp ? SOURCEGRAPH_APP_STEPS : CORE_STEPS), [isSourcegraphApp])
 
     const handleStepChange = useCallback(
         (step: StepConfiguration): void => {
@@ -87,7 +87,7 @@ function LocalRepositoriesStep(props: any): ReactElement {
 function SyncRepositoriesStep(props: any): ReactElement {
     return (
         <section {...props}>
-            <Text>
+            <Text className="mb-2">
                 It may take a few moments to clone and index each repository. Repository statuses are displayed below.
             </Text>
             <SiteAdminRepositoriesContainer />

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -34,7 +34,7 @@ const SOURCEGRAPH_STEPS = [
         path: '/setup/local-repositories',
         component: LocalRepositoriesStep,
     },
-    ...CORE_STEPS
+    ...CORE_STEPS,
 ]
 
 interface SetupWizardProps {
@@ -45,7 +45,7 @@ export const SetupWizard: FC<SetupWizardProps> = props => {
     const { isSourcegraphApp } = props
 
     const [activeStepId, setStepId, status] = useTemporarySetting('setup.activeStepId')
-    const steps = useMemo(() => isSourcegraphApp ? SOURCEGRAPH_STEPS : CORE_STEPS, [isSourcegraphApp])
+    const steps = useMemo(() => (isSourcegraphApp ? SOURCEGRAPH_STEPS : CORE_STEPS), [isSourcegraphApp])
 
     const handleStepChange = useCallback(
         (step: StepConfiguration): void => {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -6,15 +6,15 @@ import { Routes, Route, matchPath, useLocation } from 'react-router-dom'
 
 import { Container, Text } from '@sourcegraph/wildcard'
 
-import { GetCodeHostsResult } from '../../../graphql-operations';
+import { GetCodeHostsResult } from '../../../graphql-operations'
 import { FooterWidget, CustomNextButton } from '../setup-steps'
 
 import { CodeHostDeleteModal, CodeHostToDelete } from './components/code-host-delete-modal'
 import { CodeHostsPicker } from './components/code-host-picker'
 import { CodeHostCreation, CodeHostEdit } from './components/code-hosts'
 import { CodeHostsNavigation } from './components/navigation'
-import { isAnyConnectedCodeHosts } from './helpers';
-import { GET_CODE_HOSTS } from './queries';
+import { isAnyConnectedCodeHosts } from './helpers'
+import { GET_CODE_HOSTS } from './queries'
 
 import styles from './RemoteRepositoriesStep.module.scss'
 
@@ -33,7 +33,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
         fetchPolicy: 'cache-and-network',
         // Polling the most recent data about code host in order to track
         // the current progress of repositories syncing
-        pollInterval: 5000
+        pollInterval: 5000,
     })
 
     return (
@@ -69,9 +69,10 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
             <CustomNextButton
                 label="Next"
                 disabled={!isAnyConnectedCodeHosts(codeHostQueryResult.data)}
-                tooltip={isAnyConnectedCodeHosts(codeHostQueryResult.data)
-                    ? 'You can get back to this later'
-                    : 'You have to connect at least one code host'
+                tooltip={
+                    isAnyConnectedCodeHosts(codeHostQueryResult.data)
+                        ? 'You can get back to this later'
+                        : 'You have to connect at least one code host'
                 }
             />
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -38,7 +38,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
 
     return (
         <div {...attributes} className={classNames(className, styles.root)}>
-            <Text size="small" className="mb-2">
+            <Text className="mb-2">
                 Connect remote code hosts where your source code lives.
             </Text>
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -38,9 +38,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
 
     return (
         <div {...attributes} className={classNames(className, styles.root)}>
-            <Text className="mb-2">
-                Connect remote code hosts where your source code lives.
-            </Text>
+            <Text className="mb-2">Connect remote code hosts where your source code lives.</Text>
 
             <section className={styles.content}>
                 <Container className={styles.contentNavigation}>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -1,16 +1,20 @@
 import { FC, HTMLAttributes, useState } from 'react'
 
+import { useQuery } from '@apollo/client'
 import classNames from 'classnames'
 import { Routes, Route, matchPath, useLocation } from 'react-router-dom'
 
 import { Container, Text } from '@sourcegraph/wildcard'
 
+import { GetCodeHostsResult } from '../../../graphql-operations';
 import { FooterWidget, CustomNextButton } from '../setup-steps'
 
 import { CodeHostDeleteModal, CodeHostToDelete } from './components/code-host-delete-modal'
 import { CodeHostsPicker } from './components/code-host-picker'
 import { CodeHostCreation, CodeHostEdit } from './components/code-hosts'
 import { CodeHostsNavigation } from './components/navigation'
+import { isAnyConnectedCodeHosts } from './helpers';
+import { GET_CODE_HOSTS } from './queries';
 
 import styles from './RemoteRepositoriesStep.module.scss'
 
@@ -25,6 +29,13 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
     const editConnectionRouteMatch = matchPath('/setup/remote-repositories/:codehostId/edit', location.pathname)
     const newConnectionRouteMatch = matchPath('/setup/remote-repositories/:codeHostType/create', location.pathname)
 
+    const codeHostQueryResult = useQuery<GetCodeHostsResult>(GET_CODE_HOSTS, {
+        fetchPolicy: 'cache-and-network',
+        // Polling the most recent data about code host in order to track
+        // the current progress of repositories syncing
+        pollInterval: 5000
+    })
+
     return (
         <div {...attributes} className={classNames(className, styles.root)}>
             <Text size="small" className="mb-2">
@@ -34,6 +45,7 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
             <section className={styles.content}>
                 <Container className={styles.contentNavigation}>
                     <CodeHostsNavigation
+                        codeHostQueryResult={codeHostQueryResult}
                         activeConnectionId={editConnectionRouteMatch?.params?.codehostId}
                         createConnectionType={newConnectionRouteMatch?.params?.codeHostType}
                         className={styles.navigation}
@@ -54,7 +66,14 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
             </section>
 
             <FooterWidget>Hello custom content in the footer</FooterWidget>
-            <CustomNextButton label="Custom next step label" disabled={true} />
+            <CustomNextButton
+                label="Next"
+                disabled={!isAnyConnectedCodeHosts(codeHostQueryResult.data)}
+                tooltip={isAnyConnectedCodeHosts(codeHostQueryResult.data)
+                    ? 'You can get back to this later'
+                    : 'You have to connect at least one code host'
+                }
+            />
 
             {codeHostToDelete && (
                 <CodeHostDeleteModal codeHost={codeHostToDelete} onDismiss={() => setCodeHostToDelete(null)} />

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
@@ -10,7 +10,11 @@ import styles from './CodeHostsPicker.module.scss'
 const SUPPORTED_CODE_HOSTS = [
     ExternalServiceKind.GITHUB,
     ExternalServiceKind.GITLAB,
+    ExternalServiceKind.GERRIT,
     ExternalServiceKind.BITBUCKETCLOUD,
+    ExternalServiceKind.BITBUCKETSERVER,
+    ExternalServiceKind.AWSCODECOMMIT,
+    ExternalServiceKind.GITOLITE,
 ]
 
 export const CodeHostsPicker: FC = () => (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -12,6 +12,7 @@ import {
     AddExternalServiceInput,
     AddRemoteCodeHostResult,
     AddRemoteCodeHostVariables,
+    GetCodeHostsResult,
 } from '../../../../../graphql-operations'
 import { getCodeHostKindFromURLParam } from '../../helpers'
 import { ADD_CODE_HOST, CODE_HOST_FRAGMENT } from '../../queries'
@@ -90,7 +91,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
 
                 cache.modify({
                     fields: {
-                        externalServices(codeHosts) {
+                        externalServices(codeHosts: GetCodeHostsResult['externalServices']) {
                             const newCodeHost = cache.writeFragment({
                                 data: data.addExternalService,
                                 fragment: CODE_HOST_FRAGMENT,

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -284,7 +284,12 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
                     label="Add selected repositories"
                     onChange={handleRepositoriesModeChange}
                 >
-                    <GithubRepositoriesPicker repositories={repositories} onChange={handleRepositoriesChange} />
+                    <GithubRepositoriesPicker
+                        token={accessTokenField.input.value}
+                        disabled={accessTokenField.meta.validState !== 'VALID'}
+                        repositories={repositories}
+                        onChange={handleRepositoriesChange}
+                    />
                 </RadioGroupSection>
             </section>
         </>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -268,7 +268,12 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
                     label="Add all repositories from selected organizations or users"
                     onChange={handleOrganizationsModeChange}
                 >
-                    <GithubOrganizationsPicker organizations={organizations} onChange={handleOrganizationsChange} />
+                    <GithubOrganizationsPicker
+                        token={accessTokenField.input.value}
+                        disabled={accessTokenField.meta.validState !== 'VALID'}
+                        organizations={organizations}
+                        onChange={handleOrganizationsChange}
+                    />
                 </RadioGroupSection>
 
                 <RadioGroupSection

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -59,15 +59,12 @@
     }
 
     &--with-more-link {
-        border-top: 1px solid var(--border-color);
         position: sticky;
         bottom: 0;
-        background-color: var(--light-text);
-        margin-top: auto;
-        margin-bottom: -1rem;
-        margin-left: -1rem;
-        margin-right: -1rem;
         padding: 0 0.5rem;
+        margin: auto -1rem -1rem;
+        background-color: var(--color-bg-1);
+        border-top: 1px solid var(--border-color);
     }
 
     &--creation {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactElement } from 'react'
 
-import { useQuery } from '@apollo/client'
+import { QueryResult } from '@apollo/client'
 import { mdiInformationOutline, mdiDelete, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 
@@ -8,11 +8,11 @@ import { ErrorAlert, Icon, LoadingSpinner, Button, Tooltip, Link } from '@source
 
 import { CodeHost, GetCodeHostsResult } from '../../../../../graphql-operations'
 import { getCodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../../helpers'
-import { GET_CODE_HOSTS } from '../../queries'
 
 import styles from './CodeHostsNavigation.module.scss'
 
 interface CodeHostsNavigationProps {
+    codeHostQueryResult: QueryResult<GetCodeHostsResult>
     activeConnectionId: string | undefined
     createConnectionType: string | undefined
     className?: string
@@ -20,11 +20,8 @@ interface CodeHostsNavigationProps {
 }
 
 export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
-    const { activeConnectionId, createConnectionType, className, onCodeHostDelete } = props
-
-    const { data, loading, error, refetch } = useQuery<GetCodeHostsResult>(GET_CODE_HOSTS, {
-        fetchPolicy: 'cache-and-network',
-    })
+    const { codeHostQueryResult, activeConnectionId, createConnectionType, className, onCodeHostDelete } = props
+    const { data, loading, error, refetch } = codeHostQueryResult
 
     if (error && !loading) {
         return (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
@@ -8,16 +8,18 @@ export const getCodeHostIcon = (codeHostType: ExternalServiceKind | null): strin
     switch (codeHostType) {
         case ExternalServiceKind.GITHUB:
             return mdiGithub
-        case ExternalServiceKind.GITLAB:
-            return mdiGitlab
         case ExternalServiceKind.BITBUCKETCLOUD:
             return mdiBitbucket
+        case ExternalServiceKind.BITBUCKETSERVER:
+            return mdiBitbucket
+        case ExternalServiceKind.GITLAB:
+            return mdiGitlab
+        case ExternalServiceKind.GITOLITE:
+            return mdiGit
         case ExternalServiceKind.AWSCODECOMMIT:
             return mdiAws
         case ExternalServiceKind.AZUREDEVOPS:
             return mdiGit
-        case ExternalServiceKind.BITBUCKETSERVER:
-            return mdiBitbucket
         default:
             // TODO: Add support for other code host
             return ''
@@ -32,8 +34,14 @@ export const getCodeHostName = (codeHostType: ExternalServiceKind | null): strin
             return 'GitLab'
         case ExternalServiceKind.BITBUCKETCLOUD:
             return 'BitBucket.org'
+        case ExternalServiceKind.BITBUCKETSERVER:
+            return 'BitBucket Server'
         case ExternalServiceKind.AWSCODECOMMIT:
             return 'AWS Code Commit'
+        case ExternalServiceKind.GITOLITE:
+            return 'Gitolite'
+        case ExternalServiceKind.GERRIT:
+            return 'Gerrit'
 
         default:
             // TODO: Add support for other code host

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
@@ -2,6 +2,8 @@ import { mdiBitbucket, mdiGithub, mdiGitlab, mdiAws, mdiGit } from '@mdi/js'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 
+import { GetCodeHostsResult } from '../../../graphql-operations';
+
 export const getCodeHostIcon = (codeHostType: ExternalServiceKind | null): string => {
     switch (codeHostType) {
         case ExternalServiceKind.GITHUB:
@@ -45,4 +47,12 @@ export const getCodeHostKindFromURLParam = (possibleCodeHostType: string): Exter
     const possibleKind = ExternalServiceKind[possibleCodeHostType.toUpperCase() as ExternalServiceKind]
 
     return possibleKind ?? null
+}
+
+export const isAnyConnectedCodeHosts = (data?: GetCodeHostsResult): boolean => {
+    if (!data) {
+        return false
+    }
+
+    return data.externalServices.nodes.length > 0
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.ts
@@ -2,7 +2,7 @@ import { mdiBitbucket, mdiGithub, mdiGitlab, mdiAws, mdiGit } from '@mdi/js'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 
-import { GetCodeHostsResult } from '../../../graphql-operations';
+import { GetCodeHostsResult } from '../../../graphql-operations'
 
 export const getCodeHostIcon = (codeHostType: ExternalServiceKind | null): string => {
     switch (codeHostType) {

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
@@ -98,6 +98,7 @@
     flex-direction: column;
     position: sticky;
     bottom: 0;
+    background-color: var(--gray-02);
 
     $self: &;
 
@@ -107,7 +108,6 @@
 
     &-navigation {
         display: flex;
-        background-color: var(--gray-02);
         border-top: 1px solid var(--border-color);
     }
 

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
@@ -86,7 +86,7 @@
     flex-grow: 1;
     margin: auto;
     max-width: 55rem;
-    padding: 0.5rem;
+    padding: 0 0.5rem 0.5rem;
 }
 
 .actions {

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -18,7 +18,7 @@ import { noop } from 'lodash'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate, Routes, Route, Navigate, matchPath } from 'react-router-dom'
 
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './SetupSteps.module.scss'
 
@@ -229,10 +229,11 @@ export const FooterWidget: FC<PropsWithChildren<{}>> = props => {
 interface CustomNextButtonProps {
     label: string
     disabled: boolean
+    tooltip?: string
 }
 
 export const CustomNextButton: FC<CustomNextButtonProps> = props => {
-    const { label, disabled } = props
+    const { label, disabled, tooltip } = props
     const { nextButtonPortal, onNextStep } = useContext(SetupStepsContext)
 
     if (!nextButtonPortal) {
@@ -240,9 +241,12 @@ export const CustomNextButton: FC<CustomNextButtonProps> = props => {
     }
 
     return createPortal(
-        <Button variant="primary" disabled={disabled} onClick={onNextStep}>
-            {label}
-        </Button>,
+        <Tooltip content={tooltip}>
+            <Button variant="primary" disabled={disabled} onClick={onNextStep}>
+                {label}
+                <Icon svgPath={mdiChevronRight} aria-hidden={true} />
+            </Button>
+        </Tooltip>,
         nextButtonPortal
     )
 }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47237

This PR connected different parts of setup wizard, 
- Hide local repositories step (if you're running non Sourcegraph app instance)
- Connect next button with number of connected code hosts (you're not able to go to the next step until you connect at least one code host)
- Add a few new supported code host in the main remote code hosts list
- Connects orgs and repositories picker to newly merged API 

A few important parts will be resolved in follow PRs
- Add access token async validation, (it turned out that access token query hasn't been merged yet, we discussed it with Garry and it seems that there is a way to get this query soon, if something will show up we will use a workaround for this)
- Edit UI pickers doesn't work properly, also this is because pickers API for the edit UI haven't been merged yet

## Test plan
- Run you instance and
- Enable setup wizard feature flat `experimentalFeatures: { setupWizard: true }`
- Go to the `/setup` URL 
- Try to connect one of available code host 
- If you're connecting Github code host it should be possible to use form UI instead of code host json editor option 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-prepare-first-setup-prototype.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
