### PR TITLE
[ranking] Enable ranking background jobs thru site config

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -158,6 +158,7 @@ type JSContext struct {
 	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
+	// TODO HERE MAYBE
 
 	CodeInsightsEnabled bool `json:"codeInsightsEnabled"`
 

--- a/enterprise/internal/codeintel/ranking/config.go
+++ b/enterprise/internal/codeintel/ranking/config.go
@@ -3,13 +3,14 @@ package ranking
 import (
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 type rankingConfig struct {
 	env.BaseConfig
 
-	DocumentReferenceCountsEnabled  bool
+	// DocumentReferenceCountsEnabled  bool
 	DocumentReferenceCountsGraphKey string
 	SymbolExporterInterval          time.Duration
 	SymbolExporterNumRoutines       int
@@ -23,13 +24,15 @@ type rankingConfig struct {
 var ConfigInst = &rankingConfig{}
 
 func (c *rankingConfig) Load() {
-	c.DocumentReferenceCountsEnabled = c.GetBool("CODEINTEL_RANKING_DOCUMENT_REFERENCE_COUNTS_ENABLED", "false", "Whether or not to run the ranking job.")
-	c.DocumentReferenceCountsGraphKey = c.Get("CODEINTEL_RANKING_DOCUMENT_REFERENCE_COUNTS_GRAPH_KEY", "dev", "Backdoor value used to restart the ranking export procedure.")
 	c.SymbolExporterInterval = c.GetInterval("CODEINTEL_RANKING_SYMBOL_EXPORTER_INTERVAL", "1s", "How frequently to serialize a batch of the code intel graph for ranking.")
 	c.SymbolExporterNumRoutines = c.GetInt("CODEINTEL_RANKING_SYMBOL_EXPORTER_NUM_ROUTINES", "4", "The number of concurrent ranking graph serializer routines to run per worker instance.")
 	c.SymbolExporterReadBatchSize = c.GetInt("CODEINTEL_RANKING_SYMBOL_EXPORTER_READ_BATCH_SIZE", "16", "How many uploads to process at once.")
 	c.SymbolExporterWriteBatchSize = c.GetInt("CODEINTEL_RANKING_SYMBOL_EXPORTER_WRITE_BATCH_SIZE", "10000", "The number of definitions and references to populate the ranking graph per batch.")
-	c.MapReducerInterval = c.GetInterval("CODEINTEL_RANKING_MAP_REDUCER_INTERVAL", "72h", "The maximum age of document reference count values used for ranking before being considered stale.")
 	c.MapperBatchSize = c.GetInt("CODEINTEL_RANKING_MAPPER_BATCH_SIZE", "1000", "How many definitions and references to map at once.")
 	c.ReducerBatchSize = c.GetInt("CODEINTEL_RANKING_REDUCER_BATCH_SIZE", "1000", "How many path counts to reduce at once.")
+
+	// Site config
+	// c.DocumentReferenceCountsEnabled = conf.CodeIntelRankingDocumentReferenceCountsEnabled()
+	c.DocumentReferenceCountsGraphKey = conf.CodeIntelRankingDocumentReferenceCountsGraphKey()
+	c.MapReducerInterval = conf.CodeIntelRankingMapReducerInterval()
 }

--- a/enterprise/internal/codeintel/ranking/init.go
+++ b/enterprise/internal/codeintel/ranking/init.go
@@ -34,7 +34,6 @@ func NewSymbolExporter(observationCtx *observation.Context, rankingService *Serv
 			ConfigInst.SymbolExporterNumRoutines,
 			ConfigInst.SymbolExporterInterval,
 			ConfigInst.SymbolExporterWriteBatchSize,
-			ConfigInst.DocumentReferenceCountsEnabled,
 		),
 	}
 }
@@ -45,7 +44,6 @@ func NewMapper(observationCtx *observation.Context, rankingService *Service) []g
 			observationCtx,
 			rankingService,
 			ConfigInst.SymbolExporterInterval,
-			ConfigInst.DocumentReferenceCountsEnabled,
 		),
 	}
 }
@@ -56,7 +54,6 @@ func NewReducer(observationCtx *observation.Context, rankingService *Service) []
 			observationCtx,
 			rankingService,
 			ConfigInst.SymbolExporterInterval,
-			ConfigInst.DocumentReferenceCountsEnabled,
 		),
 	}
 }

