### PR TITLE
experimental search input: Use 'Enter' display name on Linux/Windows

### DIFF
--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -159,9 +159,9 @@ const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
             {option.info && renderStringOrRenderer(option.info, option)}
             {!option.info && (
                 <>
-                    <ActionInfo action={option.action} shortcut="Return" />{' '}
+                    <ActionInfo action={option.action} shortcut="Enter" />{' '}
                     {option.alternativeAction && (
-                        <ActionInfo action={option.alternativeAction} shortcut="Shift+Return" />
+                        <ActionInfo action={option.alternativeAction} shortcut="Shift+Enter" />
                     )}
                 </>
             )}

--- a/client/shared/src/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts.ts
@@ -33,6 +33,7 @@ const KEY_TO_NAME: { [P in Key | ModifierKey | string]?: string } = {
     '†': 't',
     ArrowUp: '↑',
     ArrowDown: '↓',
+    Enter: isMacPlatform() ? 'Return' : 'Enter',
 }
 KEY_TO_NAME.Mod = KEY_TO_NAME[getModKey()]
 


### PR DESCRIPTION

## Test plan

Manual testing. 
<img width="835" alt="2023-03-07_10-10" src="https://user-images.githubusercontent.com/179026/223392545-bd242653-26a7-4b34-bea4-ee75e6a5f80f.png">


## App preview:

- [Web](https://sg-web-fkling-search-input-keyname.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
