### PR TITLE
SCIM: Add security event log to when a users SCIM data is updated

### DIFF
--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -197,6 +197,9 @@ AND deleted_at IS NULL
 		return s.Insert(ctx, userID, extsvc.AccountSpec{ServiceType: "scim", ServiceID: "scim", AccountID: accountID}, data)
 	}
 
+	// Log action
+	logAccountModifiedEvent(ctx, NewDBWith(s.logger, s), userID, "scim")
+
 	return
 }
 

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -197,7 +197,7 @@ AND deleted_at IS NULL
 		return s.Insert(ctx, userID, extsvc.AccountSpec{ServiceType: "scim", ServiceID: "scim", AccountID: accountID}, data)
 	}
 
-	// Log action
+	// This logs an audit event for account changes but only if they are initiated via SCIM
 	logAccountModifiedEvent(ctx, NewDBWith(s.logger, s), userID, "scim")
 
 	return

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -29,9 +29,10 @@ const (
 	SecurityEventNameSignInFailed    SecurityEventName = "SignInFailed"
 	SecurityEventNameSignInSucceeded SecurityEventName = "SignInSucceeded"
 
-	SecurityEventNameAccountCreated SecurityEventName = "AccountCreated"
-	SecurityEventNameAccountDeleted SecurityEventName = "AccountDeleted"
-	SecurityEventNameAccountNuked   SecurityEventName = "AccountNuked"
+	SecurityEventNameAccountCreated  SecurityEventName = "AccountCreated"
+	SecurityEventNameAccountDeleted  SecurityEventName = "AccountDeleted"
+	SecurityEventNameAccountModified SecurityEventName = "AccountModified"
+	SecurityEventNameAccountNuked    SecurityEventName = "AccountNuked"
 
 	SecurityEventNamPasswordResetRequested SecurityEventName = "PasswordResetRequested"
 	SecurityEventNamPasswordRandomized     SecurityEventName = "PasswordRandomized"

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -456,6 +456,29 @@ func logAccountCreatedEvent(ctx context.Context, db DB, u *types.User, serviceTy
 	db.SecurityEventLogs().LogEvent(ctx, event)
 }
 
+func logAccountModifiedEvent(ctx context.Context, db DB, userID int32, serviceType string) {
+	a := actor.FromContext(ctx)
+	arg, _ := json.Marshal(struct {
+		Modifier    int32  `json:"modifier"`
+		ServiceType string `json:"service_type"`
+	}{
+		Modifier:    a.UID,
+		ServiceType: serviceType,
+	})
+
+	event := &SecurityEvent{
+		Name:            SecurityEventNameAccountModified,
+		URL:             "",
+		UserID:          uint32(userID),
+		AnonymousUserID: "",
+		Argument:        arg,
+		Source:          "BACKEND",
+		Timestamp:       time.Now(),
+	}
+
+	db.SecurityEventLogs().LogEvent(ctx, event)
+}
+
 // orgsForAllUsersToJoin returns the list of org names that all users should be joined to. The second return value
 // is a list of errors encountered while generating this list. Note that even if errors are returned, the first
 // return value is still valid.


### PR DESCRIPTION
This adds an audit log when an account is changed by SCIM.  Account changes that are initiated by non-SCIM methods will continue to **not**  be logged.

## Test plan
Run SCIM PATCH commands and see expected audit log

| id | name | url | user\_id | anonymous\_user\_id | source | argument | version | timestamp |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 293 | AccountModified |  | 193 |  | BACKEND | {"modifier": 0, "service\_type": "scim"} | 0.0.0+dev | 2023-03-06 18:06:58.551791 +00:00 |
| 304 | AccountModified |  | 201 |  | BACKEND | {"modifier": 0, "service\_type": "scim"} | 0.0.0+dev | 2023-03-06 18:09:49.952155 +00:00 |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
