### PR TITLE
[Request access] Add admin analytics

### DIFF
--- a/client/web/src/site-admin/UserManagement/index.tsx
+++ b/client/web/src/site-admin/UserManagement/index.tsx
@@ -7,6 +7,7 @@ import { H1, Card, Text, Icon, Button, Link, Alert, LoadingSpinner, AnchorLink }
 
 import { UsersManagementSummaryResult, UsersManagementSummaryVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
+import { checkRequestAccessAllowed } from '../../util/checkRequestAccessAllowed'
 import { ValueLegendList, ValueLegendListProps } from '../analytics/components/ValueLegendList'
 
 import { UsersList } from './components/UsersList'
@@ -54,6 +55,22 @@ export const UsersManagement: React.FunctionComponent = () => {
                 tooltip: 'The number of users with site admin permissions.',
             },
         ]
+
+        const isRequestAccessAllowed = checkRequestAccessAllowed(
+            window.context.sourcegraphDotComMode,
+            window.context.allowSignup,
+            window.context.experimentalFeatures
+        )
+
+        if (isRequestAccessAllowed) {
+            legends.push({
+                value: data.pendingAccessRequests.totalCount,
+                description: 'Pending requests',
+                color: 'var(--cyan)',
+                position: 'left',
+                tooltip: 'The number of users who have requested access to your Sourcegraph instance.',
+            })
+        }
 
         return legends
     }, [data])

--- a/client/web/src/site-admin/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/UserManagement/queries.tsx
@@ -15,6 +15,9 @@ export const USERS_MANAGEMENT_SUMMARY = gql`
                 totalCount
             }
         }
+        pendingAccessRequests: accessRequests(status: PENDING) {
+            totalCount
+        }
     }
 `
 

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
@@ -31,6 +31,9 @@ export const OVERVIEW_STATISTICS = gql`
             averageScore
             netPromoterScore
         }
+        pendingAccessRequests: accessRequests(status: PENDING) {
+            totalCount
+        }
     }
 `
 

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -686,6 +686,10 @@ const USER_ANALYTICS_QUERY_MOCK: MockedResponse<UsersStatisticsResult> = {
                 totalCount: 49036,
                 __typename: 'UserConnection',
             },
+            pendingAccessRequests: {
+                totalCount: 123,
+                __typename: 'AccessRequestConnection',
+            },
         },
     },
 }

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -8,6 +8,7 @@ import { Card, LoadingSpinner, useMatchMedia, Text, LineChart, BarChart, Series 
 
 import { UsersStatisticsResult, UsersStatisticsVariables } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
+import { checkRequestAccessAllowed } from '../../../util/checkRequestAccessAllowed'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
@@ -19,7 +20,6 @@ import { StandardDatum, FrequencyDatum, buildFrequencyDatum } from '../utils'
 import { USERS_STATISTICS } from './queries'
 
 import styles from './AnalyticsUsersPage.module.scss'
-import { checkRequestAccessAllowed } from '../../../util/checkRequestAccessAllowed'
 
 export const AnalyticsUsersPage: FC = () => {
     const { dateRange, aggregation, grouping } = useChartFilters({ name: 'Users', aggregation: 'uniqueUsers' })

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/queries.ts
@@ -37,5 +37,8 @@ export const USERS_STATISTICS = gql`
         users {
             totalCount
         }
+        pendingAccessRequests: accessRequests(status: PENDING) {
+            totalCount
+        }
     }
 `


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48252.

This PR adds "# of pending requests" to AnalyticsOverviewPage, AnalyticsUsersPage, and UserManagement pages.

## Screenshot

| Before | After |
| --: | :-- |
| <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221851003-cbc9927c-6799-4b44-9209-de69b3c73499.png"> | <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221850823-92b5a7ad-55cf-4940-819c-d1783dcfb048.png"> | 
| <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221851030-b6399b14-3cdb-4bbd-92ff-df558ea7bb6c.png"> | <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221851211-73929581-4300-49d6-bdda-a341c3dcd415.png"> |
| <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221851056-cf40e820-a9b4-446b-b40c-d8dec8f81828.png"> | <img width="1727" alt="image" src="https://user-images.githubusercontent.com/6717049/221851110-1af5d3df-04cd-49d0-998c-4e1b96f9ed50.png"> |

## Test plan
- `sg start`
- Disable built-in signup
- Open https://sourcegraph.test:3443/site-admin
- Open https://sourcegraph.test:3443/site-admin/analytics/users
- Open https://sourcegraph.test:3443/site-admin/users
- Check that the "# of pending requests" are shown on the pages

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-add-request-access-admin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
