### PR TITLE
rbac: allow permissions to be assigned on role creation

### DIFF
--- a/cmd/frontend/graphqlbackend/rbac.go
+++ b/cmd/frontend/graphqlbackend/rbac.go
@@ -42,7 +42,8 @@ type DeleteRoleArgs struct {
 }
 
 type CreateRoleArgs struct {
-	Name string
+	Name        string
+	Permissions []graphql.ID
 }
 
 type ListRoleArgs struct {

--- a/cmd/frontend/graphqlbackend/rbac.graphql
+++ b/cmd/frontend/graphqlbackend/rbac.graphql
@@ -170,7 +170,7 @@ extend type Mutation {
     """
     Creates a role.
     """
-    createRole(name: String!): Role!
+    createRole(name: String!, permissions: [ID!]!): Role!
 }
 
 extend type User {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func (r *Resolver) Roles(ctx context.Context, args *gql.ListRoleArgs) (*graphqlutil.ConnectionResolver[gql.RoleResolver], error) {
@@ -105,13 +106,36 @@ func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gq
 		return nil, err
 	}
 
-	newRole, err := r.db.Roles().Create(ctx, args.Name, false)
+	var role *types.Role
+	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
+		role, err = tx.Roles().Create(ctx, args.Name, false)
+		if err != nil {
+			return err
+		}
+
+		if len(args.Permissions) > 0 {
+			opts := database.BulkAssignPermissionsToRoleOpts{RoleID: role.ID}
+			for _, permissionID := range args.Permissions {
+				id, err := unmarshalPermissionID(permissionID)
+				if err != nil {
+					return err
+				}
+				opts.Permissions = append(opts.Permissions, id)
+			}
+			err = tx.RolePermissions().BulkAssignPermissionsToRole(ctx, opts)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &roleResolver{
 		db:   r.db,
-		role: newRole,
+		role: role,
 	}, nil
 }

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/rbac/resolvers/apitest"
@@ -316,8 +318,14 @@ func TestCreateRole(t *testing.T) {
 	s, err := newSchema(db, r)
 	assert.NoError(t, err)
 
+	perm, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
+		Namespace: types.BatchChangesNamespace,
+		Action:    "READ",
+	})
+	require.NoError(t, err)
+
 	t.Run("as non site-admin", func(t *testing.T) {
-		input := map[string]any{"name": "TEST-ROLE"}
+		input := map[string]any{"name": "TEST-ROLE", "permissions": []graphql.ID{}}
 
 		var response struct{ CreateRole apitest.Role }
 		errs := apitest.Exec(actorCtx, t, s, input, &response, createRoleMutation)
@@ -331,26 +339,64 @@ func TestCreateRole(t *testing.T) {
 	})
 
 	t.Run("as site-admin", func(t *testing.T) {
-		input := map[string]any{"name": "TEST-ROLE"}
+		t.Run("without permissions", func(t *testing.T) {
+			input := map[string]any{"name": "TEST-ROLE-1", "permissions": []graphql.ID{}}
 
-		var response struct{ CreateRole apitest.Role }
-		// First time it should work, because the role exists
-		apitest.MustExec(adminActorCtx, t, s, input, &response, createRoleMutation)
+			var response struct{ CreateRole apitest.Role }
+			// First time it should work, because the role exists
+			apitest.MustExec(adminActorCtx, t, s, input, &response, createRoleMutation)
 
-		// Second time it should fail because role names must be unique
-		errs := apitest.Exec(adminActorCtx, t, s, input, &response, createRoleMutation)
-		if len(errs) != 1 {
-			t.Fatalf("expected a single error, but got %d", len(errs))
-		}
-		if have, want := errs[0].Message, "cannot create role: err_name_exists"; have != want {
-			t.Fatalf("wrong error code. want=%q, have=%q", want, have)
-		}
+			// Second time it should fail because role names must be unique
+			errs := apitest.Exec(adminActorCtx, t, s, input, &response, createRoleMutation)
+			if len(errs) != 1 {
+				t.Fatalf("expected a single error, but got %d", len(errs))
+			}
+			if have, want := errs[0].Message, "cannot create role: err_name_exists"; have != want {
+				t.Fatalf("wrong error code. want=%q, have=%q", want, have)
+			}
+
+			roleID, err := unmarshalRoleID(graphql.ID(response.CreateRole.ID))
+			require.NoError(t, err)
+			rps, err := db.RolePermissions().GetByRoleID(ctx, database.GetRolePermissionOpts{
+				RoleID: roleID,
+			})
+			require.NoError(t, err)
+			require.Len(t, rps, 0)
+		})
+
+		t.Run("with permissions", func(t *testing.T) {
+			input := map[string]any{"name": "TEST-ROLE-2", "permissions": []graphql.ID{
+				marshalPermissionID(perm.ID),
+			}}
+
+			var response struct{ CreateRole apitest.Role }
+			// First time it should work, because the role exists
+			apitest.MustExec(adminActorCtx, t, s, input, &response, createRoleMutation)
+
+			// Second time it should fail because role names must be unique
+			errs := apitest.Exec(adminActorCtx, t, s, input, &response, createRoleMutation)
+			if len(errs) != 1 {
+				t.Fatalf("expected a single error, but got %d", len(errs))
+			}
+			if have, want := errs[0].Message, "cannot create role: err_name_exists"; have != want {
+				t.Fatalf("wrong error code. want=%q, have=%q", want, have)
+			}
+
+			roleID, err := unmarshalRoleID(graphql.ID(response.CreateRole.ID))
+			require.NoError(t, err)
+			rps, err := db.RolePermissions().GetByRoleID(ctx, database.GetRolePermissionOpts{
+				RoleID: roleID,
+			})
+			require.NoError(t, err)
+			require.Len(t, rps, 1)
+			require.Equal(t, rps[0].PermissionID, perm.ID)
+		})
 	})
 }
 
 const createRoleMutation = `
-mutation CreateRole($name: String!) {
-	createRole(name: $name) {
+mutation CreateRole($name: String!, $permissions: [ID!]!) {
+	createRole(name: $name, permissions: $permissions) {
 		id
 		name
 		system

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -42655,6 +42655,10 @@ type MockRolePermissionStore struct {
 	// AssignToSystemRoleFunc is an instance of a mock function object
 	// controlling the behavior of the method AssignToSystemRole.
 	AssignToSystemRoleFunc *RolePermissionStoreAssignToSystemRoleFunc
+	// BulkAssignPermissionsToRoleFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// BulkAssignPermissionsToRole.
+	BulkAssignPermissionsToRoleFunc *RolePermissionStoreBulkAssignPermissionsToRoleFunc
 	// BulkAssignPermissionsToSystemRolesFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// BulkAssignPermissionsToSystemRoles.
@@ -42695,6 +42699,11 @@ func NewMockRolePermissionStore() *MockRolePermissionStore {
 		},
 		AssignToSystemRoleFunc: &RolePermissionStoreAssignToSystemRoleFunc{
 			defaultHook: func(context.Context, AssignToSystemRoleOpts) (r0 error) {
+				return
+			},
+		},
+		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) (r0 error) {
 				return
 			},
 		},
@@ -42756,6 +42765,11 @@ func NewStrictMockRolePermissionStore() *MockRolePermissionStore {
 				panic("unexpected invocation of MockRolePermissionStore.AssignToSystemRole")
 			},
 		},
+		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
+			defaultHook: func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToRole")
+			},
+		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
 			defaultHook: func(context.Context, BulkAssignPermissionsToSystemRolesOpts) error {
 				panic("unexpected invocation of MockRolePermissionStore.BulkAssignPermissionsToSystemRoles")
@@ -42809,6 +42823,9 @@ func NewMockRolePermissionStoreFrom(i RolePermissionStore) *MockRolePermissionSt
 		},
 		AssignToSystemRoleFunc: &RolePermissionStoreAssignToSystemRoleFunc{
 			defaultHook: i.AssignToSystemRole,
+		},
+		BulkAssignPermissionsToRoleFunc: &RolePermissionStoreBulkAssignPermissionsToRoleFunc{
+			defaultHook: i.BulkAssignPermissionsToRole,
 		},
 		BulkAssignPermissionsToSystemRolesFunc: &RolePermissionStoreBulkAssignPermissionsToSystemRolesFunc{
 			defaultHook: i.BulkAssignPermissionsToSystemRoles,
@@ -43048,6 +43065,115 @@ func (c RolePermissionStoreAssignToSystemRoleFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RolePermissionStoreAssignToSystemRoleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RolePermissionStoreBulkAssignPermissionsToRoleFunc describes the behavior
+// when the BulkAssignPermissionsToRole method of the parent
+// MockRolePermissionStore instance is invoked.
+type RolePermissionStoreBulkAssignPermissionsToRoleFunc struct {
+	defaultHook func(context.Context, BulkAssignPermissionsToRoleOpts) error
+	hooks       []func(context.Context, BulkAssignPermissionsToRoleOpts) error
+	history     []RolePermissionStoreBulkAssignPermissionsToRoleFuncCall
+	mutex       sync.Mutex
+}
+
+// BulkAssignPermissionsToRole delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockRolePermissionStore) BulkAssignPermissionsToRole(v0 context.Context, v1 BulkAssignPermissionsToRoleOpts) error {
+	r0 := m.BulkAssignPermissionsToRoleFunc.nextHook()(v0, v1)
+	m.BulkAssignPermissionsToRoleFunc.appendCall(RolePermissionStoreBulkAssignPermissionsToRoleFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// BulkAssignPermissionsToRole method of the parent MockRolePermissionStore
+// instance is invoked and the hook queue is empty.
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// BulkAssignPermissionsToRole method of the parent MockRolePermissionStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushHook(hook func(context.Context, BulkAssignPermissionsToRoleOpts) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+		return r0
+	})
+}
+
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) nextHook() func(context.Context, BulkAssignPermissionsToRoleOpts) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) appendCall(r0 RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RolePermissionStoreBulkAssignPermissionsToRoleFuncCall objects describing
+// the invocations of this function.
+func (f *RolePermissionStoreBulkAssignPermissionsToRoleFunc) History() []RolePermissionStoreBulkAssignPermissionsToRoleFuncCall {
+	f.mutex.Lock()
+	history := make([]RolePermissionStoreBulkAssignPermissionsToRoleFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RolePermissionStoreBulkAssignPermissionsToRoleFuncCall is an object that
+// describes an invocation of method BulkAssignPermissionsToRole on an
+// instance of MockRolePermissionStore.
+type RolePermissionStoreBulkAssignPermissionsToRoleFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 BulkAssignPermissionsToRoleOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RolePermissionStoreBulkAssignPermissionsToRoleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
The current mutation for creating a role doesn't allow for permission assignment at the point of role creation. This PR allows the mutation takes an additional variable containing the list of permissions to be assigned to that role after creation.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Add unit tests
* Manual testing via GraphQL playground