### PR TITLE
batches: fetch current user permissions

### DIFF
--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -53,6 +53,12 @@ export const currentAuthStateQuery = gql`
                 id
                 contents
             }
+            permissions {
+                nodes {
+                    id
+                    displayName
+                }
+            }
         }
     }
 `

--- a/client/shared/src/testing/integration/graphQlResults.ts
+++ b/client/shared/src/testing/integration/graphQlResults.ts
@@ -22,6 +22,7 @@ export const currentUserMock = {
     searchable: true,
     emails: [{ email: 'felix@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
+    permissions: { nodes: [] },
 } satisfies AuthenticatedUser
 
 /**

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -58,7 +58,6 @@ import { setQueryStateFromSettings, useNavbarQueryState } from './stores'
 import { eventLogger } from './tracking/eventLogger'
 import { UserSessionStores } from './UserSessionStores'
 import { siteSubjectNoAdmin, viewerSubjectFromSettings } from './util/settings'
-import { log } from 'console'
 
 interface LegacySourcegraphWebAppState extends SettingsCascadeProps {
     error?: Error

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -58,6 +58,7 @@ import { setQueryStateFromSettings, useNavbarQueryState } from './stores'
 import { eventLogger } from './tracking/eventLogger'
 import { UserSessionStores } from './UserSessionStores'
 import { siteSubjectNoAdmin, viewerSubjectFromSettings } from './util/settings'
+import { log } from 'console'
 
 interface LegacySourcegraphWebAppState extends SettingsCascadeProps {
     error?: Error
@@ -340,3 +341,5 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
     ): Observable<string[][]> =>
         fetchHighlightedFileLineRanges({ ...parameters, platformContext: this.platformContext }, force)
 }
+
+console.log(authenticatedUserValue, 'authenticatedUserValue')

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -341,5 +341,3 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
     ): Observable<string[][]> =>
         fetchHighlightedFileLineRanges({ ...parameters, platformContext: this.platformContext }, force)
 }
-
-console.log(authenticatedUserValue, 'authenticatedUserValue')

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -66,6 +66,7 @@ const authUser: AuthenticatedUser = {
     searchable: true,
     emails: [{ email: 'alice@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
+    permissions: { nodes: [] },
 }
 
 const repositories: SearchContextFields['repositories'] = [

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -27,6 +27,7 @@ export const mockUser: AuthenticatedUser = {
     searchable: true,
     emails: [{ email: 'user@me.com', isPrimary: true, verified: true }],
     latestSettings: null,
+    permissions: { nodes: [] },
 }
 
 export const mockCodeMonitorFields: CodeMonitorFields = {

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -88,6 +88,7 @@ const authUser: AuthenticatedUser = {
     searchable: true,
     emails: [{ email: 'alice@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
+    permissions: { nodes: [] },
 }
 
 const deleteSearchContext = sinon.fake(() => NEVER)

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -98,6 +98,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 searchable: true,
                 emails: [],
                 latestSettings: null,
+                permissions: { nodes: [] },
             },
         }),
         ...overrides,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -54,6 +54,7 @@ export type SourcegraphContextCurrentUser = Pick<
     | 'session'
     | 'emails'
     | 'latestSettings'
+    | 'permissions'
 >
 
 /**

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -464,6 +464,9 @@ func resolveUserPermissions(ctx context.Context, userResolver *graphqlbackend.Us
 		ConnectionResolverArgs: graphqlutil.ConnectionResolverArgs{},
 		User:                   &userID,
 	})
+	if err != nil {
+		return nil
+	}
 
 	nodes, err := permissionResolver.Nodes(ctx)
 	userPermissions := make([]Permission, 0, len(nodes))

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -453,7 +453,7 @@ func derefString(s *string) string {
 	return *s
 }
 
-func resolverUserPermissions(ctx context.Context, userResolver *graphqlbackend.UserResolver, licenseInfo *hooks.LicenseInfo) *PermissionsConnection {
+func resolveUserPermissions(ctx context.Context, userResolver *graphqlbackend.UserResolver, licenseInfo *hooks.LicenseInfo) *PermissionsConnection {
 	if isFreePlan(licenseInfo) {
 		return nil
 	}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -84,15 +84,15 @@ type TemporarySettings struct {
 	Contents        string `json:"contents"`
 }
 
-type Permissions struct {
+type Permission struct {
 	GraphQLTypename string     `json:"__typename"`
 	ID              graphql.ID `json:"id"`
 	DisplayName     string     `json:"displayName"`
 }
 
 type PermissionsConnection struct {
-	GraphQLTypename string        `json:"__typename"`
-	Nodes           []Permissions `json:"nodes"`
+	GraphQLTypename string       `json:"__typename"`
+	Nodes           []Permission `json:"nodes"`
 }
 type CurrentUser struct {
 	GraphQLTypename     string     `json:"__typename"`
@@ -442,7 +442,7 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB, li
 		URL:                 userResolver.URL(),
 		Username:            userResolver.Username(),
 		ViewerCanAdminister: canAdminister,
-		Permissions:         resolverUserPermissions(ctx, userResolver, licenseInfo),
+		Permissions:         resolveUserPermissions(ctx, userResolver, licenseInfo),
 	}
 }
 
@@ -465,13 +465,13 @@ func resolveUserPermissions(ctx context.Context, userResolver *graphqlbackend.Us
 		User:                   &userID,
 	})
 
-	userPermissions := []Permissions{}
 	nodes, err := permissionResolver.Nodes(ctx)
+	userPermissions := make([]Permission, 0, len(nodes))
 	// When an error occurs, we don't want to return nil - because when that occurs, we assume the user is on a free plan
 	// and doesn't have access to RBAC. Instead we return an empty permission slice.
 	if err == nil {
 		for _, node := range nodes {
-			userPermissions = append(userPermissions, Permissions{
+			userPermissions = append(userPermissions, Permission{
 				GraphQLTypename: "Permission",
 				ID:              node.ID(),
 				DisplayName:     node.DisplayName(),

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -83,6 +83,16 @@ type TemporarySettings struct {
 	Contents        string `json:"contents"`
 }
 
+type Permissions struct {
+	Typename    string     `json:"__typename"`
+	ID          graphql.ID `json:"id"`
+	DisplayName *string    `json:"displayName"`
+}
+
+type PermissionsConnection struct {
+	Typename string        `json:"__typename"`
+	Nodes    []Permissions `json:"nodes"`
+}
 type CurrentUser struct {
 	GraphQLTypename     string     `json:"__typename"`
 	ID                  graphql.ID `json:"id"`
@@ -102,6 +112,7 @@ type CurrentUser struct {
 	Session        *UserSession                 `json:"session"`
 	Emails         []UserEmail                  `json:"emails"`
 	LatestSettings *UserLatestSettings          `json:"latestSettings"`
+	Permissions    *PermissionsConnection       `json:"permissions"`
 }
 
 // JSContext is made available to JavaScript code via the

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -4,7 +4,6 @@ package jscontext
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"runtime"
@@ -384,7 +383,6 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 }
 
 func isFreePlan(licenseInfo *hooks.LicenseInfo) bool {
-	fmt.Println("license info ---", licenseInfo.CurrentPlan, "<=====")
 	if licenseInfo == nil {
 		return true
 	}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -85,14 +85,14 @@ type TemporarySettings struct {
 }
 
 type Permissions struct {
-	Typename    string     `json:"__typename"`
-	ID          graphql.ID `json:"id"`
-	DisplayName string     `json:"displayName"`
+	GraphQLTypename string     `json:"__typename"`
+	ID              graphql.ID `json:"id"`
+	DisplayName     string     `json:"displayName"`
 }
 
 type PermissionsConnection struct {
-	Typename string        `json:"__typename"`
-	Nodes    []Permissions `json:"nodes"`
+	GraphQLTypename string        `json:"__typename"`
+	Nodes           []Permissions `json:"nodes"`
 }
 type CurrentUser struct {
 	GraphQLTypename     string     `json:"__typename"`
@@ -472,16 +472,16 @@ func resolverUserPermissions(ctx context.Context, userResolver *graphqlbackend.U
 	if err == nil {
 		for _, node := range nodes {
 			userPermissions = append(userPermissions, Permissions{
-				Typename:    "Permission",
-				ID:          node.ID(),
-				DisplayName: node.DisplayName(),
+				GraphQLTypename: "Permission",
+				ID:              node.ID(),
+				DisplayName:     node.DisplayName(),
 			})
 		}
 	}
 
 	return &PermissionsConnection{
-		Typename: "PermissionConnection",
-		Nodes:    userPermissions,
+		GraphQLTypename: "PermissionConnection",
+		Nodes:           userPermissions,
 	}
 }
 


### PR DESCRIPTION
closes #47218
 
add `permissions` to `currentUser` query to fetch permissions of enterprise users

## Test plan
tested retrieval of permissions data for enterprise and free tier user
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
