### PR TITLE
jscontext: add localFilePickerAvailable

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/singleprogram/filepicker"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -188,6 +189,8 @@ type JSContext struct {
 	ExtsvcConfigAllowEdits bool `json:"extsvcConfigAllowEdits"`
 
 	RunningOnMacOS bool `json:"runningOnMacOS"`
+
+	LocalFilePickerAvailable bool `json:"localFilePickerAvailable"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -355,6 +358,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		ExtsvcConfigAllowEdits: envvar.ExtsvcConfigAllowEdits(),
 
 		RunningOnMacOS: runningOnMacOS,
+
+		LocalFilePickerAvailable: deploy.IsDeployTypeSingleProgram(deploy.Type()) && filepicker.Available(),
 	}
 }
 


### PR DESCRIPTION
This is true if we have access to a local file picker in the Sourcegraph App.

Test Plan: inspect the jscontext from sg start app twice on Linux. Once where zenity is on my PATH (so returns true) and once without.

Based on https://github.com/sourcegraph/sourcegraph/pull/48712
Part of https://github.com/sourcegraph/sourcegraph/issues/48127
