### PR TITLE
Azure DevOps Webhooks for Batch Changes

### DIFF
--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -15,6 +15,7 @@ GitHub | 🟢 | 🟢 | 🟢
 GitLab | 🟢 | 🟢 | 🔴
 Bitbucket Server / Datacenter | 🟢 | 🟢 | 🔴
 Bitbucket Cloud | 🟢 | 🟢 | 🔴
+Azure DevOps | 🔴 | 🟢 | 🔴
 
 To receive webhooks both Sourcegraph and the code host need to be configured. To configure Sourcegraph, [add an incoming webhook](#adding-an-incoming-webhook). Then [configure webhooks on your code host](#configuring-webhooks-on-the-code-host)
 
@@ -150,6 +151,25 @@ Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use t
 #### Code push
 
 Follow the same steps as above, but ensure you tick the `Push` option.
+
+### Azure DevOps
+
+#### Batch changes
+
+> NOTE: Experimental webhook support for Azure DevOps was added in Sourcegraph 5.0, and does not currently support secrets. Please <a href="https://about.sourcegraph.com/contact">contact us</a> with any issues found while using webhooks.
+
+1. On Azure DevOps, go to each project, and then **Project settings > Service hooks**.
+2. Click **Create a new subscription**.
+3. Select **Web Hooks**. From the **Trigger on this type of event** drop-down, choose: **Pull request updated**.
+4. Set the filters how you like, or leave them at the default: **\[Any\]**
+5. Fill in the webhook form:
+  * **URL**: The URL found after creating an incoming webhook.
+  * Leave the rest of the fields on the default values.
+6. Click **Test** to verify the webhook works. Then click **Finish**.
+7. Repeat the steps above, this time choosing **Pull request merged** as your event type.
+
+Done! Sourcegraph will now receive webhook events from Azure DevOps and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
 
 ## Webhook logging
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -48,7 +48,7 @@ func (h *AzureDevOpsWebhook) Register(router *fewebhooks.Router) {
 func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
 	ctx = actor.WithInternalActor(ctx)
 
-	// If the event is just a general PR update event, it is best to just not try to derive the state from it and
+	// If the event is: PullRequestUpdatedEvent or PullRequestMergedEvent, it is best to just not try to derive the state from it and
 	// pull it in manually 💪.
 	switch e := event.(type) {
 	case *azuredevops.PullRequestUpdatedEvent:
@@ -123,7 +123,7 @@ func azureDevOpsPullRequestEventPRs(e azuredevops.PullRequestEvent) []PR {
 // would be difficult.
 func (h *AzureDevOpsWebhook) enqueueAzureDevOpsChangesetSyncFromEvent(ctx context.Context, esID extsvc.CodeHostBaseURL, event azuredevops.PullRequestEvent) error {
 	// We need to get our changeset ID for this to work. To get _there_, we need
-	// the repo ID, and then we can use the merge request IID to match the
+	// the repo ID, and then we can use the merge request ID to match the
 	// external ID.
 	pr := azureDevOpsToPR(event.PullRequest)
 	repo, err := h.getRepoForPR(ctx, h.Store, pr, esID)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -3,6 +3,8 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strconv"
 
 	"github.com/sourcegraph/log"
 	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
@@ -12,13 +14,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var azureDevOpsEvents = []string{
-	"git.pullrequest.created",
 	"git.pullrequest.updated",
 	"git.pullrequest.merged",
+	"git.pullrequest.approved",
+	"git.pullrequest.approved_with_suggestions",
+	"git.pullrequest.rejected",
+	"git.pullrequest.waiting_for_author",
 }
 
 type AzureDevOpsWebhook struct {
@@ -42,6 +48,28 @@ func (h *AzureDevOpsWebhook) Register(router *fewebhooks.Router) {
 func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
 	ctx = actor.WithInternalActor(ctx)
 
+	// If the event is just a general PR update event, it is best to just not try to derive the state from it and
+	// pull it in manually 💪.
+	switch e := event.(type) {
+	case *azuredevops.PullRequestUpdatedEvent:
+		event := azuredevops.PullRequestEvent(*e)
+		if err := h.enqueueAzureDevOpsChangesetSyncFromEvent(ctx, codeHostURN, event); err != nil {
+			return &httpError{
+				code: http.StatusInternalServerError,
+				err:  err,
+			}
+		}
+		return nil
+	case *azuredevops.PullRequestMergedEvent:
+		event := azuredevops.PullRequestEvent(*e)
+		if err := h.enqueueAzureDevOpsChangesetSyncFromEvent(ctx, codeHostURN, event); err != nil {
+			return &httpError{
+				code: http.StatusInternalServerError,
+				err:  err,
+			}
+		}
+		return nil
+	}
 	prs, ev, err := h.convertEvent(event)
 	if err != nil {
 		return err
@@ -63,12 +91,19 @@ func (h *AzureDevOpsWebhook) handleEvent(ctx context.Context, db database.DB, co
 
 func (h *AzureDevOpsWebhook) convertEvent(theirs interface{}) ([]PR, keyer, error) {
 	switch e := theirs.(type) {
-	case *azuredevops.PullRequestCreatedEvent:
-		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
 	case *azuredevops.PullRequestMergedEvent:
 		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case azuredevops.PullRequestApprovedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
+	case azuredevops.PullRequestApprovedWithSuggestionsEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
+	case azuredevops.PullRequestWaitingForAuthorEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
+	case azuredevops.PullRequestRejectedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
 	case *azuredevops.PullRequestUpdatedEvent:
 		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+
 	default:
 		return nil, nil, errors.Newf("unknown event type: %T", theirs)
 	}
@@ -80,5 +115,37 @@ func azureDevOpsPullRequestEventPRs(e azuredevops.PullRequestEvent) []PR {
 			ID:             int64(e.PullRequest.ID),
 			RepoExternalID: e.PullRequest.Repository.ID,
 		},
+	}
+}
+
+func (h *AzureDevOpsWebhook) enqueueAzureDevOpsChangesetSyncFromEvent(ctx context.Context, esID extsvc.CodeHostBaseURL, event azuredevops.PullRequestEvent) error {
+	// We need to get our changeset ID for this to work. To get _there_, we need
+	// the repo ID, and then we can use the merge request IID to match the
+	// external ID.
+	pr := azureDevOpsToPR(event.PullRequest)
+	repo, err := h.getRepoForPR(ctx, h.Store, pr, esID)
+	if err != nil {
+		return errors.Wrap(err, "getting repo")
+	}
+
+	c, err := h.Store.GetChangeset(ctx, store.GetChangesetOpts{
+		RepoID:              repo.ID,
+		ExternalID:          strconv.FormatInt(pr.ID, 10),
+		ExternalServiceType: h.ServiceType,
+	})
+
+	if err := repoupdater.DefaultClient.EnqueueChangesetSync(ctx, []int64{c.ID}); err != nil {
+		return errors.Wrap(err, "enqueuing changeset sync")
+	}
+
+	return nil
+}
+
+// azureDevOpsToPR instantiates a new PR instance given fields that are commonly
+// available in Azure DevOps webhook payloads.
+func azureDevOpsToPR(pr azuredevops.PullRequest) PR {
+	return PR{
+		ID:             int64(pr.ID),
+		RepoExternalID: pr.Repository.ID,
 	}
 }

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -133,6 +133,9 @@ func (h *AzureDevOpsWebhook) enqueueAzureDevOpsChangesetSyncFromEvent(ctx contex
 		ExternalID:          strconv.FormatInt(pr.ID, 10),
 		ExternalServiceType: h.ServiceType,
 	})
+	if err != nil {
+		return errors.Wrap(err, "getting changeset")
+	}
 
 	if err := repoupdater.DefaultClient.EnqueueChangesetSync(ctx, []int64{c.ID}); err != nil {
 		return errors.Wrap(err, "enqueuing changeset sync")

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -93,14 +93,14 @@ func (h *AzureDevOpsWebhook) convertEvent(theirs interface{}) ([]PR, keyer, erro
 	switch e := theirs.(type) {
 	case *azuredevops.PullRequestMergedEvent:
 		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
-	case azuredevops.PullRequestApprovedEvent:
-		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
-	case azuredevops.PullRequestApprovedWithSuggestionsEvent:
-		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
-	case azuredevops.PullRequestWaitingForAuthorEvent:
-		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
-	case azuredevops.PullRequestRejectedEvent:
-		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(e)), &e, nil
+	case *azuredevops.PullRequestApprovedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case *azuredevops.PullRequestApprovedWithSuggestionsEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case *azuredevops.PullRequestWaitingForAuthorEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
+	case *azuredevops.PullRequestRejectedEvent:
+		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
 	case *azuredevops.PullRequestUpdatedEvent:
 		return azureDevOpsPullRequestEventPRs(azuredevops.PullRequestEvent(*e)), e, nil
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/azuredevops.go
@@ -118,6 +118,9 @@ func azureDevOpsPullRequestEventPRs(e azuredevops.PullRequestEvent) []PR {
 	}
 }
 
+// enqueueAzureDevOpsChangesetSyncFromEvent enqueues a sync request for a specified changeset in repo-updater.
+// This is used instead of deriving the changeset from the incoming webhook event when doing so
+// would be difficult.
 func (h *AzureDevOpsWebhook) enqueueAzureDevOpsChangesetSyncFromEvent(ctx context.Context, esID extsvc.CodeHostBaseURL, event azuredevops.PullRequestEvent) error {
 	// We need to get our changeset ID for this to work. To get _there_, we need
 	// the repo ID, and then we can use the merge request IID to match the

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -117,7 +117,6 @@ func computeCheckState(c *btypes.Changeset, events ChangesetEvents) btypes.Chang
 	case *bbcs.AnnotatedPullRequest:
 		return computeBitbucketCloudBuildState(c.UpdatedAt, m, events)
 	case *azuredevops.AnnotatedPullRequest:
-		// TODO: @varsanojidan Not implemmented yet : return computeAzureDevOpsBuildState(c.UpdatedAt, m, events)
 		return computeAzureDevOpsBuildState(m)
 	}
 
@@ -266,8 +265,6 @@ func computeAzureDevOpsBuildState(apr *azuredevops.AnnotatedPullRequest) btypes.
 		stateMap[strconv.Itoa(status.ID)] = parseAzureDevOpsBuildState(status.State)
 	}
 
-	// TODO: @varsanojidan handle events.
-
 	states := make([]btypes.ChangesetCheckState, 0, len(stateMap))
 	for _, v := range stateMap {
 		states = append(states, v)
@@ -393,16 +390,16 @@ func combineCheckStates(states []btypes.ChangesetCheckState) btypes.ChangesetChe
 
 	switch {
 	case stateMap[btypes.ChangesetCheckStateUnknown]:
-		// If are pending, overall is Pending
+		// If there are unknown states, overall is Pending
 		return btypes.ChangesetCheckStateUnknown
 	case stateMap[btypes.ChangesetCheckStatePending]:
-		// If are pending, overall is Pending
+		// If there are pending states, overall is Pending
 		return btypes.ChangesetCheckStatePending
 	case stateMap[btypes.ChangesetCheckStateFailed]:
-		// If no pending, but have errors then overall is Failed
+		// If there are no pending states, but we have errors then overall is Failed
 		return btypes.ChangesetCheckStateFailed
 	case stateMap[btypes.ChangesetCheckStatePassed]:
-		// No pending or errors then overall is Passed
+		// No pending or error states then overall is Passed
 		return btypes.ChangesetCheckStatePassed
 	}
 
@@ -647,7 +644,7 @@ func computeSingleChangesetReviewState(c *btypes.Changeset) (s btypes.ChangesetR
 			switch reviewer.Vote {
 			case 10:
 				states[btypes.ChangesetReviewStateApproved] = true
-			case 5, -5:
+			case 5, -5, -10:
 				states[btypes.ChangesetReviewStateChangesRequested] = true
 			default:
 				states[btypes.ChangesetReviewStatePending] = true

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -390,16 +390,16 @@ func combineCheckStates(states []btypes.ChangesetCheckState) btypes.ChangesetChe
 
 	switch {
 	case stateMap[btypes.ChangesetCheckStateUnknown]:
-		// If there are unknown states, overall is Pending
+		// If there are unknown states, overall is Pending.
 		return btypes.ChangesetCheckStateUnknown
 	case stateMap[btypes.ChangesetCheckStatePending]:
-		// If there are pending states, overall is Pending
+		// If there are pending states, overall is Pending.
 		return btypes.ChangesetCheckStatePending
 	case stateMap[btypes.ChangesetCheckStateFailed]:
-		// If there are no pending states, but we have errors then overall is Failed
+		// If there are no pending states, but we have errors then overall is Failed.
 		return btypes.ChangesetCheckStateFailed
 	case stateMap[btypes.ChangesetCheckStatePassed]:
-		// No pending or error states then overall is Passed
+		// No pending or error states then overall is Passed.
 		return btypes.ChangesetCheckStatePassed
 	}
 

--- a/enterprise/internal/batches/state/state_test.go
+++ b/enterprise/internal/batches/state/state_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	azuredevops2 "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -270,6 +272,118 @@ func TestComputeBitbucketBuildStatus(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			have := computeBitbucketServerBuildStatus(lastSynced, pr, tc.events)
+			if diff := cmp.Diff(tc.want, have); diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+func TestComputeAzureDevOpsBuildStatus(t *testing.T) {
+	t.Parallel()
+
+	pr := &azuredevops2.AnnotatedPullRequest{
+		PullRequest: &azuredevops.PullRequest{},
+	}
+
+	tests := []struct {
+		name     string
+		statuses []*azuredevops.PullRequestBuildStatus
+		want     btypes.ChangesetCheckState
+	}{
+		{
+			name:     "empty slice",
+			statuses: []*azuredevops.PullRequestBuildStatus{},
+			want:     btypes.ChangesetCheckStateUnknown,
+		},
+		{
+			name: "single success",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateSucceeded,
+				},
+			},
+			want: btypes.ChangesetCheckStatePassed,
+		},
+		{
+			name: "single pending",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStatePending,
+				},
+			},
+			want: btypes.ChangesetCheckStatePending,
+		},
+		{
+			name: "single error",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateError,
+				},
+			},
+			want: btypes.ChangesetCheckStateFailed,
+		},
+		{
+			name: "single failed",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateFailed,
+				},
+			},
+			want: btypes.ChangesetCheckStateFailed,
+		},
+		{
+			name: "failed + pending",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateFailed,
+				},
+				{
+					ID:    2,
+					State: azuredevops.PullRequestBuildStatusStatePending,
+				},
+			},
+			want: btypes.ChangesetCheckStatePending,
+		},
+		{
+			name: "pending + success",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateSucceeded,
+				},
+				{
+					ID:    2,
+					State: azuredevops.PullRequestBuildStatusStatePending,
+				},
+			},
+			want: btypes.ChangesetCheckStatePending,
+		},
+		{
+			name: "failed + success",
+			statuses: []*azuredevops.PullRequestBuildStatus{
+				{
+					ID:    1,
+					State: azuredevops.PullRequestBuildStatusStateFailed,
+				},
+				{
+					ID:    2,
+					State: azuredevops.PullRequestBuildStatusStateSucceeded,
+				},
+			},
+			want: btypes.ChangesetCheckStateFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pr.Statuses = tc.statuses
+			have := computeAzureDevOpsBuildState(pr)
 			if diff := cmp.Diff(tc.want, have); diff != "" {
 				t.Fatalf(diff)
 			}

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
+
 	"github.com/goware/urlx"
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/go-diff/diff"
@@ -801,7 +803,36 @@ func (c *Changeset) Events() (events []*ChangesetEvent, err error) {
 				Metadata:    status,
 			})
 		}
