### PR TITLE
[Permissions] add user permissions info ui

### DIFF
--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.module.scss
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.module.scss
@@ -3,3 +3,7 @@
         margin: 0;
     }
 }
+
+.updated-at-cell {
+    min-width: 10rem;
+}

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -44,8 +44,8 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
 > = ({ user }) => {
     useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'), [])
 
-    const [{ q }, setSearchQuery] = useURLSyncedState({ q: '' })
-    const debouncedQ = useDebounce(q, 300)
+    const [{ query }, setSearchQuery] = useURLSyncedState({ query: '' })
+    const debouncedQuery = useDebounce(query, 300)
 
     const { connection, data, loading, error, refetch, variables, ...paginationProps } = usePageSwitcherPagination<
         UserPermissionsInfoResult,
@@ -55,7 +55,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
         query: UserPermissionsInfoQuery,
         variables: {
             userID: user.id,
-            query: debouncedQ,
+            query: debouncedQuery,
         },
         getConnection: ({ data }) => {
             if (data?.node?.__typename === 'User') {
@@ -69,10 +69,10 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
     })
 
     useEffect(() => {
-        if (debouncedQ !== variables.query) {
-            refetch({ ...variables, query: debouncedQ })
+        if (debouncedQuery !== variables.query) {
+            refetch({ ...variables, query: debouncedQuery })
         }
-    }, [debouncedQ, refetch, variables])
+    }, [debouncedQuery, refetch, variables])
 
     const permissionsInfo = data?.node?.__typename === 'User' ? (data.node as IUser).permissionsInfo : undefined
 
@@ -132,8 +132,8 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
                         type="search"
                         placeholder="Search repositories..."
                         name="query"
-                        value={q}
-                        onChange={event => setSearchQuery({ q: event.currentTarget.value })}
+                        value={query}
+                        onChange={event => setSearchQuery({ query: event.currentTarget.value })}
                         autoComplete="off"
                         autoCorrect="off"
                         autoCapitalize="off"
@@ -189,7 +189,7 @@ const TableColumns: IColumn<INode>[] = [
     },
 ]
 
