### PR TITLE
embeddings: parallel similarity search

### DIFF
--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -42,6 +42,8 @@ func searchRepoEmbeddingIndex(
 	return &embeddings.EmbeddingSearchResults{CodeResults: codeResults, TextResults: textResults}, nil
 }
 
+const SIMILARITY_SEARCH_MIN_ROWS_TO_SPLIT = 1000
+
 func searchEmbeddingIndex(
 	ctx context.Context,
 	repoName api.RepoName,
@@ -51,8 +53,8 @@ func searchEmbeddingIndex(
 	query []float32,
 	nResults int,
 ) []embeddings.EmbeddingSearchResult {
-	nWorkers := runtime.GOMAXPROCS(0)
-	rows := index.SimilaritySearch(query, nResults, nWorkers)
+	numWorkers := runtime.GOMAXPROCS(0)
+	rows := index.SimilaritySearch(query, nResults, embeddings.WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: SIMILARITY_SEARCH_MIN_ROWS_TO_SPLIT})
 
 	results := make([]embeddings.EmbeddingSearchResult, len(rows))
 	for idx, row := range rows {

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"runtime"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
@@ -50,7 +51,9 @@ func searchEmbeddingIndex(
 	query []float32,
 	nResults int,
 ) []embeddings.EmbeddingSearchResult {
-	rows := index.SimilaritySearch(query, nResults)
+	nWorkers := runtime.GOMAXPROCS(0)
+	rows := index.SimilaritySearch(query, nResults, nWorkers)
+
 	results := make([]embeddings.EmbeddingSearchResult, len(rows))
 	for idx, row := range rows {
 		fileContent, err := readFile(ctx, repoName, revision, row.FileName)

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -2,7 +2,10 @@ package embeddings
 
 import (
 	"container/heap"
+	"math"
 	"sort"
+
+	"github.com/sourcegraph/conc"
 )
 
 type nearestNeighbor struct {
@@ -11,59 +14,120 @@ type nearestNeighbor struct {
 }
 
 type nearestNeighborsHeap struct {
-	heap []nearestNeighbor
+	neighbors []nearestNeighbor
 }
 
-func (nn *nearestNeighborsHeap) Len() int { return len(nn.heap) }
+func (nn *nearestNeighborsHeap) Len() int { return len(nn.neighbors) }
 
 func (nn *nearestNeighborsHeap) Less(i, j int) bool {
-	return nn.heap[i].similarity < nn.heap[j].similarity
+	return nn.neighbors[i].similarity < nn.neighbors[j].similarity
 }
 
-func (nn *nearestNeighborsHeap) Swap(i, j int) { nn.heap[i], nn.heap[j] = nn.heap[j], nn.heap[i] }
+func (nn *nearestNeighborsHeap) Swap(i, j int) {
+	nn.neighbors[i], nn.neighbors[j] = nn.neighbors[j], nn.neighbors[i]
+}
 
 func (nn *nearestNeighborsHeap) Push(x any) {
-	nn.heap = append(nn.heap, x.(nearestNeighbor))
+	nn.neighbors = append(nn.neighbors, x.(nearestNeighbor))
 }
 
 func (nn *nearestNeighborsHeap) Pop() any {
-	old := nn.heap
+	old := nn.neighbors
 	n := len(old)
 	x := old[n-1]
-	nn.heap = old[0 : n-1]
+	nn.neighbors = old[0 : n-1]
 	return x
 }
 
 func (nn *nearestNeighborsHeap) Peek() nearestNeighbor {
-	return nn.heap[0]
+	return nn.neighbors[0]
 }
 
 func newNearestNeighborsHeap() *nearestNeighborsHeap {
-	nn := &nearestNeighborsHeap{heap: make([]nearestNeighbor, 0)}
+	nn := &nearestNeighborsHeap{neighbors: make([]nearestNeighbor, 0)}
 	heap.Init(nn)
 	return nn
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
+type partialRows struct {
+	start int
+	end   int
+}
+
+// splitRows splits nRows into nWorkers equal (or nearly equal) sized chunks.
+func splitRows(nRows int, nWorkers int) []partialRows {
+	if nWorkers == 1 || nRows <= nWorkers {
+		return []partialRows{{0, nRows}}
 	}
-	return b
+	nRowsPerWorker := int(math.Ceil(float64(nRows) / float64(nWorkers)))
+
+	rowsPerWorker := make([]partialRows, nWorkers)
+	for i := 0; i < nWorkers; i++ {
+		rowsPerWorker[i] = partialRows{
+			start: min(i*nRowsPerWorker, nRows),
+			end:   min((i+1)*nRowsPerWorker, nRows),
+		}
+	}
+	return rowsPerWorker
 }
 
 // SimilaritySearch finds the `nResults` most similar rows to a query vector. It uses the cosine similarity metric.
 // IMPORTANT: The vectors in the embedding index have to be normalized for similarity search to work correctly.
-func (index *EmbeddingIndex[T]) SimilaritySearch(query []float32, nResults int) []*T {
-	// TODO: Parallelize. Split the rows among N threads, each finds `nResults` within its chunk, combine the heaps, sort, return top `nResults`.
+func (index *EmbeddingIndex[T]) SimilaritySearch(query []float32, nResults int, nWorkers int) []*T {
 	if nResults == 0 {
 		return []*T{}
 	}
 
 	nRows := len(index.RowMetadata)
+	// Cannot request more results then there are rows.
+	nResults = min(nRows, nResults)
+	// We need at least 1 worker.
+	nWorkers = max(1, nWorkers)
+
+	// Split index rows among the workers. Each worker will run a partial similarity search on the assigned rows.
+	rowsPerWorker := splitRows(nRows, nWorkers)
+	heaps := make([]*nearestNeighborsHeap, len(rowsPerWorker))
+
+	if len(rowsPerWorker) > 1 {
+		var wg conc.WaitGroup
+		for workerIdx := 0; workerIdx < len(rowsPerWorker); workerIdx++ {
+			// Capture the loop variable value so we can use it in the closure below.
+			workerIdx := workerIdx
+			wg.Go(func() { heaps[workerIdx] = index.partialSimilaritySearch(query, nResults, rowsPerWorker[workerIdx]) })
+		}
+		wg.Wait()
+	} else {
+		// Run the similarity search directly when we have a single worker to eliminate the concurrency overhead.
+		heaps[0] = index.partialSimilaritySearch(query, nResults, rowsPerWorker[0])
+	}
+
+	// Collect all heap neighbors from workers into a single array.
+	neighbors := make([]nearestNeighbor, 0, len(rowsPerWorker)*nResults)
+	for _, heap := range heaps {
+		if heap != nil {
+			neighbors = append(neighbors, heap.neighbors...)
+		}
+	}
+	// And re-sort it according to the similarity (descending).
+	sort.Slice(neighbors, func(i, j int) bool { return neighbors[i].similarity > neighbors[j].similarity })
+
+	// Take top neighbors and return them as results.
+	results := make([]*T, nResults)
+	for idx := 0; idx < min(nResults, len(neighbors)); idx++ {
+		results[idx] = &index.RowMetadata[neighbors[idx].index]
+	}
+	return results
+}
+
+func (index *EmbeddingIndex[T]) partialSimilaritySearch(query []float32, nResults int, partialRows partialRows) *nearestNeighborsHeap {
+	nRows := partialRows.end - partialRows.start
+	if nRows <= 0 {
+		return nil
+	}
 	nResults = min(nRows, nResults)
 
 	nnHeap := newNearestNeighborsHeap()
-	for i := 0; i < nResults; i++ {
+	for i := partialRows.start; i < partialRows.start+nResults; i++ {
 		similarity := CosineSimilarity(
 			index.Embeddings[i*index.ColumnDimension:(i+1)*index.ColumnDimension],
 			query,
@@ -71,7 +135,7 @@ func (index *EmbeddingIndex[T]) SimilaritySearch(query []float32, nResults int) 
 		heap.Push(nnHeap, nearestNeighbor{i, similarity})
 	}
 
-	for i := nResults; i < nRows; i++ {
+	for i := partialRows.start + nResults; i < partialRows.end; i++ {
 		similarity := CosineSimilarity(
 			index.Embeddings[i*index.ColumnDimension:(i+1)*index.ColumnDimension],
 			query,
@@ -84,15 +148,7 @@ func (index *EmbeddingIndex[T]) SimilaritySearch(query []float32, nResults int) 
 		}
 	}
 
-	sort.Slice(nnHeap.heap, func(i, j int) bool {
-		return nnHeap.heap[i].similarity > nnHeap.heap[j].similarity
-	})
-
-	results := make([]*T, len(nnHeap.heap))
-	for idx, neighbor := range nnHeap.heap {
-		results[idx] = &index.RowMetadata[neighbor.index]
-	}
-	return results
+	return nnHeap
 }
 
 // TODO: Can potentially inline this for any performance benefits?
@@ -102,4 +158,18 @@ func CosineSimilarity(row []float32, query []float32) float32 {
 		similarity += (row[i] * query[i])
 	}
 	return similarity
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -1,42 +1,150 @@
 package embeddings
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
-	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
 )
 
+// Each line represents a separate embedding.
+var embeddings = []float32{
+	0.5061, 0.6595, 0.5558,
+	0.5764, 0.4482, 0.6833,
+	0.3162, 0.6444, 0.6963,
+	0.3736, 0.7713, 0.5153,
+	0.5219, 0.8505, 0.0653,
+	0.1040, 0.0241, 0.9943,
+	0.5109, 0.5712, 0.6425,
+	0.6612, 0.3818, 0.6458,
+	0.1775, 0.9603, 0.2151,
+	0.8171, 0.4514, 0.3587,
+	0.2824, 0.8265, 0.4869,
+	0.6770, 0.0224, 0.7356,
+	0.4771, 0.4809, 0.7356,
+	0.7695, 0.4057, 0.4932,
+	0.7215, 0.0623, 0.6896,
+	0.9385, 0.2944, 0.1804,
+}
+
+// Each line represents a separate query.
+var queries = []float32{
+	0.4227, 0.4874, 0.7641,
+	0.4038, 0.9100, 0.0940,
+	0.2965, 0.2290, 0.9272,
+}
+
+// Each subarray contains ranked nearest neighbors for each query.
+var ranks = [][]int{
+	{4, 2, 3, 6, 14, 12, 1, 5, 13, 11, 8, 10, 0, 7, 9, 15},
+	{4, 9, 6, 3, 0, 15, 5, 11, 1, 7, 2, 14, 10, 8, 13, 12},
+	{8, 2, 4, 10, 15, 0, 6, 5, 14, 12, 11, 3, 1, 9, 7, 13},
+}
+
 func TestSimilaritySearch(t *testing.T) {
-	embeddings := []float32{
-		0.26726124, 0.53452248, 0.80178373,
-		0.45584231, 0.56980288, 0.68376346,
-		0.50257071, 0.57436653, 0.64616234,
-	}
+	nRows, nQueries, columnDimension := 16, 3, 3
 	index := EmbeddingIndex[RepoEmbeddingRowMetadata]{
 		Embeddings:      embeddings,
-		ColumnDimension: 3,
-		RowMetadata: []RepoEmbeddingRowMetadata{
-			{FileName: "a"},
-			{FileName: "b"},
-			{FileName: "c"},
+		ColumnDimension: columnDimension,
+		RowMetadata:     []RepoEmbeddingRowMetadata{},
+	}
+
+	for i := 0; i < nRows; i++ {
+		index.RowMetadata = append(index.RowMetadata, RepoEmbeddingRowMetadata{FileName: fmt.Sprintf("%d", i)})
+	}
+
+	getExpectedResults := func(queryRanks []int) []*RepoEmbeddingRowMetadata {
+		results := make([]*RepoEmbeddingRowMetadata, len(queryRanks))
+		for idx, rank := range queryRanks {
+			results[rank] = &index.RowMetadata[idx]
+		}
+		return results
+	}
+
+	for _, nWorkers := range []int{0, 1, 2, 3, 5, 8, 9, 16, 20, 33} {
+		for _, nResults := range []int{0, 1, 2, 4, 9, 16, 32} {
+			for q := 0; q < nQueries; q++ {
+				t.Run(fmt.Sprintf("find nearest neighbors, query=%d, nResults=%d, nWorkers=%d", q, nResults, nWorkers), func(t *testing.T) {
+					query := queries[q*columnDimension : (q+1)*columnDimension]
+					results := index.SimilaritySearch(query, nResults, nWorkers)
+					expectedResults := getExpectedResults(ranks[q])
+					require.Equal(t, expectedResults[:min(nResults, len(expectedResults))], results)
+				})
+			}
+		}
+	}
+}
+
+func TestSplitRows(t *testing.T) {
+	tests := []struct {
+		nRows    int
+		nWorkers int
+		want     []partialRows
+	}{
+		{
+			nRows:    0,
+			nWorkers: 1,
+			want:     []partialRows{{0, 0}},
+		},
+		{
+			nRows:    128,
+			nWorkers: 1,
+			want:     []partialRows{{0, 128}},
+		},
+		{
+			nRows:    16,
+			nWorkers: 4,
+			want:     []partialRows{{0, 4}, {4, 8}, {8, 12}, {12, 16}},
+		},
+		{
+			nRows:    5,
+			nWorkers: 4,
+			want:     []partialRows{{0, 2}, {2, 4}, {4, 5}, {5, 5}},
+		},
+		{
+			nRows:    16,
+			nWorkers: 3,
+			want:     []partialRows{{0, 6}, {6, 12}, {12, 16}},
 		},
 	}
 
-	t.Run("find row with exact match", func(t *testing.T) {
-		query := embeddings[0:3]
-		results := index.SimilaritySearch(query, 1)
-		autogold.ExpectFile(t, results)
-	})
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("nRows=%d, nWorkers=%d", tt.nRows, tt.nWorkers), func(t *testing.T) {
+			got := splitRows(tt.nRows, tt.nWorkers)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
-	t.Run("find nearest neighbors", func(t *testing.T) {
-		query := []float32{0.87006284, 0.48336824, 0.09667365}
-		results := index.SimilaritySearch(query, 2)
-		autogold.ExpectFile(t, results)
-	})
+func getRandomEmbeddings(prng *rand.Rand, nElements int) []float32 {
+	slice := make([]float32, nElements)
+	for idx := range slice {
+		slice[idx] = prng.Float32()
+	}
+	return slice
+}
 
-	t.Run("request more results then there are rows", func(t *testing.T) {
-		query := embeddings[0:3]
-		results := index.SimilaritySearch(query, 5)
-		autogold.ExpectFile(t, results)
-	})
+func BenchmarkSimilaritySearch(b *testing.B) {
+	prng := rand.New(rand.NewSource(0))
+
+	nRows := 1_000_000
+	nResults := 100
+	columnDimension := 1536
+	index := &EmbeddingIndex[RepoEmbeddingRowMetadata]{
+		Embeddings:      getRandomEmbeddings(prng, nRows*columnDimension),
+		ColumnDimension: columnDimension,
+		RowMetadata:     make([]RepoEmbeddingRowMetadata, nRows),
+	}
+	query := getRandomEmbeddings(prng, columnDimension)
+
+	b.ResetTimer()
+
+	for _, nWorkers := range []int{1, 2, 4, 8, 16} {
+		b.Run(fmt.Sprintf("nWorkers=%d", nWorkers), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_ = index.SimilaritySearch(query, nResults, nWorkers)
+			}
+		})
+	}
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Data below was generated using the testdata/generate_similarity_search_test_data.py script.
+
 // Each line represents a separate embedding.
 var embeddings = []float32{
 	0.5061, 0.6595, 0.5558,

--- a/enterprise/internal/embeddings/testdata/TestSimilaritySearch/find_nearest_neighbors.golden
+++ b/enterprise/internal/embeddings/testdata/TestSimilaritySearch/find_nearest_neighbors.golden
@@ -1,6 +1,0 @@
-[]*embeddings.RepoEmbeddingRowMetadata{
-	{
-		FileName: "c",
-	},
-	{FileName: "b"},
-}

--- a/enterprise/internal/embeddings/testdata/TestSimilaritySearch/find_row_with_exact_match.golden
+++ b/enterprise/internal/embeddings/testdata/TestSimilaritySearch/find_row_with_exact_match.golden
@@ -1,3 +1,0 @@
-[]*embeddings.RepoEmbeddingRowMetadata{{
-	FileName: "a",
-}}

--- a/enterprise/internal/embeddings/testdata/TestSimilaritySearch/request_more_results_then_there_are_rows.golden
+++ b/enterprise/internal/embeddings/testdata/TestSimilaritySearch/request_more_results_then_there_are_rows.golden
@@ -1,7 +1,0 @@
-[]*embeddings.RepoEmbeddingRowMetadata{
-	{
-		FileName: "a",
-	},
-	{FileName: "b"},
-	{FileName: "c"},
-}

--- a/enterprise/internal/embeddings/testdata/generate_similarity_search_test_data.py
+++ b/enterprise/internal/embeddings/testdata/generate_similarity_search_test_data.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+np.random.seed(0)
+
+
+def print_as_array(name, arr):
+    print("var", name, "= []float32{")
+    for row in arr:
+        print("\t", end="")
+        for col in row:
+            print(f"{col:.4f}, ", end="")
+        print()
+    print("}")
+
+
+def print_as_2d_array(name, arr):
+    print("var", name, "= [][]int{")
+    for row in arr:
+        print("\t{", end="")
+        for col in row:
+            print(f"{col}, ", end="")
+        print("},")
+    print("}")
+
+
+N_ROWS, N_COLS, N_QUERIES = 16, 3, 3
+
+A = np.random.random((N_ROWS, N_COLS))
+A_norm = A / np.linalg.norm(A, axis=1, keepdims=True)
+
+q = np.random.random((N_QUERIES, N_COLS))
+q_norm = q / np.linalg.norm(q, axis=1, keepdims=True)
+
+print_as_array("embeddings", A_norm)
+print_as_array("queries", q_norm)
+
+similarities = np.matmul(q_norm, A_norm.T)
+similarity_ranks = (N_ROWS - 1) - np.argsort(
+    np.argsort(similarities, axis=1),
+    axis=1,
+)
+print_as_2d_array("ranks", similarity_ranks)


### PR DESCRIPTION
Implements parallel similarity search using the `conc` library. The procedure is as follows:

* Split the index rows into consecutive chunks for each worker
* Each worker takes the assigned chunk and finds the nearest neighbors in the chunk
* Wait for all workers
* Main thread merges all neighbors from workers into a single array and sorts it by similarity
* Take top `nResults` from the array and return them as results

## Benchmark

1M rows, 1536 columns, and requesting 100 results.

```
$ GOMAXPROCS=16 go test -run=^$ -bench ^BenchmarkSimilaritySearch$ github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings
cpu: VirtualApple @ 2.50GHz
BenchmarkSimilaritySearch/nWorkers=1-16         	       1	1640556709 ns/op
BenchmarkSimilaritySearch/nWorkers=2-16         	       2	 745612270 ns/op
BenchmarkSimilaritySearch/nWorkers=4-16         	       3	 376688542 ns/op
BenchmarkSimilaritySearch/nWorkers=8-16         	       4	 251485469 ns/op
BenchmarkSimilaritySearch/nWorkers=16-16        	       6	 194714326 ns/op
PASS
ok  	github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings	21.599s
```

## Test plan

* Should be covered by the unit test and the benchmark