### PR TITLE
build: still need BAZEL_BINDIR for webpack_bundle custom rule

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,4 @@
-const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
 const rootDir = IS_BAZEL ? process.cwd() : __dirname
 
 module.exports = {

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -8,7 +8,7 @@ const path = require('path')
 const logger = require('signale')
 
 // TODO(bazel): drop when non-bazel removed.
-if (!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)) {
+if (!(process.env.JS_BINARY__TARGET || process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)) {
   throw new Error(__filename + ' is only for use with Bazel')
 }
 

--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
 
 // NOTE: use fs.realpathSync() in addition to path.resolve() to resolve
 // symlinks to the real path. This is required for webpack plugins using

--- a/client/build-config/src/webpack/getCacheConfig.ts
+++ b/client/build-config/src/webpack/getCacheConfig.ts
@@ -5,7 +5,7 @@ import webpack from 'webpack'
 import { ROOT_PATH } from '../paths'
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!process.env.JS_BINARY__TARGET
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_BINDIR)
 
 interface CacheConfigOptions {
     invalidateCacheFiles?: string[]

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // TODO(bazel): drop when non-bazel removed.
-const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_TEST)
+const IS_BAZEL = !!(process.env.JS_BINARY__TARGET || process.env.BAZEL_BINDIR || process.env.BAZEL_TEST)
 const SRC_EXT = IS_BAZEL ? 'js' : 'ts'
 const rootDir = IS_BAZEL ? process.cwd() : __dirname
 


### PR DESCRIPTION
Actually, webpack_bundle doesn't have JS_BINARY__TARGET set since it is a custom build rule.... To handle all the cases I think we have to check for both. 😞 

See https://github.com/sourcegraph/sourcegraph/pull/48795#issuecomment-1457594735

Test plan: CI

## App preview:

- [Web](https://sg-web-also-use-bazel-bindir.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
