### PR TITLE
completions: redact access token

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -220,6 +220,7 @@ var siteConfigSecrets = []struct {
 	{readPath: `dotcom.srcCliVersionCache.github.token`, editPaths: []string{"dotcom", "srcCliVersionCache", "github", "token"}},
 	{readPath: `dotcom.srcCliVersionCache.github.webhookSecret`, editPaths: []string{"dotcom", "srcCliVersionCache", "github", "webhookSecret"}},
 	{readPath: `embeddings.accessToken`, editPaths: []string{"embeddings", "accessToken"}},
+	{readPath: `completions.accessToken`, editPaths: []string{"completions", "accessToken"}},
 }
 
 // UnredactSecrets unredacts unchanged secrets back to their original value for


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Open site config
* Completions access token should be redacted