### PR TITLE
search input: Improve dark mode default cursor color

### DIFF
--- a/client/shared/src/components/CodeMirrorEditor.tsx
+++ b/client/shared/src/components/CodeMirrorEditor.tsx
@@ -26,6 +26,13 @@ if (process.env.INTEGRATION_TESTS) {
         EditorView.findFromDOM(element)
 }
 
+const defaultTheme = EditorView.baseTheme({
+    // Overwrites the default cursor color, which has too low contrast in dark mode
+    '&dark .cm-cursor': {
+        borderLeftColor: 'var(--grey-07)',
+    },
+})
+
 /**
  * Hook for rendering and updating a CodeMirror instance.
  */
@@ -35,8 +42,19 @@ export function useCodeMirror(
     value: string,
     extensions?: EditorStateConfig['extensions']
 ): void {
-    // Update editor value if necessary. This also sets the intial value of the
-    // editor.
+    const allExtensions = useMemo(() => [defaultTheme, extensions ?? []], [extensions])
+
+    // The order of effects is important here:
+    //
+    // - If the editor hasn't been created yet (editorRef.current is null) it should be
+    //   fully instantiated with value and extensions. The value/extension update effects
+    //   should not have any ... effect.
+    // - When the hook runs on subsequent renders the value and extensions get update if
+    //   the respective values changed.
+    //
+    // We achieve this by putting the update effects before the creation effect.
+
+    // Update editor value if necessary
     useEffect(() => {
         if (editorRef.current) {
             const changes = replaceValue(editorRef.current, value ?? '')
@@ -47,21 +65,22 @@ export function useCodeMirror(
         }
     }, [editorRef, value])
 
+    // Reconfigure/update extensions if necessary
     useEffect(() => {
-        if (editorRef.current && extensions) {
-            editorRef.current.dispatch({ effects: StateEffect.reconfigure.of(extensions) })
+        if (editorRef.current) {
+            editorRef.current.dispatch({ effects: StateEffect.reconfigure.of(allExtensions) })
         }
-    }, [editorRef, extensions])
+    }, [editorRef, allExtensions])
 
     // Create editor if necessary
     useEffect(() => {
         if (!editorRef.current && containerRef.current) {
             editorRef.current = new EditorView({
-                state: EditorState.create({ doc: value, extensions }),
+                state: EditorState.create({ doc: value, extensions: allExtensions }),
                 parent: containerRef.current,
             })
         }
-    }, [editorRef, containerRef, value, extensions])
+    }, [editorRef, containerRef, value, allExtensions])
 
     // Clean up editor on unmount
     useEffect(


### PR DESCRIPTION
The new search input uses the CodeMirror's own functionality for rendering the (text) selection and cursor.
The default cursor color doesn't have a good contrast. This commit overwrites the default cursor color in dark mode for all editor instances.

Note that I've explicitly used `baseTheme` here because I think this affects all editable CodeMirror instances and it allows me to use the special `&dark` modifier. But that also means instances who do not explicitly use this hook will be affected.


## Test plan

<img width="801" alt="2023-03-06_15-28" src="https://user-images.githubusercontent.com/179026/223157598-1c038303-044b-4062-af1f-8f062a7842be.png">


## App preview:

- [Web](https://sg-web-fkling-search-input-cursor-color.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
