### PR TITLE
Alert user that no repos are connected instead of default message

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -192,8 +192,13 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
             codeHostMessage = 'Indexing repositories...'
             iconProps = { as: CloudSyncIconRefresh }
         } else {
-            codeHostMessage = 'Repositories up to date'
-            iconProps = { as: CloudCheckIconRefresh }
+            if (data.repositories.totalCount) {
+                codeHostMessage = `${data.repositories.totalCount} repo(s) updated`
+                iconProps = { as: CloudCheckIconRefresh }
+            } else {
+                codeHostMessage = 'No repositories connected'
+                iconProps = { as: CloudAlertIconRefresh }
+            }
         }
 
         return (
@@ -214,17 +219,31 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
 
         // no status messages
         if (data.statusMessages.length === 0) {
-            return (
-                <StatusMessagesNavItemEntry
-                    key="up-to-date"
-                    title="Repositories up to date"
-                    message="Repositories synced from code host and available for search."
-                    linkTo="/site-admin/repositories"
-                    linkText="View repositories"
-                    linkOnClick={toggleIsOpen}
-                    entryType="success"
-                />
-            )
+            if (data.repositories.totalCount) {
+                return (
+                    <StatusMessagesNavItemEntry
+                        key="up-to-date"
+                        title="Repositories up to date"
+                        message="Repositories synced from code host and available for search."
+                        linkTo="/site-admin/repositories"
+                        linkText="View repositories"
+                        linkOnClick={toggleIsOpen}
+                        entryType="success"
+                    />
+                )
+            } else {
+                return (
+                    <StatusMessagesNavItemEntry
+                        key="no-repositories-connected"
+                        title="No Repositories connected"
+                        message="Unlock the power of Sourcegraph by connecting repos."
+                        linkTo="site-admin/external-services/new"
+                        linkText="Connect a repo"
+                        linkOnClick={toggleIsOpen}
+                        entryType="warning"
+                    />
+                )
+            }
         }
 
         return (

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -37,5 +37,9 @@ export const STATUS_MESSAGES = gql`
                 }
             }
         }
+
+        repositories {
+            totalCount
+        }
     }
 `


### PR DESCRIPTION
On first install, show user that no repos are connected instead of the default "Repositories up to date" message.

![image](https://user-images.githubusercontent.com/40180234/222640884-e2864e74-998d-44f9-8684-8a7aa9c9cc43.png)
