### PR TITLE
Fix teams pages flashing 404 error on page load

### DIFF
--- a/client/web/src/team/TeamsArea.tsx
+++ b/client/web/src/team/TeamsArea.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Routes, Route } from 'react-router-dom'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
@@ -31,7 +31,14 @@ export interface Props {
  * Renders a layout of a sidebar and a content area to display team-related pages.
  */
 const AuthenticatedTeamsArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    const [enableTeams] = useFeatureFlag('search-ownership')
+    const [enableTeams, fetchStatus, fetchError] = useFeatureFlag('search-ownership')
+
+    switch (fetchStatus) {
+        case 'initial':
+            return <LoadingSpinner className="m-2" />
+        case 'error':
+            return <ErrorAlert prefix="Failed to load teams feature flag" error={fetchError} />
+    }
 
     // No teams on sourcegraph.com
     if (!enableTeams || props.isSourcegraphDotCom) {


### PR DESCRIPTION
Because the feature flag is not yet loaded immediately after page load, the teams pages would briefly flash a 404 page. This fixes it by adding proper loading and error states.

## Test plan

Verified it no longer flashes a 404 page on refreshes.

## App preview:

- [Web](https://sg-web-es-teams-404-flash.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