-		// TODO: @varsanojida Add for ADO.
+	case *adobatches.AnnotatedPullRequest:
+		// There are two types of event that we create from an annotated pull
+		// request: review events, based on the reviewers within the pull
+		// request, and check events, based on the build statuses.
+
+		var kind ChangesetEventKind
+
+		for _, reviewer := range m.Reviewers {
+			if kind, err = ChangesetEventKindFor(&reviewer); err != nil {
+				return
+			}
+			appendEvent(&ChangesetEvent{
+				ChangesetID: c.ID,
+				Key:         reviewer.ID,
+				Kind:        kind,
+				Metadata:    reviewer,
+			})
+		}
+
+		for _, status := range m.Statuses {
+			if kind, err = ChangesetEventKindFor(status); err != nil {
+				return
+			}
+			appendEvent(&ChangesetEvent{
+				ChangesetID: c.ID,
+				Key:         strconv.Itoa(status.ID),
+				Kind:        kind,
+				Metadata:    status,
+			})
+		}
 	}
 	return events, nil
 }
@@ -1201,8 +1232,45 @@ func ChangesetEventKindFor(e any) (ChangesetEventKind, error) {
 		return ChangesetEventKindBitbucketCloudRepoCommitStatusCreated, nil
 	case *bitbucketcloud.RepoCommitStatusUpdatedEvent:
 		return ChangesetEventKindBitbucketCloudRepoCommitStatusUpdated, nil
-	}
 
