### PR TITLE
Try a trie

### DIFF
--- a/internal/own/codeowners/file.go
+++ b/internal/own/codeowners/file.go
@@ -36,7 +36,7 @@ func (x *Ruleset) FindOwners(path string) []*codeownerspb.Owner {
 
 type CompiledRule struct {
 	proto       *codeownerspb.Rule
-	glob        globPattern
+	glob        *globPattern
 	compileOnce sync.Once
 }
 

--- a/internal/own/codeowners/find_owners_test.go
+++ b/internal/own/codeowners/find_owners_test.go
@@ -3,6 +3,7 @@ package codeowners_test
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -441,5 +442,267 @@ func BenchmarkOwnersMatchLiteralLargeRuleset(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		rs.FindOwners(pattern)
+	}
+}
+
+func init() {
+	c := `/.github/workflows/codenotify.yml @unknwon
+/.github/workflows/licenses-check.yml          @bobheadxi
+/.github/workflows/licenses-update.yml         @bobheadxi
+/.github/workflows/renovate-downstream.yml     @bobheadxi
+/.github/workflows/renovate-downstream.json    @bobheadxi
+
+/client/branded/src/search-ui/components/** @limitedmage @fkling
+
+/client/jetbrains/** @vdavid @philipp-spiess
+
+/client/shared/src/search/**/* @fkling
+
+/client/shared/src/search/query/**/* @fkling
+
+/client/web/src/enterprise/batches/**/* @eseliger @courier-new @BolajiOlajide
+
+/client/web/src/enterprise/code-monitoring/**/* @limitedmage
+
+/client/web/src/enterprise/codeintel/**/* @efritz
+
+/client/web/src/enterprise/executors/**/* @efritz @eseliger
+
+/client/web/src/integration/batches* @eseliger @courier-new @BolajiOlajide
+/client/web/src/integration/search* @limitedmage
+/client/web/src/integration/code-monitoring* @limitedmage
+
+/client/web/src/search/**/* @limitedmage @fkling
+
+/cmd/blobstore/**/* @slimsag
+
+/cmd/frontend/graphqlbackend/observability.go @bobheadxi
+/cmd/frontend/graphqlbackend/site_monitoring.go @bobheadxi
+/cmd/frontend/graphqlbackend/*search*.go @keegancsmith
+/cmd/frontend/graphqlbackend/*zoekt*.go @keegancsmith
+/cmd/frontend/graphqlbackend/batches.go @eseliger @courier-new
+/cmd/frontend/graphqlbackend/insights.go @sourcegraph/code-insights-backend
+/cmd/frontend/graphqlbackend/codeintel.go @efritz
+/cmd/frontend/graphqlbackend/oobmigrations.go @efritz
+
+/cmd/frontend/internal/search/** @keegancsmith
+/cmd/frontend/internal/search/**/* @camdencheek
+
+/cmd/gitserver/server/* @indradhanush @sashaostrikov
+
+/cmd/repo-updater/* @indradhanush @sashaostrikov
+
+/cmd/searcher/**/* @keegancsmith
+
+/cmd/server/internal/goreman/** @keegancsmith
+
+/cmd/server/internal/goremancmd/** @keegancsmith
+
+/cmd/symbols/** @keegancsmith
+
+/cmd/worker/**/* @efritz
+
+/dev/authtest/**/* @unknwon
+
+/dev/codeintel-qa/**/* @efritz
+
+/dev/depgraph/**/* @efritz
+
+/dev/gqltest/**/* @unknwon
+
+/doc/**/admin/** @sourcegraph/delivery
+/doc/dev/background-information/adding_ping_data.md @ebrodymoore @dadlerj
+
+/doc/batch_changes/**/* @eseliger @courier-new
+
+/doc/code_navigation/**/* @efritz
+
+/doc/code_search/**/* @rvantonder
+
+/doc/dev/adr/**/* @unknwon
+
+/doc/dev/background-information/codeintel/**/* @efritz
+
+/docker-images/cadvisor/**/* @bobheadxi
+
+/docker-images/grafana/**/* @bobheadxi
+
+/docker-images/postgres-12-alpine/**/* @sourcegraph/delivery
+
+/docker-images/prometheus/**/* @bobheadxi
+
+/enterprise/cmd/executor/**/* @efritz
+
+/enterprise/cmd/frontend/internal/auth/**/* @unknwon
+
+/enterprise/cmd/frontend/internal/authz/**/* @unknwon
+
+/enterprise/cmd/frontend/internal/codeintel/**/* @efritz
+
+/enterprise/cmd/frontend/internal/executorqueue/**/* @efritz @eseliger
+
+/enterprise/cmd/frontend/internal/licensing/**/* @unknwon
+
+/enterprise/cmd/migrator/**/* @efritz
+
+/enterprise/cmd/precise-code-intel-worker/**/* @efritz
+
+/enterprise/cmd/repo-updater/**/* @indradhanush
+
+/enterprise/cmd/repo-updater/internal/authz/**/* @unknwon
+
+/enterprise/cmd/worker/**/* @efritz
+
+/enterprise/cmd/worker/internal/batches/**/* @eseliger
+
+/enterprise/cmd/worker/internal/executorqueue/**/* @efritz @eseliger
+
+/enterprise/cmd/worker/internal/executors/**/* @efritz
+
+/enterprise/dev/ci/**/* @bobheadxi
+
+/enterprise/internal/authz/**/* @unknwon
+
+/enterprise/internal/batches/**/* @eseliger
+
+/enterprise/internal/cloud/**/* @unknwon @michaellzc
+
+/enterprise/internal/codeintel/**/* @efritz @Strum355
+
+/enterprise/internal/database/external_services* @unknwon
+/enterprise/internal/database/perms_store* @unknwon
+
+/enterprise/internal/executor/**/* @efritz
+
+/enterprise/internal/insights/**/* @sourcegraph/code-insights-backend
+
+/enterprise/internal/license/**/* @unknwon
+
+/enterprise/internal/licensing/**/* @unknwon
+
+/internal/authz/**/* @unknwon
+
+/internal/codeintel/**/* @efritz
+
+/internal/codeintel/dependencies/**/* @mrnugget
+
+/internal/database/external* @eseliger
+/internal/database/namespaces* @eseliger
+/internal/database/repos* @eseliger
+/internal/database/permissions* @BolajiOlajide
+/internal/database/user_roles* @BolajiOlajide
+/internal/database/roles* @BolajiOlajide
+/internal/database/role_permissions* @BolajiOlajide
+
+/internal/database/basestore/**/* @efritz
+
+/internal/database/batch/**/* @efritz
+
+/internal/database/connections/**/* @efritz
+
+/internal/database/dbconn/**/* @efritz
+
+/internal/database/dbtest/**/* @efritz
+
+/internal/database/dbutil/**/* @efritz
+
+/internal/database/locker/**/* @efritz
+
+/internal/database/migration/**/* @efritz
+
+/internal/database/postgresdsn/**/* @efritz
+
+/internal/debugserver/** @keegancsmith
+
+/internal/diskcache/** @keegancsmith
+
+/internal/endpoint/** @keegancsmith
+
+/internal/env/baseconfig.go @efritz
+
+/internal/extsvc/**/* @eseliger
+
+/internal/extsvc/auth/**/* @unknwon
+
+/internal/gitserver/* @indradhanush @sashaostrikov
+
+/internal/goroutine/**/* @efritz
+
+/internal/gqltestutil/**/* @unknwon
+
+/internal/honey/** @keegancsmith
+
+/internal/httpcli/** @keegancsmith
+
+/internal/lazyregexp/** @keegancsmith
+
+/internal/luasandbox/**/* @efritz
+
+/internal/mutablelimiter/** @keegancsmith
+
+/internal/observation/**/* @sourcegraph/dev-experience
+
+/internal/oobmigration/**/* @efritz
+
+/internal/rcache/** @keegancsmith
+
+/internal/redispool/** @keegancsmith
+
+/internal/repos/* @indradhanush @sashaostrikov
+
+/internal/search/**/* @keegancsmith @camdencheek
+
+/internal/src-cli/**/* @eseliger @BolajiOlajide @courier-new
+
+/internal/symbols/** @keegancsmith
+
+/internal/sysreq/** @keegancsmith
+
+/internal/trace/** @keegancsmith
+/internal/trace/**/* @sourcegraph/dev-experience
+
+/internal/tracer/** @keegancsmith
+/internal/tracer/**/* @sourcegraph/dev-experience
+
+/internal/usagestats/batches.go @eseliger
+/internal/usagestats/batches_test.go @eseliger
+/internal/usagestats/*codeintel*.go @efritz
+
+/internal/vcs/** @keegancsmith
+
+/internal/workerutil/**/* @efritz
+
+/lib/codeintel/**/* @efritz
+
+/lib/errors/**/* @sourcegraph/dev-experience
+
+/lib/servicecatalog/**/* @sourcegraph/cloud @sourcegraph/security
+
+/monitoring/**/* @bobheadxi @slimsag @sourcegraph/delivery
+/monitoring/frontend.go @efritz
+/monitoring/precise_code_intel_* @efritz @sourcegraph/code-intelligence`
+
+	file, _ = codeowners.Parse(strings.NewReader(c))
+	forist, _ = codeowners.ParseTrie(strings.NewReader(c))
+}
+
+var file *codeowners.Ruleset
+var forist codeowners.PatternForist
+
+var cases = []string{
+	"/main/src/foo/bar/README.txt",
+}
+
+func BenchmarkRuleset(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pattern := cases[i%len(cases)]
+		file.FindOwners(pattern)
+	}
+}
+
+func BenchmarkTrie(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pattern := cases[i%len(cases)]
+		forist.Find(strings.Split(pattern, "/"))
 	}
 }

