### PR TITLE
codeintel: normalize scip-typescript `scheme` to `npm` instead of `scip-typescript`

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
@@ -213,7 +213,7 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.
 }
 
 // newPackage constructs a precise.Package from the given shared.Package,
-// applying any normalization or necessary transformations that lsif uploads
+// applying any normalization or necessary transformations that LSIF/SCIP uploads
 // require for internal consistency.
 func newPackage(pkg uploadsshared.Package) (*precise.Package, error) {
 	p := precise.Package{
@@ -227,10 +227,11 @@ func newPackage(pkg uploadsshared.Package) (*precise.Package, error) {
 	case dependencies.JVMPackagesScheme:
 		p.Name = strings.TrimPrefix(p.Name, "maven/")
 		p.Name = strings.ReplaceAll(p.Name, "/", ":")
-	case dependencies.NpmPackagesScheme:
+	case dependencies.NpmPackagesScheme, "scip-typescript":
 		if _, err := reposource.ParseNpmPackageFromPackageSyntax(reposource.PackageName(p.Name)); err != nil {
 			return nil, err
 		}
+		p.Scheme = dependencies.NpmPackagesScheme
 	case "scip-python":
 		// Override scip-python scheme so that we are able to autoindex
 		// index.scip created by scip-python


### PR DESCRIPTION
When we translated SCIP to LSIF before native SCIP support, we hard-coded translating the scheme for {scip,lsif}-typescript uploads to `npm`. This was no longer happening when we started accepting SCIP natively, meaning scheme would yield `scip-typescript` and not match the map of known scheme kinds, so package repos for NPM were not being synced.

## Test plan

Locally compared the data to confirm the values
