### PR TITLE
web: test web app enteprise build with Bazel

### DIFF
--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -24,7 +24,6 @@ export const WORKSPACES_PATH = resolveWithSymlink(ROOT_PATH, 'client')
 export const NODE_MODULES_PATH = resolveWithSymlink(ROOT_PATH, 'node_modules')
 export const MONACO_EDITOR_PATH = resolveWithSymlink(NODE_MODULES_PATH, 'monaco-editor')
 export const STATIC_ASSETS_PATH = resolveWithSymlink(ROOT_PATH, 'ui/assets')
-export const STATIC_INDEX_PATH = resolveWithSymlink(STATIC_ASSETS_PATH, 'index.html')
 
 function getWorkspaceNodeModulesPaths(): string[] {
     const workspaces = fs.readdirSync(WORKSPACES_PATH)

--- a/client/web/dev/server/production.server.ts
+++ b/client/web/dev/server/production.server.ts
@@ -24,8 +24,6 @@ function startProductionServer(): void {
 
     signale.await('Starting production server', ENVIRONMENT_CONFIG)
 
-    const staticAssetsPath = process.env.STATIC_ASSETS_PATH || STATIC_ASSETS_PATH
-
     const app = express()
 
     // Serve index.html in place of any 404 responses.
@@ -34,7 +32,7 @@ function startProductionServer(): void {
     // Serve build artifacts.
     app.use(
         '/.assets',
-        expressStaticGzip(staticAssetsPath, {
+        expressStaticGzip(STATIC_ASSETS_PATH, {
             enableBrotli: true,
             orderPreference: ['br', 'gz'],
             index: false,

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+
 /**
  * Unpack all `process.env.*` variables used during the build
  * time of the web application in this module to keep one source of truth.

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -1,8 +1,9 @@
+import path from 'path'
 /**
  * Unpack all `process.env.*` variables used during the build
  * time of the web application in this module to keep one source of truth.
  */
-import { getEnvironmentBoolean } from '@sourcegraph/build-config'
+import { getEnvironmentBoolean, STATIC_ASSETS_PATH } from '@sourcegraph/build-config'
 
 import { DEFAULT_SITE_CONFIG_PATH } from './constants'
 
@@ -44,6 +45,7 @@ export const ENVIRONMENT_CONFIG = {
     WEBPACK_EXPORT_STATS_FILENAME: process.env.WEBPACK_EXPORT_STATS_FILENAME,
     // Allow to adjust https://webpack.js.org/configuration/devtool/ in the dev environment.
     WEBPACK_DEVELOPMENT_DEVTOOL: process.env.WEBPACK_DEVELOPMENT_DEVTOOL || 'eval-cheap-module-source-map',
+    STATIC_ASSETS_PATH: process.env.STATIC_ASSETS_PATH || STATIC_ASSETS_PATH,
 
     // The commit SHA the client bundle was built with.
     COMMIT_SHA: process.env.COMMIT_SHA,
@@ -99,3 +101,5 @@ const { SOURCEGRAPH_HTTPS_DOMAIN, SOURCEGRAPH_HTTPS_PORT, SOURCEGRAPH_HTTP_PORT 
 
 export const HTTPS_WEB_SERVER_URL = `https://${SOURCEGRAPH_HTTPS_DOMAIN}:${SOURCEGRAPH_HTTPS_PORT}`
 export const HTTP_WEB_SERVER_URL = `http://localhost:${SOURCEGRAPH_HTTP_PORT}`
+
+export const STATIC_INDEX_PATH = path.resolve(ENVIRONMENT_CONFIG.STATIC_ASSETS_PATH, 'index.html')

--- a/client/web/dev/utils/get-index-html.ts
+++ b/client/web/dev/utils/get-index-html.ts
@@ -3,13 +3,11 @@ import path from 'path'
 
 import { WebpackPluginFunction } from 'webpack'
 
-import { STATIC_ASSETS_PATH, STATIC_INDEX_PATH } from '@sourcegraph/build-config'
-
 import { SourcegraphContext } from '../../src/jscontext'
 
-import { createJsContext, ENVIRONMENT_CONFIG, HTTPS_WEB_SERVER_URL } from '.'
+import { createJsContext, ENVIRONMENT_CONFIG, HTTPS_WEB_SERVER_URL, STATIC_INDEX_PATH } from '.'
 
-const { NODE_ENV } = ENVIRONMENT_CONFIG
+const { NODE_ENV, STATIC_ASSETS_PATH } = ENVIRONMENT_CONFIG
 
 export const WEBPACK_MANIFEST_PATH = path.resolve(STATIC_ASSETS_PATH, 'webpack.manifest.json')
 

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -123,6 +123,7 @@ const config = {
       splitChunks: false,
     }),
   },
+  // entry: { ... SET BY BAZEL RULE ... }
   devServer: {
     port: 8080,
   },

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -126,7 +126,7 @@ const config = {
   // entry: { ... SET BY BAZEL RULE ... }
   // TODO(bazel): why is this sest by webpack_bundle() but not webpack_dev_server()?
   entry: {
-    app: './client/web/src/main.js',
+    app: './client/web/src/enterprise/main.js',
   },
   devServer: {
     port: 8080,

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -123,11 +123,6 @@ const config = {
       splitChunks: false,
     }),
   },
-  // entry: { ... SET BY BAZEL RULE ... }
-  // TODO(bazel): why is this sest by webpack_bundle() but not webpack_dev_server()?
-  entry: {
-    app: './client/web/src/enterprise/main.js',
-  },
   devServer: {
     port: 8080,
   },


### PR DESCRIPTION
## Context

Testing the web application enterprise build with Bazel.

## Test plan

1. `bazel build //client/web:bundle-enterprise`
2. To start the node.js server with the Bazel web application build.
`STATIC_ASSETS_PATH=XXX/sourcegraph/bazel-bin/client/web/bundle-enterprise WEBPACK_SERVE_INDEX=true SOURCEGRAPH_API_URL=https://sourcegraph.sourcegraph.com pnpm --filter @sourcegraph/web run serve:prod`

## App preview:

- [Web](https://sg-web-vb-bazel-webpack-build.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
