### PR TITLE
setup-experience: add setup info to `jscontext`.

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -20,6 +20,8 @@ var HTTPAddrInternal = env.Get(
 
 var sourcegraphDotComMode, _ = strconv.ParseBool(env.Get("SOURCEGRAPHDOTCOM_MODE", "false", "run as Sourcegraph.com, with add'l marketing and redirects"))
 var openGraphPreviewServiceURL = env.Get("OPENGRAPH_PREVIEW_SERVICE_URL", "", "The URL of the OpenGraph preview image generating service")
+var extsvcConfigFile = env.Get("EXTSVC_CONFIG_FILE", "", "EXTSVC_CONFIG_FILE can contain configurations for multiple code host connections. See https://docs.sourcegraph.com/admin/config/advanced_config_file for details.")
+var extsvcConfigAllowEdits, _ = strconv.ParseBool(env.Get("EXTSVC_CONFIG_ALLOW_EDITS", "false", "When EXTSVC_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
 
 // SourcegraphDotComMode is true if this server is running Sourcegraph.com
 // (solely by checking the SOURCEGRAPHDOTCOM_MODE env var). Sourcegraph.com shows
@@ -35,4 +37,15 @@ func MockSourcegraphDotComMode(value bool) {
 
 func OpenGraphPreviewServiceURL() string {
 	return openGraphPreviewServiceURL
+}
+
+// ExtsvcConfigFile returns value of EXTSVC_CONFIG_FILE environment variable
+func ExtsvcConfigFile() string {
+	return extsvcConfigFile
+}
+
+// ExtsvcConfigAllowEdits returns boolean value of EXTSVC_CONFIG_ALLOW_EDITS
+// environment variable.
+func ExtsvcConfigAllowEdits() bool {
+	return extsvcConfigAllowEdits
 }

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -13,13 +13,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
@@ -29,12 +29,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var ExtsvcConfigAllowEdits, _ = strconv.ParseBool(env.Get("EXTSVC_CONFIG_ALLOW_EDITS", "false", "When EXTSVC_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
-
-var ExtsvcConfigFile = env.Get("EXTSVC_CONFIG_FILE", "", "EXTSVC_CONFIG_FILE can contain configurations for multiple code host connections. See https://docs.sourcegraph.com/admin/config/advanced_config_file for details.")
-
 func externalServicesWritable() error {
-	if ExtsvcConfigFile != "" && !ExtsvcConfigAllowEdits {
+	if envvar.ExtsvcConfigFile() != "" && !envvar.ExtsvcConfigAllowEdits() {
 		return errors.New("adding external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 	return nil

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -29,12 +29,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var extsvcConfigAllowEdits, _ = strconv.ParseBool(env.Get("EXTSVC_CONFIG_ALLOW_EDITS", "false", "When EXTSVC_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
+var ExtsvcConfigAllowEdits, _ = strconv.ParseBool(env.Get("EXTSVC_CONFIG_ALLOW_EDITS", "false", "When EXTSVC_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
 
-var extsvcConfigFile = env.Get("EXTSVC_CONFIG_FILE", "", "EXTSVC_CONFIG_FILE can contain configurations for multiple code host connections. See https://docs.sourcegraph.com/admin/config/advanced_config_file for details.")
+var ExtsvcConfigFile = env.Get("EXTSVC_CONFIG_FILE", "", "EXTSVC_CONFIG_FILE can contain configurations for multiple code host connections. See https://docs.sourcegraph.com/admin/config/advanced_config_file for details.")
 
 func externalServicesWritable() error {
-	if extsvcConfigFile != "" && !extsvcConfigAllowEdits {
+	if ExtsvcConfigFile != "" && !ExtsvcConfigAllowEdits {
 		return errors.New("adding external service not allowed when using EXTSVC_CONFIG_FILE")
 	}
 	return nil

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -44,11 +44,7 @@ func (r *schemaResolver) siteByGQLID(_ context.Context, id graphql.ID) (Node, er
 	if siteGQLID != singletonSiteGQLID {
 		return nil, errors.Errorf("site not found: %q", siteGQLID)
 	}
-	return &siteResolver{
-		logger: r.logger,
-		db:     r.db,
-		gqlID:  siteGQLID,
-	}, nil
+	return newSiteResolver(r.logger, r.db), nil
 }
 
 func marshalSiteGQLID(siteID string) graphql.ID { return relay.MarshalID("Site", siteID) }
@@ -63,9 +59,17 @@ func unmarshalSiteGQLID(id graphql.ID) (siteID string, err error) {
 }
 
 func (r *schemaResolver) Site() *siteResolver {
+	return newSiteResolver(r.logger, r.db)
+}
+
+func NewSiteResolver(logger log.Logger, db database.DB) *siteResolver {
+	return newSiteResolver(logger, db)
+}
+
+func newSiteResolver(logger log.Logger, db database.DB) *siteResolver {
 	return &siteResolver{
-		logger: r.logger,
-		db:     r.db,
+		logger: logger,
+		db:     db,
 		gqlID:  singletonSiteGQLID,
 	}
 }

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -71,5 +71,5 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 	return *NoLicenseWarningUserCount <= int32(userCount), nil
 }
 
-func (r *siteResolver) ExternalServicesFromFile() bool          { return extsvcConfigFile != "" }
-func (r *siteResolver) AllowEditExternalServicesWithFile() bool { return extsvcConfigAllowEdits }
+func (r *siteResolver) ExternalServicesFromFile() bool          { return ExtsvcConfigFile != "" }
+func (r *siteResolver) AllowEditExternalServicesWithFile() bool { return ExtsvcConfigAllowEdits }

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -71,5 +71,7 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 	return *NoLicenseWarningUserCount <= int32(userCount), nil
 }
 
-func (r *siteResolver) ExternalServicesFromFile() bool          { return ExtsvcConfigFile != "" }
-func (r *siteResolver) AllowEditExternalServicesWithFile() bool { return ExtsvcConfigAllowEdits }
+func (r *siteResolver) ExternalServicesFromFile() bool { return envvar.ExtsvcConfigFile() != "" }
+func (r *siteResolver) AllowEditExternalServicesWithFile() bool {
+	return envvar.ExtsvcConfigAllowEdits()
+}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	logger "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
@@ -172,6 +174,14 @@ type JSContext struct {
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit"`
 
 	DisableFeedbackSurvey bool `json:"disableFeedbackSurvey"`
+
+	NeedsRepositoryConfiguration bool `json:"needsRepositoryConfiguration"`
+
+	ExtsvcConfigFileExists bool `json:"extsvcConfigFileExists"`
+
+	ExtsvcConfigAllowEdits bool `json:"extsvcConfigAllowEdits"`
+
+	RunningOnMacOS bool `json:"runningOnMacOS"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -245,6 +255,15 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		licenseInfo = hooks.GetLicenseInfo(user != nil && user.SiteAdmin)
 	}
 
+	siteResolver := graphqlbackend.NewSiteResolver(logger.Scoped("jscontext", "constructing jscontext"), db)
+	needsRepositoryConfiguration, err := siteResolver.NeedsRepositoryConfiguration(ctx)
+	if err != nil {
+		needsRepositoryConfiguration = false
+	}
+
+	extsvcConfigFileExists := graphqlbackend.ExtsvcConfigFile != ""
+	runningOnMacOS := runtime.GOOS == "darwin"
+
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's
@@ -317,6 +336,14 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		OutboundRequestLogLimit: conf.Get().OutboundRequestLogLimit,
 
 		DisableFeedbackSurvey: conf.Get().DisableFeedbackSurvey,
+
+		NeedsRepositoryConfiguration: needsRepositoryConfiguration,
+
+		ExtsvcConfigFileExists: extsvcConfigFileExists,
+
+		ExtsvcConfigAllowEdits: graphqlbackend.ExtsvcConfigAllowEdits,
+
+		RunningOnMacOS: runningOnMacOS,
 	}
 }
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -261,7 +261,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		needsRepositoryConfiguration = false
 	}
 
-	extsvcConfigFileExists := graphqlbackend.ExtsvcConfigFile != ""
+	extsvcConfigFileExists := envvar.ExtsvcConfigFile() != ""
 	runningOnMacOS := runtime.GOOS == "darwin"
 
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
@@ -341,7 +341,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		ExtsvcConfigFileExists: extsvcConfigFileExists,
 
-		ExtsvcConfigAllowEdits: graphqlbackend.ExtsvcConfigAllowEdits,
+		ExtsvcConfigAllowEdits: envvar.ExtsvcConfigAllowEdits(),
 
 		RunningOnMacOS: runningOnMacOS,
 	}

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -40,8 +40,15 @@ func TestRedirects(t *testing.T) {
 		gss := database.NewMockGlobalStateStore()
 		gss.GetFunc.SetDefaultReturn(database.GlobalState{SiteID: "a"}, nil)
 
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
+		extSvcs := database.NewMockExternalServiceStore()
+		extSvcs.CountFunc.SetDefaultReturn(0, nil)
+
 		db := database.NewMockDB()
 		db.GlobalStateFunc.SetDefaultReturn(gss)
+		db.UsersFunc.SetDefaultReturn(users)
+		db.ExternalServicesFunc.SetDefaultReturn(extSvcs)
 
 		InitRouter(db, jobutil.NewUnimplementedEnterpriseJobs())
 		rw := httptest.NewRecorder()


### PR DESCRIPTION
Test plan:
Local sg run and `window.context` check.

Closes https://github.com/sourcegraph/sourcegraph/issues/48546