### PR TITLE
Update to latest versions of aspect_bazel_lib, apsect_rules_js, aspect_rules_ts

### DIFF
--- a/.aspect/bazelrc/convenience.bazelrc
+++ b/.aspect/bazelrc/convenience.bazelrc
@@ -1,7 +1,6 @@
 # Attempt to build & test every target whose prerequisites were successfully built.
 # Docs: https://bazel.build/docs/user-manual#keep-going
 build --keep_going
-test  --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
 # fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
@@ -26,4 +25,4 @@ common --enable_platform_specific_config
 # The dump will be written to `<output_base>/<invocation_id>.heapdump.hprof`.
 # You may need to configure CI to capture this artifact and upload for later use.
 # Docs: https://bazel.build/reference/command-line-reference#flag--heap_dump_on_oom
-build --heap_dump_on_oom
+common --heap_dump_on_oom

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -11,7 +11,6 @@ build --noremote_upload_local_results
 # Developers should tag targets with `tags=["requires-network"]` to opt-out of the enforcement.
 # Docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
 build --sandbox_default_allow_network=false
-test --sandbox_default_allow_network=false
 
 # Warn if a test's timeout is significantly longer than the test's actual execution time.
 # Bazel's default for test_timeout is medium (5 min), but most tests should instead be short (1 min).

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -41,8 +41,6 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
-run --nolegacy_external_runfiles
-test --nolegacy_external_runfiles
 
 # Some actions are always IO-intensive but require little compute. It's wasteful to put the output
 # in the remote cache, it just saturates the network and fills the cache storage causing earlier

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,29 +15,23 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "b4cd1114874ab15f794134eefbc254eb89d3e1de640bf4a11f2f402e886ad29e",
-    strip_prefix = "bazel-lib-1.27.2",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.27.2/bazel-lib-v1.27.2.tar.gz",
+    sha256 = "2518c757715d4f5fc7cc7e0a68742dd1155eaafc78fb9196b8a18e13a738cea2",
+    strip_prefix = "bazel-lib-1.28.0",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "9fadde0ae6e0101755b8aedabf7d80b166491a8de297c60f6a5179cd0d0fea58",
-    strip_prefix = "rules_js-1.20.0",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v1.20.0/rules_js-v1.20.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_nodejs",
-    sha256 = "08337d4fffc78f7fe648a93be12ea2fc4e8eb9795a4e6aa48595b66b34555626",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.0/rules_nodejs-core-5.8.0.tar.gz"],
+    sha256 = "1aa0ab76d1f9520bb8993e2d84f82da2a9c87da1e6e8d121dbb4c857a292c2cd",
+    strip_prefix = "rules_js-1.20.1",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v1.20.1/rules_js-v1.20.1.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_ts",
-    sha256 = "db77d904284d21121ae63dbaaadfd8c75ff6d21ad229f92038b415c1ad5019cc",
-    strip_prefix = "rules_ts-1.3.0",
-    url = "https://github.com/aspect-build/rules_ts/releases/download/v1.3.0/rules_ts-v1.3.0.tar.gz",
+    sha256 = "02480b6a1cd12516edf364e678412e9da10445fe3f1070c014ac75e922c969ea",
+    strip_prefix = "rules_ts-1.3.1",
+    url = "https://github.com/aspect-build/rules_ts/releases/download/v1.3.1/rules_ts-v1.3.1.tar.gz",
 )
 
 http_archive(
@@ -83,18 +77,18 @@ http_archive(
     ],
 )
 
-# Node toolchain setup ==========================
-load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
-
-nodejs_register_toolchains(
-    name = "nodejs",
-    node_version = DEFAULT_NODE_VERSION,
-)
-
 # rules_js setup ================================
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()
+
+# node toolchain setup ==========================
+load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = "16.19.0",
+)
 
 # rules_js npm setup ============================
 load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")


### PR DESCRIPTION
- aspect_bazel_lib update brings in an update to the Aspect bazelrc presets
- rules_ts has a sourcemap fix in this update for worker mode
- the bump in rules_js also bumps the rules_nodejs toolchain (which can be brought in as a transitive instead a direct dep); we pin the nodejs version in WORKSPACE here to that it is not bumped with the bump in rules_nodejs version

## Test plan

`bazel build ...`