### PR TITLE
add note about SYMBOLS_CACHE_DIR bug in helm charts

### DIFF
--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -38,6 +38,7 @@
 - Searcher and Symbols now use StatefulSets and PVCs to avoid large `ephermeralStorage` requests [#242](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/242)
 - This release updates `searcher` and `symbols` services to be headless.
   - Before upgrading, delete your `searcher` and `symbols` services (ex: `kubectl delete svc/searcher svc/symbols`) [#250](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/250)
+- An env var `CACHE_DIR` was renamed to `SYMBOLS_CACHE_DIR` in `sourcegraph/sourcegraph`, this change was missed in the helm charts, and causes a permissions issue resolving some symbols searches. For more details see the PR to fix the env var: [#258](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258)
 
 ## v4.4.1 ➔ v4.4.2
 


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258
_^^ Don't merge till this is validated!_
## Test plan
`sg run docsite`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
