### PR TITLE
experimental search input: Remove filter field background

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -25,7 +25,7 @@ import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
 import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
-import { filterHighlight } from './codemirror/syntax-highlighting'
+import { filterDecoration } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
 import { editorConfigFacet, Source, suggestions, startCompletion } from './suggestionsExtension'
 
@@ -175,7 +175,7 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
         keymap.of(defaultKeymap),
         codemirrorHistory(),
         filterPlaceholder,
-        Prec.low([querySyntaxHighlighting, modeScope([filterHighlight, tokenInfo()], [null])]),
+        Prec.low([querySyntaxHighlighting, modeScope([tokenInfo(), filterDecoration], [null])]),
         EditorView.theme({
             '&': {
                 flex: 1,

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -106,14 +106,6 @@
     }
 }
 
-.filter-field {
-    color: var(--search-filter-keyword-color);
-    background-color: var(--oc-blue-0);
-    // border: 1px solid var(--oc-blue-1);
-    border-radius: 3px;
-    padding: 0;
-}
-
 .icon {
     color: var(--icon-color);
 }

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -1,50 +1,29 @@
 import { RangeSetBuilder } from '@codemirror/state'
 import { Decoration, EditorView } from '@codemirror/view'
-import inRange from 'lodash/inRange'
 
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { isFilterOfType } from '@sourcegraph/shared/src/search/query/utils'
 
 import { decoratedTokens, queryTokens } from '../../codemirror/parsedQuery'
 
-const validFilter = Decoration.mark({ class: 'sg-query-token-filter' })
-const invalidFilter = Decoration.mark({ class: 'sg-query-token-filter sg-query-token-filter-invalid' })
 const contextFilter = Decoration.mark({ class: 'sg-query-token-filter-context', inclusiveEnd: false })
 
-export const filterHighlight = [
+export const filterDecoration = [
     EditorView.baseTheme({
-        '.sg-query-token-filter': {
-            backgroundColor: 'var(--oc-blue-0)',
-            borderRadius: '3px',
-            padding: '0px',
-        },
-        '.sg-query-token-filter-invalid': {
-            backgroundColor: 'var(--oc-red-1)',
-            borderColor: 'var(--oc-red-2)',
-        },
         '.sg-query-token-filter-context': {
             borderRadius: '3px',
             border: '1px solid var(--border-color)',
+        },
+        '&dark .sg-query-token-filter-context': {
+            borderColor: 'var(--border-color-2)',
         },
     }),
     EditorView.decorations.compute([decoratedTokens, 'selection'], state => {
         const query = state.facet(queryTokens)
         const builder = new RangeSetBuilder<Decoration>()
         for (const token of query.tokens) {
-            if (token.type === 'filter') {
-                const withinRange = inRange(state.selection.main.head, token.range.start, token.range.end + 1) // or cursor is within field
-                const isValid =
-                    token?.value?.value || // has non-empty value
-                    token?.value?.quoted || // or is quoted
-                    withinRange // or cursor is within field
-
-                // context: filters are styled differnetly
-                if (isFilterOfType(token, FilterType.context)) {
-                    builder.add(token.range.start, token.range.end, contextFilter)
-                } else {
-                    // +1 to include the colon (:)
-                    builder.add(token.range.start, token.field.range.end + 1, isValid ? validFilter : invalidFilter)
-                }
+            if (token.type === 'filter' && isFilterOfType(token, FilterType.context)) {
+                builder.add(token.range.start, token.range.end, contextFilter)
             }
         }
         return builder.finish()

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -7,7 +7,7 @@ import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
 import styles from './Suggestions.module.scss'
 
 const FilterOption: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <span className={classnames(styles.filterOption, styles.filterField)}>
+    <span className={classnames(styles.filterOption, 'search-filter-keyword')}>
         {option.matches ? <HighlightedLabel label={option.label} matches={option.matches} /> : option.label}
         <span className={styles.separator}>:</span>
     </span>
@@ -21,7 +21,7 @@ const FilterValueOption: React.FunctionComponent<{ option: Option }> = ({ option
 
     return (
         <span className={styles.filterOption}>
-            <span className={styles.filterField}>
+            <span className="search-filter-keyword">
                 {field}
                 <span className={styles.separator}>:</span>
             </span>


### PR DESCRIPTION
We decided to remove the background color and continue to use the same styling we already have. By removing it we also magically fix this part of the dark mode problem ;)

Whether or not to keep the context filter border is still up for debate but I've slightly tweaked the border color for now to make it more visible in dark mode.

Moving `tokenInfo` before `filterDecoration` fixes the "layout shift" when hovering over the `context:` filter.


<img width="819" alt="2023-03-02_14-58" src="https://user-images.githubusercontent.com/179026/222465999-ec5528be-5c03-4a14-96d9-77d85e8be2b1.png">


## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-search-input-style.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
