### PR TITLE
servegit: introduce MaxDepth and Timeout to discovery

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -32,14 +32,16 @@ func main() {
 	var c servegit.Config
 	c.Load()
 
-	root := flag.String("root", c.ReposRoot, "the directory we search from.")
+	root := flag.String("root", c.Root, "the directory we search from.")
 	block := flag.Bool("block", false, "by default we stream out the repos we find. This is not exactly what sourcegraph uses, so enable this flag for the same behaviour.")
 	verbose := flag.Bool("v", false, "verbose output")
 
 	flag.Parse()
 
+	c.Root = *root
+
 	srv := &servegit.Serve{
-		Root:   *root,
+		Config: c,
 		Logger: log.Scoped("serve", ""),
 	}
 

--- a/internal/service/servegit/serve.go
+++ b/internal/service/servegit/serve.go
@@ -27,8 +27,8 @@ import (
 )
 
 type Serve struct {
-	Addr   string
-	Root   string
+	Config
+
 	Logger log.Logger
 }
 
@@ -238,7 +238,14 @@ func (s *Serve) Repos() ([]Repo, error) {
 func (s *Serve) Walk(root string, repoC chan<- Repo) (bool, error) {
 	var reposRootIsRepo atomic.Bool
 
-	ignore := mkIgnoreSubPath(root)
+	ctx := context.Background()
+	if s.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.Timeout)
+		defer cancel()
+	}
+
+	ignore := mkIgnoreSubPath(root, s.MaxDepth)
 
 	// We use fastwalk since it is much faster. Notes for people used to
 	// filepath.WalkDir:
@@ -248,6 +255,10 @@ func (s *Serve) Walk(root string, repoC chan<- Repo) (bool, error) {
 	//     files (so will only get dirs)
 	//   - filepath.SkipDir has the same meaning
 	err := fastwalk.Walk(root, func(path string, typ os.FileMode) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		if !typ.IsDir() {
 			return fastwalk.ErrSkipFiles
 		}
@@ -300,12 +311,18 @@ func (s *Serve) Walk(root string, repoC chan<- Repo) (bool, error) {
 		return filepath.SkipDir
 	})
 
+	// If we timed out return what we found without an error
+	if err == context.DeadlineExceeded {
+		err = nil
+		s.Logger.Warn("stopped discovering repos since reached timeout", log.String("root", root), log.Duration("timeout", s.Timeout))
+	}
+
 	return reposRootIsRepo.Load(), err
 }
 
 // mkIgnoreSubPath which acts on subpaths to root. It returns true if the
 // subpath should be ignored.
-func mkIgnoreSubPath(root string) func(string) bool {
+func mkIgnoreSubPath(root string, maxDepth int) func(string) bool {
 	// A list of dirs which cause us trouble and are unlikely to contain
 	// repos.
 	ignoredSubPaths := ignoredPaths(root)
@@ -323,6 +340,10 @@ func mkIgnoreSubPath(root string) func(string) bool {
 	}
 
 	return func(subpath string) bool {
+		if maxDepth > 0 && strings.Count(subpath, string(os.PathSeparator)) >= maxDepth {
+			return true
+		}
+
 		// Previously we recursed into bare repositories which is why this check was here.
 		// Now we use this as a sanity check to make sure we didn't somehow stumble into a .git dir.
 		base := filepath.Base(subpath)

--- a/internal/service/servegit/serve.go
+++ b/internal/service/servegit/serve.go
@@ -312,7 +312,7 @@ func (s *Serve) Walk(root string, repoC chan<- Repo) (bool, error) {
 	})
 
 	// If we timed out return what we found without an error
-	if err == context.DeadlineExceeded {
+	if errors.Is(err, context.DeadlineExceeded) {
 		err = nil
 		s.Logger.Warn("stopped discovering repos since reached timeout", log.String("root", root), log.Duration("timeout", s.Timeout))
 	}

--- a/internal/service/servegit/serve_test.go
+++ b/internal/service/servegit/serve_test.go
@@ -38,8 +38,10 @@ func TestReposHandler(t *testing.T) {
 
 			h := (&Serve{
 				Logger: logtest.Scoped(t),
-				Addr:   testAddress,
-				Root:   root,
+				Config: Config{
+					Addr: testAddress,
+					Root: root,
+				},
 			}).handler()
 
 			var want []Repo
@@ -157,7 +159,9 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 
 	repos, err := (&Serve{
 		Logger: logtest.Scoped(t),
-		Root:   root,
+		Config: Config{
+			Root: root,
+		},
 	}).Repos()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
With these two parameters we should avoid overly long discovery operations. Right now if we hit these we just log to the console a warning which isn't the best API. But as we shape this API up we should be able to better report these errors.

The default of 10 max depth and 5s is plucked out of thin air. Will likely need tuning.

Test Plan: ran app-discover-repos -root ~ with the following different values

- n/a :: everything worked as usual
- SRC_DISCOVER_TIMEOUT=10ms :: got timeout warning
- SRC_DISCOVER_MAX_DEPTH=3 :: only got repo names with at most 3 components

Part of https://github.com/sourcegraph/sourcegraph/issues/48176