### PR TITLE
Fix enterprise search jobs sometimes not initialized in insights

### DIFF
--- a/enterprise/cmd/frontend/shared/shared.go
+++ b/enterprise/cmd/frontend/shared/shared.go
@@ -46,7 +46,6 @@ import (
 type EnterpriseInitializer = func(context.Context, *observation.Context, database.DB, codeintel.Services, conftypes.UnifiedWatchable, *enterprise.Services) error
 
 var initFunctions = map[string]EnterpriseInitializer{
-	"search":         search.Init,
 	"app":            app.Init,
 	"authz":          authz.Init,
 	"batches":        batches.Init,
@@ -87,6 +86,12 @@ func EnterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterp
 	})
 	if err != nil {
 		logger.Fatal("failed to initialize code intelligence", log.Error(err))
+	}
+
+	// Inititalize search first, as we require enterprise search jobs to be already
+	// when other initializers are called.
+	if err := search.Init(ctx, observationCtx, db, codeIntelServices, conf, &enterpriseServices); err != nil {
+		logger.Fatal("failed to initialize search", log.Error(err))
 	}
 
 	for name, fn := range initFunctions {

--- a/enterprise/cmd/frontend/shared/shared.go
+++ b/enterprise/cmd/frontend/shared/shared.go
@@ -88,7 +88,7 @@ func EnterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterp
 		logger.Fatal("failed to initialize code intelligence", log.Error(err))
 	}
 
-	// Inititalize search first, as we require enterprise search jobs to be already
+	// Initialize search first, as we require enterprise search jobs to exist already
 	// when other initializers are called.
 	if err := search.Init(ctx, observationCtx, db, codeIntelServices, conf, &enterpriseServices); err != nil {
 		logger.Fatal("failed to initialize search", log.Error(err))


### PR DESCRIPTION
God damn got bitten by map indeterministic ordering again :( Now with this change, search _actually_ initializes before other jobs. On some startups, it could mean that insights aggregations won't work with it. Restart might fix it. Now it should work consistently.

## Test plan

Can see that moving it to after the loop breaks it consistently, so this gives me confidence it does something useful.