### PR TITLE
own: Support more section patterns on GitLab

### DIFF
--- a/enterprise/internal/own/codeowners/parse.go
+++ b/enterprise/internal/own/codeowners/parse.go
@@ -35,7 +35,8 @@ func Parse(codeownersFile io.Reader) (*Ruleset, error) {
 		// Need to handle this error once, codeownerspb.File supports
 		// error metadata.
 		r := codeownerspb.Rule{
-			Pattern:     unescape(pattern),
+			Pattern: unescape(pattern),
+			// Section names are case-insensitive, so we lowercase it.
 			SectionName: strings.TrimSpace(strings.ToLower(p.section)),
 			LineNumber:  lineNumber,
 		}
@@ -112,9 +113,11 @@ func (p *parsing) matchRule() (string, []string, bool) {
 	return filePattern, owners, true
 }
 
-var sectionPattern = lazyregexp.New(`^\s*\[([^\]]+)\]\s*$`)
+var sectionPattern = lazyregexp.New(`^\s*\^?\s*\[([^\]]+)\]\s*(?:\[[0-9]+\])?\s*$`)
 
 // matchSection tries to extract a section which looks like `[section name]`.
+// A section can also be defined as `^[Section]`, meaning it is optional for approval.
+// It can also be `[Section][2]`, meaning two approvals are required.
 func (p *parsing) matchSection() bool {
 	match := sectionPattern.FindStringSubmatch(p.lineWithoutComments())
 	if len(match) != 2 {

--- a/enterprise/internal/own/codeowners/parse_test.go
+++ b/enterprise/internal/own/codeowners/parse_test.go
@@ -434,16 +434,54 @@ func TestParsePathWithSpaces(t *testing.T) {
 func TestParseSection(t *testing.T) {
 	got, err := codeowners.Parse(strings.NewReader(
 		`[PM]
-		own/codeowners/* @own-pms`))
+own/codeowners/* @own-pms
+
+# Optional approvers.
+^[Eng]
+own/codeowners/* @own-engs
+
+# Multiple approvers required.
+[Eng][2]
+own/codeowners/* @own-engs
+
+# Case-insensitivity.
+[pm]
+own/codeowners/* @own-pms
+`))
 	require.NoError(t, err)
-	want := []*codeownerspb.Rule{{
-		Pattern:     "own/codeowners/*",
-		SectionName: "pm",
-		Owner: []*codeownerspb.Owner{
-			{Handle: "own-pms"},
+	want := []*codeownerspb.Rule{
+		{
+			Pattern:     "own/codeowners/*",
+			SectionName: "pm",
+			Owner: []*codeownerspb.Owner{
+				{Handle: "own-pms"},
+			},
+			LineNumber: 2,
 		},
-		LineNumber: 2,
-	}}
+		{
+			Pattern:     "own/codeowners/*",
+			SectionName: "eng",
+			Owner: []*codeownerspb.Owner{
+				{Handle: "own-engs"},
+			},
+			LineNumber: 6,
+		},
+		{
+			Pattern:     "own/codeowners/*",
+			SectionName: "eng",
+			Owner: []*codeownerspb.Owner{
+				{Handle: "own-engs"},
+			},
+			LineNumber: 10,
+		},
+		{
+			Pattern:     "own/codeowners/*",
+			SectionName: "pm",
+			Owner: []*codeownerspb.Owner{
+				{Handle: "own-pms"},
+			},
+			LineNumber: 14,
+		}}
 	assert.Equal(t, codeowners.NewRuleset(&codeownerspb.File{Rule: want}), got)
 }
 


### PR DESCRIPTION
There's two additional syntax additions I've found in GitLab docs, so added them to our parser.

## Test plan

Added tests.