### PR TITLE
search input: Refactor "focused filter" logic

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
@@ -12,6 +12,25 @@
             // Codemirror shows a focus ring by default. Since we handle that
             // differently, disable it here.
             outline: none;
+
+            :global(.sg-query-filter-placeholder) {
+                display: inline;
+            }
+
+            // The placeholder needs to explicilty have the same background color because it
+            // appears to be placed outside of active filter decoration rather than within it.
+            :global(.sg-query-filter-placeholder),
+            :global(.sg-query-filter-active) {
+                background-color: var(--gray-02);
+
+                :global(.theme-dark) & {
+                    background-color: var(--gray-08);
+                }
+            }
+        }
+
+        :global(.sg-query-filter-placeholder) {
+            display: none;
         }
 
         :global(.cm-scroller) {
@@ -137,22 +156,10 @@
         }
     }
 
-    // .placeholder needs to explicilty have the same background color because it
-    // appears to be placed outside of .focusedFilter rather than within it.
-    .placeholder,
-    .focusedFilter {
-        background-color: var(--gray-02);
-
-        :global(.theme-dark) & {
-            background-color: var(--gray-08);
-        }
+    :global(.sg-query-filter-placeholder) {
+        color: var(--text-muted);
+        font-style: italic;
     }
-}
-
-.placeholder {
-    color: var(--text-muted);
-    font-style: italic;
-    pointer-events: none;
 }
 
 // Copied and adapted from the Wildcard LoadingSpinner component

--- a/client/branded/src/search-ui/input/codemirror/active-filter.ts
+++ b/client/branded/src/search-ui/input/codemirror/active-filter.ts
@@ -1,0 +1,98 @@
+import { Extension, Facet, RangeSetBuilder } from '@codemirror/state'
+import { Decoration, EditorView, WidgetType } from '@codemirror/view'
+
+import { Filter } from '@sourcegraph/shared/src/search/query/token'
+import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
+
+import { queryTokens } from './parsedQuery'
+
+const activeFilterFacet = Facet.define<Filter>()
+const activeFilterExtension = activeFilterFacet.computeN([queryTokens, 'selection'], state => {
+    const query = state.facet(queryTokens)
+    const position = state.selection.main.head
+    return query.tokens.filter(
+        (token): token is Filter =>
+            // Inclusive end so that the filter is selected when
+            // the cursor is positioned directly after the value
+            token.type === 'filter' && token.range.start <= position && token.range.end >= position
+    )
+})
+
+const activeFilterDecoration = Decoration.mark({ class: 'sg-query-filter-active' })
+
+/**
+ * An extension that adds the class .sg-query-filter-active to the filter token
+ * "touched" by the cursor.
+ */
+export const decorateActiveFilter: Extension = [
+    activeFilterExtension,
+    EditorView.decorations.compute([activeFilterFacet], state => {
+        const selectedFilters = state.facet(activeFilterFacet)
+        if (selectedFilters.length === 0) {
+            return Decoration.none
+        }
+
+        const decorations = new RangeSetBuilder<Decoration>()
+        for (const filter of selectedFilters) {
+            decorations.add(filter.range.start, filter.range.end, activeFilterDecoration)
+        }
+
+        return decorations.finish()
+    }),
+]
+
+class PlaceholderWidget extends WidgetType {
+    constructor(private placeholder: string) {
+        super()
+    }
+
+    /* eslint-disable-next-line id-length */
+    public eq(other: PlaceholderWidget): boolean {
+        return this.placeholder === other.placeholder
+    }
+
+    public toDOM(): HTMLElement {
+        const span = document.createElement('span')
+        span.className = 'sg-query-filter-placeholder'
+        span.textContent = this.placeholder
+        return span
+    }
+}
+
+/**
+ * An extension that shows the preconfigured placeholder (if available) for the active
+ * filter. The placeholder is given the class .sg-query-filter-placeholder
+ */
+export const filterPlaceholder: Extension = [
+    activeFilterExtension,
+    EditorView.decorations.compute([activeFilterFacet], state => {
+        const selectedFilters = state.facet(activeFilterFacet)
+        if (selectedFilters.length === 0) {
+            return Decoration.none
+        }
+
+        const decorations = new RangeSetBuilder<Decoration>()
+        for (const filter of selectedFilters) {
+            if (!filter.value?.value) {
+                const resolvedFilter = resolveFilterMemoized(filter.field.value)
+                if (resolvedFilter?.definition.placeholder) {
+                    decorations.add(
+                        filter.range.end,
+                        filter.range.end,
+                        Decoration.widget({
+                            widget: new PlaceholderWidget(resolvedFilter.definition.placeholder),
+                            side: 1, // show after the cursor
+                        })
+                    )
+                }
+            }
+        }
+
+        return decorations.finish()
+    }),
+    EditorView.baseTheme({
+        '.sg-query-filter-placeholder': {
+            pointerEvents: 'none',
+        },
+    }),
+]

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -19,6 +19,7 @@ import { getTokenLength } from '@sourcegraph/shared/src/search/query/utils'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { singleLine, placeholder as placeholderExtension } from '../codemirror'
+import { filterPlaceholder } from '../codemirror/active-filter'
 import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
 import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
@@ -173,6 +174,7 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
         keymap.of(historyKeymap),
         keymap.of(defaultKeymap),
         codemirrorHistory(),
+        filterPlaceholder,
         Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
         EditorView.theme({
             '&': {
@@ -206,6 +208,10 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
             },
             '.sg-decorated-token-hover': {
                 borderRadius: '3px',
+            },
+            '.sg-query-filter-placeholder': {
+                color: 'var(--text-muted)',
+                fontStyle: 'italic',
             },
         }),
     ]


### PR DESCRIPTION
The current search input has an extension to decorate the "focused" filter (the filter the cursor is at) to show a different background. The same extension also showed a filter placeholder text when it was available.

This PR refactors this logic into two separate extensions so the placeholder one can be reused by the new search input (and maybe also the (now called) active filter extension, but that's still up for debate). The extensions use class names that can be used to customize styles for different instances.

This PR also changes how these extensions work: Until now the extension itself decided to render the decorations based on whether the input was focused or not. Now this job is delegated to CSS.
What's great about this is that it also fixes an issue where the CodeMirror input was somehow "stealing" focus when a filter was active and the user tried to move the focus away from the input. win-win



## Test plan

- Enable old query input
  - Type in filter with placeholder, e.g. `file:`: Filter has a different background and placeholder shows.
  - Type 'space': Background color and highlight disappear
  - Press left arrow to go back to filter: Highlight and placeholder appears
  - Entering a value for the filter hides the placeholder
  - Moving focus outside the input makes the background color and placeholder disappear

- Enable new input
  - Typing `file:` shows placeholder
  - Entering a filter value hides the placeholder

## App preview:

- [Web](https://sg-web-fkling-reuse-filter-placeholder.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
