### PR TITLE
sentinel: Add store methods to insert and query vulnerabilities

### DIFF
--- a/enterprise/internal/codeintel/sentinel/internal/store/observability.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/observability.go
@@ -1,31 +1,43 @@
 package store
 
 import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type operations struct {
+	vulnerabilityByID       *observation.Operation
+	getVulnerabilitiesByIDs *observation.Operation
+	getVulnerabilities      *observation.Operation
+	insertVulnerabilities   *observation.Operation
 }
 
-// var m = new(metrics.SingletonREDMetrics)
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationCtx *observation.Context) *operations {
-	// m := m.Get(func() *metrics.REDMetrics {
-	// 	return metrics.NewREDMetrics(
-	// 		observationCtx.Registerer,
-	// 		"codeintel_sentinel_store",
-	// 		metrics.WithLabels("op"),
-	// 		metrics.WithCountHelp("Total number of method invocations."),
-	// 	)
-	// })
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationCtx.Registerer,
+			"codeintel_sentinel_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
-	// op := func(name string) *observation.Operation {
-	// 	return observationCtx.Operation(observation.Op{
-	// 		Name:              fmt.Sprintf("codeintel.sentinel.store.%s", name),
-	// 		MetricLabelValues: []string{name},
-	// 		Metrics:           m,
-	// 	})
-	// }
+	op := func(name string) *observation.Operation {
+		return observationCtx.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.sentinel.store.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           m,
+		})
+	}
 
-	return &operations{}
+	return &operations{
+		vulnerabilityByID:       op("VulnerabilityByID"),
+		getVulnerabilitiesByIDs: op("GetVulnerabilitiesByIDs"),
+		getVulnerabilities:      op("GetVulnerabilities"),
+		insertVulnerabilities:   op("InsertVulnerabilities"),
+	}
 }

