### PR TITLE
permissions-center: add permissions sync jobs filters by `reason` and `state`.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.module.scss
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.module.scss
@@ -6,3 +6,12 @@
         align-items: center;
     }
 }
+
+.filters {
+    &__grid {
+        display: grid;
+        grid-template-columns: [reason] max-content [state] max-content [searchType] minmax(auto, 1fr) [search] auto;
+        column-gap: 1rem;
+        align-items: center;
+    }
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -146,12 +146,12 @@ function getSyncJobs(): PermissionsSyncJob[] {
         }
 
         const subject: subject =
-            index % 2 == 0
+            index % 2 === 0
                 ? {
                       __typename: 'Repository',
                       name: `sourcegraph/repo-${index}`,
                       externalRepository: {
-                          serviceType: index % 3 == 0 ? ExternalServiceKind.GITHUB : ExternalServiceKind.GITLAB,
+                          serviceType: index % 3 === 0 ? ExternalServiceKind.GITHUB : ExternalServiceKind.GITLAB,
                       },
                   }
                 : {

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -1,6 +1,6 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
-import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import {
@@ -29,6 +29,20 @@ const config: Meta = {
 export default config
 
 const TIMESTAMP_MOCK = subMinutes(Date.now(), 5)
+const JOBS_MOCK_DATA = getSyncJobs()
+const MANUAL_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.reason.group === PermissionsSyncJobReasonGroup.MANUAL)
+const SCHEDULE_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(
+    job => job.reason.group === PermissionsSyncJobReasonGroup.SCHEDULE
+)
+const SG_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.reason.group === PermissionsSyncJobReasonGroup.SOURCEGRAPH)
+const WEBHOOK_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.reason.group === PermissionsSyncJobReasonGroup.WEBHOOK)
+
+const CANCELED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.CANCELED)
+const COMPLETED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.COMPLETED)
+const ERRORED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.ERRORED)
+const FAILED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.FAILED)
+const PROCESSING_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.PROCESSING)
+const QUEUED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.QUEUED)
 
 export const SixSyncJobsFound: Story = () => (
     <WebStory>
@@ -36,112 +50,17 @@ export const SixSyncJobsFound: Story = () => (
             <MockedTestProvider
                 link={
                     new WildcardMockLink([
-                        {
-                            request: {
-                                query: getDocumentNode(PERMISSIONS_SYNC_JOBS_QUERY),
-                                variables: MATCH_ANY_PARAMETERS,
-                            },
-                            result: {
-                                data: {
-                                    permissionsSyncJobs: {
-                                        nodes: [
-                                            createSyncJobMock(
-                                                '1',
-                                                PermissionsSyncJobState.COMPLETED,
-                                                {
-                                                    __typename: 'Repository',
-                                                    name: 'sourcegraph/sourcegraph',
-                                                    externalRepository: {
-                                                        serviceType: ExternalServiceKind.GITHUB,
-                                                    },
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.WEBHOOK,
-                                                    reason: PermissionsSyncJobReason.REASON_GITHUB_REPO_EVENT,
-                                                }
-                                            ),
-                                            createSyncJobMock(
-                                                '2',
-                                                PermissionsSyncJobState.ERRORED,
-                                                {
-                                                    __typename: 'User',
-                                                    username: 'abdul',
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.SOURCEGRAPH,
-                                                    reason: PermissionsSyncJobReason.REASON_USER_EMAIL_VERIFIED,
-                                                }
-                                            ),
-                                            createSyncJobMock(
-                                                '3',
-                                                PermissionsSyncJobState.FAILED,
-                                                {
-                                                    __typename: 'Repository',
-                                                    name: 'sourcegraph/hoursegraph',
-                                                    externalRepository: {
-                                                        serviceType: ExternalServiceKind.BITBUCKETSERVER,
-                                                    },
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.SCHEDULE,
-                                                    reason: PermissionsSyncJobReason.REASON_REPO_OUTDATED_PERMS,
-                                                }
-                                            ),
-                                            createSyncJobMock(
-                                                '4',
-                                                PermissionsSyncJobState.PROCESSING,
-                                                {
-                                                    __typename: 'User',
-                                                    username: 'omar',
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.MANUAL,
-                                                    reason: PermissionsSyncJobReason.REASON_MANUAL_USER_SYNC,
-                                                }
-                                            ),
-                                            createSyncJobMock(
-                                                '5',
-                                                PermissionsSyncJobState.QUEUED,
-                                                {
-                                                    __typename: 'Repository',
-                                                    name: 'sourcegraph/stillfunny',
-                                                    externalRepository: {
-                                                        serviceType: ExternalServiceKind.GITLAB,
-                                                    },
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.MANUAL,
-                                                    reason: PermissionsSyncJobReason.REASON_MANUAL_REPO_SYNC,
-                                                }
-                                            ),
-                                            createSyncJobMock(
-                                                '6',
-                                                PermissionsSyncJobState.CANCELED,
-                                                {
-                                                    __typename: 'Repository',
-                                                    name: 'sourcegraph/dont-sync-me',
-                                                    externalRepository: {
-                                                        serviceType: ExternalServiceKind.AWSCODECOMMIT,
-                                                    },
-                                                },
-                                                {
-                                                    group: PermissionsSyncJobReasonGroup.SCHEDULE,
-                                                    reason: PermissionsSyncJobReason.REASON_REPO_OUTDATED_PERMS,
-                                                }
-                                            ),
-                                        ],
-                                        totalCount: 6,
-                                        pageInfo: {
-                                            hasNextPage: true,
-                                            hasPreviousPage: false,
-                                            startCursor: null,
-                                            endCursor: null,
-                                        },
-                                    },
-                                },
-                            },
-                            nMatches: Number.POSITIVE_INFINITY,
-                        },
+                        generateResponse(null, null, JOBS_MOCK_DATA, 20),
+                        generateResponse(null, PermissionsSyncJobReasonGroup.MANUAL, MANUAL_JOBS_MOCK_DATA, 6),
+                        generateResponse(null, PermissionsSyncJobReasonGroup.SCHEDULE, SCHEDULE_JOBS_MOCK_DATA, 6),
+                        generateResponse(null, PermissionsSyncJobReasonGroup.SOURCEGRAPH, SG_JOBS_MOCK_DATA, 3),
+                        generateResponse(null, PermissionsSyncJobReasonGroup.WEBHOOK, WEBHOOK_JOBS_MOCK_DATA, 8),
+                        generateResponse(PermissionsSyncJobState.CANCELED, null, CANCELED_JOBS_MOCK_DATA, 4),
+                        generateResponse(PermissionsSyncJobState.COMPLETED, null, COMPLETED_JOBS_MOCK_DATA, 4),
+                        generateResponse(PermissionsSyncJobState.ERRORED, null, ERRORED_JOBS_MOCK_DATA, 3),
+                        generateResponse(PermissionsSyncJobState.FAILED, null, FAILED_JOBS_MOCK_DATA, 3),
+                        generateResponse(PermissionsSyncJobState.PROCESSING, null, PROCESSING_JOBS_MOCK_DATA, 3),
+                        generateResponse(PermissionsSyncJobState.QUEUED, null, QUEUED_JOBS_MOCK_DATA, 3),
                     ])
                 }
             >
@@ -172,6 +91,113 @@ interface reason {
     __typename?: 'PermissionsSyncJobReasonWithGroup'
     group: PermissionsSyncJobReasonGroup
     reason: PermissionsSyncJobReason
+}
+
+function getSyncJobs(): PermissionsSyncJob[] {
+    const jobs: PermissionsSyncJob[] = []
+
+    for (let index = 0; index < 20; index++) {
+        let state: PermissionsSyncJobState
+        let reason: reason
+        switch (index % 6) {
+            case 0:
+                state = PermissionsSyncJobState.CANCELED
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.WEBHOOK,
+                    reason: PermissionsSyncJobReason.REASON_GITHUB_REPO_EVENT,
+                }
+                break
+            case 1:
+                state = PermissionsSyncJobState.COMPLETED
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.WEBHOOK,
+                    reason: PermissionsSyncJobReason.REASON_GITHUB_REPO_EVENT,
+                }
+                break
+            case 2:
+                state = PermissionsSyncJobState.ERRORED
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.MANUAL,
+                    reason: PermissionsSyncJobReason.REASON_MANUAL_REPO_SYNC,
+                }
+                break
+            case 3:
+                state = PermissionsSyncJobState.FAILED
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.MANUAL,
+                    reason: PermissionsSyncJobReason.REASON_MANUAL_USER_SYNC,
+                }
+                break
+            case 4:
+                state = PermissionsSyncJobState.PROCESSING
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.SCHEDULE,
+                    reason: PermissionsSyncJobReason.REASON_REPO_OUTDATED_PERMS,
+                }
+                break
+            case 5:
+            default:
+                state = PermissionsSyncJobState.QUEUED
+                reason = {
+                    group: PermissionsSyncJobReasonGroup.SOURCEGRAPH,
+                    reason: PermissionsSyncJobReason.REASON_USER_EMAIL_VERIFIED,
+                }
+                break
+        }
+
+        const subject: subject =
+            index % 2 == 0
+                ? {
+                      __typename: 'Repository',
+                      name: `sourcegraph/repo-${index}`,
+                      externalRepository: {
+                          serviceType: index % 3 == 0 ? ExternalServiceKind.GITHUB : ExternalServiceKind.GITLAB,
+                      },
+                  }
+                : {
+                      __typename: 'User',
+                      username: `username-${index}`,
+                  }
+
+        jobs.push(createSyncJobMock(index.toString(), state, subject, reason))
+    }
+    return jobs
+}
+
+function generateResponse(
+    state: PermissionsSyncJobState | null,
+    reasonGroup: PermissionsSyncJobReasonGroup | null,
+    jobs: PermissionsSyncJob[],
+    count: number
+) {
+    return {
+        request: {
+            query: getDocumentNode(PERMISSIONS_SYNC_JOBS_QUERY),
+            variables: {
+                first: 20,
+                last: null,
+                after: null,
+                before: null,
+                reasonGroup: reasonGroup ?? null,
+                state: state ?? null,
+            },
+        },
+        result: {
+            data: {
+                permissionsSyncJobs: {
+                    nodes: jobs,
+                    totalCount: count,
+                    pageInfo: {
+                        hasNextPage: true,
+                        hasPreviousPage: false,
+                        startCursor: null,
+                        endCursor: null,
+                    },
+                },
+            },
+        },
+        nMatches: Number.POSITIVE_INFINITY,
+    }
 }
 
 function createSyncJobMock(

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FC, useCallback, useEffect } from 'react'
 
 import { mdiMapSearch } from '@mdi/js'
