### PR TITLE
Proposal: simplify wording

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -115,11 +115,9 @@ const OwnExplanation: React.FunctionComponent<{}> = () => {
                     Find code owners from a CODEOWNERS file in this repository, or from your external ownership tracking
                     system here. <Link to="/help/own">Learn more</Link>
                     <br />
-                    In the future, we will suggest you many options of people to reach out to, including language
-                    experts, codebase experts, and domain experts.
                 </Text>
                 <Text className={classNames(styles.ownExplanationContent, 'mb-1')}>
-                    Try Sourcegraph Own in Search as well
+                    Sourcegraph Own also works in search:
                 </Text>
                 <Button
                     variant="secondary"


### PR DESCRIPTION
Removing future vision from in-product experience. Consider linking to the marketing page instead (easier to iterate on!)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mm-own-wording.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
