### PR TITLE
gRPC: mvoe from feature flag to ExperimentalFeatures

### DIFF
--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
 
 // MultiplexHandlers takes a gRPC server and a plain HTTP handler and multiplexes the
@@ -39,5 +39,5 @@ func IsGRPCEnabled(ctx context.Context) bool {
 	if val, err := strconv.ParseBool(os.Getenv(envGRPCEnabled)); err == nil {
 		return val
 	}
-	return featureflag.FromContext(ctx).GetBoolOr("grpc", false)
+	return conf.Get().ExperimentalFeatures.EnableGRPC
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -743,6 +743,8 @@ type ExperimentalFeatures struct {
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
+	// EnableGRPC description: Enables gRPC for communication between internal services
+	EnableGRPC bool `json:"enableGRPC,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visibility of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
@@ -836,6 +838,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "bitbucketServerFastPerm")
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")
+	delete(m, "enableGRPC")
 	delete(m, "enableGithubInternalRepoVisibility")
 	delete(m, "enablePermissionsWebhooks")
 	delete(m, "enablePostSignupFlow")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -356,6 +356,12 @@
           "type": "boolean",
           "default": false
         },
+        "enableGRPC": {
+          "description": "Enables gRPC for communication between internal services",
+          "type": "boolean",
+          "default": false,
+          "!go": { "pointer": false }
+        },
         "enablePermissionsWebhooks": {
           "description": "Enables webhook consumers to sync permissions from external services faster than the defaults schedule",
           "type": "boolean",


### PR DESCRIPTION
This just moves the toggle for gRPC from a feature flag to the longer-term `ExperimentalFeatures`. Customers are generally more familiar with enabling features via config rather than with feature flags.

## Test plan

Double checked that with the setting enabled, gRPC calls are reflected in the traces and without the feature enabled, I'm not seeing gRPC calls in the traces. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