--- a/enterprise/internal/codeintel/sentinel/internal/store/store.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/store.go
@@ -1,14 +1,21 @@
 package store
 
 import (
+	"context"
+
 	logger "github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type Store interface {
+	VulnerabilityByID(ctx context.Context, id int) (_ shared.Vulnerability, _ bool, err error)
+	GetVulnerabilitiesByIDs(ctx context.Context, ids ...int) (_ []shared.Vulnerability, err error)
+	GetVulnerabilities(ctx context.Context, args shared.GetVulnerabilitiesArgs) (_ []shared.Vulnerability, _ int, err error)
+	InsertVulnerabilities(ctx context.Context, vulnerabilities []shared.Vulnerability) (err error)
 }
 
 type store struct {

--- a/enterprise/internal/codeintel/sentinel/internal/store/vulnerabilities.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/vulnerabilities.go
@@ -1,0 +1,501 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/batch"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func (s *store) VulnerabilityByID(ctx context.Context, id int) (_ shared.Vulnerability, _ bool, err error) {
+	ctx, _, endObservation := s.operations.vulnerabilityByID.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	vulnerabilities, _, err := scanVulnerabilitiesAndCount(s.db.Query(ctx, sqlf.Sprintf(getVulnerabilityByIDQuery, id)))
+	if err != nil || len(vulnerabilities) == 0 {
+		return shared.Vulnerability{}, false, err
+	}
+
+	return vulnerabilities[0], true, nil
+}
+
+const getVulnerabilityByIDQuery = `
+SELECT
+	` + vulnerabilityFields + `,
+	` + vulnerabilityAffectedPackageFields + `,
+	` + vulnerabilityAffectedSymbolFields + `,
+	0 AS count
+FROM vulnerabilities v
+LEFT JOIN vulnerability_affected_packages vap ON vap.vulnerability_id = v.id
+LEFT JOIN vulnerability_affected_symbols vas ON vas.vulnerability_affected_package_id = vap.id
+WHERE v.id = %s
+ORDER BY vap.id, vas.id
+`
+
+const vulnerabilityFields = `
+	v.id,
+	v.source_id,
+	v.summary,
+	v.details,
+	v.cpes,
+	v.cwes,
+	v.aliases,
+	v.related,
+	v.data_source,
+	v.urls,
+	v.severity,
+	v.cvss_vector,
+	v.cvss_score,
+	v.published_at,
+	v.modified_at,
+	v.withdrawn_at
+`
+
+const vulnerabilityAffectedPackageFields = `
+	vap.package_name,
+	vap.language,
+	vap.namespace,
+	vap.version_constraint,
+	vap.fixed,
+	vap.fixed_in
+`
+
+const vulnerabilityAffectedSymbolFields = `
+	vas.path,
+	vas.symbols
+`
+
+func (s *store) GetVulnerabilitiesByIDs(ctx context.Context, ids ...int) (_ []shared.Vulnerability, err error) {
+	ctx, _, endObservation := s.operations.getVulnerabilitiesByIDs.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	vulnerabilities, _, err := scanVulnerabilitiesAndCount(s.db.Query(ctx, sqlf.Sprintf(getVulnerabilitiesByIDsQuery, pq.Array(ids))))
+	return vulnerabilities, err
+}
+
+const getVulnerabilitiesByIDsQuery = `
+SELECT
+	` + vulnerabilityFields + `,
+	` + vulnerabilityAffectedPackageFields + `,
+	` + vulnerabilityAffectedSymbolFields + `,
+	0 AS count
+FROM vulnerabilities v
+LEFT JOIN vulnerability_affected_packages vap ON vap.vulnerability_id = v.id
+LEFT JOIN vulnerability_affected_symbols vas ON vas.vulnerability_affected_package_id = vap.id
+WHERE v.id = ANY(%s)
+ORDER BY v.id, vap.id, vas.id
+`
+
+func (s *store) GetVulnerabilities(ctx context.Context, args shared.GetVulnerabilitiesArgs) (_ []shared.Vulnerability, _ int, err error) {
+	ctx, _, endObservation := s.operations.getVulnerabilities.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return scanVulnerabilitiesAndCount(s.db.Query(ctx, sqlf.Sprintf(getVulnerabilitiesQuery, args.Limit, args.Offset)))
+}
+
+const getVulnerabilitiesQuery = `
+WITH limited_vulnerabilities AS (
+	SELECT
+		` + vulnerabilityFields + `,
+		COUNT(*) OVER() AS count
+	FROM vulnerabilities v
+	ORDER BY id
+	LIMIT %s
+	OFFSET %s
+)
+SELECT
+	` + vulnerabilityFields + `,
+	` + vulnerabilityAffectedPackageFields + `,
+	` + vulnerabilityAffectedSymbolFields + `,
+	v.count
+FROM limited_vulnerabilities v
+LEFT JOIN vulnerability_affected_packages vap ON vap.vulnerability_id = v.id
+LEFT JOIN vulnerability_affected_symbols vas ON vas.vulnerability_affected_package_id = vap.id
+ORDER BY v.id, vap.id, vas.id
+`
+
+var scanSingleVulnerabilityAndCount = func(s dbutil.Scanner) (v shared.Vulnerability, count int, _ error) {
+	var (
+		vap     shared.AffectedPackage
+		vas     shared.AffectedSymbol
+		fixedIn string
+	)
+
+	if err := s.Scan(
+		&v.ID,
+		&v.SourceID,
+		&v.Summary,
+		&v.Details,
+		pq.Array(&v.CPEs),
+		pq.Array(&v.CWEs),
+		pq.Array(&v.Aliases),
+		pq.Array(&v.Related),
+		&v.DataSource,
+		pq.Array(&v.URLs),
+		&v.Severity,
+		&v.CVSSVector,
+		&v.CVSSScore,
+		&v.PublishedAt,
+		&v.ModifiedAt,
+		&v.WithdrawnAt,
+		// RHS(s) of left join (may be null)
+		&dbutil.NullString{S: &vap.PackageName},
+		&dbutil.NullString{S: &vap.Language},
+		&dbutil.NullString{S: &vap.Namespace},
+		pq.Array(&vap.VersionConstraint),
+		&dbutil.NullBool{B: &vap.Fixed},
+		&dbutil.NullString{S: &fixedIn},
+		&dbutil.NullString{S: &vas.Path},
+		pq.Array(vas.Symbols),
+		&count,
+	); err != nil {
+		return shared.Vulnerability{}, 0, err
+	}
+
+	if fixedIn != "" {
+		vap.FixedIn = &fixedIn
+	}
+	if vas.Path != "" {
+		vap.AffectedSymbols = append(vap.AffectedSymbols, vas)
+	}
+	if vap.PackageName != "" {
+		v.AffectedPackages = append(v.AffectedPackages, vap)
+	}
+
+	return v, count, nil
+}
+
+var flattenPackages = func(packages []shared.AffectedPackage) []shared.AffectedPackage {
+	flattened := []shared.AffectedPackage{}
+	for _, pkg := range packages {
+		i := len(flattened) - 1
+		if len(flattened) == 0 || flattened[i].Namespace != pkg.Namespace || flattened[i].Language != pkg.Language || flattened[i].PackageName != pkg.PackageName {
+			flattened = append(flattened, pkg)
+		} else {
+			flattened[i].AffectedSymbols = append(flattened[i].AffectedSymbols, pkg.AffectedSymbols...)
+		}
+	}
+
+	return flattened
+}
+
+var flattenVulnerabilities = func(vs []shared.Vulnerability) []shared.Vulnerability {
+	flattened := []shared.Vulnerability{}
+	for _, v := range vs {
+		i := len(flattened) - 1
+		if len(flattened) == 0 || flattened[i].ID != v.ID {
+			flattened = append(flattened, v)
+		} else {
+			flattened[i].AffectedPackages = flattenPackages(append(flattened[i].AffectedPackages, v.AffectedPackages...))
+		}
+	}
+
+	return flattened
+}
+
+var scanVulnerabilitiesAndCount = func(rows basestore.Rows, queryErr error) ([]shared.Vulnerability, int, error) {
+	values, totalCount, err := basestore.NewSliceWithCountScanner(func(s dbutil.Scanner) (shared.Vulnerability, int, error) {
+		return scanSingleVulnerabilityAndCount(s)
+	})(rows, queryErr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return flattenVulnerabilities(values), totalCount, nil
+}
+
+func (s *store) InsertVulnerabilities(ctx context.Context, vulnerabilities []shared.Vulnerability) (err error) {
+	ctx, _, endObservation := s.operations.insertVulnerabilities.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	vulnerabilities = canonicalizeVulnerabilities(vulnerabilities)
+
+	tx, err := s.db.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(insertVulnerabilitiesTemporaryVulnerabilitiesTableQuery)); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(insertVulnerabilitiesTemporaryVulnerabilityAffectedPackagesTableQuery)); err != nil {
+		return err
+	}
+
+	if err := batch.WithInserter(
+		ctx,
+		tx.Handle(),
+		"t_vulnerabilities",
+		batch.MaxNumPostgresParameters,
+		[]string{
+			"source_id",
+			"summary",
+			"details",
+			"cpes",
+			"cwes",
+			"aliases",
+			"related",
+			"data_source",
+			"urls",
+			"severity",
+			"cvss_vector",
+			"cvss_score",
+			"published_at",
+			"modified_at",
+			"withdrawn_at",
+		},
+		func(inserter *batch.Inserter) error {
+			for _, v := range vulnerabilities {
+				if err := inserter.Insert(
+					ctx,
+					v.SourceID,
+					v.Summary,
+					v.Details,
+					v.CPEs,
+					v.CWEs,
+					v.Aliases,
+					v.Related,
+					v.DataSource,
+					v.URLs,
+					v.Severity,
+					v.CVSSVector,
+					v.CVSSScore,
+					v.PublishedAt,
+					dbutil.NullTime{Time: v.ModifiedAt},
+					dbutil.NullTime{Time: v.WithdrawnAt},
+				); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}); err != nil {
+		return err
+	}
+
+	if err := batch.WithInserter(
+		ctx,
+		tx.Handle(),
+		"t_vulnerability_affected_packages",
+		batch.MaxNumPostgresParameters,
+		[]string{
+			"source_id",
+			"package_name",
+			"language",
+			"namespace",
+			"version_constraint",
+			"fixed",
+			"fixed_in",
+			"affected_symbols",
+		},
+		func(inserter *batch.Inserter) error {
+			for _, v := range vulnerabilities {
+				for _, ap := range v.AffectedPackages {
+					serialized, err := json.Marshal(ap.AffectedSymbols)
+					if err != nil {
+						return err
+					}
+
+					if err := inserter.Insert(
+						ctx,
+						v.SourceID,
+						ap.PackageName,
+						ap.Language,
+						ap.Namespace,
+						ap.VersionConstraint,
+						ap.Fixed,
+						ap.FixedIn,
+						serialized,
+					); err != nil {
+						return err
+					}
+				}
+			}
+
+			return nil
+		}); err != nil {
+		return err
+	}
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(insertVulnerabilitiesUpdateQuery)); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(insertVulnerabilitiesAffectedPackagesUpdateQuery)); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(insertVulnerabilitiesAffectedSymbolsUpdateQuery)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const insertVulnerabilitiesTemporaryVulnerabilitiesTableQuery = `
+CREATE TEMPORARY TABLE t_vulnerabilities (
+	source_id     TEXT NOT NULL,
+	summary       TEXT NOT NULL,
+	details       TEXT NOT NULL,
+	cpes          TEXT[] NOT NULL,
+	cwes          TEXT[] NOT NULL,
+	aliases       TEXT[] NOT NULL,
+	related       TEXT[] NOT NULL,
+	data_source   TEXT NOT NULL,
+	urls          TEXT[] NOT NULL,
+	severity      TEXT NOT NULL,
+	cvss_vector   TEXT NOT NULL,
+	cvss_score    TEXT NOT NULL,
+	published_at  TIMESTAMP WITH TIME ZONE NOT NULL,
+	modified_at   TIMESTAMP WITH TIME ZONE,
+	withdrawn_at  TIMESTAMP WITH TIME ZONE
+) ON COMMIT DROP
+`
+
+const insertVulnerabilitiesTemporaryVulnerabilityAffectedPackagesTableQuery = `
+CREATE TEMPORARY TABLE t_vulnerability_affected_packages (
+	source_id           TEXT NOT NULL,
+	package_name        TEXT NOT NULL,
+	language            TEXT NOT NULL,
+	namespace           TEXT NOT NULL,
+	version_constraint  TEXT[] NOT NULL,
+	fixed               boolean NOT NULL,
+	fixed_in            TEXT,
+	affected_symbols    JSON NOT NULL
+) ON COMMIT DROP
+`
+
+const insertVulnerabilitiesUpdateQuery = `
+INSERT INTO vulnerabilities (
+	source_id,
+	summary,
+	details,
+	cpes,
+	cwes,
+	aliases,
+	related,
+	data_source,
+	urls,
+	severity,
+	cvss_vector,
+	cvss_score,
+	published_at,
+	modified_at,
+	withdrawn_at
+)
+SELECT
+	source_id,
+	summary,
+	details,
+	cpes,
+	cwes,
+	aliases,
+	related,
+	data_source,
+	urls,
+	severity,
+	cvss_vector,
+	cvss_score,
+	published_at,
+	modified_at,
+	withdrawn_at
+FROM t_vulnerabilities
+-- TODO - we'd prefer to update rather than keep first write
+ON CONFLICT DO NOTHING
+`
+
+const insertVulnerabilitiesAffectedPackagesUpdateQuery = `
+INSERT INTO vulnerability_affected_packages(
+	vulnerability_id,
+	package_name,
+	language,
+	namespace,
+	version_constraint,
+	fixed,
+	fixed_in
+)
+SELECT
+	(SELECT v.id FROM vulnerabilities v WHERE v.source_id = vap.source_id),
+	package_name,
+	language,
+	namespace,
+	version_constraint,
+	fixed,
+	fixed_in
+FROM t_vulnerability_affected_packages vap
+-- TODO - we'd prefer to update rather than keep first write
+ON CONFLICT DO NOTHING
+`
+
+const insertVulnerabilitiesAffectedSymbolsUpdateQuery = `
+WITH
+json_candidates AS (
+	SELECT
+		vap.id,
+		json_array_elements(tvap.affected_symbols) AS affected_symbol
+	FROM t_vulnerability_affected_packages tvap
+	JOIN vulnerability_affected_packages vap ON vap.package_name = tvap.package_name
+	JOIN vulnerabilities v ON v.id = vap.vulnerability_id
+	WHERE
+		v.source_id = tvap.source_id
+),
+candidates AS (
+	SELECT
+		c.id,
+		c.affected_symbol->'path'::text AS path,
+		ARRAY(SELECT json_array_elements_text(c.affected_symbol->'symbols'))::text[] AS symbols
+	FROM json_candidates c
+)
+INSERT INTO vulnerability_affected_symbols(vulnerability_affected_package_id, path, symbols)
+SELECT c.id, c.path, c.symbols FROM candidates c
+-- TODO - we'd prefer to update rather than keep first write
+ON CONFLICT DO NOTHING
+`
+
+func canonicalizeVulnerabilities(vs []shared.Vulnerability) []shared.Vulnerability {
+	for i, v := range vs {
+		vs[i] = canonicalizeVulnerability(v)
+	}
+
+	return vs
+}
+
+func canonicalizeVulnerability(v shared.Vulnerability) shared.Vulnerability {
+	if v.CPEs == nil {
+		v.CPEs = []string{}
+	}
+	if v.CWEs == nil {
+		v.CWEs = []string{}
+	}
+	if v.Aliases == nil {
+		v.Aliases = []string{}
+	}
+	if v.Related == nil {
+		v.Related = []string{}
+	}
+	if v.URLs == nil {
+		v.URLs = []string{}
+	}
+	for i, ap := range v.AffectedPackages {
+		v.AffectedPackages[i] = canonicalizeAffectedPackage(ap)
+	}
+
+	return v
+}
+
+func canonicalizeAffectedPackage(ap shared.AffectedPackage) shared.AffectedPackage {
+	if ap.VersionConstraint == nil {
+		ap.VersionConstraint = []string{}
+	}
+	if ap.AffectedSymbols == nil {
+		ap.AffectedSymbols = []shared.AffectedSymbol{}
+	}
+
+	return ap
+}

