### PR TITLE
gitserver: Don't load entire PyPi zips into memory

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -995,7 +995,16 @@ func (s *Server) acquireCloneableLimiter(ctx context.Context) (context.Context, 
 // This directory is cleaned up by gitserver and will be ignored by repository
 // listing operations.
 func (s *Server) tempDir(prefix string) (name string, err error) {
-	dir := filepath.Join(s.ReposDir, tempDirName)
+	return tempDir(s.ReposDir, prefix)
+}
+
+// tempDir is a wrapper around os.MkdirTemp, but using the given reposDir
+// temporary directory filepath.Join(s.ReposDir, tempDirName).
+//
+// This directory is cleaned up by gitserver and will be ignored by repository
+// listing operations.
+func tempDir(reposDir, prefix string) (name string, err error) {
+	dir := filepath.Join(reposDir, tempDirName)
 
 	// Create tmpdir directory if doesn't exist yet.
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -1,11 +1,11 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"io/fs"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -24,6 +24,7 @@ func NewPythonPackagesSyncer(
 	connection *schema.PythonPackagesConnection,
 	svc *dependencies.Service,
 	client *pypi.Client,
+	reposDir string,
 ) VCSSyncer {
 	return &vcsPackagesSyncer{
 		logger:      log.Scoped("PythonPackagesSyncer", "sync Python packages"),
@@ -32,13 +33,14 @@ func NewPythonPackagesSyncer(
 		placeholder: reposource.ParseVersionedPackage("sourcegraph.com/placeholder@v0.0.0"),
 		svc:         svc,
 		configDeps:  connection.Dependencies,
-		source:      &pythonPackagesSyncer{client: client},
+		source:      &pythonPackagesSyncer{client: client, reposDir: reposDir},
 	}
 }
 
 // pythonPackagesSyncer implements packagesSource
 type pythonPackagesSyncer struct {
-	client *pypi.Client
+	client   *pypi.Client
+	reposDir string
 }
 
 func (pythonPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
@@ -70,18 +72,18 @@ func (s *pythonPackagesSyncer) Download(ctx context.Context, dir string, dep rep
 	}
 	defer pkgData.Close()
 
-	if err = unpackPythonPackage(pkgData, packageURL, dir); err != nil {
+	if err = unpackPythonPackage(pkgData, packageURL, s.reposDir, dir); err != nil {
 		return errors.Wrap(err, "failed to unzip python module")
 	}
 
 	return nil
 }
 
-// unpackPythonPackages unpacks the given python package archive into workDir, skipping any
+// unpackPythonPackage unpacks the given python package archive into workDir, skipping any
 // files that aren't valid or that are potentially malicious. It detects the kind of archive
 // and compression used with the given packageURL.
-func unpackPythonPackage(pkg io.Reader, packageURL, workDir string) error {
-	logger := log.Scoped("unpackPythonPackages", "unpackPythonPackages unpacks the given python package archive into workDir")
+func unpackPythonPackage(pkg io.Reader, packageURL, reposDir, workDir string) error {
+	logger := log.Scoped("unpackPythonPackage", "unpackPythonPackage unpacks the given python package archive into workDir")
 	u, err := url.Parse(packageURL)
 	if err != nil {
 		return errors.Wrap(err, "bad python package URL")
@@ -112,22 +114,58 @@ func unpackPythonPackage(pkg io.Reader, packageURL, workDir string) error {
 	switch {
 	case strings.HasSuffix(filename, ".tar.gz"), strings.HasSuffix(filename, ".tgz"):
 		err = unpack.Tgz(pkg, workDir, opts)
-	case strings.HasSuffix(filename, ".whl"), strings.HasSuffix(filename, ".zip"):
-		var pkgBytes []byte
-		pkgBytes, err = io.ReadAll(pkg)
 		if err != nil {
-			break
+			return err
 		}
-		err = unpack.Zip(bytes.NewReader(pkgBytes), int64(len(pkgBytes)), workDir, opts)
+	case strings.HasSuffix(filename, ".whl"), strings.HasSuffix(filename, ".zip"):
+		// We cannot unzip in a streaming fashion, so we write the zip file to
+		// a temporary file. Otherwise, we would need to load the entire zip into
+		// memory, which isn't great for multi-megabyte+ files.
+
+		// Create a tmpdir that gitserver manages.
+		tmpdir, err := tempDir(reposDir, "pypi-packages")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tmpdir)
+
+		// Write the whole package to a temporary file.
+		zip, zipLen, err := writeZipToTemp(tmpdir, pkg)
+		if err != nil {
+			return err
+		}
+		defer zip.Close()
+
+		err = unpack.Zip(zip, zipLen, workDir, opts)
+		if err != nil {
+			return err
+		}
 	case strings.HasSuffix(filename, ".tar"):
 		err = unpack.Tar(pkg, workDir, opts)
+		if err != nil {
+			return err
+		}
 	default:
 		return errors.Errorf("unsupported python package type %q", filename)
 	}
 
+	return stripSingleOutermostDirectory(workDir)
+}
+
+func writeZipToTemp(tmpdir string, pkg io.Reader) (*os.File, int64, error) {
+	// Create a temp file.
+	f, err := os.CreateTemp(tmpdir, "pypi-package-")
 	if err != nil {
-		return err
+		return nil, 0, err
 	}
 
-	return stripSingleOutermostDirectory(workDir)
+	// Write contents to file.
+	read, err := io.Copy(f, pkg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Reset read head.
+	_, err = f.Seek(0, 0)
+	return f, read, err
 }

--- a/cmd/gitserver/server/vcs_syncer_python_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages_test.go
@@ -56,7 +56,7 @@ func TestUnpackPythonPackage_TGZ(t *testing.T) {
 	pkg := bytes.NewReader(createTgz(t, files))
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp); err != nil {
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp, tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -126,7 +126,7 @@ func TestUnpackPythonPackage_ZIP(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp); err != nil {
+	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp, tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -170,13 +170,13 @@ func TestUnpackPythonPackage_InvalidZip(t *testing.T) {
 
 	pkg := bytes.NewReader(createTgz(t, files))
 
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir()); err == nil {
-		t.Fatal()
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir(), t.TempDir()); err == nil {
+		t.Fatal("no error returned from unpack package")
 	}
 }
 
 func TestUnpackPythonPackage_UnsupportedFormat(t *testing.T) {
-	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", ""); err == nil {
+	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", "", ""); err == nil {
 		t.Fatal()
 	}
 }
@@ -208,7 +208,7 @@ func TestUnpackPythonPackage_Wheel(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(b, wheelURL, tmp); err != nil {
+	if err := unpackPythonPackage(b, wheelURL, tmp, tmp); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -500,7 +500,7 @@ func getVCSSyncer(
 			return nil, err
 		}
 		cli := pypi.NewClient(urn, c.Urls, httpcli.ExternalDoer)
-		return server.NewPythonPackagesSyncer(&c, depsSvc, cli), nil
+		return server.NewPythonPackagesSyncer(&c, depsSvc, cli, reposDir), nil
 	case extsvc.TypeRustPackages:
 		var c schema.RustPackagesConnection
 		urn, err := extractOptions(&c)


### PR DESCRIPTION
I've looked at our profiler and noticed that we use a LOT of memory in this single function. Since unzipping requires a ReaderAt, the most efficient way is to buffer the zip to a temp file. The temp file directory is managed by gitserver so it
- lives inside the mounted disk, so we don't need to worry about write permissions
- is cleaned up by gitserver, so we don't need to worry about potential FS pollution

<img width="1700" alt="Screenshot 2023-03-07 at 05 43 40@2x" src="https://user-images.githubusercontent.com/19534377/223322759-23c0d852-33cf-415e-b6f8-e74bf766352f.png">
(Yes, almost all of it)

## Test plan

The tests still pass, so this should be good? Let me know how I could test this, as I don't know much about packages on local dev.
