### PR TITLE
experimental search input: Initialize cursor position to input end

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -339,6 +339,15 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
         )
     )
 
+    // Position cursor at the end of the input when it is initialized
+    useEffect(() => {
+        if (editorRef.current) {
+            editorRef.current.dispatch({
+                selection: { anchor: editorRef.current.state.doc.length },
+            })
+        }
+    }, [])
+
     const focus = useCallback(() => {
         editorRef.current?.contentDOM.focus()
     }, [editorRef])


### PR DESCRIPTION
I noticed that the placeholder text in the new search input is not showing up on a fresh page load and that's because the initial cursor position is 0.
This change makes is to so that initial position will be at the end of the input.



## Test plan

Loading https://sourcegraph.test:3443/search now shows the placeholder text.

## App preview:

- [Web](https://sg-web-fkling-search-input-initial.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
