### PR TITLE
codeintel: Unblock auto-indexing experience frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The LSIF upload endpoint is no longer supported and has been replaced by a diagnostic error page. src-cli v4.5+ will translate all local LSIF files to SCIP prior to upload. [#47547](https://github.com/sourcegraph/sourcegraph/pull/47547)
 - The experimental setting `authz.syncJobsRecordsLimit` has been removed. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
 - Storing permissions sync jobs statuses in Redis has been removed as now all permissions sync related data is stored in a database. [#47933](https://github.com/sourcegraph/sourcegraph/pull/47933)
+- The key `shared_steps` has been removed from auto-indexing configuration descriptions. If you have a custom JSON auto-indexing configuration set for a repository that defines this key, you should inline the content into each index job's `steps` array. [#48770](https://github.com/sourcegraph/sourcegraph/pull/48770)
 
 ## 4.5.1
 

--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -31,14 +31,6 @@
   },
   "type": "object",
   "properties": {
-    "shared_steps": {
-      "description": "A set of pre-index steps that are performed before each index job.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/docker_step"
-      },
-      "additionalItems": false
-    },
     "index_jobs": {
       "description": "The set of index steps to be performed over a repository.",
       "type": "array",
@@ -89,5 +81,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["shared_steps", "index_jobs"]
+  "required": ["index_jobs"]
 }

--- a/client/web/src/enterprise/codeintel/configuration/schema.json
+++ b/client/web/src/enterprise/codeintel/configuration/schema.json
@@ -72,6 +72,13 @@
           "outfile": {
             "description": "The path to the LSIF index relative to the index root.",
             "type": "string"
+          },
+          "requestedEnvVars": {
+            "description": "A list of environment variables made available to the indexer.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false,

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -2008,6 +2008,11 @@ The configuration and execution summary of the indexer.
 """
 type IndexStep {
     """
+    Commands to run in the same image as the indexer but before the indexer is invoked.
+    """
+    commands: [String!]!
+
+    """
     The arguments to supply to the indexer container.
     """
     indexerArgs: [String!]!
@@ -2016,6 +2021,11 @@ type IndexStep {
     The path to the index file relative to the root directory (dump.lsif by default).
     """
     outfile: String
+
+    """
+    A list of environment variables (VAR=VAL) that should be made available to the indexer.
+    """
+    requestedEnvVars: [String!]
 
     """
     The execution summary (if completed or errored) of the index command.
@@ -2221,6 +2231,11 @@ type CodeIntelIndexer {
     URL to the source of the indexer e.g. https://github.com/sourcegraph/lsif-go
     """
     url: String!
+
+    """
+    A Docker image name used to distribute the indexer to the executor for via auto-indexing.
+    """
+    imageName: String
 }
 
 """

--- a/doc/code_navigation/references/auto_indexing_configuration.md
+++ b/doc/code_navigation/references/auto_indexing_configuration.md
@@ -10,46 +10,11 @@ This document details the expected contents of [explicit index job configuration
 
 ## Keys
 
-The root of the configuration has two top-level keys, `index_jobs` and `shared_steps`, documented below.
+The root of the configuration has one top-level key, `index_jobs`, documented below.
 
 ### [`index_jobs`](#index-jobs)
 
 The index jobs field defines a set of [index job objects](#index-job-object) describing the actions to perform to successfully index a fresh clone of a repository. Each index job is executed independently (and possibly in parallel) by an executor.
-
-### [`shared_steps`](#shared-steps)
-
-The shared steps field defines an ordered sequence of pre-indexing actions (formatted as a [Docker step object](#docker-step-object)). Each step is executed before each index job is executed. Shared steps are executed individually once _per indexing job_ and are designed to be used as a way of sharing code and common configuration for projects within a repository (but are not designed as a way to share compute resources).
-
-## Examples
-
-In the following example, we have a repository configured to index three different projects: `cmd/foo`, `cmd/bar`, and `cmd/baz`. These projects are executed concurrently by available executor processes. Each index job shares an initial step that runs a `setup.sh` script in the root of the repository and installs Go dependencies. The index job for `cmd/bar` additionally requires a code generation step, which is performed after the shared step but before the indexer invocation.
-
-```yaml
-shared_steps:
-  image: sourcegraph/lsif-go
-  commands:
-    - ./setup.sh      # Run a custom setup script
-    - go mod download # Download dependencies
-
-index_jobs:
-  # Index cmd/foo
-  - indexer: sourcegraph/lsif-go
-    root: cmd/foo
-
-  # Index cmd/bar
-  # Requires an additional codegen step
-  - indexer: sourcegraph/lsif-go
-    steps:
-      - image: sourcegraph/lsif-go
-        commands:
-          - go generate ./...
-        root: cmd/bar
-    root: cmd/bar
-  
-  # Index cmd/baz
-  - indexer: sourcegraph/lsif-go
-    root: cmd/baz
-```
 
 ## Index job object
 
@@ -72,7 +37,7 @@ Each indexing job object can be configured with the following keys.
 
 #### [`steps`](#index-job-steps)
 
-The steps field defines an ordered sequence of pre-indexing actions (formatted as a [Docker step object](#docker-step-object)). If `shared_steps` are defined in the top level of the configuration, those steps are **prepended** to this sequence. Each step is executed before the indexer itself is invoked.
+The steps field defines an ordered sequence of pre-indexing actions (formatted as a [Docker step object](#docker-step-object)). Each step is executed before the indexer itself is invoked.
 
 #### [`indexer`](#index-job-indexer)
 

--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
@@ -206,13 +206,6 @@ func (s *JobSelector) inferIndexRecordsFromRepositoryStructure(ctx context.Conte
 func convertIndexConfiguration(repositoryID int, commit string, indexConfiguration config.IndexConfiguration) (indexes []types.Index) {
 	for _, indexJob := range indexConfiguration.IndexJobs {
 		var dockerSteps []types.DockerStep
-		for _, dockerStep := range indexConfiguration.SharedSteps {
-			dockerSteps = append(dockerSteps, types.DockerStep{
-				Root:     dockerStep.Root,
-				Image:    dockerStep.Image,
-				Commands: dockerStep.Commands,
-			})
-		}
 		for _, dockerStep := range indexJob.Steps {
 			dockerSteps = append(dockerSteps, types.DockerStep{
 				Root:     dockerStep.Root,

--- a/enterprise/internal/codeintel/autoindexing/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/service_test.go
@@ -25,15 +25,6 @@ func init() {
 
 func TestQueueIndexesExplicit(t *testing.T) {
 	conf := `{
-		"shared_steps": [
-			{
-				"root": "/",
-				"image": "node:12",
-				"commands": [
-					"yarn install --frozen-lockfile --non-interactive",
-				],
-			}
-		],
 		"index_jobs": [
 			{
 				"steps": [
@@ -100,11 +91,6 @@ func TestQueueIndexesExplicit(t *testing.T) {
 			State:        "queued",
 			DockerSteps: []types.DockerStep{
 				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-				{
 					Image:    "go:latest",
 					Commands: []string{"go mod vendor"},
 				},
@@ -116,17 +102,11 @@ func TestQueueIndexesExplicit(t *testing.T) {
 			RepositoryID: 42,
 			Commit:       "c42",
 			State:        "queued",
-			DockerSteps: []types.DockerStep{
-				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-			},
-			Root:        "web/",
-			Indexer:     "scip-typescript",
-			IndexerArgs: []string{"index", "--no-progress-bar"},
-			Outfile:     "lsif.dump",
+			DockerSteps:  nil,
+			Root:         "web/",
+			Indexer:      "scip-typescript",
+			IndexerArgs:  []string{"index", "--no-progress-bar"},
+			Outfile:      "lsif.dump",
 		},
 	}
 	if diff := cmp.Diff(expectedIndexes, indexes); diff != "" {
@@ -139,15 +119,6 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 		ID:           1,
 		RepositoryID: 42,
 		Data: []byte(`{
-			"shared_steps": [
-				{
-					"root": "/",
-					"image": "node:12",
-					"commands": [
-						"yarn install --frozen-lockfile --non-interactive",
-					],
-				}
-			],
 			"index_jobs": [
 				{
 					"steps": [
@@ -230,11 +201,6 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 			State:        "queued",
 			DockerSteps: []types.DockerStep{
 				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-				{
 					Image:    "go:latest",
 					Commands: []string{"go mod vendor"},
 				},
@@ -246,17 +212,11 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 			RepositoryID: 42,
 			Commit:       "c42",
 			State:        "queued",
-			DockerSteps: []types.DockerStep{
-				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-			},
-			Root:        "web/",
-			Indexer:     "scip-typescript",
-			IndexerArgs: []string{"index", "--no-progress-bar"},
-			Outfile:     "lsif.dump",
+			DockerSteps:  nil,
+			Root:         "web/",
+			Indexer:      "scip-typescript",
+			IndexerArgs:  []string{"index", "--no-progress-bar"},
+			Outfile:      "lsif.dump",
 		},
 	}
 	if diff := cmp.Diff(expectedIndexes, indexes); diff != "" {
@@ -265,12 +225,6 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 }
 
 var yamlIndexConfiguration = []byte(`
-shared_steps:
-  - root: /
-    image: node:12
-    commands:
-      - yarn install --frozen-lockfile --non-interactive
-
 index_jobs:
   -
     steps:
@@ -340,11 +294,6 @@ func TestQueueIndexesInRepository(t *testing.T) {
 			State:        "queued",
 			DockerSteps: []types.DockerStep{
 				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-				{
 					Image:    "go:latest",
 					Commands: []string{"go mod vendor"},
 				},
@@ -356,17 +305,11 @@ func TestQueueIndexesInRepository(t *testing.T) {
 			RepositoryID: 42,
 			Commit:       "c42",
 			State:        "queued",
-			DockerSteps: []types.DockerStep{
-				{
-					Root:     "/",
-					Image:    "node:12",
-					Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-				},
-			},
-			Root:        "web/",
-			Indexer:     "scip-typescript",
-			IndexerArgs: []string{"index", "--no-progress-bar"},
-			Outfile:     "lsif.dump",
+			DockerSteps:  nil,
+			Root:         "web/",
+			Indexer:      "scip-typescript",
+			IndexerArgs:  []string{"index", "--no-progress-bar"},
+			Outfile:      "lsif.dump",
 		},
 	}
 	if diff := cmp.Diff(expectedIndexes, indexes); diff != "" {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/codeintel_tree_info_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/codeintel_tree_info_resolver.go
@@ -83,7 +83,7 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) (resolve
 				resolvers = append(resolvers, &codeIntelTreePreciseCoverageResolver{
 					confidence: indexJobInfered,
 					// drop the tag if it exists
-					indexer: codeinteltypes.NewCodeIntelIndexerResolver(job.Indexer),
+					indexer: codeinteltypes.NewCodeIntelIndexerResolver(job.Indexer, ""),
 				})
 			}
 		}
@@ -103,7 +103,7 @@ func (r *codeIntelTreeInfoResolver) PreciseSupport(ctx context.Context) (resolve
 			resolvers = append(resolvers, &codeIntelTreePreciseCoverageResolver{
 				confidence: confidence,
 				// expected that job hints don't include a tag in the indexer name
-				indexer: codeinteltypes.NewCodeIntelIndexerResolver(hint.Indexer),
+				indexer: codeinteltypes.NewCodeIntelIndexerResolver(hint.Indexer, ""),
 			})
 		}
 	}

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_based_support_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_based_support_resolver.go
@@ -25,7 +25,7 @@ func NewPreciseCodeIntelSupportResolver(filepath string) resolverstubs.PreciseSu
 
 	resolvers := make([]resolverstubs.CodeIntelIndexerResolver, 0, len(indexers))
 	for _, indexer := range indexers {
-		resolvers = append(resolvers, types.NewCodeIntelIndexerResolverFrom(indexer))
+		resolvers = append(resolvers, types.NewCodeIntelIndexerResolverFrom(indexer, ""))
 	}
 
 	return &preciseCodeIntelSupportResolver{

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
@@ -41,7 +41,7 @@ func (r *rootResolver) IndexerKeys(ctx context.Context, args *resolverstubs.Inde
 
 	keyMap := map[string]struct{}{}
 	for _, indexer := range indexers {
-		keyMap[types.NewCodeIntelIndexerResolver(indexer).Key()] = struct{}{}
+		keyMap[types.NewCodeIntelIndexerResolver(indexer, "").Key()] = struct{}{}
 	}
 
 	var keys []string

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -293,7 +293,7 @@ func (r *autoIndexJobDescriptionResolver) Root() string {
 }
 
 func (r *autoIndexJobDescriptionResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	return types.NewCodeIntelIndexerResolver(r.indexJob.Indexer)
+	return types.NewCodeIntelIndexerResolver(r.indexJob.Indexer, r.indexJob.Indexer)
 }
 
 func (r *autoIndexJobDescriptionResolver) ComparisonKey() string {

--- a/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
@@ -128,5 +128,5 @@ func (r *indexResolver) ProjectRoot(ctx context.Context) (_ resolverstubs.GitTre
 }
 
 func (r *indexResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	return types.NewCodeIntelIndexerResolver(r.index.Indexer)
+	return types.NewCodeIntelIndexerResolver(r.index.Indexer, r.index.Indexer)
 }

--- a/enterprise/internal/codeintel/shared/resolvers/index_step_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_step_resolver.go
@@ -20,8 +20,16 @@ func NewIndexStepResolver(siteAdminChecker SiteAdminChecker, index types.Index, 
 	}
 }
 
+func (r *indexStepResolver) Commands() []string    { return r.index.LocalSteps }
 func (r *indexStepResolver) IndexerArgs() []string { return r.index.IndexerArgs }
 func (r *indexStepResolver) Outfile() *string      { return strPtr(r.index.Outfile) }
+
+func (r *indexStepResolver) RequestedEnvVars() *[]string {
+	if len(r.index.RequestedEnvVars) == 0 {
+		return nil
+	}
+	return &r.index.RequestedEnvVars
+}
 
 func (r *indexStepResolver) LogEntry() resolverstubs.ExecutionLogEntryResolver {
 	if r.entry != nil {

--- a/enterprise/internal/codeintel/shared/resolvers/indexes_repository_namespace_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/indexes_repository_namespace_resolver.go
@@ -23,7 +23,7 @@ func (r *lsifIndexesWithRepositoryNamespaceResolver) Root() string {
 }
 
 func (r *lsifIndexesWithRepositoryNamespaceResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	return types.NewCodeIntelIndexerResolver(r.indexesSummary.Indexer)
+	return types.NewCodeIntelIndexerResolver(r.indexesSummary.Indexer, "")
 }
 
 func (r *lsifIndexesWithRepositoryNamespaceResolver) Indexes() []resolverstubs.LSIFIndexResolver {

--- a/enterprise/internal/codeintel/shared/resolvers/summary.go
+++ b/enterprise/internal/codeintel/shared/resolvers/summary.go
@@ -196,7 +196,7 @@ func (r *codeIntelRepositoryWithConfigurationResolver) Indexers() []resolverstub
 	var resolvers []resolverstubs.IndexerWithCountResolver
 	for indexer, meta := range r.availableIndexers {
 		resolvers = append(resolvers, &indexerWithCountResolver{
-			indexer: types.NewCodeIntelIndexerResolver(indexer),
+			indexer: types.NewCodeIntelIndexerResolver(indexer, ""),
 			count:   int32(len(meta.Roots)),
 		})
 	}
@@ -271,7 +271,7 @@ func (r *repositorySummaryResolver) RecentUploads() []resolverstubs.LSIFUploadsW
 func (r *repositorySummaryResolver) AvailableIndexers() []resolverstubs.InferredAvailableIndexersResolver {
 	resolvers := make([]resolverstubs.InferredAvailableIndexersResolver, 0, len(r.availableIndexers))
 	for _, indexer := range r.availableIndexers {
-		resolvers = append(resolvers, resolverstubs.NewInferredAvailableIndexersResolver(types.NewCodeIntelIndexerResolverFrom(indexer.Indexer), indexer.Roots))
+		resolvers = append(resolvers, resolverstubs.NewInferredAvailableIndexersResolver(types.NewCodeIntelIndexerResolverFrom(indexer.Indexer, ""), indexer.Roots))
 	}
 	return resolvers
 }

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
@@ -148,7 +148,7 @@ func (r *UploadResolver) RetentionPolicyOverview(ctx context.Context, args *reso
 }
 
 func (r *UploadResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	return types.NewCodeIntelIndexerResolver(r.upload.Indexer)
+	return types.NewCodeIntelIndexerResolver(r.upload.Indexer, "")
 }
 
 func (r *UploadResolver) DocumentPaths(ctx context.Context, args *resolverstubs.LSIFUploadDocumentPathsQueryArgs) (resolverstubs.LSIFUploadDocumentPathsConnectionResolver, error) {

--- a/enterprise/internal/codeintel/shared/resolvers/uploads_repository_namespace_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/uploads_repository_namespace_resolver.go
@@ -23,7 +23,7 @@ func (r *lsifUploadsWithRepositoryNamespaceResolver) Root() string {
 }
 
 func (r *lsifUploadsWithRepositoryNamespaceResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
-	return types.NewCodeIntelIndexerResolver(r.uploadsSummary.Indexer)
+	return types.NewCodeIntelIndexerResolver(r.uploadsSummary.Indexer, "")
 }
 
 func (r *lsifUploadsWithRepositoryNamespaceResolver) Uploads() []resolverstubs.LSIFUploadResolver {

--- a/enterprise/internal/codeintel/shared/types/indexer_resolver.go
+++ b/enterprise/internal/codeintel/shared/types/indexer_resolver.go
@@ -6,14 +6,16 @@ type CodeIntelIndexerResolver interface {
 	Key() string
 	Name() string
 	URL() string
+	ImageName() *string
 }
 
 type codeIntelIndexerResolver struct {
-	indexer CodeIntelIndexer
+	indexer   CodeIntelIndexer
+	imageName string
 }
 
-func NewCodeIntelIndexerResolver(name string) CodeIntelIndexerResolver {
-	return NewCodeIntelIndexerResolverFrom(indexerFromName(name))
+func NewCodeIntelIndexerResolver(name, imageName string) CodeIntelIndexerResolver {
+	return NewCodeIntelIndexerResolverFrom(indexerFromName(name), imageName)
 }
 
 func indexerFromName(name string) CodeIntelIndexer {
@@ -34,8 +36,8 @@ func indexerFromName(name string) CodeIntelIndexer {
 	return CodeIntelIndexer{Name: name}
 }
 
-func NewCodeIntelIndexerResolverFrom(indexer CodeIntelIndexer) CodeIntelIndexerResolver {
-	return &codeIntelIndexerResolver{indexer: indexer}
+func NewCodeIntelIndexerResolverFrom(indexer CodeIntelIndexer, imageName string) CodeIntelIndexerResolver {
+	return &codeIntelIndexerResolver{indexer: indexer, imageName: imageName}
 }
 
 func (r *codeIntelIndexerResolver) Key() string {
@@ -52,4 +54,12 @@ func (r *codeIntelIndexerResolver) URL() string {
 	}
 
 	return "https://" + r.indexer.URN
+}
+
+func (r *codeIntelIndexerResolver) ImageName() *string {
+	if r.imageName == "" {
+		return nil
+	}
+
+	return &r.imageName
 }

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -374,6 +374,7 @@ type CodeIntelIndexerResolver interface {
 	Key() string
 	Name() string
 	URL() string
+	ImageName() *string
 }
 
 type IndexConfigurationResolver interface {
@@ -661,8 +662,10 @@ type LSIFUploadsAuditLogsResolver interface {
 }
 
 type IndexStepResolver interface {
+	Commands() []string
 	IndexerArgs() []string
 	Outfile() *string
+	RequestedEnvVars() *[]string
 	LogEntry() ExecutionLogEntryResolver
 }
 

--- a/lib/codeintel/autoindex/config/json.go
+++ b/lib/codeintel/autoindex/config/json.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/jsonx"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -14,14 +15,6 @@ func MarshalJSON(config IndexConfiguration) ([]byte, error) {
 	nonNil := config
 	if nonNil.IndexJobs == nil {
 		nonNil.IndexJobs = []IndexJob{}
-	}
-	if nonNil.SharedSteps == nil {
-		nonNil.SharedSteps = []DockerStep{}
-	}
-	for idx := range nonNil.SharedSteps {
-		if nonNil.SharedSteps[idx].Commands == nil {
-			nonNil.SharedSteps[idx].Commands = []string{}
-		}
 	}
 	for idx := range nonNil.IndexJobs {
 		if nonNil.IndexJobs[idx].IndexerArgs == nil {

--- a/lib/codeintel/autoindex/config/json_test.go
+++ b/lib/codeintel/autoindex/config/json_test.go
@@ -8,15 +8,6 @@ import (
 
 const jsonTestInput = `
 {
-	"shared_steps": [
-		{
-			"root": "/",
-			"image": "node:12",
-			"commands": [
-				"yarn install --frozen-lockfile --non-interactive",
-			],
-		}
-	],
 	"index_jobs": [
 		{
 			"steps": [
@@ -46,13 +37,6 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 
 	expected := IndexConfiguration{
-		SharedSteps: []DockerStep{
-			{
-				Root:     "/",
-				Image:    "node:12",
-				Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-			},
-		},
 		IndexJobs: []IndexJob{
 			{
 				Steps: []DockerStep{

--- a/lib/codeintel/autoindex/config/types.go
+++ b/lib/codeintel/autoindex/config/types.go
@@ -3,8 +3,7 @@ package config
 import "strings"
 
 type IndexConfiguration struct {
-	SharedSteps []DockerStep `json:"shared_steps" yaml:"shared_steps"`
-	IndexJobs   []IndexJob   `json:"index_jobs" yaml:"index_jobs"`
+	IndexJobs []IndexJob `json:"index_jobs" yaml:"index_jobs"`
 }
 
 type IndexJob struct {

--- a/lib/codeintel/autoindex/config/yaml_test.go
+++ b/lib/codeintel/autoindex/config/yaml_test.go
@@ -7,12 +7,6 @@ import (
 )
 
 const yamlTestInput = `
-shared_steps:
-  - root: /
-    image: node:12
-    commands:
-      - yarn install --frozen-lockfile --non-interactive
-
 index_jobs:
   -
     steps:
@@ -36,13 +30,6 @@ func TestUnmarshalYAML(t *testing.T) {
 	}
 
 	expected := IndexConfiguration{
-		SharedSteps: []DockerStep{
-			{
-				Root:     "/",
-				Image:    "node:12",
-				Commands: []string{"yarn install --frozen-lockfile --non-interactive"},
-			},
-		},
 		IndexJobs: []IndexJob{
 			{
 				Steps: []DockerStep{


### PR DESCRIPTION
@umpox had a short list of things he needed from the backend:

- Expose requestedEnvVars via GraphQL(also also add it to the JSON schema)
- Expose the Docker image name for indexer types via GraphQL
- Expose the pre-index commands via GraphQL

```graphql
{
  inferAutoIndexJobsForRepo(repository: "UmVwb3NpdG9yeToyMTE3NjM4") {
    steps {
      preIndex {
        commands
        image
        root
      }
      index {
        commands
        indexerArgs
        requestedEnvVars
      }
    }
    indexer {
      imageName
    }
  }
}
```

![image](https://user-images.githubusercontent.com/103087/223236888-8ca476d2-3422-41e2-bea7-d51ec79dd337.png)

We also agreed to remove `shared_steps` as a concept from the YAML/JSON configuration as it really muddies up the form-builder type of UX we're going for. This feature appears completely unused.

## Test plan

Updated unit tests.