### PR TITLE
own: export owner search results as CSV

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -595,7 +595,7 @@ export function getCommitMatchUrl(commitMatch: CommitMatch): string {
     return '/' + encodeURI(commitMatch.repository) + '/-/commit/' + commitMatch.oid
 }
 
-export function getOwnerMatchUrl(ownerMatch: OwnerMatch): string {
+export function getOwnerMatchUrl(ownerMatch: OwnerMatch, ignoreUnknownPerson: boolean = false): string {
     if (ownerMatch.type === 'person' && ownerMatch.user) {
         return '/users/' + encodeURI(ownerMatch.user.username)
     }
@@ -606,10 +606,14 @@ export function getOwnerMatchUrl(ownerMatch: OwnerMatch): string {
         return `mailto:${ownerMatch.email}`
     }
 
+    if (ignoreUnknownPerson) {
+        return ''
+    }
     // Unknown person with only a handle.
-    // We need some unique dummy data here because this is used
+    // We can't ignore this person and return an empty string, we
+    // need some unique dummy data here because this is used
     // as the key in the virtual list. We can't use the index.
-    // Once we have enough data, we may be able to link to the
+    // In the future we may be able to link to the
     // person's profile page in the external code host.
     return '/unknown-person/' + encodeURI(ownerMatch.handle || 'unknown')
 }

--- a/client/web/src/search/results/searchResultsExport.test.ts
+++ b/client/web/src/search/results/searchResultsExport.test.ts
@@ -1386,7 +1386,7 @@ describe('searchResultsToFileContent', () => {
                     displayName: 'Example Team',
                 },
             ],
-            'Match type,Handle,Email,User or team name,Display name\nperson,alice,alice@example.com,alice,Alice Example\nperson,bob,,,\nteam,example-team,example-team@example.com,example-team,Example Team',
+            'Match type,Handle,Email,User or team name,Display name,Profile URL\nperson,alice,alice@example.com,alice,Alice Example,http://localhost:3443/users/alice\nperson,bob,,,,\nteam,example-team,example-team@example.com,example-team,Example Team,http://localhost:3443/teams/example-team',
         ],
     ]
 

