### PR TITLE
auth/azureoauth: Fix ServiceID in provider

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
@@ -185,7 +185,7 @@ func parseProvider(logger log.Logger, db database.DB, sourceCfg schema.AuthProvi
 		},
 		SourceConfig: sourceCfg,
 		StateConfig:  oauth.GetStateConfig(stateCookie),
-		ServiceID:    parsedURL.String(),
+		ServiceID:    azuredevops.AzureDevOpsAPIURL,
 		ServiceType:  extsvc.TypeAzureDevOps,
 		Login:        loginHandler,
 		Callback: func(config oauth2.Config) http.Handler {

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider_test.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider_test.go
@@ -20,7 +20,7 @@ func newOauthProvider(oauth2Config oauth2.Config) *oauth.Provider {
 			AuthPrefix:   "/.auth/azuredevops",
 			OAuth2Config: func() oauth2.Config { return oauth2Config },
 			StateConfig:  oauth.GetStateConfig(stateCookie),
-			ServiceID:    "https://app.vssps.visualstudio.com/",
+			ServiceID:    "https://dev.azure.com/",
 			ServiceType:  extsvc.TypeAzureDevOps,
 		},
 	}


### PR DESCRIPTION
This should be set to the Azure API URL because we also store this as the value of service_id in the user_external_accounts table when a user signs up with Azure DevOps.

The bug was identified when connected accounts were not showing up in the account security page, because the service ID expected there was the Visual Studio URL vs the GQL API returning the Azure API URL.

The regression appeared when we fixed the backend to use the Azure API URL while creating the external account in 4b62fa25404d9d6deec242ddf91537515dd555e7 but did not change the creation of the auth provider to also use the Azure API URL as the service ID.

Link to code where we set the Azure API URL in the write path: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ae576578e46cec33156c74a1da10cf891b7f3631/-/blob/enterprise/cmd/frontend/internal/auth/azureoauth/session.go?L72&subtree=true


## Test plan

- Tested locally
- Updated tests
- Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
