### PR TITLE
Fix GitHub pull links for blame lines

### DIFF
--- a/client/web/src/repo/commit/CommitMessageWithLinks.test.tsx
+++ b/client/web/src/repo/commit/CommitMessageWithLinks.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
+
+import { ExternalServiceKind } from '../../graphql-operations'
+
+import { CommitMessageWithLinks } from './CommitMessageWithLinks'
+
+describe('CommitMessageWithLinks', () => {
+    test('works with a commit link', () => {
+        const content = renderWithBrandedContext(
+            <CommitMessageWithLinks
+                message="dev/sg: migrate to urfave/cli (#1234)"
+                to="/foo/bar"
+                className=""
+                externalURLs={[
+                    {
+                        serviceKind: ExternalServiceKind.GITHUB,
+                        url: 'https://github.com/sourcegraph/sourcegraph/commit/aad9f1050b914041feb8d965deaa49a301cb3a28',
+                    },
+                ]}
+            />
+        )
+        expect(content.asFragment()).toMatchSnapshot()
+    })
+
+    test('works with a repo link', () => {
+        const content = renderWithBrandedContext(
+            <CommitMessageWithLinks
+                message="dev/sg: migrate to urfave/cli (#1234)"
+                to="/foo/bar"
+                className=""
+                externalURLs={[
+                    {
+                        serviceKind: ExternalServiceKind.GITHUB,
+                        url: 'https://github.com/sourcegraph/sourcegraph',
+                    },
+                ]}
+            />
+        )
+        expect(content.asFragment()).toMatchSnapshot()
+    })
+})

--- a/client/web/src/repo/commit/CommitMessageWithLinks.tsx
+++ b/client/web/src/repo/commit/CommitMessageWithLinks.tsx
@@ -88,7 +88,7 @@ export const CommitMessageWithLinks = ({
 // https://github.com/sourcegraph/sourcegraph/commit/ad1ea519e5a31bb868be947107bcf43f4f9fc672
 //
 // This function removes those unwanted parts
-const GITHUB_URL_SCHEMA = /^(https?:\/\/[^/]+\/[^/]+\/[^/]+)(.+)$/
+const GITHUB_URL_SCHEMA = /^(https?:\/\/[^/]+\/[^/]+\/[^/]+)(.*)$/
 function githubRepoUrl(url: string): string {
     const match = url.match(GITHUB_URL_SCHEMA)
     if (match?.[1]) {

--- a/client/web/src/repo/commit/__snapshots__/CommitMessageWithLinks.test.tsx.snap
+++ b/client/web/src/repo/commit/__snapshots__/CommitMessageWithLinks.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommitMessageWithLinks works with a commit link 1`] = `
+<DocumentFragment>
+  <a
+    class="anchorLink"
+    data-testid="git-commit-node-message-subject"
+    href="/foo/bar"
+  >
+    dev/sg: migrate to urfave/cli (
+  </a>
+  <a
+    class="anchorLink"
+    href="https://github.com/sourcegraph/sourcegraph/pull/1234"
+    rel="noreferrer noopener"
+    target="blank"
+  >
+    #1234
+  </a>
+  <a
+    class="anchorLink"
+    data-testid="git-commit-node-message-subject"
+    href="/foo/bar"
+  >
+    )
+  </a>
+</DocumentFragment>
+`;
+
+exports[`CommitMessageWithLinks works with a repo link 1`] = `
+<DocumentFragment>
+  <a
+    class="anchorLink"
+    data-testid="git-commit-node-message-subject"
+    href="/foo/bar"
+  >
+    dev/sg: migrate to urfave/cli (
+  </a>
+  <a
+    class="anchorLink"
+    href="https://github.com/sourcegraph/sourcegraph/pull/1234"
+    rel="noreferrer noopener"
+    target="blank"
+  >
+    #1234
+  </a>
+  <a
+    class="anchorLink"
+    data-testid="git-commit-node-message-subject"
+    href="/foo/bar"
+  >
+    )
+  </a>
+</DocumentFragment>
+`;


### PR DESCRIPTION
When constructing the GitHub links inside the git blame feature, we were getting the repo URL instead of the commit URL. Because the last capture group in the regex was `+` instead of `*` it still had to match at least one character and so it was cutting of the last sign.

## Test plan

- Check the snapshot tests. The URL is now correct in both cases.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-github-repo-parsing-regex.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