+	case *azuredevops.PullRequestMergedEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestMerged, nil
+	case *azuredevops.PullRequestApprovedEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestApproved, nil
+	case *azuredevops.PullRequestApprovedWithSuggestionsEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestApprovedWithSuggestions, nil
+	case *azuredevops.PullRequestWaitingForAuthorEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestWaitingForAuthor, nil
+	case *azuredevops.PullRequestRejectedEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestRejected, nil
+	case *azuredevops.PullRequestUpdatedEvent:
+		return ChangesetEventKindAzureDevOpsPullRequestUpdated, nil
+	case *azuredevops.Reviewer:
+		switch e.Vote {
+		case 10:
+			return ChangesetEventKindAzureDevOpsPullRequestApproved, nil
+		case 5:
+			return ChangesetEventKindAzureDevOpsPullRequestApprovedWithSuggestions, nil
+		case 0:
+			return ChangesetEventKindAzureDevOpsPullRequesReviewed, nil
+		case -5:
+			return ChangesetEventKindAzureDevOpsPullRequestWaitingForAuthor, nil
+		case -10:
+			return ChangesetEventKindAzureDevOpsPullRequestRejected, nil
+		}
+
+	case *azuredevops.PullRequestBuildStatus:
+		switch e.State {
+		case azuredevops.PullRequestBuildStatusStateSucceeded:
+			return ChangesetEventKindAzureDevOpsPullRequestBuildSucceeded, nil
+		case azuredevops.PullRequestBuildStatusStateError:
+			return ChangesetEventKindAzureDevOpsPullRequestBuildError, nil
+		case azuredevops.PullRequestBuildStatusStateFailed:
+			return ChangesetEventKindAzureDevOpsPullRequestBuildFailed, nil
+		default:
+			return ChangesetEventKindAzureDevOpsPullRequestBuildPending, nil
+		}
+	}
 	return ChangesetEventKindInvalid, errors.Errorf("unknown changeset event kind for %T", e)
 }
 
