### PR TITLE
Fix VSCode build

### DIFF
--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -91,6 +91,12 @@ function getExtensionCoreConfiguration(targetType) {
           exclude: /node_modules/,
           use: [getBabelLoader()],
         },
+        {
+          test: /\.m?js/,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
       ],
     },
     plugins: [
@@ -124,8 +130,8 @@ const searchSidebarWebviewPath = path.resolve(webviewSourcePath, 'sidebars', 'se
 const helpSidebarWebviewPath = path.resolve(webviewSourcePath, 'sidebars', 'help')
 // Extension Host Worker Path
 const extensionHostWorker = /main\.worker\.ts$/
-// Monaco Editor Path
-const MONACO_EDITOR_PATH = path.resolve(rootPath, 'node_modules', 'monaco-editor')
+// Codicons Path
+const CODICONS_PATH = path.resolve(rootPath, 'node_modules', '@vscode', 'codicons')
 /** @type {import('webpack').Configuration}*/
 const webviewConfig = {
   context: __dirname, // needed when running `gulp` from the root dir
@@ -215,10 +221,15 @@ const webviewConfig = {
       // to reference path in the extension when we load the font ourselves.
       {
         test: /\.ttf$/,
-        include: [MONACO_EDITOR_PATH],
         type: 'asset/resource',
         generator: {
           filename: '[name][ext]',
+        },
+      },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false,
         },
       },
     ],


### PR DESCRIPTION
There were two issues:

- One was resolved by following the steps in https://github.com/microsoft/PowerBI-visuals-tools/issues/365#issuecomment-1099716186
- The other one was caused by the .ttf icon in monaco being moved, I changed the rule to now bundle any ttf with the full name (we only have one anyways).

## Test plan

<img width="2560" alt="Screenshot 2023-03-02 at 16 25 55" src="https://user-images.githubusercontent.com/458591/222474927-3772362a-6241-4396-97a1-b16b2afa9141.png">

Always happy to see @muratsu's face again 🙂 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
