### PR TITLE
own: Small ingestion API fixes

### DIFF
--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -78,8 +78,13 @@ type CodeownersFileInput struct {
 	RepoName     *string
 }
 
+type DeleteCodeownersFilesInput struct {
+	RepoID   *graphql.ID
+	RepoName *string
+}
+
 type DeleteCodeownersFileArgs struct {
-	RepositoryIDs []int32
+	Repositories []DeleteCodeownersFilesInput
 }
 
 type CodeownersIngestedFilesArgs struct {

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -155,6 +155,10 @@ extend type Mutation {
     deleteCodeownersFiles(repositories: [DeleteCodeownersFilesInput!]!): EmptyResponse
 }
 
+"""
+A repository to pass to the deleteCodeownersFiles mutation. Either repoID or repoName
+must be provided.
+"""
 input DeleteCodeownersFilesInput {
     """
     The repo ID to ingest the file for. Cannot be set with repositoryName.
@@ -167,7 +171,7 @@ input DeleteCodeownersFilesInput {
 }
 
 """
-codeownersArgs represents the input for ingesting codeowners files
+CodeownersFileInput represents the input for ingesting codeowners files
 """
 input CodeownersFileInput {
     """

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -150,9 +150,20 @@ extend type Mutation {
     """
     updateCodeownersFile(input: CodeownersFileInput!): CodeownersIngestedFile!
     """
-    deleteCodeownersFile deletes any existing Codeowners file for the given repositories.
+    deleteCodeownersFiles deletes any existing Codeowners file for the given repositories.
     """
-    deleteCodeownersFiles(repositoryIDs: [Int!]!): EmptyResponse
+    deleteCodeownersFiles(repositories: [DeleteCodeownersFilesInput!]!): EmptyResponse
+}
+
+input DeleteCodeownersFilesInput {
+    """
+    The repo ID to ingest the file for. Cannot be set with repositoryName.
+    """
+    repoID: ID
+    """
+    The repo name to ingest the file for. Cannot be set with repositoryID.
+    """
+    repoName: String
 }
 
 """

--- a/enterprise/internal/database/codeowners.go
+++ b/enterprise/internal/database/codeowners.go
@@ -30,7 +30,7 @@ type CodeownersStore interface {
 	// GetCodeownersForRepo gets a manually ingested Codeowners file for the given repo if it exists.
 	GetCodeownersForRepo(ctx context.Context, id api.RepoID) (*types.CodeownersFile, error)
 	// DeleteCodeownersForRepos deletes manually ingested Codeowners files for the given repos if it exists.
-	DeleteCodeownersForRepos(ctx context.Context, ids ...int32) error
+	DeleteCodeownersForRepos(ctx context.Context, ids ...api.RepoID) error
 	// ListCodeowners lists manually ingested Codeowners files given the options.
 	ListCodeowners(ctx context.Context, opts ListCodeownersOpts) ([]*types.CodeownersFile, int32, error)
 	// CountCodeownersFiles counts the number of manually ingested Codeowners files.
@@ -178,7 +178,7 @@ WHERE %s
 LIMIT 1
 `
 
-func (s *codeownersStore) DeleteCodeownersForRepos(ctx context.Context, ids ...int32) error {
+func (s *codeownersStore) DeleteCodeownersForRepos(ctx context.Context, ids ...api.RepoID) error {
 	return s.WithTransact(ctx, func(tx CodeownersStore) error {
 		conds := []*sqlf.Query{
 			sqlf.Sprintf("repo_id = ANY (%s)", pq.Array(ids)),


### PR DESCRIPTION
- GraphQL APIs have to take IDs vs ints, so I adjusted that and also allowed names now, which makes things a bit easier in src-cli
- Removed a redundant err.Wrap, that was rendering the same content twice

## Test plan

Verified with new src-cli interface.