### PR TITLE
bitbucketserver: fix go test error in 1.20

### DIFF
--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1155,7 +1155,7 @@ func TestAuth(t *testing.T) {
 			} else if have.Client.Client.Credentials.Token != "foo" {
 				t.Errorf("unexpected token: have=%q want=%q", have.Client.Client.Credentials.Token, "foo")
 			} else if !key.Equal(have.Client.Client.PrivateKey) {
-				t.Errorf("unexpected key: have=%q want=%q", have.Client.Client.PrivateKey, key)
+				t.Errorf("unexpected key: have=%v want=%v", have.Client.Client.PrivateKey, key)
 			}
 		})
 	})


### PR DESCRIPTION
"%q" is not valid for these types and in go1.20 go test will error out. This is the only go lint error in our codebase currently that breaks in 1.20.

Test Plan: go test with go1.20