### PR TITLE
experimental serach input: Improve mobile view

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .container {
     flex: 1;
     position: relative;
@@ -43,10 +45,19 @@
         display: block;
     }
 
+    @media (--xs-breakpoint-down) {
+        flex-direction: column;
+        align-items: start;
+        padding: 0.5rem;
+        gap: 0.5rem;
+    }
+
     &:focus-within {
-        outline: 2px solid var(--primary-2);
-        outline-offset: 0;
-        border-color: var(--primary-2);
+        @media (--sm-breakpoint-up) {
+            outline: 2px solid var(--primary-2);
+            outline-offset: 0;
+            border-color: var(--primary-2);
+        }
 
         .hide-when-focused {
             display: none;
@@ -72,11 +83,35 @@
         }
     }
 
-    .global-shortcut {
-        display: block;
-        align-self: center;
-        border: 1px solid var(--border-color-2);
-        width: 1.5rem;
+    :global(.cm-content) {
+        @media (--xs-breakpoint-down) {
+            // Automatically enable line wrapping on small screens.
+            // CodeMirror's own lineWrapping extension does the same
+            // (also see https://codemirror.net/examples/styling/)
+            white-space: pre-wrap; // For IE
+            white-space: break-spaces;
+            word-break: break-word; // For Safari, which doesn't support overflow-wrap: anywhere
+            overflow-wrap: anywhere;
+            flex-shrink: 1;
+        }
+    }
+
+    .input {
+        display: contents;
+
+        @media (--xs-breakpoint-down) {
+            display: block;
+            width: 100%;
+            border: 1px solid var(--border-color-2);
+            border-radius: 4px;
+            padding: 0.375rem 0.5rem;
+
+            &:focus-within {
+                outline: 2px solid var(--primary-2);
+                outline-offset: 0;
+                border-color: var(--primary-2);
+            }
+        }
     }
 }
 
@@ -114,6 +149,10 @@
     &.active {
         color: var(--logo-purple);
         padding: 0;
+        border: 0;
+    }
+
+    @media (--xs-breakpoint-down) {
         border: 0;
     }
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -366,7 +366,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
                         </Tooltip>
                         {mode && <span className="ml-1">{mode}:</span>}
                     </div>
-                    <div ref={editorContainerRef} className="d-contents" />
+                    <div ref={editorContainerRef} className={styles.input} />
                     {children}
                 </div>
                 <div ref={setSuggestionsContainer} className={styles.suggestions} />

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .container {
     overflow-y: hidden;
     display: flex;
@@ -41,6 +43,50 @@
                 padding: 0 0.5rem;
             }
 
