### PR TITLE
licensing: always allow promoting site admin for SOAP users

### DIFF
--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -110,8 +110,7 @@ func NewBeforeSetUserIsSiteAdmin() func(ctx context.Context, isSiteAdmin bool) e
 		//
 		// NOTE: It is important to make sure the Sourcegraph Operator authentication
 		// provider is actually enabled.
-		if cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() && actor.FromContext(ctx).SourcegraphOperator
-			 {
+		if cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() && actor.FromContext(ctx).SourcegraphOperator {
 			return nil
 		}
 

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -102,8 +103,18 @@ func NewAfterCreateUserHook() func(context.Context, database.DB, *types.User) er
 
 // NewBeforeSetUserIsSiteAdmin returns a BeforeSetUserIsSiteAdmin closure that determines whether
 // the creation or removal of site admins are allowed.
-func NewBeforeSetUserIsSiteAdmin() func(isSiteAdmin bool) error {
-	return func(isSiteAdmin bool) error {
+func NewBeforeSetUserIsSiteAdmin() func(ctx context.Context, isSiteAdmin bool) error {
+	return func(ctx context.Context, isSiteAdmin bool) error {
+		// Exempt user accounts that are created by the Sourcegraph Operator
+		// authentication provider.
+		//
+		// NOTE: It is important to make sure the Sourcegraph Operator authentication
+		// provider is actually enabled.
+		if actor.FromContext(ctx).SourcegraphOperator &&
+			cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() {
+			return nil
+		}
+
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
 			return err

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -110,8 +110,8 @@ func NewBeforeSetUserIsSiteAdmin() func(ctx context.Context, isSiteAdmin bool) e
 		//
 		// NOTE: It is important to make sure the Sourcegraph Operator authentication
 		// provider is actually enabled.
-		if actor.FromContext(ctx).SourcegraphOperator &&
-			cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() {
+		if cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() && actor.FromContext(ctx).SourcegraphOperator
+			 {
 			return nil
 		}
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -46,7 +46,7 @@ var (
 	AfterCreateUser func(ctx context.Context, db DB, user *types.User) error
 	// BeforeSetUserIsSiteAdmin (if set) is a hook called before promoting/revoking a user to be a
 	// site admin.
-	BeforeSetUserIsSiteAdmin func(isSiteAdmin bool) error
+	BeforeSetUserIsSiteAdmin func(ctx context.Context, isSiteAdmin bool) error
 )
 
 // UserStore provides access to the `users` table.
@@ -798,7 +798,7 @@ func (u *userStore) RecoverUsersList(ctx context.Context, ids []int32) (_ []int3
 // to the user when `isSiteAdmin` is true and revokes the role when false.
 func (u *userStore) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bool) error {
 	if BeforeSetUserIsSiteAdmin != nil {
-		if err := BeforeSetUserIsSiteAdmin(isSiteAdmin); err != nil {
+		if err := BeforeSetUserIsSiteAdmin(ctx, isSiteAdmin); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
We aren't able to fix the expired license issue for a MI without being a site admin but also aren't able to be automatically promoted to be site admin with an expired license on the MI 😂 

## Test plan

CI
