### PR TITLE
codeintel: Fix bad table reference when authz conds are used

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -56,11 +56,11 @@ combined_indexers AS (
 )
 SELECT DISTINCT u.indexer
 FROM combined_indexers u
-JOIN repo r ON r.id = u.repository_id
+JOIN repo ON repo.id = u.repository_id
 WHERE
 	%s AND
-	r.deleted_at IS NULL AND
-	r.blocked IS NULL
+	repo.deleted_at IS NULL AND
+	repo.blocked IS NULL
 `
 
 // GetUploads returns a list of uploads and the total count of records matching the given conditions.


### PR DESCRIPTION
Noticed in this on dotcom, but it doesn't happen locally. We use `repo r` but authz conds require the name `repo`.

## Test plan

N/A. 🥚 