### PR TITLE
Improve regex batch spec to handle repo paths with spaces

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/library/sed.batch.yaml
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/sed.batch.yaml
@@ -8,10 +8,11 @@ steps:
   # In each repo, iterate over search results files using templating
   # https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating
   - run: |
+      while read -r file
       for file in "${{ join repository.search_result_paths " " }}";
       do
-        sed -i 's/replace-me/by-me/g;' ${file}
-      done
+        sed -i 's/replace-me/by-me/g;' "${file}"
+      done < <(echo '${{ join repository.search_result_paths "\n" }}')
     container: alpine:3
 
 changesetTemplate:

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/sed.batch.yaml
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/sed.batch.yaml
@@ -9,7 +9,6 @@ steps:
   # https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating
   - run: |
       while read -r file
-      for file in "${{ join repository.search_result_paths " " }}";
       do
         sed -i 's/replace-me/by-me/g;' "${file}"
       done < <(echo '${{ join repository.search_result_paths "\n" }}')


### PR DESCRIPTION
## Test plan

- Set up a repo with a path containing spaces
- Run a batch change touching a path containing spaces
- Verify that `sed -i` did not fail because a path has been split at a space boundary

The handbook contains this path with a space: `content/departments/marketing/comms/field marketing.md`. I ran a batch change to the handbook based on this template here:

https://sourcegraph.sourcegraph.com/users/dominiccooney/batch-changes/hiring-to-ask-hiring/executions

## App preview:

- [Web](https://sg-web-dominiccooney-sed-ition.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
