### PR TITLE
[feat] Add OOB migration for unified permissions model in user_repo_permissions

### DIFF
--- a/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator.go
@@ -1,0 +1,146 @@
+package iam
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+type unifiedPermissionsMigrator struct {
+	store           *basestore.Store
+	batchSize       int
+	intervalSeconds int // time interval in seconds between iterations
+}
+
+var _ oobmigration.Migrator = &unifiedPermissionsMigrator{}
+
+// shamelessly copied from scip_migrator.go
+func getEnv(name string, defaultValue int) int {
+	if value, _ := strconv.Atoi(os.Getenv(name)); value != 0 {
+		return value
+	}
+
+	return defaultValue
+}
+
+func NewUnifiedPermissionsMigrator(store *basestore.Store, batchSize, intervalSeconds int) *unifiedPermissionsMigrator {
+	computedBatchSize := getEnv("UNIFIED_PERMISSIONS_MIGRATOR_BATCH_SIZE", batchSize)
+	computedInterval := getEnv("UNIFIED_PERMISSIONS_MIGRATOR_INTERVAL_SECONDS", intervalSeconds)
+
+	return &unifiedPermissionsMigrator{
+		store:           store,
+		batchSize:       computedBatchSize,
+		intervalSeconds: computedInterval,
+	}
+}
+
+func (m *unifiedPermissionsMigrator) ID() int { return 22 }
+func (m *unifiedPermissionsMigrator) Interval() time.Duration {
+	return time.Duration(m.intervalSeconds) * time.Second
+}
+
+func (m *unifiedPermissionsMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(unifiedPermissionsMigratorProgressQuery)))
+	return progress, err
+}
+
+const unifiedPermissionsMigratorProgressQuery = `
+SELECT
+	CASE c2.count WHEN 0 THEN 1 ELSE
+		cast(c1.count as float) / cast(c2.count as float)
+	END
+FROM
+	(SELECT count(*) as count FROM user_permissions WHERE migrated) c1,
+	(SELECT count(*) as count FROM user_permissions) c2
+`
+
+func (m *unifiedPermissionsMigrator) Up(ctx context.Context) (err error) {
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// get the next batch of userIDs to migrate
+	userIds, err := basestore.ScanInt32s(tx.Query(ctx, sqlf.Sprintf(unifiedPermissionsNonMigratedUsersQuery, m.batchSize)))
+	if err != nil {
+		return err
+	}
+
+	// write data to user_repo_permissions table
+	err = tx.Exec(ctx, sqlf.Sprintf(unifiedPermissionsMigratorQuery, pq.Array(userIds)))
+	if err != nil {
+		return err
+	}
+
+	// mark the userIDs as migrated
+	updates := make([]*sqlf.Query, 0, len(userIds))
+	for _, userID := range userIds {
+		updates = append(updates, sqlf.Sprintf("(%s::integer)", userID))
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(unifiedPermissionsMigratorMarkAsMigratedQuery, sqlf.Join(updates, ", "))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The migration is based on user_permissions table, because current customer instances
+// usually have only a few thousand users and potentially tens of thousands of repositories.
+// So it should be more efficient to cycle through users instead of repositories.
+
+// Query to get the userIds to migrate
+const unifiedPermissionsNonMigratedUsersQuery = `
+SELECT u.user_id
+	FROM user_permissions as u
+	WHERE NOT migrated
+	LIMIT %s
+	FOR UPDATE SKIP LOCKED
+`
+
+// Migration of data to new unified table
+const unifiedPermissionsMigratorQuery = `
+-- First get a row for each pair of user_id, repo_id by unnesting object_ids_ints array
+WITH s AS (
+	SELECT u.user_id, unnest(u.object_ids_ints) as repo_id, u.updated_at as created_at, u.updated_at, 'user_sync' as source
+	FROM user_permissions as u
+	WHERE u.user_id = ANY(%s)
+)
+-- Insert the data here
+INSERT INTO user_repo_permissions(user_id, user_external_account_id, repo_id, created_at, updated_at, source)
+SELECT s.user_id, ua.id as user_external_account_id, s.repo_id, s.created_at, s.updated_at, s.source
+FROM
+  s
+-- Need to join with repo table to not transfer permissions for deleted repos
+INNER JOIN repo AS r ON
+  r.deleted_at IS NULL AND r.id = s.repo_id
+-- Need to join with the user_external_accounst table to get the user_external_account_id
+INNER JOIN user_external_accounts AS ua ON
+  ua.user_id = s.user_id AND ua.deleted_at IS NULL
+  AND ua.service_type = r.external_service_type
+  AND ua.service_id = r.external_service_id
+-- It might be that some of the rows are already there because of repo-centric permission sync
+-- In that case do nothing
+ON CONFLICT (user_id, user_external_account_id, repo_id) DO NOTHING
+RETURNING user_repo_permissions.id
+`
+
+// Mark the userIDs as migrated
+const unifiedPermissionsMigratorMarkAsMigratedQuery = `
+UPDATE user_permissions
+SET migrated = TRUE
+FROM (VALUES %s) AS updates(user_id)
+WHERE user_permissions.user_id = updates.user_id
+`
+
+func (m *unifiedPermissionsMigrator) Down(_ context.Context) error {
+	// non-destructive
+	return nil
+}

--- a/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator_test.go
@@ -1,0 +1,226 @@
+package iam
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func addUser(t *testing.T, ctx context.Context, store *basestore.Store, userName string) *extsvc.Account {
+	t.Helper()
+
+	userID, _, err := basestore.ScanFirstInt(store.Query(ctx, sqlf.Sprintf(`INSERT INTO users(username, display_name, created_at) VALUES (%s, %s, NOW()) RETURNING id`, userName, userName)))
+	require.NoError(t, err)
+
+	externalAccountID, _, err := basestore.ScanFirstInt(store.Query(ctx, sqlf.Sprintf(`
+		INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at)
+		VALUES(%s, %s, %s, %s, %s, NOW(), NOW()) RETURNING id`,
+		userID,
+		"test-service-type",
+		"test-service-id",
+		"test-"+userName,
+		"test-client-id-"+userName,
+	)))
+	require.NoError(t, err)
+
+	return &extsvc.Account{
+		UserID: int32(userID),
+		ID:     int32(externalAccountID),
+		AccountSpec: extsvc.AccountSpec{
+			ServiceType: "test-service-type",
+			ServiceID:   "test-service-id",
+			AccountID:   "test-" + userName,
+			ClientID:    "test-client-id-" + userName,
+		},
+	}
+}
+
+func addRepos(t *testing.T, ctx context.Context, store *basestore.Store, accessibleBy []*extsvc.Account, count int) {
+	t.Helper()
+
+	currentCount, _, err := basestore.ScanFirstInt(store.Query(ctx, sqlf.Sprintf(`SELECT COUNT(*) FROM repo`)))
+	require.NoError(t, err)
+
+	values := make([]*sqlf.Query, 0, count)
+	for i := currentCount; i < count+currentCount; i++ {
+		values = append(values, sqlf.Sprintf("(%s, 'test-service-type', 'test-service-id')", "test-repo-"+strconv.Itoa(i)))
+	}
+	repoIDs, err := basestore.ScanInt32s(store.Query(ctx, sqlf.Sprintf(`
+	INSERT INTO repo(name, external_service_type, external_service_id)
+	VALUES %s
+	RETURNING id`, sqlf.Join(values, ","))))
+	require.NoError(t, err)
+
+	userPerms := make([]*sqlf.Query, 0, len(accessibleBy))
+	for _, account := range accessibleBy {
+		userPerms = append(userPerms, sqlf.Sprintf("(%s::integer, 'read', 'repos', NOW(), NOW(), %s, FALSE)", account.UserID, pq.Array(repoIDs)))
+	}
+
+	if len(userPerms) == 0 {
+		return
+	}
+
+	err = store.Exec(ctx, sqlf.Sprintf(`
+	INSERT INTO user_permissions AS p (user_id, permission, object_type, updated_at, synced_at, object_ids_ints, migrated)
+	VALUES %s
+	ON CONFLICT ON CONSTRAINT
+  		user_permissions_perm_object_unique
+	DO UPDATE SET
+		object_ids_ints = p.object_ids_ints || excluded.object_ids_ints`,
+		sqlf.Join(userPerms, ",")))
+	require.NoError(t, err)
+}
+
+var scanPermissions = basestore.NewSliceScanner(func(s dbutil.Scanner) (*authz.Permission, error) {
+	var p authz.Permission
+	if err := s.Scan(&p.UserID, &p.ExternalAccountID, &p.RepoID, &p.Source); err != nil {
+		return nil, err
+	}
+	return &p, nil
+})
+
+func cleanUpTables(ctx context.Context, store *basestore.Store) error {
+	return store.Exec(ctx, sqlf.Sprintf(`
+		DELETE FROM user_permissions;
+		DELETE FROM user_repo_permissions;
+		DELETE FROM user_external_accounts;
+		DELETE FROM users;
+		DELETE FROM repo;
+	`))
+}
+
+func TestUnifiedPermissionsMigrator(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := basestore.NewWithHandle(db.Handle())
+
+	t.Run("Migrator uses params provided", func(t *testing.T) {
+		migrator := NewUnifiedPermissionsMigrator(store, 100, 30)
+		assert.Equal(t, 100, migrator.batchSize)
+		assert.Equal(t, 30, int(migrator.Interval().Seconds()))
+	})
+
+	t.Run("Env overrides hardcoded parameters", func(t *testing.T) {
+		os.Setenv("UNIFIED_PERMISSIONS_MIGRATOR_BATCH_SIZE", "20")
+		os.Setenv("UNIFIED_PERMISSIONS_MIGRATOR_INTERVAL_SECONDS", "120")
+
+		defer func() {
+			os.Unsetenv("UNIFIED_PERMISSIONS_MIGRATOR_BATCH_SIZE")
+			os.Unsetenv("UNIFIED_PERMISSIONS_MIGRATOR_INTERVAL_SECONDS")
+		}()
+
+		migrator := NewUnifiedPermissionsMigrator(store, 100, 30)
+		assert.Equal(t, 20, migrator.batchSize)
+		assert.Equal(t, 120, int(migrator.Interval().Seconds()))
+	})
+
+	t.Run("Works in batches and progress is updated", func(t *testing.T) {
+		t.Cleanup(func() {
+			require.NoError(t, cleanUpTables(ctx, store))
+		})
+
+		// setup 100 users with 3 repos each
+		for i := 0; i < 100; i++ {
+			account := addUser(t, ctx, store, "user-"+strconv.Itoa(i))
+			addRepos(t, ctx, store, []*extsvc.Account{account}, 3)
+		}
+
+		// Ensure there is no progress before migration
+		migrator := NewUnifiedPermissionsMigrator(store, 10, 10)
+
+		progress, err := migrator.Progress(ctx, false)
+		require.NoError(t, err)
+		require.Equal(t, float64(0), progress)
+
+		for i := 0; i < 10; i++ {
+			err = migrator.Up(ctx)
+			require.NoError(t, err)
+
+			progress, err = migrator.Progress(ctx, false)
+			require.NoError(t, err)
+			require.Equal(t, float64(i+1)/10, progress)
+		}
+
+		require.Equal(t, float64(1), progress)
+	})
+
+	t.Run("Migrates data correctly", func(t *testing.T) {
+		t.Cleanup(func() {
+			require.NoError(t, cleanUpTables(ctx, store))
+		})
+
+		// Set up test data
+		alice, bob := addUser(t, ctx, store, "alice"), addUser(t, ctx, store, "bob")
+		addRepos(t, ctx, store, []*extsvc.Account{alice, bob}, 2)
+		addRepos(t, ctx, store, []*extsvc.Account{alice}, 3)
+		addRepos(t, ctx, store, []*extsvc.Account{bob}, 1)
+		addRepos(t, ctx, store, []*extsvc.Account{}, 1)
+
+		// Ensure there is no progress before migration
+		migrator := NewUnifiedPermissionsMigrator(store, 100, 10)
+
+		progress, err := migrator.Progress(ctx, false)
+		require.NoError(t, err)
+		require.Equal(t, 0.0, progress)
+
+		// Perform the migration and recheck the progress
+		err = migrator.Up(ctx)
+		require.NoError(t, err)
+
+		progress, err = migrator.Progress(ctx, false)
+		require.NoError(t, err)
+		require.Equal(t, 1.0, progress)
+
+		// Ensure rows were marked as migrated
+		userIDs, err := basestore.ScanInt32s(store.Query(ctx, sqlf.Sprintf(`SELECT user_id FROM user_permissions WHERE NOT migrated`)))
+		require.NoError(t, err)
+		require.Empty(t, userIDs)
+
+		// Ensure the permissions were migrated correctly
+		permissions, err := scanPermissions(store.Query(ctx, sqlf.Sprintf(`SELECT user_id, user_external_account_id, repo_id, source FROM user_repo_permissions`)))
+		require.NoError(t, err)
+		require.NotEmpty(t, permissions)
+		assert.Equal(t, 8, len(permissions), "unexpected number of permissions")
+
+		alicePerms := make([]*authz.Permission, 0, 5)
+		bobPerms := make([]*authz.Permission, 0, 3)
+		aliceRepos := make(map[int32]struct{})
+		for _, p := range permissions {
+			if p.UserID == alice.UserID {
+				alicePerms = append(alicePerms, p)
+				assert.Equal(t, alice.ID, p.ExternalAccountID, "unexpected external account id for alice")
+				aliceRepos[p.RepoID] = struct{}{}
+			} else if p.UserID == bob.UserID {
+				bobPerms = append(bobPerms, p)
+				assert.Equal(t, bob.ID, p.ExternalAccountID, "unexpected external account id for bob")
+			}
+		}
+
+		assert.Equal(t, 5, len(alicePerms), "unexpected number of permissions for alice")
+		assert.Equal(t, 3, len(bobPerms), "unexpected number of permissions for bob")
+
+		commonCount := 0
+		for _, p := range bobPerms {
+			if _, ok := aliceRepos[p.RepoID]; ok {
+				commonCount++
+			}
+		}
+
+		assert.Equal(t, 2, commonCount, "unexpected number of common permissions between alice and bob")
+	})
+}

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -93,7 +93,7 @@ func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps
 	migrators := []migrations.TaggedMigrator{
 		iam.NewSubscriptionAccountNumberMigrator(deps.store, 500),
 		iam.NewLicenseKeyFieldsMigrator(deps.store, 500),
-		iam.NewUnifiedPermissionsMigrator(deps.store, 100, 60),
+		iam.NewUnifiedPermissionsMigrator(deps.store),
 		batches.NewSSHMigratorWithDB(deps.store, deps.keyring.BatchChangesCredentialKey, 5),
 		batches.NewExternalForkNameMigrator(deps.store, 500),
 		codeintel.NewDiagnosticsCountMigrator(deps.codeIntelStore, 1000, 0),

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -93,6 +93,7 @@ func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps
 	migrators := []migrations.TaggedMigrator{
 		iam.NewSubscriptionAccountNumberMigrator(deps.store, 500),
 		iam.NewLicenseKeyFieldsMigrator(deps.store, 500),
+		iam.NewUnifiedPermissionsMigrator(deps.store, 100, 60),
 		batches.NewSSHMigratorWithDB(deps.store, deps.keyring.BatchChangesCredentialKey, 5),
 		batches.NewExternalForkNameMigrator(deps.store, 500),
 		codeintel.NewDiagnosticsCountMigrator(deps.codeIntelStore, 1000, 0),

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -142,5 +142,5 @@
   description: Migrate data from user_permissions table to unified user_repo_permissions.
   non_destructive: true
   is_enterprise: true
-  introduced_version_major: 4
-  introduced_version_minor: 5
+  introduced_version_major: 5
+  introduced_version_minor: 0

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -136,3 +136,11 @@
   is_enterprise: true
   introduced_version_major: 4
   introduced_version_minor: 5
+- id: 22
+  team: iam
+  component: frontend-db.user_repo_permissions
+  description: Migrate data from user_permissions table to unified user_repo_permissions.
+  non_destructive: true
+  is_enterprise: true
+  introduced_version_major: 4
+  introduced_version_minor: 5


### PR DESCRIPTION
## Description

The migration will migrate data in batches from `user_permissions` table into the new & shiny unified `user_repo_permissions` table. The new model uses row-per-permission instead of array based storage.

## Test plan

Unit tests added + heavily tested locally.