-const PermissionReasonBadgeProps: { [k: string]: BadgeProps } = {
+const PermissionReasonBadgeProps: { [reason: string]: BadgeProps } = {
     'Permissions Sync': {
         variant: 'success',
         tooltip: 'The repository is accessible to the user due to permissions syncing from code host.',

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -1,14 +1,36 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect } from 'react'
+
+import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
-import { Container, PageHeader, LoadingSpinner, useObservable, Alert, Link } from '@sourcegraph/wildcard'
+import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import {
+    Container,
+    useDebounce,
+    PageSwitcher,
+    PageHeader,
+    LoadingSpinner,
+    Input,
+    Link,
+    Badge,
+    BadgeProps,
+} from '@sourcegraph/wildcard'
 
+import { usePageSwitcherPagination } from '../../../../components/FilteredConnection/hooks/usePageSwitcherPagination'
 import { PageTitle } from '../../../../components/PageTitle'
-import { UserSettingsAreaUserFields } from '../../../../graphql-operations'
+import {
+    UserPermissionsInfoResult,
+    UserPermissionsInfoVariables,
+    PermissionsInfoRepositoryFields as INode,
+    UserPermissionsInfoUserNode as IUser,
+} from '../../../../graphql-operations'
+import { useURLSyncedState } from '../../../../hooks'
 import { ActionContainer } from '../../../../repo/settings/components/ActionContainer'
+import { ExternalRepositoryIcon } from '../../../../site-admin/components/ExternalRepositoryIcon'
+import { Table, IColumn } from '../../../../site-admin/UserManagement/components/Table'
 import { eventLogger } from '../../../../tracking/eventLogger'
 
-import { scheduleUserPermissionsSync, userPermissionsInfo } from './backend'
+import { scheduleUserPermissionsSync, UserPermissionsInfoQuery } from './backend'
 
 import styles from './UserSettingsPermissionsPage.module.scss'
 
@@ -17,13 +39,44 @@ import styles from './UserSettingsPermissionsPage.module.scss'
  */
 export const UserSettingsPermissionsPage: React.FunctionComponent<
     React.PropsWithChildren<{
-        user: UserSettingsAreaUserFields
+        user: { id: string; username: string }
     }>
 > = ({ user }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'))
-    const permissionsInfo = useObservable(useMemo(() => userPermissionsInfo(user.id), [user.id]))
+    useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'), [])
 
-    if (permissionsInfo === undefined) {
+    const [{ q }, setSearchQuery] = useURLSyncedState({ q: '' })
+    const debouncedQ = useDebounce(q, 300)
+
+    const { connection, data, loading, error, refetch, variables, ...paginationProps } = usePageSwitcherPagination<
+        UserPermissionsInfoResult,
+        UserPermissionsInfoVariables,
+        INode
+    >({
+        query: UserPermissionsInfoQuery,
+        variables: {
+            userID: user.id,
+            query: debouncedQ,
+        },
+        getConnection: ({ data }) => {
+            if (data?.node?.__typename === 'User') {
+                const node = data.node as IUser
+
+                return node.permissionsInfo?.repositories || undefined
+            }
+
+            return undefined
+        },
+    })
+
+    useEffect(() => {
+        if (debouncedQ !== variables.query) {
+            refetch({ ...variables, query: debouncedQ })
+        }
+    }, [debouncedQ, refetch, variables])
+
+    const permissionsInfo = data?.node?.__typename === 'User' ? (data.node as IUser).permissionsInfo : undefined
+
+    if (!permissionsInfo || !connection) {
         return <LoadingSpinner />
     }
 
@@ -45,49 +98,108 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
                 className="mb-3"
             />
             <Container className="mb-3">
-                {user.siteAdmin && !window.context.site['authz.enforceForSiteAdmins'] ? (
-                    <Alert className="mb-0" variant="info">
-                        Site admin can access all repositories in the Sourcegraph instance.
-                    </Alert>
-                ) : !permissionsInfo ? (
-                    <Alert className="mb-0" variant="info">
-                        This user is queued to sync permissions, it can only access non-private repositories until
-                        syncing is finished.
-                    </Alert>
-                ) : (
-                    <>
-                        <table className="table">
-                            <tbody>
-                                <tr>
-                                    <th className="border-0">Last complete sync</th>
-                                    <td className="border-0">
-                                        {permissionsInfo.syncedAt ? (
-                                            <Timestamp date={permissionsInfo.syncedAt} />
-                                        ) : (
-                                            'Never'
-                                        )}
-                                    </td>
-                                    <td className="text-muted border-0">Updated by user permissions syncing</td>
-                                </tr>
-                                <tr>
-                                    <th>Last incremental sync</th>
-                                    <td>
-                                        <Timestamp date={permissionsInfo.updatedAt} />
-                                    </td>
-                                    <td className="text-muted">Updated by repository permissions syncing</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <ScheduleUserPermissionsSyncActionContainer user={user} />
-                    </>
-                )}
+                <>
+                    <table className="table">
+                        <tbody>
+                            <tr>
+                                <th className="border-0">Last complete sync</th>
+                                <td className="border-0">
+                                    {permissionsInfo.syncedAt ? <Timestamp date={permissionsInfo.syncedAt} /> : 'Never'}
+                                </td>
+                                <td className="text-muted border-0">Updated by user permissions syncing</td>
+                            </tr>
+                            <tr>
+                                <th>Last incremental sync</th>
+                                <td>
+                                    <Timestamp date={permissionsInfo.updatedAt} />
+                                </td>
+                                <td className="text-muted">Updated by repository permissions syncing</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <ScheduleUserPermissionsSyncActionContainer user={user} />
+                </>
+            </Container>
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Accessible Repositories' }]}
+                description="List of repositories which are accessible to the user."
+                className="my-3 pt-3"
+            />
+            <Container>
+                <div className="d-flex">
+                    <Input
+                        type="search"
+                        placeholder="Search repositories..."
+                        name="query"
+                        value={q}
+                        onChange={event => setSearchQuery({ q: event.currentTarget.value })}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        aria-label="Search repositories..."
+                        variant="regular"
+                    />
+                    <div className="flex-1" />
+                </div>
+                <Table<INode> columns={TableColumns} getRowId={node => node.id} data={connection.nodes} />
+                <PageSwitcher
+                    {...paginationProps}
+                    className="mt-4"
+                    totalCount={connection?.totalCount ?? null}
+                    totalLabel="accessible repositories"
+                />
             </Container>
         </div>
     )
 }
 
+const TableColumns: IColumn<INode>[] = [
+    {
+        key: 'repository',
+        header: 'Repository',
+        render: ({ repository }: INode) =>
+            repository && (
+                <div key={repository.id} className="py-2">
+                    <ExternalRepositoryIcon externalRepo={repository.externalRepository} />
+                    <RepoLink repoName={repository.name} to={repository.url} />
+                </div>
+            ),
+    },
+    {
+        key: 'reason',
+        header: { label: 'Reason', align: 'center' },
+        align: 'center',
+        render: ({ reason }: INode) => (
+            <div className="d-flex justify-content-center">
+                <Badge {...(PermissionReasonBadgeProps[reason] || {})}>{reason}</Badge>
+            </div>
+        ),
+    },
+    {
+        key: 'updatedAt',
+        header: { label: 'Updated At', align: 'center' },
+        align: 'center',
+        render: ({ updatedAt }: INode) => (
+            <div className={classNames('d-flex justify-content-center', styles.updatedAtCell)}>
+                {updatedAt ? <Timestamp date={updatedAt} /> : '-'}
+            </div>
+        ),
+    },
+]
+
+const PermissionReasonBadgeProps: { [k: string]: BadgeProps } = {
+    'Permissions Sync': {
+        variant: 'success',
+        tooltip: 'The repository is accessible to the user due to permissions syncing from code host.',
+    },
+    Unrestricted: { variant: 'primary', tooltip: 'The repository is unrestricted and accessible to all the users. ' },
+    'Site Admin': { variant: 'secondary', tooltip: 'The user is site admin and has access to all the repositories.' },
+}
+
 interface ScheduleUserPermissionsSyncActionContainerProps {
-    user: UserSettingsAreaUserFields
+    user: { id: string; username: string }
 }
 
 class ScheduleUserPermissionsSyncActionContainer extends React.PureComponent<ScheduleUserPermissionsSyncActionContainerProps> {

--- a/client/web/src/site-admin/UserManagement/components/Table.module.scss
+++ b/client/web/src/site-admin/UserManagement/components/Table.module.scss
@@ -12,14 +12,18 @@
 
 .header {
     display: flex;
+    height: 1.75rem;
     align-items: flex-start;
 
     &.align-right {
         justify-content: end;
     }
 
+    &.align-center {
+        justify-content: center;
+    }
+
     &.sortable {
-        height: 1.75rem;
         cursor: pointer;
         justify-content: space-between;
     }

--- a/client/web/src/site-admin/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/UserManagement/components/UsersList.tsx
@@ -12,6 +12,7 @@ import {
     mdiLock,
     mdiLockOpen,
     mdiAccountReactivate,
+    mdiSecurity,
 } from '@mdi/js'
 import classNames from 'classnames'
 import { formatDistanceToNowStrict, startOfDay, endOfDay } from 'date-fns'
@@ -323,6 +324,14 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 onClick: handleRecoverUsers,
                                 bulk: true,
                                 condition: users => users.some(user => user.deletedAt),
+                            },
+                            {
+                                key: 'view-permissions',
+                                label: 'View Permissions',
+                                icon: mdiSecurity,
+                                href: ([user]) => `/users/${user.username}/settings/permissions`,
+                                target: '_blank',
+                                condition: ([user]) => !!user,
                             },
                         ]}
                         columns={[

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -90,7 +91,9 @@ func (s *permissionsInfoRepositoriesStore) MarshalCursor(node graphqlbackend.Per
 }
 
 func (s *permissionsInfoRepositoriesStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
-	return &cursor, nil
+	cursorSQL := fmt.Sprintf("'%s'", cursor)
+
+	return &cursorSQL, nil
 }
 
 func (s *permissionsInfoRepositoriesStore) ComputeTotal(ctx context.Context) (*int32, error) {


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/47870
closes: https://github.com/sourcegraph/sourcegraph/issues/47878

- Adds accessible repos section under the user permissions page with pagination & search
- Adds View Permissions link in users management actions

https://www.loom.com/share/4c1d2024134741c4802b4d8c43662dbc

## Test plan

Manually tested.