### PR TITLE
experimental search input: Support Ctrl-n/p navigation for suggestions on macOS

### DIFF
--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -590,6 +590,14 @@ const defaultKeyboardBindings: KeyBinding[] = [
         run: moveSelection('backward'),
     },
     {
+        mac: 'Ctrl-n',
+        run: moveSelection('forward'),
+    },
+    {
+        mac: 'Ctrl-p',
+        run: moveSelection('backward'),
+    },
+    {
         key: 'Mod-Space',
         run(view) {
             startCompletion(view)


### PR DESCRIPTION
Based on popular demand.

## Test plan

Unfortunately I don't have an easy way to test this. I trust CodeMirror but I'd be happy if someone can test this 😅 

## App preview:

- [Web](https://sg-web-fkling-search-input-suggestion.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
