### PR TITLE
graphqlbackend: remove parameter gore in NewSchema

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -47,28 +47,14 @@ type Services struct {
 	// Handler for completions stream.
 	NewCompletionsStreamHandler NewCompletionsStreamHandler
 
-	PermissionsGitHubWebhook    webhooks.Registerer
-	NewCodeIntelUploadHandler   NewCodeIntelUploadHandler
-	RankingService              RankingService
-	NewExecutorProxyHandler     NewExecutorProxyHandler
-	NewGitHubAppSetupHandler    NewGitHubAppSetupHandler
-	NewComputeStreamHandler     NewComputeStreamHandler
-	EnterpriseSearchJobs        jobutil.EnterpriseJobs
-	AuthzResolver               graphqlbackend.AuthzResolver
-	BatchChangesResolver        graphqlbackend.BatchChangesResolver
-	CodeIntelResolver           graphqlbackend.CodeIntelResolver
-	InsightsResolver            graphqlbackend.InsightsResolver
-	CodeMonitorsResolver        graphqlbackend.CodeMonitorsResolver
-	LicenseResolver             graphqlbackend.LicenseResolver
-	DotcomResolver              graphqlbackend.DotcomRootResolver
-	SearchContextsResolver      graphqlbackend.SearchContextsResolver
-	NotebooksResolver           graphqlbackend.NotebooksResolver
-	ComputeResolver             graphqlbackend.ComputeResolver
-	InsightsAggregationResolver graphqlbackend.InsightsAggregationResolver
-	WebhooksResolver            graphqlbackend.WebhooksResolver
-	EmbeddingsResolver          graphqlbackend.EmbeddingsResolver
-	RBACResolver                graphqlbackend.RBACResolver
-	OwnResolver                 graphqlbackend.OwnResolver
+	PermissionsGitHubWebhook  webhooks.Registerer
+	NewCodeIntelUploadHandler NewCodeIntelUploadHandler
+	RankingService            RankingService
+	NewExecutorProxyHandler   NewExecutorProxyHandler
+	NewGitHubAppSetupHandler  NewGitHubAppSetupHandler
+	NewComputeStreamHandler   NewComputeStreamHandler
+	EnterpriseSearchJobs      jobutil.EnterpriseJobs
+	graphqlbackend.OptionalResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -438,10 +438,35 @@ func NewSchema(
 	rbacResolver RBACResolver,
 	ownResolver OwnResolver,
 ) (*graphql.Schema, error) {
+	return NewSchemaGucci(db, gitserverClient, enterpriseJobs, OptionalResolver{
+		BatchChangesResolver:        batchChanges,
+		CodeIntelResolver:           codeIntel,
+		InsightsResolver:            insights,
+		AuthzResolver:               authz,
+		CodeMonitorsResolver:        codeMonitors,
+		LicenseResolver:             license,
+		DotcomRootResolver:          dotcom,
+		SearchContextsResolver:      searchContexts,
+		NotebooksResolver:           notebooks,
+		ComputeResolver:             compute,
+		InsightsAggregationResolver: insightsAggregation,
+		WebhooksResolver:            webhooksResolver,
+		EmbeddingsResolver:          embeddingsResolver,
+		RBACResolver:                rbacResolver,
+		OwnResolver:                 ownResolver,
+	})
+}
+
+func NewSchemaGucci(
+	db database.DB,
+	gitserverClient gitserver.Client,
+	enterpriseJobs jobutil.EnterpriseJobs,
+	optional OptionalResolver,
+) (*graphql.Schema, error) {
 	resolver := newSchemaResolver(db, gitserverClient, enterpriseJobs)
 	schemas := []string{mainSchema, outboundWebhooksSchema}
 
-	if batchChanges != nil {
+	if batchChanges := optional.BatchChangesResolver; batchChanges != nil {
 		EnterpriseResolvers.batchChangesResolver = batchChanges
 		resolver.BatchChangesResolver = batchChanges
 		schemas = append(schemas, batchesSchema)
@@ -451,7 +476,7 @@ func NewSchema(
 		}
 	}
 
-	if codeIntel != nil {
+	if codeIntel := optional.CodeIntelResolver; codeIntel != nil {
 		EnterpriseResolvers.codeIntelResolver = codeIntel
 		resolver.CodeIntelResolver = codeIntel
 		schemas = append(schemas, codeIntelSchema)
@@ -461,19 +486,19 @@ func NewSchema(
 		}
 	}
 
-	if insights != nil {
+	if insights := optional.InsightsResolver; insights != nil {
 		EnterpriseResolvers.insightsResolver = insights
 		resolver.InsightsResolver = insights
 		schemas = append(schemas, insightsSchema)
 	}
 
-	if authz != nil {
+	if authz := optional.AuthzResolver; authz != nil {
 		EnterpriseResolvers.authzResolver = authz
 		resolver.AuthzResolver = authz
 		schemas = append(schemas, authzSchema)
 	}
 
-	if codeMonitors != nil {
+	if codeMonitors := optional.CodeMonitorsResolver; codeMonitors != nil {
 		EnterpriseResolvers.codeMonitorsResolver = codeMonitors
 		resolver.CodeMonitorsResolver = codeMonitors
 		schemas = append(schemas, codeMonitorsSchema)
@@ -483,14 +508,14 @@ func NewSchema(
 		}
 	}
 
-	if license != nil {
+	if license := optional.LicenseResolver; license != nil {
 		EnterpriseResolvers.licenseResolver = license
 		resolver.LicenseResolver = license
 		schemas = append(schemas, licenseSchema)
 		// No NodeByID handlers currently.
 	}
 
-	if dotcom != nil {
+	if dotcom := optional.DotcomRootResolver; dotcom != nil {
 		EnterpriseResolvers.dotcomResolver = dotcom
 		resolver.DotcomRootResolver = dotcom
 		schemas = append(schemas, dotcomSchema)
@@ -500,7 +525,7 @@ func NewSchema(
 		}
 	}
 
-	if searchContexts != nil {
+	if searchContexts := optional.SearchContextsResolver; searchContexts != nil {
 		EnterpriseResolvers.searchContextsResolver = searchContexts
 		resolver.SearchContextsResolver = searchContexts
 		schemas = append(schemas, searchContextsSchema)
@@ -510,7 +535,7 @@ func NewSchema(
 		}
 	}
 
-	if notebooks != nil {
+	if notebooks := optional.NotebooksResolver; notebooks != nil {
 		EnterpriseResolvers.notebooksResolver = notebooks
 		resolver.NotebooksResolver = notebooks
 		schemas = append(schemas, notebooksSchema)
@@ -520,19 +545,19 @@ func NewSchema(
 		}
 	}
 
-	if compute != nil {
+	if compute := optional.ComputeResolver; compute != nil {
 		EnterpriseResolvers.computeResolver = compute
 		resolver.ComputeResolver = compute
 		schemas = append(schemas, computeSchema)
 	}
 
-	if insightsAggregation != nil {
+	if insightsAggregation := optional.InsightsAggregationResolver; insightsAggregation != nil {
 		EnterpriseResolvers.InsightsAggregationResolver = insightsAggregation
 		resolver.InsightsAggregationResolver = insightsAggregation
 		schemas = append(schemas, insightsAggregationsSchema)
 	}
 
-	if webhooksResolver != nil {
+	if webhooksResolver := optional.WebhooksResolver; webhooksResolver != nil {
 		EnterpriseResolvers.webhooksResolver = webhooksResolver
 		resolver.WebhooksResolver = webhooksResolver
 		// Register NodeByID handlers.
@@ -541,13 +566,13 @@ func NewSchema(
 		}
 	}
 
-	if embeddingsResolver != nil {
+	if embeddingsResolver := optional.EmbeddingsResolver; embeddingsResolver != nil {
 		EnterpriseResolvers.embeddingsResolver = embeddingsResolver
 		resolver.EmbeddingsResolver = embeddingsResolver
 		schemas = append(schemas, embeddingsSchema)
 	}
 
-	if rbacResolver != nil {
+	if rbacResolver := optional.RBACResolver; rbacResolver != nil {
 		EnterpriseResolvers.rbacResolver = rbacResolver
 		resolver.RBACResolver = rbacResolver
 		schemas = append(schemas, rbacSchema)
@@ -557,7 +582,7 @@ func NewSchema(
 		}
 	}
 
-	if ownResolver != nil {
+	if ownResolver := optional.OwnResolver; ownResolver != nil {
 		EnterpriseResolvers.ownResolver = ownResolver
 		resolver.OwnResolver = ownResolver
 		schemas = append(schemas, ownSchema)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -595,8 +595,12 @@ type schemaResolver struct {
 	nodeByIDFns          map[string]NodeByIDFunc
 	enterpriseSearchJobs jobutil.EnterpriseJobs
 
-	// SubResolvers are assigned using the Schema constructor.
+	OptionalResolver
+}
 
+// OptionalResolver are the resolvers that do not have to be set. If a field
+// is non-nil, NewSchema will register the corresponding graphql schema.
+type OptionalResolver struct {
 	BatchChangesResolver
 	AuthzResolver
 	CodeIntelResolver

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -383,81 +383,42 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{})
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{NotebooksResolver: notebooks})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{NotebooksResolver: notebooks})
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{AuthzResolver: authz})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{AuthzResolver: authz})
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{BatchChangesResolver: batchChanges})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{BatchChangesResolver: batchChanges})
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{CodeMonitorsResolver: codeMonitors})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{CodeMonitorsResolver: codeMonitors})
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{LicenseResolver: license})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{LicenseResolver: license})
 }
 
 func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{WebhooksResolver: webhooksResolver})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{WebhooksResolver: webhooksResolver})
 }
 
 func NewSchemaWithRBACResolver(db database.DB, rbacResolver RBACResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{RBACResolver: rbacResolver})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{RBACResolver: rbacResolver})
 }
 
 func NewSchemaWithOwnResolver(db database.DB, own OwnResolver) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{OwnResolver: own})
+	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{OwnResolver: own})
 }
 
 func NewSchema(
-	db database.DB,
-	gitserverClient gitserver.Client,
-	enterpriseJobs jobutil.EnterpriseJobs,
-	batchChanges BatchChangesResolver,
-	codeIntel CodeIntelResolver,
-	insights InsightsResolver,
-	authz AuthzResolver,
-	codeMonitors CodeMonitorsResolver,
-	license LicenseResolver,
-	dotcom DotcomRootResolver,
-	searchContexts SearchContextsResolver,
-	notebooks NotebooksResolver,
-	compute ComputeResolver,
-	insightsAggregation InsightsAggregationResolver,
-	webhooksResolver WebhooksResolver,
-	embeddingsResolver EmbeddingsResolver,
-	rbacResolver RBACResolver,
-	ownResolver OwnResolver,
-) (*graphql.Schema, error) {
-	return NewSchemaGucci(db, gitserverClient, enterpriseJobs, OptionalResolver{
-		BatchChangesResolver:        batchChanges,
-		CodeIntelResolver:           codeIntel,
-		InsightsResolver:            insights,
-		AuthzResolver:               authz,
-		CodeMonitorsResolver:        codeMonitors,
-		LicenseResolver:             license,
-		DotcomRootResolver:          dotcom,
-		SearchContextsResolver:      searchContexts,
-		NotebooksResolver:           notebooks,
-		ComputeResolver:             compute,
-		InsightsAggregationResolver: insightsAggregation,
-		WebhooksResolver:            webhooksResolver,
-		EmbeddingsResolver:          embeddingsResolver,
-		RBACResolver:                rbacResolver,
-		OwnResolver:                 ownResolver,
-	})
-}
-
-func NewSchemaGucci(
 	db database.DB,
 	gitserverClient gitserver.Client,
 	enterpriseJobs jobutil.EnterpriseJobs,

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -383,39 +383,39 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{})
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{NotebooksResolver: notebooks})
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{AuthzResolver: authz})
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{BatchChangesResolver: batchChanges})
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{CodeMonitorsResolver: codeMonitors})
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{LicenseResolver: license})
 }
 
 func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, webhooksResolver, nil, nil, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{WebhooksResolver: webhooksResolver})
 }
 
 func NewSchemaWithRBACResolver(db database.DB, rbacResolver RBACResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, rbacResolver, nil)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{RBACResolver: rbacResolver})
 }
 
 func NewSchemaWithOwnResolver(db database.DB, own OwnResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, own)
