### PR TITLE
servegit: skip files unlikely to contain code

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sourcegraph/log"
@@ -63,7 +64,7 @@ func main() {
 		repoC := make(chan servegit.Repo, 4)
 		go func() {
 			defer close(repoC)
-			_, err := srv.Walk(*root, repoC)
+			_, err := srv.Walk(filepath.Clean(*root), repoC)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Walk returned error: %v\n", err)
 				os.Exit(1)

--- a/internal/fastwalk/fastwalk.go
+++ b/internal/fastwalk/fastwalk.go
@@ -188,7 +188,7 @@ func (w *walker) walk(root string, runUserCallback bool) error {
 		if err == filepath.SkipDir {
 			return nil
 		}
-		if err != nil {
+		if err != nil && err != ErrSkipFiles {
 			return err
 		}
 	}


### PR DESCRIPTION
I tweaked this code until it ran in under 1s for my home directory on my macbook. So all heuristics in it are based on that. They could easily not apply for another user, so another commit will try and bound the work done.

Test Plan: Ran locally via app-discover-repos

``` shellsession
$ go install ./dev/internal/cmd/app-discover-repos
$ /usr/bin/time app-discover-repos -root ~ | wc -l
  0.43 real         0.78 user         0.94 sys
  43
```

Part of https://github.com/sourcegraph/sourcegraph/issues/48176
