### PR TITLE
chore: fix deployment lag notifier

### DIFF
--- a/enterprise/dev/deployment-lag-notifier/github.go
+++ b/enterprise/dev/deployment-lag-notifier/github.go
@@ -56,7 +56,7 @@ func getCommit(client *http.Client, sha string) (Commit, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return commit, errors.Newf("received non-200 status code %v", resp.StatusCode)
+		return commit, errors.Newf("received non-200 status code %v: %s", resp.StatusCode, err.Error())
 	}
 
 	defer resp.Body.Close()
@@ -116,7 +116,7 @@ func getCommitLog(client *http.Client, numCommits int) ([]Commit, error) {
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				return nil, errors.Newf("received non-200 status code %v", resp.StatusCode)
+				return nil, errors.Newf("received non-200 status code %v: %s", resp.StatusCode, err.Error())
 			}
 
 			body, err := io.ReadAll(resp.Body)

--- a/enterprise/dev/deployment-lag-notifier/main.go
+++ b/enterprise/dev/deployment-lag-notifier/main.go
@@ -70,7 +70,7 @@ func getLiveVersion(client *http.Client, url string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return version, errors.Newf("received non-200 status code %v", resp.StatusCode)
+		return version, errors.Newf("received non-200 status code %v: %s", resp.StatusCode, err.Error())
 	}
 
 	defer resp.Body.Close()
@@ -78,19 +78,31 @@ func getLiveVersion(client *http.Client, url string) (string, error) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return version, err
-
 	}
 
-	// Response is in format build_date_hash
-	parts := strings.Split(string(body), "_")
+	return getCommitFromLiveVersion(string(body))
+}
+
+// getCommitFromLiveVersion strips the SHA from the live version string
+func getCommitFromLiveVersion(liveVersion string) (string, error) {
+	// Response is in format taggedversion-build_date_hash
+	parts := strings.Split(liveVersion, "_")
 
 	if len(parts) != 3 {
-		return version, errors.Newf("unknown version format %s", string(body))
+		return liveVersion, errors.Newf("unknown version format %s", liveVersion)
 	}
 
-	version = parts[2]
+	version := parts[2]
 
-	return version, nil
+	// New version format for continuous builds includes the tagged version, which needs to be stripped
+	parts = strings.Split(version, "-")
+	if len(parts) != 2 {
+		return version, errors.Newf("Unable to get SHA from version with format %s", version)
+	}
+
+	sha := parts[1]
+
+	return sha, nil
 }
 
 // checkForCommit checks for the current version in the

--- a/enterprise/dev/deployment-lag-notifier/main_test.go
+++ b/enterprise/dev/deployment-lag-notifier/main_test.go
@@ -36,6 +36,34 @@ func TestCheckForCommit(t *testing.T) {
 	}
 }
 
+func TestGetCommitFromLiveVersion(t *testing.T) {
+	tt := []struct {
+		Name        string
+		LiveVersion string
+		Result      string
+	}{
+		{
+			Name:        "CommitFromLiveVersionSuccess",
+			LiveVersion: "203800_2023-03-06_4.5-adc006d905fe",
+			Result:      "adc006d905fe",
+		},
+		{
+			Name:        "CommitFromLiveVersionFailure",
+			LiveVersion: "203800_2023-03-06_4.5-confusion-adc006d905fe",
+			Result:      "4.5-confusion-adc006d905fe",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.Name, func(t *testing.T) {
+			result, _ := getCommitFromLiveVersion(test.LiveVersion)
+			if result != test.Result {
+				t.Errorf("Invalid result. Expected: %v Got %v", test.Result, result)
+			}
+		})
+	}
+}
+
 func duration(s string) time.Duration {
 	d, _ := time.ParseDuration(s)
 	return d

--- a/enterprise/dev/deployment-lag-notifier/slack.go
+++ b/enterprise/dev/deployment-lag-notifier/slack.go
@@ -70,7 +70,7 @@ func (s *SlackClient) PostMessage(b bytes.Buffer) error {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Println(string(body))
-		return errors.Newf("received non-200 status code %v", resp.StatusCode)
+		return errors.Newf("received non-200 status code %v: %s", resp.StatusCode, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
The deployment lag notifier has been failing since the introduction of the [latest tagged version in the continuous build version](https://github.com/sourcegraph/sourcegraph/pull/48050). This PR fixes the parsing of the version string.  

Also adds the error output to some wrapped errors.

## Test plan
`go test` passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
