### PR TITLE
cody: update docs and specify model in site config for completions

### DIFF
--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -12,13 +12,14 @@ Cody is in private alpha (tagged as an [experimental](../doc/admin/beta_and_expe
 
 To enable the Cody extension to work with your Sourcegraph instance (requires site-admin permissions), follow the steps below. Note that this assumes you've reached out to us to get required `accessToken`(s).
 
-* Go to Site admin > Site configuration (`/site-admin/configuration`) on your instance
+* Go to Site admin > Site configuration (`/site-admin/configuration`) on your instance.
 * (Required) Add the `completions` config:
 
 ```json
 "completions": {
   "enabled": true,
   "accessToken": "<token>",
+  "model": "claude-v1",
   "provider": "anthropic"
 }
 ```
@@ -46,6 +47,8 @@ Here is the config for the OpenAI Embeddings API:
   "dimensions": 1536
 }
 ```
+
+* Navigate to Site admin > Cody (`/site-admin/cody`) and schedule repositories for embedding.
 
 > NOTE: By enabling Cody, you agree to the [Cody Notice and Usage Policy](https://about.sourcegraph.com/terms/cody-notice). In particular, some code snippets will be sent to a third-party language model provider when you use the Cody extension.
 

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
@@ -14,7 +14,6 @@ import (
 
 const API_URL = "https://api.anthropic.com/v1/complete"
 const CLIENT_ID = "sourcegraph/1.0"
-const ANTHROPIC_MODEL = "claude-v1"
 
 var DONE_BYTES = []byte("[DONE]")
 var STOP_SEQUENCES = []string{HUMAN_PROMPT}
@@ -33,12 +32,14 @@ type AnthropicCompletionsRequestParameters struct {
 type anthropicCompletionStreamClient struct {
 	cli         httpcli.Doer
 	accessToken string
+	model       string
 }
 
-func NewAnthropicCompletionStreamClient(cli httpcli.Doer, accessToken string) types.CompletionStreamClient {
+func NewAnthropicCompletionStreamClient(cli httpcli.Doer, accessToken string, model string) types.CompletionStreamClient {
 	return &anthropicCompletionStreamClient{
 		cli:         cli,
 		accessToken: accessToken,
+		model:       model,
 	}
 }
 
@@ -55,7 +56,7 @@ func (a *anthropicCompletionStreamClient) Stream(
 	payload := AnthropicCompletionsRequestParameters{
 		Stream:            true,
 		StopSequences:     STOP_SEQUENCES,
-		Model:             ANTHROPIC_MODEL,
+		Model:             a.model,
 		Temperature:       requestParams.Temperature,
 		MaxTokensToSample: requestParams.MaxTokensToSample,
 		TopP:              requestParams.TopP,

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic_test.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic_test.go
@@ -36,7 +36,7 @@ func getMockClient(responseBody []byte) types.CompletionStreamClient {
 		func(r *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(responseBody))}, nil
 		},
-	}, "")
+	}, "", "")
 }
 
 func TestValidAnthropicStream(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -29,10 +29,10 @@ type streamHandler struct {
 	logger log.Logger
 }
 
-func getCompletionStreamClient(provider string, accessToken string) (types.CompletionStreamClient, error) {
+func getCompletionStreamClient(provider string, accessToken string, model string) (types.CompletionStreamClient, error) {
 	switch provider {
 	case "anthropic":
-		return anthropic.NewAnthropicCompletionStreamClient(httpcli.ExternalDoer, accessToken), nil
+		return anthropic.NewAnthropicCompletionStreamClient(httpcli.ExternalDoer, accessToken, model), nil
 	default:
 		return nil, errors.Newf("unknown completion stream provider: %s", provider)
 	}
@@ -66,7 +66,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		tr.Finish()
 	}()
 
-	completionStreamClient, err := getCompletionStreamClient(completionsConfig.Provider, completionsConfig.AccessToken)
+	completionStreamClient, err := getCompletionStreamClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -70,6 +70,9 @@ func (r *Resolver) EmbeddingsSearch(ctx context.Context, args graphqlbackend.Emb
 }
 
 func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graphqlbackend.IsContextRequiredForChatQueryInputArgs) (bool, error) {
+	if !conf.EmbeddingsEnabled() {
+		return false, errors.New("embeddings are not configured or disabled")
+	}
 	return r.embeddingsClient.IsContextRequiredForChatQuery(ctx, embeddings.IsContextRequiredForChatQueryParameters{Query: args.Query})
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -547,6 +547,8 @@ type Completions struct {
 	AccessToken string `json:"accessToken"`
 	// Enabled description: Toggles whether completions are enabled.
 	Enabled bool `json:"enabled"`
+	// Model description: The model used for completions.
+	Model string `json:"model"`
 	// Provider description: The external completions provider.
 	Provider string `json:"provider"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1880,12 +1880,16 @@
     "completions": {
       "description": "Configuration for the completions service.",
       "type": "object",
-      "required": ["enabled", "accessToken", "provider"],
+      "required": ["enabled", "model", "accessToken", "provider"],
       "properties": {
         "enabled": {
           "description": "Toggles whether completions are enabled.",
           "type": "boolean",
           "default": false
+        },
+        "model": {
+          "description": "The model used for completions.",
+          "type": "string"
         },
         "accessToken": {
           "description": "The access token used to authenticate with the external completions provider.",


### PR DESCRIPTION
Adds a note about the Cody Site admin page to docs and updates the example completions config. I also found that we're not checking if embeddings are enabled in the `IsContextRequiredForChatQuery`, so I included a fix for that as well.


## Test plan

* When saving the completions in site config, the `model` field is now required.
 