### PR TITLE
Extend owner types by User

### DIFF
--- a/client/branded/src/search-ui/components/OwnerSearchResult.tsx
+++ b/client/branded/src/search-ui/components/OwnerSearchResult.tsx
@@ -29,17 +29,18 @@ export const OwnerSearchResult: React.FunctionComponent<PersonSearchResultProps>
     const displayName = useMemo(() => {
         let displayName = ''
         if (result.type === 'person') {
-            displayName =
-                result.user?.displayName || result.user?.username || result.handle || result.email || 'Unknown person'
+            displayName = result.handle || result.email || 'Unknown person'
+        } else if (result.type === 'user') {
+            displayName = result.user.displayName || result.user.username
         } else if (result.type === 'team') {
-            displayName = result.displayName || result.name || result.handle || result.email || 'Unknown team'
+            displayName = result.displayName || result.name
         }
         return displayName
     }, [result])
 
     const avatarUser = useMemo(() => {
         const avatarUser: UserAvatarData = { username: displayName, avatarURL: null, displayName }
-        if (result.type === 'person' && result.user) {
+        if (result.type === 'user') {
             avatarUser.username = result.user.username
             avatarUser.avatarURL = result.user.avatarURL || null
         }
@@ -48,7 +49,7 @@ export const OwnerSearchResult: React.FunctionComponent<PersonSearchResultProps>
 
     const url = useMemo(() => {
         const url = getOwnerMatchUrl(result)
-        if (result.type === 'person' && !result.user) {
+        if (result.type === 'person') {
             // This is not a real URL, remove it.
             return ''
         }
@@ -83,7 +84,7 @@ export const OwnerSearchResult: React.FunctionComponent<PersonSearchResultProps>
                 <div className={resultStyles.matchType}>
                     <small>Owner match</small>
                 </div>
-                {result.type === 'person' && !result.user && (
+                {result.type === 'person' && (
                     <>
                         <div className={resultStyles.dividerVertical} />
                         <small className="d-block font-italic">

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -32,6 +32,7 @@ const accessibleResultType: Record<SearchMatch['type'], string> = {
     path: 'file path',
     commit: 'commit',
     person: 'person',
+    user: 'user',
     team: 'team',
 }
 

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -224,6 +224,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                             />
                         )
                     case 'person':
+                    case 'user':
                     case 'team':
                         return (
                             <OwnerSearchResult

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -155,7 +155,7 @@ export interface RepositoryMatch {
     descriptionMatches?: Range[]
 }
 
-export type OwnerMatch = PersonMatch | TeamMatch
+export type OwnerMatch = PersonMatch | UserMatch | TeamMatch
 
 export interface BaseOwnerMatch {
     handle?: string
@@ -166,7 +166,13 @@ export interface PersonMatch extends BaseOwnerMatch {
     type: 'person'
     handle?: string
     email?: string
-    user?: {
+}
+
+export interface UserMatch extends BaseOwnerMatch {
+    type: 'user'
+    handle?: string
+    email?: string
+    user: {
         username: string
         displayName?: string
         avatarURL?: string
@@ -596,7 +602,7 @@ export function getCommitMatchUrl(commitMatch: CommitMatch): string {
 }
 
 export function getOwnerMatchUrl(ownerMatch: OwnerMatch, ignoreUnknownPerson: boolean = false): string {
-    if (ownerMatch.type === 'person' && ownerMatch.user) {
+    if (ownerMatch.type === 'user') {
         return '/users/' + encodeURI(ownerMatch.user.username)
     }
     if (ownerMatch.type === 'team') {
@@ -629,6 +635,7 @@ export function getMatchUrl(match: SearchMatch): string {
         case 'repo':
             return getRepoMatchUrl(match)
         case 'person':
+        case 'user':
         case 'team':
             return getOwnerMatchUrl(match)
     }

--- a/client/web/src/search/results/searchResultsExport.test.ts
+++ b/client/web/src/search/results/searchResultsExport.test.ts
@@ -1367,9 +1367,14 @@ describe('searchResultsToFileContent', () => {
                     type: 'person',
                     handle: 'alice',
                     email: 'alice@example.com',
+                },
+                {
+                    type: 'user',
+                    handle: 'john',
+                    email: 'john@example.com',
                     user: {
-                        username: 'alice',
-                        displayName: 'Alice Example',
+                        username: 'john',
+                        displayName: 'John Example',
                         avatarURL: 'https://example.com',
                     },
                 },
@@ -1386,7 +1391,7 @@ describe('searchResultsToFileContent', () => {
                     displayName: 'Example Team',
                 },
             ],
-            'Match type,Handle,Email,User or team name,Display name,Profile URL\nperson,alice,alice@example.com,alice,Alice Example,http://localhost:3443/users/alice\nperson,bob,,,,\nteam,example-team,example-team@example.com,example-team,Example Team,http://localhost:3443/teams/example-team',
+            'Match type,Handle,Email,User or team name,Display name,Profile URL\nperson,alice,alice@example.com,,,mailto:alice@example.com\nuser,john,john@example.com,john,John Example,http://localhost:3443/users/john\nperson,bob,,,,\nteam,example-team,example-team@example.com,example-team,Example Team,http://localhost:3443/teams/example-team',
         ],
     ]
 

--- a/client/web/src/search/results/searchResultsExport.ts
+++ b/client/web/src/search/results/searchResultsExport.ts
@@ -12,6 +12,7 @@ import {
     PersonMatch,
     TeamMatch,
     getOwnerMatchUrl,
+    UserMatch,
 } from '@sourcegraph/shared/src/search/stream'
 
 import { eventLogger } from '../../tracking/eventLogger'
@@ -162,8 +163,8 @@ export const searchResultsToFileContent = (searchResults: SearchMatch[], sourceg
                 ['Match type', 'Handle', 'Email', 'User or team name', 'Display name', 'Profile URL'],
                 ...searchResults
                     .filter(
-                        (result: SearchMatch): result is PersonMatch | TeamMatch =>
-                            result.type === 'person' || result.type === 'team'
+                        (result: SearchMatch): result is PersonMatch | UserMatch | TeamMatch =>
+                            result.type === 'person' || result.type === 'user' || result.type === 'team'
                     )
                     .map(result => {
                         let profileUrl = getOwnerMatchUrl(result, true)
@@ -175,8 +176,12 @@ export const searchResultsToFileContent = (searchResults: SearchMatch[], sourceg
                             result.type,
                             result.handle,
                             result.email,
-                            result.type === 'person' ? result.user?.username : result.name,
-                            result.type === 'person' ? result.user?.displayName : result.displayName,
+                            result.type === 'user' ? result.user.username : result.type === 'team' ? result.name : null,
+                            result.type === 'user'
+                                ? result.user.displayName
+                                : result.type === 'team'
+                                ? result.displayName
+                                : null,
                             profileUrl,
                         ]
                     }),

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -521,19 +521,22 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 func fromOwner(owner *result.OwnerMatch) streamhttp.EventMatch {
 	switch v := owner.ResolvedOwner.(type) {
 	case *result.OwnerPerson:
-		person := &streamhttp.EventPersonMatch{
+		return &streamhttp.EventPersonMatch{
 			Type:   streamhttp.PersonMatchType,
 			Handle: v.Handle,
 			Email:  v.Email,
 		}
-		if v.User != nil {
-			person.User = &streamhttp.UserMetadata{
+	case *result.OwnerUser:
+		return &streamhttp.EventPersonMatch{
+			Type:   streamhttp.UserMatchType,
+			Handle: v.Handle,
+			Email:  v.Email,
+			User: &streamhttp.UserMetadata{
 				Username:    v.User.Username,
 				DisplayName: v.User.DisplayName,
 				AvatarURL:   v.User.AvatarURL,
-			}
+			},
 		}
-		return person
 	case *result.OwnerTeam:
 		return &streamhttp.EventTeamMatch{
 			Type:        streamhttp.TeamMatchType,

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -124,6 +124,12 @@ func ownerToResult(o codeowners.ResolvedOwner) result.Owner {
 		return &result.OwnerPerson{
 			Handle: v.Handle,
 			Email:  v.Email,
+		}
+	}
+	if v, ok := o.(*codeowners.User); ok {
+		return &result.OwnerUser{
+			Handle: v.Handle,
+			Email:  v.Email,
 			User:   v.User,
 		}
 	}

--- a/enterprise/internal/own/search/select_job_test.go
+++ b/enterprise/internal/own/search/select_job_test.go
@@ -122,7 +122,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 		}
 		want := []result.Match{
 			&result.OwnerMatch{
-				ResolvedOwner: &result.OwnerPerson{User: personOwnerByEmail, Email: "user@email.com"},
+				ResolvedOwner: &result.OwnerUser{User: personOwnerByEmail, Email: "user@email.com"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",
@@ -136,7 +136,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 				LimitHit:      0,
 			},
 			&result.OwnerMatch{
-				ResolvedOwner: &result.OwnerPerson{User: personOwnerByHandle, Handle: "testUserHandle"},
+				ResolvedOwner: &result.OwnerUser{User: personOwnerByHandle, Handle: "testUserHandle"},
 				InputRev:      nil,
 				Repo:          types.MinimalRepo{},
 				CommitID:      "",

--- a/enterprise/internal/own/service_test.go
+++ b/enterprise/internal/own/service_test.go
@@ -128,7 +128,7 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err := ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
-			&codeowners.Person{
+			&codeowners.User{
 				User:   testUser,
 				Handle: handle,
 			},
@@ -152,7 +152,7 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err := ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
-			&codeowners.Person{
+			&codeowners.User{
 				User:  testUser,
 				Email: email,
 			},
@@ -250,8 +250,8 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err := ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		want := []codeowners.ResolvedOwner{
-			&codeowners.Person{User: testUserWithHandle, Handle: userHandle},
-			&codeowners.Person{User: testUserWithEmail, Email: userEmail},
+			&codeowners.User{User: testUserWithHandle, Handle: userHandle},
+			&codeowners.User{User: testUserWithEmail, Email: userEmail},
 			&codeowners.Team{Team: testTeamWithHandle, Handle: teamHandle},
 			testUnknownOwner,
 		}
@@ -282,7 +282,7 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err := ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
-			&codeowners.Person{
+			&codeowners.User{
 				User:  testUser,
 				Email: email,
 			},
@@ -291,7 +291,7 @@ func TestResolveOwnersWithType(t *testing.T) {
 		got, err = ownService.ResolveOwnersWithType(context.Background(), owners)
 		require.NoError(t, err)
 		assert.Equal(t, []codeowners.ResolvedOwner{
-			&codeowners.Person{
+			&codeowners.User{
 				User:  testUser,
 				Email: email,
 			},

--- a/internal/search/result/owner.go
+++ b/internal/search/result/owner.go
@@ -14,15 +14,28 @@ type Owner interface {
 type OwnerPerson struct {
 	Handle string
 	Email  string
-	User   *types.User
 }
 
 func (o OwnerPerson) Identifier() string {
-	return "Person:" + o.Handle + o.Email
+	return o.Handle + o.Email
 }
 
 func (o OwnerPerson) Type() string {
 	return "person"
+}
+
+type OwnerUser struct {
+	Handle string
+	Email  string
+	User   *types.User
+}
+
+func (o OwnerUser) Identifier() string {
+	return o.User.Username
+}
+
+func (o OwnerUser) Type() string {
+	return "user"
 }
 
 type OwnerTeam struct {
@@ -32,7 +45,7 @@ type OwnerTeam struct {
 }
 
 func (o OwnerTeam) Identifier() string {
-	return "Team:" + o.Team.Name
+	return o.Team.Name
 }
 
 func (o OwnerTeam) Type() string {

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -246,6 +246,7 @@ const (
 	CommitMatchType
 	PathMatchType
 	PersonMatchType
+	UserMatchType
 	TeamMatchType
 )
 
@@ -263,6 +264,8 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"path"`), nil
 	case PersonMatchType:
 		return []byte(`"person"`), nil
+	case UserMatchType:
+		return []byte(`"user"`), nil
 	case TeamMatchType:
 		return []byte(`"team"`), nil
 	default:
@@ -283,6 +286,8 @@ func (t *MatchType) UnmarshalJSON(b []byte) error {
 		*t = PathMatchType
 	} else if bytes.Equal(b, []byte(`"person"`)) {
 		*t = PersonMatchType
+	} else if bytes.Equal(b, []byte(`"user"`)) {
+		*t = UserMatchType
 	} else if bytes.Equal(b, []byte(`"team"`)) {
 		*t = TeamMatchType
 	} else {


### PR DESCRIPTION
This adds a new result type called User. This is in preparation of better mapping between codehost and Sourcegraph. With a distinct user type, we can distinguish non-resolved, but same named entries from matched entries.

## Test plan

Search still works and renders correctly locally. 