@@ -1314,6 +1382,29 @@ func NewChangesetEventMetadata(k ChangesetEventKind) (any, error) {
 			return new(gitlab.MergeRequestMergedEvent), nil
 		case ChangesetEventKindGitLabReopened:
 			return new(gitlab.MergeRequestReopenedEvent), nil
+		}
+	case strings.HasPrefix(string(k), "azuredevops"):
+		switch k {
+		case ChangesetEventKindAzureDevOpsPullRequestMerged:
+			return new(azuredevops.PullRequestMergedEvent), nil
+		case ChangesetEventKindAzureDevOpsPullRequestApproved:
+			return new(azuredevops.PullRequestApprovedEvent), nil
+		case ChangesetEventKindAzureDevOpsPullRequestApprovedWithSuggestions:
+			return new(azuredevops.PullRequestApprovedWithSuggestionsEvent), nil
+		case ChangesetEventKindAzureDevOpsPullRequestWaitingForAuthor:
+			return new(azuredevops.PullRequestWaitingForAuthorEvent), nil
+		case ChangesetEventKindAzureDevOpsPullRequestRejected:
+			return new(azuredevops.PullRequestRejectedEvent), nil
+		case ChangesetEventKindAzureDevOpsPullRequestBuildSucceeded:
+			return new(azuredevops.PullRequestBuildStatus), nil
+		case ChangesetEventKindAzureDevOpsPullRequestBuildFailed:
+			return new(azuredevops.PullRequestBuildStatus), nil
+		case ChangesetEventKindAzureDevOpsPullRequestBuildError:
+			return new(azuredevops.PullRequestBuildStatus), nil
+		case ChangesetEventKindAzureDevOpsPullRequestBuildPending:
+			return new(azuredevops.PullRequestBuildStatus), nil
+		default:
+			return new(azuredevops.PullRequestUpdatedEvent), nil
 		}
 	}
 	return nil, errors.Errorf("unknown changeset event kind %q", k)

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	PULL_REQUEST_APPROVED_TEXT                  = "approved pull request"
-	PULL_REQUEST_APPROVED_WITH_SUGGESTIONS_TEXT = "has approved and left suggestions in pull request"
-	PULL_REQUEST_REJECTED_TEXT                  = "rejected pull request"
-	PULL_REQUEST_WAITING_FOR_AUTHOR_TEXT        = "is waiting for the author in pull request"
+	PullRequestApprovedText                = "approved pull request"
+	PullRequestApprovedWithSuggestionsText = "has approved and left suggestions in pull request"
+	PullRequestRejectedText                = "rejected pull request"
+	PullRequestWaitingForAuthorText        = "is waiting for the author in pull request"
 
 	PullRequestMergedEventType                  AzureDevOpsEvent = "git.pullrequest.merged"
 	PullRequestUpdatedEventType                 AzureDevOpsEvent = "git.pullrequest.updated"
