### PR TITLE
Add logic to handle `versions.auto_upgrade` in `migrator upgrade` command & UI improvements for Updates page

### DIFF
--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -127,7 +127,7 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
         SITE_UPGRADE_READINESS,
         {}
     )
-    const [isExpanded, setIsExpanded] = useState(false)
+    const [isExpanded, setIsExpanded] = useState(true)
     return (
         <>
             {error && !loading && <ErrorAlert error={error} />}

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -28,7 +28,6 @@ import {
     CollapseHeader,
     CollapsePanel,
     H3,
-    H4,
 } from '@sourcegraph/wildcard'
 
 import { LogOutput } from '../components/LogOutput'

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import React, { FunctionComponent, useMemo, useState } from 'react'
 
-import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown, mdiCheckBold, mdiAlertOctagram } from '@mdi/js'
+import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown } from '@mdi/js'
 import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -482,6 +482,8 @@ func (r *schemaResolver) SetAutoUpgrade(ctx context.Context, args *struct {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return &EmptyResponse{}, err
 	}
-	upgradestore.NewWith(r.db.Handle()).SetAutoUpgrade(ctx, args.Enable)
+	if err := upgradestore.NewWith(r.db.Handle()).SetAutoUpgrade(ctx, args.Enable); err != nil {
+		return &EmptyResponse{}, err
+	}
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -482,8 +482,6 @@ func (r *schemaResolver) SetAutoUpgrade(ctx context.Context, args *struct {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return &EmptyResponse{}, err
 	}
-	if err := upgradestore.NewWith(r.db.Handle()).SetAutoUpgrade(ctx, args.Enable); err != nil {
-		return &EmptyResponse{}, err
-	}
-	return &EmptyResponse{}, nil
+	err := upgradestore.NewWith(r.db.Handle()).SetAutoUpgrade(ctx, args.Enable)
+	return &EmptyResponse{}, err
 }

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration/migrations"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	"github.com/sourcegraph/sourcegraph/internal/version/upgradestore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -21,12 +24,12 @@ func Upgrade(
 	fromFlag := &cli.StringFlag{
 		Name:     "from",
 		Usage:    "The source (current) instance version. Must be of the form `{Major}.{Minor}` or `v{Major}.{Minor}`.",
-		Required: true,
+		Required: false,
 	}
 	toFlag := &cli.StringFlag{
 		Name:     "to",
 		Usage:    "The target instance version. Must be of the form `{Major}.{Minor}` or `v{Major}.{Minor}`.",
-		Required: true,
+		Required: false,
 	}
 	unprivilegedOnlyFlag := &cli.BoolFlag{
 		Name:  "unprivileged-only",
@@ -65,13 +68,45 @@ func Upgrade(
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		from, ok := oobmigration.NewVersionFromString(fromFlag.Get(cmd))
-		if !ok {
-			return errors.New("bad format for -from")
+		runner, err := runnerFactory(schemas.SchemaNames, schemas.Schemas)
+		if err != nil {
+			return errors.Wrap(err, "new runner")
 		}
-		to, ok := oobmigration.NewVersionFromString(toFlag.Get(cmd))
+
+		// connect to db and get upgrade readiness state
+		db, err := extractDatabase(ctx, runner)
+		if err != nil {
+			return errors.Wrap(err, "new db handle")
+		}
+		store := upgradestore.New(db)
+		currentVersion, autoUpgrade, err := store.GetAutoUpgrade(ctx)
+		if err != nil {
+			return errors.Wrap(err, "checking auto upgrade")
+		}
+
+		// determine versioning logic for upgrade based on auto_upgrade readiness and existence of to and from flags
+		var fromStr, toStr string
+		if fromFlag.Get(cmd) != "" || toFlag.Get(cmd) != "" {
+			fromStr = fromFlag.Get(cmd)
+			toStr = toFlag.Get(cmd)
+		} else {
+			if autoUpgrade {
+				fromStr = currentVersion
+				toStr = version.Version()
+			}
+		}
+		// check for null case
+		if fromStr == "" || toStr == "" {
+			return errors.New("the -from and -to flags are required when auto upgrade is not enabled")
+		}
+
+		from, ok := oobmigration.NewVersionFromString(fromStr)
 		if !ok {
-			return errors.New("bad format for -to")
+			return errors.Newf("bad format for -from = %s", fromStr)
+		}
+		to, ok := oobmigration.NewVersionFromString(toStr)
+		if !ok {
+			return errors.Newf("bad format for -to = %s", toStr)
 		}
 		if oobmigration.CompareVersions(from, to) != oobmigration.VersionOrderBefore {
 			return errors.Newf("invalid range (from=%s >= to=%s)", from, to)

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -89,11 +89,9 @@ func Upgrade(
 		if fromFlag.Get(cmd) != "" || toFlag.Get(cmd) != "" {
 			fromStr = fromFlag.Get(cmd)
 			toStr = toFlag.Get(cmd)
-		} else {
-			if autoUpgrade {
-				fromStr = currentVersion
-				toStr = version.Version()
-			}
+		} else if autoUpgrade {
+			fromStr = currentVersion
+			toStr = version.Version()
 		}
 		// check for null case
 		if fromStr == "" || toStr == "" {


### PR DESCRIPTION
This PR adds graphQL resolver methods to allow handling of the `auto_upgrade` db column via a toggle switch. It also creates logic to handle the state of the `auto_upgrade` flag in the `migrator upgrade` command. 

Currently the flag will be set at default as `false` and cannot be changed via the frontend or any other method besides manually altering the table via SQL queries. Meaning that `upgrade` will never hit the `auto_upgrade` path here.

Toggle switch UI elements and API console methods have been separated into another branch: https://github.com/sourcegraph/sourcegraph/pull/50206

Finally this PR adds some visibility improvements to the UI and expands drift by default. 


_local dev env for testing_
```
export CODEINTEL_PG_ALLOW_SINGLE_DB=1
export PGUSER=sourcegraph
export PGPASSWORD=sourcegraph
export PGDATABASE=sourcegraph
```


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start` was used to check the UI site-admin updates page

`go install cmd/migrator && migrator upgrade` was used to check logic for handling the `auto_upgrade` column state

---

Part of https://github.com/sourcegraph/sourcegraph/issues/48048