--- a/client/web/src/search/results/searchResultsExport.test.ts
+++ b/client/web/src/search/results/searchResultsExport.test.ts
@@ -4,7 +4,7 @@ import { searchResultsToFileContent, buildFileName } from './searchResultsExport
 
 describe('searchResultsToFileContent', () => {
     const sourcegraphURL = 'http://localhost:3443'
-    const data: [SearchType | null, SearchMatch[], string][] = [
+    const data: [SearchType | 'owner' | null, SearchMatch[], string][] = [
         [
             null,
             [
@@ -1359,6 +1359,34 @@ describe('searchResultsToFileContent', () => {
             ],
 
             'Match type,Repository,Repository external URL,Date,Author,Subject,oid,Commit URL\ncommit,github.com/EbookFoundation/free-programming-books,http://localhost:3443/github.com/EbookFoundation/free-programming-books,2022-10-30T03:07:11Z,Karen Ketlyn Ferreira Barcelos,"Added two courses R PT_BR (#7415)* Added two courses R PT_BR\r\rHello! I\'m trying to help by adding courses that helped me!\r\r* fix: URL fragments goes in lowercase\r\r* lint: leave 2 blank lines between listings and next heading\r\r* Update courses/free-courses-pt_BR.md\r\rCo-authored-by: David Ordás <3125580+davorpa@users.noreply.github.com>\r\r* Update courses/free-courses-pt_BR.md\r\rCo-authored-by: David Ordás <3125580+davorpa@users.noreply.github.com>\r\rCo-authored-by: David Ordás <3125580+davorpa@users.noreply.github.com>\rCo-authored-by: Eric Hellman <eric@hellman.net>",91cdcd907bbf070b1310f9120b06bb03f481edb6,http://localhost:3443/github.com/EbookFoundation/free-programming-books/-/commit/91cdcd907bbf070b1310f9120b06bb03f481edb6\ncommit,github.com/freeCodeCamp/freeCodeCamp,http://localhost:3443/github.com/freeCodeCamp/freeCodeCamp,2022-07-12T07:13:40Z,Harsh Kashyap,"fix(curriculum): corrected grammar in line 12 of the description section of learn HTML forms.md (#46859)* Update 60fad1cafcde010995e15306.md\r\rHello, \rI have changed the sentence, please have a look.\r\r* Update curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md\r\rThank you, I have committed the changes suggested by you.\r\rCo-authored-by: Jeremy L Thompson <jeremy@jeremylt.org>\r\rCo-authored-by: Jeremy L Thompson <jeremy@jeremylt.org>",3ecc381f95383dfa8314846a5a7d815b359d95d1,http://localhost:3443/github.com/freeCodeCamp/freeCodeCamp/-/commit/3ecc381f95383dfa8314846a5a7d815b359d95d1\ncommit,github.com/EbookFoundation/free-programming-books,http://localhost:3443/github.com/EbookFoundation/free-programming-books,2022-10-07T14:42:09Z,yakirk,"Change link of repojacking vulnerable link (#7723)Hello from Hacktoberfest :)\rThe link to https://raw.githubusercontent.com/teten777/free-ebook-springboot-basic/master/Memulai%20Java%20Enterprise%20dengan%20Spring%20Boot.pdf is vulnerable to repojacking (it redirects to the orignial project that changed name), you should change the link to the current name of the project. if you won\'t change the link, an attacker can open the linked repository and attacks users that trust your links.\rThe new repository name is:\rhttps://raw.githubusercontent.com/teten-nugraha/free-ebook-springboot-basic/master/Memulai%20Java%20Enterprise%20dengan%20Spring%20Boot.pdf",c019ebd5db296ff9fba99a2ebb73ba5d3aa5f854,http://localhost:3443/github.com/EbookFoundation/free-programming-books/-/commit/c019ebd5db296ff9fba99a2ebb73ba5d3aa5f854\ncommit,github.com/EbookFoundation/free-programming-books,http://localhost:3443/github.com/EbookFoundation/free-programming-books,2022-07-21T05:52:57Z,Muhammad Anas,"New Django Course! (#6945)I have added a new course under the Django section. It was undoubtedly a must. It teaches everything from head to toe! From creating a simple **Hello World** site to a fully functional website to deployment! All is here!",a55f727e669f2a6ce694ac5821ff06a15a889328,http://localhost:3443/github.com/EbookFoundation/free-programming-books/-/commit/a55f727e669f2a6ce694ac5821ff06a15a889328\ncommit,github.com/EbookFoundation/free-programming-books,http://localhost:3443/github.com/EbookFoundation/free-programming-books,2020-10-31T20:49:54Z,Diego Mateos,"Added Hello SDL by LazyFoo (#4956)* Addded Hello SDL by LazyFoo\r\r* removed the redundant part of the URL",e364fc5254fedbbdbf179912aa59dfd773519d14,http://localhost:3443/github.com/EbookFoundation/free-programming-books/-/commit/e364fc5254fedbbdbf179912aa59dfd773519d14',
+        ],
+        [
+            'owner',
+            [
+                {
+                    type: 'person',
+                    handle: 'alice',
+                    email: 'alice@example.com',
+                    user: {
+                        username: 'alice',
+                        displayName: 'Alice Example',
+                        avatarURL: 'https://example.com',
+                    },
+                },
+                {
+                    type: 'person',
+                    handle: 'bob',
+                    email: '',
+                },
+                {
+                    type: 'team',
+                    handle: 'example-team',
+                    email: 'example-team@example.com',
+                    name: 'example-team',
+                    displayName: 'Example Team',
+                },
+            ],
+            'Match type,Handle,Email,User or team name,Display name\nperson,alice,alice@example.com,alice,Alice Example\nperson,bob,,,\nteam,example-team,example-team@example.com,example-team,Example Team',
         ],
     ]
 

--- a/client/web/src/search/results/searchResultsExport.ts
+++ b/client/web/src/search/results/searchResultsExport.ts
@@ -11,6 +11,7 @@ import {
     SymbolMatch,
     PersonMatch,
     TeamMatch,
+    getOwnerMatchUrl,
 } from '@sourcegraph/shared/src/search/stream'
 
 import { eventLogger } from '../../tracking/eventLogger'
@@ -158,19 +159,27 @@ export const searchResultsToFileContent = (searchResults: SearchMatch[], sourceg
         case 'person':
         case 'team': {
             content = [
-                ['Match type', 'Handle', 'Email', 'User or team name', 'Display name'],
+                ['Match type', 'Handle', 'Email', 'User or team name', 'Display name', 'Profile URL'],
                 ...searchResults
                     .filter(
                         (result: SearchMatch): result is PersonMatch | TeamMatch =>
                             result.type === 'person' || result.type === 'team'
                     )
-                    .map(result => [
-                        result.type,
-                        result.handle,
-                        result.email,
-                        result.type === 'person' ? result.user?.username : result.name,
-                        result.type === 'person' ? result.user?.displayName : result.displayName,
-                    ]),
+                    .map(result => {
+                        let profileUrl = getOwnerMatchUrl(result, true)
+                        if (profileUrl) {
+                            profileUrl = new URL(profileUrl, sourcegraphURL).toString()
+                        }
+
+                        return [
+                            result.type,
+                            result.handle,
+                            result.email,
+                            result.type === 'person' ? result.user?.username : result.name,
+                            result.type === 'person' ? result.user?.displayName : result.displayName,
+                            profileUrl,
+                        ]
+                    }),
             ]
             break
         }

--- a/client/web/src/search/results/searchResultsExport.ts
+++ b/client/web/src/search/results/searchResultsExport.ts
@@ -9,6 +9,8 @@ import {
     CommitMatch,
     getCommitMatchUrl,
     SymbolMatch,
+    PersonMatch,
+    TeamMatch,
 } from '@sourcegraph/shared/src/search/stream'
 
 import { eventLogger } from '../../tracking/eventLogger'
@@ -149,6 +151,26 @@ export const searchResultsToFileContent = (searchResults: SearchMatch[], sourceg
                             commitURL,
                         ]
                     }),
+            ]
+            break
+        }
+
+        case 'person':
+        case 'team': {
+            content = [
+                ['Match type', 'Handle', 'Email', 'User or team name', 'Display name'],
+                ...searchResults
+                    .filter(
+                        (result: SearchMatch): result is PersonMatch | TeamMatch =>
+                            result.type === 'person' || result.type === 'team'
+                    )
+                    .map(result => [
+                        result.type,
+                        result.handle,
+                        result.email,
+                        result.type === 'person' ? result.user?.username : result.name,
+                        result.type === 'person' ? result.user?.displayName : result.displayName,
+                    ]),
             ]
             break
         }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48661

Note that most emails won't be populated until https://github.com/orgs/sourcegraph/projects/307/views/1?filterQuery=email&pane=issue&itemId=20664014 is addressed.

## Test plan

Added unit test

## App preview:

- [Web](https://sg-web-jp-exportownersearchcsv.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
