### PR TITLE
permissions-center: add sidebar item and feature flag check for permissions sync table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Greatly improves keyboard handling and accessibility of the files and symbol tree on the repository pages. [#12916](https://github.com/sourcegraph/sourcegraph/issues/12916)
 - The file tree on the repository page now automatically expands into single-child directories. [#47117](https://github.com/sourcegraph/sourcegraph/pull/47117)
 - When encountering GitHub rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423)
+- Added a dashboard with information about user and repository permissions sync jobs. [#46317](https://github.com/sourcegraph/sourcegraph/issues/46317)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Greatly improves keyboard handling and accessibility of the files and symbol tree on the repository pages. [#12916](https://github.com/sourcegraph/sourcegraph/issues/12916)
 - The file tree on the repository page now automatically expands into single-child directories. [#47117](https://github.com/sourcegraph/sourcegraph/pull/47117)
 - When encountering GitHub rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423)
-- Added a dashboard with information about user and repository permissions sync jobs. [#46317](https://github.com/sourcegraph/sourcegraph/issues/46317)
+- Added a dashboard with information about user and repository background permissions sync jobs. [#46317](https://github.com/sourcegraph/sourcegraph/issues/46317)
 
 ### Changed
 

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -158,6 +158,10 @@ const usersGroup: SiteAdminSideBarGroup = {
             label: 'Roles',
             to: '/site-admin/roles',
         },
+        {
+            label: 'Permissions',
+            to: '/site-admin/permissions-syncs',
+        },
     ],
 }
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -21,6 +21,7 @@ export type FeatureFlagName =
     | 'search-ownership'
     | 'cody'
     | 'search-ranking'
+    | 'database-permission-sync-worker'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
@@ -39,9 +39,9 @@ export const PermissionsSyncJobsPage: React.FunctionComponent<React.PropsWithChi
         <PermissionsSyncJobsTable telemetryService={telemetryService} />
     ) : (
         <>
-            <PageTitle title="Permissions Sync Dashboard - Admin" />
+            <PageTitle title="Permissions Sync - Admin" />
             <PageHeader
-                path={[{ text: 'Permissions Sync Dashboard' }]}
+                path={[{ text: 'Permissions Sync' }]}
                 headingElement="h2"
                 description={
                     <>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
@@ -1,14 +1,11 @@
 import React from 'react'
 
-import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, AlertLink, Code, Container, H4, Link, PageHeader } from '@sourcegraph/wildcard'
 
-import { ConnectionError, ConnectionLoading } from '../../components/FilteredConnection/ui'
 import { PageTitle } from '../../components/PageTitle'
-import { DatabaseBackedPermsSyncFeatureFlagResult } from '../../graphql-operations'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 
-import { DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY } from './backend'
 import { PermissionsSyncJobsTable } from './PermissionsSyncJobsTable'
 
 interface Props extends TelemetryProps {}
@@ -18,22 +15,7 @@ const FEATURE_FLAG_NAME = 'database-permission-sync-worker'
 export const PermissionsSyncJobsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
 }) => {
-    const { data, loading, error } = useQuery<DatabaseBackedPermsSyncFeatureFlagResult>(
-        DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY,
-        {
-            variables: {
-                name: FEATURE_FLAG_NAME,
-            },
-        }
-    )
-
-    if (error) {
-        return <ConnectionError errors={[error.message]} />
-    }
-    if (loading) {
-        return <ConnectionLoading />
-    }
-    const enabled = (data?.featureFlag?.__typename === 'FeatureFlagBoolean' && data.featureFlag.value) || undefined
+    const [enabled] = useFeatureFlag(FEATURE_FLAG_NAME)
 
     return enabled ? (
         <PermissionsSyncJobsTable telemetryService={telemetryService} />

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Alert, AlertLink, Code, Container, H4, Link, PageHeader } from '@sourcegraph/wildcard'
+
+import { ConnectionError, ConnectionLoading } from '../../components/FilteredConnection/ui'
+import { PageTitle } from '../../components/PageTitle'
+import { DatabaseBackedPermsSyncFeatureFlagResult } from '../../graphql-operations'
+
+import { DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY } from './backend'
+import { PermissionsSyncJobsTable } from './PermissionsSyncJobsTable'
+
+interface Props extends TelemetryProps {}
+
+const FEATURE_FLAG_NAME = 'database-permission-sync-worker'
+
+export const PermissionsSyncJobsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryService,
+}) => {
+    const { data, loading, error } = useQuery<DatabaseBackedPermsSyncFeatureFlagResult>(
+        DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY,
+        {
+            variables: {
+                name: FEATURE_FLAG_NAME,
+            },
+        }
+    )
+
+    if (error) {
+        return <ConnectionError errors={[error.message]} />
+    }
+    if (loading) {
+        return <ConnectionLoading />
+    }
+    const enabled = (data?.featureFlag?.__typename === 'FeatureFlagBoolean' && data.featureFlag.value) || undefined
+
+    return enabled ? (
+        <PermissionsSyncJobsTable telemetryService={telemetryService} />
+    ) : (
+        <>
+            <PageTitle title="Permissions Sync Dashboard - Admin" />
+            <PageHeader
+                path={[{ text: 'Permissions Sync Dashboard' }]}
+                headingElement="h2"
+                description={
+                    <>
+                        List of permissions sync jobs. Learn more about{' '}
+                        <Link to="/help/admin/permissions/syncing">permissions syncing</Link>.
+                    </>
+                }
+                className="mb-3"
+            />
+            <Container>
+                <Alert variant="info" className="d-flex align-items-center">
+                    <div className="flex-grow-1">
+                        <H4>Database-backed permissions sync is disabled.</H4>
+                        Please create and enable a <Code>{FEATURE_FLAG_NAME}</Code> feature flag to use this dashboard.
+                    </div>
+                    <AlertLink className="mr-2" to="/site-admin/feature-flags/configuration/new">
+                        Create feature flag
+                    </AlertLink>
+                </Alert>
+            </Container>
+        </>
+    )
+}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsPage.tsx
@@ -21,13 +21,14 @@ export const PermissionsSyncJobsPage: React.FunctionComponent<React.PropsWithChi
         <PermissionsSyncJobsTable telemetryService={telemetryService} />
     ) : (
         <>
-            <PageTitle title="Permissions Sync - Admin" />
+            <PageTitle title="Permissions - Admin" />
             <PageHeader
-                path={[{ text: 'Permissions Sync' }]}
+                path={[{ text: 'Permissions' }]}
                 headingElement="h2"
                 description={
                     <>
-                        List of permissions sync jobs. Learn more about{' '}
+                        List of permissions sync jobs. A permission sync job fetches the newest permissions for a given
+                        repository or user from the respective code host. Learn more about{' '}
                         <Link to="/help/admin/permissions/syncing">permissions syncing</Link>.
                     </>
                 }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -105,13 +105,14 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
 
     return (
         <div>
-            <PageTitle title="Permissions Sync - Admin" />
+            <PageTitle title="Permissions - Admin" />
             <PageHeader
-                path={[{ text: 'Permissions Sync' }]}
+                path={[{ text: 'Permissions' }]}
                 headingElement="h2"
                 description={
                     <>
-                        List of permissions sync jobs. Learn more about{' '}
+                        List of permissions sync jobs. A permission sync job fetches the newest permissions for a given
+                        repository or user from the respective code host. Learn more about{' '}
                         <Link to="/help/admin/permissions/syncing">permissions syncing</Link>.
                     </>
                 }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -105,9 +105,9 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
 
     return (
         <div>
-            <PageTitle title="Permissions Sync Dashboard - Admin" />
+            <PageTitle title="Permissions Sync - Admin" />
             <PageHeader
-                path={[{ text: 'Permissions Sync Dashboard' }]}
+                path={[{ text: 'Permissions Sync' }]}
                 headingElement="h2"
                 description={
                     <>

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -80,13 +80,3 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         }
     }
 `
-
-export const DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY = gql`
-    query DatabaseBackedPermsSyncFeatureFlag($name: String!) {
-        featureFlag(name: $name) {
-            ... on FeatureFlagBoolean {
-                value
-            }
-        }
-    }
-`

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -80,3 +80,13 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         }
     }
 `
+
+export const DB_BACKED_PERMISSIONS_SYNC_FEATURE_FLAG_QUERY = gql`
+    query DatabaseBackedPermsSyncFeatureFlag($name: String!) {
+        featureFlag(name: $name) {
+            ... on FeatureFlagBoolean {
+                value
+            }
+        }
+    }
+`

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -3,7 +3,7 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { checkRequestAccessAllowed } from '../util/checkRequestAccessAllowed'
 
 import { isPackagesEnabled } from './flags'
-import { PermissionsSyncJobsTable } from './permissions-center/PermissionsSyncJobsTable'
+import { PermissionsSyncJobsPage } from './permissions-center/PermissionsSyncJobsPage'
 import { SiteAdminAreaRoute } from './SiteAdminArea'
 
 const AnalyticsOverviewPage = lazyComponent(() => import('./analytics/AnalyticsOverviewPage'), 'AnalyticsOverviewPage')
@@ -244,6 +244,6 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/permissions-syncs',
-        render: props => <PermissionsSyncJobsTable {...props} />,
+        render: props => <PermissionsSyncJobsPage {...props} />,
     },
 ]


### PR DESCRIPTION
Test plan:
Local sg run and test.

Closes https://github.com/sourcegraph/sourcegraph/issues/48416

### Demo

https://user-images.githubusercontent.com/94846361/223148121-7fd21cee-9268-4c95-a1d0-3ba8ffce93b5.mp4


## App preview:

- [Web](https://sg-web-ao-ui-pc-feature-flag-check.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
