### PR TITLE
dockertools: create functions for parsing docker container strings into structs

### DIFF
--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -41,7 +41,7 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, doc
 	}
 
 	image := spec.Image
-	if options.DockerOptions.RegistryUrl != "" && dockertools.ParseImageString(image).Registry == "" {
+	if options.DockerOptions.RegistryUrl != "" && dockertools.ParseImageString(image).IsPublicDockerHub() {
 		image = fmt.Sprintf("%s/%s", options.DockerOptions.RegistryUrl, image)
 	}
 

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+
+	"github.com/sourcegraph/sourcegraph/internal/dockertools"
 )
 
 // ScriptsPath is the location relative to the executor workspace where the executor
@@ -38,10 +40,8 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, doc
 		hostDir = filepath.Join(options.ResourceOptions.DockerHostMountPath, filepath.Base(dir))
 	}
 
-	// TODO check that the original spec.Image isn't fully qualified so we don't inject our path
-	// and create an invalid docker name
 	image := spec.Image
-	if options.DockerOptions.RegistryUrl != "" {
+	if options.DockerOptions.RegistryUrl != "" && dockertools.ParseImageString(image).Registry == "" {
 		image = fmt.Sprintf("%s/%s", options.DockerOptions.RegistryUrl, image)
 	}
 

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -356,8 +355,6 @@ func TestFormatRawOrDockerCommandDockerScriptWithRegistryPrefixAndFullyQualified
 	}
 
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
-		fmt.Println("want: ", expected.Command)
-		fmt.Println("got: ", actual.Command)
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
 	}
 

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -147,7 +147,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job types.Job) 
 	// Invoke each docker step sequentially
 	for i, dockerStep := range job.DockerSteps {
 		image := dockerStep.Image
-		if options.DockerOptions.RegistryUrl != "" && dockertools.ParseImageString(image).Registry == "" {
+		if options.DockerOptions.RegistryUrl != "" && dockertools.ParseImageString(image).IsPublicDockerHub() {
 			image = fmt.Sprintf("%s/%s", options.DockerOptions.RegistryUrl, image)
 		}
 

--- a/internal/dockertools/images.go
+++ b/internal/dockertools/images.go
@@ -15,6 +15,12 @@ type ImageReference struct {
 	Digest    string // sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
 }
 
+// IsPublicDockerHub determines if the container is coming from a public docker registry
+// upstream, either by not specifying a registry or speciying one of the Docker Hub URLs
+func (i ImageReference) IsPublicDockerHub() bool {
+	return i.Registry == "" || i.Registry == "index.docker.io" || i.Registry == "docker.io"
+}
+
 func (image ImageReference) String() string {
 	s := image.Name
 	if image.Namespace != "" {
@@ -34,9 +40,12 @@ func (image ImageReference) String() string {
 }
 
 // ParseImageString parses a docker image into a Go ImageReference type in the
-// format: registry_hostname[:port]/][user_name/](repository_name[:version_tag])
+// format: <registry.example.com/subpaths>/<namespace>/<name>:<tag>@<digest>
 //
-// Needs to be able to support registries that have subpaths in them
+// Supports registries with a variable number of subpaths included in them.
+// Please note: this is a best-effort string parsing implementation and may
+// struggle with certain registries that allow variable formats (e.g. GitLab)
+// Please validate the results manually before trusting this function.
 func ParseImageString(dockerName string) ImageReference {
 	var image ImageReference
 

--- a/internal/dockertools/images.go
+++ b/internal/dockertools/images.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ImageReference represents a fully qualified Docker image:
+// e.g. index.docker.io/sourcegraph/frontend:insiders@sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+type ImageReference struct {
+	Registry  string // index.docker.io
+	Namespace string // sourcegraph
+	Name      string // frontend
+	Tag       string // insiders
+	Digest    string // sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+}
+
+func (image ImageReference) String() string {
+	s := image.Name
+	if image.Namespace != "" {
+		s = fmt.Sprintf("%s/%s", image.Namespace, s)
+	}
+	if image.Tag != "" {
+		s = fmt.Sprintf("%s:%s", s, image.Tag)
+	}
+	if image.Digest != "" {
+		s = fmt.Sprintf("%s@%s", s, image.Digest)
+	}
+	if image.Registry != "" {
+		s = fmt.Sprintf("%s/%s", image.Registry, s)
+	}
+
+	return s
+}
+
+// ParseImageString parses a docker image into a Go ImageReference type in the
+// format: registry_hostname[:port]/][user_name/](repository_name[:version_tag])
+//
+// Needs to be able to support registries that have subpaths in them
+func ParseImageString(dockerName string) ImageReference {
+	var image ImageReference
+
+	// Check if the input string contains a "digest" tag (denoted by an "@" symbol after the tag).
+	if strings.Contains(dockerName, "@") {
+		// Extract the digest from the input string and trim it from the input string.
+		atIdx := strings.LastIndex(dockerName, "@")
+		image.Digest = dockerName[atIdx+1:]
+		dockerName = dockerName[:atIdx]
+	}
+
+	// Split the input string into its parts using the last colon as a delimiter.
+	colonIdx := strings.LastIndex(dockerName, ":")
+
+	if colonIdx != -1 {
+		// Extract the tag from the input string.
+		image.Tag = dockerName[colonIdx+1:]
+		dockerName = dockerName[:colonIdx]
+	}
+
+	parts := strings.Split(dockerName, "/")
+
+	// If the input string does not contain any slashes, assume that the first part is the image name.
+	if len(parts) == 1 {
+		image.Name = parts[0]
+		return image
+	}
+
+	// If the input string contains at least one slash, assume that the first part is the registry (if it contains a dot),
+	// and the last two parts are the image namespace and name.
+	// If the input string contains two or more slashes, assume that the first parts (up to the third slash) are the registry,
+	// the fourth part is the region (if present), and the last two parts are the image namespace and name.
+	image.Name = parts[len(parts)-1]
+	image.Namespace = parts[len(parts)-2]
+	if len(parts) > 2 {
+		if strings.Contains(parts[0], ".") {
+			image.Registry = strings.Join(parts[:len(parts)-2], "/")
+		} else if len(parts) > 3 {
+			image.Registry = strings.Join(parts[:3], "/")
+			if len(parts) > 4 {
+				image.Registry += "/" + parts[3]
+			}
+		}
+	}
+
+	return image
+}

--- a/internal/dockertools/images.go
+++ b/internal/dockertools/images.go
@@ -1,4 +1,4 @@
-package docker
+package dockertools
 
 import (
 	"fmt"

--- a/internal/dockertools/images_test.go
+++ b/internal/dockertools/images_test.go
@@ -81,6 +81,30 @@ var tt = []struct {
 			Tag:       "insiders",
 		},
 	},
+	{
+		In: "nodejs:16",
+		Want: ImageReference{
+			Name: "nodejs",
+			Tag:  "16",
+		},
+	},
+	{
+		In: "arm64/nodejs:16",
+		Want: ImageReference{
+			Namespace: "arm64",
+			Name:      "nodejs",
+			Tag:       "16",
+		},
+	},
+	{
+		In: "privateartifactory.sgdev.org/nodejs/nodejs:16",
+		Want: ImageReference{
+			Registry:  "privateartifactory.sgdev.org",
+			Namespace: "nodejs",
+			Name:      "nodejs",
+			Tag:       "16",
+		},
+	},
 }
 
 func TestParseImageString(t *testing.T) {

--- a/internal/dockertools/images_test.go
+++ b/internal/dockertools/images_test.go
@@ -1,0 +1,104 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var tt = []struct {
+	In   string
+	Want ImageReference
+}{
+	{
+		In: "sourcegraph/executor",
+		Want: ImageReference{
+			Namespace: "sourcegraph",
+			Name:      "executor",
+		},
+	},
+	{
+		In: "sourcegraph/executor:insiders",
+		Want: ImageReference{
+			Namespace: "sourcegraph",
+			Name:      "executor",
+			Tag:       "insiders",
+		},
+	},
+	{
+		In: "index.docker.io/sourcegraph/executor:insiders",
+		Want: ImageReference{
+			Namespace: "sourcegraph",
+			Registry:  "index.docker.io",
+			Name:      "executor",
+			Tag:       "insiders",
+		},
+	},
+	{
+		In: "index.docker.io/sourcegraph/executor:insiders@sha256:abc123",
+		Want: ImageReference{
+			Registry:  "index.docker.io", // index.docker.io strings are replaced by docker.io
+			Namespace: "sourcegraph",
+			Name:      "executor",
+			Tag:       "insiders",
+			Digest:    "sha256:abc123",
+		},
+	},
+	{
+		In: "us-central1-docker.pkg.dev/project-id/repo/sourcegraph/executor",
+		Want: ImageReference{
+			Registry:  "us-central1-docker.pkg.dev/project-id/repo",
+			Namespace: "sourcegraph",
+			Name:      "executor",
+		},
+	},
+	{
+		In: "us-central1-docker.pkg.dev/project-id/repo/sourcegraph/executor:insiders",
+		Want: ImageReference{
+			Registry:  "us-central1-docker.pkg.dev/project-id/repo",
+			Namespace: "sourcegraph",
+			Name:      "executor",
+			Tag:       "insiders",
+		},
+	},
+	{
+		In: "us-central1-docker.pkg.dev/project-id/repo/sourcegraph/executor:insiders@sha256:abc123",
+		Want: ImageReference{
+			Registry:  "us-central1-docker.pkg.dev/project-id/repo",
+			Namespace: "sourcegraph",
+			Name:      "executor",
+			Tag:       "insiders",
+			Digest:    "sha256:abc123",
+		},
+	},
+	{
+		In: "us.gcr.io/sourcegraph-dev/searcher:insiders",
+		Want: ImageReference{
+			Registry:  "us.gcr.io",
+			Namespace: "sourcegraph-dev",
+			Name:      "searcher",
+			Tag:       "insiders",
+		},
+	},
+}
+
+func TestParseImageString(t *testing.T) {
+	for idx, tc := range tt {
+		name := fmt.Sprintf("%v_input=%s", idx, tc.In)
+		t.Run(name, func(t *testing.T) {
+			// string -> ImageReference
+			got := ParseImageString(tc.In)
+			if !cmp.Equal(tc.Want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tc.Want, got))
+			}
+
+			// ImageReference -> string
+			s := got.String()
+			if s != tc.In {
+				t.Errorf("Expected: %s, got: %s\n", tc.In, s)
+			}
+
+		})
+	}
+}

--- a/internal/dockertools/images_test.go
+++ b/internal/dockertools/images_test.go
@@ -1,4 +1,4 @@
-package docker
+package dockertools
 
 import (
 	"fmt"


### PR DESCRIPTION
Created to be able to validate images for https://github.com/sourcegraph/sourcegraph/pull/48499/files

This code attempts to create a generic-enough function for parsing docker container strings into a Go struct so we can easily reference the various components of the string. It works pretty well with one _major_ caveat: subpaths in registry strings are non-deterministic and not part of the docker spec. This means that there can be any arbitrary number of sub paths in the "registry" part of the string and there's no way to discern the parts. I've made a best-effort and tried to cover all popular registries that we may run into (notably this covers the "artifact registry" case where the registry is `<region>-docker.pkg.dev/<project-id>/<repository-name>`).

The unit tests try and capture the supported structures pretty well but unfortunately there's no easy way to determine how to parse `registry.com/subpath/container-with-no-namespace`. For example: `us-central1-docker.pkg.dev/project-id/repo/golang:1.20` is _technically_ a valid container for Artifact Registry but will not parse correctly as the code cannot tell which part of the URL is the registry and which is the namespace/name combo.

## Test plan
Unit tests, manual validation, ChatGPT said it was pretty good.