### PR TITLE
Remove Sign Out when in App

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -329,6 +329,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                 {...props}
                                 authenticatedUser={props.authenticatedUser}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
+                                isSourcegraphApp={isSourcegraphApp}
                                 codeHostIntegrationMessaging={
                                     (!isErrorLike(props.settingsCascade.final) &&
                                         props.settingsCascade.final?.['alerts.codeHostIntegrationMessaging']) ||

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -66,6 +66,7 @@ const authenticatedUser: UserNavItemProps['authenticatedUser'] = {
 const commonProps = (props: Args): UserNavItemProps => ({
     authenticatedUser,
     isSourcegraphDotCom: props.isSourcegraphDotCom,
+    isSourcegraphApp: false,
     codeHostIntegrationMessaging: props.codeHostIntegrationMessaging,
     showKeyboardShortcutsHelp: () => undefined,
     showFeedbackModal: () => undefined,

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -54,6 +54,7 @@ describe('UserNavItem', () => {
                         showKeyboardShortcutsHelp={() => undefined}
                         authenticatedUser={USER}
                         isSourcegraphDotCom={true}
+                        isSourcegraphApp={false}
                         codeHostIntegrationMessaging="browser-extension"
                         showFeedbackModal={() => undefined}
                     />
@@ -68,6 +69,7 @@ describe('UserNavItem', () => {
                 showKeyboardShortcutsHelp={() => undefined}
                 authenticatedUser={USER}
                 isSourcegraphDotCom={true}
+                isSourcegraphApp={false}
                 codeHostIntegrationMessaging="browser-extension"
                 showFeedbackModal={() => undefined}
             />

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -41,6 +41,7 @@ type MinimalAuthenticatedUser = Pick<
 export interface UserNavItemProps {
     authenticatedUser: MinimalAuthenticatedUser
     isSourcegraphDotCom: boolean
+    isSourcegraphApp: boolean
     codeHostIntegrationMessaging: 'browser-extension' | 'native-integration'
     menuButtonRef?: React.Ref<HTMLButtonElement>
     showFeedbackModal: () => void
@@ -55,6 +56,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
     const {
         authenticatedUser,
         isSourcegraphDotCom,
+        isSourcegraphApp,
         codeHostIntegrationMessaging,
         menuButtonRef,
         showFeedbackModal,
@@ -208,7 +210,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
 
                             <MenuItem onSelect={showKeyboardShortcutsHelp}>Keyboard shortcuts</MenuItem>
 
-                            {authenticatedUser.session?.canSignOut && (
+                            {authenticatedUser.session?.canSignOut && !isSourcegraphApp && (
                                 <MenuLink as={AnchorLink} to="/-/sign-out">
                                     Sign out
                                 </MenuLink>


### PR DESCRIPTION
This removes "Sign Out" from the user nav bar dropdown, in Sourcegraph App.

Currently because App works with a single local user, it doesn't make sense to log out.

Future parts of the sign up/sign in story for App is tracked in:

- #47907 
- #47998 

Closes #48365 

## Test plan

- In App mode, visit the user nav dropdown and check the absence of "Sign Out"
- Outside of App mode, visit the user nav dropdown and check that "Sign Out" is still there

## App preview:

- [Web](https://sg-web-marek-app-remove-logout.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

