### PR TITLE
release-tool: always save release config when accepting input

### DIFF
--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -247,6 +247,7 @@ async function getScheduledReleaseWithInput(
         )
         scheduled = await newReleaseFromInput(releaseVersion)
         addScheduledRelease(config, scheduled)
+        saveReleaseConfig(config)
     }
     return scheduled
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48133

In the 4.5 release I noticed the new release config doesn't auto save from some commands.

## Test plan
Tested by running the tracking:issues with dry run enabled and the file updated.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-save-release-config-if.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
