### PR TITLE
app: fix homebrew release updating

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -19,7 +19,7 @@ Learn more about [how this fits into our product strategy](https://handbook.sour
 **macOS:** via homebrew:
 
 ```sh
-brew install sourcegraph/sourcegraph-app/sourcegraph
+brew install sourcegraph/app/sourcegraph
 ```
 
 **Linux:** via [deb pkg](https://storage.googleapis.com/sourcegraph-app-releases/0.0.200198-snapshot+20230220-35357c/sourcegraph_0.0.200198-snapshot+20230220-35357c_linux_amd64.deb) installer:

--- a/enterprise/dev/app/goreleaser.yaml
+++ b/enterprise/dev/app/goreleaser.yaml
@@ -108,8 +108,7 @@ brews:
     license: "Sourcegraph Enterprise License (portions licensed under Apache 2)"
     tap:
       owner: sourcegraph
-      # TODO(sqs): use just sourcegraph/homebrew-sourcegraph
-      name: homebrew-sourcegraph-app
+      name: homebrew-app
     url_template: https://storage.googleapis.com/sourcegraph-app-releases/{{ .Tag }}/{{ .ArtifactName }}
     commit_author:
       name: sourcegraph-buildkite

--- a/enterprise/dev/app/goreleaser.yaml
+++ b/enterprise/dev/app/goreleaser.yaml
@@ -125,6 +125,6 @@ announce:
   slack:
     enabled: true
     message_template: |
-      New version `{{.Version}}` (<https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/{{.FullCommit}}|{{.ShortCommit}}>): `brew install sourcegraph/sourcegraph-app/sourcegraph`, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_darwin_all.zip|macOS .zip>, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_linux_amd64.zip|Linux .zip>, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_linux_amd64.deb|Linux .deb>. Winners ship, shippers win! :ship: :ship: :ship:
+      New version `{{.Version}}` (<https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/{{.FullCommit}}|{{.ShortCommit}}>): `brew install sourcegraph/app/sourcegraph`, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_darwin_all.zip|macOS .zip>, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_linux_amd64.zip|Linux .zip>, <https://storage.googleapis.com/sourcegraph-app-releases/{{.Version}}/sourcegraph_{{.Version}}_linux_amd64.deb|Linux .deb>. Winners ship, shippers win! :ship: :ship: :ship:
 
 # TODO(sqs): add back `dockers`, `scoop`, `snapcraft` as needed


### PR DESCRIPTION
https://github.com/sourcegraph/homebrew-sourcegraph-app was renamed to https://github.com/sourcegraph/homebrew-app - the new `brew install` command is:

```
brew install sourcegraph/app/sourcegraph
```

As a result, these needed to be updated.

## Test plan

Ran the above brew install command and confirmed it works. Will perform a release once merged to confirm brew binary updating works.