### PR TITLE
httpcli: remove high cardinality prometheus label internal transport

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -446,7 +446,10 @@ func MeteredTransportOpt(subsystem string) Opt {
 		}
 
 		cli.Transport = meter.Transport(cli.Transport, func(u *url.URL) string {
-			return u.Path
+			// We don't have a way to return a low cardinality label here (for
+			// the prometheus label "category"). Previously we returned u.Path
+			// but that blew up prometheus. So we just return unknown.
+			return "unknown"
 		})
 
 		return nil


### PR DESCRIPTION
On sourcegraph.com the label with the highest memory usage is category (562346 bytes vs the 2nd which is 179764). We tracked it down to the metric src_internal_request_duration_seconds_bucket. For example we register 3 metrics for every git repo we clone internally thanks to using the path.

There is no reasonable alternative for us to use, nor is anyone relying on this metric and category. So we are removing it for now by just recording unknown.

Test Plan: go test

Co-authored-by: @stefanhengl