### PR TITLE
Setup Experience: Optional use existing external service configuration for discovery

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -448,7 +448,18 @@ func (r *externalServiceNamespaceConnectionResolver) compute(ctx context.Context
 			return
 		}
 
-		args := protocol.ExternalServiceNamespacesArgs{Kind: r.args.Kind, Config: config}
+		var externalServiceID *int64
+		if r.args.ID != nil {
+			id, err := UnmarshalExternalServiceID(*r.args.ID)
+			if err != nil {
+				r.err = err
+				return
+			}
+			externalServiceID = &id
+		}
+
+		args := protocol.ExternalServiceNamespacesArgs{ExternalServiceID: externalServiceID, Kind: r.args.Kind, Config: config}
+
 		res, err := r.repoupdaterClient.ExternalServiceNamespaces(ctx, args)
 		if err != nil {
 			r.err = err
@@ -512,7 +523,17 @@ func (r *externalServiceRepositoryConnectionResolver) compute(ctx context.Contex
 			first = *r.args.First
 		}
 
-		reposArgs := protocol.ExternalServiceRepositoriesArgs{Kind: r.args.Kind, Query: r.args.Query, Config: config, First: first, ExcludeRepos: r.args.ExcludeRepos}
+		var externalServiceID *int64
+		if r.args.ID != nil {
+			id, err := UnmarshalExternalServiceID(*r.args.ID)
+			if err != nil {
+				r.err = err
+				return
+			}
+			externalServiceID = &id
+		}
+
+		reposArgs := protocol.ExternalServiceRepositoriesArgs{ExternalServiceID: externalServiceID, Kind: r.args.Kind, Query: r.args.Query, Config: config, First: first, ExcludeRepos: r.args.ExcludeRepos}
 		res, err := r.repoupdaterClient.ExternalServiceRepositories(ctx, reposArgs)
 		if err != nil {
 			r.err = err

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -458,9 +458,9 @@ func (r *externalServiceNamespaceConnectionResolver) compute(ctx context.Context
 			externalServiceID = &id
 		}
 
-		args := protocol.ExternalServiceNamespacesArgs{ExternalServiceID: externalServiceID, Kind: r.args.Kind, Config: config}
+		namespacesArgs := protocol.ExternalServiceNamespacesArgs{ExternalServiceID: externalServiceID, Kind: r.args.Kind, Config: config}
 
-		res, err := r.repoupdaterClient.ExternalServiceNamespaces(ctx, args)
+		res, err := r.repoupdaterClient.ExternalServiceNamespaces(ctx, namespacesArgs)
 		if err != nil {
 			r.err = err
 			return

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -449,6 +449,7 @@ func (r *schemaResolver) CancelExternalServiceSync(ctx context.Context, args *ca
 }
 
 type externalServiceNamespacesArgs struct {
+	ID    *graphql.ID
 	Kind  string
 	Token string
 	Url   string
@@ -476,6 +477,7 @@ type externalServiceNamespaceConnectionResolver struct {
 }
 
 type externalServiceRepositoriesArgs struct {
+	ID           *graphql.ID
 	Kind         string
 	Token        string
 	Url          string

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1300,6 +1300,12 @@ type Query {
     """
     externalServiceNamespaces(
         """
+        The id of the external service whose configuration will be used to create request parameters.
+        If no external service exists which provides the necessary request parameters then leave ID nil and
+        provide kind, token and url.
+        """
+        id: ID
+        """
         The kind of the external service.
         """
         kind: ExternalServiceKind!
@@ -1316,6 +1322,12 @@ type Query {
     Lists all repositories for a given external service connection.
     """
     externalServiceRepositories(
+        """
+        The id of the external service whose configuration will be used to create request parameters.
+        If no external service exists which provides the necessary request parameters then leave ID nil and
+        provide kind, token and url.
+        """
+        id: ID
         """
         The kind of the external service.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1300,9 +1300,10 @@ type Query {
     """
     externalServiceNamespaces(
         """
-        The id of the external service whose configuration will be used to create request parameters.
+        The GraphQL ID of the external service whose configuration will be used to define the code host remote url to
+        submit requests to and the token value to authenticate with.
         If no external service exists which provides the necessary request parameters then leave ID nil and
-        provide kind, token and url.
+        provide kind, remote code host token and url.
         """
         id: ID
         """
@@ -1323,9 +1324,10 @@ type Query {
     """
     externalServiceRepositories(
         """
-        The id of the external service whose configuration will be used to create request parameters.
+        The GraphQL ID of the external service whose configuration will be used to define the code host remote url to
+        submit requests to and the token value to authenticate with.
         If no external service exists which provides the necessary request parameters then leave ID nil and
-        provide kind, token and url.
+        provide kind, remote code host token and url.
         """
         id: ID
         """

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -412,14 +412,33 @@ func (s *Server) handleExternalServiceNamespaces(w http.ResponseWriter, r *http.
 		return
 	}
 
-	externalSvc := &types.ExternalService{
-		Kind:   req.Kind,
-		Config: extsvc.NewUnencryptedConfig(req.Config),
+	var (
+		externalSvc *types.ExternalService
+		err         error
+		result      *protocol.ExternalServiceNamespacesResult
+	)
+
+	externalServiceID := req.ExternalServiceID
+
+	if externalServiceID != nil {
+		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *externalServiceID)
+		if err != nil {
+			result = &protocol.ExternalServiceNamespacesResult{Error: err.Error()}
+			if errcode.IsNotFound(err) {
+				s.respond(w, http.StatusNotFound, result)
+			} else {
+				s.respond(w, http.StatusInternalServerError, result)
+			}
+			return
+		}
+	} else {
+		externalSvc = &types.ExternalService{
+			Kind:   req.Kind,
+			Config: extsvc.NewUnencryptedConfig(req.Config),
+		}
 	}
 
 	logger := s.Logger.With(log.String("ExternalServiceKind", req.Kind))
-
-	var result *protocol.ExternalServiceNamespacesResult
 
 	genericSourcer := s.NewGenericSourcer(logger)
 	genericSrc, err := genericSourcer(ctx, externalSvc)
@@ -480,14 +499,33 @@ func (s *Server) handleExternalServiceRepositories(w http.ResponseWriter, r *htt
 		return
 	}
 
-	externalSvc := &types.ExternalService{
-		Kind:   req.Kind,
-		Config: extsvc.NewUnencryptedConfig(req.Config),
+	var (
+		externalSvc *types.ExternalService
+		err         error
+		result      *protocol.ExternalServiceRepositoriesResult
+	)
+
+	externalServiceID := req.ExternalServiceID
+
+	if externalServiceID != nil {
+		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *externalServiceID)
+		if err != nil {
+			result = &protocol.ExternalServiceRepositoriesResult{Error: err.Error()}
+			if errcode.IsNotFound(err) {
+				s.respond(w, http.StatusNotFound, result)
+			} else {
+				s.respond(w, http.StatusInternalServerError, result)
+			}
+			return
+		}
+	} else {
+		externalSvc = &types.ExternalService{
+			Kind:   req.Kind,
+			Config: extsvc.NewUnencryptedConfig(req.Config),
+		}
 	}
 
 	logger := s.Logger.With(log.String("ExternalServiceKind", req.Kind))
-
-	var result *protocol.ExternalServiceRepositoriesResult
 
 	genericSourcer := s.NewGenericSourcer(logger)
 	genericSrc, err := genericSourcer(ctx, externalSvc)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -418,10 +418,8 @@ func (s *Server) handleExternalServiceNamespaces(w http.ResponseWriter, r *http.
 		result      *protocol.ExternalServiceNamespacesResult
 	)
 
-	externalServiceID := req.ExternalServiceID
-
-	if externalServiceID != nil {
-		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *externalServiceID)
+	if req.ExternalServiceID != nil {
+		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *req.ExternalServiceID)
 		if err != nil {
 			result = &protocol.ExternalServiceNamespacesResult{Error: err.Error()}
 			if errcode.IsNotFound(err) {
@@ -505,10 +503,8 @@ func (s *Server) handleExternalServiceRepositories(w http.ResponseWriter, r *htt
 		result      *protocol.ExternalServiceRepositoriesResult
 	)
 
-	externalServiceID := req.ExternalServiceID
-
-	if externalServiceID != nil {
-		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *externalServiceID)
+	if req.ExternalServiceID != nil {
+		externalSvc, err = s.ExternalServiceStore().GetByID(ctx, *req.ExternalServiceID)
 		if err != nil {
 			result = &protocol.ExternalServiceRepositoriesResult{Error: err.Error()}
 			if errcode.IsNotFound(err) {

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -937,7 +937,7 @@ func TestServer_ExternalServiceNamespaces(t *testing.T) {
 		},
 	}
 
-	const idDoesNotExist int64 = 99
+	var idDoesNotExist int64 = 99
 
 	testCases := []struct {
 		name              string

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -937,7 +937,7 @@ func TestServer_ExternalServiceNamespaces(t *testing.T) {
 		},
 	}
 
-	var idDoesNotExist int64 = 99
+	const idDoesNotExist int64 = 99
 
 	testCases := []struct {
 		name              string

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -450,8 +450,9 @@ type ExternalServiceSyncResult struct {
 }
 
 type ExternalServiceNamespacesArgs struct {
-	Kind   string
-	Config string
+	ExternalServiceID *int64
+	Kind              string
+	Config            string
 }
 
 type ExternalServiceNamespacesResult struct {
@@ -460,11 +461,12 @@ type ExternalServiceNamespacesResult struct {
 }
 
 type ExternalServiceRepositoriesArgs struct {
-	Kind         string
-	Query        string
-	Config       string
-	First        int32
-	ExcludeRepos []string
+	ExternalServiceID *int64
+	Kind              string
+	Query             string
+	Config            string
+	First             int32
+	ExcludeRepos      []string
 }
 
 type ExternalServiceRepositoriesResult struct {


### PR DESCRIPTION
With PRs https://github.com/sourcegraph/sourcegraph/pull/47932 and https://github.com/sourcegraph/sourcegraph/pull/48096 one can submit graphql queries for discover repositories and organizations on github remote source. A token and remote url are both required.

For the use case of discovery on a remote source that is stored in ExternalServicesStore we should accept an external service ID, Get the external service by ID, and use the existing configuration for discovery related requests that repoupdater submits to the remote github source.

In addition to the above functionality I've also refactored some existing tests to reduce duplicated logic.

GH Issue: https://github.com/sourcegraph/sourcegraph/issues/47984
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Add new repoupdater server tests and external service tests.