### PR TITLE
Setup Experience: Fix try unmarshal external service ID

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -109,9 +109,10 @@ func TryUnmarshalExternalServiceID(externalServiceID *graphql.ID) (*int64, error
 		if err != nil {
 			return nil, err
 		}
+		return &id, nil
 	}
 
-	return &id, err
+	return nil, nil
 }
 
 func (r *externalServiceResolver) ID() graphql.ID {


### PR DESCRIPTION
 Fix try unmarshal external service ID since a nil external service ID needs to be passed as argument for `ExternalServiceRepositoriesResult`. as well as the respective `NamespacesResult` (see [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/repoupdater/protocol/repoupdater.go?L472
)).

Issue 47984: https://github.com/sourcegraph/sourcegraph/issues/47984

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
existing tests