### PR TITLE
experimental search input: Fix repo and file value completions

### DIFF
--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -167,11 +167,6 @@ interface CodeSymbol {
  */
 function toRepoSuggestion(result: FzfResultItem<Repo>, from: number, to?: number): Option {
     const option = toRepoCompletion(result, from, to, 'repo:')
-    option.action.name = 'Add'
-    option.alternativeAction = {
-        type: 'goto',
-        url: `/${result.item.name}`,
-    }
     option.render = filterValueRenderer
     return option
 }
@@ -194,6 +189,10 @@ function toRepoCompletion(
             insertValue: valuePrefix + regexInsertText(item.name, { globbing: false }) + ' ',
             from,
             to,
+        },
+        alternativeAction: {
+            type: 'goto',
+            url: `/${item.name}`,
         },
     }
 }
@@ -266,6 +265,10 @@ function toFileCompletion(
             from,
             to,
         },
+        alternativeAction: {
+            type: 'goto',
+            url: item.url,
+        },
     }
 }
 
@@ -274,11 +277,6 @@ function toFileCompletion(
  */
 function toFileSuggestion(result: FzfResultItem<File>, from: number, to?: number): Option {
     const option = toFileCompletion(result, from, to, 'file:')
-    option.action.name = 'Add'
-    option.alternativeAction = {
-        type: 'goto',
-        url: result.item.url,
-    }
     option.render = filterValueRenderer
     return option
 }
@@ -407,7 +405,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                                             ? ALL_FILTER_VALUE_LIST_SIZE
                                             : MULTIPLE_FILTER_VALUE_LIST_SIZE
                                     )
-                                    .map(item => toRepoSuggestion(item, from, to)),
+                                    .map(item => toRepoCompletion(item, from, to)),
                             },
                         ]
 
@@ -434,7 +432,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                             {
                                 title: 'Files',
                                 options: entries
-                                    .map(item => toFileSuggestion(item, from, to))
+                                    .map(item => toFileCompletion(item, from, to))
                                     .slice(
                                         0,
                                         predicates.length === 0


### PR DESCRIPTION
This was introduced in #48491. The suggestions explicitly insert `repo:`/`file:` to the value and I didn't test the change properly.

This commit updates the completion functions to include the goto action and switch back to using that.


## Test plan

- Type into query input, select repo suggestion -> suggestion gets inserted with `repo:` prefix
- Type into query input, select file suggestion -> suggestion gets inserted with `file:` prefix
- Type `repo:` into input -> suggestions include "go to" action
  - Applying a suggestion with "Enter" inserts the repo name only 
  - Applying a suggestion with "Shift-Enter" goes to repo
- Type `file:` into input -> suggestions include "go to" action
  - Applying a suggestion with "Enter" inserts the file name only 
  - Applying a suggestion with "Shift-Enter" goes to file

## App preview:

- [Web](https://sg-web-fkling-search-input-double-filter.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
