### PR TITLE
app: revamp approach to releasing app, versioning scheme

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -19,10 +19,11 @@ const (
 
 	// Nightly builds - must be first because they take precedence
 
-	ReleaseNightly     // release branch nightly healthcheck builds
-	BextNightly        // browser extension nightly build
-	VsceNightly        // vs code extension nightly build
-	AppSnapshotRelease // app snapshot build
+	ReleaseNightly // release branch nightly healthcheck builds
+	BextNightly    // browser extension nightly build
+	VsceNightly    // vs code extension nightly build
+	AppRelease     // app release build
+	AppInsiders    // app insiders build
 
 	// Release branches
 
@@ -109,9 +110,14 @@ func (t RunType) Matcher() *RunTypeMatcher {
 			BranchExact: true,
 		}
 
-	case AppSnapshotRelease:
+	case AppRelease:
 		return &RunTypeMatcher{
-			Branch:      "app/release-snapshot",
+			Branch:      "app/release",
+			BranchExact: true,
+		}
+	case AppInsiders:
+		return &RunTypeMatcher{
+			Branch:      "app/insiders",
 			BranchExact: true,
 		}
 
@@ -189,8 +195,10 @@ func (t RunType) String() string {
 		return "Browser extension nightly release build"
 	case VsceNightly:
 		return "VS Code extension nightly release build"
-	case AppSnapshotRelease:
-		return "App snapshot release"
+	case AppRelease:
+		return "App release build"
+	case AppInsiders:
+		return "App insiders build"
 	case TaggedRelease:
 		return "Tagged release"
 	case ReleaseBranch:

--- a/dev/ci/runtype/runtype_test.go
+++ b/dev/ci/runtype/runtype_test.go
@@ -69,9 +69,15 @@ func TestComputeRunType(t *testing.T) {
 	}, {
 		name: "app release",
 		args: args{
-			branch: "app/release-snapshot",
+			branch: "app/release",
 		},
-		want: AppSnapshotRelease,
+		want: AppRelease,
+	}, {
+		name: "app release insiders",
+		args: args{
+			branch: "app/insiders",
+		},
+		want: AppInsiders,
 	}, {
 		name: "release nightly",
 		args: args{

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -162,9 +162,18 @@ Base pipeline (more steps might be included based on branch changes):
 - Tests for VS Code extension
 - Upload build trace
 
-### App snapshot release
+### App release build
 
-The run type for branches matching `app/release-snapshot` (exact match).
+The run type for branches matching `app/release` (exact match).
+
+Base pipeline (more steps might be included based on branch changes):
+
+- App release
+- Upload build trace
+
+### App insiders build
+
+The run type for branches matching `app/insiders` (exact match).
 
 Base pipeline (more steps might be included based on branch changes):
 

--- a/enterprise/cmd/sourcegraph/README.md
+++ b/enterprise/cmd/sourcegraph/README.md
@@ -18,20 +18,6 @@ Check the **Sourcegraph App release** bot in [`#app`](https://app.slack.com/clie
 
 ## Build and release
 
-### Snapshot releases
-
-> Sourcegraph App is in internal alpha and only has snapshot releases. There are no versioned or tagged releases yet.
-
-To build and release a snapshot for other people to use, push a commit to the special `app/release-snapshot` branch:
-
-```shell
-git push -f origin HEAD:app/release-snapshot
-```
-
-This runs the `../../dev/app/release.sh` script in CI, which uses [goreleaser](https://goreleaser.com/) to build for many platforms, package, and publish to the `sourcegraph-app-releases` Google Cloud Storage bucket.
-
-Check the build status in [Buildkite `app/release-snapshot` branch builds](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=app%2Frelease-snapshot).
-
 ### Local builds (without releasing)
 
 To build it locally for all platforms (without releasing, uploading, or publishing it anywhere), run:
@@ -43,3 +29,28 @@ VERSION=0.0.0+dev enterprise/dev/app/release.sh --snapshot
 The builds are written to the `dist` directory.
 
 If you just need a local build for your current platform, run `sg start app` (as mentioned in the [Development](#development) section) and then grab the `.bin/sourcegraph` binary. This binary does not have the web bundle (JavaScript/CSS) embedded into it.
+
+### CI builds (releasing)
+
+Our CI pipeline runs the `../../dev/app/release.sh` script, which uses [goreleaser](https://goreleaser.com/) to build for many platforms, package, and publish to the `sourcegraph-app-releases` Google Cloud Storage bucket.
+
+#### Insiders
+
+Insiders builds may be created from non-`main` branches; they are much more experimental. To create one push your current branch to the special `app/insiders` branch:
+
+```shell
+git push -f origin HEAD:app/insiders
+```
+
+Check the build status in [Buildkite `app/insiders` branch builds](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=app%2Finsiders).
+
+### Official releases
+
+Official releases may only be created from `main` (or sometimes `main-app` during a code freeze); to create one push the latest remote branch to the special `app/release` branch:
+
+```shell
+git fetch
+git push -f origin origin/main:app/release
+```
+
+Check the build status in [Buildkite `app/release` branch builds](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=app%2Frelease).

--- a/enterprise/dev/app/goreleaser.yaml
+++ b/enterprise/dev/app/goreleaser.yaml
@@ -74,7 +74,7 @@ release:
   github:
     owner: sourcegraph
     # TODO(sqs): use just sourcegraph/sourcegraph?
-    name: sourcegraph-app
+    name: homebrew-app
   draft: true
   prerelease: auto
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -604,13 +604,22 @@ func addVsceReleaseSteps(pipeline *bk.Pipeline) {
 }
 
 // Release a snapshot of App.
-func addAppSnapshotReleaseSteps(c Config) operations.Operation {
-	// TODO(sqs): Use goreleaser-pro nightly feature? Blocked on
-	// https://github.com/goreleaser/goreleaser-cross/issues/22.
-
-	// goreleaser requires that the version is semver-compatible
-	// (https://goreleaser.com/limitations/semver/). This is fine for now in alpha.
-	version := fmt.Sprintf("0.0.%d-snapshot+%s-%.6s", c.BuildNumber, c.Time.Format("20060102"), c.Commit)
+func addAppReleaseSteps(c Config, insiders bool) operations.Operation {
+	// The version scheme we use for App is one of:
+	//
+	// * yyyy.mm.dd+$BUILDNUM.$COMMIT
+	// * yyyy.mm.dd-insiders+$BUILDNUM.$COMMIT
+	//
+	// We do not follow the Sourcegraph enterprise versioning scheme, because Sourcegraph App is
+	// released much more frequently than the enterprise versions by nature of being a desktop
+	// app.
+	//
+	// Also note that goreleaser requires the version is semver-compatible.
+	insidersStr := ""
+	if insiders {
+		insidersStr = "-insiders"
+	}
+	version := fmt.Sprintf("%s%s+%d.%.6s", c.Time.Format("2006.01.06"), insidersStr, c.BuildNumber, c.Commit)
 
 	return func(pipeline *bk.Pipeline) {
 		// Release App (.zip/.deb/.rpm to Google Cloud Storage, new tap for Homebrew, etc.).

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -193,9 +193,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addVsceTests,
 		)
 
-	case runtype.AppSnapshotRelease:
-		// If this is an App snapshot build, release a snapshot.
-		ops = operations.NewSet(addAppSnapshotReleaseSteps(c))
+	case runtype.AppRelease:
+		ops = operations.NewSet(addAppReleaseSteps(c, false))
+
+	case runtype.AppInsiders:
+		ops = operations.NewSet(addAppReleaseSteps(c, true))
 
 	case runtype.ImagePatch:
 		// only build image for the specified image in the branch name


### PR DESCRIPTION
Before:

* Pushes to `app/release-snapshot` created a snapshot release.
* The version scheme was `0.0.200198-snapshot+20230220-35357c` (yuck!)

After:

* Pushes to `app/release` create a release (from `main` only)
* Pushes to `app/insiders` create an "insiders" release (from any branch, experimental stuff)
* The old version scheme `0.0.200198-snapshot+20230220-35357c` has been changed to a date+commit version instead (which differs from Enterprise because App is released much more frequently as it is a desktop app):
  * (release) `2023.02.20+200198.35357c`
  * (insiders) `2023.02.20-insiders+200198.35357c`

## Test plan

Followed the new instructions in README.md to confirm they work and create a release as expected.
