### PR TITLE
sg: specify postgres version for homebrew

### DIFF
--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -149,7 +149,7 @@ If you've installed PostgreSQL with Homebrew that should be the case.
 
 If you used another method, make sure psql is available.`,
 				Check: checkAction(check.InPath("psql")),
-				Fix:   cmdFix("brew install postgresql@14"),
+				Fix:   cmdFix("brew install postgresql@15"),
 			},
 			{
 				Name: "Start Postgres",
@@ -165,7 +165,7 @@ If you used another method, make sure psql is available.`,
 					}
 					return checkPostgresConnection(ctx)
 				},
-				Description: `Sourcegraph requires the PostgreSQL database to be running.
+				Description: `Sourcegraph requires the PostgreSQL database (v12+) to be running.
 
 We recommend installing it with Homebrew and starting it as a system service.
 If you know what you're doing, you can also install PostgreSQL another way.

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -149,7 +149,7 @@ If you've installed PostgreSQL with Homebrew that should be the case.
 
 If you used another method, make sure psql is available.`,
 				Check: checkAction(check.InPath("psql")),
-				Fix:   cmdFix("brew install postgresql"),
+				Fix:   cmdFix("brew install postgresql@14"),
 			},
 			{
 				Name: "Start Postgres",

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -161,7 +161,7 @@ var Ubuntu = []category{
 				},
 				Description: `Sourcegraph requires the PostgreSQL database to be running.
 
-We recommend installing it with Homebrew and starting it as a system service.
+We recommend installing it with your OS package manager  and starting it as a system service.
 If you know what you're doing, you can also install PostgreSQL another way.
 For example: you can use https://postgresapp.com/
 


### PR DESCRIPTION
`brew install postgresql` does not install the latest version of postgres anymore, instead it has the following message
```
Warning: No available formula with the name "postgresql". Did you mean postgresql@13, postgresql@12, postgresql@11, postgresql@15, postgresql@10, postgresql@14, postgresql@9.5, postgresql@9.4, postgrest or qt-postgresql?
postgresql breaks existing databases on upgrade without human intervention.
```

We now specify `postgresql@15` to be installed aka the latest version.
## Test plan
github action testing `sg setup` to pass for mac
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
