### PR TITLE
Only link update if available, link changelog

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo } from 'react'
 
-import { mdiAccount, mdiSourceRepository, mdiCommentOutline } from '@mdi/js'
+import { mdiAccount, mdiCommentOutline, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
 import format from 'date-fns/format'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { Card, H2, Text, LoadingSpinner, AnchorLink } from '@sourcegraph/wildcard'
+import { AnchorLink, Card, H2, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
 import { ErrorBoundary } from '../../../components/ErrorBoundary'
 import { OverviewStatisticsResult, OverviewStatisticsVariables } from '../../../graphql-operations'
@@ -74,6 +74,7 @@ export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
     const { productSubscription } = data.site
     const licenseExpiresAt = productSubscription.license ? new Date(productSubscription.license.expiresAt) : null
 
+    const changelogUrl = getChangelogUrl(data.site.productVersion)
     return (
         <>
             <AnalyticsPageTitle>Overview</AnalyticsPageTitle>
@@ -84,18 +85,27 @@ export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
                         <H2 className="mb-3">{data.site.productSubscription.productNameWithBrand}</H2>
                         <div className="d-flex">
                             <Text className="text-muted">
-                                Version <span className={styles.purple}>{data.site.productVersion}</span>
+                                Version{' '}
+                                {changelogUrl ? (
+                                    <Link to={changelogUrl} className={styles.purple}>
+                                        {data.site.productVersion}
+                                    </Link>
+                                ) : (
+                                    <span className={styles.purple}>{data.site.productVersion}</span>
+                                )}
                             </Text>
                             {productSubscription.license && licenseExpiresAt ? (
                                 <>
-                                    <AnchorLink
-                                        to="/help/admin/updates"
-                                        target="_blank"
-                                        rel="noopener"
-                                        className="ml-1"
-                                    >
-                                        Upgrade
-                                    </AnchorLink>
+                                    {data.site.updateCheck.updateVersionAvailable || error ? (
+                                        <AnchorLink
+                                            to="/help/admin/updates"
+                                            target="_blank"
+                                            rel="noopener"
+                                            className="ml-1"
+                                        >
+                                            Upgrade
+                                        </AnchorLink>
+                                    ) : null}
                                     <Text className="text-muted mx-2">|</Text>
                                     <Text className="text-muted">
                                         License
@@ -185,4 +195,13 @@ export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
             </Card>
         </>
     )
+}
+
+function getChangelogUrl(version: string): string | null {
+    const versionAnchor = version.replace(/\./g, '-')
+    // Only show changelog link for versions that match the X.Y.Z format.
+    // Other versions don't have a changelog entry.
+    return version.match(/^\d+-\d+-\d+$/)
+        ? `https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md#${versionAnchor}`
+        : null
 }

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
@@ -12,6 +12,9 @@ export const OVERVIEW_STATISTICS = gql`
                     expiresAt
                 }
             }
+            updateCheck {
+                updateVersionAvailable
+            }
             adminUsers: users(siteAdmin: true, deletedAt: { empty: true }) {
                 totalCount
             }


### PR DESCRIPTION
Updates the site admin front page based on customer feedback.

Two changes:

1. Links current version in changelog:

![image](https://user-images.githubusercontent.com/2552265/222424080-7738b946-2022-4fa8-b77b-d2ae6577455e.png)

2. If there's no update available, hides the "Update" link:

<img width="735" alt="CleanShot 2023-03-02 at 13 06 24@2x" src="https://user-images.githubusercontent.com/2552265/222424274-5f2809cd-64c9-412a-9e6a-67a8175227ff.png">

Notes:
- If there was an error fetching updates, it still displays the "Update" link.

## Test plan

This is a tiny change—if CI's happy, I'm happy

## App preview:

- [Web](https://sg-web-dv-improve-version-and-upgrade.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
