### PR TITLE
app: allow running without ctags/docker

### DIFF
--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -105,7 +105,7 @@ func NewHandler(
 
 	// Initialize the legacy JSON API server
 	mux := http.NewServeMux()
-	mux.HandleFunc("/search", handleSearchWith(jsonLogger, searchFuncWrapper, ctagsBinary))
+	mux.HandleFunc("/search", handleSearchWith(jsonLogger, searchFuncWrapper))
 	mux.HandleFunc("/healthz", handleHealthCheck(jsonLogger))
 	mux.HandleFunc("/list-languages", handleListLanguages(ctagsBinary))
 
@@ -117,7 +117,7 @@ func NewHandler(
 	return internalgrpc.MultiplexHandlers(grpcServer, mux)
 }
 
-func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc, ctagsBinary string) http.HandlerFunc {
+func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var args search.SymbolsParameters
 		if err := json.NewDecoder(r.Body).Decode(&args); err != nil {

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 
@@ -58,8 +59,13 @@ func LoadCtagsConfig(baseConfig env.BaseConfig) CtagsConfig {
 		logCtagsErrorsDefault = "true"
 	}
 
+	ctagsCommandDefault := "universal-ctags"
+	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
+	if isSingleProgram {
+		ctagsCommandDefault = ""
+	}
 	return CtagsConfig{
-		Command:            baseConfig.Get("CTAGS_COMMAND", "universal-ctags", "ctags command (should point to universal-ctags executable compiled with JSON and seccomp support)"),
+		Command:            baseConfig.Get("CTAGS_COMMAND", ctagsCommandDefault, "ctags command (should point to universal-ctags executable compiled with JSON and seccomp support)"),
 		PatternLengthLimit: baseConfig.GetInt("CTAGS_PATTERN_LENGTH_LIMIT", "250", "the maximum length of the patterns output by ctags"),
 		LogErrors:          baseConfig.GetBool("LOG_CTAGS_ERRORS", logCtagsErrorsDefault, "log ctags errors"),
 		DebugLogs:          false,

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -3,11 +3,15 @@
 package singleprogram
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
@@ -134,16 +138,72 @@ func Init(logger log.Logger) {
 
 	setDefaultEnv(logger, "CTAGS_PROCESSES", "2")
 
+	haveDocker := isDockerAvailable()
+	if !haveDocker {
+		printStatusCheckError(
+			"Docker is unavailable",
+			"Sourcegraph is better when Docker is available; some features may not work:",
+			"- Batch changes",
+			"- Symbol search",
+			"- Symbols overview tab (on repository pages)",
+		)
+	}
+
 	// generate a shell script to run a ctags Docker image
 	// unless the environment is already set up to find ctags
 	ctagsPath := os.Getenv("CTAGS_COMMAND")
 	if stat, err := os.Stat(ctagsPath); err != nil || stat.IsDir() {
-		// Write script that invokes universal-ctags via Docker.
-		// TODO(sqs): TODO(single-binary): stop relying on a ctags Docker image
-		ctagsPath = filepath.Join(cacheDir, "universal-ctags-dev")
-		writeFile(ctagsPath, []byte(universalCtagsDevScript), 0700)
-		setDefaultEnv(logger, "CTAGS_COMMAND", ctagsPath)
+		// Write script that invokes universal-ctags via Docker, if Docker is available.
+		// TODO(single-binary): stop relying on a ctags Docker image
+		if haveDocker {
+			ctagsPath = filepath.Join(cacheDir, "universal-ctags-dev")
+			writeFile(ctagsPath, []byte(universalCtagsDevScript), 0700)
+			setDefaultEnv(logger, "CTAGS_COMMAND", ctagsPath)
+		}
 	}
+}
+
+func printStatusCheckError(title, description string, details ...string) {
+	pad := func(s string, n int) string {
+		spaces := n - len(s)
+		if spaces < 0 {
+			spaces = 0
+		}
+		return s + strings.Repeat(" ", spaces)
+	}
+
+	newLine := "\033[0m\n"
+	titleRed := color.New(color.FgRed, color.BgYellow, color.Bold)
+	titleRed.Fprintf(os.Stderr, "|------------------------------------------------------------------------------|"+newLine)
+	titleRed.Fprintf(os.Stderr, "| %s |"+newLine, pad(title, 76))
+	titleRed.Fprintf(os.Stderr, "|------------------------------------------------------------------------------|"+newLine)
+
+	subline := func(s string) string {
+		return color.RedString("%s %s %s"+newLine, titleRed.Sprint("|"), pad(s, 76), titleRed.Sprint("|"))
+	}
+	msg := subline(description)
+	msg += subline("")
+	for _, detail := range details {
+		msg += subline(detail)
+	}
+	msg += subline("")
+	fmt.Fprintf(os.Stderr, "%s", msg)
+	titleRed.Fprintf(os.Stderr, "|------------------------------------------------------------------------------|"+newLine)
+}
+
+func isDockerAvailable() bool {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return false
+	}
+
+	cmd := exec.Command("docker", "stats", "--no-stream")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
 }
 
 // universalCtagsDevScript is copied from cmd/symbols/universal-ctags-dev.


### PR DESCRIPTION
Prior to this change, if you ran Sourcegraph App without Docker installed or running then when you ran a search request the backend would make numerous requests to the `symbols` service, which would then spew an _endless_ stream of errors to the console complaining that `docker run` failed as the App `CTAGS_COMMAND` tried to run ctags via Docker.

**I am actively working on bundling/building ctags into the Go binary** so that it will always be present and this will not be an issue, however, I need more time to fix that proper and right now this issue is *severe* and blocks us from showing App to more people: https://github.com/sourcegraph/sourcegraph/issues/48766

This change improves the current status quo substantially by adding a few `if isSingleProgram` conditions to simply disable `symbols` (have it return no results) if you are running App and ctags cannot be started via Docker. An easy to read message is also shown to the user to tell them Docker is missing and how it would make Sourcegraph better for them:

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/3173176/223233097-f184c4cd-c7a6-47bc-a437-bb301ef946f8.png">

Fixes #48766
Helps #47992

## Test plan

* Ran `sg start app` both with and without Docker running on my system, verified behavior of both.
* All changes are gated behind a `if isSingleProgram` conditional and so very low risk to other deployments.
