### PR TITLE
[fix] repositories admin page code host filter not adhering to URL query params

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -167,26 +167,25 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent = () => {
             return FILTERS
         }
 
-        const values = [
-            {
-                label: 'All',
-                value: 'all',
-                tooltip: 'Show all repositories',
-                args: {},
-            },
-        ]
-
-        for (const extSvc of extSvcs.externalServices.nodes) {
-            values.push({
-                label: extSvc.displayName,
-                value: extSvc.id,
-                tooltip: `Show all repositories discovered on ${extSvc.displayName}`,
-                args: { externalService: extSvc.id },
-            })
-        }
-
         const filtersWithExternalServices = FILTERS.slice() // use slice to copy array
         if (location.pathname !== PageRoutes.SetupWizard) {
+            const values = [
+                {
+                    label: 'All',
+                    value: 'all',
+                    tooltip: 'Show all repositories',
+                    args: {},
+                },
+            ]
+
+            for (const extSvc of extSvcs.externalServices.nodes) {
+                values.push({
+                    label: extSvc.displayName,
+                    value: extSvc.id,
+                    tooltip: `Show all repositories discovered on ${extSvc.displayName}`,
+                    args: { externalService: extSvc.id },
+                })
+            }
             filtersWithExternalServices.push({
                 id: 'codeHost',
                 label: 'Code Host',
@@ -200,6 +199,10 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent = () => {
     const [filterValues, setFilterValues] = useState<Map<string, FilteredConnectionFilterValue>>(() =>
         getFilterFromURL(new URLSearchParams(location.search), filters)
     )
+
+    useEffect(() => {
+        setFilterValues(getFilterFromURL(new URLSearchParams(location.search), filters))
+    }, [filters, location])
 
     const [searchQuery, setSearchQuery] = useState<string>(
         () => new URLSearchParams(location.search).get('query') || ''


### PR DESCRIPTION
## Description

1. visit repos page under site admin
1. select code host from code host filter
1. The URL will be updated, copy the URL
1. Visit the URL in a new tab
1. The code host filter won't be pre-populated.

This has now been fixed

fixes #48341
- #48341



## Video

https://www.loom.com/share/3c9749e5fd9c4e38a07e13ad728328c0

## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-milan-fix-repositories-url.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
