### PR TITLE
Cclark/fix data retention minimum samples

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -167,9 +167,7 @@ func GetBackgroundDataRetentionJob(ctx context.Context, observationCtx *observat
 // Individual insights workers may then _also_ want to register their own metrics, if desired, in
 // their NewWorker functions.
 func newWorkerMetrics(observationCtx *observation.Context, workerName string) (workerutil.WorkerObservability, dbworker.ResetterMetrics) {
-	workerMetrics := workerutil.NewMetrics(observationCtx, workerName+"_processor", workerutil.WithSampler(func(job workerutil.Record) bool {
-		return true
-	}))
+	workerMetrics := workerutil.NewMetrics(observationCtx, workerName+"_processor")
 	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
 	return workerMetrics, resetterMetrics
 }

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -167,7 +167,9 @@ func GetBackgroundDataRetentionJob(ctx context.Context, observationCtx *observat
 // Individual insights workers may then _also_ want to register their own metrics, if desired, in
 // their NewWorker functions.
 func newWorkerMetrics(observationCtx *observation.Context, workerName string) (workerutil.WorkerObservability, dbworker.ResetterMetrics) {
-	workerMetrics := workerutil.NewMetrics(observationCtx, workerName+"_processor")
+	workerMetrics := workerutil.NewMetrics(observationCtx, workerName+"_processor", workerutil.WithSampler(func(job workerutil.Record) bool {
+		return true
+	}))
 	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
 	return workerMetrics, resetterMetrics
 }

--- a/enterprise/internal/insights/background/retention/worker.go
+++ b/enterprise/internal/insights/background/retention/worker.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
@@ -68,7 +69,7 @@ func (h *dataRetentionHandler) Handle(ctx context.Context, logger log.Logger, re
 func getMaximumSampleSize(logger log.Logger) int {
 	// Default should match what is shown in the schema not to be confusing
 	maximumSampleSize := 30
-	if configured := conf.Get().InsightsMaximumSampleSize; configured >= 0 {
+	if configured := conf.Get().InsightsMaximumSampleSize; configured > 0 {
 		maximumSampleSize = configured
 	}
 	if maximumSampleSize > 90 {


### PR DESCRIPTION
When not configured the minimum sample size value was defaulting to zero, causing a negative offset when looking up recording times. This PR prohibits the zero value of a missing configuration from being selected and will default to the 30 sample size.


## Test plan
Unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
