### PR TITLE
remove "click to go to definition" behavior

### DIFF
--- a/client/browser/src/browser-extension/web-extension-api/types.ts
+++ b/client/browser/src/browser-extension/web-extension-api/types.ts
@@ -23,17 +23,11 @@ export interface FeatureFlags {
      * Send telemetry
      */
     sendTelemetry: boolean
-
-    /**
-     * Token single click takes user to variable definition.
-     */
-    clickToGoToDefinition: boolean
 }
 
 export const featureFlagDefaults: FeatureFlags = {
     allowErrorReporting: false,
     sendTelemetry: true,
-    clickToGoToDefinition: false,
 }
 
 interface SourcegraphURL {

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -24,7 +24,6 @@ import {
     concatAll,
     concatMap,
     filter,
-    finalize,
     map,
     mergeMap,
     observeOn,
@@ -60,7 +59,7 @@ import {
 } from '@sourcegraph/common'
 import { WorkspaceRoot } from '@sourcegraph/extension-api-types'
 import { gql, isHTTPAuthError } from '@sourcegraph/http-client'
-import { ActionItemAction, urlForClientCommandOpen } from '@sourcegraph/shared/src/actions/ActionItem'
+import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { CodeEditorData, CodeEditorWithPartialModel } from '@sourcegraph/shared/src/api/viewerTypes'
 import { isRepoNotFoundErrorLike } from '@sourcegraph/shared/src/backend/errors'
@@ -103,7 +102,7 @@ import { resolveRevision, retryWhenCloneInProgressError, resolvePrivateRepo } fr
 import { ConditionalTelemetryService, EventLogger } from '../../tracking/eventLogger'
 import { DEFAULT_SOURCEGRAPH_URL, getPlatformName, isDefaultSourcegraphUrl } from '../../util/context'
 import { MutationRecordLike, querySelectorOrSelf } from '../../util/dom'
-import { observeOptionFlag, observeSendTelemetry } from '../../util/optionFlags'
+import { observeSendTelemetry } from '../../util/optionFlags'
 import { bitbucketCloudCodeHost } from '../bitbucket-cloud/codeHost'
 import { bitbucketServerCodeHost } from '../bitbucket/codeHost'
 import { gerritCodeHost } from '../gerrit/codeHost'
@@ -466,59 +465,6 @@ function initCodeIntelligence({
                 hoverifier.hoverStateUpdates.subscribe(update => {
                     this.setState(update)
                 })
-            )
-            this.subscription.add(
-                hoverifier.hoverStateUpdates
-                    .pipe(
-                        withLatestFrom(observeOptionFlag('clickToGoToDefinition')),
-                        filter(([, clickToGoToDefinition]) => clickToGoToDefinition),
-                        map(([hoverState]) => hoverState),
-                        switchMap(({ hoveredTokenElement: token, hoverOverlayProps }) => {
-                            if (token === undefined) {
-                                return EMPTY
-                            }
-                            if (hoverOverlayProps === undefined) {
-                                return EMPTY
-                            }
-
-                            const { actionsOrError } = hoverOverlayProps
-                            const definitionAction =
-                                Array.isArray(actionsOrError) &&
-                                actionsOrError.find(a => a.action.id === 'goToDefinition.preloaded' && !a.disabledWhen)
-
-                            const referenceAction =
-                                Array.isArray(actionsOrError) &&
-                                actionsOrError.find(a => a.action.id === 'findReferences' && !a.disabledWhen)
-
-                            const action = definitionAction || referenceAction
-                            if (!action) {
-                                return EMPTY
-                            }
-
-                            const defer = urlForClientCommandOpen(action.action, window.location.hash)
-                            if (!defer) {
-                                return EMPTY
-                            }
-
-                            const oldCursor = token.style.cursor
-                            token.style.cursor = 'pointer'
-
-                            return fromEvent(token, 'click').pipe(
-                                tap(() => {
-                                    const selection = window.getSelection()
-                                    if (selection !== null && selection.toString() !== '') {
-                                        return
-                                    }
-
-                                    const actionType = action === definitionAction ? 'definition' : 'reference'
-                                    telemetryService.log(`${actionType}CodeHost.click`)
-                                    window.location.href = defer
-                                }),
-                                finalize(() => (token.style.cursor = oldCursor))
-                            )
-                        })
-                    )
-                    .subscribe()
             )
             containerComponentUpdates.next()
         }

--- a/client/browser/src/shared/util/optionFlags.ts
+++ b/client/browser/src/shared/util/optionFlags.ts
@@ -10,7 +10,7 @@ import { isDefaultSourcegraphUrl, observeSourcegraphURL } from './context'
 
 const OPTION_FLAGS_SYNC_STORAGE_KEY = 'featureFlags'
 
-export type OptionFlagKey = 'sendTelemetry' | 'allowErrorReporting' | 'clickToGoToDefinition'
+export type OptionFlagKey = 'sendTelemetry' | 'allowErrorReporting'
 
 export interface OptionFlagDefinition {
     label: string
@@ -33,16 +33,11 @@ export const optionFlagDefinitions: OptionFlagDefinition[] = [
         key: 'allowErrorReporting',
         label: 'Allow error reporting',
     },
-    {
-        key: 'clickToGoToDefinition',
-        label: 'Enable click to go to definition',
-    },
 ]
 
 const optionFlagDefaults: OptionFlagValues = {
     sendTelemetry: false,
     allowErrorReporting: false,
-    clickToGoToDefinition: false,
 }
 
 const assignOptionFlagValues = (values: OptionFlagValues): OptionFlagWithValue[] =>

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -1,15 +1,13 @@
 import React, { useCallback, useEffect } from 'react'
 
 import classNames from 'classnames'
-import { Location, useLocation } from 'react-router-dom'
-import { fromEvent, Observable } from 'rxjs'
-import { finalize, tap } from 'rxjs/operators'
+import { Observable } from 'rxjs'
 
 import { isErrorLike } from '@sourcegraph/common'
 import { urlForClientCommandOpen } from '@sourcegraph/shared/src/actions/ActionItem'
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { HoverOverlay, HoverOverlayProps } from '@sourcegraph/shared/src/hover/HoverOverlay'
-import { Settings, SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { AlertProps, useLocalStorage } from '@sourcegraph/wildcard'
 
 import { HoverThresholdProps } from '../../repo/RepoContainer'
@@ -43,7 +41,6 @@ export interface WebHoverOverlayProps
 }
 
 export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<WebHoverOverlayProps>> = props => {
-    const location = useLocation()
     const { onAlertDismissed: outerOnAlertDismissed } = props
     const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
     const onAlertDismissed = useCallback(
@@ -75,62 +72,6 @@ export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<We
             onHoverShown?.()
         }
     }, [hoveredToken?.filePath, hoveredToken?.line, hoveredToken?.character, onHoverShown, hoverHasValue])
-
-    const clickToGoToDefinition = getClickToGoToDefinition(props.settingsCascade)
-
-    useEffect(() => {
-        if (!clickToGoToDefinition) {
-            return
-        }
-
-        const token = props.hoveredTokenElement
-        const click = props.hoveredTokenClick ?? (token ? fromEvent(token, 'click') : null)
-        const nav = props.nav
-        if (!click || !nav) {
-            return
-        }
-
-        const urlAndType = getGoToURL(props.actionsOrError, location)
-        if (!urlAndType) {
-            return
-        }
-        const { url, actionType } = urlAndType
-
-        const oldCursor = token?.style.cursor
-        if (token) {
-            token.style.cursor = 'pointer'
-        }
-
-        const subscription = click
-            .pipe(
-                tap(() => {
-                    const selection = window.getSelection()
-                    if (selection !== null && selection.toString() !== '') {
-                        return
-                    }
-
-                    props.telemetryService.log(`${actionType}HoverOverlay.click`)
-                    nav(url)
-                }),
-                finalize(() => {
-                    if (token && oldCursor) {
-                        token.style.cursor = oldCursor
-                    }
-                })
-            )
-            .subscribe()
-
-        return () => subscription.unsubscribe()
-    }, [
-        props.actionsOrError,
-        props.hoveredTokenElement,
-        props.hoveredTokenClick,
-        location,
-        props.nav,
-        props.telemetryService,
-        clickToGoToDefinition,
-        hoveredToken,
-    ])
 
     return (
         <HoverOverlay
@@ -178,12 +119,4 @@ export const getGoToURL = (
     }
 
     return { url, actionType: action === definitionAction ? 'definition' : 'reference' }
-}
-
-export const getClickToGoToDefinition = (settingsCascade: SettingsCascadeOrError<Settings>): boolean => {
-    if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-        const value = settingsCascade.final['codeIntelligence.clickToGoToDefinition'] as boolean
-        return value ?? true
-    }
-    return true
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2001,8 +2001,6 @@ type Settings struct {
 	CodeIntelTraceExtension bool `json:"codeIntel.traceExtension,omitempty"`
 	// CodeIntelligenceAutoIndexPopularRepoLimit description: Up to this number of repos are auto-indexed automatically. Ordered by star count.
 	CodeIntelligenceAutoIndexPopularRepoLimit int `json:"codeIntelligence.autoIndexPopularRepoLimit,omitempty"`
-	// CodeIntelligenceClickToGoToDefinition description: Enable click to go to definition.
-	CodeIntelligenceClickToGoToDefinition bool `json:"codeIntelligence.clickToGoToDefinition,omitempty"`
 	// ExperimentalFeatures description: Experimental features and settings.
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// FileSidebarVisibleByDefault description: Whether the sidebar on the repo view should be open by default.
@@ -2102,7 +2100,6 @@ func (v *Settings) UnmarshalJSON(data []byte) error {
 	delete(m, "codeIntel.mixPreciseAndSearchBasedReferences")
 	delete(m, "codeIntel.traceExtension")
 	delete(m, "codeIntelligence.autoIndexPopularRepoLimit")
-	delete(m, "codeIntelligence.clickToGoToDefinition")
 	delete(m, "experimentalFeatures")
 	delete(m, "fileSidebarVisibleByDefault")
 	delete(m, "history.defaultPageSize")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -440,11 +440,6 @@
       "minimum": 0,
       "default": 0
     },
-    "codeIntelligence.clickToGoToDefinition": {
-      "description": "Enable click to go to definition.",
-      "type": "boolean",
-      "default": true
-    },
     "search.contextLines": {
       "description": "The default number of lines to show as context below and above search results. Default is 1.",
       "type": "integer",


### PR DESCRIPTION
In the web app, the new selection-driven code nav UI (https://github.com/sourcegraph/sourcegraph/pull/44698 https://github.com/sourcegraph/sourcegraph/pull/48066) does not use this.

The browser extension's implementation is separate from the web app's in implementation and backstory, but it is also removed because it presents the same future UX problems and is inconsistent with the direction we're taking for the web app.

## Test plan

Ensure code navigation in the remaining selection-driven mode still works.