### PR TITLE
Add configurable option to wait for GitHub external rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Kubernetes Deployments: The new Kustomize deployment ([deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s)) introduces a new base cluster that runs all Sourcegraph services as non-root users with limited privileges and eliminates the need to create RBAC resources. [#4213](https://github.com/sourcegraph/deploy-sourcegraph/pull/4213)
 - Added the `other.exclude` setting to [Other external service config](https://docs.sourcegraph.com/admin/external_service/other#configuration). It can be configured to exclude mirroring of repositories matching a pattern similar to other external services. This is useful when you want to exclude repositories discovered via `src serve-git`. [#48168](https://github.com/sourcegraph/sourcegraph/pull/48168)
 - The **Site admin > Updates** page displays the upgrade readiness information about schema drift and out-of-band migrations. [#48046](https://github.com/sourcegraph/sourcegraph/pull/48046)
+- When encountering GitHub rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423)
 
 ### Changed
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -81,6 +81,8 @@ GitHub's fine-grained personal access tokens are not yet supported.
 
 You should always include a token in a configuration for a GitHub.com URL to avoid being denied service by GitHub's [unauthenticated rate limits](https://developer.github.com/v3/#rate-limiting). If you don't want to automatically synchronize repositories from the account associated with your personal access token, you can create a token without a [`repo` scope](https://developer.github.com/apps/building-oauth-apps/scopes-for-oauth-apps/#available-scopes) for the purposes of bypassing rate limit restrictions only.
 
+If Sourcegraph hits a rate limit imposed by GitHub.com, Sourcegraph will wait the appropriate amount of time specified by GitHub.com before retrying the request. This can be several minutes in extreme cases.
+
 ## GitHub Enterprise Server rate limits
 
 Rate limiting may not be enabled by default. To check and verify the current rate limit settings, you may make a request to the `/rate_limit` endpoint like this:

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -42,6 +42,7 @@ type client interface {
 
 	GetAuthenticatedOAuthScopes(ctx context.Context) ([]string, error)
 	WithAuthenticator(auther auth.Authenticator) client
+	SetWaitForRateLimit(wait bool)
 }
 
 var _ client = (*ClientAdapter)(nil)
@@ -55,4 +56,8 @@ func (c *ClientAdapter) WithAuthenticator(auther auth.Authenticator) client {
 	return &ClientAdapter{
 		V3Client: c.V3Client.WithAuthenticator(auther),
 	}
+}
+
+func (c *ClientAdapter) SetWaitForRateLimit(wait bool) {
+	c.V3Client.WaitForRateLimit = wait
 }

--- a/enterprise/internal/authz/github/client.go
+++ b/enterprise/internal/authz/github/client.go
@@ -57,7 +57,3 @@ func (c *ClientAdapter) WithAuthenticator(auther auth.Authenticator) client {
 		V3Client: c.V3Client.WithAuthenticator(auther),
 	}
 }
-
-func (c *ClientAdapter) SetWaitForRateLimit(wait bool) {
-	c.V3Client.WaitForRateLimit = wait
-}

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -166,7 +166,12 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
 	logger := log.Scoped("fetchUserPermsByToken", "fetches all the private repo ids that the token can access.")
 
-	client := &ClientAdapter{github.NewV3Client(logger, p.urn, p.codeHost.BaseURL, token, nil)}
+	client, err := p.client()
+	if err != nil {
+		return nil, errors.Wrap(err, "get client")
+	}
+
+	client = client.WithAuthenticator(token)
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -164,11 +164,9 @@ func (p *Provider) requiredAuthScopes() (requiredAuthScope, bool) {
 // This may return a partial result if an error is encountered, e.g. via rate limits.
 func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.AccountID, token *auth.OAuthBearerToken, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
-	client, err := p.client()
-	if err != nil {
-		return nil, errors.Wrap(err, "get client")
-	}
-	client = client.WithAuthenticator(token)
+	logger := log.Scoped("fetchUserPermsByToken", "fetches all the private repo ids that the token can access.")
+
+	client := &ClientAdapter{github.NewV3Client(logger, p.urn, p.codeHost.BaseURL, token, nil)}
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
@@ -239,8 +237,6 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 	if err != nil {
 		return perms, errors.Wrap(err, "get groups affiliated with user")
 	}
-
-	logger := log.Scoped("fetchUserPermsByToken", "fetches all the private repo ids that the token can access.")
 
 	// Get repos from groups, cached if possible.
 	for _, group := range groups {

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -169,6 +169,7 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 		return nil, errors.Wrap(err, "get client")
 	}
 	client = client.WithAuthenticator(token)
+	client.SetWaitForRateLimit(true)
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -169,7 +169,6 @@ func (p *Provider) fetchUserPermsByToken(ctx context.Context, accountID extsvc.A
 		return nil, errors.Wrap(err, "get client")
 	}
 	client = client.WithAuthenticator(token)
-	client.SetWaitForRateLimit(true)
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.

--- a/enterprise/internal/authz/github/mocks_test.go
+++ b/enterprise/internal/authz/github/mocks_test.go
@@ -60,6 +60,9 @@ type MockClient struct {
 	// ListTeamRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method ListTeamRepositories.
 	ListTeamRepositoriesFunc *ClientListTeamRepositoriesFunc
+	// SetWaitForRateLimitFunc is an instance of a mock function object
+	// controlling the behavior of the method SetWaitForRateLimit.
+	SetWaitForRateLimitFunc *ClientSetWaitForRateLimitFunc
 	// WithAuthenticatorFunc is an instance of a mock function object
 	// controlling the behavior of the method WithAuthenticator.
 	WithAuthenticatorFunc *ClientWithAuthenticatorFunc
@@ -126,6 +129,11 @@ func NewMockClient() *MockClient {
 		},
 		ListTeamRepositoriesFunc: &ClientListTeamRepositoriesFunc{
 			defaultHook: func(context.Context, string, string, int) (r0 []*github.Repository, r1 bool, r2 int, r3 error) {
+				return
+			},
+		},
+		SetWaitForRateLimitFunc: &ClientSetWaitForRateLimitFunc{
+			defaultHook: func(bool) {
 				return
 			},
 		},
@@ -201,6 +209,11 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.ListTeamRepositories")
 			},
 		},
+		SetWaitForRateLimitFunc: &ClientSetWaitForRateLimitFunc{
+			defaultHook: func(bool) {
+				panic("unexpected invocation of MockClient.SetWaitForRateLimit")
+			},
+		},
 		WithAuthenticatorFunc: &ClientWithAuthenticatorFunc{
 			defaultHook: func(auth.Authenticator) client {
 				panic("unexpected invocation of MockClient.WithAuthenticator")
@@ -225,6 +238,7 @@ type surrogateMockClient interface {
 	ListRepositoryTeams(context.Context, string, string, int) ([]*github.Team, bool, error)
 	ListTeamMembers(context.Context, string, string, int) ([]*github.Collaborator, bool, error)
 	ListTeamRepositories(context.Context, string, string, int) ([]*github.Repository, bool, int, error)
+	SetWaitForRateLimit(bool)
 	WithAuthenticator(auth.Authenticator) client
 }
 
@@ -267,6 +281,9 @@ func NewMockClientFrom(i surrogateMockClient) *MockClient {
 		},
 		ListTeamRepositoriesFunc: &ClientListTeamRepositoriesFunc{
 			defaultHook: i.ListTeamRepositories,
+		},
+		SetWaitForRateLimitFunc: &ClientSetWaitForRateLimitFunc{
+			defaultHook: i.SetWaitForRateLimit,
 		},
 		WithAuthenticatorFunc: &ClientWithAuthenticatorFunc{
 			defaultHook: i.WithAuthenticator,
@@ -1684,6 +1701,105 @@ func (c ClientListTeamRepositoriesFuncCall) Args() []interface{} {
 // invocation.
 func (c ClientListTeamRepositoriesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+}
+
+// ClientSetWaitForRateLimitFunc describes the behavior when the
+// SetWaitForRateLimit method of the parent MockClient instance is invoked.
+type ClientSetWaitForRateLimitFunc struct {
+	defaultHook func(bool)
+	hooks       []func(bool)
+	history     []ClientSetWaitForRateLimitFuncCall
+	mutex       sync.Mutex
+}
+
+// SetWaitForRateLimit delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockClient) SetWaitForRateLimit(v0 bool) {
+	m.SetWaitForRateLimitFunc.nextHook()(v0)
+	m.SetWaitForRateLimitFunc.appendCall(ClientSetWaitForRateLimitFuncCall{v0})
+	return
+}
+
+// SetDefaultHook sets function that is called when the SetWaitForRateLimit
+// method of the parent MockClient instance is invoked and the hook queue is
+// empty.
+func (f *ClientSetWaitForRateLimitFunc) SetDefaultHook(hook func(bool)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SetWaitForRateLimit method of the parent MockClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ClientSetWaitForRateLimitFunc) PushHook(hook func(bool)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ClientSetWaitForRateLimitFunc) SetDefaultReturn() {
+	f.SetDefaultHook(func(bool) {
+		return
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ClientSetWaitForRateLimitFunc) PushReturn() {
+	f.PushHook(func(bool) {
+		return
+	})
+}
+
+func (f *ClientSetWaitForRateLimitFunc) nextHook() func(bool) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ClientSetWaitForRateLimitFunc) appendCall(r0 ClientSetWaitForRateLimitFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ClientSetWaitForRateLimitFuncCall objects
+// describing the invocations of this function.
+func (f *ClientSetWaitForRateLimitFunc) History() []ClientSetWaitForRateLimitFuncCall {
+	f.mutex.Lock()
+	history := make([]ClientSetWaitForRateLimitFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ClientSetWaitForRateLimitFuncCall is an object that describes an
+// invocation of method SetWaitForRateLimit on an instance of MockClient.
+type ClientSetWaitForRateLimitFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 bool
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ClientSetWaitForRateLimitFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ClientSetWaitForRateLimitFuncCall) Results() []interface{} {
+	return []interface{}{}
 }
 
 // ClientWithAuthenticatorFunc describes the behavior when the

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/go-github/v41/github"
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -127,6 +128,7 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 		rateLimit:        rl,
 		rateLimitMonitor: rlm,
 		resource:         resource,
+		WaitForRateLimit: true,
 	}
 }
 
@@ -223,10 +225,10 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		}
 
 		if retry > 0 {
-			time.Sleep(retry)
+			timeutil.SleepWithContext(ctx, retry)
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)
 		} else if remaining == 0 && reset > 0 {
-			time.Sleep(reset)
+			timeutil.SleepWithContext(ctx, reset)
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)
 		}
 	}

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -55,8 +55,8 @@ type V3Client struct {
 	// externalRateLimiter is the external API rate limit monitor.
 	externalRateLimiter *ratelimit.Monitor
 
-	// rateLimit is our self-imposed rate limiter
-	rateLimit *ratelimit.InstrumentedLimiter
+	// internalRateLimiter is our self-imposed rate limiter
+	internalRateLimiter *ratelimit.InstrumentedLimiter
 
 	// waitForRateLimit determines whether or not the client will wait and retry a request if external rate limits are encountered
 	waitForRateLimit bool
@@ -123,7 +123,7 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 		githubDotCom:        urlIsGitHubDotCom(apiURL),
 		auth:                a,
 		httpClient:          cli,
-		rateLimit:           rl,
+		internalRateLimiter: rl,
 		externalRateLimiter: rlm,
 		resource:            resource,
 		waitForRateLimit:    true,
@@ -202,7 +202,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		req.Header.Add("Accept", "application/vnd.github.nebula-preview+json")
 	}
 
-	err := c.rateLimit.Wait(ctx)
+	err := c.internalRateLimiter.Wait(ctx)
 	if err != nil {
 		// We don't want to return a misleading rate limit exceeded error if the error is coming
 		// from the context.

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -61,6 +61,9 @@ type V3Client struct {
 	// waitForRateLimit determines whether or not the client will wait and retry a request if external rate limits are encountered
 	waitForRateLimit bool
 
+	// numRateLimitRetries determines how many times we retry requests due to rate limits
+	numRateLimitRetries int
+
 	// resource specifies which API this client is intended for.
 	// One of 'rest' or 'search'.
 	resource string
@@ -127,6 +130,7 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 		externalRateLimiter: rlm,
 		resource:            resource,
 		waitForRateLimit:    true,
+		numRateLimitRetries: 2,
 	}
 }
 
@@ -221,12 +225,20 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 	var resp *httpResponseState
 	resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 
-	// If we receive a StatusForbidden, we might have hit a rate limit
 	apiError := &APIError{}
-	if errors.As(err, &apiError) && c.waitForRateLimit && apiError.Code == http.StatusForbidden {
+	numRetries := 0
+	// We retry only if waitForRateLimit is set, and until:
+	// 1. We've exceeded the number of retries
+	// 2. The error returned is not a rate limit error
+	// 3. We succeed
+	for c.waitForRateLimit && err != nil && numRetries < c.numRateLimitRetries &&
+		errors.As(err, &apiError) && apiError.Code == http.StatusForbidden {
 		// If we end up waiting because of an external rate limit, we need to retry the request.
 		if c.externalRateLimiter.WaitForRateLimit(ctx) {
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
+		} else {
+			// We did not wait because of rate limiting, so we break the loop
+			break
 		}
 	}
 

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -1067,6 +1067,7 @@ func TestRateLimitRetry(t *testing.T) {
 	})
 
 	t.Run("secondary rate limit hit", func(t *testing.T) {
+		defer done()
 		hitSecondaryLimit = true
 
 		// We do a simple request to test the retry

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -600,7 +600,7 @@ func ExtractRateLimit(config, kind string) (rate.Limit, error) {
 // GetLimitFromConfig gets RateLimitConfig from an already parsed config schema.
 func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 	// Rate limit config can be in a few states:
-	// 1. Not defined: We fall back to default specified in code.
+	// 1. Not defined: Some infinite, some limited, depending on code host.
 	// 2. Defined and enabled: We use their defined limit.
 	// 3. Defined and disabled: We use an infinite limiter.
 
@@ -613,8 +613,8 @@ func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.GitHubConnection:
-		// 5000 per hour is the default enforced by GitHub on their end
-		limit = rate.Limit(5000.0 / 3600.0)
+		// Use an infinite rate limiter. GitHub has an external rate limiter we obey.
+		limit = rate.Inf
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -79,7 +79,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			name:   "GitHub default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitHub,
-			want:   1.3888888888888888,
+			want:   rate.Inf,
 		},
 		{
 			name:   "Bitbucket Server default",

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -179,9 +179,9 @@ func newGithubSource(
 	}
 
 	for resource, monitor := range map[string]*ratelimit.Monitor{
-		"rest":    v3Client.RateLimitMonitor(),
+		"rest":    v3Client.ExternalRateLimiter(),
 		"graphql": v4Client.RateLimitMonitor(),
-		"search":  searchClient.RateLimitMonitor(),
+		"search":  searchClient.ExternalRateLimiter(),
 	} {
 		// Copy the resource or funcs below will use the last one seen while iterating
 		// the map
@@ -543,7 +543,7 @@ func (s *GitHubSource) listOrg(ctx context.Context, org string, results chan *gi
 					}
 				}
 
-				remaining, reset, retry, _ := s.v3Client.RateLimitMonitor().Get()
+				remaining, reset, retry, _ := s.v3Client.ExternalRateLimiter().Get()
 				s.logger.Debug(
 					"github sync: ListOrgRepositories",
 					log.Int("repos", len(repos)),
@@ -611,7 +611,7 @@ func (s *GitHubSource) listUser(ctx context.Context, user string, results chan *
 				fail, err = err, nil
 			}
 
-			remaining, reset, retry, _ := s.v3Client.RateLimitMonitor().Get()
+			remaining, reset, retry, _ := s.v3Client.ExternalRateLimiter().Get()
 			s.logger.Debug(
 				"github sync: ListUserRepositories",
 				log.Int("repos", len(repos)),
@@ -754,7 +754,7 @@ func (s *GitHubSource) listPublicArchivedRepos(ctx context.Context, results chan
 func (s *GitHubSource) listAffiliated(ctx context.Context, results chan *githubResult) {
 	s.paginate(ctx, results, func(page int) (repos []*github.Repository, hasNext bool, cost int, err error) {
 		defer func() {
-			remaining, reset, retry, _ := s.v3Client.RateLimitMonitor().Get()
+			remaining, reset, retry, _ := s.v3Client.ExternalRateLimiter().Get()
 			s.logger.Debug(
 				"github sync: ListAffiliated",
 				log.Int("repos", len(repos)),
@@ -1109,7 +1109,7 @@ func (s *GitHubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 		err   error
 	)
 	defer func() {
-		remaining, reset, retry, _ := s.v3Client.RateLimitMonitor().Get()
+		remaining, reset, retry, _ := s.v3Client.ExternalRateLimiter().Get()
 		s.logger.Debug(
 			"github sync: ListAffiliated",
 			log.Int("repos", len(repos)),

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -88,7 +88,7 @@ func TestSyncRateLimiters(t *testing.T) {
 		require.NoError(t, err)
 
 		gh := reg.Get(svcs[0].URN())
-		assert.Equal(t, rate.Limit(5000.0/3600.0), gh.Limit())
+		assert.Equal(t, rate.Inf, gh.Limit())
 
 		gl := reg.Get(svcs[1].URN())
 		assert.Equal(t, rate.Limit(10.0/3600.0), gl.Limit())
@@ -117,7 +117,7 @@ func TestSyncRateLimiters(t *testing.T) {
 		require.NoError(t, err)
 
 		gh := reg.Get(svcs[0].URN())
-		assert.Equal(t, rate.Limit(5000.0/3600.0), gh.Limit())
+		assert.Equal(t, rate.Inf, gh.Limit())
 
 		// GitLab should have the infinite
 		gl := reg.Get(svcs[1].URN())


### PR DESCRIPTION
Closes #48540

Sets the default GitHub rate limit to infinite, and adds an option to the V3Client to wait based on the rate limit headers returned by GitHub.

**Before this PR**
The default rate limit is set to `5000/3600` when no rate limit default is set, which severely handicaps our interactions with GitHub. It is also a poor approximation for the actual rate limit from GitHub's side.

**After this PR**
Now, if specified, the client will check the provided headers from GItHub and if a rate limit is hit, it will wait the specified amount of time before retrying. This may be quite a long time depending on which rate limit is hit, but it also does not make sense to fail the job when the rate limit is hit and have impartial data.

## Test plan

Tests adjusted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
