### PR TITLE
[docs] fixed papercuts in new permission docs

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -102,7 +102,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
                             <li>Periodically pulling cloned repositories to ensure search results are current.</li>
                             <li>
                                 Fetching{' '}
-                                <Link to="/help/admin/repo/permissions" target="_blank" rel="noopener noreferrer">
+                                <Link to="/help/admin/permissions" target="_blank" rel="noopener noreferrer">
                                     user repository access permissions
                                 </Link>
                                 , if you have enabled this feature.

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -35,11 +35,7 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
                 className="mb-3"
                 description={
                     <>
-                        Learn more about{' '}
-                        <Link to="/help/admin/repo/permissions#background-permissions-syncing">
-                            background permissions syncing
-                        </Link>
-                        .
+                        Learn more about <Link to="/help/admin/permissions/syncing">permission syncing</Link>.
                     </>
                 }
             />

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -35,11 +35,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<
                 path={[{ text: 'Permissions' }]}
                 description={
                     <>
-                        Learn more about{' '}
-                        <Link to="/help/admin/repo/permissions#background-permissions-syncing">
-                            background permissions syncing
-                        </Link>
-                        .
+                        Learn more about <Link to="/help/admin/permissions/syncing">permissions syncing</Link>.
                     </>
                 }
                 className="mb-3"

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -38,7 +38,7 @@ Administration is usually handled by site administrators are the admins responsi
 - [User authentication](auth/index.md)
   - [User data deletion](user_data_deletion.md)
 - [Setting the URL for your instance](url.md)
