### PR TITLE
fix broken "Settings" link for items on saved searches list page

### DIFF
--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -95,7 +95,7 @@ class SavedSearchNode extends React.PureComponent<NodeProps, NodeState> {
                     <Tooltip content="Saved search settings">
                         <Button
                             className="test-edit-saved-search-button"
-                            to={`searches/${this.props.savedSearch.id}`}
+                            to={this.props.savedSearch.id}
                             variant="secondary"
                             size="sm"
                             as={Link}


### PR DESCRIPTION
The link was `/users/USERNAME/searches/searches/ID` (note duplicate `searches/searches`).




## Test plan

View saved searches page and click a Settings link.

## App preview:

- [Web](https://sg-web-sqs-saved-searches-broken-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
