### PR TITLE
use enterprise file in enterprise build

### DIFF
--- a/enterprise/cmd/gitserver/build.sh
+++ b/enterprise/cmd/gitserver/build.sh
@@ -12,7 +12,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-cp -a ./cmd/gitserver/p4-fusion-install-alpine.sh "$OUTPUT"
+cp -a ./enterprise/cmd/gitserver/p4-fusion-install-alpine.sh "$OUTPUT"
 
 # Environment for building linux binaries
 export GO111MODULE=on


### PR DESCRIPTION
`enterprise/cmd/gitserver/build.sh` was using `cmd/gitserver/p4-fusion-install-alpine.sh` instead of `enterprise/cmd/gitserver/p4-fusion-install-alpine.sh`. Granted, they are identical, but since the enterprise file exists, the enterprise build should use it.



## Test plan
run `enterprise/cmd/gitserver/build.sh`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
