### PR TITLE
servegit: simplify Walk behaviour around root is repo

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -66,7 +66,7 @@ func main() {
 		repoC := make(chan servegit.Repo, 4)
 		go func() {
 			defer close(repoC)
-			_, err := srv.Walk(filepath.Clean(*root), repoC)
+			err := srv.Walk(filepath.Clean(*root), repoC)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Walk returned error: %v\n", err)
 				os.Exit(1)


### PR DESCRIPTION
If the root is a repository then we just return that as a repository. We
had some complicated logic here which handled the case when we used to
recurse further into repositories looking for more. But now it can be
simplified so that we don't need to post-process the names.

Test Plan: a test case was added for repository is root. Tested that it
broke in the state where I removed the older post filtering code but not
the new is repo root check.

plz-review-url: https://plz.review/review/20014