### PR TITLE
bazel: fix enterprise build

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1815,6 +1815,7 @@ WEBPACK_CONFIG_DEPS = [
     "//:node_modules/path-browserify",
     "//:node_modules/punycode",
     "//:node_modules/util",
+    "//:node_modules/events",
     "//:node_modules/webpack-manifest-plugin",
     "//:node_modules/webpack-stats-plugin",
     "//:node_modules/monaco-editor",

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -238,6 +238,7 @@ const config = {
       path: require.resolve('path-browserify'),
       punycode: require.resolve('punycode'),
       util: require.resolve('util'),
+      events: require.resolve('events'),
     },
     alias: {
       // react-visibility-sensor's main field points to a UMD bundle instead of ESM

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -238,6 +238,7 @@ const config = {
       path: require.resolve('path-browserify'),
       punycode: require.resolve('punycode'),
       util: require.resolve('util'),
+      events: require.resolve('events'),
     },
     alias: {
       // react-visibility-sensor's main field points to a UMD bundle instead of ESM


### PR DESCRIPTION
## Context

The enterprise web-app build fails in Bazel because of the missing events fallback. This PR fixes it. 

## Test plan

`bazel build //client/web:bundle-enterprise`

## App preview:

- [Web](https://sg-web-vb-bazel-configure-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
