### PR TITLE
experimental search input: Add "go to" support for repo/file filter value suggestions

### DIFF
--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -407,7 +407,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                                             ? ALL_FILTER_VALUE_LIST_SIZE
                                             : MULTIPLE_FILTER_VALUE_LIST_SIZE
                                     )
-                                    .map(item => toRepoCompletion(item, from, to)),
+                                    .map(item => toRepoSuggestion(item, from, to)),
                             },
                         ]
 
@@ -434,7 +434,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                             {
                                 title: 'Files',
                                 options: entries
-                                    .map(item => toFileCompletion(item, from, to))
+                                    .map(item => toFileSuggestion(item, from, to))
                                     .slice(
                                         0,
                                         predicates.length === 0


### PR DESCRIPTION
Until now the "go to" action has only be added to "default" suggestions not to `repo:` or `file:` filter value suggestions. One feedback was that this feels inconsistent so this PR adds that behavior.

<img width="877" alt="2023-03-01_19-48" src="https://user-images.githubusercontent.com/179026/222250853-1da38c1c-83b2-4575-80a3-422232b7370c.png">


## Test plan

- Enter `repo:source`, note that suggestions have a "go to" action. Select action via `Shift+enter`.
- Enter `file:source`, note that suggestions have a "go to" action. Select action via `Shift+enter`.

## App preview:

- [Web](https://sg-web-fkling-go-to-all-the-things.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
