### PR TITLE
nogo: use go vet

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo", "TOOLS_NGO")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -206,7 +206,8 @@ nogo(
     name = "sg_nogo",
     config = ":nogo_config.json",
     visibility = ["//visibility:public"],  # must have public visibility
-    deps = TOOLS_NGO + [
+    vet = True,
+    deps = [
         "//dev/linters/bodyclose",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo", "TOOLS_NGO")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -206,15 +206,8 @@ nogo(
     name = "sg_nogo",
     config = ":nogo_config.json",
     visibility = ["//visibility:public"],  # must have public visibility
-    deps = [
+    deps = TOOLS_NGO + [
         "//dev/linters/bodyclose",
-        "@org_golang_x_tools//go/analysis/passes/asmdecl:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/assign:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/atomic:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/atomicalign:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/bools:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/buildssa:go_default_library",
-        "@org_golang_x_tools//go/analysis/passes/buildtag:go_default_library",
     ],
 )
 

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -1,11 +1,19 @@
 {
+  "_base": {
+    "description": "Base config which all analyzers will inherit, even unspecified",
+    "exclude_files": {
+      "external/*": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code",
+      ".*_pb\\.go$": "ignore protobuff generated code"
+    }
+  },
   "bodyclose": {
     "exclude_files": {
-      "external/": "no need to vet third party code",
+      "external/*": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
+      ".*_test\\.go": "exclude bodyclose lint from tests because leaking connections in tests is a non issue",
       "internal/extsvc/": "ignore temporarily",
-      ".*_test\\.go": "Exclude bodyclose lint from tests because leaking connections in tests is a non issue",
       "cmd/frontend/internal/gosrc/import_path.go": "temp ignore till we support nolint: comment"
     }
   }


### PR DESCRIPTION
Run go vet analyzers in nogo instead of specifying the manually.

## Test plan
`bazel build //...` succeeds without any nogo failures

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
