### PR TITLE
gitserver: remove unused create-commit-from-patch

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -46,36 +46,6 @@ func (s *Server) handleCreateCommitFromPatchBinary(w http.ResponseWriter, r *htt
 	}
 }
 
-func (s *Server) handleCreateCommitFromPatch(w http.ResponseWriter, r *http.Request) {
-	var req protocol.V1CreateCommitFromPatchRequest
-	var resp protocol.CreateCommitFromPatchResponse
-	var status int
-
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		resp := new(protocol.CreateCommitFromPatchResponse)
-		resp.SetError("", "", "", errors.Wrap(err, "decoding V1CreateCommitFromPatchRequest"))
-		status = http.StatusBadRequest
-	} else {
-		binaryReq := protocol.CreateCommitFromPatchRequest{
-			Repo:         req.Repo,
-			BaseCommit:   req.BaseCommit,
-			Patch:        []byte(req.Patch),
-			TargetRef:    req.TargetRef,
-			UniqueRef:    req.UniqueRef,
-			CommitInfo:   req.CommitInfo,
-			Push:         req.Push,
-			GitApplyArgs: req.GitApplyArgs,
-		}
-		status, resp = s.createCommitFromPatch(r.Context(), binaryReq)
-	}
-
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
-
 func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
 	logger := s.Logger.Scoped("createCommitFromPatch", "").
 		With(

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -574,7 +574,6 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/repo-update", trace.WithRouteName("repo-update", s.handleRepoUpdate))
 	mux.HandleFunc("/repo-clone", trace.WithRouteName("repo-clone", s.handleRepoClone))
 	mux.HandleFunc("/create-commit-from-patch-binary", trace.WithRouteName("create-commit-from-patch-binary", s.handleCreateCommitFromPatchBinary))
-	mux.HandleFunc("/create-commit-from-patch", trace.WithRouteName("create-commit-from-patch", s.handleCreateCommitFromPatch))
 	mux.HandleFunc("/ping", trace.WithRouteName("ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1291,24 +1291,6 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 		return "", err
 	}
 	defer resp.Body.Close()
-	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
-	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
-		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", protocol.V1CreateCommitFromPatchRequest{
-			Repo:         req.Repo,
-			BaseCommit:   req.BaseCommit,
-			Patch:        string(req.Patch),
-			TargetRef:    req.TargetRef,
-			UniqueRef:    req.UniqueRef,
-			CommitInfo:   req.CommitInfo,
-			Push:         req.Push,
-			GitApplyArgs: req.GitApplyArgs,
-		})
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -416,29 +416,6 @@ type CreateCommitFromPatchRequest struct {
 	GitApplyArgs []string
 }
 
-// V1CreateCommitFromPatchRequest is the request information needed for creating
-// the simulated staging area git object for a repo.
-type V1CreateCommitFromPatchRequest struct {
-	// Repo is the repository to get information about.
-	Repo api.RepoName
-	// BaseCommit is the revision that the staging area object is based on
-	BaseCommit api.CommitID
-	// Patch is the diff contents to be used to create the staging area revision
-	Patch string
-	// TargetRef is the ref that will be created for this patch
-	TargetRef string
-	// If set to true and the TargetRef already exists, an unique number will be appended to the end (ie TargetRef-{#}). The generated ref will be returned.
-	UniqueRef bool
-	// CommitInfo is the information that will be used when creating the commit from a patch
-	CommitInfo PatchCommitInfo
-	// Push specifies whether the target ref will be pushed to the code host: if
-	// nil, no push will be attempted, if non-nil, a push will be attempted.
-	Push *PushConfig
-	// GitApplyArgs are the arguments that will be passed to `git apply` along
-	// with `--cached`.
-	GitApplyArgs []string
-}
-
 // PatchCommitInfo will be used for commit information when creating a commit from a patch
 type PatchCommitInfo struct {
 	Message        string


### PR DESCRIPTION
This was replaced by the create-commit-from-patch-binary endpoint and was retained for the purpose of keeping frontend backwards-compatible with an old gitserver for a single version upgrade cycle. We can now remove it.

Motivated by: me not wanting to translate any more things to gRPC than I have to.

## Test plan

It compiles and tests pass. This code path should be completely unused and unreferenced with new gitservers.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
