### PR TITLE
Setup Experience: repoupdater discerns status code

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -432,7 +432,11 @@ func (s *Server) handleExternalServiceNamespaces(w http.ResponseWriter, r *http.
 
 	if err = genericSrc.CheckConnection(ctx); err != nil {
 		result = &protocol.ExternalServiceNamespacesResult{Error: err.Error()}
-		s.respond(w, http.StatusServiceUnavailable, result)
+		if errcode.IsUnauthorized(err) {
+			s.respond(w, http.StatusUnauthorized, result)
+		} else {
+			s.respond(w, http.StatusServiceUnavailable, result)
+		}
 		return
 	}
 
@@ -500,7 +504,11 @@ func (s *Server) handleExternalServiceRepositories(w http.ResponseWriter, r *htt
 
 	if err = genericSrc.CheckConnection(ctx); err != nil {
 		result = &protocol.ExternalServiceRepositoriesResult{Error: err.Error()}
-		s.respond(w, http.StatusServiceUnavailable, result)
+		if errcode.IsUnauthorized(err) {
+			s.respond(w, http.StatusUnauthorized, result)
+		} else {
+			s.respond(w, http.StatusServiceUnavailable, result)
+		}
 		return
 	}
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -434,9 +434,10 @@ func (s *Server) handleExternalServiceNamespaces(w http.ResponseWriter, r *http.
 		result = &protocol.ExternalServiceNamespacesResult{Error: err.Error()}
 		if errcode.IsUnauthorized(err) {
 			s.respond(w, http.StatusUnauthorized, result)
-		} else {
-			s.respond(w, http.StatusServiceUnavailable, result)
+			return
 		}
+
+		s.respond(w, http.StatusServiceUnavailable, result)
 		return
 	}
 


### PR DESCRIPTION
When we pass the non empty token value to github to check connection, if github returns 401 unauthorized then we should discern this from any other returned error. In the case of 401 our internal retry policy does not trigger further retries which, for an unauthorized token value, will receive the same result from github for each attempt.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
run graphql queries with invalid non empty token value