### PR TITLE
codeintel: Split counts from upload/index fetches

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
@@ -142,18 +142,33 @@ func (s *store) GetIndexes(ctx context.Context, opts shared.GetIndexesOptions) (
 	}
 	conds = append(conds, authzConds)
 
-	indexes, totalCount, err := scanIndexesWithCount(tx.db.Query(ctx, sqlf.Sprintf(getIndexesQuery, sqlf.Join(conds, " AND "), opts.Limit, opts.Offset)))
+	indexes, err := scanIndexes(tx.db.Query(ctx, sqlf.Sprintf(
+		getIndexesSelectQuery,
+		sqlf.Join(conds, " AND "),
+		opts.Limit,
+		opts.Offset,
+	)))
+	if err != nil {
+		return nil, 0, err
+	}
+	trace.AddEvent("scanIndexesWithCount",
+		attribute.Int("numIndexes", len(indexes)))
+
+	totalCount, _, err := basestore.ScanFirstInt(tx.db.Query(ctx, sqlf.Sprintf(
+		getIndexesCountQuery,
+		sqlf.Join(conds, " AND "),
+	)))
 	if err != nil {
 		return nil, 0, err
 	}
 	trace.AddEvent("scanIndexesWithCount",
 		attribute.Int("totalCount", totalCount),
-		attribute.Int("numIndexes", len(indexes)))
+	)
 
 	return indexes, totalCount, nil
 }
 
-const getIndexesQuery = `
+const getIndexesSelectQuery = `
 SELECT
 	u.id,
 	u.commit,
@@ -177,13 +192,19 @@ SELECT
 	u.local_steps,
 	` + indexAssociatedUploadIDQueryFragment + `,
 	u.should_reindex,
-	u.requested_envvars,
-	COUNT(*) OVER() AS count
+	u.requested_envvars
 FROM lsif_indexes u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
 JOIN repo ON repo.id = u.repository_id
 WHERE repo.deleted_at IS NULL AND %s ORDER BY queued_at DESC, u.id LIMIT %d OFFSET %d
+`
+
+const getIndexesCountQuery = `
+SELECT COUNT(*) AS count
+FROM lsif_indexes u
+JOIN repo ON repo.id = u.repository_id
+WHERE repo.deleted_at IS NULL AND %s
 `
 
 // DeleteIndexes deletes indexes matching the given filter criteria.


### PR DESCRIPTION
Remove the `COUNT(*) OVER() AS count` trick, which caused us to sort the entire result set for a count before trimming the head. This trick only works with moderately sized data sets, and lsif_uploads/indexes exceeds the size at which this was beneficial.

Two smaller queries are faster as the count that has to go over a larger data set can avoid left joins, etc.

## Test plan

Existing unit tests.