### PR TITLE
ci: exclude internal/database from all go test

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -499,7 +499,7 @@ func buildGoTests(f func(description, testSuffix string, additionalOpts ...bk.St
 		"github.com/sourcegraph/sourcegraph/dev/sg",                                             // small, but much more practical to have it in its own job
 	}
 
-	allSlowPackages := append(slowGoTestPackagesGRPC, slowGoTestPackagesGRPC...)
+	allSlowPackages := append(slowGoTestPackagesNonGRPC, slowGoTestPackagesGRPC...)
 	enableGRPCEnvOpt := bk.Env("SG_FEATURE_FLAG_GRPC", "true")
 
 	// Run all tests that aren't slow both with and without gRPC enabled


### PR DESCRIPTION
This was a regression introduced when we added running tests with and without gRPC. I noticed this because I was confused why CI was taking so long and came across that we were running internal/database in our "all" test.

Test Plan: CI is faster for this PR