### PR TITLE
Retry requests if GitLab external rate limit is hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The file tree on the repository page now automatically expands into single-child directories. [#47117](https://github.com/sourcegraph/sourcegraph/pull/47117)
 - When encountering GitHub rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423)
 - Added a dashboard with information about user and repository background permissions sync jobs. [#46317](https://github.com/sourcegraph/sourcegraph/issues/46317)
+- When encountering GitHub or GitLab rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423), [#48616](https://github.com/sourcegraph/sourcegraph/pull/48616)
 
 ### Changed
 

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -150,7 +150,7 @@ func (p *ClientProvider) getClient(a auth.Authenticator) *Client {
 		return c
 	}
 
-	c := p.newClient(a)
+	c := p.NewClient(a)
 	p.gitlabClients[key] = c
 	return c
 }
@@ -178,18 +178,15 @@ type Client struct {
 	Auth                auth.Authenticator
 	externalRateLimiter *ratelimit.Monitor
 	internalRateLimiter *ratelimit.InstrumentedLimiter // Our internal rate limiter
+	waitForRateLimit    bool
 }
 
-// newClient creates a new GitLab API client with an optional personal access token to authenticate requests.
+// NewClient creates a new GitLab API client with an optional personal access token to authenticate requests.
 //
 // The URL must point to the base URL of the GitLab instance. This is https://gitlab.com for GitLab.com and
 // http[s]://[gitlab-hostname] for self-hosted GitLab instances.
 //
 // See the docstring of Client for the meaning of the parameters.
-func (p *ClientProvider) newClient(a auth.Authenticator) *Client {
-	return p.NewClient(a)
-}
-
 func (p *ClientProvider) NewClient(a auth.Authenticator) *Client {
 	// Cache for GitLab project metadata.
 	var cacheTTL time.Duration
@@ -217,6 +214,7 @@ func (p *ClientProvider) NewClient(a auth.Authenticator) *Client {
 		Auth:                a,
 		internalRateLimiter: rl,
 		externalRateLimiter: rlm,
+		waitForRateLimit:    true,
 	}
 }
 

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -232,9 +232,11 @@ func (c *Client) Urn() string {
 // do is the default method for making API requests and will prepare the correct
 // base path.
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
-	err = c.internalRateLimiter.Wait(ctx)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "rate limit")
+	if c.internalRateLimiter != nil {
+		err = c.internalRateLimiter.Wait(ctx)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "rate limit")
+		}
 	}
 
 	if c.waitForRateLimit {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -177,7 +177,7 @@ type Client struct {
 	projCache              *rcache.Cache
 	Auth                   auth.Authenticator
 	externalRateLimiter    *ratelimit.Monitor
-	internalRateLimiter    *ratelimit.InstrumentedLimiter // Our internal rate limiter
+	internalRateLimiter    *ratelimit.InstrumentedLimiter
 	waitForRateLimit       bool
 	maxNumRateLimitRetries int
 }
@@ -232,11 +232,9 @@ func (c *Client) Urn() string {
 // do is the default method for making API requests and will prepare the correct
 // base path.
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
-	if c.internalRateLimiter != nil {
-		err = c.internalRateLimiter.Wait(ctx)
-		if err != nil {
-			return nil, 0, errors.Wrap(err, "rate limit")
-		}
+	err = c.internalRateLimiter.Wait(ctx)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "rate limit")
 	}
 
 	if c.waitForRateLimit {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -216,6 +216,7 @@ func (p *ClientProvider) NewClient(a auth.Authenticator) *Client {
 		internalRateLimiter: rl,
 		externalRateLimiter: rlm,
 		waitForRateLimit:    true,
+		numRateLimitRetries: 2,
 	}
 }
 
@@ -307,8 +308,8 @@ func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result an
 	return resp.Header, resp.StatusCode, json.Unmarshal(body, result)
 }
 
