### PR TITLE
sentinel: Vulnerability matcher routine

### DIFF
--- a/enterprise/internal/codeintel/sentinel/config.go
+++ b/enterprise/internal/codeintel/sentinel/config.go
@@ -11,6 +11,7 @@ type sentinelConfig struct {
 
 	DownloaderInterval time.Duration
 	MatcherInterval    time.Duration
+	BatchSize          int
 }
 
 var ConfigInst = &sentinelConfig{}
@@ -18,4 +19,5 @@ var ConfigInst = &sentinelConfig{}
 func (c *sentinelConfig) Load() {
 	c.DownloaderInterval = c.GetInterval("CODEINTEL_SENTINEL_DOWNLOADER_INTERVAL", "1h", "How frequently to sync the vulnerability database.")
 	c.MatcherInterval = c.GetInterval("CODEINTEL_SENTINEL_MATCHER_INTERVAL", "1s", "How frequently to match existing records against known vulnerabilities.")
+	c.BatchSize = c.GetInt("CODEINTEL_SENTINEL_BATCH_SIZE", "100", "How many precise indexes to scan at once for vulnerabilities.")
 }

--- a/enterprise/internal/codeintel/sentinel/init.go
+++ b/enterprise/internal/codeintel/sentinel/init.go
@@ -35,6 +35,6 @@ func CVEScannerJob(observationCtx *observation.Context, service *Service) []goro
 
 	return []goroutine.BackgroundRoutine{
 		background.NewCVEDownloader(service.store, metrics, ConfigInst.DownloaderInterval),
-		background.NewCVEMatcher(service.store, metrics, ConfigInst.MatcherInterval),
+		background.NewCVEMatcher(service.store, metrics, ConfigInst.MatcherInterval, ConfigInst.BatchSize),
 	}
 }

--- a/enterprise/internal/codeintel/sentinel/internal/background/cve_matcher.go
+++ b/enterprise/internal/codeintel/sentinel/internal/background/cve_matcher.go
@@ -8,13 +8,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func NewCVEMatcher(store store.Store, metrics *Metrics, interval time.Duration) goroutine.BackgroundRoutine {
+func NewCVEMatcher(store store.Store, metrics *Metrics, interval time.Duration, batchSize int) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
-		"codeintel.sentinel-cve-matcher", "TODO",
+		"codeintel.sentinel-cve-matcher", "Matches SCIP indexes against known vulnerabilities.",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
-			// Currently unimplemented
+			numReferencesScanned, numVulnerabilityMatches, err := store.ScanMatches(ctx, batchSize)
+			if err != nil {
+				return err
+			}
+
+			metrics.numReferencesScanned.Add(float64(numReferencesScanned))
+			metrics.numVulnerabilityMatches.Add(float64(numVulnerabilityMatches))
 			return nil
 		}),
 	)

--- a/enterprise/internal/codeintel/sentinel/internal/background/metrics.go
+++ b/enterprise/internal/codeintel/sentinel/internal/background/metrics.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Metrics struct {
+	numReferencesScanned       prometheus.Counter
+	numVulnerabilityMatches    prometheus.Counter
 	numVulnerabilitiesInserted prometheus.Counter
 }
 
@@ -25,8 +27,18 @@ func NewMetrics(observationCtx *observation.Context) *Metrics {
 		"src_codeintel_sentinel_num_vulnerabilities_inserted_total",
 		"The number of vulnerability records inserted into Postgres.",
 	)
+	numReferencesScanned := counter(
+		"src_codeintel_sentinel_num_references_scanned_total",
+		"The total number of references scanned for vulnerabilities.",
+	)
+	numVulnerabilityMatches := counter(
+		"src_codeintel_sentinel_num_vulnerability_matches_total",
+		"The total number of vulnerability matches found.",
+	)
 
 	return &Metrics{
+		numReferencesScanned:       numReferencesScanned,
+		numVulnerabilityMatches:    numVulnerabilityMatches,
 		numVulnerabilitiesInserted: numVulnerabilitiesInserted,
 	}
 }

--- a/enterprise/internal/codeintel/sentinel/internal/store/matches_test.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/matches_test.go
@@ -33,7 +33,7 @@ func TestVulnerabilityMatchByID(t *testing.T) {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
 	}
 
