### PR TITLE
Fix not counting the number of retries on GitHub rate limit requests

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -236,6 +236,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		// If we end up waiting because of an external rate limit, we need to retry the request.
 		if c.externalRateLimiter.WaitForRateLimit(ctx) {
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
+			numRetries++
 		} else {
 			// We did not wait because of rate limiting, so we break the loop
 			break

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -1106,6 +1106,21 @@ func TestRateLimitRetry(t *testing.T) {
 		assert.False(t, succeeded)
 		assert.Equal(t, 1, numRequests)
 	})
+
+	t.Run("retry maximum number of times", func(t *testing.T) {
+		defer done()
+		hitPrimaryLimit = true
+		hitSecondaryLimit = true
+		client.numRateLimitRetries = 2
+
+		_, err = client.GetVersion(ctx)
+		require.NoError(t, err)
+
+		assert.False(t, hitPrimaryLimit)
+		assert.False(t, hitSecondaryLimit)
+		assert.True(t, succeeded)
+		assert.Equal(t, 3, numRequests)
+	})
 }
 
 func TestListPublicRepositories(t *testing.T) {


### PR DESCRIPTION
`numRetries` was never actually incremented so it would retry forever.

## Test plan

Added test to verify the correct behaviour

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
