### PR TITLE
web: remove ignore plugin from the webpack.bazel.config.js

### DIFF
--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -154,11 +154,6 @@ const config = {
       resource.request = resource.request.replace(/\.scss$/, '.css')
     }),
 
-    // TODO(bazel): implement *.worker.ts support
-    new webpack.IgnorePlugin({
-      resourceRegExp: /.*\.worker\.ts/,
-    }),
-
     new webpack.DefinePlugin({
       'process.env': mapValues(RUNTIME_ENV_VARIABLES, JSON.stringify),
     }),


### PR DESCRIPTION
## Context

Since we removed worker loaders, we no longer need to ignore worker files.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-remove-ignore-plugin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