-	if err := store.ScanMatches(ctx); err != nil {
+	if _, _, err := store.ScanMatches(ctx, 100); err != nil {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
 	}
 
@@ -68,7 +68,7 @@ func TestGetVulnerabilityMatches(t *testing.T) {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
 	}
 
-	if err := store.ScanMatches(ctx); err != nil {
+	if _, _, err := store.ScanMatches(ctx, 100); err != nil {
 		t.Fatalf("unexpected error inserting vulnerabilities: %s", err)
 	}
 

--- a/enterprise/internal/codeintel/sentinel/internal/store/store.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/store.go
@@ -19,7 +19,7 @@ type Store interface {
 
 	VulnerabilityMatchByID(ctx context.Context, id int) (shared.VulnerabilityMatch, bool, error)
 	GetVulnerabilityMatches(ctx context.Context, args shared.GetVulnerabilityMatchesArgs) ([]shared.VulnerabilityMatch, int, error)
-	ScanMatches(ctx context.Context) error
+	ScanMatches(ctx context.Context, batchSize int) (numReferencesScanned int, numVulnerabilityMatches int, _ error)
 }
 
 type store struct {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -800,6 +800,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "lsif_uploads_vulnerability_scan_id_seq",
+      "TypeName": "bigint",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 9223372036854775807,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "migration_logs_id_seq",
       "TypeName": "integer",
       "StartValue": 1,
@@ -15990,6 +15999,83 @@
         }
       ],
       "Constraints": null,
+      "Triggers": []
+    },
+    {
+      "Name": "lsif_uploads_vulnerability_scan",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "nextval('lsif_uploads_vulnerability_scan_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "last_scanned_at",
+          "Index": 3,
+          "TypeName": "timestamp without time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "upload_id",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "lsif_uploads_vulnerability_scan_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX lsif_uploads_vulnerability_scan_pkey ON lsif_uploads_vulnerability_scan USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "lsif_uploads_vulnerability_scan_upload_id",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX lsif_uploads_vulnerability_scan_upload_id ON lsif_uploads_vulnerability_scan USING btree (upload_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "fk_upload_id",
+          "ConstraintType": "f",
+          "RefTableName": "lsif_uploads",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE"
+        }
+      ],
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2274,6 +2274,7 @@ Check constraints:
 Referenced by:
     TABLE "codeintel_ranking_exports" CONSTRAINT "codeintel_ranking_exports_upload_id_fkey" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE SET NULL
     TABLE "vulnerability_matches" CONSTRAINT "fk_upload" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
+    TABLE "lsif_uploads_vulnerability_scan" CONSTRAINT "fk_upload_id" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_dependency_syncing_jobs" CONSTRAINT "lsif_dependency_indexing_jobs_upload_id_fkey" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_dependency_indexing_jobs" CONSTRAINT "lsif_dependency_indexing_jobs_upload_id_fkey1" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_packages" CONSTRAINT "lsif_packages_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
@@ -2392,6 +2393,21 @@ Associates a repository with the set of LSIF upload identifiers that can serve i
 **is_default_branch**: Whether the specified branch is the default of the repository. Always false for tags.
 
 **upload_id**: The identifier of the upload visible from the tip of the specified branch or tag.