+            /*
+                Layout of a row
+                The icon is always top aligned next to the label.
+                Label and description can wrap around if necessary, in which case the 
+                action labels are centered.
+                On small screens the action labels are shown on a separate row.
+
+                Normal:
+                       ┌── inner-row ────────────────────────┐
+                       │┌────────────────────────┐           │
+               ┌──────┐││┌───────┐┌─────────────┐│┌─────────┐│
+               │ Icon ││││ Label ││ Description │││ Actions ││
+               └──────┘││└───────┘└─────────────┘│└─────────┘│
+                       │└────────────────────────┘           │
+                       └─────────────────────────────────────┘
+
+                Wrapped description:
+                       ┌─── inner-row ───────────────────────┐
+                       │┌────────────────────────┐           │
+               ┌──────┐││┌──────────────────────┐│           │
+               │ Icon ││││ Label                ││┌─────────┐│
+               └──────┘││└──────────────────────┘││ Actions ││
+                       ││┌──────────────────────┐│└─────────┘│
+                       │││ Description          ││           │
+                       ││└──────────────────────┘│           │
+                       │└────────────────────────┘           │
+                       └─────────────────────────────────────┘
+
+                Mobile:
+                       ┌─── inner-row ───────────────────────┐
+                       │┌───────────────────────────────────┐│
+               ┌──────┐││┌─────────────────────────────────┐││
+               │ Icon ││││ Label                           │││
+               └──────┘││└─────────────────────────────────┘││
+                       ││┌─────────────────────────────────┐││
+                       │││ Description                     │││
+                       ││└─────────────────────────────────┘││
+                       │└───────────────────────────────────┘│
+                       │┌───────────────────────────────────┐│
+                       ││ Actions                           ││
+                       │└───────────────────────────────────┘│
+                       └─────────────────────────────────────┘
+
+            */
             [role='row'] {
                 display: flex;
                 align-items: center;
@@ -58,6 +104,19 @@
                 &:hover {
                     background-color: var(--color-bg-2);
                     cursor: pointer;
+                }
+
+                // Used to make label and actions wrappable
+                .inner-row {
+                    display: flex;
+                    flex: 1;
+                    align-items: center;
+
+                    @media (--xs-breakpoint-down) {
+                        flex-direction: column;
+                        align-items: start;
+                        gap: 0.25rem;
+                    }
                 }
 
                 .label {
@@ -80,6 +139,10 @@
                     display: flex;
                     white-space: nowrap;
 
+                    @media (--xs-breakpoint-down) {
+                        margin-left: 0;
+                    }
+
                     > [role='gridcell'] {
                         padding: 0 0.5rem;
 
@@ -89,6 +152,12 @@
 
                         + [role='gridcell'] {
                             border-left: 1px solid var(--border-color-2);
+                        }
+
+                        @media (--xs-breakpoint-down) {
+                            &:first-of-type {
+                                padding-left: 0;
+                            }
                         }
                     }
                 }

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -116,31 +116,33 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
                                             <Icon className={styles.icon} svgPath={option.icon} aria-hidden="true" />
                                         </div>
                                     )}
-                                    <div className="d-flex flex-wrap">
-                                        <div role="gridcell" className={styles.label}>
-                                            {option.render ? (
-                                                renderStringOrRenderer(option.render, option)
-                                            ) : option.matches ? (
-                                                <HighlightedLabel label={option.label} matches={option.matches} />
-                                            ) : (
-                                                option.label
+                                    <div className={styles.innerRow}>
+                                        <div className="d-flex flex-wrap">
+                                            <div role="gridcell" className={styles.label}>
+                                                {option.render ? (
+                                                    renderStringOrRenderer(option.render, option)
+                                                ) : option.matches ? (
+                                                    <HighlightedLabel label={option.label} matches={option.matches} />
+                                                ) : (
+                                                    option.label
+                                                )}
+                                            </div>
+                                            {option.description && (
+                                                <div role="gridcell" className={styles.description}>
+                                                    {option.description}
+                                                </div>
                                             )}
                                         </div>
-                                        {option.description && (
-                                            <div role="gridcell" className={styles.description}>
-                                                {option.description}
+                                        <div className={styles.note}>
+                                            <div role="gridcell" data-action="primary">
+                                                {getActionName(option.action)}
                                             </div>
-                                        )}
-                                    </div>
-                                    <div className={styles.note}>
-                                        <div role="gridcell" data-action="primary">
-                                            {getActionName(option.action)}
+                                            {option.alternativeAction && (
+                                                <div role="gridcell" data-action="secondary">
+                                                    {getActionName(option.alternativeAction)}
+                                                </div>
+                                            )}
                                         </div>
-                                        {option.alternativeAction && (
-                                            <div role="gridcell" data-action="secondary">
-                                                {getActionName(option.alternativeAction)}
-                                            </div>
-                                        )}
                                     </div>
                                 </li>
                             ))}


### PR DESCRIPTION
Currently the new search input is not very usable on mobile because we render everything on a single line, including suggestions.

With this PR, on small screens the new search input looks more like the current one.

- History button, search input and toggle buttons are all on their own row.
- The focus outline is put on the actual input only (having it around the whole element like in the single line case felt weird).
- In suggestions actions are moved to a separate row.

Before: 
<img width="250" alt="2023-03-02_22-15" src="https://user-images.githubusercontent.com/179026/222571611-8b364ccf-f6ac-4b03-9921-ee9904b87388.png">

After: 

https://user-images.githubusercontent.com/179026/222571631-77247145-35b6-4ffd-95a2-a31b0a0d2e22.mp4




## Test plan

Resize page.
