### PR TITLE
Clean up data-loading in file tree

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -58,7 +58,6 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
         settingsSchemaJSON.properties.fileSidebarVisibleByDefault.default
     )
     const [enableAccessibleFileTree] = useFeatureFlag('accessible-file-tree')
-    const [enableAccessibleFileTreeAlwaysLoadAncestors] = useFeatureFlag('accessible-file-tree-always-load-ancestors')
 
     const isWideScreen = useMatchMedia('(min-width: 768px)', false)
     const [isVisible, setIsVisible] = useState(persistedIsVisible && isWideScreen)
@@ -160,7 +159,6 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                                             filePath={props.filePath}
                                             filePathIsDirectory={props.isDir}
                                             telemetryService={props.telemetryService}
-                                            alwaysLoadAncestors={enableAccessibleFileTreeAlwaysLoadAncestors}
                                         />
                                     ) : (
                                         <Tree


### PR DESCRIPTION
We discussed this with @valerybugakov briefly today.

I noticed an issue where the Apollo cache wasn't properly used when you switch from the symbols tab back to the files tab. The issue is that the current implementation relies on  `notifyOnNetworkStatusChange` which caused the loading spinner to appear when the revalidation behavior of Apollo was triggered.

To simplify the data fetching, we now use `useQuery` only for the initial content and a manual `client.query()` for further requests. This way we don't have to rely on `useQuery` callbacks.

In a future version we want to make it so that the tab contents are never unmounted in the first place to preserve the full context though.

Another thing this PR does is it removes the `alwaysLoadAncestor` option which was an opt-out of the logic that applies the node to jump to the parent directory and load all dirs as flat:

<img width="376" alt="Screenshot 2023-02-28 at 15 20 26" src="https://user-images.githubusercontent.com/458591/221881143-dbac85fb-d393-4ea2-9175-87495c228843.png">

I think the current behavior that we've settled on (see screenshot above) is much much better than the original `..` implementation so we don't need the opt-out anymore. 

## Test plan

Test locally. To repro the issue from before, open the files tab, then the symbols tab, and then switch back to the files tab.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-treeview-fixes-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
