### PR TITLE
http(search): Don't copy repo IDs for type conversion

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -165,14 +165,14 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		rankingLastUpdatedAt = make(map[api.RepoID]time.Time)
 	}
 
-	getRepoIndexOptions := func(repoID int32) (*searchbackend.RepoIndexOptions, error) {
+	getRepoIndexOptions := func(repoID api.RepoID) (*searchbackend.RepoIndexOptions, error) {
 		if loadReposErr != nil {
 			return nil, loadReposErr
 		}
 		// Replicate what database.Repos.GetByName would do here:
-		repo, ok := reposMap[api.RepoID(repoID)]
+		repo, ok := reposMap[repoID]
 		if !ok {
-			return nil, &database.RepoNotFoundErr{ID: api.RepoID(repoID)}
+			return nil, &database.RepoNotFoundErr{ID: repoID}
 		}
 
 		getVersion := func(branch string) (string, error) {
@@ -192,13 +192,13 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		priority := float64(repo.Stars) + repoRankFromConfig(siteConfig, string(repo.Name))
 
 		var documentRanksVersion string
-		if t, ok := rankingLastUpdatedAt[api.RepoID(repoID)]; ok {
+		if t, ok := rankingLastUpdatedAt[repoID]; ok {
 			documentRanksVersion = t.String()
 		}
 
 		return &searchbackend.RepoIndexOptions{
 			Name:       string(repo.Name),
-			RepoID:     int32(repo.ID),
+			RepoID:     repo.ID,
 			Public:     !repo.Private,
 			Priority:   priority,
 			Fork:       repo.Fork,
@@ -210,25 +210,18 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 	}
 
 	revisionsForRepo, revisionsForRepoErr := h.SearchContextsRepoRevs(ctx, indexedIDs)
-	getSearchContextRevisions := func(repoID int32) ([]string, error) {
+	getSearchContextRevisions := func(repoID api.RepoID) ([]string, error) {
 		if revisionsForRepoErr != nil {
 			return nil, revisionsForRepoErr
 		}
 		return revisionsForRepo[api.RepoID(repoID)], nil
 	}
 
-	// searchbackend uses int32 instead of api.RepoID currently, so build
-	// up a slice of that.
-	repoIDs := make([]int32, len(indexedIDs))
-	for i := range indexedIDs {
-		repoIDs[i] = int32(indexedIDs[i])
-	}
-
 	b := searchbackend.GetIndexOptions(
 		&siteConfig,
 		getRepoIndexOptions,
 		getSearchContextRevisions,
-		repoIDs...,
+		indexedIDs...,
 	)
 	_, _ = w.Write(b)
 	return nil

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"golang.org/x/exp/slices"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -22,7 +23,7 @@ type zoektIndexOptions struct {
 	Name string
 
 	// RepoID is the Sourcegraph Repository ID.
-	RepoID int32
+	RepoID api.RepoID
 
 	// Public is true if the repository is public and does not require auth
 	// filtering.
@@ -64,7 +65,7 @@ type RepoIndexOptions struct {
 	Name string
 
 	// RepoID is the Sourcegraph Repository ID.
-	RepoID int32
+	RepoID api.RepoID
 
 	// Public is true if the repository is public and does not require auth
 	// filtering.
@@ -90,15 +91,15 @@ type RepoIndexOptions struct {
 	GetVersion func(branch string) (string, error)
 }
 
-type getRepoIndexOptsFn func(repoID int32) (*RepoIndexOptions, error)
+type getRepoIndexOptsFn func(repoID api.RepoID) (*RepoIndexOptions, error)
 
 // GetIndexOptions returns a json blob for consumption by
 // sourcegraph-zoekt-indexserver. It is for repos based on site settings c.
 func GetIndexOptions(
 	c *schema.SiteConfiguration,
 	getRepoIndexOptions getRepoIndexOptsFn,
-	getSearchContextRevisions func(repoID int32) ([]string, error),
-	repos ...int32,
+	getSearchContextRevisions func(repoID api.RepoID) ([]string, error),
+	repos ...api.RepoID,
 ) []byte {
 	// Limit concurrency to 32 to avoid too many active network requests and
 	// strain on gitserver (as ported from zoekt-sourcegraph-indexserver). In
@@ -125,9 +126,9 @@ func GetIndexOptions(
 
 func getIndexOptions(
 	c *schema.SiteConfiguration,
-	repoID int32,
-	getRepoIndexOptions func(repoID int32) (*RepoIndexOptions, error),
-	getSearchContextRevisions func(repoID int32) ([]string, error),
+	repoID api.RepoID,
+	getRepoIndexOptions func(repoID api.RepoID) (*RepoIndexOptions, error),
+	getSearchContextRevisions func(repoID api.RepoID) ([]string, error),
 	getSiteConfigRevisions revsRuleFunc,
 ) []byte {
 	opts, err := getRepoIndexOptions(repoID)

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/zoekt"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestGetIndexOptions(t *testing.T) {
 	const (
-		REPO = int32(iota + 1)
+		REPO = api.RepoID(iota + 1)
 		FOO
 		NOT_IN_VERSION_CONTEXT
 		PRIORITY
@@ -25,11 +26,11 @@ func TestGetIndexOptions(t *testing.T) {
 		RANKED
 	)
 
-	name := func(repo int32) string {
+	name := func(repo api.RepoID) string {
 		return fmt.Sprintf("repo-%.2d", repo)
 	}
 
-	withBranches := func(c schema.SiteConfiguration, repo int32, branches ...string) schema.SiteConfiguration {
+	withBranches := func(c schema.SiteConfiguration, repo api.RepoID, branches ...string) schema.SiteConfiguration {
 		if c.ExperimentalFeatures == nil {
 			c.ExperimentalFeatures = &schema.ExperimentalFeatures{}
 		}
@@ -45,7 +46,7 @@ func TestGetIndexOptions(t *testing.T) {
 		name              string
 		conf              schema.SiteConfiguration
 		searchContextRevs []string
-		repo              int32
+		repo              api.RepoID
 		want              zoektIndexOptions
 	}
 
@@ -250,7 +251,7 @@ func TestGetIndexOptions(t *testing.T) {
 		})
 	}
 
-	var getRepoIndexOptions getRepoIndexOptsFn = func(repo int32) (*RepoIndexOptions, error) {
+	var getRepoIndexOptions getRepoIndexOptsFn = func(repo api.RepoID) (*RepoIndexOptions, error) {
 		var priority float64
 		if repo == PRIORITY {
 			priority = 10
@@ -276,7 +277,7 @@ func TestGetIndexOptions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			getSearchContextRevisions := func(int32) ([]string, error) { return tc.searchContextRevs, nil }
+			getSearchContextRevisions := func(api.RepoID) ([]string, error) { return tc.searchContextRevs, nil }
 
 			b := GetIndexOptions(&tc.conf, getRepoIndexOptions, getSearchContextRevisions, tc.repo)
 
@@ -294,7 +295,7 @@ func TestGetIndexOptions(t *testing.T) {
 
 func TestGetIndexOptions_getVersion(t *testing.T) {
 	conf := schema.SiteConfiguration{}
-	getSearchContextRevs := func(int32) ([]string, error) { return []string{"b1", "b2"}, nil }
+	getSearchContextRevs := func(api.RepoID) ([]string, error) { return []string{"b1", "b2"}, nil }
 
 	boom := errors.New("boom")
 	cases := []struct {
@@ -344,7 +345,7 @@ func TestGetIndexOptions_getVersion(t *testing.T) {
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			getRepoIndexOptions := func(repo int32) (*RepoIndexOptions, error) {
+			getRepoIndexOptions := func(repo api.RepoID) (*RepoIndexOptions, error) {
 				return &RepoIndexOptions{
 					GetVersion: tc.f,
 				}, nil
@@ -372,14 +373,14 @@ func TestGetIndexOptions_getVersion(t *testing.T) {
 }
 
 func TestGetIndexOptions_batch(t *testing.T) {
-	isError := func(repo int32) bool {
+	isError := func(repo api.RepoID) bool {
 		return repo%20 == 0
 	}
 	var (
-		repos []int32
+		repos []api.RepoID
 		want  []zoektIndexOptions
 	)
-	for repo := int32(1); repo < 100; repo++ {
+	for repo := api.RepoID(1); repo < 100; repo++ {
 		repos = append(repos, repo)
 		if isError(repo) {
 			want = append(want, zoektIndexOptions{Error: "error"})
@@ -392,7 +393,7 @@ func TestGetIndexOptions_batch(t *testing.T) {
 			})
 		}
 	}
-	getRepoIndexOptions := func(repo int32) (*RepoIndexOptions, error) {
+	getRepoIndexOptions := func(repo api.RepoID) (*RepoIndexOptions, error) {
 		return &RepoIndexOptions{
 			GetVersion: func(branch string) (string, error) {
 				if isError(repo) {
@@ -403,7 +404,7 @@ func TestGetIndexOptions_batch(t *testing.T) {
 		}, nil
 	}
 
-	getSearchContextRevs := func(int32) ([]string, error) { return nil, nil }
+	getSearchContextRevs := func(api.RepoID) ([]string, error) { return nil, nil }
 
 	b := GetIndexOptions(&schema.SiteConfiguration{}, getRepoIndexOptions, getSearchContextRevs, repos...)
 	dec := json.NewDecoder(bytes.NewReader(b))


### PR DESCRIPTION
We would duplicate this data in memory for a simple type mismatch, so I've gone ahead and finally changed the type.

This should not break anything on the zoekt side, right?



## Test plan

Since this is "just" a removed type alias conversion, CI should find issues.