### PR TITLE
Remove unused setters on EnterpriseSearchJobs

### DIFF
--- a/enterprise/internal/search/jobs.go
+++ b/enterprise/internal/search/jobs.go
@@ -12,14 +12,8 @@ func NewEnterpriseSearchJobs() jobutil.EnterpriseJobs {
 
 type enterpriseJobs struct{}
 
-func (e *enterpriseJobs) SetFileHasOwnerJob(j func(child job.Job, includeOwners, excludeOwners []string) job.Job) {
-}
-
 func (e *enterpriseJobs) FileHasOwnerJob(child job.Job, includeOwners, excludeOwners []string) job.Job {
 	return search.NewFileHasOwnersJob(child, includeOwners, excludeOwners)
-}
-
-func (e *enterpriseJobs) SetSelectFileOwnerJob(j func(child job.Job) job.Job) {
 }
 
 func (e *enterpriseJobs) SelectFileOwnerJob(child job.Job) job.Job {


### PR DESCRIPTION
Forgot to remove these after a paradigm switch in the PR that introduced this struct.



## Test plan

CI will tell us if they were used.