### PR TITLE
Set a maximum for the repo update scheduler interval

### DIFF
--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -244,6 +244,10 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 					// This is the heuristic that is described in the UpdateScheduler documentation.
 					// Update that documentation if you update this logic.
 					interval := resp.LastFetched.Sub(*resp.LastChanged) / 2
+					maxUpdateInterval := conf.Get().GitMaxRepoUpdateInterval
+					if maxUpdateInterval > 0 && interval.Hours() > float64(maxUpdateInterval) {
+						interval = time.Duration(maxUpdateInterval) * time.Hour
+					}
 					s.schedule.updateInterval(repo, interval)
 				}
 			}(ctx, repo, cancel)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -243,7 +243,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 						if maxUpdateInterval > 0 && interval.Hours() > float64(maxUpdateInterval) {
 							interval = time.Duration(maxUpdateInterval) * time.Hour
 						}
-						s.schedule.updateInterval(repo)
+						s.schedule.updateInterval(repo, interval)
 					}
 				} else if resp != nil && resp.LastFetched != nil && resp.LastChanged != nil {
 					// This is the heuristic that is described in the UpdateScheduler documentation.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2427,6 +2427,8 @@ type SiteConfiguration struct {
 	GitMaxCodehostRequestsPerSecond *int `json:"gitMaxCodehostRequestsPerSecond,omitempty"`
 	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
+	// GitMaxRepoUpdateInterval description: Maximum interval of time, in hours, for scheduling a repository update. The repository updater heuristic will not exceed this value when scheduling updates. Default is one week, values <= 0 means no maximum, and custom intervals take precedence over this.
+	GitMaxRepoUpdateInterval int `json:"gitMaxRepoUpdateInterval,omitempty"`
 	// GitRecorder description: Record git operations that are executed on configured repositories. The following commands are not recorded: show, log, rev-parse and diff.
 	GitRecorder *GitRecorder `json:"gitRecorder,omitempty"`
 	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
@@ -2622,6 +2624,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "gitLongCommandTimeout")
 	delete(m, "gitMaxCodehostRequestsPerSecond")
 	delete(m, "gitMaxConcurrentClones")
+	delete(m, "gitMaxRepoUpdateInterval")
 	delete(m, "gitRecorder")
 	delete(m, "gitUpdateInterval")
 	delete(m, "htmlBodyBottom")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -687,6 +687,12 @@
       },
       "group": "External services"
     },
+    "gitMaxRepoUpdateInterval": {
+      "description": "Maximum interval of time, in hours, for scheduling a repository update. The repository updater heuristic will not exceed this value when scheduling updates. Default is one week, values <= 0 means no maximum, and custom intervals take precedence over this.",
+      "type": "integer",
+      "default": 168,
+      "group": "External services"
+    },
     "disablePublicRepoRedirects": {
       "description": "Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",


### PR DESCRIPTION
There is nothing that stops repos with low activity from being pushed back a LONG time before they see any updates.
This code sets a default maximum for how far in the future a repo can scheduled for an update. This value is configurable and can be turned off altogether to maintain current behavior.

Im not opposed to not setting a default if we want to maintain current behavior by default, but I think its better to have it capped by default.

## Test plan
Small change, manual testing.