### PR TITLE
bazel: enable ReactRefreshWebpackPlugin and MonacoWebpackPlugin

### DIFF
--- a/client/build-config/BUILD.bazel
+++ b/client/build-config/BUILD.bazel
@@ -33,12 +33,15 @@ ts_project(
     deps = [
         ":node_modules/@statoscope/webpack-plugin",
         ":node_modules/buffer",  #keep
+        ":node_modules/css-loader",  #keep
         ":node_modules/monaco-editor-webpack-plugin",
         ":node_modules/process",  #keep
+        ":node_modules/style-loader",  #keep
         ":node_modules/terser-webpack-plugin",
         ":node_modules/webpack",
         "//:node_modules/@types/node",
         "//:node_modules/monaco-editor",  #keep
+        "//:node_modules/monaco-yaml",  #keep
         "//client/build-config/src/esbuild",
     ],
 )

--- a/client/build-config/src/webpack/monaco-editor.ts
+++ b/client/build-config/src/webpack/monaco-editor.ts
@@ -30,8 +30,8 @@ export const MONACO_LANGUAGES_AND_FEATURES: Required<
     customLanguages: [
         {
             label: 'yaml',
-            entry: 'monaco-yaml/lib/esm/monaco.contribution',
-            worker: { id: 'vs/language/yaml/yamlWorker', entry: 'monaco-yaml/lib/esm/yaml.worker' },
+            entry: require.resolve('monaco-yaml/lib/esm/monaco.contribution'),
+            worker: { id: 'vs/language/yaml/yamlWorker', entry: require.resolve('monaco-yaml/lib/esm/yaml.worker') },
         },
     ],
     features: [

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1805,7 +1805,9 @@ jest_test(
 # webpack dev environment -------------------
 WEBPACK_CONFIG_DEPS = [
     ":node_modules/@sourcegraph/build-config",
+    "//:node_modules/@pmmmwh/react-refresh-webpack-plugin",
     "//:node_modules/@sentry/webpack-plugin",
+    "//:node_modules/buffer",
     "//:node_modules/css-loader",
     "//:node_modules/style-loader",
     "//:node_modules/css-minimizer-webpack-plugin",
@@ -1813,6 +1815,7 @@ WEBPACK_CONFIG_DEPS = [
     "//:node_modules/mini-css-extract-plugin",
     "//:node_modules/path-browserify",
     "//:node_modules/punycode",
+    "//:node_modules/util",
     "//:node_modules/webpack-manifest-plugin",
     "//:node_modules/webpack-stats-plugin",
     "//:node_modules/monaco-editor",
@@ -1821,6 +1824,7 @@ WEBPACK_CONFIG_DEPS = [
     "//:node_modules/webpack",
     "//:node_modules/react-refresh",
     "//client/web/dev",
+    "//client/web/src/integration",
     "//:node_modules/react-visibility-sensor",  # required for https://github.com/joshwnj/react-visibility-sensor/issues/148 workaround
 
     # HACKS: bundle-time css import

--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -27,6 +27,7 @@ ts_project(
         "temporarySettingsContext.ts",
         "utils.ts",
     ],
+    module = "commonjs",
     tsconfig = ":tsconfig",
     # TODO(bazel): type-only imports
     deps = [

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin')
@@ -26,6 +27,7 @@ const {
 } = require('@sourcegraph/build-config')
 
 const { IS_PRODUCTION, IS_DEVELOPMENT, ENVIRONMENT_CONFIG, writeIndexHTMLPlugin } = require('./dev/utils')
+const { isHotReloadEnabled } = require('./src/integration/environment')
 
 const {
   NODE_ENV,
@@ -114,6 +116,9 @@ const config = {
       },
     },
     ...(IS_DEVELOPMENT && {
+      // Running multiple entries on a single page that do not share a runtime chunk from the same compilation is not supported.
+      // https://github.com/webpack/webpack-dev-server/issues/2792#issuecomment-808328432
+      runtimeChunk: isHotReloadEnabled ? 'single' : false,
       removeAvailableModules: false,
       removeEmptyChunks: false,
       splitChunks: false,
@@ -157,7 +162,7 @@ const config = {
           ? 'styles/[name].[contenthash].bundle.css'
           : 'styles/[name].bundle.css',
     }),
-    // getMonacoWebpackPlugin(),
+    getMonacoWebpackPlugin(),
     new WebpackManifestPlugin({
       writeToFileEmit: false,
       fileName: 'webpack.manifest.json',
@@ -170,6 +175,7 @@ const config = {
     }),
     ...(WEBPACK_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
     WEBPACK_BUNDLE_ANALYZER && getStatoscopePlugin(WEBPACK_STATS_NAME),
+    isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     IS_PRODUCTION &&
       new CompressionPlugin({
         filename: '[path][base].gz',


### PR DESCRIPTION
## Test plan

Manual

## App preview:

- [Web](https://sg-web-bazel-webpack.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
