### PR TITLE
[Permissions] add graphql api for listing repos accessible to a user

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -118,4 +118,17 @@ type PermissionsInfoResolver interface {
 	SyncedAt() *gqlutil.DateTime
 	UpdatedAt() gqlutil.DateTime
 	Unrestricted() bool
+	Repositories(ctx context.Context, args PermissionsInfoRepositoriesArgs) (*graphqlutil.ConnectionResolver[PermissionsInfoRepositoryResolver], error)
+}
+
+type PermissionsInfoRepositoryResolver interface {
+	ID() graphql.ID
+	Repository() *RepositoryResolver
+	Reason() string
+	UpdatedAt() *gqlutil.DateTime
+}
+
+type PermissionsInfoRepositoriesArgs struct {
+	graphqlutil.ConnectionResolverArgs
+	Query *string
 }

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -374,7 +374,7 @@ type PermissionsInfoRepositoryNode {
     """
     The repository corresponding to the permission.
     """
-    repository: Repository!
+    repository: Repository
     """
     The reason why the current user has permission to access the repository.
     """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -317,6 +317,72 @@ type PermissionsInfo {
     It will always be false for users.
     """
     unrestricted: Boolean!
+
+    """
+    The connection for repository permissions accessible to the user.
+    """
+    repositories(
+        """
+        Number of nodes returned during forward pagination. Maximum number of returned nodes is 100. Up to 20 nodes are returned by default.
+        """
+        first: Int
+        """
+        Number of nodes returned during backward pagination. Maximum number of returned nodes is 100. Up to 20 nodes are returned by default.
+        """
+        last: Int
+        """
+        Opaque pagination cursor to be used when paginating forwards.
+        """
+        after: String
+        """
+        Opaque pagination cursor to be used when paginating backwards.
+        """
+        before: String
+        """
+        Search query to filter repositories based on name.
+        """
+        query: String
+    ): PermissionsInfoRepositoriesConnection
+}
+
+"""
+Connection for repository permissions accessible to the user
+"""
+type PermissionsInfoRepositoriesConnection implements Connection {
+    """
+    List of repository permission info nodes
+    """
+    nodes: [PermissionsInfoRepositoryNode!]!
+    """
+    The total number of repository permission info nodes in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: ConnectionPageInfo!
+}
+
+"""
+Repository permission node defining why the repository is accessible to the user
+"""
+type PermissionsInfoRepositoryNode {
+    """
+    The ID of the repository.
+    """
+    id: ID!
+    """
+    The repository corresponding to the permission.
+    """
+    repository: Repository!
+    """
+    The reason why the current user has permission to access the repository.
+    """
+    reason: String!
+    """
+    The timestamp when the permission was last updated at.
+    """
+    updatedAt: DateTime
 }
 
 """

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -21,7 +22,7 @@ type permissionsInfoResolver struct {
 	db           edb.EnterpriseDB
 	ossDB        database.DB
 	userID       int32
-	repoID       int32
+	repoID       api.RepoID
 	perms        authz.Perms
 	syncedAt     time.Time
 	updatedAt    time.Time
@@ -55,7 +56,7 @@ var permissionsInfoRepositoryConnectionOptions = &graphqlutil.ConnectionResolver
 	MaxPageSize: &permissionsInfoRepositoryConnectionMaxPageSize,
 }
 
-func (r *permissionsInfoResolver) Repositories(ctx context.Context, args graphqlbackend.PermissionsInfoRepositoriesArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsInfoRepositoryResolver], error) {
+func (r *permissionsInfoResolver) Repositories(_ context.Context, args graphqlbackend.PermissionsInfoRepositoriesArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsInfoRepositoryResolver], error) {
 	if r.userID == 0 {
 		return nil, nil
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -1,0 +1,138 @@
+package resolvers
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+)
+
+type permissionsInfoResolver struct {
+	db           edb.EnterpriseDB
+	ossDB        database.DB
+	userID       int32
+	repoID       int32
+	perms        authz.Perms
+	syncedAt     time.Time
+	updatedAt    time.Time
+	unrestricted bool
+}
+
+func (r *permissionsInfoResolver) Permissions() []string {
+	return strings.Split(strings.ToUpper(r.perms.String()), ",")
+}
+
+func (r *permissionsInfoResolver) SyncedAt() *gqlutil.DateTime {
+	if r.syncedAt.IsZero() {
+		return nil
+	}
+	return &gqlutil.DateTime{Time: r.syncedAt}
+}
+
+func (r *permissionsInfoResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.updatedAt}
+}
+
+func (r *permissionsInfoResolver) Unrestricted() bool {
+	return r.unrestricted
+}
+
+var permissionsInfoRepositoryConnectionMaxPageSize = 100
+
+var permissionsInfoRepositoryConnectionOptions = &graphqlutil.ConnectionResolverOptions{
+	OrderBy:     database.OrderBy{{Field: "repo.name"}},
+	Ascending:   true,
+	MaxPageSize: &permissionsInfoRepositoryConnectionMaxPageSize,
+}
+
+func (r *permissionsInfoResolver) Repositories(ctx context.Context, args graphqlbackend.PermissionsInfoRepositoriesArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsInfoRepositoryResolver], error) {
+	if r.userID == 0 {
+		return nil, nil
+	}
+
+	query := ""
+	if args.Query != nil {
+		query = *args.Query
+	}
+
+	connectionStore := &permissionsInfoRepositoriesStore{
+		userID: r.userID,
+		db:     r.db,
+		ossDB:  r.ossDB,
+		query:  query,
+	}
+
+	return graphqlutil.NewConnectionResolver[graphqlbackend.PermissionsInfoRepositoryResolver](connectionStore, &args.ConnectionResolverArgs, permissionsInfoRepositoryConnectionOptions)
+}
+
+type permissionsInfoRepositoriesStore struct {
+	userID int32
+	db     edb.EnterpriseDB
+	ossDB  database.DB
+	query  string
+}
+
+func (s *permissionsInfoRepositoriesStore) MarshalCursor(node graphqlbackend.PermissionsInfoRepositoryResolver, _ database.OrderBy) (*string, error) {
+	cursor := node.Repository().Name()
+
+	return &cursor, nil
+}
+
+func (s *permissionsInfoRepositoriesStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+	return &cursor, nil
+}
+
+func (s *permissionsInfoRepositoriesStore) ComputeTotal(ctx context.Context) (*int32, error) {
+	count, err := s.ossDB.Repos().Count(actor.WithActor(ctx, actor.FromUser(s.userID)), database.ReposListOptions{Query: s.query})
+	if err != nil {
+		return nil, err
+	}
+
+	total := int32(count)
+	return &total, nil
+}
+
+func (s *permissionsInfoRepositoriesStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]graphqlbackend.PermissionsInfoRepositoryResolver, error) {
+	permissions, err := s.db.Perms().ListUserPermissions(ctx, s.userID, &edb.ListUserPermissionsArgs{Query: s.query, PaginationArgs: args})
+	if err != nil {
+		return nil, err
+	}
+
+	var permissionResolvers []graphqlbackend.PermissionsInfoRepositoryResolver
+	for _, perm := range permissions {
+		permissionResolvers = append(permissionResolvers, permissionsInfoRepositoryResolver{perm: perm, db: s.ossDB})
+	}
+
+	return permissionResolvers, nil
+}
+
+type permissionsInfoRepositoryResolver struct {
+	db   database.DB
+	perm *edb.UserPermission
+}
+
+func (r permissionsInfoRepositoryResolver) ID() graphql.ID {
+	return graphqlbackend.MarshalRepositoryID(r.perm.Repo.ID)
+}
+
+func (r permissionsInfoRepositoryResolver) Repository() *graphqlbackend.RepositoryResolver {
+	return graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), r.perm.Repo)
+}
+
+func (r permissionsInfoRepositoryResolver) Reason() string {
+	return string(r.perm.Reason)
+}
+
+func (r permissionsInfoRepositoryResolver) UpdatedAt() *gqlutil.DateTime {
+	return gqlutil.FromTime(r.perm.UpdatedAt)
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -549,7 +549,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 	return &permissionsInfoResolver{
 		db:           r.db,
 		ossDB:        r.ossDB,
-		repoID:       int32(repoID),
+		repoID:       repoID,
 		perms:        p.Perm,
 		syncedAt:     p.SyncedAt,
 		updatedAt:    p.UpdatedAt,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
@@ -22,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -34,6 +32,7 @@ var errDisabledSourcegraphDotCom = errors.New("not enabled on sourcegraph.com")
 type Resolver struct {
 	logger log.Logger
 	db     edb.EnterpriseDB
+	ossDB  database.DB
 }
 
 // checkLicense returns a user-facing error if the provided feature is not purchased
@@ -55,6 +54,7 @@ func NewResolver(observationCtx *observation.Context, db database.DB) graphqlbac
 	return &Resolver{
 		logger: observationCtx.Logger.Scoped("authz.Resolver", ""),
 		db:     edb.NewEnterpriseDB(db),
+		ossDB:  db,
 	}
 }
 
@@ -518,32 +518,6 @@ func getOrDefault[T any](ptr *T) T {
 	}
 }
 
-type permissionsInfoResolver struct {
-	perms        authz.Perms
-	syncedAt     time.Time
-	updatedAt    time.Time
-	unrestricted bool
-}
-
-func (r *permissionsInfoResolver) Permissions() []string {
-	return strings.Split(strings.ToUpper(r.perms.String()), ",")
-}
-
-func (r *permissionsInfoResolver) SyncedAt() *gqlutil.DateTime {
-	if r.syncedAt.IsZero() {
-		return nil
-	}
-	return &gqlutil.DateTime{Time: r.syncedAt}
-}
-
-func (r *permissionsInfoResolver) UpdatedAt() gqlutil.DateTime {
-	return gqlutil.DateTime{Time: r.updatedAt}
-}
-
-func (r *permissionsInfoResolver) Unrestricted() bool {
-	return r.unrestricted
-}
-
 func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID) (graphqlbackend.PermissionsInfoResolver, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
@@ -573,6 +547,9 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 	}
 
 	return &permissionsInfoResolver{
+		db:           r.db,
+		ossDB:        r.ossDB,
+		repoID:       int32(repoID),
 		perms:        p.Perm,
 		syncedAt:     p.SyncedAt,
 		updatedAt:    p.UpdatedAt,
@@ -611,6 +588,9 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 	}
 
 	return &permissionsInfoResolver{
+		db:        r.db,
+		ossDB:     r.ossDB,
+		userID:    userID,
 		perms:     p.Perm,
 		syncedAt:  p.SyncedAt,
 		updatedAt: p.UpdatedAt,


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/47869

Exposes Graphql API to list repos accessible to a user. 

## Test plan

- Manually well tested
- Unit tests present for db store funcs and connection resolver