--- a/internal/own/codeowners/find_owners_test.go
+++ b/internal/own/codeowners/find_owners_test.go
@@ -231,3 +231,141 @@ func TestFileOwnersOrder(t *testing.T) {
 	got := file.FindOwners("/top-level-directory/some/path/main.go")
 	assert.Equal(t, wantOwner, got)
 }
+
+func BenchmarkOwnersMatchLiteral(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchRelativeGlob(b *testing.B) {
+	pattern := "**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchAbsoluteGlob(b *testing.B) {
+	pattern := "/main/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchLiteral(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchRelativeGlob(b *testing.B) {
+	pattern := "**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchAbsoluteGlob(b *testing.B) {
+	pattern := "/main/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}

--- a/internal/own/codeowners/find_owners_test.go
+++ b/internal/own/codeowners/find_owners_test.go
@@ -1,6 +1,7 @@
 package codeowners_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -360,6 +361,79 @@ func BenchmarkOwnersMismatchAbsoluteGlob(b *testing.B) {
 			{Pattern: pattern, Owner: owner},
 		},
 	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchMultiHole(b *testing.B) {
+	pattern := "/main/**/foo/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMismatchMultiHole(b *testing.B) {
+	pattern := "/main/**/foo/**/*.md"
+	paths := []string{
+		"/main/src/foo/bar/README.txt",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	rs := codeowners.NewRuleset(&codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	})
+	// Warm cache.
+	for _, path := range paths {
+		rs.FindOwners(path)
+	}
+
+	for i := 0; i < b.N; i++ {
+		rs.FindOwners(pattern)
+	}
+}
+
+func BenchmarkOwnersMatchLiteralLargeRuleset(b *testing.B) {
+	pattern := "/main/src/foo/bar/README.md"
+	paths := []string{
+		"/main/src/foo/bar/README.md",
+	}
+	owner := []*codeownerspb.Owner{
+		{Handle: "foo"},
+	}
+	f := &codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{Pattern: pattern, Owner: owner},
+		},
+	}
+	for i := 0; i < 10000; i++ {
+		f.Rule = append(f.Rule, &codeownerspb.Rule{Pattern: fmt.Sprintf("%s-%d", pattern, i), Owner: owner})
+	}
+	rs := codeowners.NewRuleset(f)
 	// Warm cache.
 	for _, path := range paths {
 		rs.FindOwners(path)

--- a/internal/own/codeowners/trie.go
+++ b/internal/own/codeowners/trie.go
@@ -1,0 +1,98 @@
+package codeowners
+
+import (
+	"log"
+
+	codeownerspb "github.com/sourcegraph/sourcegraph/internal/own/codeowners/v1"
+)
+
+type PatternTrie struct {
+	rules    []*codeownerspb.Rule
+	part     patternPart
+	children PatternForist
+}
+
+// put associates given pattern with given rule in this sub-trie.
+func (p *PatternTrie) put(pattern []patternPart, rule *codeownerspb.Rule) {
+	if len(pattern) == 0 {
+		p.rules = append(p.rules, rule)
+		return
+	}
+	f := &p.children
+	f.Add(pattern, rule)
+}
+
+// Forist is to Forest what Trie is to Tree.
+type PatternForist []PatternTrie
+
+// Add extends this forist with given pattern and associated rule.
+// pattern must be non-empty
+func (f *PatternForist) Add(pattern []patternPart, rule *codeownerspb.Rule) {
+	if len(pattern) == 0 {
+		log.Fatal("empty pattern in a forist")
+	}
+	part, rest := pattern[0], pattern[1:]
+	var q *PatternTrie
+	for i := range *f {
+		if (*f)[i].part.Eq(part) {
+			q = &((*f)[i])
+			break
+		}
+	}
+	if q == nil {
+		*f = append(*f, PatternTrie{part: part})
+		q = &((*f)[len(*f)-1])
+	}
+	q.put(rest, rule)
+}
+
+// Make a single step into a forist with a path chunk.
+// Each trie responds to the step, and only matching children
+// are returned, while ** introduce proper indeterminism.
+//
+// Invariant: if f contains ** then children of ** are also in f.
+func (f PatternForist) step(pathChunk string) PatternForist {
+	var next PatternForist
+	for _, t := range f {
+		if t.part.Eq(anySubPath{}) {
+			next = append(next, t)
+			continue
+		}
+		if t.part.Match(pathChunk) {
+			next = append(next, t.children...)
+		}
+	}
+	return next.includeSkipDoubleAsterisk()
+}
+
+func (f PatternForist) Find(path []string) *codeownerspb.Rule {
+	var state PatternForist
+	state = append(state, f...)
+	state = state.includeSkipDoubleAsterisk()
+	for _, p := range path {
+		state = state.step(p)
+	}
+	var rule *codeownerspb.Rule
+	for _, t := range state {
+		for _, r := range t.rules {
+			if rule == nil || rule.LineNumber < r.LineNumber {
+				rule = r
+			}
+		}
+	}
+	return rule
+}
+
+func (f PatternForist) includeSkipDoubleAsterisk() PatternForist {
+	var added PatternForist
+	for _, t := range f {
+		if t.part.Eq(anySubPath{}) {
+			added = append(added, t.children...)
+		}
+	}
+	if added == nil {
+		return f
+	}
+	// NOTE: This can be made into a loop if recursive version does not perform.
+	return append(added.includeSkipDoubleAsterisk(), f...)
+}


### PR DESCRIPTION

## Test plan

On the `test.CODEOWNERS` file a ~10x improvement? But haven't checked if it works 🤭 

```
pkg: github.com/sourcegraph/sourcegraph/internal/own/codeowners
BenchmarkTrie-10    	 3239188	       374.9 ns/op	     736 B/op	       2 allocs/op
PASS
ok  	github.com/sourcegraph/sourcegraph/internal/own/codeowners	2.022s
Running tool: /Users/cbart/.asdf/shims/go test -benchmem -run=^$ -bench ^BenchmarkRuleset$ github.com/sourcegraph/sourcegraph/internal/own/codeowners

goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/internal/own/codeowners
BenchmarkRuleset-10    	  355056	      3359 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/sourcegraph/sourcegraph/internal/own/codeowners	1.406s
```
