### PR TITLE
search input: Move query validation to reusable module

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/diagnostics.ts
+++ b/client/branded/src/search-ui/input/codemirror/diagnostics.ts
@@ -1,0 +1,88 @@
+import { type Diagnostic as CMDiagnostic, linter, type LintSource } from '@codemirror/lint'
+import { Compartment, Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+
+import { renderMarkdown } from '@sourcegraph/common'
+import { type Diagnostic, getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
+
+import { queryTokens } from './parsedQuery'
+
+/**
+ * Sets up client side query validation.
+ */
+export function queryDiagnostic(): Extension {
+    // The setup is a bit "strange" because @codemirror/lint only triggers
+    // linting when the document changes. But in our case the linting rules
+    // change depending on the query "type" (regexp, structural, ...). Changing
+    // the query type does not involve changing the document and to linting
+    // wouldn't be triggered. To work around this we explictly reconfigure the
+    // linter via a compartment when the parsed query changes but the document
+    // hadsn't change. This queues a new linting pass.
+    // See
+    // - https://discuss.codemirror.net/t/can-we-manually-force-linting-even-if-the-document-hasnt-changed/3570/2
+    // - https://github.com/sourcegraph/sourcegraph/issues/43836
+    //
+    const source: LintSource = view => {
+        const query = view.state.facet(queryTokens)
+        return query.tokens.length > 0 ? getDiagnostics(query.tokens, query.patternType).map(toCMDiagnostic) : []
+    }
+    const config = {
+        delay: 200,
+    }
+
+    const linterCompartment = new Compartment()
+
+    return [
+        linterCompartment.of(linter(source, config)),
+        EditorView.updateListener.of(update => {
+            if (update.state.facet(queryTokens) !== update.startState.facet(queryTokens) && !update.docChanged) {
+                update.view.dispatch({ effects: linterCompartment.reconfigure(linter(source, config)) })
+            }
+        }),
+        EditorView.theme({
+            '.cm-diagnosticText': {
+                display: 'block',
+            },
+            '.cm-diagnosticAction': {
+                color: 'var(--body-color)',
+                borderColor: 'var(--secondary)',
+                backgroundColor: 'var(--secondary)',
+                borderRadius: 'var(--border-radius)',
+                padding: 'var(--btn-padding-y-sm) .5rem',
+                fontSize: 'calc(min(0.75rem, 0.9166666667em))',
+                lineHeight: '1rem',
+                margin: '0.5rem 0 0 0',
+            },
+            '.cm-diagnosticAction + .cm-diagnosticAction': {
+                marginLeft: '1rem',
+            },
+        }),
+    ]
+}
+
+function renderMarkdownNode(message: string): Element {
+    const div = document.createElement('div')
+    div.innerHTML = renderMarkdown(message)
+    return div.firstElementChild || div
+}
+
+function toCMDiagnostic(diagnostic: Diagnostic): CMDiagnostic {
+    return {
+        from: diagnostic.range.start,
+        to: diagnostic.range.end,
+        message: diagnostic.message,
+        renderMessage() {
+            return renderMarkdownNode(diagnostic.message)
+        },
+        severity: diagnostic.severity,
+        actions: diagnostic.actions?.map(action => ({
+            name: action.label,
+            apply(view) {
+                view.dispatch({ changes: action.change, selection: action.selection })
+                if (action.selection && !view.hasFocus) {
+                    view.focus()
+                }
+            },
+        })),
+    }
+}

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -20,6 +20,7 @@ import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { singleLine, placeholder as placeholderExtension } from '../codemirror'
 import { filterPlaceholder } from '../codemirror/active-filter'
+import { queryDiagnostic } from '../codemirror/diagnostics'
 import { parseInputAsQuery, tokens } from '../codemirror/parsedQuery'
 import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
@@ -175,6 +176,7 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
         keymap.of(defaultKeymap),
         codemirrorHistory(),
         filterPlaceholder,
+        queryDiagnostic(),
         Prec.low([querySyntaxHighlighting, modeScope([tokenInfo(), filterDecoration], [null])]),
         EditorView.theme({
             '&': {


### PR DESCRIPTION
This moves the query validation extension into its own module and adds it to the new query input.

## Test plan

Manual test.

## App preview:

- [Web](https://sg-web-fkling-search-input-validation.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
