### PR TITLE
internal/database: Do not wait for rate limiter inside transaction

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -51,9 +51,9 @@ type GitserverRepoStore interface {
 	// a matching row does not yet exist a new one will be created.
 	// If the size value hasn't changed, the row will not be updated.
 	SetRepoSize(ctx context.Context, name api.RepoName, size int64, shardID string) error
-	// IterateWithNonemptyLastError iterates over repos w/ non-empty last_error field and calls the repoFn for these repos.
+	// ListReposWithLastError iterates over repos w/ non-empty last_error field and calls the repoFn for these repos.
 	// note that this currently filters out any repos which do not have an associated external service where cloud_default = true.
-	IterateWithNonemptyLastError(ctx context.Context, repoFn func(repo api.RepoName) error) error
+	ListReposWithLastError(ctx context.Context) ([]*api.RepoName, error)
 	// IteratePurgeableRepos iterates over all purgeable repos. These are repos that
 	// are cloned on disk but have been deleted or blocked.
 	IteratePurgeableRepos(ctx context.Context, options IteratePurgableReposOptions, repoFn func(repo api.RepoName) error) error
@@ -148,28 +148,19 @@ WHERE
 	AND es.cloud_default IS TRUE
 `
 
-func (s *gitserverRepoStore) IterateWithNonemptyLastError(ctx context.Context, repoFn func(repo api.RepoName) error) (err error) {
+func (s *gitserverRepoStore) ListReposWithLastError(ctx context.Context) ([]*api.RepoName, error) {
 	rows, err := s.Query(ctx, sqlf.Sprintf(nonemptyLastErrorQuery))
-	if err != nil {
-		return errors.Wrap(err, "fetching repos with nonempty last_error")
-	}
-	defer func() {
-		err = basestore.CloseRows(rows, err)
-	}()
+	return scanLastErroredRepos(rows, err)
+}
 
-	for rows.Next() {
-		var name api.RepoName
-		if err := rows.Scan(&name); err != nil {
-			return errors.Wrap(err, "scanning row")
-		}
-		err := repoFn(name)
-		if err != nil {
-			// Abort
-			return errors.Wrap(err, "calling repoFn")
-		}
-	}
+type lastErroredRepo struct {
+	Name string
+}
 
-	return nil
+func scanLastErroredRepoRow(scanner dbutil.Scanner) (*api.RepoName, error) {
+	var name api.RepoName
+	err := scanner.Scan(&name)
+	return &name, err
 }
 
 const nonemptyLastErrorQuery = `
@@ -184,6 +175,8 @@ WHERE
 	AND repo.deleted_at IS NULL
 	AND es.cloud_default IS TRUE
 `
+
+var scanLastErroredRepos = basestore.NewSliceScanner(scanLastErroredRepoRow)
 
 type IteratePurgableReposOptions struct {
 	// DeletedBefore will filter the deleted repos to only those that were deleted

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -213,10 +213,8 @@ func TestListReposWithLastError(t *testing.T) {
 	type testCase struct {
 		name               string
 		testRepos          []testRepo
-		expectedReposFound []*api.RepoName
+		expectedReposFound []api.RepoName
 	}
-	repo1 := api.RepoName("github.com/sourcegraph/repo1")
-	repo2 := api.RepoName("github.com/sourcegraph/repo2")
 	testCases := []testCase{
 		{
 			name: "get repos with last error",
@@ -231,7 +229,7 @@ func TestListReposWithLastError(t *testing.T) {
 					cloudDefault: true,
 				},
 			},
-			expectedReposFound: []*api.RepoName{&repo1},
+			expectedReposFound: []api.RepoName{"github.com/sourcegraph/repo1"},
 		},
 		{
 			name: "filter out non cloud_default repos",
@@ -247,7 +245,7 @@ func TestListReposWithLastError(t *testing.T) {
 					hasLastError: true,
 				},
 			},
-			expectedReposFound: []*api.RepoName{&repo2},
+			expectedReposFound: []api.RepoName{"github.com/sourcegraph/repo2"},
 		},
 		{
 			name: "no cloud_default repos with non-empty last errors",

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -199,8 +199,6 @@ func TestIteratePurgeableRepos(t *testing.T) {
 	}
 }
 
-func strPtr(s string) *string { return &s }
-
 func TestListReposWithLastError(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -25061,7 +25061,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
-			defaultHook: func(context.Context) (r0 []*api.RepoName, r1 error) {
+			defaultHook: func(context.Context) (r0 []api.RepoName, r1 error) {
 				return
 			},
 		},
@@ -25154,7 +25154,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
-			defaultHook: func(context.Context) ([]*api.RepoName, error) {
+			defaultHook: func(context.Context) ([]api.RepoName, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.ListReposWithLastError")
 			},
 		},
@@ -25932,15 +25932,15 @@ func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Results() []interf
 // the ListReposWithLastError method of the parent MockGitserverRepoStore
 // instance is invoked.
 type GitserverRepoStoreListReposWithLastErrorFunc struct {
-	defaultHook func(context.Context) ([]*api.RepoName, error)
-	hooks       []func(context.Context) ([]*api.RepoName, error)
+	defaultHook func(context.Context) ([]api.RepoName, error)
+	hooks       []func(context.Context) ([]api.RepoName, error)
 	history     []GitserverRepoStoreListReposWithLastErrorFuncCall
 	mutex       sync.Mutex
 }
 
 // ListReposWithLastError delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) ListReposWithLastError(v0 context.Context) ([]*api.RepoName, error) {
+func (m *MockGitserverRepoStore) ListReposWithLastError(v0 context.Context) ([]api.RepoName, error) {
 	r0, r1 := m.ListReposWithLastErrorFunc.nextHook()(v0)
 	m.ListReposWithLastErrorFunc.appendCall(GitserverRepoStoreListReposWithLastErrorFuncCall{v0, r0, r1})
 	return r0, r1
@@ -25949,7 +25949,7 @@ func (m *MockGitserverRepoStore) ListReposWithLastError(v0 context.Context) ([]*
 // SetDefaultHook sets function that is called when the
 // ListReposWithLastError method of the parent MockGitserverRepoStore
 // instance is invoked and the hook queue is empty.
-func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultHook(hook func(context.Context) ([]*api.RepoName, error)) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultHook(hook func(context.Context) ([]api.RepoName, error)) {
 	f.defaultHook = hook
 }
 
@@ -25958,7 +25958,7 @@ func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushHook(hook func(context.Context) ([]*api.RepoName, error)) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushHook(hook func(context.Context) ([]api.RepoName, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -25966,20 +25966,20 @@ func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushHook(hook func(contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultReturn(r0 []*api.RepoName, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]*api.RepoName, error) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultReturn(r0 []api.RepoName, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]api.RepoName, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushReturn(r0 []*api.RepoName, r1 error) {
-	f.PushHook(func(context.Context) ([]*api.RepoName, error) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushReturn(r0 []api.RepoName, r1 error) {
+	f.PushHook(func(context.Context) ([]api.RepoName, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverRepoStoreListReposWithLastErrorFunc) nextHook() func(context.Context) ([]*api.RepoName, error) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) nextHook() func(context.Context) ([]api.RepoName, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -26019,7 +26019,7 @@ type GitserverRepoStoreListReposWithLastErrorFuncCall struct {
 	Arg0 context.Context
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []*api.RepoName
+	Result0 []api.RepoName
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -24989,10 +24989,9 @@ type MockGitserverRepoStore struct {
 	// object controlling the behavior of the method
 	// IterateRepoGitserverStatus.
 	IterateRepoGitserverStatusFunc *GitserverRepoStoreIterateRepoGitserverStatusFunc
-	// IterateWithNonemptyLastErrorFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// IterateWithNonemptyLastError.
-	IterateWithNonemptyLastErrorFunc *GitserverRepoStoreIterateWithNonemptyLastErrorFunc
+	// ListReposWithLastErrorFunc is an instance of a mock function object
+	// controlling the behavior of the method ListReposWithLastError.
+	ListReposWithLastErrorFunc *GitserverRepoStoreListReposWithLastErrorFunc
 	// ListReposWithoutSizeFunc is an instance of a mock function object
 	// controlling the behavior of the method ListReposWithoutSize.
 	ListReposWithoutSizeFunc *GitserverRepoStoreListReposWithoutSizeFunc
@@ -25061,8 +25060,8 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 				return
 			},
 		},
-		IterateWithNonemptyLastErrorFunc: &GitserverRepoStoreIterateWithNonemptyLastErrorFunc{
-			defaultHook: func(context.Context, func(repo api.RepoName) error) (r0 error) {
+		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
+			defaultHook: func(context.Context) (r0 []*api.RepoName, r1 error) {
 				return
 			},
 		},
@@ -25154,9 +25153,9 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.IterateRepoGitserverStatus")
 			},
 		},
-		IterateWithNonemptyLastErrorFunc: &GitserverRepoStoreIterateWithNonemptyLastErrorFunc{
-			defaultHook: func(context.Context, func(repo api.RepoName) error) error {
-				panic("unexpected invocation of MockGitserverRepoStore.IterateWithNonemptyLastError")
+		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
+			defaultHook: func(context.Context) ([]*api.RepoName, error) {
+				panic("unexpected invocation of MockGitserverRepoStore.ListReposWithLastError")
 			},
 		},
 		ListReposWithoutSizeFunc: &GitserverRepoStoreListReposWithoutSizeFunc{
@@ -25235,8 +25234,8 @@ func NewMockGitserverRepoStoreFrom(i GitserverRepoStore) *MockGitserverRepoStore
 		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
 			defaultHook: i.IterateRepoGitserverStatus,
 		},
-		IterateWithNonemptyLastErrorFunc: &GitserverRepoStoreIterateWithNonemptyLastErrorFunc{
-			defaultHook: i.IterateWithNonemptyLastError,
+		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
+			defaultHook: i.ListReposWithLastError,
 		},
 		ListReposWithoutSizeFunc: &GitserverRepoStoreListReposWithoutSizeFunc{
 			defaultHook: i.ListReposWithoutSize,
@@ -25929,37 +25928,37 @@ func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Results() []interf
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// GitserverRepoStoreIterateWithNonemptyLastErrorFunc describes the behavior
-// when the IterateWithNonemptyLastError method of the parent
-// MockGitserverRepoStore instance is invoked.
-type GitserverRepoStoreIterateWithNonemptyLastErrorFunc struct {
-	defaultHook func(context.Context, func(repo api.RepoName) error) error
-	hooks       []func(context.Context, func(repo api.RepoName) error) error
-	history     []GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall
+// GitserverRepoStoreListReposWithLastErrorFunc describes the behavior when
+// the ListReposWithLastError method of the parent MockGitserverRepoStore
+// instance is invoked.
+type GitserverRepoStoreListReposWithLastErrorFunc struct {
+	defaultHook func(context.Context) ([]*api.RepoName, error)
+	hooks       []func(context.Context) ([]*api.RepoName, error)
+	history     []GitserverRepoStoreListReposWithLastErrorFuncCall
 	mutex       sync.Mutex
 }
 
-// IterateWithNonemptyLastError delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) IterateWithNonemptyLastError(v0 context.Context, v1 func(repo api.RepoName) error) error {
-	r0 := m.IterateWithNonemptyLastErrorFunc.nextHook()(v0, v1)
-	m.IterateWithNonemptyLastErrorFunc.appendCall(GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall{v0, v1, r0})
-	return r0
+// ListReposWithLastError delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) ListReposWithLastError(v0 context.Context) ([]*api.RepoName, error) {
+	r0, r1 := m.ListReposWithLastErrorFunc.nextHook()(v0)
+	m.ListReposWithLastErrorFunc.appendCall(GitserverRepoStoreListReposWithLastErrorFuncCall{v0, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// IterateWithNonemptyLastError method of the parent MockGitserverRepoStore
+// ListReposWithLastError method of the parent MockGitserverRepoStore
 // instance is invoked and the hook queue is empty.
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) SetDefaultHook(hook func(context.Context, func(repo api.RepoName) error) error) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultHook(hook func(context.Context) ([]*api.RepoName, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// IterateWithNonemptyLastError method of the parent MockGitserverRepoStore
+// ListReposWithLastError method of the parent MockGitserverRepoStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) PushHook(hook func(context.Context, func(repo api.RepoName) error) error) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushHook(hook func(context.Context) ([]*api.RepoName, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -25967,20 +25966,20 @@ func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) PushHook(hook func(
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, func(repo api.RepoName) error) error {
-		return r0
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) SetDefaultReturn(r0 []*api.RepoName, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]*api.RepoName, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, func(repo api.RepoName) error) error {
-		return r0
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) PushReturn(r0 []*api.RepoName, r1 error) {
+	f.PushHook(func(context.Context) ([]*api.RepoName, error) {
+		return r0, r1
 	})
 }
 
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) nextHook() func(context.Context, func(repo api.RepoName) error) error {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) nextHook() func(context.Context) ([]*api.RepoName, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -25993,49 +25992,49 @@ func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) nextHook() func(con
 	return hook
 }
 
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) appendCall(r0 GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall) {
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) appendCall(r0 GitserverRepoStoreListReposWithLastErrorFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall objects describing
-// the invocations of this function.
-func (f *GitserverRepoStoreIterateWithNonemptyLastErrorFunc) History() []GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall {
+// GitserverRepoStoreListReposWithLastErrorFuncCall objects describing the
+// invocations of this function.
+func (f *GitserverRepoStoreListReposWithLastErrorFunc) History() []GitserverRepoStoreListReposWithLastErrorFuncCall {
 	f.mutex.Lock()
-	history := make([]GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall, len(f.history))
+	history := make([]GitserverRepoStoreListReposWithLastErrorFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall is an object that
-// describes an invocation of method IterateWithNonemptyLastError on an
-// instance of MockGitserverRepoStore.
-type GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall struct {
+// GitserverRepoStoreListReposWithLastErrorFuncCall is an object that
+// describes an invocation of method ListReposWithLastError on an instance
+// of MockGitserverRepoStore.
+type GitserverRepoStoreListReposWithLastErrorFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 func(repo api.RepoName) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 []*api.RepoName
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitserverRepoStoreListReposWithLastErrorFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GitserverRepoStoreListReposWithLastErrorFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverRepoStoreListReposWithoutSizeFunc describes the behavior when

--- a/internal/repos/sync_errored.go
+++ b/internal/repos/sync_errored.go
@@ -55,12 +55,11 @@ func (s *Syncer) SyncReposWithLastErrors(ctx context.Context, rateLimiter *ratel
 		if err != nil {
 			return errors.Errorf("error waiting for rate limiter: %s", err)
 		}
-		_, err = s.SyncRepo(ctx, *repoName, false)
+		_, err = s.SyncRepo(ctx, repoName, false)
 		if err != nil {
-			s.ObsvCtx.Logger.Error("error syncing repo", log.String("repo", string(*repoName)), log.Error(err))
+			s.ObsvCtx.Logger.Error("error syncing repo", log.String("repo", string(repoName)), log.Error(err))
 		}
 		erroredRepoGauge.Inc()
-		return nil
 	}
 
 	return err

--- a/internal/repos/sync_errored.go
+++ b/internal/repos/sync_errored.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -46,18 +45,24 @@ func (s *Syncer) RunSyncReposWithLastErrorsWorker(ctx context.Context, rateLimit
 func (s *Syncer) SyncReposWithLastErrors(ctx context.Context, rateLimiter *ratelimit.InstrumentedLimiter) error {
 	erroredRepoGauge.Set(0)
 	s.setTotalErroredRepos(ctx)
-	err := s.Store.GitserverReposStore().IterateWithNonemptyLastError(ctx, func(repo api.RepoName) error {
+	repoNames, err := s.Store.GitserverReposStore().ListReposWithLastError(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to list gitserver_repos with last_error not null")
+	}
+
+	for _, repoName := range repoNames {
 		err := rateLimiter.Wait(ctx)
 		if err != nil {
 			return errors.Errorf("error waiting for rate limiter: %s", err)
 		}
-		_, err = s.SyncRepo(ctx, repo, false)
+		_, err = s.SyncRepo(ctx, *repoName, false)
 		if err != nil {
-			s.ObsvCtx.Logger.Error("error syncing repo", log.String("repo", string(repo)), log.Error(err))
+			s.ObsvCtx.Logger.Error("error syncing repo", log.String("repo", string(*repoName)), log.Error(err))
 		}
 		erroredRepoGauge.Inc()
 		return nil
-	})
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Load up all the repo names in memory and sync them one at a time instead of holding onto the transaction waiting for the rate limiter.

Earlier today, we had an incident where the repo table was locked from all queries. As a side effect of that investigation, we also found out that this [query was running](https://sourcegraph.slack.com/archives/C04SLUZNTLM/p1678178077061789) for ~1.5 hours:

```
-- query hash: 804980436
-- query length: 281 (0 args)
-- caller: internal/database.(*gitserverRepoStore).IterateWithNonemptyLastError
-- source: internal/database/gitserver_repos.go:152

SELECT
	repo.name
FROM repo
JOIN gitserver_repos gr ON repo.id = gr.repo_id
JOIN external_service_repos esr ON repo.id = esr.repo_id
JOIN external_services es on esr.external_service_id = es.id
WHERE
	gr.last_error != ''
	AND repo.deleted_at IS NULL
	AND es.cloud_default IS TRUE
```

While this was not the source of the problem - rather a side effect of the deadlock on the table, we can refactor this to load up the repo names in memory instead of scanning through one at a time and waiting on the rate limiter. In a worst case scenario where the syncer is rate limited, this will unnecessarily wait for a long enough time until the rate limiter is available or the PG backend cancels the query.


## Test plan

- Updated existing tests
- Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
