### PR TITLE
permissions-center: add "re-trigger sync" button to actions menu.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -74,6 +74,7 @@ SixSyncJobsFound.storyName = 'Six sync jobs'
 
 interface repo {
     __typename: 'Repository'
+    id: string
     name: string
     externalRepository: {
         serviceType: ExternalServiceKind
@@ -82,6 +83,7 @@ interface repo {
 
 interface user {
     __typename: 'User'
+    id: string
     username: string
 }
 
@@ -149,6 +151,7 @@ function getSyncJobs(): PermissionsSyncJob[] {
             index % 2 === 0
                 ? {
                       __typename: 'Repository',
+                      id: index.toString(),
                       name: `sourcegraph/repo-${index}`,
                       externalRepository: {
                           serviceType: index % 3 === 0 ? ExternalServiceKind.GITHUB : ExternalServiceKind.GITLAB,
@@ -156,6 +159,7 @@ function getSyncJobs(): PermissionsSyncJob[] {
                   }
                 : {
                       __typename: 'User',
+                      id: index.toString(),
                       username: `username-${index}`,
                   }
 

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -1,9 +1,12 @@
 import React, { ChangeEvent, FC, useCallback, useEffect, useState } from 'react'
 
-import { mdiMapSearch } from '@mdi/js'
+import { mdiClose, mdiMapSearch, mdiReload } from '@mdi/js'
+import { noop } from 'lodash'
 
+import { useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
+    Alert,
     Button,
     Container,
     Icon,
@@ -25,11 +28,15 @@ import {
     PermissionsSyncJobsSearchType,
     PermissionsSyncJobState,
     PermissionsSyncJobsVariables,
+    ScheduleRepoPermissionsSyncResult,
+    ScheduleRepoPermissionsSyncVariables,
+    ScheduleUserPermissionsSyncResult,
+    ScheduleUserPermissionsSyncVariables,
 } from '../../graphql-operations'
 import { useURLSyncedState } from '../../hooks'
 import { IColumn, Table } from '../UserManagement/components/Table'
 
-import { PERMISSIONS_SYNC_JOBS_QUERY } from './backend'
+import { PERMISSIONS_SYNC_JOBS_QUERY, TRIGGER_REPO_SYNC, TRIGGER_USER_SYNC } from './backend'
 import {
     PermissionsSyncJobNumbers,
     PermissionsSyncJobReasonByline,
@@ -44,6 +51,11 @@ interface Filters {
     state: string
     searchType: string
     query: string
+}
+
+interface Notification {
+    text: React.ReactNode
+    isError?: boolean
 }
 
 const DEFAULT_FILTERS = {
@@ -103,6 +115,41 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
         [setFilters]
     )
 
+    const [notification, setNotification] = useState<Notification | undefined>(undefined)
+    const dismissNotification = useCallback(() => setNotification(undefined), [])
+
+    const [triggerUserSync] = useMutation<ScheduleUserPermissionsSyncResult, ScheduleUserPermissionsSyncVariables>(
+        TRIGGER_USER_SYNC
+    )
+    const [triggerRepoSync] = useMutation<ScheduleRepoPermissionsSyncResult, ScheduleRepoPermissionsSyncVariables>(
+        TRIGGER_REPO_SYNC
+    )
+
+    const triggerPermsSync = useCallback(
+        ([job]: PermissionsSyncJob[]) => {
+            if (job.subject.__typename === 'Repository') {
+                triggerRepoSync({
+                    variables: { repo: job.subject.id },
+                    onCompleted: () => setNotification({ text: 'Repository permissions sync successfully scheduled' }),
+                    onError: error => setNotification({ text: error.message, isError: true }),
+                }).catch(
+                    // noop here is used because an error is handled in `onError` option of `useMutation` above.
+                    noop
+                )
+            } else {
+                triggerUserSync({
+                    variables: { user: job.subject.id },
+                    onCompleted: () => setNotification({ text: 'User permissions sync successfully scheduled' }),
+                    onError: error => setNotification({ text: error.message, isError: true }),
+                }).catch(
+                    // noop here is used because an error is handled in `onError` option of `useMutation` above.
+                    noop
+                )
+            }
+        },
+        [triggerUserSync, triggerRepoSync]
+    )
+
     return (
         <div>
             <PageTitle title="Permissions Sync Dashboard - Admin" />
@@ -134,11 +181,31 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                     </div>
                 )}
                 {connection?.nodes?.length === 0 && <EmptyList />}
+                {notification && (
+                    <Alert
+                        className="mt-2 d-flex justify-content-between align-items-center"
+                        variant={notification.isError ? 'danger' : 'success'}
+                    >
+                        {notification.text}
+                        <Button variant="secondary" outline={true} onClick={dismissNotification}>
+                            <Icon aria-label="Close notification" svgPath={mdiClose} />
+                        </Button>
+                    </Alert>
+                )}
                 {!!connection?.nodes?.length && (
                     <Table<PermissionsSyncJob>
                         columns={TableColumns}
                         getRowId={node => node.id}
                         data={connection.nodes}
+                        actions={[
+                            {
+                                key: 'Re-trigger job',
+                                label: 'Re-trigger job',
+                                icon: mdiReload,
+                                onClick: triggerPermsSync,
+                                condition: ([node]) => finalState(node.state),
+                            },
+                        ]}
                     />
                 )}
                 <PageSwitcher
@@ -309,3 +376,6 @@ const EmptyList: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
         <div className="pt-2">No permissions sync jobs have been found.</div>
     </div>
 )
+
+const finalState = (state: PermissionsSyncJobState): boolean =>
+    state !== PermissionsSyncJobState.QUEUED && state !== PermissionsSyncJobState.PROCESSING

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, FC, useCallback, useEffect, useState } from 'react'
 
+import { ApolloError } from '@apollo/client/errors'
 import { mdiClose, mdiMapSearch, mdiReload } from '@mdi/js'
 import { noop } from 'lodash'
 
@@ -45,7 +46,6 @@ import {
 } from './PermissionsSyncJobNode'
 
 import styles from './PermissionsSyncJobsTable.module.scss'
-import { ApolloError } from '@apollo/client/errors'
 
 interface Filters {
     reason: string
@@ -128,12 +128,12 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
 
     const triggerPermsSync = useCallback(
         ([job]: PermissionsSyncJob[]) => {
-            const onError = (error: ApolloError) => setNotification({ text: error.message, isError: true })
+            const onError = (error: ApolloError): void => setNotification({ text: error.message, isError: true })
             if (job.subject.__typename === 'Repository') {
                 triggerRepoSync({
                     variables: { repo: job.subject.id },
                     onCompleted: () => setNotification({ text: 'Repository permissions sync successfully scheduled' }),
-                    onError: onError,
+                    onError,
                 }).catch(
                     // noop here is used because an error is handled in `onError` option of `useMutation` above.
                     noop
@@ -142,7 +142,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 triggerUserSync({
                     variables: { user: job.subject.id },
                     onCompleted: () => setNotification({ text: 'User permissions sync successfully scheduled' }),
-                    onError: onError,
+                    onError,
                 }).catch(
                     // noop here is used because an error is handled in `onError` option of `useMutation` above.
                     noop

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -45,6 +45,7 @@ import {
 } from './PermissionsSyncJobNode'
 
 import styles from './PermissionsSyncJobsTable.module.scss'
+import { ApolloError } from '@apollo/client/errors'
 
 interface Filters {
     reason: string
@@ -127,11 +128,12 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
 
     const triggerPermsSync = useCallback(
         ([job]: PermissionsSyncJob[]) => {
+            const onError = (error: ApolloError) => setNotification({ text: error.message, isError: true })
             if (job.subject.__typename === 'Repository') {
                 triggerRepoSync({
                     variables: { repo: job.subject.id },
                     onCompleted: () => setNotification({ text: 'Repository permissions sync successfully scheduled' }),
-                    onError: error => setNotification({ text: error.message, isError: true }),
+                    onError: onError,
                 }).catch(
                     // noop here is used because an error is handled in `onError` option of `useMutation` above.
                     noop
@@ -140,7 +142,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 triggerUserSync({
                     variables: { user: job.subject.id },
                     onCompleted: () => setNotification({ text: 'User permissions sync successfully scheduled' }),
-                    onError: error => setNotification({ text: error.message, isError: true }),
+                    onError: onError,
                 }).catch(
                     // noop here is used because an error is handled in `onError` option of `useMutation` above.
                     noop

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -7,6 +7,7 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         subject {
             ... on Repository {
                 __typename
+                id
                 name
                 externalRepository {
                     serviceType
@@ -14,6 +15,7 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
             }
             ... on User {
                 __typename
+                id
                 username
             }
         }
@@ -77,6 +79,22 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
             nodes {
                 ...PermissionsSyncJob
             }
+        }
+    }
+`
+
+export const TRIGGER_USER_SYNC = gql`
+    mutation ScheduleUserPermissionsSync($user: ID!) {
+        scheduleUserPermissionsSync(user: $user) {
+            alwaysNil
+        }
+    }
+`
+
+export const TRIGGER_REPO_SYNC = gql`
+    mutation ScheduleRepoPermissionsSync($repo: ID!) {
+        scheduleRepositoryPermissionsSync(repository: $repo) {
+            alwaysNil
         }
     }
 `


### PR DESCRIPTION
Test plan:
Local sg run and test.

Closes https://github.com/sourcegraph/sourcegraph/issues/47879

### Demo

https://user-images.githubusercontent.com/94846361/223409167-2eccb956-cf90-4edc-bd95-c67aac136aa8.mp4

## App preview:

- [Web](https://sg-web-ao-ui-pc-retrigger-sync.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
