### PR TITLE
[feat] Read only from unified perms table if feature flag is set

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -455,11 +455,9 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 					if err != nil {
 						return results, errors.Wrap(err, "fetching existing repo permissions")
 					}
-				}
-				// Use the old user_permissions table if feature flag is off or no repos found.
-				// We need to do this because data might not have been migrated to the new table yet.
-				// TODO: refactor to be bulletproof once we have the OOB migration ready
-				if len(currentRepos) == 0 {
+				} else if len(currentRepos) == 0 {
+					// Use the old user_permissions table if feature flag is off
+					// TODO: refactor to be bulletproof once we have the OOB migration ready
 					currentRepos, err = s.permsStore.FetchReposByUserAndExternalService(ctx, user.ID, provider.ServiceType(), provider.ServiceID())
 					if err != nil {
 						return results, errors.Wrap(err, "fetching existing repo permissions")
@@ -469,7 +467,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 				for _, repoID := range currentRepos {
 					results.repoPerms[acct.ID] = append(results.repoPerms[acct.ID], int32(repoID))
 				}
-
 			}
 
 			// Process partial results if this is an initial fetch.

--- a/internal/database/zoekt_repos_test.go
+++ b/internal/database/zoekt_repos_test.go
@@ -286,7 +286,7 @@ func benchmarkUpdateIndexStatus(b *testing.B, numRepos int) {
 // BenchmarkZoektRepos_UpdateIndexStatus_500000/update-none-10                 5858           2377811 ns/op
 
 func BenchmarkZoektRepos_UpdateIndexStatus_10000(b *testing.B) {
-	benchmarkUpdateIndexStatus(b, 10_00)
+	benchmarkUpdateIndexStatus(b, 10_000)
 }
 
 func BenchmarkZoektRepos_UpdateIndexStatus_50000(b *testing.B) {


### PR DESCRIPTION
Also added a go benchmark with some results

## Benchmark results

```
// BenchmarkAuthzQuery_ListMinimalRepos_1000repos_1000users_50reposPerUser/list_repos,_using_unified_user_repo_permissions_table-10                   23928            495697 ns/op
// BenchmarkAuthzQuery_ListMinimalRepos_1000repos_1000users_50reposPerUser/list_repos,_using_legacy_user_permissions_table-10                         24399            486467 ns/op

// BenchmarkAuthzQuery_ListMinimalRepos_10krepos_10kusers_150reposPerUser/list_repos,_using_unified_user_repo_permissions_table-10                     3180           4023709 ns/op
// BenchmarkAuthzQuery_ListMinimalRepos_10krepos_10kusers_150reposPerUser/list_repos,_using_legacy_user_permissions_table-10                           2911           4020591 ns/op

// BenchmarkAuthzQuery_ListMinimalRepos_10krepos_10kusers_500reposPerUser/list_repos,_using_unified_user_repo_permissions_table-10                     3201           4101237 ns/op
// BenchmarkAuthzQuery_ListMinimalRepos_10krepos_10kusers_500reposPerUser/list_repos,_using_legacy_user_permissions_table-10                           2944           4144971 ns/op

// BenchmarkAuthzQuery_ListMinimalRepos_500krepos_40kusers_500reposPerUser/list_repos,_using_unified_user_repo_permissions_table-10                      63         186395579 ns/op
// BenchmarkAuthzQuery_ListMinimalRepos_500krepos_40kusers_500reposPerUser/list_repos,_using_legacy_user_permissions_table-10                            62         190570966 ns/op
```

The performance of both old and new authzQuery is really similar, the new query is marginally faster on datasets with lots of repositories per user. The old query is marginally faster on smaller datasets with not as many repositories per user.

## Test plan

Unit tests modified, tested locally.