--- a/enterprise/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+var testVulnerabilities = []shared.Vulnerability{
+	// IDs assumed by insertion order
+	{ID: 1, SourceID: "CVE-ABC"},
+	{ID: 2, SourceID: "CVE-DEF"},
+	{ID: 3, SourceID: "CVE-GHI"},
+	{ID: 4, SourceID: "CVE-JKL"},
+	{ID: 5, SourceID: "CVE-MNO"},
+	{ID: 6, SourceID: "CVE-PQR"},
+	{ID: 7, SourceID: "CVE-STU"},
+	{ID: 8, SourceID: "CVE-VWX"},
+	{ID: 9, SourceID: "CVE-Y&Z"},
+}
+
+func TestVulnerabilityByID(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	if err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
+		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
+	}
+
+	vulnerability, ok, err := store.VulnerabilityByID(ctx, 2)
+	if err != nil {
+		t.Fatalf("failed to get vulnerability by id: %s", err)
+	}
+	if !ok {
+		t.Fatalf("unexpected vulnerability to exist")
+	}
+	if diff := cmp.Diff(canonicalizeVulnerability(testVulnerabilities[1]), vulnerability); diff != "" {
+		t.Errorf("unexpected vulnerability (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetVulnerabilitiesByIDs(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	if err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
+		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
+	}
+
+	vulnerabilities, err := store.GetVulnerabilitiesByIDs(ctx, 2, 3, 4)
+	if err != nil {
+		t.Fatalf("failed to get vulnerability by id: %s", err)
+	}
+	if diff := cmp.Diff(canonicalizeVulnerabilities(testVulnerabilities[1:4]), vulnerabilities); diff != "" {
+		t.Errorf("unexpected vulnerabilities (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetVulnerabilities(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	if err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
+		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
+	}
+
+	type testCase struct {
+		name              string
+		expectedSourceIDs []string
+	}
+	testCases := []testCase{
+		{
+			name:              "all",
+			expectedSourceIDs: []string{"CVE-ABC", "CVE-DEF", "CVE-GHI", "CVE-JKL", "CVE-MNO", "CVE-PQR", "CVE-STU", "CVE-VWX", "CVE-Y&Z"},
+		},
+	}
+
+	runTest := func(testCase testCase, lo, hi int) (errors int) {
+		t.Run(testCase.name, func(t *testing.T) {
+			vulnerabilities, totalCount, err := store.GetVulnerabilities(ctx, shared.GetVulnerabilitiesArgs{
+				Limit:  3,
+				Offset: lo,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error getting vulnerabilities: %s", err)
+			}
+			if totalCount != len(testCase.expectedSourceIDs) {
+				t.Errorf("unexpected total count. want=%d have=%d", len(testCase.expectedSourceIDs), totalCount)
+			}
+
+			if totalCount != 0 {
+				var ids []string
+				for _, vulnerability := range vulnerabilities {
+					ids = append(ids, vulnerability.SourceID)
+				}
+				if diff := cmp.Diff(testCase.expectedSourceIDs[lo:hi], ids); diff != "" {
+					t.Errorf("unexpected vulnerability ids at offset %d-%d (-want +got):\n%s", lo, hi, diff)
+					errors++
+				}
+			}
+		})
+
+		return
+	}
+
+	for _, testCase := range testCases {
+		if n := len(testCase.expectedSourceIDs); n == 0 {
+			runTest(testCase, 0, 0)
+		} else {
+			for lo := 0; lo < n; lo++ {
+				if numErrors := runTest(testCase, lo, int(math.Min(float64(lo)+3, float64(n)))); numErrors > 0 {
+					break
+				}
+			}
+		}
+	}
+}

--- a/enterprise/internal/codeintel/sentinel/shared/types.go
+++ b/enterprise/internal/codeintel/sentinel/shared/types.go
@@ -1,0 +1,46 @@
+package shared
+
+import "time"
+
+type GetVulnerabilitiesArgs struct {
+	Limit  int
+	Offset int
+}
+
+type Vulnerability struct {
+	ID               int    // internal ID
+	SourceID         string // external ID
+	Summary          string
+	Details          string
+	CPEs             []string
+	CWEs             []string
+	Aliases          []string
+	Related          []string
+	DataSource       string
+	URLs             []string
+	Severity         string
+	CVSSVector       string
+	CVSSScore        string
+	PublishedAt      time.Time
+	ModifiedAt       *time.Time
+	WithdrawnAt      *time.Time
+	AffectedPackages []AffectedPackage
+}
+
+// Data that varies across instances of a vulnerability
+// Need to decide if this will be flat inside Vulnerability (and have multiple duplicate vulns)
+// or a separate struct/table
+type AffectedPackage struct {
+	PackageName       string
+	Language          string
+	Namespace         string
+	VersionConstraint []string
+	Fixed             bool
+	FixedIn           *string
+	AffectedSymbols   []AffectedSymbol
+}
+
+type AffectedSymbol struct {
+	Path    string   `json:"path"`
+	Symbols []string `json:"symbols"`
+}


### PR DESCRIPTION
Pulled from #47531. This PR adds the methods related to querying and inserting vulnerabilities. Will be populated by the CVE scanner background job and queried by the GraphQL layer in the future.

## Test plan

Included unit tests.