### PR TITLE
oobmigration: Parse new version string

### DIFF
--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -33,7 +33,10 @@ func newDevVersion(major, minor int) Version {
 	}
 }
 
-var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
+var (
+	versionPattern         = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
+	insidersVersionPattern = lazyregexp.New(`^[\w-]+_\d{4}-\d{2}-\d{2}_(\d+)\.(\d+)-\w+$`)
+)
 
 // NewVersionFromString parses the major and minor version from the given string. If
 // the string does not look like a parseable version, a false-valued flag is returned.
@@ -55,7 +58,12 @@ func NewVersionAndPatchFromString(v string) (Version, int, bool) {
 
 	matches := versionPattern.FindStringSubmatch(v)
 	if len(matches) < 3 {
-		return Version{}, 0, false
+		matches = insidersVersionPattern.FindStringSubmatch(v)
+		if len(matches) < 3 {
+			return Version{}, 0, false
+		}
+
+		newVersion = newDevVersion
 	}
 
 	major, _ := strconv.Atoi(matches[1])

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -18,6 +18,7 @@ func TestNewVersionFromString(t *testing.T) {
 		{"v3.50", NewVersion(3, 50), 0, true},
 		{"3.50.3", NewVersion(3, 50), 3, true},
 		{"3.50.3+dev", newDevVersion(3, 50), 3, true},
+		{"202659_2023-03-01_4.5-dc2f6ca215c3", newDevVersion(4, 5), 0, true},
 		{"350", Version{}, 0, false},
 		{"350+dev", Version{}, 0, false},
 	}


### PR DESCRIPTION
Should fix the following issue:

![image](https://user-images.githubusercontent.com/103087/222262405-796d15cf-2318-4055-a01c-0e3dd38e67e0.png)

This will parse the version from the new insiders version string so that we're returning the _next_ tag that will be released at the time of its build. For upgrade readiness, I think this is intuitive.

## Test plan

New unit test case.