### PR TITLE
Add k3s deployType

### DIFF
--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -13,6 +13,7 @@ const (
 	Helm          = "helm"
 	Kustomize     = "kustomize"
 	SingleProgram = "single-program"
+	K3s           = "k3s"
 )
 
 var mock string
@@ -44,7 +45,7 @@ func Mock(val string) {
 func IsDeployTypeKubernetes(deployType string) bool {
 	switch deployType {
 	// includes older Kubernetes aliases for backwards compatibility
-	case "k8s", "cluster", Kubernetes, Helm, Kustomize:
+	case "k8s", "cluster", Kubernetes, Helm, Kustomize, K3s:
 		return true
 	}
 


### PR DESCRIPTION
Add k3s as new deployType for AMI installations for data collection purpose.

Currently all AMI installations are registered under deployType: kubernetes

Once this is merged, we should update the deployType to k3s in frontend for all new AMI installations

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Set deployType to k3s in frontend and run sg start. The instance works as expected.