### PR TITLE
rbac: create utility function for checking permission

### DIFF
--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -36857,6 +36857,9 @@ type MockPermissionStore struct {
 	// GetByIDFunc is an instance of a mock function object controlling the
 	// behavior of the method GetByID.
 	GetByIDFunc *PermissionStoreGetByIDFunc
+	// GetPermissionForUserFunc is an instance of a mock function object
+	// controlling the behavior of the method GetPermissionForUser.
+	GetPermissionForUserFunc *PermissionStoreGetPermissionForUserFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *PermissionStoreHandleFunc
@@ -36900,6 +36903,11 @@ func NewMockPermissionStore() *MockPermissionStore {
 		},
 		GetByIDFunc: &PermissionStoreGetByIDFunc{
 			defaultHook: func(context.Context, GetPermissionOpts) (r0 *types.Permission, r1 error) {
+				return
+			},
+		},
+		GetPermissionForUserFunc: &PermissionStoreGetPermissionForUserFunc{
+			defaultHook: func(context.Context, GetPermissionForUserOpts) (r0 *types.Permission, r1 error) {
 				return
 			},
 		},
@@ -36955,6 +36963,11 @@ func NewStrictMockPermissionStore() *MockPermissionStore {
 				panic("unexpected invocation of MockPermissionStore.GetByID")
 			},
 		},
