### PR TITLE
ci: add caching flags for bazel in stateful agents

### DIFF
--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -69,3 +69,15 @@ build --remote_local_fallback
 # Fixes builds hanging on CI that get the TCP connection closed without sending RST packets.
 # Docs: https://bazel.build/reference/command-line-reference#flag--grpc_keepalive_time
 build --grpc_keepalive_time=30s
+
+# Use repo caching for building and testing.
+# Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
+# Docs: https://bazel.build/reference/command-line-reference#flag--repository_cache
+build --repository_cache=/home/buildkite/repocache-sourcegraph
+test --repository_cache=/home/buildkite/repocache-sourcegraph
+
+# Use Disk caching for building and testing.
+# Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
+# Docs: https://bazel.build/reference/command-line-reference#flag--disk_cache
+build --disk_cache=/home/buildkite/diskcache
+test --disk_cache=/home/buildkite/diskcache

--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -74,10 +74,8 @@ build --grpc_keepalive_time=30s
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
 # Docs: https://bazel.build/reference/command-line-reference#flag--repository_cache
 build --repository_cache=/home/buildkite/repocache-sourcegraph
-test --repository_cache=/home/buildkite/repocache-sourcegraph
 
 # Use Disk caching for building and testing.
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
 # Docs: https://bazel.build/reference/command-line-reference#flag--disk_cache
 build --disk_cache=/home/buildkite/diskcache
-test --disk_cache=/home/buildkite/diskcache


### PR DESCRIPTION
This adds two flags that will be applied only in CI to enable the stateful agents to cache things locally across builds. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested: https://sourcegraph.slack.com/archives/C03LUEB7TJS/p1677867236690509