### PR TITLE
Fix typeof check for esbuild

### DIFF
--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -268,7 +268,10 @@ export const SettingsProvider: React.FC<React.PropsWithChildren<SettingsProvider
  */
 export const useSettingsCascade = (): SettingsCascadeOrError => {
     const { settingsCascade } = useContext(SettingsContext)
-    if (settingsCascade === EMPTY_SETTINGS_CASCADE && process.env.JEST_WORKER_ID === undefined) {
+    if (
+        settingsCascade === EMPTY_SETTINGS_CASCADE &&
+        (typeof globalThis.process === 'undefined' || process.env.JEST_WORKER_ID === undefined)
+    ) {
         logger.error(
             'useSettingsCascade must be used within a SettingsProvider, falling back to an empty settings object'
         )


### PR DESCRIPTION
When using the esbuild target, it was possible to get this condition to throw because `process` is not injected. 

A fix to prevent the error message is here: https://github.com/sourcegraph/sourcegraph/pull/48449/files#diff-80f6b2cd75c6f99e4ffad5de4ddff16a51f0d8d49b30911aa27018ba66d89668

## Test plan

- You can see the sign-in page again

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-typeof-check.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
