### PR TITLE
rename CACHE_DIR env var for searcher as well, and other follow-throughs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- The symbols service `CACHE_DIR` and `MAX_TOTTAL_PATHS_LENGTH` were renamed to have a `SYMBOLS_` prefix in the last version of Sourcegraph; this version fixes a bug where the old names without the `SYMBOLS_` prefix were not respected correctly. Both names now work.
+- The symbols service `CACHE_DIR` and `MAX_TOTAL_PATHS_LENGTH` were renamed to have a `SYMBOLS_` prefix in the last version of Sourcegraph; this version fixes a bug where the old names without the `SYMBOLS_` prefix were not respected correctly. Both names now work.
 - Fixed issues with propagating tracing configuration throughout the application. [#47428](https://github.com/sourcegraph/sourcegraph/pull/47428)
 - Enable `auto gc` on fetch when `SRC_ENABLE_GC_AUTO` is set to `true`. [#47852](https://github.com/sourcegraph/sourcegraph/pull/47852)
 - Fixes syntax highlighting and line number issues in the code preview rendered inside the references panel. [#48107](https://github.com/sourcegraph/sourcegraph/pull/48107)

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -21,8 +21,10 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-ENV SEARCHER_CACHE_DIR=/mnt/cache/searcher
-RUN mkdir -p ${SEARCHER_CACHE_DIR} && chown -R sourcegraph:sourcegraph ${SEARCHER_CACHE_DIR}
+# Use SEARCHER_CACHE_DIR to set the cache dir at runtime for searcher. Setting CACHE_DIR will also
+# apply to other services and is deprecated.
+ENV CACHE_DIR=/mnt/cache/searcher
+RUN mkdir -p ${CACHE_DIR} && chown -R sourcegraph:sourcegraph ${CACHE_DIR}
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/searcher"]
 COPY searcher /usr/local/bin/

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -21,8 +21,8 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
-ENV CACHE_DIR=/mnt/cache/searcher
-RUN mkdir -p ${CACHE_DIR} && chown -R sourcegraph:sourcegraph ${CACHE_DIR}
+ENV SEARCHER_CACHE_DIR=/mnt/cache/searcher
+RUN mkdir -p ${SEARCHER_CACHE_DIR} && chown -R sourcegraph:sourcegraph ${SEARCHER_CACHE_DIR}
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/searcher"]
 COPY searcher /usr/local/bin/

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -38,7 +38,9 @@ import (
 )
 
 var (
-	cacheDir    = env.Get("CACHE_DIR", "/tmp", "directory to store cached archives.")
+	cacheDirName = env.ChooseFallbackVariableName("SEARCHER_CACHE_DIR", "CACHE_DIR")
+
+	cacheDir    = env.Get(cacheDirName, "/tmp", "directory to store cached archives.")
 	cacheSizeMB = env.Get("SEARCHER_CACHE_SIZE_MB", "100000", "maximum size of the on disk cache in megabytes")
 
 	// Same environment variable name (and default value) used by symbols.

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -52,7 +52,7 @@ var DefaultEnv = map[string]string{
 
 	// Limit our cache size to 100GB, same as prod. We should probably update
 	// searcher/symbols to ensure this value isn't larger than the volume for
-	// CACHE_DIR.
+	// SYMBOLS_CACHE_DIR and SEARCHER_CACHE_DIR.
 	"SEARCHER_CACHE_SIZE_MB": "50000",
 	"SYMBOLS_CACHE_SIZE_MB":  "50000",
 
@@ -105,7 +105,9 @@ func Main() {
 	// Next persistence
 	{
 		SetDefaultEnv("SRC_REPOS_DIR", filepath.Join(DataDir, "repos"))
-		SetDefaultEnv("CACHE_DIR", filepath.Join(DataDir, "cache"))
+		cacheDir := filepath.Join(DataDir, "cache")
+		SetDefaultEnv("SYMBOLS_CACHE_DIR", cacheDir)
+		SetDefaultEnv("SEARCHER_CACHE_DIR", cacheDir)
 	}
 
 	// Special case some convenience environment variables

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=symbols-build /symbols /usr/local/bin/symbols
 # symbols is cgo, ensure we have the requisite dynamic libraries
 RUN env SANITY_CHECK=true /usr/local/bin/symbols
 
-ENV CACHE_DIR=/mnt/cache/symbols
-RUN mkdir -p ${CACHE_DIR}
+ENV SYMBOLS_CACHE_DIR=/mnt/cache/symbols
+RUN mkdir -p ${SYMBOLS_CACHE_DIR}
 EXPOSE 3184
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/symbols"]

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -66,7 +66,9 @@ COPY --from=symbols-build /symbols /usr/local/bin/symbols
 # symbols is cgo, ensure we have the requisite dynamic libraries
 RUN env SANITY_CHECK=true /usr/local/bin/symbols
 
-ENV SYMBOLS_CACHE_DIR=/mnt/cache/symbols
-RUN mkdir -p ${SYMBOLS_CACHE_DIR}
+# Use SYMBOLS_CACHE_DIR to set the cache dir at runtime for the symbols service. Setting CACHE_DIR
+# will also apply to other services and is deprecated.
+ENV CACHE_DIR=/mnt/cache/symbols
+RUN mkdir -p ${CACHE_DIR}
 EXPOSE 3184
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/symbols"]

--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -38,7 +38,7 @@
 - Searcher and Symbols now use StatefulSets and PVCs to avoid large `ephermeralStorage` requests [#242](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/242)
 - This release updates `searcher` and `symbols` services to be headless.
   - Before upgrading, delete your `searcher` and `symbols` services (ex: `kubectl delete svc/searcher svc/symbols`) [#250](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/250)
-- An env var `CACHE_DIR` was renamed to `SYMBOLS_CACHE_DIR` in `sourcegraph/sourcegraph`, this change was missed in the helm charts, and causes a permissions issue resolving some symbols searches. For more details see the PR to fix the env var: [#258](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258)
+- An env var `CACHE_DIR` was renamed to `SYMBOLS_CACHE_DIR` in `sourcegraph/sourcegraph`. This change was missed in the Helm charts, which caused a permissions issue during some symbols searches. For more details, see the PR to fix the env var: [#258](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258).
   - A revision to the 4.5.1 chart (`4.5.1-rev.1`) was released to address the above issue. Use this revision for upgrades to 4.5.1. (ex: `helm upgrade --install --version 4.5.1-rev.1`) [#259](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/259)
 
 ## v4.4.1 ➔ v4.4.2

--- a/doc/code_navigation/explanations/search_based_code_navigation.md
+++ b/doc/code_navigation/explanations/search_based_code_navigation.md
@@ -39,7 +39,7 @@ The symbols container recognizes these environment variables:
 - `CTAGS_PATTERN_LENGTH_LIMIT`: defaults to `250`, the maximum length of the patterns output by ctags
 - `LOG_CTAGS_ERRORS`: defaults to `false`, log ctags errors
 - `SANITY_CHECK`: defaults to `false`, check that go-sqlite3 works then exit 0 if it's ok or 1 if not
-- `CACHE_DIR`: defaults to `/tmp/symbols-cache`, directory in which to store cached symbols
+- `SYMBOLS_CACHE_DIR`: defaults to `/tmp/symbols-cache`, directory in which to store cached symbols
 - `SYMBOLS_CACHE_SIZE_MB`: defaults to `100000`, maximum size of the disk cache (in megabytes)
 - `CTAGS_PROCESSES`: defaults to `strconv.Itoa(runtime.GOMAXPROCS(0))`, number of concurrent parser processes to run
 - `REQUEST_BUFFER_SIZE`: defaults to `8192`, maximum size of buffered parser request channel

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -65,7 +65,8 @@ func Init(logger log.Logger) {
 
 	setDefaultEnv(logger, "SRC_REPOS_DIR", filepath.Join(cacheDir, "repos"))
 	setDefaultEnv(logger, "BLOBSTORE_DATA_DIR", filepath.Join(cacheDir, "blobstore"))
-	setDefaultEnv(logger, "CACHE_DIR", filepath.Join(cacheDir, "cache"))
+	setDefaultEnv(logger, "SYMBOLS_CACHE_DIR", filepath.Join(cacheDir, "symbols"))
+	setDefaultEnv(logger, "SEARCHER_CACHE_DIR", filepath.Join(cacheDir, "searcher"))
 
 	configDir, err := os.UserConfigDir()
 	if err == nil {


### PR DESCRIPTION
- Prefer `SEARCHER_CACHE_DIR` env var name to `CACHE_DIR`.
- Use the `{SEARCHER,SYMBOLS}_CACHE_DIR` env var names in Dockerfiles, App init (`singleprogram`), and the single Docker image (`server`).
- Fix typos/grammar in the changelog and docs.

Also fixes a panic when lauching App: `env var "CACHE_DIR" already registered with a different description or value`.




## Test plan

Run `sg start app` and notice it does not panic upon startup.