### PR TITLE
experimental search input: Hide search type buttons in history mode

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -341,7 +341,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
 
     const focus = useCallback(() => {
         editorRef.current?.contentDOM.focus()
-    }, [editorRef])
+    }, [])
 
     const toggleHistoryMode = useCallback(() => {
         if (editorRef.current) {
@@ -369,7 +369,7 @@ export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
                         {mode && <span className="ml-1">{mode}:</span>}
                     </div>
                     <div ref={editorContainerRef} className="d-contents" />
-                    {children}
+                    {!mode && children}
                 </div>
                 <div ref={setSuggestionsContainer} className={styles.suggestions} />
             </div>


### PR DESCRIPTION
This commit updates the input so that the search type buttons are hidden when history mode is active.

<img width="807" alt="2023-03-06_19-21" src="https://user-images.githubusercontent.com/179026/223211608-dcf65759-f6da-49b9-acdf-ca988ab05f8b.png">


## Test plan

- Search buttons are visible by default
- Active history mode: search buttons disappear

## App preview:

- [Web](https://sg-web-fkling-search-input-mode-buttons.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
