### PR TITLE
codeintel: Lower default failed index retention age

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/config.go
+++ b/enterprise/internal/codeintel/autoindexing/config.go
@@ -29,7 +29,7 @@ func (c *cleanupJobsConfig) Load() {
 	c.CommitResolverBatchSize = c.GetInt(commitResolverBatchSizeName, "100", "The maximum number of unique commits to resolve at a time.")
 	c.CommitResolverMaximumCommitLag = c.GetInterval(commitResolverMaximumCommitLagName, "0s", "The maximum acceptable delay between accepting an upload and its commit becoming resolvable. Be cautious about setting this to a large value, as uploads for unresolvable commits will be retried periodically during this interval.")
 	c.FailedIndexBatchSize = c.GetInt("CODEINTEL_AUTOINDEXING_FAILED_INDEX_BATCH_SIZE", "1000", "The number of old, failed index records to delete at once.")
-	c.FailedIndexMaxAge = c.GetInterval("CODEINTEL_AUTOINDEXING_FAILED_INDEX_MAX_AGE", "2190h", "The maximum age a non-relevant failed index record will remain queryable.")
+	c.FailedIndexMaxAge = c.GetInterval("CODEINTEL_AUTOINDEXING_FAILED_INDEX_MAX_AGE", "730h", "The maximum age a non-relevant failed index record will remain queryable.")
 }
 
 type dependencyIndexJobsConfig struct {


### PR DESCRIPTION
So, #48468 was already implemented, but the default value was just way too high. Lowering from 3mo to 1mo.

Fixes #48468 (I guess).

## Test plan

N/A.