### PR TITLE
Fix analytics page date selector being squished

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -80,8 +80,11 @@ export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
 
             <Card className="p-3" data-testid="product-certificate">
                 <div className="d-flex justify-content-between align-items-start mb-3 text-nowrap">
-                    <div>
-                        <H2 className="mb-3">{data.site.productSubscription.productNameWithBrand}</H2>
+                    <div className="w-100">
+                        <div className="d-flex">
+                            <H2 className="mb-3">{data.site.productSubscription.productNameWithBrand}</H2>
+                            <HorizontalSelect<typeof dateRange.value> {...dateRange} className="mb-3 ml-auto" />
+                        </div>
                         <div className="d-flex">
                             <Text className="text-muted">
                                 Version <span className={styles.purple}>{data.site.productVersion}</span>
@@ -118,7 +121,6 @@ export const AnalyticsOverviewPage: React.FunctionComponent<Props> = () => {
                             )}
                         </div>
                     </div>
-                    <HorizontalSelect<typeof dateRange.value> {...dateRange} />
                 </div>
                 <div className={classNames('d-flex mt-3', styles.padded)}>
                     <div className={styles.main}>


### PR DESCRIPTION
Fixes #48420 

**Before this PR**

![image](https://user-images.githubusercontent.com/6427795/222428781-7cf5208d-d7fb-45f2-aa9c-6184a9937207.png)

**After this PR**

<img width="910" alt="image" src="https://user-images.githubusercontent.com/6427795/222429061-c35a2f34-ed96-4468-ba85-54505148753b.png">

## Test plan

Visual confirmation as seen above

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-48420-timerange-label-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
