### PR TITLE
storm: make Apollo Cache persistor use preloaded data

### DIFF
--- a/client/browser/src/shared/backend/requestGraphQl.ts
+++ b/client/browser/src/shared/backend/requestGraphQl.ts
@@ -110,7 +110,6 @@ export function createGraphQLHelpers(sourcegraphURL: string, isExtension: boolea
             cache,
             headers: getHeaders(),
             baseUrl: sourcegraphURL,
-            isAuthenticated: false,
             credentials: 'include',
         })
     )

--- a/client/shared/src/api/client/mainthread-api.test.ts
+++ b/client/shared/src/api/client/mainthread-api.test.ts
@@ -14,7 +14,7 @@ import { SettingsEdit } from './services/settings'
 
 describe('MainThreadAPI', () => {
     // TODO(tj): commands, notifications
-    const getGraphQLClient = () => getGraphQLClientBase({ headers: {}, isAuthenticated: false, cache })
+    const getGraphQLClient = () => getGraphQLClientBase({ headers: {}, cache })
 
     describe('graphQL', () => {
         test('PlatformContext#requestGraphQL is called with the correct arguments', async () => {

--- a/client/web/src/backend/getPersistentCache.ts
+++ b/client/web/src/backend/getPersistentCache.ts
@@ -1,0 +1,62 @@
+import { InMemoryCache, NormalizedCacheObject } from '@apollo/client'
+import { PersistentStorage, CachePersistor } from 'apollo3-cache-persist'
+
+import { cache } from '@sourcegraph/shared/src/backend/apolloCache'
+
+import { CacheObject, persistenceMapper, ROOT_QUERY_KEY } from './persistenceMapper'
+
+/**
+ * 🚨 SECURITY: Use two unique keys for authenticated and anonymous users
+ * to avoid keeping private information in localStorage after logout.
+ */
+const getApolloPersistCacheKey = (isAuthenticated: boolean): string =>
+    `apollo-cache-persist-${isAuthenticated ? 'authenticated' : 'anonymous'}`
+
+/**
+ * Persistence storage is based on `localStorage`, which uses the
+ * data preloaded on the server and transferred to the client via `window.context`.
+ */
+class LocalStorageWrapper implements PersistentStorage<CacheObject | null> {
+    public removeItem(key: string): void {
+        window.localStorage.removeItem(key)
+    }
+
+    public setItem(key: string, value: CacheObject | null): void {
+        window.localStorage.setItem(key, JSON.stringify(value))
+    }
+
+    public getItem(key: string): CacheObject | null {
+        const maybeData = window.localStorage.getItem(key) ?? '{}'
+        const persistedData = JSON.parse(maybeData) as CacheObject
+
+        const hydratedData: CacheObject = {
+            ...persistedData,
+            [ROOT_QUERY_KEY]: {
+                __typename: 'Query',
+                ...persistedData[ROOT_QUERY_KEY],
+                temporarySettings: window.context.temporarySettings,
+            },
+        }
+
+        return hydratedData
+    }
+}
+
+export async function getPersistentCache(isAuthenticated: boolean): Promise<InMemoryCache> {
+    const persistor = new CachePersistor<NormalizedCacheObject>({
+        cache,
+        persistenceMapper,
+        // Use max 4 MB for persistent cache. Leave 1 MB for other means out of 5 MB available.
+        // If exceeded, persistence will pause and app will start up cold on next launch.
+        maxSize: 1024 * 1024 * 4,
+        key: getApolloPersistCacheKey(isAuthenticated),
+        storage: new LocalStorageWrapper() as any, // `as any` is required because third-party types are incorrect.
+        serialize: false as true, // `as true` is required because third-party types are incorrect.
+    })
+
+    // 🚨 SECURITY: Drop persisted cache item in case `isAuthenticated` value changed.
+    localStorage.removeItem(getApolloPersistCacheKey(!isAuthenticated))
+    await persistor.restore()
+
+    return cache
+}

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -2,11 +2,10 @@ import { memoize } from 'lodash'
 import { Observable } from 'rxjs'
 
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
-import { cache } from '@sourcegraph/shared/src/backend/apolloCache'
 
 import { WebGraphQlOperations } from '../graphql-operations'
 
-import { persistenceMapper } from './persistenceMapper'
+import { getPersistentCache } from './getPersistentCache'
 
 const getHeaders = (): { [header: string]: string } => {
     const headers: { [header: string]: string } = {
@@ -91,18 +90,13 @@ export const mutateGraphQL = <TResult extends WebGraphQlOperationResults>(
  * Memoized Apollo Client getter. It should be executed once to restore the cache from the local storage.
  * After that, the same instance should be used by all consumers.
  */
-export const getWebGraphQLClient = memoize(() => {
-    // Initilize Apollo Client cache with preloaded data.
-    const hydratedCache = cache.restore({
-        ROOT_QUERY: {
-            temporarySettings: window.context.temporarySettings,
-        },
-    })
+export const getWebGraphQLClient = memoize(async () => {
+    const persistentCache = await getPersistentCache(window.context.isAuthenticatedUser)
 
-    return getGraphQLClient({
-        cache: hydratedCache,
-        persistenceMapper,
-        isAuthenticated: window.context.isAuthenticatedUser,
+    const client = await getGraphQLClient({
+        cache: persistentCache,
         headers: getHeaders(),
     })
+
+    return client
 })

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -91,7 +91,12 @@ export const mutateGraphQL = <TResult extends WebGraphQlOperationResults>(
  * After that, the same instance should be used by all consumers.
  */
 export const getWebGraphQLClient = memoize(async () => {
-    const persistentCache = await getPersistentCache(window.context.isAuthenticatedUser)
+    const persistentCache = await getPersistentCache({
+        isAuthenticatedUser: window.context.isAuthenticatedUser,
+        preloadedQueries: {
+            temporarySettings: window.context.temporarySettings,
+        },
+    })
 
     const client = await getGraphQLClient({
         cache: persistentCache,

--- a/client/web/src/backend/persistenceMapper.test.ts
+++ b/client/web/src/backend/persistenceMapper.test.ts
@@ -1,24 +1,22 @@
-import { persistenceMapper, ROOT_QUERY_KEY, CacheObject } from './persistenceMapper'
+import { persistenceMapper, ROOT_QUERY_KEY } from './persistenceMapper'
 
 describe('persistenceMapper', () => {
     const userKey = 'User:01'
     const settingsKey = 'Settings:01'
 
     const createStringifiedCache = (rootQuery: Record<string, unknown>, references?: Record<string, unknown>) =>
-        JSON.stringify({
+        ({
             [ROOT_QUERY_KEY]: {
-                __typename: 'query',
+                __typename: 'Query',
                 ...rootQuery,
             },
             ...references,
-        })
-
-    const parseCacheString = (cacheString: string) => JSON.parse(cacheString) as CacheObject
+        } as const)
 
     it('does not persist anything if the cache is empty', async () => {
-        const persistedString = await persistenceMapper(JSON.stringify({}))
+        const persistedString = await persistenceMapper({})
 
-        expect(Object.keys(parseCacheString(persistedString))).toEqual([])
+        expect(Object.keys(persistedString)).toEqual([])
     })
 
     it('persists only hardcoded queries', async () => {
@@ -29,7 +27,7 @@ describe('persistenceMapper', () => {
             })
         )
 
-        expect(Object.keys(parseCacheString(persistedString).ROOT_QUERY)).not.toContain('shouldNotBePersisted')
+        expect(Object.keys(persistedString.ROOT_QUERY!)).not.toContain('shouldNotBePersisted')
     })
 
     it('persists cache references', async () => {
@@ -46,7 +44,7 @@ describe('persistenceMapper', () => {
             )
         )
 
-        expect(Object.keys(parseCacheString(persistedString))).toEqual([ROOT_QUERY_KEY, userKey, settingsKey])
+        expect(Object.keys(persistedString)).toEqual([ROOT_QUERY_KEY, userKey, settingsKey])
     })
 
     it('persists array of cache references', async () => {
@@ -63,7 +61,7 @@ describe('persistenceMapper', () => {
             )
         )
 
-        expect(Object.keys(parseCacheString(persistedString))).toEqual([ROOT_QUERY_KEY, userKey, settingsKey])
+        expect(Object.keys(persistedString)).toEqual([ROOT_QUERY_KEY, userKey, settingsKey])
     })
 
     it('persists deeply nested cache references', async () => {
@@ -79,6 +77,6 @@ describe('persistenceMapper', () => {
             )
         )
 
-        expect(Object.keys(parseCacheString(persistedString))).toEqual([ROOT_QUERY_KEY, userKey])
+        expect(Object.keys(persistedString)).toEqual([ROOT_QUERY_KEY, userKey])
     })
 })

--- a/client/web/src/backend/persistenceMapper.ts
+++ b/client/web/src/backend/persistenceMapper.ts
@@ -5,7 +5,7 @@ import { QueryFieldPolicy } from '@sourcegraph/shared/src/graphql-operations'
  * After the implementation of the `persistLink` which will support `@persist` directive
  * hardcoded query names will be deprecated.
  */
-export const QUERIES_TO_PERSIST: (keyof QueryFieldPolicy)[] = ['viewerSettings', 'temporarySettings']
+export const QUERIES_TO_PERSIST: (keyof QueryFieldPolicy)[] = ['viewerSettings']
 export const ROOT_QUERY_KEY = 'ROOT_QUERY'
 
 export interface CacheReference {
@@ -13,22 +13,23 @@ export interface CacheReference {
 }
 
 export interface CacheObject {
-    ROOT_QUERY: Record<string, unknown>
+    ROOT_QUERY?: {
+        __typename: 'Query'
+        [key: string]: unknown
+    }
     [cacheKey: string]: unknown
 }
 
 // Ensures that we persist data required only for `QUERIES_TO_PERSIST`. Everything else is ignored.
-export const persistenceMapper = (data: string): Promise<string> => {
-    const initialData = JSON.parse(data) as CacheObject
-
+export const persistenceMapper = (data: CacheObject): Promise<CacheObject> => {
     // If `ROOT_QUERY` cache is empty, return initial data right away.
-    if (!initialData[ROOT_QUERY_KEY] || Object.keys(initialData[ROOT_QUERY_KEY]).length === 0) {
-        return Promise.resolve(data)
+    if (!data[ROOT_QUERY_KEY] || Object.keys(data[ROOT_QUERY_KEY]).length === 0) {
+        return Promise.resolve(data as CacheObject)
     }
 
-    const dataToPersist: Record<string, unknown> = {
+    const dataToPersist: CacheObject = {
         [ROOT_QUERY_KEY]: {
-            __typename: initialData[ROOT_QUERY_KEY].__typename,
+            __typename: data[ROOT_QUERY_KEY].__typename,
         },
     }
 
@@ -44,8 +45,8 @@ export const persistenceMapper = (data: string): Promise<string> => {
         } else if (isCacheReference(entry)) {
             const referenceKey = entry.__ref
 
-            dataToPersist[referenceKey] = initialData[referenceKey]
-            findNestedCacheReferences(initialData[referenceKey])
+            dataToPersist[referenceKey] = data[referenceKey]
+            findNestedCacheReferences(data[referenceKey])
         } else if (entry && typeof entry === 'object') {
             for (const item of Object.values(entry)) {
                 findNestedCacheReferences(item)
@@ -61,7 +62,7 @@ export const persistenceMapper = (data: string): Promise<string> => {
      * 'User:01' should be persisted, to have a complete cached response to the `viewerSettings` query.
      */
     for (const queryName of QUERIES_TO_PERSIST) {
-        const entryToPersist = initialData[ROOT_QUERY_KEY][queryName]
+        const entryToPersist = data[ROOT_QUERY_KEY][queryName]
 
         if (entryToPersist) {
             Object.assign(dataToPersist[ROOT_QUERY_KEY] as object, {
@@ -72,7 +73,7 @@ export const persistenceMapper = (data: string): Promise<string> => {
         }
     }
 
-    return Promise.resolve(JSON.stringify(dataToPersist))
+    return Promise.resolve(dataToPersist)
 }
 
 function isCacheReference(entry: any): entry is CacheReference {

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -5,7 +5,7 @@ import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'
 import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
 
-import { asError } from '@sourcegraph/common'
+import { asError, logger } from '@sourcegraph/common'
 import { Button, Code, Text } from '@sourcegraph/wildcard'
 
 import { isWebpackChunkError } from '../monitoring'
@@ -102,6 +102,7 @@ export const RouteError: React.FC = () => {
         return asError(routeError)
     }, [routeError])
     useEffect(() => {
+        logger.error(error)
         if (typeof Sentry !== 'undefined') {
             Sentry.captureException(error)
         }


### PR DESCRIPTION
## Context

Addresses [the issue](https://github.com/sourcegraph/sourcegraph/pull/48463#issuecomment-1454894102) spotted by @vovakulikov in https://github.com/sourcegraph/sourcegraph/pull/48463. 

- The Apollo Client cache persistor is updated to use the preloaded data on reads instead of only data available in `localStorage`. 
- The `temporarySettings` query is no longer persisted to the `localStorage`.

## Test plan

Use repro instructions shared by @vovakulikov:

1. Read a temporary settings field,
2. See one value of this field (let's say we have a boolean flag, and its value is `true`).
3. Change this flag value from a different browser or via the API console (editTemporalSettings mutation).
4. Refresh the page and see that `window.context.temporarySettings` has a correct new value.
5. But `useTemporarySettings` returns the old value because it's using a cached value from the local storage that persistMapper provided for the Apollo cache.

## App preview:

- [Web](https://sg-web-vb-storm-5.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
