### PR TITLE
auto-indexing: Fix available indexer key

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_summary_builder.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_summary_builder.go
@@ -64,18 +64,18 @@ func NewSummaryBuilder(
 
 					return err
 				}
-				indexJobHints, err := jobSelector.InferIndexJobHintsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit)
-				if err != nil {
-					if errors.As(err, &inference.LimitError{}) {
-						continue
-					}
+				// indexJobHints, err := jobSelector.InferIndexJobHintsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit)
+				// if err != nil {
+				// 	if errors.As(err, &inference.LimitError{}) {
+				// 		continue
+				// 	}
 
-					return err
-				}
+				// 	return err
+				// }
 
 				inferredAvailableIndexers := map[string]shared.AvailableIndexer{}
 				inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
-				inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
+				// inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
 
 				if err := store.SetConfigurationSummary(ctx, repositoryWithCount.RepositoryID, repositoryWithCount.Count, inferredAvailableIndexers); err != nil {
 					return err

--- a/enterprise/internal/codeintel/autoindexing/shared/indexers.go
+++ b/enterprise/internal/codeintel/autoindexing/shared/indexers.go
@@ -31,7 +31,7 @@ func PopulateInferredAvailableIndexers[J JobsOrHints](jobsOrHints []J, blocklist
 				ai.Indexer = p
 			}
 
-			inferredAvailableIndexers[indexer] = ai
+			inferredAvailableIndexers[key] = ai
 		}
 	}
 

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -510,18 +510,18 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ 
 
 		limitErr = errors.Append(limitErr, err)
 	}
-	indexJobHints, err := r.autoindexSvc.InferIndexJobHintsFromRepositoryStructure(ctx, repoID, commit)
-	if err != nil {
-		if !errors.As(err, &inference.LimitError{}) {
-			return nil, err
-		}
+	// indexJobHints, err := r.autoindexSvc.InferIndexJobHintsFromRepositoryStructure(ctx, repoID, commit)
+	// if err != nil {
+	// 	if !errors.As(err, &inference.LimitError{}) {
+	// 		return nil, err
+	// 	}
 
-		limitErr = errors.Append(limitErr, err)
-	}
+	// 	limitErr = errors.Append(limitErr, err)
+	// }
 
 	inferredAvailableIndexers := map[string]shared.AvailableIndexer{}
 	inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
-	inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
+	// inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
 
 	inferredAvailableIndexersResolver := make([]sharedresolvers.InferredAvailableIndexers, 0, len(inferredAvailableIndexers))
 	for _, indexer := range inferredAvailableIndexers {


### PR DESCRIPTION
Fix the key used to aggregate indexer/roots. We were using indexer for assignment by accident.

I'm also removing _hints_ from the GraphQL layer in these resolvers since they'll be very noisy for the dashboards and we don't have a proper CTA on them yet. Will re-introduce them once we have a better UX.

## Test plan

Tested by hand.