### PR TITLE
filepicker: introduce package for local file dialogs

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/service/servegit"
+	"github.com/sourcegraph/sourcegraph/internal/singleprogram/filepicker"
 )
 
 const usage = `
@@ -33,9 +35,25 @@ func main() {
 
 	root := flag.String("root", c.Root, "the directory we search from.")
 	block := flag.Bool("block", false, "by default we stream out the repos we find. This is not exactly what sourcegraph uses, so enable this flag for the same behaviour.")
+	picker := flag.Bool("picker", false, "try run the file picker.")
 	verbose := flag.Bool("v", false, "verbose output")
 
 	flag.Parse()
+
+	if *picker {
+		p, ok := filepicker.Lookup(log.Scoped("picker", ""))
+		if !ok {
+			fmt.Fprintf(os.Stderr, "filepicker not found\n")
+		} else {
+			path, err := p(context.Background())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "filepicker error: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "filepicker picked %q\n", path)
+			*root = path
+		}
+	}
 
 	c.Root = *root
 

--- a/internal/singleprogram/filepicker/filepicker.go
+++ b/internal/singleprogram/filepicker/filepicker.go
@@ -1,0 +1,116 @@
+// package filepicker has a best-effort implementation of GUI file dialogs.
+//
+// The implementation looks for executables that can be run.
+package filepicker
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func osascript(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx,
+		"osascript", "-e",
+		`return the POSIX path of (choose folder with prompt "Select a repository or folder with repositories")`)
+	path, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	// Output looks something like "/path/to/dir/\n". We can reliably strip
+	// out the trailing new line by just returning upto the last /
+	i := bytes.LastIndexByte(path, '/')
+	if i < 0 {
+		return "", errors.Errorf("returned value from file picker is missing /: %q", string(path))
+	} else if i == 0 {
+		return "/", nil
+	}
+	return string(path[:i]), nil
+}
+
+func zenity(ctx context.Context) (string, error) {
+	// nix-shell -p gnome.zenity
+	cmd := exec.CommandContext(ctx, "zenity", "--file-selection", "--directory")
+	path, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return trimTrailingNewline(path), nil
+}
+
+func kdialog(ctx context.Context) (string, error) {
+	// nix-shell -p kdialog
+	cmd := exec.CommandContext(ctx, "kdialog", "--getexistingdirectory")
+	pathRaw, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	path := trimTrailingNewline(pathRaw)
+
+	// kdialog may return a file, if so pick its parent
+	if info, err := os.Lstat(path); err != nil {
+		return "", errors.Wrap(err, "failed to Lstat user selected path via kdialog")
+	} else if !info.IsDir() {
+		return filepath.Dir(path), nil
+	}
+
+	return path, nil
+}
+
+func trimTrailingNewline(b []byte) string {
+	return string(bytes.TrimSuffix(b, []byte{'\n'}))
+}
+
+// Picker returns the filepath to a directory a user picked. It should exclude
+// the trailing /. If the operation times out or the user cancels, an error is
+// returned.
+type Picker func(ctx context.Context) (string, error)
+
+// Lookup finds a Picker to run. If no Picker can be found, ok is false.
+func Lookup(logger log.Logger) (_ Picker, ok bool) {
+	pickers := []struct {
+		// Cmd must exist on PATH for Run to work.
+		Cmd string
+		// RequiredEnv is an optional envvar needed for Cmd to work.
+		RequiredEnv string
+		// Run is the picker implementation.
+		Run Picker
+	}{{
+		Cmd: "osascript",
+		Run: osascript,
+	}, {
+		Cmd:         "zenity",
+		RequiredEnv: "DISPLAY",
+		Run:         zenity,
+	}, {
+		Cmd:         "kdialog",
+		RequiredEnv: "DISPLAY",
+		Run:         kdialog,
+	}}
+
+	for _, picker := range pickers {
+		if _, err := exec.LookPath(picker.Cmd); err != nil {
+			logger.Debug("skipping filepicker due to not being on PATH", log.String("cmd", picker.Cmd), log.Error(err))
+			continue
+		}
+
+		if picker.RequiredEnv != "" && os.Getenv(picker.RequiredEnv) == "" {
+			logger.Debug("skipping filepicker due to missing envvar", log.String("cmd", picker.Cmd), log.String("envvar", picker.RequiredEnv))
+			continue
+		}
+
+		logger.Debug("found filepicker", log.String("cmd", picker.Cmd))
+		return picker.Run, true
+	}
+
+	logger.Debug("no filepicker found")
+	return nil, false
+}

--- a/internal/singleprogram/filepicker/filepicker_test.go
+++ b/internal/singleprogram/filepicker/filepicker_test.go
@@ -1,0 +1,129 @@
+package filepicker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/singleprogram/filepicker"
+)
+
+func TestPicker(t *testing.T) {
+	// We can't do proper tests since running GUI apps + having those deps on
+	// CI is no fun. So we do the next best thing, we simulate it.
+
+	// disable GUI since our checks rely on it
+	if v, ok := os.LookupEnv("DISPLAY"); ok {
+		os.Unsetenv("DISPLAY")
+		defer os.Setenv("DISPLAY", v)
+	}
+
+	// kdialog requires a real file since we do lstat
+	kdialogDir := t.TempDir()
+	kdialogPath := filepath.Join(kdialogDir, "horse ")
+	if err := os.WriteFile(kdialogPath, []byte("graph"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		bin      map[string]string
+		display  bool
+		nopicker bool
+		want     string
+		wantErr  bool
+	}{{
+		name:     "none",
+		nopicker: true,
+	}, {
+		name: "nodisplay",
+		bin: map[string]string{
+			"zenity":  "echo /zenity",
+			"kdialog": "echo /kdialog",
+		},
+		nopicker: true,
+	}, {
+		name: "osascript-fail",
+		bin: map[string]string{
+			"osascript": "exit 1",
+		},
+		wantErr: true,
+	}, {
+		name: "zenity-fail",
+		bin: map[string]string{
+			"zenity": "exit 1",
+		},
+		display: true,
+		wantErr: true,
+	}, {
+		name: "kdialog-fail",
+		bin: map[string]string{
+			"kdialog": "exit 1",
+		},
+		display: true,
+		wantErr: true,
+	}, {
+		name: "osascript",
+		bin: map[string]string{
+			"osascript": "echo '/path /with spaces/trailing /'",
+		},
+		want: "/path /with spaces/trailing ",
+	}, {
+		name: "zenity",
+		bin: map[string]string{
+			"zenity": "echo '/path /with spaces/trailing '",
+		},
+		display: true,
+		want:    "/path /with spaces/trailing ",
+	}, {
+		name: "kdialog",
+		bin: map[string]string{
+			"kdialog": fmt.Sprintf("echo %q", kdialogPath),
+		},
+		display: true,
+		want:    kdialogDir,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup bindir based on tc.bin
+			bin := t.TempDir()
+			t.Setenv("PATH", bin)
+			for cmd, script := range tc.bin {
+				err := os.WriteFile(
+					filepath.Join(bin, cmd),
+					[]byte("#!/bin/sh\n"+script),
+					0700,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Our linux based tools require display to be set
+			if tc.display {
+				t.Setenv("DISPLAY", ":test")
+			}
+
+			picker, ok := filepicker.Lookup(logtest.Scoped(t))
+			if ok != !tc.nopicker {
+				t.Fatal("unexpected response from Lookup")
+			}
+			if tc.nopicker {
+				return
+			}
+
+			got, err := picker(context.Background())
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("unexpected error from picker: %v", err)
+			}
+
+			if got != tc.want {
+				t.Fatalf("unexpected path from picker.\nwant: %q\ngot:  %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This package implements a best-effort approach to running a file dialog selector. Instead of linking in a GUI framework into Sourcegraph App, we rely on shelling out to common utilities used by shell scripts to run a dialog.

For Mac we can use osascript which is always available. For Linux (and unofficially BSD/etc) we can rely on what the display manager provides (zenity for gnome/gtk environments, kdialog for KDE).

For now this commit only integrates it into the test program app-discover-repos for testing. We intend to integrate this into the Sourcegraph App though via an API.

Test Plan: app-discover-repos -picker on linux with and without zenity and kdialog. The same on darwin, which always worked. Also manually changed app-discover-repos to pass in a short context timeout, an error was returned as expected.

Based on that manual testing I created unit tests which simulate what the programs do.

Part of https://github.com/sourcegraph/sourcegraph/issues/48127