-// RateLimitMonitor exposes the rate limit monitor.
-func (c *Client) RateLimitMonitor() *ratelimit.Monitor {
+// ExternalRateLimiter exposes the rate limit monitor.
+func (c *Client) ExternalRateLimiter() *ratelimit.Monitor {
 	return c.externalRateLimiter
 }
 

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,8 @@ func TestClient_doWithBaseURL(t *testing.T) {
 }
 
 func TestRateLimitRetries(t *testing.T) {
+	rcache.SetupForTest(t)
+
 	ctx := context.Background()
 	hitRetryAfter := false
 	hitRateLimit := false

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -120,100 +120,110 @@ func TestClient_doWithBaseURL(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRateLimitRetries(t *testing.T) {
+func TestRateLimitRetry(t *testing.T) {
 	rcache.SetupForTest(t)
 
 	ctx := context.Background()
-	hitRetryAfter := false
-	hitRateLimit := false
-	succeeded := false
-	numRequests := 0
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		numRequests += 1
-		if hitRetryAfter {
-			w.Header().Add("Retry-After", "1")
-			w.WriteHeader(http.StatusTooManyRequests)
-			w.Write([]byte("Try again later"))
+	type test struct {
+		client *Client
 
-			hitRetryAfter = false
-			return
-		}
-
-		if hitRateLimit {
-			w.Header().Add("RateLimit-Name", "test")
-			w.Header().Add("RateLimit-Limit", "60")
-			w.Header().Add("RateLimit-Observed", "67")
-			w.Header().Add("RateLimit-Remaining", "0")
-			resetTime := time.Now().Add(time.Second)
-			w.Header().Add("RateLimit-Reset", strconv.Itoa(int(resetTime.Unix())))
-			w.WriteHeader(http.StatusTooManyRequests)
-			w.Write([]byte("Try again later"))
-
-			hitRateLimit = false
-			return
-		}
-
-		succeeded = true
-		w.Write([]byte(`{"some": "response"}`))
-	}))
-
-	srvURL, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-
-	provider := NewClientProvider("Test", srvURL, nil)
-	client := provider.getClient(nil)
-
-	done := func() {
-		hitRetryAfter = false
-		hitRateLimit = false
-		succeeded = false
-		numRequests = 0
-		client.waitForRateLimit = true
+		rateLimitWasHit  bool
+		retryAfterWasHit bool
+		succeeded        bool
+		numRequests      int
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "url", nil)
-	require.NoError(t, err)
+	buildNewTest := func(t *testing.T, useRateLimit, useRetryAfter bool) (*test, *httptest.Server) {
+		testCase := &test{}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			testCase.numRequests += 1
+			if useRetryAfter {
+				w.Header().Add("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte("Try again later"))
+
+				useRetryAfter = false
+				testCase.retryAfterWasHit = true
+				return
+			}
+
+			if useRateLimit {
+				w.Header().Add("RateLimit-Name", "test")
+				w.Header().Add("RateLimit-Limit", "60")
+				w.Header().Add("RateLimit-Observed", "67")
+				w.Header().Add("RateLimit-Remaining", "0")
+				resetTime := time.Now().Add(time.Second)
+				w.Header().Add("RateLimit-Reset", strconv.Itoa(int(resetTime.Unix())))
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte("Try again later"))
+
+				useRateLimit = false
+				testCase.rateLimitWasHit = true
+				return
+			}
+
+			testCase.succeeded = true
+			w.Write([]byte(`{"some": "response"}`))
+		}))
+
+		t.Cleanup(srv.Close)
+
+		srvURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		provider := NewClientProvider("Test", srvURL, nil)
+		testCase.client = provider.getClient(nil)
+
+		return testCase, srv
+	}
+
 	var result map[string]any
 
 	t.Run("retry-after hit", func(t *testing.T) {
-		t.Cleanup(done)
-		hitRetryAfter = true
-
-		_, _, err := client.do(ctx, req, &result)
+		req, err := http.NewRequest(http.MethodGet, "url", nil)
 		require.NoError(t, err)
-		assert.Equal(t, 2, numRequests)
-		assert.True(t, succeeded)
+		test, _ := buildNewTest(t, false, true)
+
+		_, _, err = test.client.do(ctx, req, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 2, test.numRequests)
+		assert.True(t, test.succeeded)
 	})
 
 	t.Run("rate limit hit", func(t *testing.T) {
-		t.Cleanup(done)
-		hitRateLimit = true
-
-		_, _, err := client.do(ctx, req, &result)
+		req, err := http.NewRequest(http.MethodGet, "url", nil)
 		require.NoError(t, err)
-		assert.Equal(t, 2, numRequests)
-		assert.True(t, succeeded)
+		test, _ := buildNewTest(t, true, false)
+
+		_, _, err = test.client.do(ctx, req, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 2, test.numRequests)
+		assert.True(t, test.succeeded)
 	})
 
 	t.Run("no rate limit hit", func(t *testing.T) {
-		t.Cleanup(done)
-
-		_, _, err := client.do(ctx, req, &result)
+		req, err := http.NewRequest(http.MethodGet, "url", nil)
 		require.NoError(t, err)
-		assert.Equal(t, 1, numRequests)
-		assert.True(t, succeeded)
+		test, _ := buildNewTest(t, false, false)
+
+		_, _, err = test.client.do(ctx, req, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 1, test.numRequests)
+		assert.True(t, test.succeeded)
 	})
 
 	t.Run("error if rate limit hit but waitForRateLimit disabled", func(t *testing.T) {
-		t.Cleanup(done)
-		client.waitForRateLimit = false
-		hitRateLimit = true
+		req, err := http.NewRequest(http.MethodGet, "url", nil)
+		require.NoError(t, err)
+		test, _ := buildNewTest(t, true, false)
+		test.client.waitForRateLimit = false
 
-		_, _, err := client.do(ctx, req, &result)
+		_, _, err = test.client.do(ctx, req, &result)
 		require.Error(t, err)
-		assert.Equal(t, 1, numRequests)
-		assert.False(t, succeeded)
+		assert.Equal(t, 1, test.numRequests)
+		assert.False(t, test.succeeded)
 	})
 }
 

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -192,6 +192,26 @@ func TestRateLimitRetries(t *testing.T) {
 		assert.Equal(t, 2, numRequests)
 		assert.True(t, succeeded)
 	})
