### PR TITLE
esbuild.context requires calling rebuild to build initially

### DIFF
--- a/client/jetbrains/scripts/build.ts
+++ b/client/jetbrains/scripts/build.ts
@@ -54,6 +54,7 @@ export async function build(): Promise<void> {
         sourcemap: true,
         outdir: distributionPath,
     })
+    await ctx.rebuild()
     if (process.env.WATCH) {
         await ctx.watch()
     }

--- a/client/vscode/scripts/build.ts
+++ b/client/vscode/scripts/build.ts
@@ -141,8 +141,11 @@ export async function build(): Promise<void> {
 
     const ctxs = await Promise.all(buildPromises)
 
+    await Promise.all(ctxs.map(ctx => ctx.rebuild()))
+
     if (process.env.WATCH) {
         await Promise.all(ctxs.map(ctx => ctx.watch()))
     }
+
     await Promise.all(ctxs.map(ctx => ctx.dispose()))
 }

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -99,6 +99,7 @@ export const build = async (): Promise<void> => {
     }
     if (!omitSlowDeps) {
         const ctx = await buildMonaco(STATIC_ASSETS_PATH)
+        await ctx.rebuild()
         await ctx.dispose()
     }
 }

--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -22,6 +22,7 @@ export const esbuildDevelopmentServer = async (
     // is rare enough to ignore here).
     if (!ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS) {
         const ctx = await buildMonaco(STATIC_ASSETS_PATH)
+        await ctx.rebuild()
         await ctx.dispose()
     }
 


### PR DESCRIPTION
I had assumed that `esbuild.context(...)` performs the initial build, but that was incorrect. You must call `rebuild()` on the awaited promise to perform the initial build.

Because esbuild is still only used as an alternative build system in local dev (and by occasional VS Code extension builds), this was not noticed before.




## Test plan

n/a; local dev only

## App preview:

- [Web](https://sg-web-sqs-esbuild-context-api-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
