### PR TITLE
app does not require syntax-highlighter or docker (anymore)

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1379,14 +1379,11 @@ commandsets:
   app:
     requiresDevPrivate: true
     checks:
-      - docker
       - git
     commands:
       - sourcegraph
       - docsite
       - web
-      # TODO: App's dependency on syntax-highlighter will be removed.
-      - syntax-highlighter
       - caddy
 
 tests:


### PR DESCRIPTION
We can remove these from the `sg start app` list of prereqs/services.


## Test plan

Run `sg start app`.