+
+	t.Run("no rate limit hit", func(t *testing.T) {
+		t.Cleanup(done)
+
+		_, _, err := client.do(ctx, req, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 1, numRequests)
+		assert.True(t, succeeded)
+	})
+
+	t.Run("error if rate limit hit but waitForRateLimit disabled", func(t *testing.T) {
+		t.Cleanup(done)
+		client.waitForRateLimit = false
+		hitRateLimit = true
+
+		_, _, err := client.do(ctx, req, &result)
+		require.Error(t, err)
+		assert.Equal(t, 1, numRequests)
+		assert.False(t, succeeded)
+	})
 }
 
 func TestGetOAuthContext(t *testing.T) {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -123,8 +123,6 @@ func (c *Client) CreateMergeRequest(ctx context.Context, project *Project, opts 
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
-
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/merge_requests", project.ID), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request to create a merge request")
@@ -149,8 +147,6 @@ func (c *Client) GetMergeRequest(ctx context.Context, project *Project, iid ID) 
 	if MockGetMergeRequest != nil {
 		return MockGetMergeRequest(c, ctx, project, iid)
 	}
-
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("projects/%d/merge_requests/%d", project.ID, iid), nil)
 	if err != nil {
@@ -195,8 +191,6 @@ func (c *Client) GetOpenMergeRequestByRefs(ctx context.Context, project *Project
 	u := &url.URL{
 		Path: fmt.Sprintf("projects/%d/merge_requests", project.ID), RawQuery: values.Encode(),
 	}
-
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
@@ -249,8 +243,6 @@ func (c *Client) UpdateMergeRequest(ctx context.Context, project *Project, mr *M
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
-
 	req, err := http.NewRequest("PUT", fmt.Sprintf("projects/%d/merge_requests/%d", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request to update a merge request")
@@ -290,8 +282,6 @@ func (c *Client) MergeMergeRequest(ctx context.Context, project *Project, mr *Me
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
-
 	req, err := http.NewRequest("PUT", fmt.Sprintf("projects/%d/merge_requests/%d/merge", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request to merge a merge request")
@@ -323,8 +313,6 @@ func (c *Client) CreateMergeRequestNote(ctx context.Context, project *Project, m
 	if err != nil {
 		return errors.Wrap(err, "marshalling payload")
 	}
-
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/merge_requests/%d/notes", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -123,7 +123,7 @@ func (c *Client) CreateMergeRequest(ctx context.Context, project *Project, opts 
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/merge_requests", project.ID), bytes.NewBuffer(data))
 	if err != nil {
@@ -150,7 +150,7 @@ func (c *Client) GetMergeRequest(ctx context.Context, project *Project, iid ID) 
 		return MockGetMergeRequest(c, ctx, project, iid)
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("projects/%d/merge_requests/%d", project.ID, iid), nil)
 	if err != nil {
@@ -196,7 +196,7 @@ func (c *Client) GetOpenMergeRequestByRefs(ctx context.Context, project *Project
 		Path: fmt.Sprintf("projects/%d/merge_requests", project.ID), RawQuery: values.Encode(),
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
@@ -249,7 +249,7 @@ func (c *Client) UpdateMergeRequest(ctx context.Context, project *Project, mr *M
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("projects/%d/merge_requests/%d", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {
@@ -290,7 +290,7 @@ func (c *Client) MergeMergeRequest(ctx context.Context, project *Project, mr *Me
 		return nil, errors.Wrap(err, "marshalling options")
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("projects/%d/merge_requests/%d/merge", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {
@@ -324,7 +324,7 @@ func (c *Client) CreateMergeRequestNote(ctx context.Context, project *Project, m
 		return errors.Wrap(err, "marshalling payload")
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/merge_requests/%d/notes", project.ID, mr.IID), bytes.NewBuffer(data))
 	if err != nil {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Masterminds/semver"
 

--- a/internal/extsvc/gitlab/notes.go
+++ b/internal/extsvc/gitlab/notes.go
@@ -30,8 +30,6 @@ func (c *Client) GetMergeRequestNotes(ctx context.Context, project *Project, iid
 			return page, nil
 		}
 
-		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
-
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err

--- a/internal/extsvc/gitlab/notes.go
+++ b/internal/extsvc/gitlab/notes.go
@@ -30,7 +30,7 @@ func (c *Client) GetMergeRequestNotes(ctx context.Context, project *Project, iid
 			return page, nil
 		}
 
-		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {

--- a/internal/extsvc/gitlab/pipelines.go
+++ b/internal/extsvc/gitlab/pipelines.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -29,8 +28,6 @@ func (c *Client) GetMergeRequestPipelines(ctx context.Context, project *Project,
 		if currentPage == "" {
 			return page, nil
 		}
-
-		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {

--- a/internal/extsvc/gitlab/pipelines.go
+++ b/internal/extsvc/gitlab/pipelines.go
@@ -30,7 +30,7 @@ func (c *Client) GetMergeRequestPipelines(ctx context.Context, project *Project,
 			return page, nil
 		}
 
-		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {

--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/peterhellberg/link"
 	"github.com/prometheus/client_golang/prometheus"
@@ -280,8 +279,6 @@ func (c *Client) ForkProject(ctx context.Context, project *Project, namespace *s
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling payload")
 	}
-
-	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/fork", project.ID), bytes.NewBuffer(data))
 	if err != nil {

--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -281,7 +281,7 @@ func (c *Client) ForkProject(ctx context.Context, project *Project, namespace *s
 		return nil, errors.Wrap(err, "marshalling payload")
 	}
 
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("projects/%d/fork", project.ID), bytes.NewBuffer(data))
 	if err != nil {

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -30,7 +30,7 @@ func (c *Client) GetMergeRequestResourceStateEvents(ctx context.Context, project
 			return page, nil
 		}
 
-		time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -30,8 +30,6 @@ func (c *Client) GetMergeRequestResourceStateEvents(ctx context.Context, project
 			return page, nil
 		}
 
-		time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
-
 		parsedUrl, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err

--- a/internal/extsvc/gitlab/util_test.go
+++ b/internal/extsvc/gitlab/util_test.go
@@ -48,9 +48,9 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 func newTestClient(t *testing.T) *Client {
 	rcache.SetupForTest(t)
 	return &Client{
-		baseURL:          &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
-		httpClient:       &http.Client{},
-		rateLimitMonitor: &ratelimit.Monitor{},
-		projCache:        rcache.NewWithTTL("__test__gl_proj", 1000),
+		baseURL:             &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+		httpClient:          &http.Client{},
+		externalRateLimiter: &ratelimit.Monitor{},
+		projCache:           rcache.NewWithTTL("__test__gl_proj", 1000),
 	}
 }

--- a/internal/extsvc/gitlab/version.go
+++ b/internal/extsvc/gitlab/version.go
@@ -13,7 +13,7 @@ func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	if MockGetVersion != nil {
 		return MockGetVersion(ctx)
 	}
-	time.Sleep(c.rateLimitMonitor.RecommendedWaitForBackgroundOp(1))
+	time.Sleep(c.externalRateLimiter.RecommendedWaitForBackgroundOp(1))
 
 	var v struct {
 		Version  string `json:"version"`

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -607,8 +607,7 @@ func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 	var limit rate.Limit
 	switch c := config.(type) {
 	case *schema.GitLabConnection:
-		// 10/s is the default enforced by GitLab on their end
-		limit = rate.Limit(10)
+		limit = rate.Inf
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -73,7 +73,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			name:   "GitLab default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitLab,
-			want:   10.0,
+			want:   rate.Inf,
 		},
 		{
 			name:   "GitHub default",

--- a/internal/ratelimit/monitor.go
+++ b/internal/ratelimit/monitor.go
@@ -162,41 +162,46 @@ func (c *Monitor) RecommendedWaitForBackgroundOp(cost int) (timeRemaining time.D
 	return timeRemaining * time.Duration(cost) / time.Duration(limitRemaining)
 }
 
-// WaitForRateLimit determines whether or not an external rate limit is being applied
-// and sleeps an amount of time recommended by the external rate limiter.
-// It returns true if rate limiting was applying, and false if not.
-// This can be used to determine whether or not a request should be retried.
-func (c *Monitor) WaitForRateLimit(ctx context.Context) bool {
-	// NOTE: We manually unlock the mutex in this function so that it does not remain locked while sleeping
+func (c *Monitor) calcRateLimitWaitTime() time.Duration {
 	c.mu.Lock()
-	// If the "Retry-After" header was set, we need to wait the specified amount of time.
+	defer c.mu.Unlock()
+
 	if !c.retry.IsZero() {
 		if remaining := c.retry.Sub(c.now()); remaining > 0 {
 			// Unlock before sleeping
-			c.mu.Unlock()
-			timeutil.SleepWithContext(ctx, remaining)
-			return true
+			return remaining
 		}
 	}
 
 	// If the external rate limit is unknown, or if there are still remaining tokens,
 	// we don't wait.
 	if !c.known || c.remaining > 0 {
-		c.mu.Unlock()
-		return false
+		return time.Duration(0)
 	}
 
 	// If the rate limit reset is still in the future, we wait until the limit is reset.
 	// If it is in the past, the rate limit is outdated and we don't need to wait.
 	if remaining := c.reset.Sub(c.now()); remaining > 0 {
 		// Unlock before sleeping
-		c.mu.Unlock()
-		timeutil.SleepWithContext(ctx, remaining)
-		return true
+		return remaining
 	}
 
-	c.mu.Unlock()
-	return false
+	return time.Duration(0)
+}
+
+// WaitForRateLimit determines whether or not an external rate limit is being applied
+// and sleeps an amount of time recommended by the external rate limiter.
+// It returns true if rate limiting was applying, and false if not.
+// This can be used to determine whether or not a request should be retried.
+func (c *Monitor) WaitForRateLimit(ctx context.Context) bool {
+	sleepDuration := c.calcRateLimitWaitTime()
+
+	if sleepDuration == 0 {
+		return false
+	}
+
+	timeutil.SleepWithContext(ctx, sleepDuration)
+	return true
 }
 
 // Update updates the monitor's rate limit information based on the HTTP response headers.

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -115,7 +115,7 @@ func newGitLabSource(logger log.Logger, svc *types.ExternalService, c *schema.Gi
 	}
 
 	if !envvar.SourcegraphDotComMode() || svc.CloudDefault {
-		client.RateLimitMonitor().SetCollector(&ratelimit.MetricsCollector{
+		client.ExternalRateLimiter().SetCollector(&ratelimit.MetricsCollector{
 			Remaining: func(n float64) {
 				gitlabRemainingGauge.WithLabelValues("rest", svc.DisplayName).Set(n)
 			},
@@ -280,7 +280,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				}
 
 				// 0-duration sleep unless nearing rate limit exhaustion. If context has been canceled, next iteration of loop will return error.
-				timeutil.SleepWithContext(ctx, s.client.RateLimitMonitor().RecommendedWaitForBackgroundOp(1))
+				timeutil.SleepWithContext(ctx, s.client.ExternalRateLimiter().RecommendedWaitForBackgroundOp(1))
 			}
 		}()
 	}
@@ -333,7 +333,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				urlStr = *nextPageURL
 
 				// 0-duration sleep unless nearing rate limit exhaustion. If context has been canceled, next iteration of loop will return error.
-				timeutil.SleepWithContext(ctx, s.client.RateLimitMonitor().RecommendedWaitForBackgroundOp(1))
+				timeutil.SleepWithContext(ctx, s.client.ExternalRateLimiter().RecommendedWaitForBackgroundOp(1))
 			}
 		}(projectQuery)
 	}

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -278,9 +278,6 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				} else {
 					ch <- batch{projs: []*gitlab.Project{proj}}
 				}
-
-				// 0-duration sleep unless nearing rate limit exhaustion. If context has been canceled, next iteration of loop will return error.
-				timeutil.SleepWithContext(ctx, s.client.ExternalRateLimiter().RecommendedWaitForBackgroundOp(1))
 			}
 		}()
 	}
@@ -331,9 +328,6 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 					return
 				}
 				urlStr = *nextPageURL
-
-				// 0-duration sleep unless nearing rate limit exhaustion. If context has been canceled, next iteration of loop will return error.
-				timeutil.SleepWithContext(ctx, s.client.ExternalRateLimiter().RecommendedWaitForBackgroundOp(1))
 			}
 		}(projectQuery)
 	}


### PR DESCRIPTION
Closes #48614 

**Before this PR**
GitLab requests all share a single global internal rate limiter. This is a very crude and inaccurate approximation of GitLab's actual rate limits.

**After this PR**
GitLab requests now use GitLab's response headers to keep track of individual user rate limits. This allows Sourcegraph to make a lot more requests and stay up to date faster while staying inside GitLab's rate limits.

## Test plan

Unit tests added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
