### PR TITLE
build: use JS_BINARY__TARGET instead of BAZEL_BINDIR

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,4 @@
-const IS_BAZEL = !!(process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
 const rootDir = IS_BAZEL ? process.cwd() : __dirname
 
 module.exports = {

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -8,7 +8,7 @@ const path = require('path')
 const logger = require('signale')
 
 // TODO(bazel): drop when non-bazel removed.
-if (!(process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)) {
+if (!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)) {
   throw new Error(__filename + ' is only for use with Bazel')
 }
 

--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!(process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
 
 // NOTE: use fs.realpathSync() in addition to path.resolve() to resolve
 // symlinks to the real path. This is required for webpack plugins using

--- a/client/build-config/src/webpack/getCacheConfig.ts
+++ b/client/build-config/src/webpack/getCacheConfig.ts
@@ -5,7 +5,7 @@ import webpack from 'webpack'
 import { ROOT_PATH } from '../paths'
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!process.env.BAZEL_BINDIR
+const IS_BAZEL = !!process.env.JS_BINARY__TARGET
 
 interface CacheConfigOptions {
     invalidateCacheFiles?: string[]

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!(process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
 const SRC_EXT = IS_BAZEL ? 'js' : 'ts'
 const rootDir = IS_BAZEL ? process.cwd() : __dirname
 


### PR DESCRIPTION
`BAZEL_BINDIR` is set for build targets only while `JS_BINARY__TARGET` should be set for all js_binary, js_test, js_run_binary targets as well as any custom binary/test rules that use the js_binary launcher for bazel build, test & run contexts.

Test plan: CI

## App preview:

- [Web](https://sg-web-dont-use-bazel-bindir.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
