### PR TITLE
remove unused methods for outbook webhooks

### DIFF
--- a/enterprise/internal/batches/webhooks/util.go
+++ b/enterprise/internal/batches/webhooks/util.go
@@ -5,26 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"reflect"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func nullable[T any](value T) *T {
-	if reflect.ValueOf(value).IsZero() {
-		return nil
-	}
-	return &value
-}
-
-func nullableMap[T, U any](value T, mapper func(T) U) *U {
-	if reflect.ValueOf(value).IsZero() {
-		return nil
-	}
-	mapped := mapper(value)
-	return &mapped
-}
 
 func makeRequest[T any](ctx context.Context, q queryInfo, client httpcli.Doer, res T) error {
 	reqBody, err := json.Marshal(q)


### PR DESCRIPTION
This PR should remove some of the lint warnings we get on CI about these methods that are unused.

<img width="1182" alt="CleanShot 2023-02-28 at 15 13 39@2x" src="https://user-images.githubusercontent.com/25608335/221879569-63450f5a-69af-4f9f-9eb2-5067762b0442.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Everything works fine after removal