### PR TITLE
Fix docs links in App and add UTM, version, and OS parameters

### DIFF
--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -60,8 +60,6 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 
 	// For App, add UTM parameters to the docs url.
 	if sourcegraphAppMode {
-		// Add to query params, keeping existing ones
-		// Add ?utm_source=app&utm_medium=app&utm_campaign=app
 		q := dest.Query()
 		q.Set("utm_source", "sg_app")
 		q.Set("utm_medium", "referral")

--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
@@ -20,13 +22,18 @@ import (
 func serveHelp(w http.ResponseWriter, r *http.Request) {
 	page := strings.TrimPrefix(r.URL.Path, "/help")
 	versionStr := version.Version()
+	sourcegraphAppMode := deploy.IsDeployTypeSingleProgram(deploy.Type())
 
-	// For release builds, use the version string. Otherwise, don't use any version string because:
+	// For release builds, use the version string. Otherwise, don't use any
+	// version string because:
 	//
 	// - For unreleased dev builds, we serve the contents from the working tree.
-	// - Sourcegraph.com users probably want the latest docs on the default branch.
+	// - Sourcegraph.com users probably want the latest docs on the default
+	//   branch.
+	// - For Sourcegraph App users we also want to show the latest docs,
+	//   but we add the app version as a query param.
 	var docRevPrefix string
-	if !version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
+	if !version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() && !sourcegraphAppMode {
 		v, err := semver.NewVersion(versionStr)
 		if err != nil {
 			// If not a semver, just use the version string and hope for the best
@@ -43,12 +50,26 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 	dest := &url.URL{
 		Path: path.Join("/", docRevPrefix, page),
 	}
-	if version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
+	if version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() && !sourcegraphAppMode {
 		dest.Scheme = "http"
 		dest.Host = "localhost:5080" // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
 	} else {
 		dest.Scheme = "https"
 		dest.Host = "docs.sourcegraph.com"
+	}
+
+	// For App, add UTM parameters to the docs url.
+	if sourcegraphAppMode {
+		// Add to query params, keeping existing ones
+		// Add ?utm_source=app&utm_medium=app&utm_campaign=app
+		q := dest.Query()
+		q.Set("utm_source", "sg_app")
+		q.Set("utm_medium", "referral")
+
+		// App version and OS
+		q.Set("app_version", versionStr)
+		q.Set("app_os", runtime.GOOS)
+		dest.RawQuery = q.Encode()
 	}
 
 	// Use temporary, not permanent, redirect, because the destination URL changes (depending on the

--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -64,9 +64,16 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 		q.Set("utm_source", "sg_app")
 		q.Set("utm_medium", "referral")
 
-		// App version and OS
+		// App OS and version
+		os := runtime.GOOS
+		if os == "darwin" {
+			// Use a more common name for mac because it'll be used for analytics.
+			os = "mac"
+		}
+
+		q.Set("app_os", os)
 		q.Set("app_version", versionStr)
-		q.Set("app_os", runtime.GOOS)
+
 		dest.RawQuery = q.Encode()
 	}
 


### PR DESCRIPTION
Fixes the issue where outbound links from Sourcegraph App to docs didn't work due to the version string in the URL. The fix is to skip putting the version into the URL when running in Sourcegraph App.

Also adds the following new functionality:

Adds UTM parameters for outbound links from Sourcegraph App to docs:
- `utm_source`
- `utm_medium`

Adds the `app_version` parameter containing the App version string.

Adds the `app_os` parameter containing the user OS.

Part of the issue:

- #48122 

Checks before merging:

- [ ] Confirm that the final UTM values for `source` and `medium` are what we want.
- [ ] Confirm that the `versionString` is the correct version value that we want to attach as a query param.


## Test plan

- Run App
- Click on a docs link
- Check the proper redirect value
- Run in non-App mode
- Click on a docs link
-  Check that the old redirect behavior is still working

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
