### PR TITLE
codeintel: Add comparison key to index configuration-like things

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -2260,7 +2260,7 @@ type AutoIndexJobDescription {
     A hash of the root and indexer values.
 
     This value can be used to quickly compare whether or not explicit configuration and inferred configuration
-    refer to the same "project" in a given repository. See `AutoIndexJobDescription.comparisonKey`.
+    refer to the same "project" in a given repository. See `RootWithKey.comparisonKey`.
     """
     comparisonKey: String!
 

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1106,7 +1106,7 @@ type RootWithKey {
     A hash of the root and indexer values.
 
     This value can be used to quickly compare whether or not explicit configuration and inferred configuration
-    refer to the same "project" in a given repository.
+    refer to the same "project" in a given repository. See `AutoIndexJobDescription.comparisonKey`.
     """
     comparisonKey: String!
 }
@@ -2023,6 +2023,11 @@ type IndexConfiguration {
     configuration: String
 
     """
+    The parsed index configuration (decoded from the raw JSON version).
+    """
+    parsedConfiguration: [AutoIndexJobDescription!]
+
+    """
     The raw JSON-encoded index configuration as inferred by the auto-indexer.
     """
     inferredConfiguration: InferredConfiguration
@@ -2036,6 +2041,11 @@ type InferredConfiguration {
     The raw JSON-encoded inferred index configuration.
     """
     configuration: String!
+
+    """
+    The parsed index configuration (decoded from the raw JSON version).
+    """
+    parsedConfiguration: [AutoIndexJobDescription!]
 
     """
     If inference of the repository contents hit a limit its error description will available here.
@@ -2245,6 +2255,14 @@ type AutoIndexJobDescription {
     The target indexer.
     """
     indexer: CodeIntelIndexer
+
+    """
+    A hash of the root and indexer values.
+
+    This value can be used to quickly compare whether or not explicit configuration and inferred configuration
+    refer to the same "project" in a given repository. See `AutoIndexJobDescription.comparisonKey`.
+    """
+    comparisonKey: String!
 
     """
     The particular steps inferred for indexing.

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1086,6 +1086,29 @@ type InferredAvailableIndexers {
     The list of roots that could be indexed.
     """
     roots: [String!]!
+
+    """
+    The list of roots that could be indexed.
+    """
+    rootsWithKeys: [RootWithKey!]!
+}
+
+"""
+Pairs a root directory with comparison key used to match index configurations for the same repository "project".
+"""
+type RootWithKey {
+    """
+    The root.
+    """
+    root: String!
+
+    """
+    A hash of the root and indexer values.
+
+    This value can be used to quickly compare whether or not explicit configuration and inferred configuration
+    refer to the same "project" in a given repository.
+    """
+    comparisonKey: String!
 }
 
 """

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/index_configuration_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/index_configuration_resolver.go
@@ -72,6 +72,10 @@ func (r *indexConfigurationResolver) InferredConfiguration(ctx context.Context) 
 	}, nil
 }
 
+func (r *indexConfigurationResolver) ParsedConfiguration(ctx context.Context) (*[]resolverstubs.AutoIndexJobDescriptionResolver, error) {
+	return nil, errors.New("unimplemented") // TODO
+}
+
 type inferredConfigurationResolver struct {
 	configuration string
 	limitErr      error
@@ -79,6 +83,10 @@ type inferredConfigurationResolver struct {
 
 func (r *inferredConfigurationResolver) Configuration() string {
 	return r.configuration
+}
+
+func (r *inferredConfigurationResolver) ParsedConfiguration(ctx context.Context) (*[]resolverstubs.AutoIndexJobDescriptionResolver, error) {
+	return nil, errors.New("unimplemented") // TODO
 }
 
 func (r *inferredConfigurationResolver) LimitError() *string {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -273,25 +273,7 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 		return nil, nil
 	}
 
-	var resolvers []resolverstubs.AutoIndexJobDescriptionResolver
-	for _, indexJob := range config.IndexJobs {
-		var steps []types.DockerStep
-		for _, step := range indexJob.Steps {
-			steps = append(steps, types.DockerStep{
-				Root:     step.Root,
-				Image:    step.Image,
-				Commands: step.Commands,
-			})
-		}
-
-		resolvers = append(resolvers, &autoIndexJobDescriptionResolver{
-			autoindexSvc: r.autoindexSvc,
-			indexJob:     indexJob,
-			steps:        steps,
-		})
-	}
-
-	return resolvers, nil
+	return newDescriptionResolvers(r.autoindexSvc, config)
 }
 
 type autoIndexJobDescriptionResolver struct {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -2,6 +2,9 @@ package graphql
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
 	"time"
 
 	"github.com/grafana/regexp"
@@ -303,6 +306,16 @@ func (r *autoIndexJobDescriptionResolver) Root() string {
 
 func (r *autoIndexJobDescriptionResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
 	return types.NewCodeIntelIndexerResolver(r.indexJob.Indexer)
+}
+
+func (r *autoIndexJobDescriptionResolver) ComparisonKey() string {
+	return comparisonKey(r.indexJob.Root, r.indexJob.Indexer)
+}
+
+func comparisonKey(root, indexer string) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(strings.Join([]string{root, indexer}, "\x00")))
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }
 
 func (r *autoIndexJobDescriptionResolver) Steps() resolverstubs.IndexStepsResolver {

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -2,6 +2,9 @@ package resolvers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
 
 	"github.com/graph-gophers/graphql-go"
 
@@ -794,6 +797,12 @@ type PreviewRepositoryFilterArgs struct {
 type InferredAvailableIndexersResolver interface {
 	Indexer() CodeIntelIndexerResolver
 	Roots() []string
+	RootsWithKeys() []RootsWithKeyResolver
+}
+
+type RootsWithKeyResolver interface {
+	Root() string
+	ComparisonKey() string
 }
 
 type inferredAvailableIndexersResolver struct {
@@ -814,4 +823,35 @@ func (r *inferredAvailableIndexersResolver) Indexer() CodeIntelIndexerResolver {
 
 func (r *inferredAvailableIndexersResolver) Roots() []string {
 	return r.roots
+}
+
+func (r *inferredAvailableIndexersResolver) RootsWithKeys() []RootsWithKeyResolver {
+	var resolvers []RootsWithKeyResolver
+	for _, root := range r.roots {
+		resolvers = append(resolvers, &rootWithKeyResolver{
+			root: root,
+			key:  comparisonKey(root, r.indexer.Name()),
+		})
+	}
+
+	return resolvers
+}
+
+type rootWithKeyResolver struct {
+	root string
+	key  string
+}
+
+func (r *rootWithKeyResolver) Root() string {
+	return r.root
+}
+
+func (r *rootWithKeyResolver) ComparisonKey() string {
+	return r.key
+}
+
+func comparisonKey(root, indexer string) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(strings.Join([]string{root, indexer}, "\x00")))
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -190,6 +190,7 @@ type PreciseIndexResolver interface {
 type AutoIndexJobDescriptionResolver interface {
 	Root() string
 	Indexer() CodeIntelIndexerResolver
+	ComparisonKey() string
 	Steps() IndexStepsResolver
 }
 
@@ -306,11 +307,13 @@ type CodeIntelIndexerResolver interface {
 
 type IndexConfigurationResolver interface {
 	Configuration(ctx context.Context) (*string, error)
+	ParsedConfiguration(ctx context.Context) (*[]AutoIndexJobDescriptionResolver, error)
 	InferredConfiguration(ctx context.Context) (InferredConfigurationResolver, error)
 }
 
 type InferredConfigurationResolver interface {
 	Configuration() string
+	ParsedConfiguration(ctx context.Context) (*[]AutoIndexJobDescriptionResolver, error)
 	LimitError() *string
 }
 


### PR DESCRIPTION
Fixes #48367. We needed to also expose _parsed_ configuration instead of treating inferred/explicit configuration as an opaque string.

## Test plan

Tested by hand in API console.