### PR TITLE
nogo: create config for all analyzers

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -1,11 +1,19 @@
 {
+  "_base": {
+    "description": "Base config which all analyzers will inherit, even unspecified",
+    "exclude_files": {
+      "external/*": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code",
+      ".*_pb\\.go$": "ignore protobuff generated code"
+    }
+  },
   "bodyclose": {
     "exclude_files": {
-      "external/": "no need to vet third party code",
+      "external/*": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
+      ".*_test\\.go": "exclude bodyclose lint from tests because leaking connections in tests is a non issue",
       "internal/extsvc/": "ignore temporarily",
-      ".*_test\\.go": "Exclude bodyclose lint from tests because leaking connections in tests is a non issue",
       "cmd/frontend/internal/gosrc/import_path.go": "temp ignore till we support nolint: comment"
     }
   }


### PR DESCRIPTION
"_base" is a special config key is inherited by all analyzers, if those that are not specified. A key thing to remember is that if a child config specified it **will overwrite** the inherited config key. For example, in the current `nogo` config, `bodyclose` overwrites the `exclude_files` config. Thus, we repeat the base config exclusions*
## Test plan
* cherry-picked this commit onto https://github.com/sourcegraph/sourcegraph/pull/48696
* `bazel test //...` - no nogo failures

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