-- [Repository permissions](repo/permissions.md)
+- [Repository permissions](permissions/index.md)
   - [Row-level security](repo/row_level_security.md)
 - [Batch Changes](../batch_changes/how-tos/site_admin_configuration.md)
 - [Configure incoming webhooks](config/webhooks.md)

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12987,8 +12987,8 @@ Query: `max by (type) (ceil(rate(src_repoupdater_perms_syncer_sync_errors_total[
 
 <p class="subtitle">Total number of repos scheduled for permissions sync</p>
 
-Indicates how many repositories have been scheduled for a permissions sync.
-More about repository permissions synchronization [here](https://docs.sourcegraph.com/admin/repo/permissions#permissions-sync-scheduling)
+Indicates how many repositories have been scheduled for a permissions sync.  
+More about repository permissions [here](https://docs.sourcegraph.com/admin/permissions)
 
 This panel has no related alerts.
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12987,8 +12987,8 @@ Query: `max by (type) (ceil(rate(src_repoupdater_perms_syncer_sync_errors_total[
 
 <p class="subtitle">Total number of repos scheduled for permissions sync</p>
 
-Indicates how many repositories have been scheduled for a permissions sync.  
-More about repository permissions [here](https://docs.sourcegraph.com/admin/permissions)
+Indicates how many repositories have been scheduled for a permissions sync.
+More about repository permissions synchronization [here](https://docs.sourcegraph.com/admin/permissions/syncing#scheduling)
 
 This panel has no related alerts.
 

--- a/doc/admin/permissions/api.md
+++ b/doc/admin/permissions/api.md
@@ -16,6 +16,12 @@ E.g. if a code host does not support permission syncing/webhooks or if it would 
 It's also a good idea to use explicit permissions API if the source of truth for the codehost permissions is already defined in some external system, e.g. LDAP group membership.
 In that case, it might be less resource intensive to sync the permissions from external source of truth directly via a periodically running routine.
 
+## SLA
+
+Sourcegraph SLA is, that **p95 of write requests to the explicit permissions API will be resolved within 10 seconds**.
+
+Sourcegraph does not provide SLA for how fresh the permissions are, since the data is provided as is to the API.
+
 ## Disadvantages
 
 It is important to note, that when using explicit permissions API, the permissions are written to the database as provided, without further verification that such permissions do exist on the code host side.

--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -1,13 +1,16 @@
 # Permissions
 
-Sourcegraph can be configured to enforce the same access to repositories and underlying source files as your code host.
-If configured, Sourcegraph will allow the user to only see the entities that they can see on the code host.
-These permissions are enforced accross the product for all the use cases that need to read data from a repository, 
-including the existence of such repository on the code host.
+Sourcegraph can be configured to enforce the same access to repositories and underlying 
+source files as your code  host. If configured, Sourcegraph will allow the user to only 
+see the entities that they can see on the code host. These permissions are enforced 
+accross the product for all the use cases that need to read data from a repository, including
+ the existence of such repository on the code host.
 
-> NOTE: Historically, we have referred to permissions-related features under different names: "authorization", "repository permissions", "code 
-host permissions". All of these terms were used interchangeably, but in general we do call it permissions or repository permissions. 
-That's not to be confused with in-product permissions, which determine who can, for example, create a batch change or who is a site admin.
+> NOTE: Historically, we have referred to permissions-related features under different 
+names: "authorization", "repository permissions", "code host permissions". All of these 
+terms were used interchangeably, but in general we do call it permissions or repository 
+permissions. That's not to be confused with in-product permissions, which determine who 
+can, for example, create a batch change or who is a site admin.
 
 ## Example
 
@@ -29,7 +32,7 @@ Sourcegraph, since `bob` does not have access to it on the code host.
 
 Today, we support 3 different methods to get the permission data from code host to Sourcegraph:
 
-1. [Background permission syncing from the code host](syncing.md)
+1. [Permission syncing from the code host](syncing.md)
 1. [Webhooks for getting permission events from code host](webhooks.md)
 1. [Explicit permissions API](api.md)
 
@@ -62,18 +65,31 @@ If not otherwise stated in the table above, all code hosts should support up to 
 These numbers come from testing the supported scale in a testing environment or running on a customer instance.
 
 > NOTE: Sourcegraph might be able to support higher scale than specified, but was not rigorously tested to do so. 
+
 Please contact support if you want to discuss bigger scale than specified.
+
+## SLAs
+
+Each method of getting permissions to Sourcegraph has different SLA on how long it takes for permissions to appear
+in Sourcegraph.
+
+- [Permission syncing SLA](./syncing.md#sla)
+- [Webhooks SLA](./webhooks.md#sla)
+- [Explicit Permissions API SLA](./api.md#sla)
 ## License requirements
 
-To have permission syncing available, the Sourcegraph instance needs to be configured with a license that has `acls` feature enabled.
-If it is not present, Sourcegraph will not enforce repository permissions and each repository will be treated as 
-public - any user that has access to Sourcegraph will be able to access it.
+To have permission syncing available, the Sourcegraph instance needs to be configured with 
+a license that has `acls` feature enabled. If it is not present, Sourcegraph will not enforce 
+repository permissions and each repository will be treated as public - any user that has access
+ to Sourcegraph will be able to access it.
 
 ## Site administrators
 
-By default, site-admins bypass all of the permissions checks. Which means, all site admins are able to view all the repositories by default.
-The default can be changed by setting the site config option `authz.enforceForSiteAdmins` to `true`.
+By default, site-admins bypass all of the permissions checks. Which means, all site admins are able to 
+view all the repositories by default. The default can be changed by setting the site config 
+option `authz.enforceForSiteAdmins` to `true`.
 
-> NOTE: However, we recommend to be cautious with this option, as it might make some operations for site admins more complicated or impossible. 
+> NOTE: However, we recommend to be cautious with this option, as it might make some operations for site admins more complicated or impossible.
+
 E.g. trying to figure out if a specific repository is syncing source code to Sourcegraph correctly 
 might become an impossible task if the site admin cannot access that repository.

--- a/doc/admin/permissions/syncing.md
+++ b/doc/admin/permissions/syncing.md
@@ -91,6 +91,11 @@ If everything works correctly in such a case, [on-demand sync request](#on-deman
 But the permissions of the entity might have changed in the time since the last sync of these pending permissions, 
 so it is safer to make the request anyway to keep the permissions as fresh as possible
 
+## SLA
+
+Sourcegraph SLA is, that the time it takes for permissions from code host to be synced via permission syncing
+to Sourcegraph is the same as the [lag-time](#lag-time) defined below. So as long as a full cycle of permission syncing takes.
+
 ## Checking permissions sync state
 
 The state of an user or repository's permissions can be checked in the UI by:

--- a/doc/admin/permissions/webhooks.md
+++ b/doc/admin/permissions/webhooks.md
@@ -13,11 +13,15 @@ Sourcegraph exposes endpoints to receive webhooks. These endpoints are authentic
 1. Based on the event data, Sourcegraph schedules a permission sync job
 1. Standard permission syncing mechanism handles the scheduled job, leading to a sync of permissions of the relevant user or repository from the code host
 
+## SLA
+
+Sourcegraph SLA is, that **p95 of webhook requests will be processed within 5 minutes**. This means, that
+when the permissions are changed on the code host, it takes at most 5 minutes for the same permissions to be reflected on the Sourcegraph side.
+
 ## Advantages
 
-- the eventual consistency time is the lowest. Our SLA is, that p95 of webhook requests will be processed within 5 minutes. This means, that when the permissions are changed on the code host, it takes at most 5 minutes for the same permissions to be reflected on the Sourcegraph side
+- the eventual consistency time is really low, see [SLA](#sla) above.
 - least amount of resource usage (bandwidth, code host rate limit), as we only ask code host for permission data when there is an actual change
-
 ## Disadvantages
 
 Webhooks are best effort and there is no 100% guarantee that a webhook will be fired from the code host side when the data change.

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -55,7 +55,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Configuration](admin/config/index.md)
   - [Code hosts](admin/external_service/index.md)
   - [User authentication](admin/auth/index.md)
-  - [Repository Permissions](admin/permissions/index.md)
+  - [Repository permissions](admin/permissions/index.md)
   - [Observability](admin/observability/index.md)
   - [Analytics](admin/analytics.md)
   - [FAQ](admin/faq.md)

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -477,7 +477,7 @@ func RepoUpdater() *monitoring.Dashboard {
 							Owner:       monitoring.ObservableOwnerIAM,
 							Interpretation: `
 								Indicates how many repositories have been scheduled for a permissions sync.
-								More about repository permissions synchronization [here](https://docs.sourcegraph.com/admin/repo/permissions#permissions-sync-scheduling)
+								More about repository permissions synchronization [here](https://docs.sourcegraph.com/admin/permissions/syncing#scheduling)
 							`,
 						},
 					},

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -166,7 +166,7 @@
       "type": "object",
       "properties": {
         "groupsCacheTTL": {
-          "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).",
+          "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/external_service/github#teams-and-organizations-permissions-caching).",
           "type": "number",
           "default": 72
         }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -982,7 +982,7 @@ type GitHubApp struct {
 
 // GitHubAuthProvider description: Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.
 type GitHubAuthProvider struct {
-	// AllowGroupsPermissionsSync description: Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).
+	// AllowGroupsPermissionsSync description: Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/external_service/github#teams-and-organizations-permissions-caching).
 	AllowGroupsPermissionsSync bool `json:"allowGroupsPermissionsSync,omitempty"`
 	// AllowOrgs description: Restricts new logins and signups (if allowSignup is true) to members of these GitHub organizations. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.
 	AllowOrgs []string `json:"allowOrgs,omitempty"`
@@ -1004,7 +1004,7 @@ type GitHubAuthProvider struct {
 
 // GitHubAuthorization description: If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
 type GitHubAuthorization struct {
-	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).
+	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/external_service/github#teams-and-organizations-permissions-caching).
 	GroupsCacheTTL float64 `json:"groupsCacheTTL,omitempty"`
 }
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2137,7 +2137,7 @@
           ]
         },
         "allowGroupsPermissionsSync": {
-          "description": "Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/repo/permissions#permissions-caching).",
+          "description": "Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/external_service/github#teams-and-organizations-permissions-caching).",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
## Description

- Fixed some glaring issues with whitespace not being good
- Fixed sidebar saying `Repository Permissions` instead of `Repository permissions`
- Fixed links to permissions docs page from everywhere
- Made SLAs more prominent and defined SLAs for all 3 types of getting permissions to sourcegraph

Old version:
https://docs.sourcegraph.com/admin/permissions

Version from this PR:
https://docs.sourcegraph.com/@milan_perms_docs_fixes/admin/permissions

## Test plan

Just docs or copy changes, so eyeballing. And verifying if the links work.
