### PR TITLE
Simplify automating batch changes in-app changelog for release

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -19,7 +19,7 @@ const CURRENT_VERSION = '4.4'
  * After every release, this will be set back to `false`. Chromatic will also verify
  * changes to this variable via visual regression testing.
  */
-const SHOW_CHANGELOG = true
+const SHOW_CHANGELOG = false
 
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
     className,

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -8,23 +8,48 @@ import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
 import styles from './BatchChangesListIntro.module.scss'
 
-export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <DismissibleAlert
-        className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-4.4"
-    >
-        <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
-            <CardBody>
-                <H4 as={H3}>Batch Changes updates in version 4.4</H4>
-                <ul className="mb-0 pl-3">
-                    <li>
-                        <Link to="/help/admin/deploy_executors#using-private-registries" rel="noopener" target="_blank">
-                            Using private container registries
-                        </Link>{' '}
-                        is now supported in server-side batch changes.
-                    </li>
-                </ul>
-            </CardBody>
-        </Card>
-    </DismissibleAlert>
-)
+/**
+ * CURRENT_VERSION is meant to be updated by release tooling to the current in-progress version.
+ * Ie. After 5.0 is cut, this should be bumped to 5.1, and so on. This ensures we
+ * always render the right changelog.
+ */
+const CURRENT_VERSION = '4.4'
+/**
+ * SHOW_CHANGELOG has to be set to true when a changelog entry is added for a release.
+ * After every release, this will be set back to `false`. Chromatic will also verify
+ * changes to this variable via visual regression testing.
+ */
+const SHOW_CHANGELOG = true
+
+export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => {
+    // IMPORTANT!! If you add an entry, make sure to set SHOW_CHANGELOG to true!
+    if (!SHOW_CHANGELOG) {
+        return null
+    }
+    return (
+        <DismissibleAlert
+            className={classNames(styles.batchChangesListIntroAlert, className)}
+            partialStorageKey={`batch-changes-list-intro-changelog-${CURRENT_VERSION}`}
+        >
+            <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
+                <CardBody>
+                    <H4 as={H3}>Batch Changes updates in version {CURRENT_VERSION}</H4>
+                    <ul className="mb-0 pl-3">
+                        <li>
+                            <Link
+                                to="/help/admin/deploy_executors#using-private-registries"
+                                rel="noopener"
+                                target="_blank"
+                            >
+                                Using private container registries
+                            </Link>{' '}
+                            is now supported in server-side batch changes.
+                        </li>
+                    </ul>
+                </CardBody>
+            </Card>
+        </DismissibleAlert>
+    )
+}

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .batch-changes-list-intro {
     /* By default, dismissible alerts are flex containers that position the
     button at the end of the "row". Since we don't want to interfere with the
@@ -24,5 +26,16 @@
 
     &__card {
         background: var(--color-bg-1);
+    }
+}
+
+.alerts-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    &-content {
+        @media (--sm-breakpoint-down) {
+            min-width: 100%;
+        }
     }
 }

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -6,6 +6,8 @@ import { CardBody, Card, Link, H4, Text } from '@sourcegraph/wildcard'
 
 import { SourcegraphIcon } from '../../../auth/icons'
 
+import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
+
 import styles from './BatchChangesListIntro.module.scss'
 
 export interface BatchChangesListIntroProps {
@@ -15,30 +17,24 @@ export interface BatchChangesListIntroProps {
 export const BatchChangesListIntro: React.FunctionComponent<React.PropsWithChildren<BatchChangesListIntroProps>> = ({
     isLicensed,
 }) => {
-    if (isLicensed === undefined || isLicensed === true) {
+    if (isLicensed === undefined) {
         return null
     }
 
     return (
-        <div className="row">
-            {/* {isLicensed === true ? (
-                <div className="col-12">
+        <div className={classNames(styles.alertsRow, 'mb-3')}>
+            {isLicensed === true ? (
+                <div className={classNames(styles.alertsRowContent, 'flex-1')}>
                     <BatchChangesChangelogAlert />
                 </div>
             ) : (
                 <>
-                    <div className="col-12 col-md-6 mb-3">
+                    <div className={classNames(styles.alertsRowContent, 'flex-1')}>
                         <BatchChangesUnlicensedAlert />
                     </div>
-                    <div className="col-12 col-md-6 mb-3">
-                        <BatchChangesChangelogAlert />
-                    </div>
+                    <BatchChangesChangelogAlert className={classNames(styles.alertsRowContent, 'flex-1')} />
                 </>
-            )} */}
-
-            <div className="col-12">
-                <BatchChangesUnlicensedAlert />
-            </div>
+            )}
         </div>
     )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -22,17 +22,17 @@ export const BatchChangesListIntro: React.FunctionComponent<React.PropsWithChild
     }
 
     return (
-        <div className={classNames(styles.alertsRow, 'mb-3')}>
+        <div className={classNames(styles.alertsRow)}>
             {isLicensed === true ? (
-                <div className={classNames(styles.alertsRowContent, 'flex-1')}>
+                <div className={classNames(styles.alertsRowContent, 'flex-1 mb-3')}>
                     <BatchChangesChangelogAlert />
                 </div>
             ) : (
                 <>
-                    <div className={classNames(styles.alertsRowContent, 'flex-1')}>
+                    <div className={classNames(styles.alertsRowContent, 'flex-1 mb-3')}>
                         <BatchChangesUnlicensedAlert />
                     </div>
-                    <BatchChangesChangelogAlert className={classNames(styles.alertsRowContent, 'flex-1')} />
+                    <BatchChangesChangelogAlert className={classNames(styles.alertsRowContent, 'flex-1 mb-3')} />
                 </>
             )}
         </div>


### PR DESCRIPTION
We usually decide manually when to add it, then add entries and make sure it lands before the release. If we forget, there would be a weird old banner showing on newer instances, so we should at least make a call to hide it (which we currently do by commenting it out), or add items to it.

New process suggestion:
- Batchers make sure that they include their in-app changelog entry in the PR the feature was created in
- The release tooling does what I documented inline, which essentially replaces two variables after the cut. That should probably happen right after the branch is cut, not when the release is going out.



## Test plan

Still looks good in storybook.

## App preview:

- [Web](https://sg-web-es-easier-in-app-changelog-mods.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