--- a/enterprise/internal/codeintel/ranking/internal/background/iface.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/iface.go
@@ -7,9 +7,9 @@ import (
 )
 
 type RankingService interface {
-	ExportRankingGraph(ctx context.Context, numRoutines int, numBatchSize int, rankingJobEnabled bool) error
-	MapRankingGraph(ctx context.Context, rankingJobEnabled bool) (int, int, error)
-	ReduceRankingGraph(ctx context.Context, rankingJobEnabled bool) (float64, float64, error)
+	ExportRankingGraph(ctx context.Context, numRoutines int, numBatchSize int) error
+	MapRankingGraph(ctx context.Context) (int, int, error)
+	ReduceRankingGraph(ctx context.Context) (float64, float64, error)
 	VacuumRankingGraph(ctx context.Context) error
 }
 

--- a/enterprise/internal/codeintel/ranking/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/job_graph_exporter.go
@@ -14,14 +14,13 @@ func NewSymbolExporter(
 	numRoutines int,
 	interval time.Duration,
 	batchSize int,
-	rankingJobEnabled bool,
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
 		"ranking.symbol-exporter", "exports SCIP data to ranking definitions and reference tables",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
-			if err := rankingService.ExportRankingGraph(ctx, numRoutines, batchSize, rankingJobEnabled); err != nil {
+			if err := rankingService.ExportRankingGraph(ctx, numRoutines, batchSize); err != nil {
 				return err
 			}
 
@@ -38,7 +37,6 @@ func NewMapper(
 	observationCtx *observation.Context,
 	rankingService RankingService,
 	interval time.Duration,
-	rankingJobEnabled bool,
 ) goroutine.BackgroundRoutine {
 	operations := newMapperOperations(observationCtx)
 
@@ -47,7 +45,7 @@ func NewMapper(
 		"ranking.file-reference-count-mapper", "maps definitions and references data to path_counts_inputs table in store",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
-			numReferenceRecordsProcessed, numInputsInserted, err := rankingService.MapRankingGraph(ctx, rankingJobEnabled)
+			numReferenceRecordsProcessed, numInputsInserted, err := rankingService.MapRankingGraph(ctx)
 			if err != nil {
 				return err
 			}
@@ -63,7 +61,6 @@ func NewReducer(
 	observationCtx *observation.Context,
 	rankingService RankingService,
 	interval time.Duration,
-	rankingJobEnabled bool,
 ) goroutine.BackgroundRoutine {
 	operations := newReducerOperations(observationCtx)
 
@@ -72,7 +69,7 @@ func NewReducer(
 		"ranking.file-reference-count-reducer", "reduces path_counts_inputs into a count of paths per repository and stores it in path_ranks table in store.",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
-			numPathRanksInserted, numPathCountsInputsProcessed, err := rankingService.ReduceRankingGraph(ctx, rankingJobEnabled)
+			numPathRanksInserted, numPathCountsInputsProcessed, err := rankingService.ReduceRankingGraph(ctx)
 			if err != nil {
 				return err
 			}

--- a/enterprise/internal/codeintel/ranking/ranking.go
+++ b/enterprise/internal/codeintel/ranking/ranking.go
@@ -11,14 +11,15 @@ import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func (s *Service) ExportRankingGraph(ctx context.Context, numRoutines int, numBatchSize int, rankingJobEnabled bool) (err error) {
+func (s *Service) ExportRankingGraph(ctx context.Context, numRoutines int, numBatchSize int) (err error) {
 	ctx, _, endObservation := s.operations.exportRankingGraph.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	if !rankingJobEnabled {
+	if enabled := conf.CodeIntelRankingDocumentReferenceCountsEnabled(); !enabled {
 		return nil
 	}
 
@@ -149,11 +150,11 @@ func (s *Service) VacuumRankingGraph(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) MapRankingGraph(ctx context.Context, rankingJobEnabled bool) (numReferenceRecordsProcessed int, numInputsInserted int, err error) {
+func (s *Service) MapRankingGraph(ctx context.Context) (numReferenceRecordsProcessed int, numInputsInserted int, err error) {
 	ctx, _, endObservation := s.operations.mapRankingGraph.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	if !rankingJobEnabled {
+	if enabled := conf.CodeIntelRankingDocumentReferenceCountsEnabled(); !enabled {
 		return 0, 0, nil
 	}
 
@@ -164,11 +165,11 @@ func (s *Service) MapRankingGraph(ctx context.Context, rankingJobEnabled bool) (
 	)
 }
 
-func (s *Service) ReduceRankingGraph(ctx context.Context, rankingJobEnabled bool) (numPathRanksInserted float64, numPathCountInputsProcessed float64, err error) {
+func (s *Service) ReduceRankingGraph(ctx context.Context) (numPathRanksInserted float64, numPathCountInputsProcessed float64, err error) {
 	ctx, _, endObservation := s.operations.reduceRankingGraph.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	if !rankingJobEnabled {
+	if enabled := conf.CodeIntelRankingDocumentReferenceCountsEnabled(); !enabled {
 		return 0, 0, nil
 	}
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -266,6 +266,27 @@ func CodeIntelAutoIndexingPolicyRepositoryMatchLimit() int {
 	return *val
 }
 
+func CodeIntelRankingDocumentReferenceCountsEnabled() bool {
+	if enabled := Get().CodeIntelRankingDocumentReferenceCountsEnabled; enabled != nil {
+		return *enabled
+	}
+	return false
+}
+
+func CodeIntelRankingDocumentReferenceCountsGraphKey() string {
+	if val := Get().CodeIntelRankingDocumentReferenceCountsGraphKey; val != "" {
+		return val
+	}
+	return "dev"
+}
+
+func CodeIntelRankingMapReducerInterval() time.Duration {
+	if val := Get().CodeIntelRankingMapReduceInterval; val > 0 {
+		return time.Duration(val)
+	}
+	return 72 * time.Hour
+}
+
 func EmbeddingsEnabled() bool {
 	embeddingsConfig := Get().Embeddings
 	return embeddingsConfig != nil && embeddingsConfig.Enabled

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2368,6 +2368,12 @@ type SiteConfiguration struct {
 	CodeIntelAutoIndexingIndexerMap map[string]string `json:"codeIntelAutoIndexing.indexerMap,omitempty"`
 	// CodeIntelAutoIndexingPolicyRepositoryMatchLimit description: The maximum number of repositories to which a single auto-indexing policy can apply. Default is -1, which is unlimited.
 	CodeIntelAutoIndexingPolicyRepositoryMatchLimit *int `json:"codeIntelAutoIndexing.policyRepositoryMatchLimit,omitempty"`
+	// CodeIntelRankingDocumentReferenceCountsEnabled description: Enables/disables the document reference counts feature. Currently experimental.
+	CodeIntelRankingDocumentReferenceCountsEnabled *bool `json:"codeIntelRanking.documentReferenceCountsEnabled,omitempty"`
+	// CodeIntelRankingDocumentReferenceCountsGraphKey description: The string used to group document reference counts for a single graph
+	CodeIntelRankingDocumentReferenceCountsGraphKey string `json:"codeIntelRanking.documentReferenceCountsGraphKey,omitempty"`
+	// CodeIntelRankingMapReduceInterval description: The interval at which to run the map/reduce job that computes document reference counts. Default is 72hrs.
+	CodeIntelRankingMapReduceInterval int `json:"codeIntelRanking.mapReduceInterval,omitempty"`
 	// Completions description: Configuration for the completions service.
 	Completions *Completions `json:"completions,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
@@ -2594,6 +2600,9 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "codeIntelAutoIndexing.enabled")
 	delete(m, "codeIntelAutoIndexing.indexerMap")
 	delete(m, "codeIntelAutoIndexing.policyRepositoryMatchLimit")
+	delete(m, "codeIntelRanking.documentReferenceCountsEnabled")
+	delete(m, "codeIntelRanking.documentReferenceCountsGraphKey")
+	delete(m, "codeIntelRanking.mapReduceInterval")
 	delete(m, "completions")
 	delete(m, "corsOrigin")
 	delete(m, "debug.search.symbolsParallelism")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -627,6 +627,25 @@
       "group": "Code intelligence",
       "default": false
     },
+    "codeIntelRanking.documentReferenceCountsEnabled": {
+      "description": "Enables/disables the document reference counts feature. Currently experimental.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Code intelligence",
+      "default": false
+    },
+    "codeIntelRanking.documentReferenceCountsGraphKey": {
+      "description": "The string used to group document reference counts for a single graph",
+      "type": "string",
+      "group": "Code intelligence",
+      "examples": ["dev"]
+    },
+    "codeIntelRanking.mapReduceInterval": {
+      "description": "The interval at which to run the map/reduce job that computes document reference counts. Default is 72hrs.",
+      "type": "integer",
+      "default": 259200000,
+      "group": "Code intelligence"
+    },
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",


### PR DESCRIPTION
Adds site config parameters to enable ranking background job instead of environment variable
## Test plan
Tested manually
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
