### PR TITLE
symbols: fix regression where old env var names were not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- The symbols service `CACHE_DIR` and `MAX_TOTTAL_PATHS_LENGTH` were renamed to have a `SYMBOLS_` prefix in the last version of Sourcegraph; this version fixes a bug where the old names without the `SYMBOLS_` prefix were not respected correctly. Both names now work.
 - Fixed issues with propagating tracing configuration throughout the application. [#47428](https://github.com/sourcegraph/sourcegraph/pull/47428)
 - Enable `auto gc` on fetch when `SRC_ENABLE_GC_AUTO` is set to `true`. [#47852](https://github.com/sourcegraph/sourcegraph/pull/47852)
 - Fixes syntax highlighting and line number issues in the code preview rendered inside the references panel. [#48107](https://github.com/sourcegraph/sourcegraph/pull/48107)

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -24,29 +24,17 @@ type SqliteConfig struct {
 	MaxConcurrentlyIndexing int
 }
 
-func aliasEnvVar(oldName, newName string) {
-	if os.Getenv(newName) != "" {
-		return // prefer using the new name
-	}
-	oldValue := os.Getenv(oldName)
-	if oldValue == "" {
-		return // old name was not set
-	}
-	// New name not in use, but old name is, so update the env.
-	_ = os.Setenv(newName, oldValue)
-}
-
 func LoadSqliteConfig(baseConfig env.BaseConfig, ctags CtagsConfig, repositoryFetcher RepositoryFetcherConfig) SqliteConfig {
 	// Variable was renamed to have SYMBOLS_ prefix to avoid a conflict with the same env var name
 	// in searcher when running as a single binary. The old name is treated as an alias to prevent
 	// customer environments from breaking if they still use it, because we have no way of migrating
 	// environment variables today.
-	aliasEnvVar("CACHE_DIR", "SYMBOLS_CACHE_DIR")
+	cacheDirName := env.ChooseFallbackVariableName("SYMBOLS_CACHE_DIR", "CACHE_DIR")
 
 	return SqliteConfig{
 		Ctags:                   ctags,
 		RepositoryFetcher:       repositoryFetcher,
-		CacheDir:                baseConfig.Get("SYMBOLS_CACHE_DIR", "/tmp/symbols-cache", "directory in which to store cached symbols"),
+		CacheDir:                baseConfig.Get(cacheDirName, "/tmp/symbols-cache", "directory in which to store cached symbols"),
 		CacheSizeMB:             baseConfig.GetInt("SYMBOLS_CACHE_SIZE_MB", "100000", "maximum size of the disk cache (in megabytes)"),
 		NumCtagsProcesses:       baseConfig.GetInt("CTAGS_PROCESSES", strconv.Itoa(runtime.GOMAXPROCS(0)), "number of concurrent parser processes to run"),
 		RequestBufferSize:       baseConfig.GetInt("REQUEST_BUFFER_SIZE", "8192", "maximum size of buffered parser request channel"),
@@ -100,10 +88,10 @@ func LoadRepositoryFetcherConfig(baseConfig env.BaseConfig) RepositoryFetcherCon
 	// in searcher when running as a single binary. The old name is treated as an alias to prevent
 	// customer environments from breaking if they still use it, because we have no way of migrating
 	// environment variables today.
-	aliasEnvVar("MAX_TOTAL_PATHS_LENGTH", "SYMBOLS_MAX_TOTAL_PATHS_LENGTH")
+	maxTotalPathsLengthName := env.ChooseFallbackVariableName("SYMBOLS_MAX_TOTAL_PATHS_LENGTH", "MAX_TOTAL_PATHS_LENGTH")
 
 	return RepositoryFetcherConfig{
-		MaxTotalPathsLength: baseConfig.GetInt("SYMBOLS_MAX_TOTAL_PATHS_LENGTH", "100000", "maximum sum of lengths of all paths in a single call to git archive"),
+		MaxTotalPathsLength: baseConfig.GetInt(maxTotalPathsLengthName, "100000", "maximum sum of lengths of all paths in a single call to git archive"),
 		MaxFileSizeKb:       baseConfig.GetInt("MAX_FILE_SIZE_KB", "1000", "maximum file size in KB, the contents of bigger files are ignored"),
 	}
 }


### PR DESCRIPTION
The env var aliasing code introduced did not work correctly, and as a result symbols searches broke in the previous version of Sourcegraph:

* https://github.com/sourcegraph/sourcegraph/pull/48606
* https://sourcegraph.slack.com/archives/C02E4HE42BX/p1677787957893839

This updates the code to use `env.ChooseFallbackVariableName` - the correct way to alias env var names (thanks Erik!) - and should fix the issue.

I've re-reviewed App changes to ensure these were the only two env vars renamed, so we shouldn't get bitten by this anywhere else.

## Test plan

Careful code review.