### PR TITLE
Remove "prototype" status badge

### DIFF
--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -35,7 +35,7 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                                     ) : (
                                         team.name
                                     )}
-                                    <ProductStatusBadge className="ml-2" status="prototype" />
+                                    <ProductStatusBadge className="ml-2" status="experimental" />
                                 </PageHeader.Breadcrumb>
                             </PageHeader.Heading>
                         </PageHeader>

--- a/client/web/src/team/list/TeamListPage.tsx
+++ b/client/web/src/team/list/TeamListPage.tsx
@@ -55,7 +55,7 @@ export const TeamListPage: React.FunctionComponent<React.PropsWithChildren<TeamL
             >
                 <PageHeader.Heading as="h2" styleAs="h1">
                     <PageHeader.Breadcrumb icon={mdiAccountMultiple}>
-                        Teams <ProductStatusBadge status="prototype" />
+                        Teams <ProductStatusBadge status="experimental" />
                     </PageHeader.Breadcrumb>
                 </PageHeader.Heading>
             </PageHeader>

--- a/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
+++ b/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
@@ -14,7 +14,6 @@ export type ProductStatusType = typeof PRODUCT_STATUSES[number]
  * Product statuses mapped to Badge style variants
  */
 const STATUS_VARIANT_MAPPING: Record<ProductStatusType, typeof BADGE_VARIANTS[number]> = {
-    prototype: 'warning',
     wip: 'warning',
     experimental: 'warning',
     beta: 'info',
@@ -60,8 +59,6 @@ export const ProductStatusBadge: React.FunctionComponent<React.PropsWithChildren
     const label =
         props.status === 'beta'
             ? 'This feature is currently in beta'
-            : props.status === 'prototype'
-            ? 'This feature is a prototype'
             : props.status === 'experimental'
             ? 'This feature is experimental'
             : props.status === 'wip'

--- a/client/wildcard/src/components/Badge/constants.ts
+++ b/client/wildcard/src/components/Badge/constants.ts
@@ -8,4 +8,4 @@ export const BADGE_VARIANTS = [
     'merged',
     'outlineSecondary',
 ] as const
-export const PRODUCT_STATUSES = ['beta', 'prototype', 'experimental', 'wip', 'new'] as const
+export const PRODUCT_STATUSES = ['beta', 'experimental', 'wip', 'new'] as const

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/__snapshots__/FeedbackBadge.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/__snapshots__/FeedbackBadge.test.tsx.snap
@@ -81,33 +81,6 @@ exports[`FeedbackBadge Renders status 'new' correctly 1`] = `
 </div>
 `;
 
-exports[`FeedbackBadge Renders status 'prototype' correctly 1`] = `
-<div
-  class="feedbackBadge"
->
-  <span
-    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-  >
-    This feature is currently in prototype
-  </span>
-  <span
-    aria-hidden="true"
-    class="productStatusBadge productStatusBadge"
-    status="prototype"
-  >
-    prototype
-  </span>
-  <a
-    class="anchor"
-    href="mailto:support@sourcegraph.com"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    Share feedback
-  </a>
-</div>
-`;
-
 exports[`FeedbackBadge Renders status 'wip' correctly 1`] = `
 <div
   class="feedbackBadge"

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/constant.ts
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/constant.ts
@@ -1,1 +1,1 @@
-export const FEEDBACK_BADGES_STATUS = ['experimental', 'prototype', 'beta', 'wip', 'new'] as const
+export const FEEDBACK_BADGES_STATUS = ['experimental', 'beta', 'wip', 'new'] as const

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -62,7 +62,7 @@ BasicHeader.parameters = {
 
 export const ComplexHeader: Story = () => (
     <PageHeader
-        annotation={<FeedbackBadge status="prototype" feedback={{ mailto: 'support@sourcegraph.com' }} />}
+        annotation={<FeedbackBadge status="experimental" feedback={{ mailto: 'support@sourcegraph.com' }} />}
         byline={
             <>
                 Created by <Link to="/page">user</Link> 3 months ago


### PR DESCRIPTION
I've learnt this is not a valid product status, so removing it and migrating teams to "experimental" instead.

## Test plan

CI will tell if it was used elsewhere.

## App preview:

- [Web](https://sg-web-es-no-prototype.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
