### PR TITLE
Add a step for verifying GitHub SSH key setup

### DIFF
--- a/doc/dev/setup/quickstart.md
+++ b/doc/dev/setup/quickstart.md
@@ -27,6 +27,10 @@ curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh
 
 See the [`sg` documentation](../background-information/sg/index.md) for more information or ask in the `#dev-experience` Slack channel.
 
+## Ensure you have SSH setup for GitHub
+
+Follow the instructions on [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for checking if you have an existing SSH for your current machine and setting one up if not.
+
 ## Run `sg setup`
 
 Open a terminal and run the following command:

--- a/doc/dev/setup/quickstart.md
+++ b/doc/dev/setup/quickstart.md
@@ -31,17 +31,9 @@ See the [`sg` documentation](../background-information/sg/index.md) for more inf
 
 Follow the instructions on [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for checking if you have an existing SSH for your current machine and setting one up if not.
 
-## Create the `sourcegraph` directory
-
-The `sg setup` tool expects to be run in a directory called sourcegraph. Open a terminal to create and move to that directory:
-
-```mkdir sourcegraph
-cd sourcegraph
-```
-
 ## Run `sg setup`
 
-Open a terminal and run the following command:
+In the directory where you want the `sourcegraph` repository to be checked out, open a terminal and run the following command:
 
 ```sh
 sg setup

--- a/doc/dev/setup/quickstart.md
+++ b/doc/dev/setup/quickstart.md
@@ -31,6 +31,14 @@ See the [`sg` documentation](../background-information/sg/index.md) for more inf
 
 Follow the instructions on [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for checking if you have an existing SSH for your current machine and setting one up if not.
 
+## Create the `sourcegraph` directory
+
+The `sg setup` tool expects to be run in a directory called sourcegraph. Open a terminal to create and move to that directory:
+
+```mkdir sourcegraph
+cd sourcegraph
+```
+
 ## Run `sg setup`
 
 Open a terminal and run the following command:


### PR DESCRIPTION

## Test plan

1. Use `sg run docsite` and navigate to the quickstart page. 
2. Read the new documentation and click on the added link