### PR TITLE
web: sync init of the GraphQL client

### DIFF
--- a/client/web/src/enterprise/EnterpriseWebApp.tsx
+++ b/client/web/src/enterprise/EnterpriseWebApp.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react'
 
 import '../SourcegraphWebApp.scss'
 
+import { logger } from '@sourcegraph/common'
+
 import { LegacySourcegraphWebApp } from '../LegacySourcegraphWebApp'
 import { SourcegraphWebApp } from '../SourcegraphWebApp'
 import {
@@ -10,6 +12,7 @@ import {
     StaticInjectedAppConfig,
     windowContextConfig,
 } from '../staticAppConfig'
+import { AppShellInit } from '../storm/app-shell-init'
 import { routes } from '../storm/routes'
 
 import { CodeIntelligenceBadgeContent } from './codeintel/badge/components/CodeIntelligenceBadgeContent'
@@ -78,12 +81,20 @@ const staticAppConfig = {
     ...hardcodedConfig,
 } satisfies StaticAppConfig
 
-export const EnterpriseWebApp: FC = () => {
+export const EnterpriseWebApp: FC<AppShellInit> = props => {
     if (window.context.experimentalFeatures.enableStorm) {
-        // eslint-disable-next-line no-console
-        console.log('Storm 🌪️ is enabled for this page load.')
+        const { graphqlClient, temporarySettingsStorage } = props
 
-        return <SourcegraphWebApp {...staticAppConfig} routes={routes} />
+        logger.log('Storm 🌪️ is enabled for this page load.')
+
+        return (
+            <SourcegraphWebApp
+                {...staticAppConfig}
+                routes={routes}
+                graphqlClient={graphqlClient}
+                temporarySettingsStorage={temporarySettingsStorage}
+            />
+        )
     }
 
     return <LegacySourcegraphWebApp {...staticAppConfig} />

--- a/client/web/src/enterprise/main.tsx
+++ b/client/web/src/enterprise/main.tsx
@@ -10,12 +10,26 @@ import '../monitoring/initMonitoring'
 
 import { createRoot } from 'react-dom/client'
 
+import { logger } from '@sourcegraph/common'
+
+import { initAppShell } from '../storm/app-shell-init'
+
 import { EnterpriseWebApp } from './EnterpriseWebApp'
+
+const appShellPromise = initAppShell()
 
 // It's important to have a root component in a separate file to create a react-refresh boundary and avoid page reload.
 // https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#edits-always-lead-to-full-reload
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
     const root = createRoot(document.querySelector('#root')!)
 
-    root.render(<EnterpriseWebApp />)
+    try {
+        const { graphqlClient, temporarySettingsStorage } = await appShellPromise
+
+        root.render(
+            <EnterpriseWebApp graphqlClient={graphqlClient} temporarySettingsStorage={temporarySettingsStorage} />
+        )
+    } catch (error) {
+        logger.error('Failed to initialize the app shell', error)
+    }
 })

--- a/client/web/src/storm/app-shell-init.ts
+++ b/client/web/src/storm/app-shell-init.ts
@@ -1,0 +1,19 @@
+import { GraphQLClient } from '@sourcegraph/http-client'
+import { TemporarySettingsStorage } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsStorage'
+
+import { getWebGraphQLClient } from '../backend/graphql'
+
+export interface AppShellInit {
+    graphqlClient: GraphQLClient
+    temporarySettingsStorage: TemporarySettingsStorage
+}
+
+export async function initAppShell(): Promise<AppShellInit> {
+    const graphqlClient = await getWebGraphQLClient()
+    const temporarySettingsStorage = new TemporarySettingsStorage(graphqlClient, window.context.isAuthenticatedUser)
+
+    return {
+        graphqlClient,
+        temporarySettingsStorage,
+    }
+}


### PR DESCRIPTION
## Context

Move initialization of the GraphQL client and `TemporarySettingsStorage` outside the render function to remove extra set state and render blocking. This is compatible with the default version of the app because the `getWebGraphQLClient` function is memorized, and `TemporarySettingsStorage` is free.

## Test plan

CI and manually testing the app init works for both the Storm and non-Storm versions.

## App preview:

- [Web](https://sg-web-vb-storm-3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