@@ -46,19 +46,19 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 		text := newTarget.Message.Text
 
 		switch {
-		case strings.Contains(text, PULL_REQUEST_APPROVED_TEXT):
+		case strings.Contains(text, PullRequestApprovedText):
 			newTarget.EventType = PullRequestApprovedEventType
 			returnTarget := PullRequestApprovedEvent(*newTarget)
 			return &returnTarget, nil
-		case strings.Contains(text, PULL_REQUEST_REJECTED_TEXT):
+		case strings.Contains(text, PullRequestRejectedText):
 			newTarget.EventType = PullRequestRejectedEventType
 			returnTarget := PullRequestRejectedEvent(*newTarget)
 			return &returnTarget, nil
-		case strings.Contains(text, PULL_REQUEST_WAITING_FOR_AUTHOR_TEXT):
+		case strings.Contains(text, PullRequestWaitingForAuthorText):
 			newTarget.EventType = PullRequestWaitingForAuthorEventType
 			returnTarget := PullRequestWaitingForAuthorEvent(*newTarget)
 			return &returnTarget, nil
-		case strings.Contains(text, PULL_REQUEST_APPROVED_WITH_SUGGESTIONS_TEXT):
+		case strings.Contains(text, PullRequestApprovedWithSuggestionsText):
 			newTarget.EventType = PullRequestApprovedWithSuggestionsEventType
 			returnTarget := PullRequestApprovedWithSuggestionsEvent(*newTarget)
 			return &returnTarget, nil

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -38,6 +38,9 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 
 	// Azure DevOps doesn't give us much in the way of differentiating webhook events, so we are going
 	// to try to parse the event message so that we can ideally simulate the different event types.
+	// In the case that we can't match this event to one of our simulated events, this will default
+	// to a regular PullRequestUpdatedEventType, which will just fetch the PullRequest from the API rather
+	// than deriving it from the event payload.
 	if eventKey == PullRequestUpdatedEventType {
 		newTarget := target.(*PullRequestUpdatedEvent)
 		text := newTarget.Message.Text

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -39,28 +39,30 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 	// Azure DevOps doesn't give us much in the way of differentiating webhook events, so we are going
 	// to try to parse the event message so that we can ideally simulate the different event types.
 	if eventKey == PullRequestUpdatedEventType {
-		var returnTarget any
 		newTarget := target.(*PullRequestUpdatedEvent)
 		text := newTarget.Message.Text
 
 		switch {
 		case strings.Contains(text, PULL_REQUEST_APPROVED_TEXT):
 			newTarget.EventType = PullRequestApprovedEventType
-			returnTarget = PullRequestApprovedEvent(*newTarget)
+			returnTarget := PullRequestApprovedEvent(*newTarget)
+			return &returnTarget, nil
 		case strings.Contains(text, PULL_REQUEST_REJECTED_TEXT):
 			newTarget.EventType = PullRequestRejectedEventType
-			returnTarget = PullRequestRejectedEvent(*newTarget)
+			returnTarget := PullRequestRejectedEvent(*newTarget)
+			return &returnTarget, nil
 		case strings.Contains(text, PULL_REQUEST_WAITING_FOR_AUTHOR_TEXT):
 			newTarget.EventType = PullRequestWaitingForAuthorEventType
-			returnTarget = PullRequestWaitingForAuthorEvent(*newTarget)
+			returnTarget := PullRequestWaitingForAuthorEvent(*newTarget)
+			return &returnTarget, nil
 		case strings.Contains(text, PULL_REQUEST_APPROVED_WITH_SUGGESTIONS_TEXT):
 			newTarget.EventType = PullRequestApprovedWithSuggestionsEventType
-			returnTarget = PullRequestApprovedWithSuggestionsEvent(*newTarget)
+			returnTarget := PullRequestApprovedWithSuggestionsEvent(*newTarget)
+			return &returnTarget, nil
 		default:
 			return target, nil
 		}
 
-		return returnTarget, nil
 	}
 
 	return target, nil

--- a/internal/extsvc/azuredevops/events.go
+++ b/internal/extsvc/azuredevops/events.go
@@ -3,20 +3,27 @@ package azuredevops
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 )
 
 var (
-	PullRequestCreatedEventType AzureDevOpsEvent = "git.pullrequest.created"
-	PullRequestMergedEventType  AzureDevOpsEvent = "git.pullrequest.merged"
-	PullRequestUpdatedEventType AzureDevOpsEvent = "git.pullrequest.updated"
+	PULL_REQUEST_APPROVED_TEXT                  = "approved pull request"
+	PULL_REQUEST_APPROVED_WITH_SUGGESTIONS_TEXT = "has approved and left suggestions in pull request"
+	PULL_REQUEST_REJECTED_TEXT                  = "rejected pull request"
+	PULL_REQUEST_WAITING_FOR_AUTHOR_TEXT        = "is waiting for the author in pull request"
+
+	PullRequestMergedEventType                  AzureDevOpsEvent = "git.pullrequest.merged"
+	PullRequestUpdatedEventType                 AzureDevOpsEvent = "git.pullrequest.updated"
+	PullRequestApprovedEventType                AzureDevOpsEvent = "git.pullrequest.approved"
+	PullRequestApprovedWithSuggestionsEventType AzureDevOpsEvent = "git.pullrequest.approved_with_suggestions"
+	PullRequestRejectedEventType                AzureDevOpsEvent = "git.pullrequest.rejected"
+	PullRequestWaitingForAuthorEventType        AzureDevOpsEvent = "git.pullrequest.waiting_for_author"
 )
 
 func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 	var target any
 	switch eventKey {
-	case PullRequestCreatedEventType:
-		target = &PullRequestCreatedEvent{}
 	case PullRequestMergedEventType:
 		target = &PullRequestMergedEvent{}
 	case PullRequestUpdatedEventType:
@@ -28,6 +35,34 @@ func ParseWebhookEvent(eventKey AzureDevOpsEvent, payload []byte) (any, error) {
 	if err := json.Unmarshal(payload, target); err != nil {
 		return nil, err
 	}
+
+	// Azure DevOps doesn't give us much in the way of differentiating webhook events, so we are going
+	// to try to parse the event message so that we can ideally simulate the different event types.
+	if eventKey == PullRequestUpdatedEventType {
+		var returnTarget any
+		newTarget := target.(*PullRequestUpdatedEvent)
+		text := newTarget.Message.Text
+
+		switch {
+		case strings.Contains(text, PULL_REQUEST_APPROVED_TEXT):
+			newTarget.EventType = PullRequestApprovedEventType
+			returnTarget = PullRequestApprovedEvent(*newTarget)
+		case strings.Contains(text, PULL_REQUEST_REJECTED_TEXT):
+			newTarget.EventType = PullRequestRejectedEventType
+			returnTarget = PullRequestRejectedEvent(*newTarget)
+		case strings.Contains(text, PULL_REQUEST_WAITING_FOR_AUTHOR_TEXT):
+			newTarget.EventType = PullRequestWaitingForAuthorEventType
+			returnTarget = PullRequestWaitingForAuthorEvent(*newTarget)
+		case strings.Contains(text, PULL_REQUEST_APPROVED_WITH_SUGGESTIONS_TEXT):
+			newTarget.EventType = PullRequestApprovedWithSuggestionsEventType
+			returnTarget = PullRequestApprovedWithSuggestionsEvent(*newTarget)
+		default:
+			return target, nil
+		}
+
+		return returnTarget, nil
+	}
+
 	return target, nil
 }
 
@@ -46,9 +81,12 @@ type PullRequestEvent struct {
 	CreatedDate time.Time               `json:"createdDate"`
 }
 
-type PullRequestCreatedEvent PullRequestEvent
 type PullRequestMergedEvent PullRequestEvent
 type PullRequestUpdatedEvent PullRequestEvent
+type PullRequestApprovedEvent PullRequestEvent
+type PullRequestApprovedWithSuggestionsEvent PullRequestEvent
+type PullRequestRejectedEvent PullRequestEvent
+type PullRequestWaitingForAuthorEvent PullRequestEvent
 
 type PullRequestEventMessage struct {
 	Text string `json:"text"`
@@ -66,19 +104,34 @@ type keyer interface {
 var (
 	_ keyer = &PullRequestUpdatedEvent{}
 	_ keyer = &PullRequestMergedEvent{}
-	_ keyer = &PullRequestCreatedEvent{}
+	_ keyer = &PullRequestApprovedEvent{}
+	_ keyer = &PullRequestApprovedWithSuggestionsEvent{}
+	_ keyer = &PullRequestRejectedEvent{}
+	_ keyer = &PullRequestWaitingForAuthorEvent{}
 )
 
 func (e *PullRequestUpdatedEvent) Key() string {
-	return strconv.Itoa(e.PullRequest.ID) + ":updated"
+	return strconv.Itoa(e.PullRequest.ID) + ":updated:" + e.CreatedDate.String()
 }
 
 func (e *PullRequestMergedEvent) Key() string {
-	return strconv.Itoa(e.PullRequest.ID) + ":merged"
+	return strconv.Itoa(e.PullRequest.ID) + ":merged:" + e.CreatedDate.String()
 }
 
-func (e *PullRequestCreatedEvent) Key() string {
-	return strconv.Itoa(e.PullRequest.ID) + ":created"
+func (e *PullRequestApprovedEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":approved:" + e.CreatedDate.String()
+}
+
+func (e *PullRequestApprovedWithSuggestionsEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":approved_with_suggestions:" + e.CreatedDate.String()
+}
+
+func (e *PullRequestRejectedEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":rejected:" + e.CreatedDate.String()
+}
+
+func (e *PullRequestWaitingForAuthorEvent) Key() string {
+	return strconv.Itoa(e.PullRequest.ID) + ":waiting_for_author:" + e.CreatedDate.String()
 }
 
 type webhookNotFoundErr struct{}

--- a/internal/extsvc/azuredevops/events_test.go
+++ b/internal/extsvc/azuredevops/events_test.go
@@ -8,25 +8,44 @@ import (
 
 func TestParseWebhookEvent(t *testing.T) {
 	for key, tc := range map[string]struct {
-		payload  string
-		wantType any
+		payload   string
+		eventType string
+		wantType  any
 	}{
-		"git.pullrequest.created": {
-			payload:  `{"eventType":"git.pullrequest.created","pullrequest":{},"resource":{}}`,
-			wantType: &PullRequestCreatedEvent{},
-		},
 		"git.pullrequest.merged": {
-			payload:  `{"eventType":"git.pullrequest.merged","pullrequest":{},"resource":{}}`,
-			wantType: &PullRequestMergedEvent{},
+			payload:   `{"eventType":"git.pullrequest.merged","pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.merged",
+			wantType:  &PullRequestMergedEvent{},
+		},
+		"git.pullrequest.approved": {
+			payload:   `{"eventType":"git.pullrequest.updated","message":{"text":"bob approved pull request 10"},"pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.updated",
+			wantType:  &PullRequestApprovedEvent{},
+		},
+		"git.pullrequest.approved_with_suggestions": {
+			payload:   `{"eventType":"git.pullrequest.updated","message":{"text":"bob has approved and left suggestions in pull request 10"},"pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.updated",
+			wantType:  &PullRequestApprovedWithSuggestionsEvent{},
+		},
+		"git.pullrequest.waiting_for_author": {
+			payload:   `{"eventType":"git.pullrequest.updated","message":{"text":"bob is waiting for the author in pull request 10"},"pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.updated",
+			wantType:  &PullRequestWaitingForAuthorEvent{},
+		},
+		"git.pullrequest.rejected": {
+			payload:   `{"eventType":"ggit.pullrequest.updated","message":{"text":"bob rejected pull request 10"},"pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.updated",
+			wantType:  &PullRequestRejectedEvent{},
 		},
 		"git.pullrequest.updated": {
-			payload:  `{"eventType":"git.pullrequest.updated","pullrequest":{},"resource":{}}`,
-			wantType: &PullRequestUpdatedEvent{},
+			payload:   `{"eventType":"git.pullrequest.updated","pullrequest":{},"resource":{}}`,
+			eventType: "git.pullrequest.updated",
+			wantType:  &PullRequestUpdatedEvent{},
 		},
 	} {
 		t.Run(key, func(t *testing.T) {
 			t.Run("success", func(t *testing.T) {
-				have, err := ParseWebhookEvent(AzureDevOpsEvent(key), []byte(tc.payload))
+				have, err := ParseWebhookEvent(AzureDevOpsEvent(tc.eventType), []byte(tc.payload))
 				assert.Nil(t, err)
 				assert.IsType(t, tc.wantType, have)
 			})

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -137,16 +137,6 @@ type PullRequestCommit struct {
 	URL      string `json:"url"`
 }
 
-type PullRequestReviewer struct {
-	ID          string `json:"id"`
-	ReviewerURL string `json:"reviewerUrl"`
-	Vote        int    `json:"vote"`
-	DisplayName string `json:"displayName"`
-	UniqueName  string `json:"uniqueName"`
-	URL         string `json:"url"`
-	ImageURL    string `json:"imageUrl"`
-}
-
 type PullRequestUpdateInput struct {
 	Status                *PullRequestStatus           `json:"status"`
 	Title                 *string                      `json:"title"`


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/46735

📺 Loom: https://www.loom.com/share/136fff58c7ca4b148bd37006a31228ab (wat at 1.2x I talk slow)

This pull requests is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/48391, it builds off of the infrastructure there to make use of the new webhook events we can now ingest from Azure DevOps.


Things I want feedback on:
1) ADO has 4 main review states: Approved, Approved with suggestions, Waiting for Author, and Rejected, I was not 100% certain how that should be represented so I made Approved -> Approved, and the other 3 -> Changes Requested. Let me know what you think this can be changed fairly easily.
2) ADO doesn't really have many webhook events, the ones associated with PRs are: `git.pullrequest.updated` and `git.pullrequest.merged`. The updated event is also pretty barebones, it doesn't really directly mention what in the PR was updated, and does not get triggered on pullrequest checks. Because of this, I sort of simulated my own events off of the `git.pullrequest.updated` event, parsing the message of the event in order to convert it to a more meaningful event type for Review state changes. Outside of changes to the review, any other `git.pullrequest.updated` event will cause a manual API fetch from ADO in order to update the Changeset.


 
## Test plan
Manual testing so far

If you want to test this, you can follow the setup instructions here: https://github.com/sourcegraph/sourcegraph/pull/47913