### PR TITLE
sg: bazel command sets block until bazel build is complete before anything else.

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -42,6 +42,8 @@ var checks = map[string]check.CheckFunc{
 		check.Combine(check.InPath("docker"), check.CommandExitCode("docker info", 0)),
 		"Docker needs to be running",
 	),
+	"bazel":  check.WrapErrMessage(check.InPath("bazel"), "brew install bazel"),
+	"ibazel": check.WrapErrMessage(check.InPath("ibazel"), "brew install ibazel"),
 }
 
 func runChecksWithName(ctx context.Context, names []string) error {

--- a/dev/sg/internal/run/bazel_build.go
+++ b/dev/sg/internal/run/bazel_build.go
@@ -2,16 +2,35 @@ package run
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/sourcegraph/lib/process"
 )
 
 // BazelBuild peforms a bazel build command with all the given targets and blocks until an
 // error is returned or the build is completed.
-func BazelBuild(ctx context.Context, dir string, targets ...string) error {
+func BazelBuild(ctx context.Context, cmds ...BazelCommand) error {
+	if len(cmds) == 0 {
+		// no Bazel commands so we return
+		return nil
+	}
+	std.Out.WriteLine(output.Styled(output.StylePending, fmt.Sprintf("Detected %d bazel targets, running bazel build before anything else", len(cmds))))
+
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return err
+	}
+
+	targets := make([]string, 0, len(cmds))
+	for _, cmd := range cmds {
+		targets = append(targets, cmd.Target)
+	}
+
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
 
@@ -25,7 +44,7 @@ func BazelBuild(ctx context.Context, dir string, targets ...string) error {
 
 	sc.cancel = cancel
 	sc.Cmd = cmd
-	sc.Cmd.Dir = dir
+	sc.Cmd.Dir = repoRoot
 
 	var stdoutWriter, stderrWriter io.Writer
 	logger := newCmdLogger(ctx, "bazel", std.Out.Output)

--- a/dev/sg/internal/run/bazel_command.go
+++ b/dev/sg/internal/run/bazel_command.go
@@ -67,7 +67,7 @@ func (bc *BazelCommand) watch(ctx context.Context) (<-chan struct{}, error) {
 }
 
 func (bc *BazelCommand) Start(ctx context.Context, dir string, parentEnv map[string]string) error {
-	std.Out.WriteLine(output.Styledf(output.StylePending, "Running 💈 %s...", bc.Name))
+	std.Out.WriteLine(output.Styledf(output.StylePending, "Running %s...", bc.Name))
 
 	// Run the binary for the first time.
 	cancel, err := bc.start(ctx, dir, parentEnv)

--- a/dev/sg/internal/run/run_bazel.go
+++ b/dev/sg/internal/run/run_bazel.go
@@ -55,11 +55,6 @@ func BazelCommands(ctx context.Context, parentEnv map[string]string, verbose boo
 		targets = append(targets, cmd.Target)
 	}
 
-	// First we build everything once, to ensure all binaries are present.
-	if err := BazelBuild(ctx, repoRoot, targets...); err != nil {
-		return err
-	}
-
 	ibazel := newIBazel(repoRoot, targets...)
 
 	p := pool.New().WithContext(ctx).WithCancelOnError()

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -113,6 +113,11 @@ func runExec(ctx *cli.Context) error {
 		return nil
 	}
 
+	// First we build everything once, to ensure all binaries are present.
+	if err := run.BazelBuild(ctx.Context, bcmds...); err != nil {
+		return err
+	}
+
 	p := pool.New().WithContext(ctx.Context).WithCancelOnError()
 	p.Go(func(ctx context.Context) error {
 		return run.Commands(ctx, config.Env, verbose, cmds...)

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -315,6 +315,11 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 		env[k] = v
 	}
 
+	// First we build everything once, to ensure all binaries are present.
+	if err := run.BazelBuild(ctx, bcmds...); err != nil {
+		return err
+	}
+
 	p := pool.New().WithContext(ctx).WithCancelOnError()
 	p.Go(func(ctx context.Context) error {
 		return run.Commands(ctx, env, verbose, cmds...)

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -293,7 +293,6 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 	bcmds := make([]run.BazelCommand, 0, len(set.BazelCommands))
 	for _, name := range set.BazelCommands {
 		bcmd, ok := conf.BazelCommands[name]
-		println(bcmd.Name)
 		if !ok {
 			return errors.Errorf("command %q not found in commandset %q", name, set.Name)
 		}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1011,6 +1011,8 @@ commandsets:
       - redis
       - postgres
       - git
+      - bazel
+      - ibazel
     bazelCommands:
       - oss-frontend
       - oss-worker
@@ -1037,6 +1039,8 @@ commandsets:
       - redis
       - postgres
       - git
+      - bazel
+      - ibazel
     commands:
       - oss-frontend
       - oss-worker
@@ -1062,6 +1066,8 @@ commandsets:
       - redis
       - postgres
       - git
+      - bazel
+      - ibazel
     bazelCommands:
       - frontend
       - worker
@@ -1126,6 +1132,8 @@ commandsets:
       - redis
       - postgres
       - git
+      - bazel
+      - ibazel
     bazelCommands:
       - frontend
       - worker


### PR DESCRIPTION
Early feedback we got was that when using the bazel commandsets, if the user never ran bazel build before, the logs would spam errors because normal services would come up way earlier and complained about not being able to reach other services. 

While is never happens if you have only a few things to build, the initial build command on a cold environment is really long. This fixes this. In essence, it behaves like the old install method for those services. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 