### PR TITLE
Fix search result outline being cut-off

### DIFF
--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -23,7 +23,6 @@
 
     &-title {
         flex: 1 1 auto;
-        overflow: hidden;
         display: flex;
         flex-wrap: wrap;
     }


### PR DESCRIPTION
This PR removes an `overflow: hidden;` that caused the focus outline to be cut-off. No matter if we use `box-shadow` or `outline`, hiding the overflow would always cut this off.

I tried to find out why the `overflow: hidden;` was needed but even for very long results, this does not seem to make any difference:

https://user-images.githubusercontent.com/458591/222447155-8c0efaf3-311f-442b-8322-eb7a26bf93e3.mov

I noticed that it was already part of the initial SG open-source release so there's likely no context around that anymore. 😅

## Test plan

<img width="808" alt="Screenshot 2023-03-02 at 14 47 41" src="https://user-images.githubusercontent.com/458591/222447211-9d0f38b6-118b-443a-adae-1c22c9117a4b.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-search-result-outline.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