+	return NewSchemaGucci(db, gitserver.NewClient(), nil, OptionalResolver{OwnResolver: own})
 }
 
 func NewSchema(

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -25,7 +25,7 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchemaGucci(db, gitserverClient, nil, OptionalResolver{})
+	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, OptionalResolver{})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -25,7 +25,7 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, parseSchemaErr := NewSchemaGucci(db, gitserverClient, nil, OptionalResolver{})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -203,7 +203,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })
 	goroutine.Go(func() { users.StartUpdateAggregatedUsersStatisticsTable(context.Background(), db) })
 
-	schema, err := graphqlbackend.NewSchemaGucci(
+	schema, err := graphqlbackend.NewSchema(
 		db,
 		gitserver.NewClient(),
 		enterpriseServices.EnterpriseSearchJobs,

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -203,25 +203,11 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })
 	goroutine.Go(func() { users.StartUpdateAggregatedUsersStatisticsTable(context.Background(), db) })
 
-	schema, err := graphqlbackend.NewSchema(
+	schema, err := graphqlbackend.NewSchemaGucci(
 		db,
 		gitserver.NewClient(),
 		enterpriseServices.EnterpriseSearchJobs,
-		enterpriseServices.BatchChangesResolver,
-		enterpriseServices.CodeIntelResolver,
-		enterpriseServices.InsightsResolver,
-		enterpriseServices.AuthzResolver,
-		enterpriseServices.CodeMonitorsResolver,
-		enterpriseServices.LicenseResolver,
-		enterpriseServices.DotcomResolver,
-		enterpriseServices.SearchContextsResolver,
-		enterpriseServices.NotebooksResolver,
-		enterpriseServices.ComputeResolver,
-		enterpriseServices.InsightsAggregationResolver,
-		enterpriseServices.WebhooksResolver,
-		enterpriseServices.EmbeddingsResolver,
-		enterpriseServices.RBACResolver,
-		enterpriseServices.OwnResolver,
+		enterpriseServices.OptionalResolver,
 	)
 	if err != nil {
 		return err

--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -47,7 +47,7 @@ func Init(
 ) error {
 	// Only enabled on Sourcegraph.com.
 	if envvar.SourcegraphDotComMode() {
-		enterpriseServices.DotcomResolver = dotcomRootResolver{
+		enterpriseServices.DotcomRootResolver = dotcomRootResolver{
 			ProductSubscriptionLicensingResolver: productsubscription.ProductSubscriptionLicensingResolver{
 				DB: db,
 			},

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -89,7 +89,7 @@ func TestBlobOwnershipPanelQueryPersonUnresolved(t *testing.T) {
 		return "42", nil
 	}
 	git := fakeGitserver{}
-	schema, err := graphqlbackend.NewSchema(db, git, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, resolvers.New(db, git, own))
+	schema, err := graphqlbackend.NewSchemaGucci(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.New(db, git, own)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -89,7 +89,7 @@ func TestBlobOwnershipPanelQueryPersonUnresolved(t *testing.T) {
 		return "42", nil
 	}
 	git := fakeGitserver{}
-	schema, err := graphqlbackend.NewSchemaGucci(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.New(db, git, own)})
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.New(db, git, own)})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Note: This is an experimental change to gather feedback. However, if it has enough approval I'll land it (which is why it isn't a draft).

This change is motivated by the very large query params we pass to NewSchema. Over a series of mechanical refactors we replace all the optional resolvers with a struct OptionalResolver. We then use embedding so everything just keeps ticking along like before.

Best reviewed commit by commit.

The main downside I imagine of this change is it is slightly easier to forget to set the field when we call it for reals in frontends setup. But you could of just as easily forget to set the fields in the enterpriseServices struct before.

Test Plan: CI
