### PR TITLE
Setup Wizard: Support code host connection edit UI

### DIFF
--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -23,6 +23,7 @@ const CORE_STEPS: StepConfiguration[] = [
         id: 'sync-repositories',
         name: 'Sync repositories',
         path: '/setup/sync-repositories',
+        nextURL: '/search',
         component: SyncRepositoriesStep,
     },
 ]

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -111,7 +111,7 @@ export const ProgressBar: FC<{}> = () => {
     }
 
     return (
-        <section className="d-flex align-items-center py-1">
+        <section className="d-flex align-items-center">
             {statusMessage}
 
             {items.map(item => (

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -24,7 +24,7 @@ export const ProgressBar: FC<{}> = () => {
 
     const { data: statusData } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
         fetchPolicy: 'no-cache',
-        pollInterval: 10000,
+        pollInterval: 5000,
     })
 
     useEffect(() => {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-delete-modal/CodeHostDeleteModal.tsx
@@ -35,7 +35,10 @@ export const CodeHostDeleteModal: FC<CodeHostDeleteModalProps> = props => {
     const [deleteCode, { loading, error }] = useMutation(DELETE_CODE_HOST)
 
     const handleDeleteConfirm = async (): Promise<void> => {
-        await deleteCode({ variables: { id: codeHost.id } })
+        await deleteCode({
+            variables: { id: codeHost.id },
+            refetchQueries: ['RepositoryStats', 'StatusMessages'],
+        })
         navigate('/setup/remote-repositories')
 
         // We have to remove it from the cache after we remove it on the backend

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -100,7 +100,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
 
                             // Update local cache and put newly created/connected code host
                             // to the beginning of code hosts list
-                            return { nodes: [newCodeHost, ...codeHosts.nodes] }
+                            return { nodes: [newCodeHost, ...(codeHosts?.nodes ?? [])] }
                         },
                     },
                 })

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -82,6 +82,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
     const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
         await addRemoteCodeHost({
             variables: { input },
+            refetchQueries: ['RepositoryStats', 'StatusMessages'],
             update: (cache, result) => {
                 const { data } = result
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -80,6 +80,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
     return (
         <CodeHostEditView
             key={codehostId}
+            codeHostId={codehostId!}
             codeHostKind={data.node.kind}
             displayName={data.node.displayName}
             configuration={data.node.config}
@@ -109,6 +110,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
 }
 
 interface CodeHostEditViewProps {
+    codeHostId: string
     codeHostKind: ExternalServiceKind
     displayName: string
     configuration: string
@@ -116,7 +118,7 @@ interface CodeHostEditViewProps {
 }
 
 const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
-    const { codeHostKind, displayName, configuration, children } = props
+    const { codeHostId, codeHostKind, displayName, configuration, children } = props
 
     const handleSubmit = async (): Promise<void> => {
         // TODO Connect edit API
@@ -130,7 +132,7 @@ const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
 
     if (codeHostKind === ExternalServiceKind.GITHUB) {
         return (
-            <GithubConnectView initialValues={initialValues} onSubmit={handleSubmit}>
+            <GithubConnectView initialValues={initialValues} externalServiceId={codeHostId} onSubmit={handleSubmit}>
                 {children}
             </GithubConnectView>
         )

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -1,14 +1,22 @@
 import { FC, ReactNode } from 'react'
 
 import { useQuery } from '@apollo/client'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
+import { useMutation } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 import { Alert, Button, ErrorAlert, H4, Link, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../../../components/externalServices/externalServices'
-import { GetExternalServiceByIdResult, GetExternalServiceByIdVariables } from '../../../../../graphql-operations'
-import { GET_CODE_HOST_BY_ID } from '../../queries'
+import { LoaderButton } from '../../../../../components/LoaderButton'
+import {
+    AddExternalServiceInput,
+    GetExternalServiceByIdResult,
+    GetExternalServiceByIdVariables,
+    UpdateRemoteCodeHostResult,
+    UpdateRemoteCodeHostVariables,
+} from '../../../../../graphql-operations'
+import { GET_CODE_HOST_BY_ID, UPDATE_CODE_HOST } from '../../queries'
 
 import { CodeHostConnectFormFields, CodeHostJSONForm, CodeHostJSONFormState } from './common'
 import { GithubConnectView } from './github/GithubConnectView'
@@ -87,8 +95,18 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
         >
             {state => (
                 <footer className={styles.footer}>
-                    <Button variant="primary" size="sm" type="submit">
-                        Update
+                    <LoaderButton
+                        type="submit"
+                        variant="primary"
+                        size="sm"
+                        label={state.submitting ? 'Updating' : 'Update'}
+                        alwaysShowLabel={true}
+                        loading={state.submitting}
+                        disabled={state.submitting}
+                    />
+
+                    <Button as={Link} size="sm" to="/setup/remote-repositories" variant="secondary">
+                        Cancel
                     </Button>
 
                     <Button
@@ -98,10 +116,6 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
                         onClick={() => onCodeHostDelete(data.node as EditableCodeHost)}
                     >
                         Delete
-                    </Button>
-
-                    <Button as={Link} size="sm" to="/setup/remote-repositories" variant="secondary">
-                        Cancel
                     </Button>
                 </footer>
             )}
@@ -120,9 +134,16 @@ interface CodeHostEditViewProps {
 const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
     const { codeHostId, codeHostKind, displayName, configuration, children } = props
 
-    const handleSubmit = async (): Promise<void> => {
-        // TODO Connect edit API
-        await Promise.resolve()
+    const navigate = useNavigate()
+    const [updateRemoteCodeHost] = useMutation<UpdateRemoteCodeHostResult, UpdateRemoteCodeHostVariables>(
+        UPDATE_CODE_HOST
+    )
+
+    const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
+        await updateRemoteCodeHost({ variables: { input: { id: codeHostId, ...input } } })
+
+        navigate('/setup/remote-repositories')
+        // TODO show notification UI that code host has been added successfully
     }
 
     const initialValues: CodeHostConnectFormFields = {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -52,7 +52,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
     const { data, loading, error, refetch } = useQuery<GetExternalServiceByIdResult, GetExternalServiceByIdVariables>(
         GET_CODE_HOST_BY_ID,
         {
-            fetchPolicy: 'cache-and-network',
+            fetchPolicy: 'network-only',
             variables: { id: codehostId! },
         }
     )
@@ -140,7 +140,10 @@ const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
     )
 
     const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
-        await updateRemoteCodeHost({ variables: { input: { id: codeHostId, ...input } } })
+        await updateRemoteCodeHost({
+            variables: { input: { id: codeHostId, ...input } },
+            refetchQueries: ['RepositoryStats', 'StatusMessages'],
+        })
 
         navigate('/setup/remote-repositories')
         // TODO show notification UI that code host has been added successfully

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
@@ -22,8 +22,8 @@ import {
 } from '../../../../../../graphql-operations'
 
 const GET_GITHUB_ORGANIZATIONS = gql`
-    query GetGitHubOrganizations($token: String!) {
-        externalServiceNamespaces(kind: GITHUB, url: "https://github.com", token: $token) {
+    query GetGitHubOrganizations($id: ID, $token: String!) {
+        externalServiceNamespaces(kind: GITHUB, url: "https://github.com", token: $token, id: $id) {
             nodes {
                 id
                 name
@@ -36,18 +36,19 @@ interface GithubOrganizationsPickerProps {
     token: string
     disabled: boolean
     organizations: string[]
+    externalServiceId: string | undefined
     onChange: (orginaziations: string[]) => void
 }
 
 export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = props => {
-    const { token, disabled, organizations, onChange } = props
+    const { token, disabled, organizations, externalServiceId, onChange } = props
     const [searchTerm, setSearchTerm] = useState('')
 
     const { data, loading, error } = useQuery<GetGitHubOrganizationsResult, GetGitHubOrganizationsVariables>(
         GET_GITHUB_ORGANIZATIONS,
         {
             skip: disabled,
-            variables: { token },
+            variables: { token, id: externalServiceId ?? null },
         }
     )
 
@@ -92,10 +93,17 @@ export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = pro
 }
 
 const GET_GITHUB_REPOSITORIES = gql`
-    query GetGitHubRepositories($first: Int!, $token: String!, $query: String!, $excludeRepositories: [String!]!) {
+    query GetGitHubRepositories(
+        $id: ID
+        $first: Int!
+        $token: String!
+        $query: String!
+        $excludeRepositories: [String!]!
+    ) {
         externalServiceRepositories(
             kind: GITHUB
             url: "https://github.com"
+            id: $id
             first: $first
             token: $token
             query: $query
@@ -113,11 +121,12 @@ interface GithubRepositoriesPickerProps {
     token: string
     disabled: boolean
     repositories: string[]
+    externalServiceId: string | undefined
     onChange: (repositories: string[]) => void
 }
 
 export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props => {
-    const { token, disabled, repositories, onChange } = props
+    const { token, disabled, repositories, externalServiceId, onChange } = props
 
     const [searchTerm, setSearchTerm] = useState('')
     const {
@@ -127,10 +136,12 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
         error,
     } = useQuery<GetGitHubRepositoriesResult, GetGitHubRepositoriesVariables>(GET_GITHUB_REPOSITORIES, {
         skip: disabled,
+        fetchPolicy: 'cache-and-network',
         variables: {
             token,
             first: 10,
             query: searchTerm,
+            id: externalServiceId ?? null,
             excludeRepositories: repositories,
         },
     })

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/helpers.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/helpers.ts
@@ -1,0 +1,43 @@
+import { parse as parseJSONC } from 'jsonc-parser'
+
+export function getAccessTokenValue(configuration: string): string {
+    const parsedConfiguration = parseJSONC(configuration) as Record<string, any>
+
+    if (typeof parsedConfiguration === 'object') {
+        return parsedConfiguration.token ?? ''
+    }
+
+    return ''
+}
+
+interface GithubFormConfiguration {
+    isAffiliatedRepositories: boolean
+    isOrgsRepositories: boolean
+    isSetRepositories: boolean
+    repositories: string[]
+    organizations: string[]
+}
+
+export function getRepositoriesSettings(configuration: string): GithubFormConfiguration {
+    const parsedConfiguration = parseJSONC(configuration) as Record<string, any>
+
+    if (typeof parsedConfiguration === 'object') {
+        const repositoryQuery: string[] = parsedConfiguration.repositoryQuery ?? []
+
+        return {
+            isAffiliatedRepositories: repositoryQuery.includes('affiliated'),
+            isOrgsRepositories: Array.isArray(parsedConfiguration.orgs),
+            organizations: parsedConfiguration.orgs ?? [],
+            isSetRepositories: Array.isArray(parsedConfiguration.repos),
+            repositories: parsedConfiguration.repos ?? [],
+        }
+    }
+
+    return {
+        isAffiliatedRepositories: false,
+        isOrgsRepositories: false,
+        organizations: [],
+        isSetRepositories: false,
+        repositories: [],
+    }
+}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/queries.ts
@@ -49,6 +49,16 @@ export const ADD_CODE_HOST = gql`
     ${CODE_HOST_FRAGMENT}
 `
 
+export const UPDATE_CODE_HOST = gql`
+    mutation UpdateRemoteCodeHost($input: UpdateExternalServiceInput!) {
+        updateExternalService(input: $input) {
+            ...CodeHost
+        }
+    }
+
+    ${CODE_HOST_FRAGMENT}
+`
+
 export const DELETE_CODE_HOST = gql`
     mutation DeleteCodeHost($id: ID!) {
         deleteExternalService(externalService: $id) {

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -152,7 +152,7 @@ export const SetupStepsContent: FC<HTMLAttributes<HTMLElement>> = props => {
                 {steps.map(({ path, component: Component }) => (
                     <Route key="hardcoded-key" path={`${path}/*`} element={<Component className={styles.content} />} />
                 ))}
-                <Route path="*" element={<Navigate to={steps[activeStepIndex].path} />} />
+                <Route path="*" element={<Navigate to={steps[activeStepIndex].path} replace={true} />} />
             </Routes>
         </div>
     )

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -26,6 +26,7 @@ export interface StepConfiguration {
     id: string
     path: string
     name: string
+    nextURL?: string
     component: ComponentType<{ className?: string }>
 }
 
@@ -98,7 +99,13 @@ export const SetupStepsRoot: FC<SetupStepsProps> = props => {
     }, [currentStep, onStepChange])
 
     const handleGoToNextStep = useCallback(() => {
+        const activeStep = steps[activeStepIndex]
         const nextStepIndex = activeStepIndex + 1
+
+        if (activeStep.nextURL) {
+            navigate(activeStep.nextURL)
+            return
+        }
 
         if (nextStepIndex < steps.length) {
             const nextStep = steps[nextStepIndex]


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/47237

This PR connects code host connection edit UI to edit *update code host mutation and also connects a proper access token validation logic.

## Test plan
- You should be able to create new code host connection 
- Make sure that code host access token is validated (you can't submit form if token is invalid)
- Make sure that you can pick repositories or/and organisations through pickers UI
- Make sure that can edit code host connection 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-support-code-host-edit-in.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
