### PR TITLE
Ranking: simplify final flush in aggregator

### DIFF
--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -162,7 +162,7 @@ func (f *flushCollectSender) Send(endpoint string, event *zoekt.SearchResult) {
 		}
 
 		if len(f.firstEvent) == 0 {
-			f.stopCollectingAndFlush(zoekt.FlushReasonTimerExpired)
+			f.stopCollectingAndFlush(zoekt.FlushReasonFinalFlush)
 		} else if f.maxSizeBytes >= 0 && f.collectSender.sizeBytes > uint64(f.maxSizeBytes) {
 			// Protect against too large aggregates. This should be the exception and only
 			// happen for queries yielding an extreme number of results.
@@ -179,7 +179,7 @@ func (f *flushCollectSender) SendDone(endpoint string) {
 	f.mu.Lock()
 	delete(f.firstEvent, endpoint)
 	if len(f.firstEvent) == 0 {
-		f.stopCollectingAndFlush(zoekt.FlushReasonTimerExpired)
+		f.stopCollectingAndFlush(zoekt.FlushReasonFinalFlush)
 	}
 	f.mu.Unlock()
 }
@@ -209,10 +209,4 @@ func (f *flushCollectSender) stopCollectingAndFlush(reason zoekt.FlushReason) {
 
 	// Stop timer goroutine if it is still running.
 	close(f.timerCancel)
-}
-
-func (f *flushCollectSender) Flush() {
-	f.mu.Lock()
-	f.stopCollectingAndFlush(zoekt.FlushReasonFinalFlush)
-	f.mu.Unlock()
 }

--- a/internal/search/backend/aggregate_test.go
+++ b/internal/search/backend/aggregate_test.go
@@ -84,8 +84,8 @@ func TestFlushCollectSender(t *testing.T) {
 	if len(results) == 0 {
 		t.Fatal("no results returned from search")
 	}
-	if results[0].Stats.FlushReason != zoekt.FlushReasonTimerExpired {
-		t.Fatalf("expected flush reason %s but got %s", zoekt.FlushReasonTimerExpired, results[0].Stats.FlushReason)
+	if results[0].Stats.FlushReason != zoekt.FlushReasonFinalFlush {
+		t.Fatalf("expected flush reason %s but got %s", zoekt.FlushReasonFinalFlush, results[0].Stats.FlushReason)
 	}
 
 	// Check that the results were streamed in the expected order

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -212,7 +212,6 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
 
 	flushSender := newFlushCollectSender(opts, endpoints, siteConfig.maxSizeBytes, streamer)
-	defer flushSender.Flush()
 
 	// During re-balancing a repository can appear on more than one replica.
 	var mu sync.Mutex


### PR DESCRIPTION
Before, when we received a first result from every endpoint, we incorrectly flushed with the reason 'timer_expired'. This switches to 'final_flush', to capture that the aggregator is done as it's seen results from all endpoints.

It also removes logic to perform a last 'flush' after all endpoints are done streaming. This is actually a dead code path, since all endpoints will have responded by then (through either calling Send or SendDone).

## Test plan

Modify existing tests