+
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, H5, Icon, PageSwitcher, Select } from '@sourcegraph/wildcard'
 
@@ -88,7 +89,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                             <PermissionsSyncJobStatePicker value={filters.state} onChange={setState} />
                         </div>
                     )}
-                    {connection?.nodes?.length == 0 && <EmptyList />}
+                    {connection?.nodes?.length === 0 && <EmptyList />}
                     {!!connection?.nodes?.length && (
                         <ConnectionList className={styles.jobsGrid} aria-label="Permissions sync jobs">
                             {connection?.nodes && <Header />}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react'
+import React, { ChangeEvent, FC, useCallback, useEffect } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, H5, PageSwitcher } from '@sourcegraph/wildcard'
+import { Container, H5, PageSwitcher, Select } from '@sourcegraph/wildcard'
 
 import { usePageSwitcherPagination } from '../../components/FilteredConnection/hooks/usePageSwitcherPagination'
 import {
@@ -10,12 +10,24 @@ import {
     ConnectionList,
     ConnectionLoading,
 } from '../../components/FilteredConnection/ui'
-import { PermissionsSyncJob, PermissionsSyncJobsResult, PermissionsSyncJobsVariables } from '../../graphql-operations'
+import {
+    PermissionsSyncJob,
+    PermissionsSyncJobReasonGroup,
+    PermissionsSyncJobsResult,
+    PermissionsSyncJobState,
+    PermissionsSyncJobsVariables,
+} from '../../graphql-operations'
+import { useURLSyncedState } from '../../hooks'
 
 import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
 import { PermissionsSyncJobNode } from './PermissionsSyncJobNode'
 
 import styles from './PermissionsSyncJobsTable.module.scss'
+
+const DEFAULT_FILTERS = {
+    reason: '',
+    state: '',
+}
 
 interface Props extends TelemetryProps {}
 
@@ -26,6 +38,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
         telemetryService.logPageView('PermissionsSyncJobsTable')
     }, [telemetryService])
 
