### PR TITLE
Treeview: Fix invalid tabIndex setting when loading from a blob view

### DIFF
--- a/client/wildcard/src/components/Tree/Tree.tsx
+++ b/client/wildcard/src/components/Tree/Tree.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { mdiMenuRight, mdiMenuDown } from '@mdi/js'
 import classNames from 'classnames'
@@ -37,7 +37,7 @@ interface Props<N extends TreeNode>
     nodeClassName?: string
 }
 export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
-    const { onSelect, onExpand, onLoadData, renderNode, loadedIds, nodeClassName, ...rest } = props
+    const { onSelect, onExpand, onLoadData, renderNode, loadedIds, nodeClassName, expandedIds, ...rest } = props
 
     const _onSelect = useCallback(
         // TreeView expects nodes to be INode but ours are extending this type,
@@ -133,9 +133,20 @@ export function Tree<N extends TreeNode>(props: Props<N>): JSX.Element {
         [loadedIds, nodeClassName, renderNode]
     )
 
+    // <TreeView /> quirk:
+    //
+    // The root node (id = 0) is not a valid target to be expanded. If it is set accidentally, it
+    // can leave the tree in an invalid state where no tabIndex={0} item is rendered (because the
+    // tabIndex is assumed it has to be on the root node).
+    const validExpandedIds = useMemo(
+        () => (expandedIds ? expandedIds.filter(id => id !== 0) : expandedIds),
+        [expandedIds]
+    )
+
     return (
         <TreeView
             {...rest}
+            expandedIds={validExpandedIds}
             className={classNames(styles.fileTree, rest.className)}
             // TreeView expects nodes to be INode but ours are extending this type.
             onSelect={_onSelect}


### PR DESCRIPTION
There's a bug in the treeview component where the tabbable node can be set to the wrong item when expanding is called with the root node (id: 0).

This manifests in the fact that tabbing into the treeview does not work anymore because none of the rendered items will have a `tabIndex={0}` set because the treeview thinks that the root item should receive the focus but it's not rendered.

We fix this in the Wildcard component by removing `0` from the list of expanded IDs.

## Test plan

https://user-images.githubusercontent.com/458591/222766676-be05c9ca-8999-4aa5-bb4f-0c1b66f05053.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-treeview-default-selection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
