### PR TITLE
Fix active state of executors nav bar items

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -47,6 +47,7 @@ const executorsGroup: SiteAdminSideBarGroup = {
         {
             to: '/site-admin/executors',
             label: 'Instances',
+            exact: true,
         },
         {
             to: '/site-admin/executors/secrets',


### PR DESCRIPTION
Was both highlighted, because secrets is a subroute of instances.

Was: 
<img width="323" alt="Screenshot 2023-03-07 at 04 30 51@2x" src="https://user-images.githubusercontent.com/19534377/223313651-fe7e4f5c-e833-4add-9669-70b298cc2753.png">


## Test plan

Visual verification. 

## App preview:

- [Web](https://sg-web-es-fix-state.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
