### PR TITLE
Ingest Webhooks from Azure DevOps

### DIFF
--- a/client/web/src/site-admin/WebhookCreateUpdatePage.tsx
+++ b/client/web/src/site-admin/WebhookCreateUpdatePage.tsx
@@ -1,16 +1,16 @@
-import React, {FC, useCallback, useMemo, useState} from 'react'
+import React, { FC, useCallback, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
-import {parse as parseJSONC} from 'jsonc-parser'
-import {noop} from 'lodash'
-import {useNavigate} from 'react-router-dom'
+import { parse as parseJSONC } from 'jsonc-parser'
+import { noop } from 'lodash'
+import { useNavigate } from 'react-router-dom'
 
-import {useMutation, useQuery} from '@sourcegraph/http-client'
-import {Alert, Button, ButtonLink, ErrorAlert, Form, H2, Input, Select} from '@sourcegraph/wildcard'
+import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { Alert, Button, ButtonLink, ErrorAlert, Form, H2, Input, Select } from '@sourcegraph/wildcard'
 
-import {EXTERNAL_SERVICES} from '../components/externalServices/backend'
-import {defaultExternalServices} from '../components/externalServices/externalServices'
-import {ConnectionLoading} from '../components/FilteredConnection/ui'
+import { EXTERNAL_SERVICES } from '../components/externalServices/backend'
+import { defaultExternalServices } from '../components/externalServices/externalServices'
+import { ConnectionLoading } from '../components/FilteredConnection/ui'
 import {
     CreateWebhookResult,
     CreateWebhookVariables,
@@ -21,9 +21,9 @@ import {
     UpdateWebhookVariables,
     WebhookFields,
 } from '../graphql-operations'
-import {generateSecret} from '../util/security'
+import { generateSecret } from '../util/security'
 
-import {CREATE_WEBHOOK_QUERY, UPDATE_WEBHOOK_QUERY} from './backend'
+import { CREATE_WEBHOOK_QUERY, UPDATE_WEBHOOK_QUERY } from './backend'
 
 import styles from './WebhookCreateUpdatePage.module.scss'
 
@@ -213,8 +213,9 @@ export const WebhookCreateUpdatePage: FC<WebhookCreateUpdatePageProps> = ({ exis
                                 <Input
                                     className={classNames(styles.first, 'flex-1 mb-0')}
                                     message={
-                                        webhook.codeHostKind &&
-                                        webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||  webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS ? (
+                                        (webhook.codeHostKind &&
+                                            webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD) ||
+                                        webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS ? (
                                             <small>Code Host doesn't support secrets.</small>
                                         ) : (
                                             <small>Randomly generated. Alter as required.</small>
@@ -223,7 +224,8 @@ export const WebhookCreateUpdatePage: FC<WebhookCreateUpdatePageProps> = ({ exis
                                     label={<span className="small">Secret</span>}
                                     disabled={
                                         webhook.codeHostKind !== null &&
-                                        (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||  webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
+                                        (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||
+                                            webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
                                     }
                                     pattern="^[a-zA-Z0-9]+$"
                                     onChange={event => {
@@ -307,7 +309,9 @@ function supportedExternalServiceKind(kind: ExternalServiceKind): boolean {
 
 function buildUpdateWebhookVariables(webhook: Webhook, id?: string): UpdateWebhookVariables {
     const secret =
-        webhook.codeHostKind !== null && (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD || webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
+        webhook.codeHostKind !== null &&
+        (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||
+            webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
             ? null
             : webhook.secret
 
@@ -323,7 +327,9 @@ function buildUpdateWebhookVariables(webhook: Webhook, id?: string): UpdateWebho
 
 function convertWebhookToCreateWebhookVariables(webhook: Webhook): CreateWebhookVariables {
     const secret =
-        webhook.codeHostKind !== null && (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD || webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
+        webhook.codeHostKind !== null &&
+        (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||
+            webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
             ? null
             : webhook.secret
     return {

--- a/client/web/src/site-admin/WebhookCreateUpdatePage.tsx
+++ b/client/web/src/site-admin/WebhookCreateUpdatePage.tsx
@@ -1,16 +1,16 @@
-import React, { FC, useCallback, useMemo, useState } from 'react'
+import React, {FC, useCallback, useMemo, useState} from 'react'
 
 import classNames from 'classnames'
-import { parse as parseJSONC } from 'jsonc-parser'
-import { noop } from 'lodash'
-import { useNavigate } from 'react-router-dom'
+import {parse as parseJSONC} from 'jsonc-parser'
+import {noop} from 'lodash'
+import {useNavigate} from 'react-router-dom'
 
-import { useMutation, useQuery } from '@sourcegraph/http-client'
-import { Alert, Button, ButtonLink, H2, Input, Select, ErrorAlert, Form } from '@sourcegraph/wildcard'
+import {useMutation, useQuery} from '@sourcegraph/http-client'
+import {Alert, Button, ButtonLink, ErrorAlert, Form, H2, Input, Select} from '@sourcegraph/wildcard'
 
-import { EXTERNAL_SERVICES } from '../components/externalServices/backend'
-import { defaultExternalServices } from '../components/externalServices/externalServices'
-import { ConnectionLoading } from '../components/FilteredConnection/ui'
+import {EXTERNAL_SERVICES} from '../components/externalServices/backend'
+import {defaultExternalServices} from '../components/externalServices/externalServices'
+import {ConnectionLoading} from '../components/FilteredConnection/ui'
 import {
     CreateWebhookResult,
     CreateWebhookVariables,
@@ -21,9 +21,9 @@ import {
     UpdateWebhookVariables,
     WebhookFields,
 } from '../graphql-operations'
-import { generateSecret } from '../util/security'
+import {generateSecret} from '../util/security'
 
-import { CREATE_WEBHOOK_QUERY, UPDATE_WEBHOOK_QUERY } from './backend'
+import {CREATE_WEBHOOK_QUERY, UPDATE_WEBHOOK_QUERY} from './backend'
 
 import styles from './WebhookCreateUpdatePage.module.scss'
 
@@ -214,8 +214,8 @@ export const WebhookCreateUpdatePage: FC<WebhookCreateUpdatePageProps> = ({ exis
                                     className={classNames(styles.first, 'flex-1 mb-0')}
                                     message={
                                         webhook.codeHostKind &&
-                                        webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ? (
-                                            <small>Bitbucket Cloud doesn't support secrets.</small>
+                                        webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||  webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS ? (
+                                            <small>Code Host doesn't support secrets.</small>
                                         ) : (
                                             <small>Randomly generated. Alter as required.</small>
                                         )
@@ -223,7 +223,7 @@ export const WebhookCreateUpdatePage: FC<WebhookCreateUpdatePageProps> = ({ exis
                                     label={<span className="small">Secret</span>}
                                     disabled={
                                         webhook.codeHostKind !== null &&
-                                        webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD
+                                        (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD ||  webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
                                     }
                                     pattern="^[a-zA-Z0-9]+$"
                                     onChange={event => {
@@ -298,6 +298,8 @@ function supportedExternalServiceKind(kind: ExternalServiceKind): boolean {
             return true
         case ExternalServiceKind.GITLAB:
             return true
+        case ExternalServiceKind.AZUREDEVOPS:
+            return true
         default:
             return false
     }
@@ -305,7 +307,7 @@ function supportedExternalServiceKind(kind: ExternalServiceKind): boolean {
 
 function buildUpdateWebhookVariables(webhook: Webhook, id?: string): UpdateWebhookVariables {
     const secret =
-        webhook.codeHostKind !== null && webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD
+        webhook.codeHostKind !== null && (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD || webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
             ? null
             : webhook.secret
 
@@ -321,7 +323,7 @@ function buildUpdateWebhookVariables(webhook: Webhook, id?: string): UpdateWebho
 
 function convertWebhookToCreateWebhookVariables(webhook: Webhook): CreateWebhookVariables {
     const secret =
-        webhook.codeHostKind !== null && webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD
+        webhook.codeHostKind !== null && (webhook.codeHostKind === ExternalServiceKind.BITBUCKETCLOUD || webhook.codeHostKind === ExternalServiceKind.AZUREDEVOPS)
             ? null
             : webhook.secret
     return {

--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"

--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
@@ -94,7 +93,7 @@ func validateCodeHostKindAndSecret(codeHostKind string, secret *string) error {
 	switch codeHostKind {
 	case extsvc.KindGitHub, extsvc.KindGitLab, extsvc.KindBitbucketServer:
 		return nil
-	case extsvc.KindBitbucketCloud:
+	case extsvc.KindBitbucketCloud, extsvc.KindAzureDevOps:
 		if secret != nil {
 			return errors.Newf("webhooks do not support secrets for code host kind %s", codeHostKind)
 		}

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -99,6 +99,7 @@ func DefaultServices() Services {
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},
 		BatchesBitbucketServerWebhook:   &emptyWebhookHandler{name: "batches bitbucket server webhook"},
 		BatchesBitbucketCloudWebhook:    &emptyWebhookHandler{name: "batches bitbucket cloud webhook"},
+		BatchesAzureDevOpsWebhook:       &emptyWebhookHandler{name: "batches azure devops webhook"},
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
 		BatchesChangesFileExistsHandler: makeNotFoundHandler("batches file exists handler"),
 		BatchesChangesFileUploadHandler: makeNotFoundHandler("batches file upload handler"),

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -26,6 +26,7 @@ type Services struct {
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
+	BatchesAzureDevOpsWebhook       webhooks.RegistererHandler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -26,7 +26,7 @@ type Services struct {
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
-	BatchesAzureDevOpsWebhook       webhooks.RegistererHandler
+	BatchesAzureDevOpsWebhook       webhooks.Registerer
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -287,6 +287,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 			BatchesGitLabWebhook:            enterprise.BatchesGitLabWebhook,
 			BatchesBitbucketServerWebhook:   enterprise.BatchesBitbucketServerWebhook,
 			BatchesBitbucketCloudWebhook:    enterprise.BatchesBitbucketCloudWebhook,
+			BatchesAzureDevOpsWebhook:       enterprise.BatchesAzureDevOpsWebhook,
 			BatchesChangesFileGetHandler:    enterprise.BatchesChangesFileGetHandler,
 			BatchesChangesFileExistsHandler: enterprise.BatchesChangesFileExistsHandler,
 			BatchesChangesFileUploadHandler: enterprise.BatchesChangesFileUploadHandler,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -41,6 +41,7 @@ func newTest(t *testing.T) *httptestutil.Client {
 			BitbucketCloudSyncWebhook:     enterpriseServices.ReposBitbucketCloudWebhook,
 			BatchesBitbucketServerWebhook: enterpriseServices.BatchesBitbucketServerWebhook,
 			BatchesBitbucketCloudWebhook:  enterpriseServices.BatchesBitbucketCloudWebhook,
+			BatchesAzureDevOpsWebhook:     enterpriseServices.BatchesAzureDevOpsWebhook,
 			SCIMHandler:                   enterpriseServices.SCIMHandler,
 			NewCodeIntelUploadHandler:     enterpriseServices.NewCodeIntelUploadHandler,
 			NewComputeStreamHandler:       enterpriseServices.NewComputeStreamHandler,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -53,6 +53,7 @@ type Handlers struct {
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
+	BatchesAzureDevOpsWebhook       webhooks.RegistererHandler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler
@@ -120,7 +121,7 @@ func NewHandler(
 	handlers.GitHubSyncWebhook.Register(&wh)
 	handlers.GitLabSyncWebhook.Register(&wh)
 	handlers.PermissionsGitHubWebhook.Register(&wh)
-
+	handlers.BatchesAzureDevOpsWebhook.Register(&wh)
 	// 🚨 SECURITY: This handler implements its own secret-based auth
 	webhookHandler := webhooks.NewHandler(logger, db, &wh)
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -53,7 +53,7 @@ type Handlers struct {
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
-	BatchesAzureDevOpsWebhook       webhooks.RegistererHandler
+	BatchesAzureDevOpsWebhook       webhooks.Registerer
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler

--- a/cmd/frontend/webhooks/azuredevops_webhooks.go
+++ b/cmd/frontend/webhooks/azuredevops_webhooks.go
@@ -26,11 +26,11 @@ func (wr *Router) HandleAzureDevOpsWebhook(logger log.Logger, w http.ResponseWri
 	ctx := actor.WithInternalActor(r.Context())
 
 	var event azuredevops.BaseEvent
+	err = json.Unmarshal(payload, &event)
 	if err != nil {
 		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
 		return
 	}
-	err = json.Unmarshal(payload, &event)
 	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
 	if err != nil {
 		if errors.Is(err, webhooks.ErrObjectKindUnknown) {

--- a/cmd/frontend/webhooks/azuredevops_webhooks.go
+++ b/cmd/frontend/webhooks/azuredevops_webhooks.go
@@ -5,15 +5,12 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
-
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (wr *Router) HandleAzureDevOpsWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
@@ -33,7 +30,7 @@ func (wr *Router) HandleAzureDevOpsWebhook(logger log.Logger, w http.ResponseWri
 	}
 	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
 	if err != nil {
-		if errors.Is(err, webhooks.ErrObjectKindUnknown) {
+		if errcode.IsNotFound(err) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/frontend/webhooks/azuredevops_webhooks.go
+++ b/cmd/frontend/webhooks/azuredevops_webhooks.go
@@ -2,10 +2,11 @@ package webhooks
 
 import (
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"io"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 
 	"github.com/sourcegraph/log"
 
@@ -25,7 +26,11 @@ func (wr *Router) HandleAzureDevOpsWebhook(logger log.Logger, w http.ResponseWri
 	ctx := actor.WithInternalActor(r.Context())
 
 	var event azuredevops.BaseEvent
-	json.Unmarshal(payload, &event)
+	if err != nil {
+		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
+		return
+	}
+	err = json.Unmarshal(payload, &event)
 	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
 	if err != nil {
 		if errors.Is(err, webhooks.ErrObjectKindUnknown) {

--- a/cmd/frontend/webhooks/azuredevops_webhooks.go
+++ b/cmd/frontend/webhooks/azuredevops_webhooks.go
@@ -1,0 +1,49 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func (wr *Router) HandleAzureDevOpsWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+	ctx := actor.WithInternalActor(r.Context())
+
+	var event azuredevops.BaseEvent
+	json.Unmarshal(payload, &event)
+	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrObjectKindUnknown) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Route the request based on the event type.
+	err = wr.Dispatch(ctx, string(event.EventType), extsvc.KindAzureDevOps, codeHostURN, e)
+	if err != nil {
+		logger.Error("Error handling Azure DevOps webhook event", log.Error(err))
+		if errcode.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -154,7 +154,6 @@ func (wr *Router) Dispatch(ctx context.Context, eventType string, codeHostKind s
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()
 
-	fmt.Printf("HANDLERS: %+v\n", wr.handlers)
 	if _, ok := wr.handlers[codeHostKind][eventType]; !ok {
 		wr.Logger.Warn("No handler for event found", log.String("eventType", eventType), log.String("codeHostKind", codeHostKind))
 		return nil

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -139,6 +139,9 @@ func handler(logger log.Logger, db database.DB, wh *Router) http.HandlerFunc {
 			// Bitbucket Cloud does not support secrets for webhooks
 			wh.HandleBitbucketCloudWebhook(logger, w, r, webhook.CodeHostURN)
 			return
+		case extsvc.KindAzureDevOps:
+			wh.HandleAzureDevOpsWebhook(logger, w, r, webhook.CodeHostURN)
+			return
 		}
 
 		http.Error(w, fmt.Sprintf("webhooks not implemented for code host kind %q", webhook.CodeHostKind), http.StatusNotImplemented)
@@ -151,6 +154,7 @@ func (wr *Router) Dispatch(ctx context.Context, eventType string, codeHostKind s
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()
 
+	fmt.Printf("HANDLERS: %+v\n", wr.handlers)
 	if _, ok := wr.handlers[codeHostKind][eventType]; !ok {
 		wr.Logger.Warn("No handler for event found", log.String("eventType", eventType), log.String("codeHostKind", codeHostKind))
 		return nil

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -85,6 +86,16 @@ func TestWebhooksHandler(t *testing.T) {
 		"http://bitbucket.com",
 		u.ID,
 		types.NewUnencryptedSecret("bbcloudsecret"),
+	)
+	require.NoError(t, err)
+
+	azureDevOpsWH, err := dbWebhooks.Create(
+		context.Background(),
+		"ado webhook",
+		extsvc.KindAzureDevOps,
+		"https://dev.azure.com",
+		u.ID,
+		types.NewUnencryptedSecret("adosecret"),
 	)
 	require.NoError(t, err)
 
@@ -388,6 +399,56 @@ func TestWebhooksHandler(t *testing.T) {
 		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
 		require.NoError(t, err)
 		req.Header.Set("X-Event-Key", "unknown_event")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("Azure DevOps returns 200", func(t *testing.T) {
+		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, azureDevOpsWH.UUID)
+
+		event := azuredevops.PullRequestUpdatedEvent{EventType: "git.pullrequest.updated"}
+		payload, err := json.Marshal(event)
+		require.NoError(t, err)
+		wh := &fakeWebhookHandler{}
+		wr.handlers = map[string]eventHandlers{
+			extsvc.KindAzureDevOps: {
+				"git.pullrequest.updated": []Handler{wh.handleEvent},
+			},
+		}
+
+		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		logs, _, err := db.WebhookLogs(keyring.Default().WebhookLogKey).List(context.Background(), database.WebhookLogListOpts{
+			WebhookID: &azureDevOpsWH.ID,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, logs, 1)
+		for _, log := range logs {
+			assert.Equal(t, azureDevOpsWH.ID, *log.WebhookID)
+		}
+		assert.Equal(t, azureDevOpsWH.CodeHostURN, wh.codeHostURNReceived)
+		assert.Equal(t, &event, wh.eventReceived)
+	})
+
+	t.Run("Azure DevOps returns 404 not found if webhook event type unknown", func(t *testing.T) {
+		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, azureDevOpsWH.UUID)
+
+		payload := []byte(`{"body": "text"}`)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
+		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := http.DefaultClient.Do(req)

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -8,10 +8,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 
 	gh "github.com/google/go-github/v43/github"
 	"github.com/google/uuid"

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -51,6 +51,7 @@ func Init(
 	enterpriseServices.BatchesBitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, gitserverClient, logger)
 	enterpriseServices.BatchesBitbucketCloudWebhook = webhooks.NewBitbucketCloudWebhook(bstore, gitserverClient, logger)
 	enterpriseServices.BatchesGitLabWebhook = webhooks.NewGitLabWebhook(bstore, gitserverClient, logger)
+	enterpriseServices.BatchesAzureDevOpsWebhook = webhooks.NewAzureDevOpsWebhook(bstore, gitserverClient, logger)
 
 	operations := httpapi.NewOperations(observationCtx)
 	fileHandler := httpapi.NewFileHandler(db, bstore, operations)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -127,7 +127,7 @@ func (h *AzureDevOpsWebhook) parseEvent(r *http.Request) (interface{}, *types.Ex
 	}
 
 	var event azuredevops.BaseEvent
-	err = json.Unmarshal(payload, event)
+	err = json.Unmarshal(payload, &event)
 	if err != nil {
 		return nil, nil, &httpError{http.StatusInternalServerError, err}
 	}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -1,0 +1,186 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	sglog "github.com/sourcegraph/log"
+
+	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+var azureDevOpsEvents = []string{
+	"git.pullrequest.created",
+	"git.pullrequest.updated",
+	"git.pullrequest.merged",
+}
+
+type AzureDevOpsWebhook struct {
+	*webhook
+}
+
+func NewAzureDevOpsWebhook(store *store.Store, gitserverClient gitserver.Client, logger sglog.Logger) *AzureDevOpsWebhook {
+	return &AzureDevOpsWebhook{
+		webhook: &webhook{store, gitserverClient, logger, extsvc.TypeAzureDevOps},
+	}
+}
+
+func (h *AzureDevOpsWebhook) Register(router *fewebhooks.Router) {
+	router.Register(
+		h.handleEvent,
+		extsvc.KindAzureDevOps,
+		azureDevOpsEvents...,
+	)
+}
+
+func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
+	ctx = actor.WithInternalActor(ctx)
+
+	prs, ev, err := h.convertEvent(event)
+	if err != nil {
+		return err
+	}
+
+	for _, pr := range prs {
+		if pr == (PR{}) {
+			h.logger.Warn("Dropping Azure DevOps webhook event", sglog.String("type", fmt.Sprintf("%T", event)))
+			continue
+		}
+
+		eventErr := h.upsertChangesetEvent(ctx, codeHostURN, pr, ev)
+		if eventErr != nil {
+			err = errors.Append(err, eventErr)
+		}
+	}
+	return err
+}
+
+func (h *AzureDevOpsWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e, extSvc, hErr := h.parseEvent(r)
+	if hErr != nil {
+		respond(w, hErr.code, hErr)
+		return
+	}
+
+	fewebhooks.SetExternalServiceID(r.Context(), extSvc.ID)
+
+	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
+	// internal actor on the context.
+	ctx := actor.WithInternalActor(r.Context())
+
+	c, err := extSvc.Configuration(ctx)
+	if err != nil {
+		h.logger.Error("Could not decode external service config", sglog.Error(err))
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
+	}
+
+	config, ok := c.(*schema.AzureDevOpsConnection)
+	if !ok {
+		h.logger.Error("Could not decode external service config", sglog.Error(err))
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
+	}
+
+	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	if err != nil {
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
+	}
+	err = h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
+	if err != nil {
+		respond(w, http.StatusInternalServerError, err)
+	} else {
+		respond(w, http.StatusNoContent, nil)
+	}
+}
+
+func (h *AzureDevOpsWebhook) parseEvent(r *http.Request) (interface{}, *types.ExternalService, *httpError) {
+	if r.Body == nil {
+		return nil, nil, &httpError{http.StatusBadRequest, errors.New("nil request body")}
+	}
+
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, nil, &httpError{http.StatusInternalServerError, err}
+	}
+
+	extSvc, err := h.getExternalServiceFromRawID(r.Context(), r.FormValue(extsvc.IDParam))
+	if err != nil {
+		return nil, nil, &httpError{http.StatusInternalServerError, err}
+	}
+
+	if extSvc == nil || err != nil {
+		return nil, nil, &httpError{http.StatusUnauthorized, err}
+	}
+
+	var event azuredevops.BaseEvent
+	err = json.Unmarshal(payload, event)
+	if err != nil {
+		return nil, nil, &httpError{http.StatusInternalServerError, err}
+	}
+	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
+	if err != nil {
+		return nil, nil, &httpError{http.StatusBadRequest, errors.Wrap(err, "parsing webhook")}
+	}
+
+	return e, extSvc, nil
+}
+
+func (h *AzureDevOpsWebhook) getExternalServiceFromRawID(ctx context.Context, raw string) (*types.ExternalService, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing the raw external service ID")
+	}
+
+	es, err := h.Store.ExternalServices().List(ctx, database.ExternalServicesListOptions{
+		IDs:   []int64{id},
+		Kinds: []string{extsvc.KindGitLab},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing external services")
+	}
+
+	if len(es) == 0 {
+		return nil, errExternalServiceNotFound
+	} else if len(es) > 1 {
+		// This _really_ shouldn't happen, since we provided only one ID above.
+		return nil, errors.New("too many external services found")
+	}
+
+	return es[0], nil
+}
+
+func (h *AzureDevOpsWebhook) convertEvent(theirs interface{}) ([]PR, keyer, error) {
+	switch e := theirs.(type) {
+	case *azuredevops.PullRequestCreatedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case *azuredevops.PullRequestMergedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case *azuredevops.PullRequestUpdatedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	default:
+		return nil, nil, errors.Newf("unknown event type: %T", theirs)
+	}
+}
+
+func azureDevOpsPullRequestEventPRs(e azuredevops.PullRequestEvent) []PR {
+	return []PR{
+		{
+			ID:             int64(e.PullRequest.ID),
+			RepoExternalID: e.PullRequest.Repository.ID,
+		},
+	}
+}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -2,14 +2,9 @@ package webhooks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strconv"
 
-	sglog "github.com/sourcegraph/log"
-
+	"github.com/sourcegraph/log"
 	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -17,9 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var azureDevOpsEvents = []string{
@@ -32,7 +25,7 @@ type AzureDevOpsWebhook struct {
 	*webhook
 }
 
-func NewAzureDevOpsWebhook(store *store.Store, gitserverClient gitserver.Client, logger sglog.Logger) *AzureDevOpsWebhook {
+func NewAzureDevOpsWebhook(store *store.Store, gitserverClient gitserver.Client, logger log.Logger) *AzureDevOpsWebhook {
 	return &AzureDevOpsWebhook{
 		webhook: &webhook{store, gitserverClient, logger, extsvc.TypeAzureDevOps},
 	}
@@ -56,7 +49,7 @@ func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, co
 
 	for _, pr := range prs {
 		if pr == (PR{}) {
-			h.logger.Warn("Dropping Azure DevOps webhook event", sglog.String("type", fmt.Sprintf("%T", event)))
+			h.logger.Warn("Dropping Azure DevOps webhook event", log.String("type", fmt.Sprintf("%T", event)))
 			continue
 		}
 
@@ -66,101 +59,6 @@ func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, co
 		}
 	}
 	return err
-}
-
-func (h *AzureDevOpsWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	e, extSvc, hErr := h.parseEvent(r)
-	if hErr != nil {
-		respond(w, hErr.code, hErr)
-		return
-	}
-
-	fewebhooks.SetExternalServiceID(r.Context(), extSvc.ID)
-
-	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
-	// internal actor on the context.
-	ctx := actor.WithInternalActor(r.Context())
-
-	c, err := extSvc.Configuration(ctx)
-	if err != nil {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	config, ok := c.(*schema.AzureDevOpsConnection)
-	if !ok {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
-	if err != nil {
-		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
-	}
-	err = h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
-	if err != nil {
-		respond(w, http.StatusInternalServerError, err)
-	} else {
-		respond(w, http.StatusNoContent, nil)
-	}
-}
-
-func (h *AzureDevOpsWebhook) parseEvent(r *http.Request) (interface{}, *types.ExternalService, *httpError) {
-	if r.Body == nil {
-		return nil, nil, &httpError{http.StatusBadRequest, errors.New("nil request body")}
-	}
-
-	payload, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, nil, &httpError{http.StatusInternalServerError, err}
-	}
-
-	extSvc, err := h.getExternalServiceFromRawID(r.Context(), r.FormValue(extsvc.IDParam))
-	if err != nil {
-		return nil, nil, &httpError{http.StatusInternalServerError, err}
-	}
-
-	if extSvc == nil || err != nil {
-		return nil, nil, &httpError{http.StatusUnauthorized, err}
-	}
-
-	var event azuredevops.BaseEvent
-	err = json.Unmarshal(payload, &event)
-	if err != nil {
-		return nil, nil, &httpError{http.StatusInternalServerError, err}
-	}
-	e, err := azuredevops.ParseWebhookEvent(event.EventType, payload)
-	if err != nil {
-		return nil, nil, &httpError{http.StatusBadRequest, errors.Wrap(err, "parsing webhook")}
-	}
-
-	return e, extSvc, nil
-}
-
-func (h *AzureDevOpsWebhook) getExternalServiceFromRawID(ctx context.Context, raw string) (*types.ExternalService, error) {
-	id, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing the raw external service ID")
-	}
-
-	es, err := h.Store.ExternalServices().List(ctx, database.ExternalServicesListOptions{
-		IDs:   []int64{id},
-		Kinds: []string{extsvc.KindGitLab},
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "listing external services")
-	}
-
-	if len(es) == 0 {
-		return nil, errExternalServiceNotFound
-	} else if len(es) > 1 {
-		// This _really_ shouldn't happen, since we provided only one ID above.
-		return nil, errors.New("too many external services found")
-	}
-
-	return es[0], nil
 }
 
 func (h *AzureDevOpsWebhook) convertEvent(theirs interface{}) ([]PR, keyer, error) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
@@ -80,6 +80,8 @@ func extractExternalServiceID(ctx context.Context, extSvc *types.ExternalService
 		serviceID = c.Url
 	case *schema.BitbucketCloudConnection:
 		serviceID = c.Url
+	case *schema.AzureDevOpsConnection:
+		serviceID = c.Url
 	}
 	if serviceID == "" {
 		return extsvc.CodeHostBaseURL{}, errors.Errorf("could not determine service id for external service %d", extSvc.ID)

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -2,9 +2,10 @@ package azuredevops
 
 import (
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"strconv"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 )
 
 var (

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"time"
-
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 )
 
 var (
@@ -24,7 +22,7 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 	case PullRequestUpdatedEventType:
 		target = &PullRequestUpdatedEvent{}
 	default:
-		return nil, webhooks.WebHookeNotFoundErr{}
+		return nil, webhookNotFoundErr{}
 	}
 
 	if err := json.Unmarshal(payload, target); err != nil {
@@ -81,4 +79,14 @@ func (e *PullRequestMergedEvent) Key() string {
 
 func (e *PullRequestCreatedEvent) Key() string {
 	return strconv.Itoa(e.PullRequest.ID) + ":created"
+}
+
+type webhookNotFoundErr struct{}
+
+func (w webhookNotFoundErr) Error() string {
+	return "webhook not found"
+}
+
+func (w webhookNotFoundErr) NotFound() bool {
+	return true
 }

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -24,7 +24,7 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 	case PullRequestUpdatedEventType:
 		target = &PullRequestUpdatedEvent{}
 	default:
-		return nil, webhooks.ErrObjectKindUnknown
+		return nil, webhooks.WebHookeNotFoundErr{}
 	}
 
 	if err := json.Unmarshal(payload, target); err != nil {

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -1,0 +1,83 @@
+package azuredevops
+
+import (
+	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"strconv"
+	"time"
+)
+
+var (
+	PullRequestCreatedEventType AzureDevOpsEvent = "git.pullrequest.created"
+	PullRequestMergedEventType  AzureDevOpsEvent = "git.pullrequest.merged"
+	PullRequestUpdatedEventType AzureDevOpsEvent = "git.pullrequest.updated"
+)
+
+func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
+	var target any
+	switch eventKey {
+	case PullRequestCreatedEventType:
+		target = &PullRequestCreatedEvent{}
+	case PullRequestMergedEventType:
+		target = &PullRequestMergedEvent{}
+	case PullRequestUpdatedEventType:
+		target = &PullRequestUpdatedEvent{}
+	default:
+		return nil, webhooks.ErrObjectKindUnknown
+	}
+
+	if err := json.Unmarshal(payload, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+type AzureDevOpsEvent string
+
+// BaseEvent is used to parse Azure DevOps events into the correct event struct.
+type BaseEvent struct {
+	EventType AzureDevOpsEvent `json:"eventType"`
+}
+
+type PullRequestEvent struct {
+	ID          string                  `json:"id"`
+	EventType   AzureDevOpsEvent        `json:"eventType"`
+	PullRequest PullRequest             `json:"resource"`
+	Message     PullRequestEventMessage `json:"message"`
+	CreatedDate time.Time               `json:"createdDate"`
+}
+
+type PullRequestCreatedEvent PullRequestEvent
+type PullRequestMergedEvent PullRequestEvent
+type PullRequestUpdatedEvent PullRequestEvent
+
+type PullRequestEventMessage struct {
+	Text string `json:"text"`
+}
+
+// Widgetry to ensure all events are keyers.
+//
+// Annoyingly, most of the pull request events don't have UUIDs associated with
+// anything we get, so we just have to do the best we can with what we have.
+
+type keyer interface {
+	Key() string
+}
+
+var (
+	_ keyer = &PullRequestUpdatedEvent{}
+	_ keyer = &PullRequestMergedEvent{}
+	_ keyer = &PullRequestCreatedEvent{}
+)
+
+func (e *PullRequestUpdatedEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":updated"
+}
+
+func (e *PullRequestMergedEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":merged"
+}
+
+func (e *PullRequestCreatedEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":created"
+}

--- a/internal/extsvc/azuredevops/events_test.go
+++ b/internal/extsvc/azuredevops/events_test.go
@@ -1,0 +1,45 @@
+package azuredevops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWebhookEvent(t *testing.T) {
+	for key, tc := range map[string]struct {
+		payload  string
+		wantType any
+	}{
+		"git.pullrequest.created": {
+			payload:  `{"eventType":"git.pullrequest.created","pullrequest":{},"resource":{}}`,
+			wantType: &PullRequestCreatedEvent{},
+		},
+		"git.pullrequest.merged": {
+			payload:  `{"eventType":"git.pullrequest.merged","pullrequest":{},"resource":{}}`,
+			wantType: &PullRequestMergedEvent{},
+		},
+		"git.pullrequest.updated": {
+			payload:  `{"eventType":"git.pullrequest.updated","pullrequest":{},"resource":{}}`,
+			wantType: &PullRequestUpdatedEvent{},
+		},
+	} {
+		t.Run(key, func(t *testing.T) {
+			t.Run("success", func(t *testing.T) {
+				have, err := ParseWebhookEvent(AzureDevOpsEvent(key), []byte(tc.payload))
+				assert.Nil(t, err)
+				assert.IsType(t, tc.wantType, have)
+			})
+
+			t.Run("invalid JSON", func(t *testing.T) {
+				_, err := ParseWebhookEvent(AzureDevOpsEvent(key), []byte("invalid JSON"))
+				assert.NotNil(t, err)
+			})
+		})
+	}
+
+	t.Run("unknown key", func(t *testing.T) {
+		_, err := ParseWebhookEvent("invalid key", []byte("{}"))
+		assert.NotNil(t, err)
+	})
+}

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -2,8 +2,6 @@ package webhooks
 
 import (
 	"encoding/json"
-	"fmt"
-
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -36,16 +34,6 @@ type PushEvent struct {
 }
 
 var ErrObjectKindUnknown = errors.New("unknown object kind")
-
-type WebHookeNotFoundErr struct{}
-
-func (w WebHookeNotFoundErr) Error() string {
-	return fmt.Sprintf("webhook not found")
-}
-
-func (w WebHookeNotFoundErr) NotFound() bool {
-	return true
-}
 
 type downcaster interface {
 	downcast() (any, error)

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -35,6 +36,16 @@ type PushEvent struct {
 }
 
 var ErrObjectKindUnknown = errors.New("unknown object kind")
+
+type WebHookeNotFoundErr struct{}
+
+func (w WebHookeNotFoundErr) Error() string {
+	return fmt.Sprintf("webhook not found")
+}
+
+func (w WebHookeNotFoundErr) NotFound() bool {
+	return true
+}
 
 type downcaster interface {
 	downcast() (any, error)

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"encoding/json"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/46735

Loom: https://www.loom.com/share/c168ccd85ff247599bb408c93221c5a9

This PR includes the changes required to ingest webhooks from Azure DevOps for Batch Changes.

Caveats:
- This is probably not the final list of webhook event types that we would be needing but its a starting point.
- Azure DevOps Webhooks use BasicAuth, which our webhooks implementation does not currently support, so as of right now the webhooks don't use a secret (like bb cloud).
- The ingest webhook event from ADO -> Batch Changes Changeset update part will be the next PR.

## Test plan

Added unit tests + manual testing

![image](https://user-images.githubusercontent.com/20795805/222171243-34df5cc1-0375-4e17-ab02-2569ebd9ed3f.png)


![image](https://user-images.githubusercontent.com/20795805/222009215-e3f43490-ec19-4053-93bd-f39ba2a3297a.png)
