### PR TITLE
Highlighting: use more variety of colors in Scala

### DIFF
--- a/docker-images/syntax-highlighter/crates/sg-syntax/queries/scala/highlights.scm
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/queries/scala/highlights.scm
@@ -1,9 +1,15 @@
 (class_definition name: (identifier) @type)
 (trait_definition name: (identifier) @type)
+(function_definition name: (identifier) @identifier.function)
 (
     (identifier) @constant.builtin
     (#eq? @constant.builtin "this")
 )
+(call_expression function: (field_expression field: (identifier) @identifier.function))
+(call_expression function: (identifier) @identifier.function)
+(type_parameters name: (identifier) @identifier.type)
+((identifier) @identifier.constant
+ (#match? @identifier.constant "^[A-Z]"))
 (identifier) @variable
 (case_class_pattern type: (type_identifier) @variable)
 (operator_identifier) @variable

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -33,6 +33,7 @@ const MATCHES_TO_SYNTAX_KINDS: &[(&str, SyntaxKind)] = &[
     ("comment",                 SyntaxKind::Comment),
     ("conditional",             SyntaxKind::IdentifierKeyword),
     ("constant",                SyntaxKind::IdentifierConstant),
+    ("identifier.constant",     SyntaxKind::IdentifierConstant),
     ("constant.builtin",        SyntaxKind::IdentifierBuiltin),
     ("constant.null",           SyntaxKind::IdentifierNull),
     ("float",                   SyntaxKind::NumericLiteral),

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/scala.scala
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/scala.scala
@@ -17,6 +17,8 @@ object Foo {
   val f = null
   def main(args: Array[String]): Unit = {
     println(args.toList)
+    System.out.println(args.toList)
+    args(1).indexOf("a")
     args.toList match {
         case 1 :: 2 :: Nil =>
         case a :: Nil =>
@@ -27,7 +29,7 @@ object Foo {
   protected def protectedMethod = 42
   private[this] def privateThisMethod = 42
   private[foobar] def privatePackageMethod = 42
-  type MyMap[T] = Map[String, T]
+  type MyMap[A, B] = Map[A, B]
   trait MyTrait[T] extends SuperTrait[T]
   enum X { case A, B }
 }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__.__plugins.scala.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__.__plugins.scala.snap
@@ -5,7 +5,7 @@ expression: "dump_document(&document, &contents)"
   scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation",
 //^^^^^^^^^^^^^ Identifier 
 //              ^^^ Identifier 
-//                  ^^^ Identifier 
+//                  ^^^ IdentifierFunction 
 //                      ^^^^^^^^^^^^ StringLiteral 
 //                                    ^^^^^^^^^^ StringLiteral 
 //                                                ^^^^^^^^^^^^^^ StringLiteral 
@@ -33,7 +33,7 @@ expression: "dump_document(&document, &contents)"
   
   enablePlugins(BuildInfoPlugin)
 //^^^^^^^^^^^^^ Identifier 
-//              ^^^^^^^^^^^^^^^ Identifier 
+//              ^^^^^^^^^^^^^^^ IdentifierConstant 
   
   // configure sbt-buildinfo to send the externalDependencyClasspath to the main build, which allows using it for the IntelliJ project config
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
@@ -49,22 +49,22 @@ expression: "dump_document(&document, &contents)"
   buildClasspath := (Compile / externalDependencyClasspath).value.map(_.data).mkString(java.io.File.pathSeparator)
 //^^^^^^^^^^^^^^ Identifier 
 //               ^^ Identifier 
-//                   ^^^^^^^ Identifier 
+//                   ^^^^^^^ IdentifierConstant 
 //                           ^ Identifier 
 //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Identifier 
 //                                                          ^^^^^ Identifier 
-//                                                                ^^^ Identifier 
+//                                                                ^^^ IdentifierFunction 
 //                                                                      ^^^^ Identifier 
-//                                                                            ^^^^^^^^ Identifier 
+//                                                                            ^^^^^^^^ IdentifierFunction 
 //                                                                                     ^^^^ Identifier 
 //                                                                                          ^^ Identifier 
-//                                                                                             ^^^^ Identifier 
+//                                                                                             ^^^^ IdentifierConstant 
 //                                                                                                  ^^^^^^^^^^^^^ Identifier 
   
   buildInfoKeys := Seq[BuildInfoKey](buildClasspath)
 //^^^^^^^^^^^^^ Identifier 
 //              ^^ Identifier 
-//                 ^^^ Identifier 
+//                 ^^^ IdentifierConstant 
 //                     ^^^^^^^^^^^^ IdentifierType 
 //                                   ^^^^^^^^^^^^^^ Identifier 
   
@@ -84,7 +84,7 @@ expression: "dump_document(&document, &contents)"
   libraryDependencies ++= Seq(
 //^^^^^^^^^^^^^^^^^^^ Identifier 
 //                    ^^^ Identifier 
-//                        ^^^ Identifier 
+//                        ^^^ IdentifierConstant 
     "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.9.201909030838-r",
 //  ^^^^^^^^^^^^^^^^^^ StringLiteral 
 //                     ^ Identifier 
@@ -106,14 +106,14 @@ expression: "dump_document(&document, &contents)"
   )
   
   Global / concurrentRestrictions := Seq(
-//^^^^^^ Identifier 
+//^^^^^^ IdentifierConstant 
 //       ^ Identifier 
 //         ^^^^^^^^^^^^^^^^^^^^^^ Identifier 
 //                                ^^ Identifier 
-//                                   ^^^ Identifier 
+//                                   ^^^ IdentifierConstant 
     Tags.limitAll(1) // workaround for https://github.com/sbt/sbt/issues/2970
-//  ^^^^ Identifier 
-//       ^^^^^^^^ Identifier 
+//  ^^^^ IdentifierConstant 
+//       ^^^^^^^^ IdentifierFunction 
 //                ^ NumericLiteral 
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
   )

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__.__scala.scala.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__.__scala.scala.snap
@@ -11,7 +11,7 @@ expression: "dump_document(&document, &contents)"
 //       ^^^^^ Identifier 
 //             ^^^^^^^^^^ Identifier 
 //                        ^^^^^^^^^ Identifier 
-//                                  ^^^^ Identifier 
+//                                  ^^^^ IdentifierConstant 
   
   // Comment
 //^^^^^^^^^^ Comment 
@@ -29,7 +29,7 @@ expression: "dump_document(&document, &contents)"
 //^^^^^^^^^^^^^^^^ Comment 
   object Foo {
 //^^^^^^ IdentifierKeyword 
-//       ^^^ Identifier 
+//       ^^^ IdentifierConstant 
     val x: Int = 42
 //  ^^^ IdentifierKeyword 
 //      ^ Identifier 
@@ -55,13 +55,13 @@ expression: "dump_document(&document, &contents)"
 //         ^^^ IdentifierType 
 //             ^^^ IdentifierType 
 //                  ^^^ IdentifierType 
-//                         ^^^ Identifier 
+//                         ^^^ IdentifierConstant 
 //                             ^^^^^ Identifier 
     val b: Foo = Foo(x = 42)
 //  ^^^ IdentifierKeyword 
 //      ^ Identifier 
 //         ^^^ IdentifierType 
-//               ^^^ Identifier 
+//               ^^^ IdentifierFunction 
 //                   ^ Identifier 
 //                       ^^ NumericLiteral 
     lazy val c = 'a'
@@ -83,15 +83,26 @@ expression: "dump_document(&document, &contents)"
 //          ^^^^ IdentifierNull 
     def main(args: Array[String]): Unit = {
 //  ^^^ IdentifierKeyword 
-//      ^^^^ Identifier 
+//      ^^^^ IdentifierFunction 
 //           ^^^^ Identifier 
 //                 ^^^^^ IdentifierType 
 //                       ^^^^^^ IdentifierType 
 //                                 ^^^^ IdentifierType 
       println(args.toList)
-//    ^^^^^^^ Identifier 
+//    ^^^^^^^ IdentifierFunction 
 //            ^^^^ Identifier 
 //                 ^^^^^^ Identifier 
+      System.out.println(args.toList)
+//    ^^^^^^ IdentifierConstant 
+//           ^^^ Identifier 
+//               ^^^^^^^ IdentifierFunction 
+//                       ^^^^ Identifier 
+//                            ^^^^^^ Identifier 
+      args(1).indexOf("a")
+//    ^^^^ IdentifierFunction 
+//         ^ NumericLiteral 
+//            ^^^^^^^ IdentifierFunction 
+//                    ^^^ StringLiteral 
       args.toList match {
 //    ^^^^ Identifier 
 //         ^^^^^^ Identifier 
@@ -102,12 +113,12 @@ expression: "dump_document(&document, &contents)"
 //               ^^ Identifier 
 //                  ^ NumericLiteral 
 //                    ^^ Identifier 
-//                       ^^^ Identifier 
+//                       ^^^ IdentifierConstant 
           case a :: Nil =>
 //        ^^^^ IdentifierKeyword 
 //             ^ Identifier 
 //               ^^ Identifier 
-//                  ^^^ Identifier 
+//                  ^^^ IdentifierConstant 
           case Some(x) =>
 //        ^^^^ IdentifierKeyword 
 //             ^^^^ Identifier 
@@ -117,44 +128,45 @@ expression: "dump_document(&document, &contents)"
     private def privateMethod = 42
 //  ^^^^^^^ IdentifierKeyword 
 //          ^^^ IdentifierKeyword 
-//              ^^^^^^^^^^^^^ Identifier 
+//              ^^^^^^^^^^^^^ IdentifierFunction 
 //                              ^^ NumericLiteral 
     protected def protectedMethod = 42
 //  ^^^^^^^^^ IdentifierKeyword 
 //            ^^^ IdentifierKeyword 
-//                ^^^^^^^^^^^^^^^ Identifier 
+//                ^^^^^^^^^^^^^^^ IdentifierFunction 
 //                                  ^^ NumericLiteral 
     private[this] def privateThisMethod = 42
 //  ^^^^^^^ IdentifierKeyword 
 //          ^^^^ IdentifierBuiltin 
 //                ^^^ IdentifierKeyword 
-//                    ^^^^^^^^^^^^^^^^^ Identifier 
+//                    ^^^^^^^^^^^^^^^^^ IdentifierFunction 
 //                                        ^^ NumericLiteral 
     private[foobar] def privatePackageMethod = 42
 //  ^^^^^^^ IdentifierKeyword 
 //          ^^^^^^ Identifier 
 //                  ^^^ IdentifierKeyword 
-//                      ^^^^^^^^^^^^^^^^^^^^ Identifier 
+//                      ^^^^^^^^^^^^^^^^^^^^ IdentifierFunction 
 //                                             ^^ NumericLiteral 
-    type MyMap[T] = Map[String, T]
+    type MyMap[A, B] = Map[A, B]
 //  ^^^^ IdentifierKeyword 
 //       ^^^^^ IdentifierType 
-//             ^ Identifier 
-//                  ^^^ IdentifierType 
-//                      ^^^^^^ IdentifierType 
-//                              ^ IdentifierType 
+//             ^ IdentifierType 
+//                ^ IdentifierType 
+//                     ^^^ IdentifierType 
+//                         ^ IdentifierType 
+//                            ^ IdentifierType 
     trait MyTrait[T] extends SuperTrait[T]
 //  ^^^^^ IdentifierKeyword 
 //        ^^^^^^^ IdentifierType 
-//                ^ Identifier 
+//                ^ IdentifierType 
 //                   ^^^^^^^ IdentifierKeyword 
 //                           ^^^^^^^^^^ IdentifierType 
 //                                      ^ IdentifierType 
     enum X { case A, B }
 //  ^^^^ IdentifierKeyword 
-//       ^ Identifier 
+//       ^ IdentifierConstant 
 //           ^^^^ IdentifierKeyword 
-//                ^ Identifier 
-//                   ^ Identifier 
+//                ^ IdentifierConstant 
+//                   ^ IdentifierConstant 
   }
 


### PR DESCRIPTION
Previously, we used `SyntaxKind.Identifier` in too many places making everything look blue. In this commit, we use different colors for functions and capitalized identifiers (which are normally used for
    constants). These small changes greatly improve the quality of the
highlighting.

Example change
![CleanShot 2023-03-03 at 12 46 28@2x](https://user-images.githubusercontent.com/1408093/222713999-d27c249e-c87a-48cb-97c2-e4b9b13c9568.png)




## Test plan

See updated snapshot tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
