### PR TITLE
validate there are no release blocking issues prior to critical momen…

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -34,7 +34,6 @@ import {
     getAuthenticatedGitHubClient,
     getTrackingIssue,
     IssueLabel,
-    listIssues,
     localSourcegraphRepo,
     queryIssues,
     releaseName,

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -432,10 +432,11 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             'Promote a release candidate to release build. Specify the full candidate tag to promote the tagged commit to release.',
         argNames: ['candidate'],
         run: async (config, candidate) => {
-            const release = await getActiveRelease(config)
-            ensureReleaseBranchUpToDate(release.branch)
             const client = await getAuthenticatedGitHubClient()
             await validateNoReleaseBlockers(client)
+
+            const release = await getActiveRelease(config)
+            ensureReleaseBranchUpToDate(release.branch)
 
             const warnMsg =
                 'Verify the provided tag is correct to promote to release. Note: it is very unusual to require a non-standard tag to promote to release, proceed with caution.'

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -50,9 +50,12 @@ import {
     ensureSrcCliUpToDate,
     formatDate,
     getAllUpgradeGuides,
-    getLatestTag, getReleaseBlockers, releaseBlockerUri,
+    getLatestTag,
+    getReleaseBlockers,
+    releaseBlockerUri,
     timezoneLink,
-    updateUpgradeGuides, validateNoReleaseBlockers,
+    updateUpgradeGuides,
+    validateNoReleaseBlockers,
     verifyWithInput,
 } from './util'
 

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -1,13 +1,14 @@
-import { readdirSync, readFileSync, writeFileSync } from 'fs'
+import {readdirSync, readFileSync, writeFileSync} from 'fs'
 import * as path from 'path'
 import * as readline from 'readline'
 
+import Octokit from '@octokit/rest';
 import chalk from 'chalk'
 import execa from 'execa'
-import { readFile, writeFile, mkdir } from 'mz/fs'
+import {mkdir, readFile, writeFile} from 'mz/fs'
 import fetch from 'node-fetch'
 
-import { EditFunc } from './github'
+import {EditFunc, listIssues} from './github'
 import * as update from './update'
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
@@ -286,5 +287,22 @@ export async function retryInput(
         } else {
             console.log(chalk.red('invalid input'))
         }
+    }
+}
+
+const blockingQuery = 'is:open org:sourcegraph label:release-blocker'
+
+export async function getReleaseBlockers(octokit: Octokit): Promise<Octokit.SearchIssuesAndPullRequestsResponseItemsItem[]> {
+    return listIssues(octokit, blockingQuery)
+}
+
+export function releaseBlockerUri():string {
+    return `https://github.com/issues?q=${encodeURIComponent(blockingQuery)}`
+}
+
+export async function validateNoReleaseBlockers(octokit: Octokit): Promise<void> {
+    const blockers = await getReleaseBlockers(octokit)
+    if (blockers.length > 0) {
+        await verifyWithInput(`Warning! There are ${chalk.red(blockers.length)} release blocking issues open!\n${releaseBlockerUri()}\nConfirm to proceed`)
     }
 }

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -1,14 +1,14 @@
-import {readdirSync, readFileSync, writeFileSync} from 'fs'
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
 import * as path from 'path'
 import * as readline from 'readline'
 
-import Octokit from '@octokit/rest';
+import Octokit from '@octokit/rest'
 import chalk from 'chalk'
 import execa from 'execa'
-import {mkdir, readFile, writeFile} from 'mz/fs'
+import { mkdir, readFile, writeFile } from 'mz/fs'
 import fetch from 'node-fetch'
 
-import {EditFunc, listIssues} from './github'
+import { EditFunc, listIssues } from './github'
 import * as update from './update'
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
@@ -292,17 +292,23 @@ export async function retryInput(
 
 const blockingQuery = 'is:open org:sourcegraph label:release-blocker'
 
-export async function getReleaseBlockers(octokit: Octokit): Promise<Octokit.SearchIssuesAndPullRequestsResponseItemsItem[]> {
+export async function getReleaseBlockers(
+    octokit: Octokit
+): Promise<Octokit.SearchIssuesAndPullRequestsResponseItemsItem[]> {
     return listIssues(octokit, blockingQuery)
 }
 
-export function releaseBlockerUri():string {
+export function releaseBlockerUri(): string {
     return `https://github.com/issues?q=${encodeURIComponent(blockingQuery)}`
 }
 
 export async function validateNoReleaseBlockers(octokit: Octokit): Promise<void> {
     const blockers = await getReleaseBlockers(octokit)
     if (blockers.length > 0) {
-        await verifyWithInput(`Warning! There are ${chalk.red(blockers.length)} release blocking issues open!\n${releaseBlockerUri()}\nConfirm to proceed`)
+        await verifyWithInput(
+            `Warning! There are ${chalk.red(
+                blockers.length
+            )} release blocking issues open!\n${releaseBlockerUri()}\nConfirm to proceed`
+        )
     }
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48306

In the 4.5.0 release I accidentally released without checking for release blockers, precipitating a patch. Fortunately we needed to patch anyway, but this raised awareness that we aren't really validating release blockers at important times. This PR adds a check before promoting the final tag, and before staging the final publishing PRs. If there are any release blockers it will require the user to enter input to proceed.

## Test plan

Test by running `pnpm run release release:promote-candidate`

<img width="880" alt="image" src="https://user-images.githubusercontent.com/5090588/222005188-ac35d365-2599-4370-9cb4-e9e342089f0d.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-check-for-release-blockers.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
