### PR TITLE
RequestAccessPage: change wording in placeholder text

### DIFF
--- a/client/web/src/auth/RequestAccessPage.tsx
+++ b/client/web/src/auth/RequestAccessPage.tsx
@@ -113,7 +113,7 @@ const RequestAccessForm: React.FunctionComponent<RequestAccessFormProps> = ({ on
                     onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setAdditionalInfo(event.target.value)}
                     className="mb-4"
                     value={additionalInfo}
-                    placeholder="Use this field to provide extra info for your request access"
+                    placeholder="Use this field to provide extra info for your access request"
                 />
             </Label>
 

--- a/client/web/src/auth/__snapshots__/RequestAccessPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/RequestAccessPage.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`RequestAccessPage renders form if all conditions are met 1`] = `
               <textarea
                 class="form-control textarea mb-4"
                 id="additionalInfo"
-                placeholder="Use this field to provide extra info for your request access"
+                placeholder="Use this field to provide extra info for your access request"
               />
             </label>
             <div


### PR DESCRIPTION
"for your request access" is wrong, I think. "for your access request" sounds much more natural.

## Test plan

- Existing tests

## App preview:

- [Web](https://sg-web-mrn-update-wording-request-access.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
