### PR TITLE
servegit: Walk has logic for using the root

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/sourcegraph/log"
@@ -66,7 +65,7 @@ func main() {
 		repoC := make(chan servegit.Repo, 4)
 		go func() {
 			defer close(repoC)
-			err := srv.Walk(filepath.Clean(*root), repoC)
+			err := srv.Walk(repoC)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Walk returned error: %v\n", err)
 				os.Exit(1)


### PR DESCRIPTION
Now that we don't have the tricky post processing we can move all the
important logic of discovering repos into the Walk function. I imagine
in the future we will have external callers to Walk so making this
correct will help.

Test Plan: go test

plz-review-url: https://plz.review/review/20015