### PR TITLE
bazel: fix gazelle lang directive

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 # gazelle:js_npm_package_target_name {dirname}_pkg
 
 # Enable: Aspect javascript, standard go
-# gazelle:lang js, go
+# gazelle:lang js,go
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
It's confusing, because the directive expects commas without spaces.

Test plan: ran locally and it worked as intended.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
