### PR TITLE
Make more fields as deprecated and explaining the newer alternatives

### DIFF
--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -70,6 +70,8 @@ export interface PlatformContext {
      * changes as a result of a call to {@link PlatformContext#updateSettings}).
      *
      * It should be a cold observable so that it does not trigger a network request upon each subscription.
+     *
+     * @deprecated Use useSettings instead
      */
     readonly settings: Subscribable<SettingsCascadeOrError<Settings>>
 
@@ -94,6 +96,8 @@ export interface PlatformContext {
     /**
      * Returns promise that resolves into Apollo Client instance after cache restoration.
      * Only `watchQuery` is available till https://github.com/sourcegraph/sourcegraph/issues/24953 is implemented.
+     *
+     * @deprecated Use Apollo instead.
      */
     getGraphQLClient: () => Promise<Pick<GraphQLClient, 'watchQuery'>>
 
@@ -103,6 +107,8 @@ export interface PlatformContext {
      * @template R The GraphQL result type
      * could leak private information such as repository names.
      * @returns Observable that emits the result or an error if the HTTP request failed
+     *
+     * @deprecated Use Apollo instead.
      */
     requestGraphQL: <R, V extends { [key: string]: any } = object>(options: {
         /**

--- a/client/shared/src/platform/context.ts
+++ b/client/shared/src/platform/context.ts
@@ -97,7 +97,7 @@ export interface PlatformContext {
      * Returns promise that resolves into Apollo Client instance after cache restoration.
      * Only `watchQuery` is available till https://github.com/sourcegraph/sourcegraph/issues/24953 is implemented.
      *
-     * @deprecated Use Apollo instead.
+     * @deprecated Use [Apollo](docs.sourcegraph.com/dev/background-information/web/graphql#graphql-client) instead
      */
     getGraphQLClient: () => Promise<Pick<GraphQLClient, 'watchQuery'>>
 
@@ -108,7 +108,7 @@ export interface PlatformContext {
      * could leak private information such as repository names.
      * @returns Observable that emits the result or an error if the HTTP request failed
      *
-     * @deprecated Use Apollo instead.
+     * @deprecated Use [Apollo](docs.sourcegraph.com/dev/background-information/web/graphql#graphql-client) instead
      */
     requestGraphQL: <R, V extends { [key: string]: any } = object>(options: {
         /**


### PR DESCRIPTION
Very minor change while I was at it. Just in case someone comes across it in the future, I thought it'd be good to note the newer alternatives.

Also made me realize we don't have a modern `updateSettings` alternative yet!  

## Test plan

Just a docs change
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-mark-more-stuff-deprecated.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
