### PR TITLE
[feat] Use unified perms table in UserIDsWithNoPerms

### DIFF
--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -58,7 +58,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
-		{"UserIDsWithNoPerms", testPermsStore_UserIDsWithNoPerms(db)},
 		{"RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
 		{"UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
 		{"ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},


### PR DESCRIPTION
Use the new unified perms table in UserIDsWithNoPerms function in perms_store.go

## Test plan

Unit test modified, everything is still behind feature flag.