+		GetPermissionForUserFunc: &PermissionStoreGetPermissionForUserFunc{
+			defaultHook: func(context.Context, GetPermissionForUserOpts) (*types.Permission, error) {
+				panic("unexpected invocation of MockPermissionStore.GetPermissionForUser")
+			},
+		},
 		HandleFunc: &PermissionStoreHandleFunc{
 			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockPermissionStore.Handle")
@@ -36995,6 +37008,9 @@ func NewMockPermissionStoreFrom(i PermissionStore) *MockPermissionStore {
 		},
 		GetByIDFunc: &PermissionStoreGetByIDFunc{
 			defaultHook: i.GetByID,
+		},
+		GetPermissionForUserFunc: &PermissionStoreGetPermissionForUserFunc{
+			defaultHook: i.GetPermissionForUser,
 		},
 		HandleFunc: &PermissionStoreHandleFunc{
 			defaultHook: i.Handle,
@@ -37647,6 +37663,117 @@ func (c PermissionStoreGetByIDFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c PermissionStoreGetByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// PermissionStoreGetPermissionForUserFunc describes the behavior when the
+// GetPermissionForUser method of the parent MockPermissionStore instance is
+// invoked.
+type PermissionStoreGetPermissionForUserFunc struct {
+	defaultHook func(context.Context, GetPermissionForUserOpts) (*types.Permission, error)
+	hooks       []func(context.Context, GetPermissionForUserOpts) (*types.Permission, error)
+	history     []PermissionStoreGetPermissionForUserFuncCall
+	mutex       sync.Mutex
+}
+
+// GetPermissionForUser delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockPermissionStore) GetPermissionForUser(v0 context.Context, v1 GetPermissionForUserOpts) (*types.Permission, error) {
+	r0, r1 := m.GetPermissionForUserFunc.nextHook()(v0, v1)
+	m.GetPermissionForUserFunc.appendCall(PermissionStoreGetPermissionForUserFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetPermissionForUser
+// method of the parent MockPermissionStore instance is invoked and the hook
+// queue is empty.
+func (f *PermissionStoreGetPermissionForUserFunc) SetDefaultHook(hook func(context.Context, GetPermissionForUserOpts) (*types.Permission, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetPermissionForUser method of the parent MockPermissionStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *PermissionStoreGetPermissionForUserFunc) PushHook(hook func(context.Context, GetPermissionForUserOpts) (*types.Permission, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *PermissionStoreGetPermissionForUserFunc) SetDefaultReturn(r0 *types.Permission, r1 error) {
+	f.SetDefaultHook(func(context.Context, GetPermissionForUserOpts) (*types.Permission, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *PermissionStoreGetPermissionForUserFunc) PushReturn(r0 *types.Permission, r1 error) {
+	f.PushHook(func(context.Context, GetPermissionForUserOpts) (*types.Permission, error) {
+		return r0, r1
+	})
+}
+
+func (f *PermissionStoreGetPermissionForUserFunc) nextHook() func(context.Context, GetPermissionForUserOpts) (*types.Permission, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *PermissionStoreGetPermissionForUserFunc) appendCall(r0 PermissionStoreGetPermissionForUserFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of PermissionStoreGetPermissionForUserFuncCall
+// objects describing the invocations of this function.
+func (f *PermissionStoreGetPermissionForUserFunc) History() []PermissionStoreGetPermissionForUserFuncCall {
+	f.mutex.Lock()
+	history := make([]PermissionStoreGetPermissionForUserFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// PermissionStoreGetPermissionForUserFuncCall is an object that describes
+// an invocation of method GetPermissionForUser on an instance of
+// MockPermissionStore.
+type PermissionStoreGetPermissionForUserFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 GetPermissionForUserOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *types.Permission
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c PermissionStoreGetPermissionForUserFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c PermissionStoreGetPermissionForUserFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -185,7 +185,7 @@ func TestPermissionDelete(t *testing.T) {
 		deleted, err := store.GetByID(ctx, GetPermissionOpts{ID: p.ID})
 		require.Nil(t, deleted)
 		require.Error(t, err)
-		require.Equal(t, err, &PermissionNotFoundErr{p.ID})
+		require.Equal(t, err, &PermissionNotFoundErr{ID: p.ID})
 	})
 
 	t.Run("non-existent role", func(t *testing.T) {
@@ -290,7 +290,7 @@ func TestPermissionBulkDelete(t *testing.T) {
 		deleted, err := store.GetByID(ctx, GetPermissionOpts{ID: ps[0].ID})
 		require.Nil(t, deleted)
 		require.Error(t, err)
-		require.Equal(t, err, &PermissionNotFoundErr{ps[0].ID})
+		require.Equal(t, err, &PermissionNotFoundErr{ID: ps[0].ID})
 	})
 }
 

--- a/internal/rbac/BUILD.bazel
+++ b/internal/rbac/BUILD.bazel
@@ -4,27 +4,40 @@ go_library(
     name = "rbac",
     srcs = [
         "permissions.go",
+        "permission.go",
         "types.go",
+        "parser.go",
     ],
     embedsrcs = ["schema.yaml"],
     importpath = "github.com/sourcegraph/sourcegraph/internal/rbac",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/actor",
+        "//internal/auth",
         "//internal/database",
         "//internal/types",
+        "//lib/errors",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
 
 go_test(
     name = "rbac_test",
-    srcs = ["permissions_test.go"],
+    srcs = [
+        "permissions_test.go",
+        "parser_test.go",
+        "permission_test.go",
+    ],
     embed = [":rbac"],
     deps = [
+        "//internal/actor",
+        "//internal/auth",
         "//internal/database",
+        "//internal/database/dbtest",
         "//internal/types",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
-        "@com_github_stretchr_testify//assert",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/rbac/parser.go
+++ b/internal/rbac/parser.go
@@ -1,8 +1,9 @@
 package rbac
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"

--- a/internal/rbac/parser.go
+++ b/internal/rbac/parser.go
@@ -1,0 +1,27 @@
+package rbac
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var permissionDisplayNameRegex = regexp.MustCompile(`^\w+#\w+$`)
+
+var invalidPermissionDisplayName = errors.New("permission display name is invalid.")
+
+// parsePermissionDisplayName parses a permission display name and returns the namespace and action.
+// It returns an error if the displayName is invalid.
+func parsePermissionDisplayName(displayName string) (namespace types.PermissionNamespace, action string, err error) {
+	if ok := permissionDisplayNameRegex.MatchString(displayName); ok {
+		parts := strings.Split(displayName, "#")
+
+		namespace = types.PermissionNamespace(parts[0])
+		action = parts[1]
+	} else {
+		err = invalidPermissionDisplayName
+	}
+	return namespace, action, err
+}

--- a/internal/rbac/parser_test.go
+++ b/internal/rbac/parser_test.go
@@ -1,0 +1,68 @@
+package rbac
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestParsePermissionDisplayName(t *testing.T) {
+	tests := []struct {
+		displayName string
+
+		namespace     types.PermissionNamespace
+		action        string
+		expectedError error
+
+		name string
+	}{
+		{
+			name:          "valid display name",
+			displayName:   fmt.Sprintf("%s#READ", types.BatchChangesNamespace),
+			namespace:     types.BatchChangesNamespace,
+			action:        "READ",
+			expectedError: nil,
+		},
+		{
+			name:          "display name without action",
+			displayName:   "BATCH_CHANGES#",
+			namespace:     "",
+			action:        "",
+			expectedError: invalidPermissionDisplayName,
+		},
+		{
+			name:          "display name without namespace",
+			displayName:   "#READ",
+			namespace:     "",
+			action:        "",
+			expectedError: invalidPermissionDisplayName,
+		},
+		{
+			name:          "display name without namespace and action",
+			displayName:   "#",
+			namespace:     "",
+			action:        "",
+			expectedError: invalidPermissionDisplayName,
+		},
+		{
+			name:          "empty string",
+			displayName:   "",
+			namespace:     "",
+			action:        "",
+			expectedError: invalidPermissionDisplayName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns, action, err := parsePermissionDisplayName(tc.displayName)
+
+			require.Equal(t, ns, tc.namespace)
+			require.Equal(t, action, tc.action)
+			require.Equal(t, err, tc.expectedError)
+		})
+	}
+}

--- a/internal/rbac/permission.go
+++ b/internal/rbac/permission.go
@@ -38,6 +38,12 @@ func CheckCurrentUserHasPermission(ctx context.Context, db database.DB, permissi
 		Action:    action,
 	})
 	if err != nil {
+		if errors.Is(err, &database.PermissionNotFoundErr{
+			Namespace: namespace,
+			Action:    action,
+		}) {
+			return ErrNotAuthorized
+		}
 		return err
 	}
 	// if permission is nil, it means the user doesn't have that permission

--- a/internal/rbac/permission.go
+++ b/internal/rbac/permission.go
@@ -1,0 +1,50 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var ErrNotAuthorized = errors.New("not authorized")
+
+// CheckCurrentUserHasPermission returns an error if the current user doesn't have a permission assigned to them.
+func CheckCurrentUserHasPermission(ctx context.Context, db database.DB, permission string) error {
+	if actor.FromContext(ctx).IsInternal() {
+		return nil
+	}
+
+	// We check the current user exists and is authenticated.
+	user, err := auth.CurrentUser(ctx, db)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return auth.ErrNotAuthenticated
+	}
+
+	namespace, action, err := parsePermissionDisplayName(permission)
+	if err != nil {
+		return err
+	}
+
+	perm, err := db.Permissions().GetPermissionForUser(ctx, database.GetPermissionForUserOpts{
+		UserID:    user.ID,
+		Namespace: namespace,
+		Action:    action,
+	})
+	if err != nil {
+		return err
+	}
+	// if permission is nil, it means the user doesn't have that permission
+	// assigned to any of their assigned roles.
+	if perm == nil {
+		return ErrNotAuthorized
+	}
+
+	return nil
+}

--- a/internal/rbac/permission_test.go
+++ b/internal/rbac/permission_test.go
@@ -1,0 +1,104 @@
+package rbac
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestCheckCurrentUserHasPermission(t *testing.T) {
+	ctx := context.Background()
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	newUser1 := database.NewUser{Username: "username-1"}
+	u1, err := db.Users().Create(ctx, newUser1)
+	require.NoError(t, err)
+
+	newUser2 := database.NewUser{Username: "username-2"}
+	u2, err := db.Users().Create(ctx, newUser2)
+	require.NoError(t, err)
+
+	p, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
+		Namespace: types.BatchChangesNamespace,
+		Action:    "EXECUTE",
+	})
+	require.NoError(t, err)
+
+	r, err := db.Roles().Create(ctx, "TEST-ROLE", false)
+	require.NoError(t, err)
+
+	err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
+		RoleID:       r.ID,
+		PermissionID: p.ID,
+	})
+	require.NoError(t, err)
+
+	err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
+		UserID: u2.ID,
+		RoleID: r.ID,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		context    context.Context
+		permission string
+
+		expectedErr error
+	}{
+		{
+			name:        "internal actor",
+			context:     actor.WithInternalActor(ctx),
+			permission:  "",
+			expectedErr: nil,
+		},
+		{
+			name:        "non-existent actor",
+			context:     actor.WithActor(ctx, &actor.Actor{UID: 9389}),
+			permission:  "",
+			expectedErr: auth.ErrNotAuthenticated,
+		},
+		{
+			name:        "invalid permission",
+			context:     actor.WithActor(ctx, &actor.Actor{UID: u1.ID}),
+			permission:  "BATCH_CHANGE@EXEC",
+			expectedErr: invalidPermissionDisplayName,
+		},
+		{
+			name:       "unauthorized user",
+			context:    actor.WithActor(ctx, &actor.Actor{UID: u1.ID}),
+			permission: p.DisplayName(),
+			expectedErr: &database.PermissionNotFoundErr{
+				Namespace: p.Namespace,
+				Action:    p.Action,
+			},
+		},
+		{
+			name:        "authorized user",
+			context:     actor.WithActor(ctx, &actor.Actor{UID: u2.ID}),
+			permission:  p.DisplayName(),
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckCurrentUserHasPermission(tc.context, db, tc.permission)
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/rbac/permission_test.go
+++ b/internal/rbac/permission_test.go
@@ -75,13 +75,10 @@ func TestCheckCurrentUserHasPermission(t *testing.T) {
 			expectedErr: invalidPermissionDisplayName,
 		},
 		{
-			name:       "unauthorized user",
-			context:    actor.WithActor(ctx, &actor.Actor{UID: u1.ID}),
-			permission: p.DisplayName(),
-			expectedErr: &database.PermissionNotFoundErr{
-				Namespace: p.Namespace,
-				Action:    p.Action,
-			},
+			name:        "unauthorized user",
+			context:     actor.WithActor(ctx, &actor.Actor{UID: u1.ID}),
+			permission:  p.DisplayName(),
+			expectedErr: ErrNotAuthorized,
 		},
 		{
 			name:        "authorized user",

--- a/internal/rbac/permissions_test.go
+++ b/internal/rbac/permissions_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -31,8 +31,8 @@ func TestComparePermissions(t *testing.T) {
 
 		added, deleted := ComparePermissions(dbPerms, schemaPerms)
 
-		assert.Len(t, added, 0)
-		assert.Len(t, deleted, 0)
+		require.Len(t, added, 0)
+		require.Len(t, deleted, 0)
 	})
 
 	t.Run("permissions deleted", func(t *testing.T) {
@@ -50,8 +50,8 @@ func TestComparePermissions(t *testing.T) {
 
 		added, deleted := ComparePermissions(dbPerms, schemaPerms)
 
-		assert.Len(t, added, 0)
-		assert.Len(t, deleted, 2)
+		require.Len(t, added, 0)
+		require.Len(t, deleted, 2)
 		if diff := cmp.Diff(want, deleted, cmpopts.SortSlices(sortDeletePermissionOptSlice)); diff != "" {
 			t.Error(diff)
 		}
@@ -76,8 +76,8 @@ func TestComparePermissions(t *testing.T) {
 
 		added, deleted := ComparePermissions(dbPerms, schemaPerms)
 
-		assert.Len(t, added, 4)
-		assert.Len(t, deleted, 0)
+		require.Len(t, added, 4)
+		require.Len(t, deleted, 0)
 		if diff := cmp.Diff(want, added); diff != "" {
 			t.Error(diff)
 		}
@@ -110,12 +110,12 @@ func TestComparePermissions(t *testing.T) {
 		// do stuff
 		added, deleted := ComparePermissions(dbPerms, schemaPerms)
 
-		assert.Len(t, added, 4)
+		require.Len(t, added, 4)
 		if diff := cmp.Diff(wantAdded, added); diff != "" {
 			t.Error(diff)
 		}
 
-		assert.Len(t, deleted, 2)
+		require.Len(t, deleted, 2)
 		less := func(a, b database.DeletePermissionOpts) bool { return a.ID < b.ID }
 		if diff := cmp.Diff(wantDeleted, deleted, cmpopts.SortSlices(less)); diff != "" {
 			t.Error(diff)


### PR DESCRIPTION
Closes #47220

The initial scope for [restricting who can create Batch Changes](https://github.com/sourcegraph/sourcegraph/issues/34491) included using GraphQL custom directives to perform authorization checks. 
However, the [graphql-go@1.5.0](https://github.com/graph-gophers/graphql-go/releases/tag/v1.5.0) library still needs to be updated to include custom directives. I'm monitoring the library for the next update, however, for now, we have to call this function in every resolver that needs guarding.

I created #48756 to call this method in the resolver method for creating Batch Changes; this should be the last backend ticket related to RBAC Restriction.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Add unit tests