### PR TITLE
[feat] Prepare for permissions data model oob migration

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -612,9 +612,9 @@ func (s *permsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermis
 func upsertUserPermissionsQuery(p *authz.UserPermissions) (*sqlf.Query, error) {
 	const format = `
 INSERT INTO user_permissions
-  (user_id, permission, object_type, object_ids_ints, updated_at, synced_at, migrated)
+  (user_id, permission, object_type, object_ids_ints, updated_at, synced_at)
 VALUES
-  (%s, %s, %s, %s, %s, %s, TRUE)
+  (%s, %s, %s, %s, %s, %s)
 ON CONFLICT ON CONSTRAINT
   user_permissions_perm_object_unique
 DO UPDATE SET

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -612,15 +612,16 @@ func (s *permsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermis
 func upsertUserPermissionsQuery(p *authz.UserPermissions) (*sqlf.Query, error) {
 	const format = `
 INSERT INTO user_permissions
-  (user_id, permission, object_type, object_ids_ints, updated_at, synced_at)
+  (user_id, permission, object_type, object_ids_ints, updated_at, synced_at, migrated)
 VALUES
-  (%s, %s, %s, %s, %s, %s)
+  (%s, %s, %s, %s, %s, %s, TRUE)
 ON CONFLICT ON CONSTRAINT
   user_permissions_perm_object_unique
 DO UPDATE SET
   object_ids_ints = excluded.object_ids_ints,
   updated_at = excluded.updated_at,
-  synced_at = excluded.synced_at
+  synced_at = excluded.synced_at,
+  migrated = TRUE
 `
 
 	if p.UpdatedAt.IsZero() {
@@ -2135,8 +2136,8 @@ WITH accessible_repos AS (
 		repo.id,
 		repo.name
 	FROM repo
-	WHERE 
-		repo.deleted_at IS NULL 
+	WHERE
+		repo.deleted_at IS NULL
 		AND %s -- Authz Conds, Pagination Conds, Search
 	ORDER BY %s
 	%s -- Limit
@@ -2145,8 +2146,8 @@ WITH accessible_repos AS (
 SELECT
 	ar.*,
 	up.updated_at AS permission_updated_at,
-	CASE 
-		WHEN up.user_id IS NOT NULL THEN 'Permissions Sync' 
+	CASE
+		WHEN up.user_id IS NOT NULL THEN 'Permissions Sync'
 		ELSE 'Unrestricted' -- If no user_permissions entry is found then the accessible repo must be unrestricted
 	END AS permission_reason
 FROM

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -23375,6 +23375,19 @@
       "Comment": "",
       "Columns": [
         {
+          "Name": "migrated",
+          "Index": 7,
+          "TypeName": "boolean",
+          "IsNullable": true,
+          "Default": "true",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "object_ids_ints",
           "Index": 6,
           "TypeName": "integer[]",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3632,6 +3632,7 @@ Indexes:
  updated_at      | timestamp with time zone |           | not null | 
  synced_at       | timestamp with time zone |           |          | 
  object_ids_ints | integer[]                |           | not null | '{}'::integer[]
+ migrated        | boolean                  |           |          | true
 Indexes:
     "user_permissions_perm_object_unique" UNIQUE CONSTRAINT, btree (user_id, permission, object_type)
 

--- a/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/down.sql
+++ b/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS user_permissions
+    DROP COLUMN IF EXISTS migrated;

--- a/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/metadata.yaml
+++ b/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/metadata.yaml
@@ -1,0 +1,2 @@
+name: add migrated column to user_permissions
+parents: [1677878270]

--- a/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/up.sql
+++ b/migrations/frontend/1678091683_add_migrated_column_to_user_permissions/up.sql
@@ -1,0 +1,7 @@
+-- First set migrated column to false on all rows
+ALTER TABLE IF EXISTS user_permissions
+    ADD COLUMN IF NOT EXISTS migrated BOOLEAN DEFAULT FALSE;
+-- Now default migrated to true, e.g. all upserted rows from now on are automatically migrated
+-- since we are writing to both user_repo_permissions and user_permissions tables
+ALTER TABLE IF EXISTS user_permissions
+    ALTER COLUMN migrated SET DEFAULT TRUE;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4216,7 +4216,8 @@ CREATE TABLE user_permissions (
     object_type text NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     synced_at timestamp with time zone,
-    object_ids_ints integer[] DEFAULT '{}'::integer[] NOT NULL
+    object_ids_ints integer[] DEFAULT '{}'::integer[] NOT NULL,
+    migrated boolean DEFAULT true
 );
 
 CREATE TABLE user_public_repos (


### PR DESCRIPTION
## Description

Created a new column `migrated` in `user_permissions` table. By default it will be `TRUE`, but all the existing rows will be marked as `false` This way, we know if the row was already migrated to new unified table or not.

Changed `perms_syncer` to write to both unified `user_repo_permissions` and old `user_permissions` tables at once. Perms syncer will write `true` to the above column for all the rows that it does touch in `user_permissions` table. This way, `perms_syncer` is already doing part of the job for the OOB migration.

## Test plan

Tested that write works for both tables locally.

Tested that the migration SQL queries work as expected.
