### PR TITLE
Add missing directive for gazelle go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 
 # Enable only the Aspect javascript plugin for gazelle
 # gazelle:lang js
+# gazelle:lang go
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
This was preventing gazelle go from running, which was a bit confusing to diagnose. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

ran locally. 