### PR TITLE
ranking: Expose new graph key setting

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/background/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/ranking.go
@@ -216,5 +216,9 @@ func reduceRankingGraph(
 // a fresh map/reduce job on a periodic cadence (equal to the bucket length). Changing the
 // parent graph key will also create a new map/reduce job (without switching buckets).
 func getCurrentGraphKey(now time.Time) string {
-	return fmt.Sprintf("%s-%d", conf.CodeIntelRankingDocumentReferenceCountsGraphKey(), now.UTC().Unix()/int64(conf.CodeIntelRankingStaleResultAge().Seconds()))
+	return fmt.Sprintf("%s-%s-%d",
+		conf.CodeIntelRankingDocumentReferenceCountsGraphKey(),
+		conf.CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix(),
+		now.UTC().Unix()/int64(conf.CodeIntelRankingStaleResultAge().Seconds()),
+	)
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -280,6 +280,13 @@ func CodeIntelRankingDocumentReferenceCountsGraphKey() string {
 	return "dev"
 }
 
+func CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix() string {
+	if val := Get().CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix; val != "" {
+		return val
+	}
+	return ""
+}
+
 func CodeIntelRankingStaleResultAge() time.Duration {
 	if val := Get().CodeIntelRankingStaleResultsAge; val > 0 {
 		return time.Duration(val) * time.Hour

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2364,9 +2364,11 @@ type SiteConfiguration struct {
 	CodeIntelAutoIndexingIndexerMap map[string]string `json:"codeIntelAutoIndexing.indexerMap,omitempty"`
 	// CodeIntelAutoIndexingPolicyRepositoryMatchLimit description: The maximum number of repositories to which a single auto-indexing policy can apply. Default is -1, which is unlimited.
 	CodeIntelAutoIndexingPolicyRepositoryMatchLimit *int `json:"codeIntelAutoIndexing.policyRepositoryMatchLimit,omitempty"`
+	// CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix description: An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).
+	CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix string `json:"codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix,omitempty"`
 	// CodeIntelRankingDocumentReferenceCountsEnabled description: Enables/disables the document reference counts feature. Currently experimental.
 	CodeIntelRankingDocumentReferenceCountsEnabled *bool `json:"codeIntelRanking.documentReferenceCountsEnabled,omitempty"`
-	// CodeIntelRankingDocumentReferenceCountsGraphKey description: The string used to group document reference counts for a single graph
+	// CodeIntelRankingDocumentReferenceCountsGraphKey description: An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).
 	CodeIntelRankingDocumentReferenceCountsGraphKey string `json:"codeIntelRanking.documentReferenceCountsGraphKey,omitempty"`
 	// CodeIntelRankingStaleResultsAge description: The interval at which to run the reduce job that computes document reference counts. Default is 72hrs.
 	CodeIntelRankingStaleResultsAge int `json:"codeIntelRanking.staleResultsAge,omitempty"`
@@ -2596,6 +2598,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "codeIntelAutoIndexing.enabled")
 	delete(m, "codeIntelAutoIndexing.indexerMap")
 	delete(m, "codeIntelAutoIndexing.policyRepositoryMatchLimit")
+	delete(m, "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix")
 	delete(m, "codeIntelRanking.documentReferenceCountsEnabled")
 	delete(m, "codeIntelRanking.documentReferenceCountsGraphKey")
 	delete(m, "codeIntelRanking.staleResultsAge")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -635,10 +635,16 @@
       "default": false
     },
     "codeIntelRanking.documentReferenceCountsGraphKey": {
-      "description": "The string used to group document reference counts for a single graph",
+      "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
       "examples": ["dev"]
+    },
+    "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
+      "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
+      "type": "string",
+      "group": "Code intelligence",
+      "examples": [""]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 72hrs.",


### PR DESCRIPTION
We want to be able to bump the (non-export) part of the graph but that currently only happens on a timer. Inserting a default empty string in the graph key so that we can change it at-will via site settings.

Will help us bump S2 on command.

## Test plan

:shrug: