### PR TITLE
reduce confusion between saved searches and code monitors

### DIFF
--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -105,10 +105,7 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
 
     return (
         <div className="saved-search-form" data-testid="saved-search-form">
-            <PageHeader
-                description="Get notifications when there are new results for specific search queries."
-                className="mb-3"
-            >
+            <PageHeader className="mb-3">
                 <PageTitle title={props.title} />
                 <PageHeader.Heading as="h3" styleAs="h2">
                     <PageHeader.Breadcrumb>{props.title}</PageHeader.Breadcrumb>

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -152,7 +152,6 @@ export const SavedSearchListPage: React.FunctionComponent<Props> = props => {
     return (
         <div className={styles.savedSearchListPage} data-testid="saved-searches-list-page">
             <PageHeader
-                description="Manage notifications and alerts for specific search queries."
                 actions={
                     <Button to="add" className="test-add-saved-search-button" variant="primary" as={Link}>
                         <Icon aria-hidden={true} svgPath={mdiPlus} /> Add saved search

--- a/doc/code_search/how-to/saved_searches.md
+++ b/doc/code_search/how-to/saved_searches.md
@@ -2,6 +2,8 @@
 
 Saved searches let you save and describe search queries so you can easily find and use them again later. You can create a saved search for anything, including diffs and commits across all branches of your repositories.
 
+If you want Sourcegraph to monitor a search query and send notifications when there are new results, use [code monitoring](../../code_monitoring/index.md).
+
 ## Creating saved searches
 
 A saved search consists of a description and a query, both of which you can define and edit.


### PR DESCRIPTION
Saved searches are now only intended for saving query strings. Previously they also supported monitoring code and sending notifications. That functionality is disabled for new saved searches, but it is still supported for old, existing saved searches.




## Test plan

n/a; copy only

## App preview:

- [Web](https://sg-web-sqs-saved-searches-etc.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
