### PR TITLE
teams: Allow creator to manage team

### DIFF
--- a/client/web/src/team/area/TeamProfilePage.tsx
+++ b/client/web/src/team/area/TeamProfilePage.tsx
@@ -3,7 +3,8 @@ import { useCallback, useState } from 'react'
 import { mdiPencil } from '@mdi/js'
 
 import { logger } from '@sourcegraph/common'
-import { Button, ErrorAlert, Form, H3, Icon, Input, Label, Modal, Text } from '@sourcegraph/wildcard'
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import { Button, ErrorAlert, Form, H3, Icon, Input, Label, Link, Modal, Text } from '@sourcegraph/wildcard'
 
 import { TEAM_DISPLAY_NAME_MAX_LENGTH } from '..'
 import { LoaderButton } from '../../components/LoaderButton'
@@ -58,6 +59,18 @@ export const TeamProfilePage: React.FunctionComponent<TeamProfilePageProps> = ({
                                 <Icon inline={true} aria-label="Edit team display name" svgPath={mdiPencil} />
                             </Button>
                         )}
+                    </Text>
+                    <H3>Creator</H3>
+                    <Text className="d-flex align-items-center">
+                        {team.creator !== null && (
+                            <>
+                                <UserAvatar user={team.creator} inline={true} className="mr-1" />
+                                <Link to={team.creator.url}>
+                                    {team.creator.displayName ? team.creator.displayName : team.creator.username}
+                                </Link>
+                            </>
+                        )}
+                        {team.creator === null && <span className="text-muted">Deleted user</span>}
                     </Text>
                 </div>
             </Page>

--- a/client/web/src/team/area/backend.ts
+++ b/client/web/src/team/area/backend.ts
@@ -39,6 +39,12 @@ export function useTeam(name: string): QueryResult<TeamResult, TeamVariables> {
                 members {
                     totalCount
                 }
+                creator {
+                    username
+                    displayName
+                    avatarURL
+                    url
+                }
             }
         `,
         {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9240,6 +9240,11 @@ type Team implements Node {
     True, if the current user can modify this team.
     """
     viewerCanAdminister: Boolean!
+
+    """
+    The creator of this team. Null, if the user was deleted.
+    """
+    creator: User
 }
 
 """

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -22318,7 +22318,7 @@
           "Name": "creator_id",
           "Index": 6,
           "TypeName": "integer",
-          "IsNullable": false,
+          "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3468,7 +3468,7 @@ Foreign-key constraints:
  display_name   | text                     |           |          | 
  readonly       | boolean                  |           | not null | false
  parent_team_id | integer                  |           |          | 
- creator_id     | integer                  |           | not null | 
+ creator_id     | integer                  |           |          | 
  created_at     | timestamp with time zone |           | not null | now()
  updated_at     | timestamp with time zone |           | not null | now()
 Indexes:

--- a/migrations/frontend/1677811663_make_team_creator_nullable/down.sql
+++ b/migrations/frontend/1677811663_make_team_creator_nullable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE teams ALTER COLUMN creator_id SET NOT NULL;

--- a/migrations/frontend/1677811663_make_team_creator_nullable/metadata.yaml
+++ b/migrations/frontend/1677811663_make_team_creator_nullable/metadata.yaml
@@ -1,0 +1,2 @@
+name: Make team creator nullable
+parents: [1677483453, 1677607213, 1677700103]

--- a/migrations/frontend/1677811663_make_team_creator_nullable/up.sql
+++ b/migrations/frontend/1677811663_make_team_creator_nullable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE teams ALTER COLUMN creator_id DROP NOT NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4037,7 +4037,7 @@ CREATE TABLE teams (
     display_name text,
     readonly boolean DEFAULT false NOT NULL,
     parent_team_id integer,
-    creator_id integer NOT NULL,
+    creator_id integer,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT teams_display_name_max_length CHECK ((char_length(display_name) <= 255)),


### PR DESCRIPTION
Currently, a user can create a new team but then cannot further modify or delete it, as they're not a member of it. This PR changes the access to "creator can always manage", so that they can modify it further, add members and such.

Closes https://github.com/sourcegraph/sourcegraph/issues/48596

## Test plan

Added tests and tried manually this is no longer a problem.