### PR TITLE
app: Add App outbound url params in navbar Cloud CTA

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -592,7 +592,7 @@ export const buildCloudTrialURL = (
  * @param campaign Optional utm_campaign value to add to the query params.
  * @returns URL string with appended query parameters
  */
-export const addSourcegraphApOutboundUrlParameters = (url: string, campaign?: string): string => {
+export const addSourcegraphAppOutboundUrlParameters = (url: string, campaign?: string): string => {
     const urlObject = new URL(url)
     urlObject.searchParams.append('utm_source', 'sg_app')
     urlObject.searchParams.append('utm_medium', 'referral')
@@ -601,27 +601,32 @@ export const addSourcegraphApOutboundUrlParameters = (url: string, campaign?: st
         urlObject.searchParams.append('utm_campaign', campaign)
     }
 
-    // urlObject.searchParams.append('app_version', version)
-    urlObject.searchParams.append('app_os', detectOS())
+    const os = detectOS()
+    if (os) {
+        urlObject.searchParams.append('app_os', os)
+    }
 
     return urlObject.toString()
 }
 
 /*
  * Detect the user's OS, for analytics purposes and not for feature detection.
- * Do not rely on this for any feature functionality.
+ * Do not rely on this for any feature functionality. Returns undefined if unknown.
  */
-function detectOS() {
+function detectOS(): 'windows' | 'mac' | 'linux' | undefined {
     const userAgent = window.navigator.userAgent
+
     if (userAgent.includes('Windows')) {
         return 'windows'
-    } else if (userAgent.includes('Mac')) {
-        return 'darwin'
-    } else if (userAgent.includes('Linux')) {
-        return 'linux'
-    } else {
-        return 'unknown'
     }
+    if (userAgent.includes('Mac')) {
+        return 'mac'
+    }
+    if (userAgent.includes('Linux')) {
+        return 'linux'
+    }
+
+    return undefined
 }
 
 /** The results of parsing a repo-revision string like "my/repo@my/revision". */

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -586,6 +586,44 @@ export const buildCloudTrialURL = (
     return url.toString()
 }
 
+/**
+ * Takes an input URL and adds Sourcegraph App specific query parameters to it. This includes the UTM parameters and app_os.
+ * @param url Original URL
+ * @param campaign Optional utm_campaign value to add to the query params.
+ * @returns URL string with appended query parameters
+ */
+export const addSourcegraphApOutboundUrlParameters = (url: string, campaign?: string): string => {
+    const urlObject = new URL(url)
+    urlObject.searchParams.append('utm_source', 'sg_app')
+    urlObject.searchParams.append('utm_medium', 'referral')
+
+    if (campaign) {
+        urlObject.searchParams.append('utm_campaign', campaign)
+    }
+
+    // urlObject.searchParams.append('app_version', version)
+    urlObject.searchParams.append('app_os', detectOS())
+
+    return urlObject.toString()
+}
+
+/*
+ * Detect the user's OS, for analytics purposes and not for feature detection.
+ * Do not rely on this for any feature functionality.
+ */
+function detectOS() {
+    const userAgent = window.navigator.userAgent
+    if (userAgent.includes('Windows')) {
+        return 'windows'
+    } else if (userAgent.includes('Mac')) {
+        return 'darwin'
+    } else if (userAgent.includes('Linux')) {
+        return 'linux'
+    } else {
+        return 'unknown'
+    }
+}
+
 /** The results of parsing a repo-revision string like "my/repo@my/revision". */
 export interface ParsedRepoRevision {
     repoName: string

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -14,7 +14,6 @@ import { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-
 import { addSourcegraphAppOutboundUrlParameters, buildCloudTrialURL } from '@sourcegraph/shared/src/util/url'
 import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
 

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -15,7 +15,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
-    addSourcegraphApOutboundUrlParameters as addSourcegraphAppOutboundUrlParameters,
+    addSourcegraphAppOutboundUrlParameters as addSourcegraphAppOutboundUrlParameters,
     buildCloudTrialURL,
 } from '@sourcegraph/shared/src/util/url'
 import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -14,10 +14,8 @@ import { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import {
-    addSourcegraphAppOutboundUrlParameters as addSourcegraphAppOutboundUrlParameters,
-    buildCloudTrialURL,
-} from '@sourcegraph/shared/src/util/url'
+
+import { addSourcegraphAppOutboundUrlParameters, buildCloudTrialURL } from '@sourcegraph/shared/src/util/url'
 import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -14,7 +14,10 @@ import { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { buildCloudTrialURL } from '@sourcegraph/shared/src/util/url'
+import {
+    addSourcegraphApOutboundUrlParameters as addSourcegraphAppOutboundUrlParameters,
+    buildCloudTrialURL,
+} from '@sourcegraph/shared/src/util/url'
 import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -265,7 +268,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         <ButtonLink
                             variant="secondary"
                             outline={true}
-                            to={buildCloudTrialURL(props.authenticatedUser)}
+                            to={addSourcegraphAppOutboundUrlParameters(buildCloudTrialURL(props.authenticatedUser))}
                             size="sm"
                             onClick={() =>
                                 eventLogger.log('ClickedOnCloudCTA', { cloudCtaType: 'NavBarSourcegraphApp' })


### PR DESCRIPTION
In Sourcegraph App, add UTM and App params to the Cloud CTA in the Navbar.

Adds `addSourcegraphAppOutboundUrlParameters` which takes a URL and returns a new URL with the appropriate query parameters added.

## Test plan

- In Sourcegraph App, click on the "Try Sourcegraph Cloud" navbar CTA
- Check that the URL params are added to the destination URL.

## App preview:

- [Web](https://sg-web-marek-app-outbound-params-cloud.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
