### PR TITLE
authz/azuredevops: Check enforcePermissions in NewAuthzProviders

### DIFF
--- a/enterprise/internal/authz/azuredevops/provider.go
+++ b/enterprise/internal/authz/azuredevops/provider.go
@@ -26,7 +26,7 @@ var mockServerURL string
 func NewAuthzProviders(db database.DB, conns []*types.AzureDevOpsConnection) *authztypes.ProviderInitResult {
 	orgs, projects := map[string]struct{}{}, map[string]struct{}{}
 
-	validAzureDevOpsConnections := []*types.AzureDevOpsConnection{}
+	authorizedConnections := []*types.AzureDevOpsConnection{}
 
 	// Iterate over all Azure Dev Ops code host connections to make sure we sync permissions for all
 	// orgs and projects in every permissions sync iteration.
@@ -49,11 +49,11 @@ func NewAuthzProviders(db database.DB, conns []*types.AzureDevOpsConnection) *au
 		}
 
 		c := c
-		validAzureDevOpsConnections = append(validAzureDevOpsConnections, c)
+		authorizedConnections = append(authorizedConnections, c)
 	}
 
 	initResults := &authztypes.ProviderInitResult{}
-	if len(validAzureDevOpsConnections) == 0 {
+	if len(authorizedConnections) == 0 {
 		return initResults
 	}
 
@@ -61,7 +61,7 @@ func NewAuthzProviders(db database.DB, conns []*types.AzureDevOpsConnection) *au
 	uniqueOrgs := maps.Keys(orgs)
 	uniqueProjects := maps.Keys(projects)
 
-	p, err := newAuthzProvider(db, validAzureDevOpsConnections, uniqueOrgs, uniqueProjects)
+	p, err := newAuthzProvider(db, authorizedConnections, uniqueOrgs, uniqueProjects)
 	if err != nil {
 		initResults.InvalidConnections = append(initResults.InvalidConnections, extsvc.TypeAzureDevOps)
 		initResults.Problems = append(initResults.Problems, err.Error())

--- a/enterprise/internal/authz/azuredevops/provider.go
+++ b/enterprise/internal/authz/azuredevops/provider.go
@@ -26,15 +26,15 @@ var mockServerURL string
 func NewAuthzProviders(db database.DB, conns []*types.AzureDevOpsConnection) *authztypes.ProviderInitResult {
 	orgs, projects := map[string]struct{}{}, map[string]struct{}{}
 
-	initResults := &authztypes.ProviderInitResult{}
-
-	if len(conns) == 0 {
-		return initResults
-	}
+	validAzureDevOpsConnections := []*types.AzureDevOpsConnection{}
 
 	// Iterate over all Azure Dev Ops code host connections to make sure we sync permissions for all
 	// orgs and projects in every permissions sync iteration.
 	for _, c := range conns {
+		if !c.EnforcePermissions {
+			continue
+		}
+
 		// The list of orgs and projects may have duplicates if there are multiple Azure DevOps code
 		// host connections that have the same project in their config.
 		//
@@ -47,13 +47,21 @@ func NewAuthzProviders(db database.DB, conns []*types.AzureDevOpsConnection) *au
 		for _, name := range c.Projects {
 			projects[name] = struct{}{}
 		}
+
+		c := c
+		validAzureDevOpsConnections = append(validAzureDevOpsConnections, c)
+	}
+
+	initResults := &authztypes.ProviderInitResult{}
+	if len(validAzureDevOpsConnections) == 0 {
+		return initResults
 	}
 
 	// Convert the map back to a slice now that we have a unique list of orgs and projects.
 	uniqueOrgs := maps.Keys(orgs)
 	uniqueProjects := maps.Keys(projects)
 
-	p, err := newAuthzProvider(db, conns, uniqueOrgs, uniqueProjects)
+	p, err := newAuthzProvider(db, validAzureDevOpsConnections, uniqueOrgs, uniqueProjects)
 	if err != nil {
 		initResults.InvalidConnections = append(initResults.InvalidConnections, extsvc.TypeAzureDevOps)
 		initResults.Problems = append(initResults.Problems, err.Error())

--- a/enterprise/internal/authz/azuredevops/provider_test.go
+++ b/enterprise/internal/authz/azuredevops/provider_test.go
@@ -428,6 +428,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		},
 	}
 
+	licensing.MockCheckFeature = allowLicensingCheck
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rcache.SetupForTest(t)
@@ -441,7 +442,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				conf.Mock(nil)
 			})
 
-			licensing.MockCheckFeature = allowLicensingCheck
 			result := NewAuthzProviders(db, []*types.AzureDevOpsConnection{
 				{
 					URN:                   "",

--- a/enterprise/internal/authz/azuredevops/provider_test.go
+++ b/enterprise/internal/authz/azuredevops/provider_test.go
@@ -513,7 +513,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		}()
 
 		licensing.MockCheckFeature = allowLicensingCheck
-
 		result := NewAuthzProviders(db, []*types.AzureDevOpsConnection{
 			{
 				URN: "1",

--- a/enterprise/internal/authz/azuredevops/provider_test.go
+++ b/enterprise/internal/authz/azuredevops/provider_test.go
@@ -152,7 +152,7 @@ func TestProvider_NewAuthzProviders(t *testing.T) {
 
 				// Just check if the URN of the connection is the as expected. Using cmp.Diff on the
 				// whole list would require to reconstruct the entire struct in the expected output.
-				for j, _ := range gotAzureProvider.conns {
+				for j := range gotAzureProvider.conns {
 					if diff := cmp.Diff(tc.expectedAzureDevOpsConnections[j].URN, gotAzureProvider.conns[j].URN); diff != "" {
 						t.Errorf("Mismatched provider connection URN, (-want, +got)\n%s", diff)
 					}
@@ -626,27 +626,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 		if diff := cmp.Diff(wantPermissions, gotPermissions); diff != "" {
 			t.Errorf("Mismatched perms, (-want, +got)\n%s", diff)
-		}
-	})
-
-	t.Run("at least one code host connection with enforcePermissions set to true", func(t *testing.T) {
-		licensing.MockCheckFeature = allowLicensingCheck
-		result := NewAuthzProviders(db, []*types.AzureDevOpsConnection{
-			{
-				URN: "1",
-				AzureDevOpsConnection: &schema.AzureDevOpsConnection{
-					EnforcePermissions: false,
-				},
-			},
-			{
-				URN: "2",
-				AzureDevOpsConnection: &schema.AzureDevOpsConnection{
-					EnforcePermissions: true,
-				},
-			},
-		})
-		if len(result.Providers) != 1 {
-			t.Fatalf("expected one provider but got %d", len(result.Providers))
 		}
 	})
 }


### PR DESCRIPTION
We do not want to run permission sync for orgs and projects that are declared in code host connections without an explicit `enforcePermissions: true`. Skip them instead.

Follow up to https://github.com/sourcegraph/sourcegraph/pull/48209#discussion_r1122990998.

Fixes #47165.

## Note to reviewers

The code change itself is small but important. Most of the added and removed lines is new tests and some refactoring of the tests.

I've added inline comments to explain the changes which should make it reviewing this more approachable.

## Test plan
- Added tests
- Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
