### PR TITLE
draft: Return usable input rev for code intel commits

### DIFF
--- a/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver.go
@@ -252,7 +252,7 @@ func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryRe
 		return nil, err
 	}
 
-	return repositoryResolver.commitFromID(&resolverstubs.RepositoryCommitArgs{Rev: commit}, commitID)
+	return repositoryResolver.commitFromID(ctx, &resolverstubs.RepositoryCommitArgs{Rev: commit}, commitID)
 }
 
 // Path resolves the git tree entry with the given commit resolver and relative path. This method must be

--- a/enterprise/internal/codeintel/shared/resolvers/git_commit_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_commit_resolver.go
@@ -23,10 +23,11 @@ type GitCommitResolver struct {
 // NewGitCommitResolver returns a new CommitResolver. When commit is set to nil,
 // commit will be loaded lazily as needed by the resolver. Pass in a commit when
 // you have batch-loaded a bunch of them and already have them at hand.
-func NewGitCommitResolver(repo *RepositoryResolver, id api.CommitID) *GitCommitResolver {
+func NewGitCommitResolver(repo *RepositoryResolver, id api.CommitID, inputRev *string) *GitCommitResolver {
 	return &GitCommitResolver{
 		oid:          GitObjectID(id),
 		repoResolver: repo,
+		inputRev:     inputRev,
 	}
 }
 

--- a/enterprise/internal/codeintel/shared/resolvers/repository_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/repository_resolver.go
@@ -47,7 +47,13 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *resolverstu
 }
 
 func (r *RepositoryResolver) commitFromID(args *resolverstubs.RepositoryCommitArgs, commitID api.CommitID) (*GitCommitResolver, error) {
-	resolver := NewGitCommitResolver(r, commitID)
+	var inputRev *string
+	if false {
+		value := "v1.2.3"
+		inputRev = &value
+	}
+
+	resolver := NewGitCommitResolver(r, commitID, inputRev)
 	if args.InputRevspec != nil {
 		resolver.inputRev = args.InputRevspec
 	} else {


### PR DESCRIPTION
Partial fix for #31937.

**WIP**: So far I've just identified one extension point where we could do a cached tag lookup as an input rev, which we support downstream but have never populated.

## Test plan

- [ ] Coming soon!