### PR TITLE
site-admin: Always order code host sync errors in status messages

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -70,7 +70,7 @@ type ExternalServiceStore interface {
 	// each external service. If the latest sync did not have an error, the
 	// string will be empty. We exclude cloud_default external services as they
 	// are never synced.
-	GetLatestSyncErrors(ctx context.Context) ([]SyncError, error)
+	GetLatestSyncErrors(ctx context.Context) ([]*SyncError, error)
 
 	// GetByID returns the external service for id.
 	//
@@ -1327,7 +1327,18 @@ type SyncError struct {
 	Message   string
 }
 
-func (e *externalServiceStore) GetLatestSyncErrors(ctx context.Context) ([]SyncError, error) {
+var scanSyncErrors = basestore.NewSliceScanner(scanExternalServiceSyncErrorRow)
+
+func scanExternalServiceSyncErrorRow(scanner dbutil.Scanner) (*SyncError, error) {
+	var s SyncError
+	err := scanner.Scan(
+		&s.ServiceID,
+		&dbutil.NullString{S: &s.Message},
+	)
+	return &s, err
+}
+
+func (e *externalServiceStore) GetLatestSyncErrors(ctx context.Context) ([]*SyncError, error) {
 	q := sqlf.Sprintf(`
 SELECT DISTINCT ON (es.id) es.id, essj.failure_message
 FROM external_services es
@@ -1344,25 +1355,7 @@ ORDER BY es.id, essj.finished_at DESC
 		return nil, err
 	}
 
-	messages := []SyncError{}
-
-	for rows.Next() {
-		var svcID int64
-		var message sql.NullString
-		if err := rows.Scan(&svcID, &message); err != nil {
-			return nil, err
-		}
-		messages = append(messages, SyncError{
-			ServiceID: svcID,
-			Message:   message.String,
-		})
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return messages, nil
+	return scanSyncErrors(rows, err)
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1350,12 +1350,7 @@ WHERE es.deleted_at IS NULL AND NOT es.cloud_default
 ORDER BY es.id, essj.finished_at DESC
 `)
 
-	rows, err := e.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	return scanSyncErrors(rows, err)
+	return scanSyncErrors(e.Query(ctx, q))
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1251,14 +1251,8 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	want := []SyncError{
-		{
-			ServiceID: extSvc1.ID,
-			Message:   "",
-		},
-		{
-			ServiceID: extSvc2.ID,
-			Message:   "",
-		},
+		{ServiceID: extSvc1.ID, Message: ""},
+		{ServiceID: extSvc2.ID, Message: ""},
 	}
 
 	if diff := cmp.Diff(want, results); diff != "" {
@@ -1278,14 +1272,8 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	want = []SyncError{
-		{
-			ServiceID: extSvc1.ID,
-			Message:   failure2,
-		},
-		{
-			ServiceID: extSvc2.ID,
-			Message:   "",
-		},
+		{ServiceID: extSvc1.ID, Message: failure2},
+		{ServiceID: extSvc2.ID, Message: ""},
 	}
 	if diff := cmp.Diff(want, results); diff != "" {
 		t.Fatalf("wrong sync errors (-want +got):\n%s", diff)
@@ -1300,14 +1288,8 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	want = []SyncError{
-		{
-			ServiceID: extSvc1.ID,
-			Message:   failure2,
-		},
-		{
-			ServiceID: extSvc2.ID,
-			Message:   "oops over here",
-		},
+		{ServiceID: extSvc1.ID, Message: failure2},
+		{ServiceID: extSvc2.ID, Message: "oops over here"},
 	}
 	if diff := cmp.Diff(want, results); diff != "" {
 		t.Fatalf("wrong sync errors (-want +got):\n%s", diff)

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1250,9 +1250,15 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want := map[int64]string{
-		extSvc1.ID: "",
-		extSvc2.ID: "",
+	want := []SyncError{
+		{
+			ServiceID: extSvc1.ID,
+			Message:   "",
+		},
+		{
+			ServiceID: extSvc2.ID,
+			Message:   "",
+		},
 	}
 
 	if diff := cmp.Diff(want, results); diff != "" {
@@ -1271,7 +1277,16 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want = map[int64]string{extSvc1.ID: failure2, extSvc2.ID: ""}
+	want = []SyncError{
+		{
+			ServiceID: extSvc1.ID,
+			Message:   failure2,
+		},
+		{
+			ServiceID: extSvc2.ID,
+			Message:   "",
+		},
+	}
 	if diff := cmp.Diff(want, results); diff != "" {
 		t.Fatalf("wrong sync errors (-want +got):\n%s", diff)
 	}
@@ -1284,7 +1299,16 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want = map[int64]string{extSvc1.ID: failure2, extSvc2.ID: "oops over here"}
+	want = []SyncError{
+		{
+			ServiceID: extSvc1.ID,
+			Message:   failure2,
+		},
+		{
+			ServiceID: extSvc2.ID,
+			Message:   "oops over here",
+		},
+	}
 	if diff := cmp.Diff(want, results); diff != "" {
 		t.Fatalf("wrong sync errors (-want +got):\n%s", diff)
 	}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1250,7 +1250,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want := []SyncError{
+	want := []*SyncError{
 		{ServiceID: extSvc1.ID, Message: ""},
 		{ServiceID: extSvc2.ID, Message: ""},
 	}
@@ -1271,7 +1271,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want = []SyncError{
+	want = []*SyncError{
 		{ServiceID: extSvc1.ID, Message: failure2},
 		{ServiceID: extSvc2.ID, Message: ""},
 	}
@@ -1287,7 +1287,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	want = []SyncError{
+	want = []*SyncError{
 		{ServiceID: extSvc1.ID, Message: failure2},
 		{ServiceID: extSvc2.ID, Message: "oops over here"},
 	}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -19128,7 +19128,7 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
-			defaultHook: func(context.Context) (r0 map[int64]string, r1 error) {
+			defaultHook: func(context.Context) (r0 []SyncError, r1 error) {
 				return
 			},
 		},
@@ -19251,7 +19251,7 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
-			defaultHook: func(context.Context) (map[int64]string, error) {
+			defaultHook: func(context.Context) ([]SyncError, error) {
 				panic("unexpected invocation of MockExternalServiceStore.GetLatestSyncErrors")
 			},
 		},
@@ -20374,15 +20374,15 @@ func (c ExternalServiceStoreGetLastSyncErrorFuncCall) Results() []interface{} {
 // the GetLatestSyncErrors method of the parent MockExternalServiceStore
 // instance is invoked.
 type ExternalServiceStoreGetLatestSyncErrorsFunc struct {
-	defaultHook func(context.Context) (map[int64]string, error)
-	hooks       []func(context.Context) (map[int64]string, error)
+	defaultHook func(context.Context) ([]SyncError, error)
+	hooks       []func(context.Context) ([]SyncError, error)
 	history     []ExternalServiceStoreGetLatestSyncErrorsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetLatestSyncErrors delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) (map[int64]string, error) {
+func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) ([]SyncError, error) {
 	r0, r1 := m.GetLatestSyncErrorsFunc.nextHook()(v0)
 	m.GetLatestSyncErrorsFunc.appendCall(ExternalServiceStoreGetLatestSyncErrorsFuncCall{v0, r0, r1})
 	return r0, r1
@@ -20391,7 +20391,7 @@ func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) (map[
 // SetDefaultHook sets function that is called when the GetLatestSyncErrors
 // method of the parent MockExternalServiceStore instance is invoked and the
 // hook queue is empty.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(context.Context) (map[int64]string, error)) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(context.Context) ([]SyncError, error)) {
 	f.defaultHook = hook
 }
 
@@ -20400,7 +20400,7 @@ func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(c
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context.Context) (map[int64]string, error)) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context.Context) ([]SyncError, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -20408,20 +20408,20 @@ func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultReturn(r0 map[int64]string, r1 error) {
-	f.SetDefaultHook(func(context.Context) (map[int64]string, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultReturn(r0 []SyncError, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]SyncError, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushReturn(r0 map[int64]string, r1 error) {
-	f.PushHook(func(context.Context) (map[int64]string, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushReturn(r0 []SyncError, r1 error) {
+	f.PushHook(func(context.Context) ([]SyncError, error) {
 		return r0, r1
 	})
 }
 
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) nextHook() func(context.Context) (map[int64]string, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) nextHook() func(context.Context) ([]SyncError, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -20461,7 +20461,7 @@ type ExternalServiceStoreGetLatestSyncErrorsFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[int64]string
+	Result0 []SyncError
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -19128,7 +19128,7 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
-			defaultHook: func(context.Context) (r0 []SyncError, r1 error) {
+			defaultHook: func(context.Context) (r0 []*SyncError, r1 error) {
 				return
 			},
 		},
@@ -19251,7 +19251,7 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		GetLatestSyncErrorsFunc: &ExternalServiceStoreGetLatestSyncErrorsFunc{
-			defaultHook: func(context.Context) ([]SyncError, error) {
+			defaultHook: func(context.Context) ([]*SyncError, error) {
 				panic("unexpected invocation of MockExternalServiceStore.GetLatestSyncErrors")
 			},
 		},
@@ -20374,15 +20374,15 @@ func (c ExternalServiceStoreGetLastSyncErrorFuncCall) Results() []interface{} {
 // the GetLatestSyncErrors method of the parent MockExternalServiceStore
 // instance is invoked.
 type ExternalServiceStoreGetLatestSyncErrorsFunc struct {
-	defaultHook func(context.Context) ([]SyncError, error)
-	hooks       []func(context.Context) ([]SyncError, error)
+	defaultHook func(context.Context) ([]*SyncError, error)
+	hooks       []func(context.Context) ([]*SyncError, error)
 	history     []ExternalServiceStoreGetLatestSyncErrorsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetLatestSyncErrors delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) ([]SyncError, error) {
+func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) ([]*SyncError, error) {
 	r0, r1 := m.GetLatestSyncErrorsFunc.nextHook()(v0)
 	m.GetLatestSyncErrorsFunc.appendCall(ExternalServiceStoreGetLatestSyncErrorsFuncCall{v0, r0, r1})
 	return r0, r1
@@ -20391,7 +20391,7 @@ func (m *MockExternalServiceStore) GetLatestSyncErrors(v0 context.Context) ([]Sy
 // SetDefaultHook sets function that is called when the GetLatestSyncErrors
 // method of the parent MockExternalServiceStore instance is invoked and the
 // hook queue is empty.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(context.Context) ([]SyncError, error)) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(context.Context) ([]*SyncError, error)) {
 	f.defaultHook = hook
 }
 
@@ -20400,7 +20400,7 @@ func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultHook(hook func(c
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context.Context) ([]SyncError, error)) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context.Context) ([]*SyncError, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -20408,20 +20408,20 @@ func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultReturn(r0 []SyncError, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]SyncError, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) SetDefaultReturn(r0 []*SyncError, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]*SyncError, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushReturn(r0 []SyncError, r1 error) {
-	f.PushHook(func(context.Context) ([]SyncError, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) PushReturn(r0 []*SyncError, r1 error) {
+	f.PushHook(func(context.Context) ([]*SyncError, error) {
 		return r0, r1
 	})
 }
 
-func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) nextHook() func(context.Context) ([]SyncError, error) {
+func (f *ExternalServiceStoreGetLatestSyncErrorsFunc) nextHook() func(context.Context) ([]*SyncError, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -20461,7 +20461,7 @@ type ExternalServiceStoreGetLatestSyncErrorsFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []SyncError
+	Result0 []*SyncError
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -39,12 +39,12 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 		return messages, nil
 	}
 
-	for id, failure := range externalServiceSyncErrors {
-		if failure != "" {
+	for _, syncError := range externalServiceSyncErrors {
+		if syncError.Message != "" {
 			messages = append(messages, StatusMessage{
 				ExternalServiceSyncError: &ExternalServiceSyncError{
-					Message:           failure,
-					ExternalServiceId: id,
+					Message:           syncError.Message,
+					ExternalServiceId: syncError.ServiceID,
 				},
 			})
 		}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -313,11 +313,8 @@ func TestStatusMessages(t *testing.T) {
 				if err != nil {
 					externalServices := database.NewMockExternalServiceStore()
 					externalServices.GetLatestSyncErrorsFunc.SetDefaultReturn(
-						[]database.SyncError{
-							{
-								ServiceID: extSvc.ID,
-								Message:   err.Error(),
-							},
+						[]*database.SyncError{
+							{ServiceID: extSvc.ID, Message: err.Error()},
 						},
 						nil,
 					)

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -313,8 +313,11 @@ func TestStatusMessages(t *testing.T) {
 				if err != nil {
 					externalServices := database.NewMockExternalServiceStore()
 					externalServices.GetLatestSyncErrorsFunc.SetDefaultReturn(
-						map[int64]string{
-							extSvc.ID: err.Error(),
+						[]database.SyncError{
+							{
+								ServiceID: extSvc.ID,
+								Message:   err.Error(),
+							},
 						},
 						nil,
 					)


### PR DESCRIPTION
**Buggy behaviour:**

_Ordering of sync errors will change on subsequent API requests_
https://user-images.githubusercontent.com/2682729/223110004-e7baef93-930e-4e9c-8aa0-a47c4f925163.mp4


**Updated behaviour**
_Ordering of sync errors remains constant on subsequent API requests_
https://user-images.githubusercontent.com/2682729/223108826-5bd696e6-c102-4126-8a7a-f73f1f0d8381.mp4





## Test plan
- Tested locally
- Updated tests
- Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
