### PR TITLE
bazel: enable js+go plugins

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,9 +13,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 # gazelle:js disabled
 # gazelle:js_npm_package_target_name {dirname}_pkg
 
-# Enable only the Aspect javascript plugin for gazelle
-# gazelle:lang js
-# gazelle:lang go
+# Enable: Aspect javascript, standard go
+# gazelle:lang js, go
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Each time it is set it overrides the previous. That took way to long to realize why the js plugin wasn't running 🤦 