### PR TITLE
Fix typo in insights UI

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/use-repo-fields.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/insight-repo-section/use-repo-fields.ts
@@ -92,7 +92,7 @@ export function useRepoFields<FormFields extends RepositoriesFields>(props: Inpu
 
 function validateRepoQuery(value?: QueryState): ValidationResult {
     if (value && value.query.trim() === '') {
-        return 'Search repositories query is a required filed, please fill in the field.'
+        return 'Search repositories query is a required field, please fill in the field.'
     }
 }
 


### PR DESCRIPTION
I assume this was meant to mean `field`?

## Test plan

Not a typo anymore.

## App preview:

- [Web](https://sg-web-es-fix-typo.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
