### PR TITLE
Optimize matching performance on average and for specific edge-cases

### DIFF
--- a/internal/own/codeowners/file.go
+++ b/internal/own/codeowners/file.go
@@ -36,7 +36,7 @@ func (x *Ruleset) FindOwners(path string) []*codeownerspb.Owner {
 
 type CompiledRule struct {
 	proto       *codeownerspb.Rule
-	glob        globPattern
+	glob        *globPattern
 	compileOnce sync.Once
 }
 

--- a/internal/own/codeowners/find_owners_test.go
+++ b/internal/own/codeowners/find_owners_test.go
@@ -231,3 +231,141 @@ func TestFileOwnersOrder(t *testing.T) {
 	got := file.FindOwners("/top-level-directory/some/path/main.go")
 	assert.Equal(t, wantOwner, got)
 }
+
+func BenchmarkOwnersMatchLiteral(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchRelativeGlob(b *testing.B) {
+	pattern := "**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchAbsoluteGlob(b *testing.B) {
+	pattern := "/main/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchLiteral(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchRelativeGlob(b *testing.B) {
+	pattern := "**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchAbsoluteGlob(b *testing.B) {
+	pattern := "/main/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}

--- a/internal/own/codeowners/find_owners_test.go
+++ b/internal/own/codeowners/find_owners_test.go
@@ -1,6 +1,7 @@
 package codeowners_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -360,6 +361,79 @@ func BenchmarkOwnersMismatchAbsoluteGlob(b *testing.B) {
 			{Pattern: pattern, Owner: owner},
 		},
 	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchMultiHole(b *testing.B) {
+	pattern := "/main/**/foo/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchMultiHole(b *testing.B) {
+	pattern := "/main/**/foo/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchLiteralLargeRuleset(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	f := &codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	}
+	for i := 0; i < 10000; i++ {
+		f.Rule = append(f.Rule, &codeownerspb.Rule{Pattern: fmt.Sprintf("%s-%d", pattern, i), Owner: owner})
+	}
+	rs := codeowners.NewRuleset(f)
 	// Warm cache.
 	for _, path := range paths {
 		rs.FindOwners(path)


### PR DESCRIPTION
Benchmark tests included!

**Before**
```
BenchmarkOwnersMatchLiteral-10                   5075626               235.8 ns/op
BenchmarkOwnersMatchRelativeGlob-10              6787929               171.9 ns/op
BenchmarkOwnersMatchAbsoluteGlob-10              6564476               182.4 ns/op
BenchmarkOwnersMismatchLiteral-10                5322088               224.8 ns/op
BenchmarkOwnersMismatchRelativeGlob-10           7058532               170.5 ns/op
BenchmarkOwnersMismatchAbsoluteGlob-10           6372730               185.2 ns/op
```

**After**
```
BenchmarkOwnersMatchLiteral-10                  128574664                9.272 ns/op
BenchmarkOwnersMatchRelativeGlob-10             23077292                51.79 ns/op
BenchmarkOwnersMatchAbsoluteGlob-10             18436671                61.25 ns/op
BenchmarkOwnersMismatchLiteral-10               131070199                9.101 ns/op
BenchmarkOwnersMismatchRelativeGlob-10          23067070                52.58 ns/op
BenchmarkOwnersMismatchAbsoluteGlob-10          19928616                61.10 ns/op
```

## Test plan

Test suite still passes and added benchmark tests to verify performance improvements.