### PR TITLE
Highlighting: switch Go highlighter engine to tree-sitter

### DIFF
--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -110,6 +110,7 @@ var baseEngineConfig = syntaxEngineConfig{
 		"tsx":        EngineTreeSitter,
 		"java":       EngineTreeSitter,
 		"c":          EngineTreeSitter,
+		"go":         EngineTreeSitter,
 		"scala":      EngineTreeSitter,
 		"rust":       EngineTreeSitter,
 		"c#":         EngineTreeSitter,


### PR DESCRIPTION
Go is the only language we have a tree-sitter highlighter for that hasn't been turned on by default. This change fixes an off-by-one error in the syntect->scip conversion that affects pages like https://sourcegraph.com/github.com/hashicorp/errwrap/-/blob/errwrap.go

## Test plan

Manually tested by loading https://sourcegraph.test:3443/github.com/hashicorp/errwrap/-/blob/errwrap.go and verifying that the off-by-one bug is fixed with the tree-sitter highlighter.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
