### PR TITLE
Treeview: Fix scrolling in symbol tree

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbolTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbolTree.tsx
@@ -15,6 +15,8 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import type { SymbolPlaceholder, SymbolWithChildren } from './RepoRevisionSidebarSymbols'
 
+import styles from './RepoRevisionSidebarSymbols.module.scss'
+
 interface Props {
     symbols: SymbolWithChildren[]
     onClick: () => void
@@ -119,6 +121,7 @@ export const RepoRevisionSidebarSymbolTree: React.FC<Props> = ({
             defaultExpandedIds={defaultExpandedIds}
             onSelect={onSelect}
             selectedIds={selectedIds}
+            nodeClassName={styles.treeNode}
             renderNode={({ element, handleSelect, props }): React.ReactNode => {
                 const { className, ...rest } = props
 

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
@@ -61,3 +61,8 @@
     list-style-type: none;
     padding-left: 0;
 }
+
+.tree-node {
+    // Account for the sticky input box at the top of the sidebar
+    scroll-margin-top: 2.75rem;
+}

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -130,7 +130,7 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
                 </div>
             )
         },
-        [loadedIds, renderNode]
+        [loadedIds, nodeClassName, renderNode]
     )
 
     return (

--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -32,9 +32,12 @@ interface Props<N extends TreeNode>
     // because we can not rely on the .length property to know if we're still
     // loading children.
     loadedIds?: Set<number>
+
+    // Optional className that is passed through to the focused nodes
+    nodeClassName?: string
 }
 export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
-    const { onSelect, onExpand, onLoadData, renderNode, loadedIds, ...rest } = props
+    const { onSelect, onExpand, onLoadData, renderNode, loadedIds, nodeClassName, ...rest } = props
 
     const _onSelect = useCallback(
         // TreeView expects nodes to be INode but ours are extending this type,
@@ -94,7 +97,7 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
                         minWidth: `calc(100% - 0.5rem - ${getMarginLeft(level, isBranch)})`,
                     }}
                     data-tree-node-id={element.id}
-                    className={classNames(styles.node, isSelected && styles.selected)}
+                    className={classNames(styles.node, isSelected && styles.selected, nodeClassName)}
                 >
                     {isBranch ? (
                         // We already handle accessibility events for expansion in the <TreeView />


### PR DESCRIPTION
The symbol tree has an input element that is `position: sticky;` which caused issues when scrolling to elements inside the view.

We fix this by adding a `scroll-margin-top` to the node component.

## Test plan

https://user-images.githubusercontent.com/458591/222445330-6fd9cf7b-5134-477e-8ab7-417e8004fa6e.mov

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-symbol-tree-scrolling.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
