### PR TITLE
build: don't bust Bazel analysis cache when switching between build & test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,5 +15,5 @@ import %workspace%/.aspect/bazelrc/performance.bazelrc
 # this file. See https://bazel.build/configure/best-practices#bazelrc-file.
 try-import %workspace%/.aspect/bazelrc/user.bazelrc
 
-# Enable bazel hack for autogold
-test --test_env=ENABLE_BAZEL_PACKAGES_LOAD_HACK=true
+# Enable bazel hack for autogold; apply to both build & test to avoid busting analysis cache
+build --test_env=ENABLE_BAZEL_PACKAGES_LOAD_HACK=true


### PR DESCRIPTION
`test` inherits from `build` in bazelrc so it is sufficient to specify `build` to get the flag set for both `bazel build` and `bazel test`

Test plan: (@jhchabran) only affects bazel, ran things locally, all good. 