### PR TITLE
Show code graph repo btn on admin repo list

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { mdiCog, mdiClose, mdiFileDocumentOutline } from '@mdi/js'
+import { mdiCog, mdiClose, mdiFileDocumentOutline, mdiBrain } from '@mdi/js'
 import classNames from 'classnames'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
@@ -83,6 +83,19 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                             <Icon aria-hidden={true} svgPath={mdiCloudDownload} /> Clone now
                         </Button>
                     )}{' '} */}
+                    {!window.location.pathname.includes('/setup') && (
+                        <Tooltip content="Repository code graph data">
+                            <Button
+                                to={`/${node.name}/-/code-graph`}
+                                variant="secondary"
+                                size="sm"
+                                className="mr-1"
+                                as={Link}
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiBrain} /> Code graph data
+                            </Button>
+                        </Tooltip>
+                    )}
                     {node.mirrorInfo.cloned && !node.mirrorInfo.lastError && !node.mirrorInfo.cloneInProgress && (
                         <Tooltip content="Repository settings">
                             <Button to={`/${node.name}/-/settings`} variant="secondary" size="sm" as={Link}>


### PR DESCRIPTION
Reinstates regression from #47141. Code graph button renders on site admin repositories list view and not the setup wizard view.

![image](https://user-images.githubusercontent.com/59381432/223189414-7ad5288a-3614-48d9-bbcd-a481be8d6e2d.png)
![image](https://user-images.githubusercontent.com/59381432/223189507-ff386a5b-9c2f-48ba-a91f-39bbb695382d.png)


## Test plan
- Ensure `Code graph data` action is viewable on `/site-admin/repositories`
- Ensure same action is not rendered in `/setup/sync-repositories` (Make sure feature flag is on in your settings to view --> `"experimentalFeatures": { "setupWizard": true }`)

## App preview:

- [Web](https://sg-web-becca-reinstate-repo-code-graph.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