+
+# Table "public.lsif_uploads_vulnerability_scan"
+```
+     Column      |            Type             | Collation | Nullable |                           Default                           
+-----------------+-----------------------------+-----------+----------+-------------------------------------------------------------
+ id              | bigint                      |           | not null | nextval('lsif_uploads_vulnerability_scan_id_seq'::regclass)
+ upload_id       | integer                     |           | not null | 
+ last_scanned_at | timestamp without time zone |           | not null | now()
+Indexes:
+    "lsif_uploads_vulnerability_scan_pkey" PRIMARY KEY, btree (id)
+    "lsif_uploads_vulnerability_scan_upload_id" UNIQUE, btree (upload_id)
+Foreign-key constraints:
+    "fk_upload_id" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
+
+```
 
 # Table "public.migration_logs"
 ```

--- a/migrations/frontend/1677803354_add_vulnerability_scan_log_table/down.sql
+++ b/migrations/frontend/1677803354_add_vulnerability_scan_log_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS lsif_uploads_vulnerability_scan;

--- a/migrations/frontend/1677803354_add_vulnerability_scan_log_table/metadata.yaml
+++ b/migrations/frontend/1677803354_add_vulnerability_scan_log_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add vulnerability scan log table
+parents: [1677483453, 1677607213, 1677700103]

--- a/migrations/frontend/1677803354_add_vulnerability_scan_log_table/up.sql
+++ b/migrations/frontend/1677803354_add_vulnerability_scan_log_table/up.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS lsif_uploads_vulnerability_scan (
     CONSTRAINT fk_upload_id FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXiSTS lsif_uploads_vulnerability_scan_upload_id ON lsif_uploads_vulnerability_scan(upload_id);
+CREATE UNIQUE INDEX IF NOT EXISTS lsif_uploads_vulnerability_scan_upload_id ON lsif_uploads_vulnerability_scan(upload_id);

--- a/migrations/frontend/1677803354_add_vulnerability_scan_log_table/up.sql
+++ b/migrations/frontend/1677803354_add_vulnerability_scan_log_table/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS lsif_uploads_vulnerability_scan (
+    ID BIGSERIAL PRIMARY KEY,
+    upload_id INT NOT NULL,
+    last_scanned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_upload_id FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXiSTS lsif_uploads_vulnerability_scan_upload_id ON lsif_uploads_vulnerability_scan(upload_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3124,6 +3124,21 @@ COMMENT ON COLUMN lsif_uploads_visible_at_tip.branch_or_tag_name IS 'The name of
 
 COMMENT ON COLUMN lsif_uploads_visible_at_tip.is_default_branch IS 'Whether the specified branch is the default of the repository. Always false for tags.';
 
+CREATE TABLE lsif_uploads_vulnerability_scan (
+    id bigint NOT NULL,
+    upload_id integer NOT NULL,
+    last_scanned_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE lsif_uploads_vulnerability_scan_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE lsif_uploads_vulnerability_scan_id_seq OWNED BY lsif_uploads_vulnerability_scan.id;
+
 CREATE VIEW lsif_uploads_with_repository_name AS
  SELECT u.id,
     u.commit,
@@ -4508,6 +4523,8 @@ ALTER TABLE ONLY lsif_uploads ALTER COLUMN id SET DEFAULT nextval('lsif_dumps_id
 
 ALTER TABLE ONLY lsif_uploads_audit_logs ALTER COLUMN sequence SET DEFAULT nextval('lsif_uploads_audit_logs_seq'::regclass);
 
+ALTER TABLE ONLY lsif_uploads_vulnerability_scan ALTER COLUMN id SET DEFAULT nextval('lsif_uploads_vulnerability_scan_id_seq'::regclass);
+
 ALTER TABLE ONLY namespace_permissions ALTER COLUMN id SET DEFAULT nextval('namespace_permissions_id_seq'::regclass);
 
 ALTER TABLE ONLY notebooks ALTER COLUMN id SET DEFAULT nextval('notebooks_id_seq'::regclass);
@@ -4856,6 +4873,9 @@ ALTER TABLE ONLY lsif_uploads
 
 ALTER TABLE ONLY lsif_uploads_reference_counts
     ADD CONSTRAINT lsif_uploads_reference_counts_upload_id_key UNIQUE (upload_id);
+
+ALTER TABLE ONLY lsif_uploads_vulnerability_scan
+    ADD CONSTRAINT lsif_uploads_vulnerability_scan_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY names
     ADD CONSTRAINT names_pkey PRIMARY KEY (name);
@@ -5352,6 +5372,8 @@ CREATE INDEX lsif_uploads_visible_at_tip_is_default_branch ON lsif_uploads_visib
 
 CREATE INDEX lsif_uploads_visible_at_tip_repository_id_upload_id ON lsif_uploads_visible_at_tip USING btree (repository_id, upload_id);
 
+CREATE UNIQUE INDEX lsif_uploads_vulnerability_scan_upload_id ON lsif_uploads_vulnerability_scan USING btree (upload_id);
+
 CREATE INDEX notebook_stars_user_id_idx ON notebook_stars USING btree (user_id);
 
 CREATE INDEX notebooks_blocks_tsvector_idx ON notebooks USING gin (blocks_tsvector);
@@ -5812,6 +5834,9 @@ ALTER TABLE ONLY codeintel_ranking_references_processed
 
 ALTER TABLE ONLY vulnerability_matches
     ADD CONSTRAINT fk_upload FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY lsif_uploads_vulnerability_scan
+    ADD CONSTRAINT fk_upload_id FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY vulnerability_affected_packages
     ADD CONSTRAINT fk_vulnerabilities FOREIGN KEY (vulnerability_id) REFERENCES vulnerabilities(id) ON DELETE CASCADE;


### PR DESCRIPTION
This PR implements the background routine that will periodically match uses of dependences in SCIP indexes against known vulnerabilities.

## Test plan

Tested locally.