### PR TITLE
gRPC: fix SymbolInfo like LocalCodeIntel

### DIFF
--- a/cmd/symbols/internal/api/handler_cgo.go
+++ b/cmd/symbols/internal/api/handler_cgo.go
@@ -10,6 +10,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	proto "github.com/sourcegraph/sourcegraph/internal/symbols/v1"
 	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // addHandlers adds handlers that require cgo.
@@ -31,11 +34,10 @@ func (s *grpcService) LocalCodeIntel(ctx context.Context, request *proto.LocalCo
 
 	payload, err := squirrelService.LocalCodeIntel(ctx, args)
 	if err != nil {
-		// TODO(camdencheek): This ignores errors from LocalCodeIntel to match the behavior found here:
-		// https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a1631d58604815917096acc3356447c55baebf22/-/blob/cmd/symbols/squirrel/http_handlers.go?L57-57
-		//
-		// This is weird, and maybe not intentional, but things break if we return an error.
-		return nil, nil
+		if errors.Is(err, squirrel.UnsupportedLanguageError) {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
+		return nil, err
 	}
 
 	var response proto.LocalCodeIntelResponse
@@ -56,6 +58,9 @@ func (s *grpcService) SymbolInfo(ctx context.Context, request *proto.SymbolInfoR
 
 	info, err := squirrelService.SymbolInfo(ctx, args)
 	if err != nil {
+		if errors.Is(err, squirrel.UnsupportedLanguageError) {
+			return nil, status.Error(codes.Unimplemented, err.Error())
+		}
 		return nil, err
 	}
 

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -57,7 +57,7 @@ func LocalCodeIntelHandler(readFile readFileFunc) func(w http.ResponseWriter, r 
 			_ = json.NewEncoder(w).Encode(nil)
 
 			// Log the error if it's not an unrecognized file extension or unsupported language error.
-			if !errors.Is(err, unrecognizedFileExtensionError) && !errors.Is(err, unsupportedLanguageError) {
+			if !errors.Is(err, unrecognizedFileExtensionError) && !errors.Is(err, UnsupportedLanguageError) {
 				log15.Error("failed to generate local code intel payload", "err", err)
 			}
 

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -250,7 +250,7 @@ func swapNodePtr(other Node, newNode *sitter.Node) *Node {
 }
 
 var unrecognizedFileExtensionError = errors.New("unrecognized file extension")
-var unsupportedLanguageError = errors.New("unsupported language")
+var UnsupportedLanguageError = errors.New("unsupported language")
 
 // Parses a file and returns info about it.
 func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCommitPath) (*Node, error) {
@@ -266,7 +266,7 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 
 	langSpec, ok := langToLangSpec[langName]
 	if !ok {
-		return nil, unsupportedLanguageError
+		return nil, UnsupportedLanguageError
 	}
 
 	s.parser.SetLanguage(langSpec.language)
@@ -425,7 +425,7 @@ func (s *SquirrelService) symbolSearchOne(ctx context.Context, repo string, comm
 		Commit: commit,
 		Path:   symbol.Path,
 	})
-	if errors.Is(err, unsupportedLanguageError) || errors.Is(err, unrecognizedFileExtensionError) {
+	if errors.Is(err, UnsupportedLanguageError) || errors.Is(err, unrecognizedFileExtensionError) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
We previously made [a fix](https://github.com/sourcegraph/sourcegraph/pull/47922) for code intel hovers in which we return nil and no error for cases when a language isn't supported. However, we run into this same edge case with the SymbolInfo endpoint. I've updated the logic to still return an error over the RPC boundary, but then to interpret an "unimplemented" error as no error and just return nil, similar to how the HTTP implementation handles this.

This is currently breaking search-based codeintel on Rust because we return an error rather than no results, so the UI bombs out rather than falls back to search-based code intel.

## Test plan

I can't reasonably add a test for this because the weird logic is in the client code. Instead, I manually tested that this fixes the hard errors logged to the console when a language is unsupported. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
