### PR TITLE
build: resolve dependencies injected with the webpack.ProviderPlugin 

### DIFF
--- a/client/build-config/BUILD.bazel
+++ b/client/build-config/BUILD.bazel
@@ -32,7 +32,9 @@ ts_project(
     tsconfig = ":tsconfig",
     deps = [
         ":node_modules/@statoscope/webpack-plugin",
+        ":node_modules/buffer",  #keep
         ":node_modules/monaco-editor-webpack-plugin",
+        ":node_modules/process",  #keep
         ":node_modules/terser-webpack-plugin",
         ":node_modules/webpack",
         "//:node_modules/@types/node",

--- a/client/build-config/package.json
+++ b/client/build-config/package.json
@@ -16,16 +16,19 @@
   "peerDependencies": {
     "css-loader": "*",
     "postcss-loader": "*",
-    "sass-loader": "*"
+    "sass-loader": "*",
+    "style-loader": "*"
   },
   "dependencies": {
     "@statoscope/webpack-plugin": "^5.24.0",
+    "buffer": "^6.0.3",
     "enhanced-resolve": "^5.9.3",
     "esbuild": "^0.17.7",
     "monaco-editor-webpack-plugin": "^3.1.0",
     "postcss": "^8.4.19",
     "postcss-cli": "^10.1.0",
     "postcss-modules": "^6.0.0",
+    "process": "^0.11.10",
     "sass": "^1.32.4",
     "signale": "^1.4.0",
     "terser-webpack-plugin": "^5.3.6",

--- a/client/build-config/src/webpack/plugins.ts
+++ b/client/build-config/src/webpack/plugins.ts
@@ -22,9 +22,9 @@ export const getProvidePlugin = (): webpack.ProvidePlugin =>
         // Adding the file extension is necessary to make importing this file
         // work inside JavaScript modules. The alternative is to set
         // `fullySpecified: false` (https://webpack.js.org/configuration/module/#resolvefullyspecified).
-        process: 'process/browser.js',
+        process: require.resolve('process/browser.js'),
         // Based on the issue: https://github.com/webpack/changelog-v5/issues/10
-        Buffer: ['buffer', 'Buffer'],
+        Buffer: [require.resolve('buffer/index.js'), 'Buffer'],
     })
 
 const STATOSCOPE_STATS: StatsOptions = {

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1794,7 +1794,6 @@ jest_test(
 # webpack dev environment -------------------
 WEBPACK_CONFIG_DEPS = [
     ":node_modules/@sourcegraph/build-config",
-    "//:node_modules/@pmmmwh/react-refresh-webpack-plugin",
     "//:node_modules/@sentry/webpack-plugin",
     "//:node_modules/css-loader",
     "//:node_modules/style-loader",

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin')
@@ -15,21 +14,18 @@ const { StatsWriterPlugin } = require('webpack-stats-plugin')
 const {
   ROOT_PATH,
   STATIC_ASSETS_PATH,
-  getBabelLoader,
   getCacheConfig,
   getMonacoWebpackPlugin,
   getBazelCSSLoaders: getCSSLoaders,
   getTerserPlugin,
   getProvidePlugin,
   getCSSModulesLoader,
-  getMonacoCSSRule,
   getMonacoTTFRule,
   getBasicCSSLoader,
   getStatoscopePlugin,
 } = require('@sourcegraph/build-config')
 
 const { IS_PRODUCTION, IS_DEVELOPMENT, ENVIRONMENT_CONFIG, writeIndexHTMLPlugin } = require('./dev/utils')
-// const { isHotReloadEnabled } = require('./src/integration/environment')
 
 const {
   NODE_ENV,
@@ -153,8 +149,7 @@ const config = {
     new webpack.DefinePlugin({
       'process.env': mapValues(RUNTIME_ENV_VARIABLES, JSON.stringify),
     }),
-    // TODO(bazel): why does the provide plugin crash?
-    // getProvidePlugin(),
+    getProvidePlugin(),
     new MiniCssExtractPlugin({
       // Do not [hash] for development -- see https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
       filename:
@@ -175,7 +170,6 @@ const config = {
     }),
     ...(WEBPACK_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
     WEBPACK_BUNDLE_ANALYZER && getStatoscopePlugin(WEBPACK_STATS_NAME),
-    // isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     IS_PRODUCTION &&
       new CompressionPlugin({
         filename: '[path][base].gz',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,7 @@ importers:
     specifiers:
       '@statoscope/webpack-plugin': ^5.24.0
       '@types/sass': 1.16.1
+      buffer: ^6.0.3
       css-loader: '*'
       enhanced-resolve: ^5.9.3
       esbuild: ^0.17.7
@@ -930,14 +931,17 @@ importers:
       postcss-cli: ^10.1.0
       postcss-loader: '*'
       postcss-modules: ^6.0.0
+      process: ^0.11.10
       sass: ^1.32.4
       sass-loader: '*'
       signale: ^1.4.0
+      style-loader: '*'
       terser-webpack-plugin: ^5.3.6
       typed-scss-modules: ^4.1.1
       webpack: '5'
     dependencies:
       '@statoscope/webpack-plugin': 5.24.0_webpack@5.75.0
+      buffer: 6.0.3
       css-loader: 6.7.2_webpack@5.75.0
       enhanced-resolve: 5.10.0
       esbuild: 0.17.8
@@ -946,9 +950,11 @@ importers:
       postcss-cli: 10.1.0_postcss@8.4.21
       postcss-loader: 7.0.2_6jdsrmfenkuhhw3gx4zvjlznce
       postcss-modules: 6.0.0_postcss@8.4.21
+      process: 0.11.10
       sass: 1.32.4
       sass-loader: 13.2.0_sass@1.32.4+webpack@5.75.0
       signale: 1.4.0
+      style-loader: 3.3.1_webpack@5.75.0
       terser-webpack-plugin: 5.3.6_6hyl5w2uqyeivowpusuiulbmoy
       typed-scss-modules: 4.1.1_sass@1.32.4
       webpack: 5.75.0_esbuild@0.17.8
@@ -1186,7 +1192,7 @@ importers:
       '@types/cookie': 0.5.1
       '@types/prismjs': 1.26.0
       eslint-plugin-svelte3: 4.0.0_dbthnr4b2bdkhyiebwn7su3hnq
-      prettier-plugin-svelte: 2.9.0_jrsxveqmsx2uadbqiuq74wlc4u
+      prettier-plugin-svelte: 2.9.0_4h247imu46srxjbpsfob5j3nnq
       svelte: 3.55.1
       svelte-check: 3.0.4_svelte@3.55.1
       tslib: 2.1.0
@@ -13038,7 +13044,7 @@ packages:
       '@babel/core': 7.20.5
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_4wpfvhs5obqvjbkpkxtqpnn5oe
     dev: true
 
   /babel-plugin-add-react-displayname/0.0.5:
@@ -13701,7 +13707,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: true
 
   /buffers/0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
@@ -15294,7 +15299,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.21
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_esbuild@0.17.8
 
   /css-minimizer-webpack-plugin/4.2.2_6hyl5w2uqyeivowpusuiulbmoy:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
@@ -20112,7 +20117,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_yrajokeiryagdtuqucziuwdxti
     dev: true
 
   /htmlparser2/6.1.0:
@@ -22327,7 +22332,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.11.18
+      '@types/node': 13.13.5
       graceful-fs: 4.2.10
     dev: false
 
@@ -22446,7 +22451,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.11.18
+      '@types/node': 13.13.5
       chalk: 4.1.2
       ci-info: 3.3.1
       graceful-fs: 4.2.10
@@ -26919,7 +26924,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.21
       semver: 7.3.8
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_esbuild@0.17.8
 
   /postcss-media-query-parser/0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
@@ -27379,16 +27384,6 @@ packages:
       svelte: 3.55.1
     dev: true
 
-  /prettier-plugin-svelte/2.9.0_jrsxveqmsx2uadbqiuq74wlc4u:
-    resolution: {integrity: sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==}
-    peerDependencies:
-      prettier: ^1.16.4 || ^2.0.0
-      svelte: ^3.2.0
-    dependencies:
-      prettier: 2.8.4
-      svelte: 3.55.1
-    dev: true
-
   /prettier/2.0.5:
     resolution: {integrity: sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==}
     engines: {node: '>=10.13.0'}
@@ -27403,12 +27398,6 @@ packages:
 
   /prettier/2.8.1:
     resolution: {integrity: sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: true
-
-  /prettier/2.8.4:
-    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -29793,7 +29782,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.32.4
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_esbuild@0.17.8
 
   /sass/1.32.4:
     resolution: {integrity: sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==}
@@ -31084,8 +31073,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
-    dev: true
+      webpack: 5.75.0_esbuild@0.17.8
 
   /style-mod/4.0.0:
     resolution: {integrity: sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==}
@@ -31697,7 +31685,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.16.1
-      webpack: 5.75.0_cf7cgeqdkm72g3fdehkr7aaod4
+      webpack: 5.75.0_esbuild@0.17.8
 
   /terser-webpack-plugin/5.3.6_oa2ac2s5skpozptxi7rtd3zsrm:
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
@@ -31723,6 +31711,32 @@ packages:
       serialize-javascript: 6.0.0
       terser: 5.16.1
       webpack: 5.75.0_yrajokeiryagdtuqucziuwdxti
+    dev: true
+
+  /terser-webpack-plugin/5.3.6_tqhwwsvj4cnhuarwr7flkmuvna:
+    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      '@swc/core': 1.3.28
+      esbuild: 0.17.8
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      terser: 5.16.1
+      webpack: 5.75.0_4wpfvhs5obqvjbkpkxtqpnn5oe
     dev: true
 
   /terser/4.8.1:
@@ -33753,6 +33767,46 @@ packages:
     resolution: {integrity: sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==}
     dev: true
 
+  /webpack/5.75.0_4wpfvhs5obqvjbkpkxtqpnn5oe:
+    resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 0.0.51
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.8.1
+      acorn-import-assertions: 1.8.0_acorn@8.8.1
+      browserslist: 4.21.4
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.10.0
+      es-module-lexer: 0.9.3
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.6_tqhwwsvj4cnhuarwr7flkmuvna
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
   /webpack/5.75.0_cf7cgeqdkm72g3fdehkr7aaod4:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
     engines: {node: '>=10.13.0'}
@@ -33831,7 +33885,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   /webpack/5.75.0_yrajokeiryagdtuqucziuwdxti:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}


### PR DESCRIPTION
The `require.resolve` and `/index.js` are required for the provided modules to resolve correctly under bazel, the added `dependencies` are required because in the root they are `devDependencies` but `build-config` needs them at runtime (note that "runtime" for `build-config` is when webpack is run on `client/web`).

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-provideplugin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
