### PR TITLE
chore: Remove unused Postgres types

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -46,28 +46,6 @@
       ]
     },
     {
-      "Name": "lsif_index_state",
-      "Labels": [
-        "queued",
-        "processing",
-        "completed",
-        "errored",
-        "failed"
-      ]
-    },
-    {
-      "Name": "lsif_upload_state",
-      "Labels": [
-        "uploading",
-        "queued",
-        "processing",
-        "completed",
-        "errored",
-        "deleted",
-        "failed"
-      ]
-    },
-    {
       "Name": "persistmode",
       "Labels": [
         "record",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -4364,24 +4364,6 @@ Foreign-key constraints:
 - bool
 - rollout
 
-# Type lsif_index_state
-
-- queued
-- processing
-- completed
-- errored
-- failed
-
-# Type lsif_upload_state
-
-- uploading
-- queued
-- processing
-- completed
-- errored
-- deleted
-- failed
-
 # Type persistmode
 
 - record

--- a/migrations/frontend/1677944569_drop_unused_types/down.sql
+++ b/migrations/frontend/1677944569_drop_unused_types/down.sql
@@ -1,0 +1,20 @@
+DROP TYPE IF EXISTS lsif_index_state;
+DROP TYPE IF EXISTS lsif_upload_state;
+
+CREATE TYPE lsif_index_state AS ENUM (
+    'queued',
+    'processing',
+    'completed',
+    'errored',
+    'failed'
+);
+
+CREATE TYPE lsif_upload_state AS ENUM (
+    'uploading',
+    'queued',
+    'processing',
+    'completed',
+    'errored',
+    'deleted',
+    'failed'
+);

--- a/migrations/frontend/1677944569_drop_unused_types/metadata.yaml
+++ b/migrations/frontend/1677944569_drop_unused_types/metadata.yaml
@@ -1,0 +1,2 @@
+name: drop unused types
+parents: [1677878270]

--- a/migrations/frontend/1677944569_drop_unused_types/up.sql
+++ b/migrations/frontend/1677944569_drop_unused_types/up.sql
@@ -1,0 +1,2 @@
+DROP TYPE IF EXISTS lsif_index_state;
+DROP TYPE IF EXISTS lsif_upload_state;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -65,24 +65,6 @@ CREATE TYPE feature_flag_type AS ENUM (
     'rollout'
 );
 
-CREATE TYPE lsif_index_state AS ENUM (
-    'queued',
-    'processing',
-    'completed',
-    'errored',
-    'failed'
-);
-
-CREATE TYPE lsif_upload_state AS ENUM (
-    'uploading',
-    'queued',
-    'processing',
-    'completed',
-    'errored',
-    'deleted',
-    'failed'
-);
-
 CREATE TYPE lsif_uploads_transition_columns AS (
 	state text,
 	expired boolean,


### PR DESCRIPTION
Clean up ur dead.

## Test plan

CI will check if we've removed anything useful in the previous version.