### PR TITLE
own: more consisten spacing in file ownership panel

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.module.scss
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.module.scss
@@ -1,5 +1,5 @@
 .contents {
-    margin: 0.75rem 1rem;
+    margin: 0.75rem 0;
 }
 
 .loader-wrapper {
@@ -10,8 +10,7 @@
 }
 
 .table {
-    width: calc(100% - 2rem);
-    margin: 0.75rem 1rem;
+    width: 100%;
 
     td {
         padding-bottom: 0.5rem;

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -54,14 +54,9 @@ export const FileOwnershipPanel: React.FunctionComponent<{
         data.node.commit.blob.ownership.nodes.length > 0
     ) {
         return (
-            <>
+            <div className={styles.contents}>
                 <OwnExplanation />
-                <Accordion
-                    as="table"
-                    collapsible={true}
-                    multiple={true}
-                    className={classNames(styles.table, styles.contents)}
-                >
+                <Accordion as="table" collapsible={true} multiple={true} className={styles.table}>
                     <thead className="sr-only">
                         <tr>
                             <th>Show details</th>
@@ -85,7 +80,7 @@ export const FileOwnershipPanel: React.FunctionComponent<{
                         )
                     )}
                 </Accordion>
-            </>
+            </div>
         )
     }
 
@@ -109,7 +104,7 @@ const OwnExplanation: React.FunctionComponent<{}> = () => {
     }
 
     return (
-        <MarketingBlock contentClassName={styles.ownExplanationContainer}>
+        <MarketingBlock contentClassName={styles.ownExplanationContainer} wrapperClassName="mb-3">
             <div className="d-flex align-items-start">
                 <div className="flex-1">
                     <H3 as={H4} className={styles.ownExplanationTitle}>


### PR DESCRIPTION
Margins in the file ownership panel were not consistent between the empty view and the populated view. Also, there was no bottom margin for the explanation box.

### Before

![image](https://user-images.githubusercontent.com/206864/222847091-d333ae47-9cc0-4087-a3de-efb66c49d502.png)
![image](https://user-images.githubusercontent.com/206864/222847152-166ad700-a955-45d1-bb82-3325cd43ddef.png)


### After
![image](https://user-images.githubusercontent.com/206864/222847237-3df3838d-59f7-4fe4-a658-85aff5630b2c.png)
![image](https://user-images.githubusercontent.com/206864/222847289-e30d3ae5-5ce9-478c-a1e3-6d659443c3b4.png)


## Test plan

Verify visually

## App preview:

- [Web](https://sg-web-jp-ownexplanationspacing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
