### PR TITLE
codeintel: Remove records for blocked repositories

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
@@ -597,7 +597,9 @@ candidates AS (
 	SELECT u.id
 	FROM repo r
 	JOIN lsif_indexes u ON u.repository_id = r.id
-	WHERE %s - r.deleted_at >= %s * interval '1 second'
+	WHERE
+		%s - r.deleted_at >= %s * interval '1 second' OR
+		r.blocked IS NOT NULL
 
 	-- Lock these rows in a deterministic order so that we don't
 	-- deadlock with other processes updating the lsif_indexes table.

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -563,7 +563,9 @@ candidates AS (
 	SELECT u.id
 	FROM repo r
 	JOIN lsif_uploads u ON u.repository_id = r.id
-	WHERE %s - r.deleted_at >= %s * interval '1 second'
+	WHERE
+		%s - r.deleted_at >= %s * interval '1 second' OR
+		r.blocked IS NOT NULL
 
 	-- Lock these rows in a deterministic order so that we don't
 	-- deadlock with other processes updating the lsif_uploads table.


### PR DESCRIPTION
Remove index/upload records for repositories that have been explicitly blocked.

```
> select COUNT(*) from lsif_uploads u join repo r on r.id = u.repository_id where r.blocked IS NOT NULL;
 count
-------
 10546
```

```
> select COUNT(*) from lsif_indexes u join repo r on r.id = u.repository_id where r.blocked IS NOT NULL;
 count
-------
 58740
```

## Test plan

Unit tests continue to pass.