+    const [filters, setFilters] = useURLSyncedState(DEFAULT_FILTERS)
     const { connection, loading, error, refetch, ...paginationProps } = usePageSwitcherPagination<
         PermissionsSyncJobsResult,
         PermissionsSyncJobsVariables,
@@ -34,10 +47,27 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
         query: PERMISSIONS_SYNC_JOBS_QUERY,
         variables: {
             first: 20,
-        },
+            reasonGroup:
+                filters.reason === ''
+                    ? null
+                    : PermissionsSyncJobReasonGroup[filters.reason as keyof typeof PermissionsSyncJobReasonGroup],
+            state:
+                filters.state === ''
+                    ? null
+                    : PermissionsSyncJobState[filters.state as keyof typeof PermissionsSyncJobState],
+        } as PermissionsSyncJobsVariables,
         getConnection: ({ data }) => data?.permissionsSyncJobs || undefined,
         options: { pollInterval: 5000 },
     })
+
+    const setReason = useCallback(
+        (reasonGroup: PermissionsSyncJobReasonGroup | null) => setFilters({ reason: reasonGroup?.toString() ?? '' }),
+        [setFilters]
+    )
+    const setState = useCallback(
+        (state: PermissionsSyncJobState | null) => setFilters({ state: state?.toString() ?? '' }),
+        [setFilters]
+    )
 
     return (
         <div>
@@ -45,6 +75,12 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}
+                    {connection && connection.nodes?.length > 0 && (
+                        <div className={styles.filtersGrid}>
+                            <PermissionsSyncJobReasonGroupPicker onChange={setReason} />
+                            <PermissionsSyncJobStatePicker onChange={setState} />
+                        </div>
+                    )}
                     <ConnectionList className={styles.jobsGrid} aria-label="Permissions sync jobs">
                         {connection && connection.nodes?.length > 0 && <Header />}
                         {connection?.nodes?.map(node => (
@@ -60,6 +96,54 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 />
             </Container>
         </div>
+    )
+}
+
+interface PermissionsSyncJobReasonGroupPickerProps {
+    onChange: (reasonGroup: PermissionsSyncJobReasonGroup | null) => void
+}
+
+export const PermissionsSyncJobReasonGroupPicker: FC<PermissionsSyncJobReasonGroupPickerProps> = props => {
+    const { onChange } = props
+
+    const handleSelect = (event: ChangeEvent<HTMLSelectElement>): void => {
+        const nextValue = event.target.value === '' ? null : (event.target.value as PermissionsSyncJobReasonGroup)
+        onChange(nextValue)
+    }
+
+    return (
+        <Select id="reasonSelector" label="Reason" onChange={handleSelect}>
+            <option value="">Any</option>
+            <option value={PermissionsSyncJobReasonGroup.MANUAL}>Manual</option>
+            <option value={PermissionsSyncJobReasonGroup.SCHEDULE}>Schedule</option>
+            <option value={PermissionsSyncJobReasonGroup.SOURCEGRAPH}>Sourcegraph</option>
+            <option value={PermissionsSyncJobReasonGroup.WEBHOOK}>Webhook</option>
+        </Select>
+    )
+}
+
+interface PermissionsSyncJobStatePickerProps {
+    onChange: (state: PermissionsSyncJobState | null) => void
+}
+
+export const PermissionsSyncJobStatePicker: FC<PermissionsSyncJobStatePickerProps> = props => {
+    const { onChange } = props
+
+    const handleSelect = (event: ChangeEvent<HTMLSelectElement>): void => {
+        const nextValue = event.target.value === '' ? null : (event.target.value as PermissionsSyncJobState)
+        onChange(nextValue)
+    }
+
+    return (
+        <Select id="stateSelector" label="State" onChange={handleSelect}>
+            <option value="">Any</option>
+            <option value={PermissionsSyncJobState.CANCELED}>Canceled</option>
+            <option value={PermissionsSyncJobState.COMPLETED}>Completed</option>
+            <option value={PermissionsSyncJobState.ERRORED}>Errored</option>
+            <option value={PermissionsSyncJobState.FAILED}>Failed</option>
+            <option value={PermissionsSyncJobState.PROCESSING}>Processing</option>
+            <option value={PermissionsSyncJobState.QUEUED}>Queued</option>
+        </Select>
     )
 }
 

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -47,8 +47,22 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         }
     }
 
-    query PermissionsSyncJobs($first: Int, $last: Int, $after: String, $before: String) {
-        permissionsSyncJobs(first: $first, last: $last, after: $after, before: $before) {
+    query PermissionsSyncJobs(
+        $first: Int
+        $last: Int
+        $after: String
+        $before: String
+        $reasonGroup: PermissionsSyncJobReasonGroup
+        $state: PermissionsSyncJobState
+    ) {
+        permissionsSyncJobs(
+            first: $first
+            last: $last
+            after: $after
+            before: $before
+            reasonGroup: $reasonGroup
+            state: $state
+        ) {
             totalCount
             pageInfo {
                 hasNextPage


### PR DESCRIPTION
Test plan:
Storybook.

Part of https://github.com/sourcegraph/sourcegraph/issues/47872

### Storybook demo

https://user-images.githubusercontent.com/94846361/222177837-8689a533-e568-4078-9d8b-af0d2dc2a46c.mp4

## App preview:

- [Web](https://sg-web-ao-ui-pc-implement-filtering.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
