### PR TITLE
Precise indexes: Support filtering by indexer

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/hooks/queryPreciseIndexes.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/hooks/queryPreciseIndexes.tsx
@@ -14,8 +14,22 @@ import {
 import { preciseIndexFieldsFragment } from './types'
 
 const PRECISE_INDEX_LIST = gql`
-    query PreciseIndexes($repo: ID, $states: [PreciseIndexState!], $query: String, $first: Int, $after: String) {
-        preciseIndexes(repo: $repo, states: $states, query: $query, first: $first, after: $after) {
+    query PreciseIndexes(
+        $repo: ID
+        $states: [PreciseIndexState!]
+        $indexerKey: String
+        $query: String
+        $first: Int
+        $after: String
+    ) {
+        preciseIndexes(
+            repo: $repo
+            states: $states
+            query: $query
+            first: $first
+            after: $after
+            indexerKey: $indexerKey
+        ) {
             nodes {
                 ...PreciseIndexFields
             }
@@ -31,13 +45,21 @@ const PRECISE_INDEX_LIST = gql`
 `
 
 export const queryPreciseIndexes = (
-    { repo, states, query, first, after }: Partial<Omit<PreciseIndexesVariables, 'states'>> & { states?: string },
+    {
+        repo,
+        states,
+        query,
+        indexerKey,
+        first,
+        after,
+    }: Partial<Omit<PreciseIndexesVariables, 'states'>> & { states?: string },
     client: ApolloClient<object>
 ): Observable<PreciseIndexConnectionFields> => {
     const typedStates = statesFromString(states)
     const variables: PreciseIndexesVariables = {
         repo: repo ?? null,
         states: typedStates.length > 0 ? typedStates : null,
+        indexerKey: indexerKey ?? null,
         query: query ?? null,
         first: first ?? null,
         after: after ?? null,

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.module.scss
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.module.scss
@@ -68,3 +68,7 @@
     font-weight: normal;
     padding: 0;
 }
+
+.form select {
+    min-width: 8rem;
+}


### PR DESCRIPTION
## Description

Adds support to filter precise index list by `indexerKeys`
 
![image](https://user-images.githubusercontent.com/9516420/221838615-43cb1ee7-d6f6-4e83-9931-e8539ae94f42.png)

## Test plan

Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-filter-by-indexer.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
