### PR TITLE
Declare BUILD.bazel files as generated content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/*.pb.go linguist-generated=true
 CHANGELOG.md merge=union
 **/mocks*_*test.go linguist-generated=true
+**/BUILD.bazel linguist-generated=true


### PR DESCRIPTION
This will auto-collapse them in PR diffs on github.



## Test plan

Will see on a future PR if it has the desired effect!