### PR TITLE
ranking: Do incremental vacuuming, not all-or-nothing deletes

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -357,6 +358,9 @@ SELECT
 // TODO - configure via envvar
 const vacuumBatchSize = 1000
 
+// TODO - configure via envvar
+var threshold = time.Duration(1) * time.Hour
+
 func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKey string) (
 	numStaleDefinitionRecordsDeleted int,
 	numStaleReferenceRecordsDeleted int,
@@ -365,7 +369,11 @@ func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKe
 	ctx, _, endObservation := s.operations.vacuumStaleDefinitionsAndReferences.With(ctx, &err, observation.Args{LogFields: []otlog.Field{}})
 	defer endObservation(1, observation.Args{})
 
-	rows, err := s.db.Query(ctx, sqlf.Sprintf(vacuumStaleDefinitionsAndReferencesQuery, graphKey, vacuumBatchSize, graphKey, vacuumBatchSize))
+	rows, err := s.db.Query(ctx, sqlf.Sprintf(
+		vacuumStaleDefinitionsAndReferencesQuery,
+		graphKey, int(threshold/time.Hour), vacuumBatchSize,
+		graphKey, int(threshold/time.Hour), vacuumBatchSize,
+	))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -385,45 +393,50 @@ func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKe
 
 const vacuumStaleDefinitionsAndReferencesQuery = `
 WITH
-visible_uploads AS (
-	SELECT uvt.upload_id
-	FROM lsif_uploads_visible_at_tip uvt
-	WHERE uvt.is_default_branch
-),
 locked_definitions AS (
-	SELECT rd.id, rd.upload_id
+	SELECT
+		rd.id,
+		rd.upload_id,
+		EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip uvt WHERE uvt.upload_id = rd.upload_id AND uvt.is_default_branch) AS safe
 	FROM codeintel_ranking_definitions rd
-	WHERE rd.graph_key = %s
-	ORDER BY rd.last_scanned_at ASC NULLS LAST
+	WHERE
+		rd.graph_key = %s AND
+		(rd.last_scanned_at IS NULL OR NOW() - rd.last_scanned_at >= %s * '1 hour'::interval)
+	ORDER BY rd.last_scanned_at ASC NULLS FIRST
 	FOR UPDATE SKIP LOCKED
 	LIMIT %s
 ),
 updated_definitions AS (
 	UPDATE codeintel_ranking_definitions
 	SET last_scanned_at = NOW()
-	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.upload_id IN (SELECT vu.upload_id FROM visible_uploads vu))
+	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.safe)
 ),
 deleted_definitions AS (
 	DELETE FROM codeintel_ranking_definitions
-	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.upload_id NOT IN (SELECT vu.upload_id FROM visible_uploads vu))
+	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE NOT ld.safe)
 	RETURNING 1
 ),
 locked_references AS (
-	SELECT rr.id, rr.upload_id
+	SELECT
+		rr.id,
+		rr.upload_id,
+		EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip uvt WHERE uvt.upload_id = rr.upload_id AND uvt.is_default_branch) AS safe
 	FROM codeintel_ranking_references rr
-	WHERE rr.graph_key = %s
-	ORDER BY rr.last_scanned_at ASC NULLS LAST
+	WHERE
+		rr.graph_key = %s AND
+		(rr.last_scanned_at IS NULL OR NOW() - rr.last_scanned_at >= %s * '1 hour'::interval)
+	ORDER BY rr.last_scanned_at ASC NULLS FIRST
 	FOR UPDATE SKIP LOCKED
 	LIMIT %s
 ),
 updated_references AS (
 	UPDATE codeintel_ranking_references
 	SET last_scanned_at = NOW()
-	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.upload_id IN (SELECT vu.upload_id FROM visible_uploads vu))
+	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.safe)
 ),
 deleted_references AS (
 	DELETE FROM codeintel_ranking_references
-	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.upload_id NOT IN (SELECT vu.upload_id FROM visible_uploads vu))
+	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE NOT lr.safe)
 	RETURNING 1
 )
 SELECT

--- a/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_ranking.go
@@ -354,6 +354,9 @@ SELECT
 	(SELECT COUNT(*) FROM inserted) AS num_inserted
 `
 
+// TODO - configure via envvar
+const vacuumBatchSize = 1000
+
 func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKey string) (
 	numStaleDefinitionRecordsDeleted int,
 	numStaleReferenceRecordsDeleted int,
@@ -362,7 +365,7 @@ func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKe
 	ctx, _, endObservation := s.operations.vacuumStaleDefinitionsAndReferences.With(ctx, &err, observation.Args{LogFields: []otlog.Field{}})
 	defer endObservation(1, observation.Args{})
 
-	rows, err := s.db.Query(ctx, sqlf.Sprintf(vacuumStaleDefinitionsAndReferencesQuery, graphKey, graphKey))
+	rows, err := s.db.Query(ctx, sqlf.Sprintf(vacuumStaleDefinitionsAndReferencesQuery, graphKey, vacuumBatchSize, graphKey, vacuumBatchSize))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -382,32 +385,45 @@ func (s *store) VacuumStaleDefinitionsAndReferences(ctx context.Context, graphKe
 
 const vacuumStaleDefinitionsAndReferencesQuery = `
 WITH
-locked_definitions AS (
-	SELECT id
-	FROM codeintel_ranking_definitions
-	WHERE
-		upload_id NOT IN (SELECT uvt.upload_id FROM lsif_uploads_visible_at_tip uvt WHERE uvt.is_default_branch) AND
-		graph_key = %s
-	ORDER BY id
-	FOR UPDATE
+visible_uploads AS (
+	SELECT uvt.upload_id
+	FROM lsif_uploads_visible_at_tip uvt
+	WHERE uvt.is_default_branch
 ),
-locked_references AS (
-	SELECT id
-	FROM codeintel_ranking_references
-	WHERE
-		upload_id NOT IN (SELECT uvt.upload_id FROM lsif_uploads_visible_at_tip uvt WHERE uvt.is_default_branch) AND
-		graph_key = %s
-	ORDER BY id
-	FOR UPDATE
+locked_definitions AS (
+	SELECT rd.id, rd.upload_id
+	FROM codeintel_ranking_definitions rd
+	WHERE rd.graph_key = %s
+	ORDER BY rd.last_scanned_at ASC NULLS LAST
+	FOR UPDATE SKIP LOCKED
+	LIMIT %s
+),
+updated_definitions AS (
+	UPDATE codeintel_ranking_definitions
+	SET last_scanned_at = NOW()
+	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.upload_id IN (SELECT vu.upload_id FROM visible_uploads vu))
 ),
 deleted_definitions AS (
 	DELETE FROM codeintel_ranking_definitions
-	WHERE id IN (SELECT id FROM locked_definitions)
+	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.upload_id NOT IN (SELECT vu.upload_id FROM visible_uploads vu))
 	RETURNING 1
+),
+locked_references AS (
+	SELECT rr.id, rr.upload_id
+	FROM codeintel_ranking_references rr
+	WHERE rr.graph_key = %s
+	ORDER BY rr.last_scanned_at ASC NULLS LAST
+	FOR UPDATE SKIP LOCKED
+	LIMIT %s
+),
+updated_references AS (
+	UPDATE codeintel_ranking_references
+	SET last_scanned_at = NOW()
+	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.upload_id IN (SELECT vu.upload_id FROM visible_uploads vu))
 ),
 deleted_references AS (
 	DELETE FROM codeintel_ranking_references
-	WHERE id IN (SELECT id FROM locked_references)
+	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.upload_id NOT IN (SELECT vu.upload_id FROM visible_uploads vu))
 	RETURNING 1
 )
 SELECT

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7573,6 +7573,19 @@
           "Comment": ""
         },
         {
+          "Name": "last_scanned_at",
+          "Index": 7,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "repository",
           "Index": 4,
           "TypeName": "text",
@@ -7622,6 +7635,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_ranking_definitions_pkey ON codeintel_ranking_definitions USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "codeintel_ranking_definitions_graph_key_last_scanned_at_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_ranking_definitions_graph_key_last_scanned_at_id ON codeintel_ranking_definitions USING btree (graph_key, last_scanned_at NULLS FIRST, id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         },
         {
           "Name": "codeintel_ranking_definitions_symbol_name",
@@ -7899,6 +7922,19 @@
           "Comment": ""
         },
         {
+          "Name": "last_scanned_at",
+          "Index": 6,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "symbol_names",
           "Index": 3,
           "TypeName": "text[]",
@@ -7935,6 +7971,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_ranking_references_pkey ON codeintel_ranking_references USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "codeintel_ranking_references_graph_key_last_scanned_at_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_ranking_references_graph_key_last_scanned_at_id ON codeintel_ranking_references USING btree (graph_key, last_scanned_at NULLS FIRST, id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         },
         {
           "Name": "codeintel_ranking_references_upload_id",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -957,16 +957,18 @@ Triggers:
 
 # Table "public.codeintel_ranking_definitions"
 ```
-    Column     |  Type   | Collation | Nullable |                          Default                          
----------------+---------+-----------+----------+-----------------------------------------------------------
- id            | bigint  |           | not null | nextval('codeintel_ranking_definitions_id_seq'::regclass)
- upload_id     | integer |           | not null | 
- symbol_name   | text    |           | not null | 
- repository    | text    |           | not null | 
- document_path | text    |           | not null | 
- graph_key     | text    |           | not null | 
+     Column      |           Type           | Collation | Nullable |                          Default                          
+-----------------+--------------------------+-----------+----------+-----------------------------------------------------------
+ id              | bigint                   |           | not null | nextval('codeintel_ranking_definitions_id_seq'::regclass)
+ upload_id       | integer                  |           | not null | 
+ symbol_name     | text                     |           | not null | 
+ repository      | text                     |           | not null | 
+ document_path   | text                     |           | not null | 
+ graph_key       | text                     |           | not null | 
+ last_scanned_at | timestamp with time zone |           |          | 
 Indexes:
     "codeintel_ranking_definitions_pkey" PRIMARY KEY, btree (id)
+    "codeintel_ranking_definitions_graph_key_last_scanned_at_id" btree (graph_key, last_scanned_at NULLS FIRST, id)
     "codeintel_ranking_definitions_symbol_name" btree (symbol_name)
     "codeintel_ranking_definitions_upload_id" btree (upload_id)
 
@@ -1008,14 +1010,16 @@ Indexes:
 
 # Table "public.codeintel_ranking_references"
 ```
-    Column    |  Type   | Collation | Nullable |                         Default                          
---------------+---------+-----------+----------+----------------------------------------------------------
- id           | bigint  |           | not null | nextval('codeintel_ranking_references_id_seq'::regclass)
- upload_id    | integer |           | not null | 
- symbol_names | text[]  |           | not null | 
- graph_key    | text    |           | not null | 
+     Column      |           Type           | Collation | Nullable |                         Default                          
+-----------------+--------------------------+-----------+----------+----------------------------------------------------------
+ id              | bigint                   |           | not null | nextval('codeintel_ranking_references_id_seq'::regclass)
+ upload_id       | integer                  |           | not null | 
+ symbol_names    | text[]                   |           | not null | 
+ graph_key       | text                     |           | not null | 
+ last_scanned_at | timestamp with time zone |           |          | 
 Indexes:
     "codeintel_ranking_references_pkey" PRIMARY KEY, btree (id)
+    "codeintel_ranking_references_graph_key_last_scanned_at_id" btree (graph_key, last_scanned_at NULLS FIRST, id)
     "codeintel_ranking_references_upload_id" btree (upload_id)
 Referenced by:
     TABLE "codeintel_ranking_references_processed" CONSTRAINT "fk_codeintel_ranking_reference" FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE

--- a/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/down.sql
+++ b/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS last_scanned_at;
+ALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS last_scanned_at;

--- a/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/metadata.yaml
+++ b/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add scan column to ranking definitions/references
+parents: [1674754280, 1675850599, 1677242688, 1677594756]

--- a/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/up.sql
+++ b/migrations/frontend/1677627515_add_scan_column_to_ranking_definitionsreferences/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS last_scanned_at timestamp with time zone;
+ALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS last_scanned_at timestamp with time zone;

--- a/migrations/frontend/1677627559_add_index_to_definition_scan_column/down.sql
+++ b/migrations/frontend/1677627559_add_index_to_definition_scan_column/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_last_scanned_at_id;

--- a/migrations/frontend/1677627559_add_index_to_definition_scan_column/metadata.yaml
+++ b/migrations/frontend/1677627559_add_index_to_definition_scan_column/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add index to definition scan column
+parents: [1677627515]
+createIndexConcurrently: true

--- a/migrations/frontend/1677627559_add_index_to_definition_scan_column/up.sql
+++ b/migrations/frontend/1677627559_add_index_to_definition_scan_column/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_definitions_graph_key_last_scanned_at_id
+ON codeintel_ranking_definitions(graph_key, last_scanned_at NULLS FIRST, id);

--- a/migrations/frontend/1677627566_add_index_to_reference_scan_column/down.sql
+++ b/migrations/frontend/1677627566_add_index_to_reference_scan_column/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_ranking_references_graph_key_last_scanned_at_id;

--- a/migrations/frontend/1677627566_add_index_to_reference_scan_column/metadata.yaml
+++ b/migrations/frontend/1677627566_add_index_to_reference_scan_column/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add index to reference scan column
+parents: [1677627559]
+createIndexConcurrently: true

--- a/migrations/frontend/1677627566_add_index_to_reference_scan_column/up.sql
+++ b/migrations/frontend/1677627566_add_index_to_reference_scan_column/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_references_graph_key_last_scanned_at_id
+ON codeintel_ranking_references(graph_key, last_scanned_at NULLS FIRST, id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1738,7 +1738,8 @@ CREATE TABLE codeintel_ranking_definitions (
     symbol_name text NOT NULL,
     repository text NOT NULL,
     document_path text NOT NULL,
-    graph_key text NOT NULL
+    graph_key text NOT NULL,
+    last_scanned_at timestamp with time zone
 );
 
 CREATE SEQUENCE codeintel_ranking_definitions_id_seq
@@ -1790,7 +1791,8 @@ CREATE TABLE codeintel_ranking_references (
     id bigint NOT NULL,
     upload_id integer NOT NULL,
     symbol_names text[] NOT NULL,
-    graph_key text NOT NULL
+    graph_key text NOT NULL,
+    last_scanned_at timestamp with time zone
 );
 
 COMMENT ON TABLE codeintel_ranking_references IS 'References for a given upload proceduced by background job consuming SCIP indexes.';
@@ -4995,6 +4997,8 @@ CREATE UNIQUE INDEX codeintel_path_ranks_repository_id_precision ON codeintel_pa
 
 CREATE INDEX codeintel_path_ranks_updated_at ON codeintel_path_ranks USING btree (updated_at) INCLUDE (repository_id);
 
+CREATE INDEX codeintel_ranking_definitions_graph_key_last_scanned_at_id ON codeintel_ranking_definitions USING btree (graph_key, last_scanned_at NULLS FIRST, id);
+
 CREATE INDEX codeintel_ranking_definitions_symbol_name ON codeintel_ranking_definitions USING btree (symbol_name);
 
 CREATE INDEX codeintel_ranking_definitions_upload_id ON codeintel_ranking_definitions USING btree (upload_id);
@@ -5004,6 +5008,8 @@ CREATE UNIQUE INDEX codeintel_ranking_exports_graph_key_upload_id ON codeintel_r
 CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_and_repository ON codeintel_ranking_path_counts_inputs USING btree (graph_key, repository);
 
 CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_repository_id_pr ON codeintel_ranking_path_counts_inputs USING btree (graph_key, repository, id) INCLUDE (document_path) WHERE (NOT processed);
+
+CREATE INDEX codeintel_ranking_references_graph_key_last_scanned_at_id ON codeintel_ranking_references USING btree (graph_key, last_scanned_at NULLS FIRST, id);
 
 CREATE UNIQUE INDEX codeintel_ranking_references_processed_graph_key_codeintel_rank ON codeintel_ranking_references_processed USING btree (graph_key, codeintel_ranking_reference_id);
 


### PR DESCRIPTION
In spirit of #48173. Previously, we were finding and deleting ALL records that are no longer relevant as a background GC process. This actually creates consistent load on the database since we have to scan a large number of records to find out we have nothing to delete.

The new query makes two behavioral changes from the old:

- We use a new timestamp _last scanned_ column to round-robin the records.
- We do not re-check the same rows within some configurable time frame. That's neurotic :)

## Test plan

Existing unit tests.