### PR TITLE
syntax-highlighter: update tree-sitter-csharp back to crates.io

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -2208,8 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c-sharp"
-version = "0.19.1"
-source = "git+https://github.com/tree-sitter/tree-sitter-c-sharp#5b6ae1f88e741b9ed738891ad1362fb9f2041671"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ab3dc608f34924fa9e10533a95f62dbc14b6de0ddd7107722eba66fe19ae31"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
@@ -36,11 +36,7 @@ tree-sitter-go = "0.19.1"
 # on our own fork.
 tree-sitter-sql = { git = "https://github.com/sourcegraph/tree-sitter-sql" }
 
-# As of 2022 Apr 06, there hasn't been a tree-sitter-c-sharp release
-# which allows for tree-sitter 0.20 as a dependency.
-# As a result, you get a type mismatch because tree-sitter 0.19.x
-# is picked by tree-sitter-c-sharp, whereas tree-sitter-go picks 0.20.x
-tree-sitter-c-sharp = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp" }
+tree-sitter-c-sharp = "0.20.0"
 
 tree-sitter-jsonnet = { git = "https://github.com/sourcegraph/tree-sitter-jsonnet" }
 


### PR DESCRIPTION
The comment for fetching from git is out of date. Using crates.io again massively speeds up the fetch as its ridiculously slow from git for some reason.
Does mean we miss out on unreleased commits since 0.20.0, but :shrug: 

## Test plan

it builds and snapshot tests still pass
