### PR TITLE
permissions-center: remove unnecessary `useEffect` usage for jobs refetch.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -41,7 +41,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
     }, [telemetryService])
 
     const [filters, setFilters] = useURLSyncedState(DEFAULT_FILTERS)
-    const { connection, loading, error, refetch, variables, ...paginationProps } = usePageSwitcherPagination<
+    const { connection, loading, error, variables, ...paginationProps } = usePageSwitcherPagination<
         PermissionsSyncJobsResult,
         PermissionsSyncJobsVariables,
         PermissionsSyncJob

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -56,18 +56,6 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
         options: { pollInterval: 5000 },
     })
 
-    useEffect(() => {
-        const newReason = stringToReason(filters.reason)
-        const newState = stringToState(filters.state)
-        if (newReason !== variables.reasonGroup || newState !== variables.state) {
-            refetch({
-                ...variables,
-                reasonGroup: newReason,
-                state: newState,
-            })
-        }
-    }, [filters, refetch, variables])
-
     const setReason = useCallback(
         (reasonGroup: PermissionsSyncJobReasonGroup | null) => setFilters({ reason: reasonGroup?.toString() || '' }),
         [setFilters]


### PR DESCRIPTION
The reason that `useEffect` is not needed is that when the filter is selected, component (`PermissionsSyncJobsTable`) state is changed at it is being re-rendered with new parameters, hence new GraphQL query is sent.

Also, `refetch` call in `useEffect` was never made with the same reason -- filters and GraphQL query variables were never different because of component state update.

Test plan:
Local sg run and manual tests.

### Demo

https://user-images.githubusercontent.com/94846361/222646547-38143f8d-0370-410f-a0f8-75c83c80e113.mp4

## App preview:

- [Web](https://sg-web-ao-ui-pc-remove-use-effect.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
