### PR TITLE
Setup search client for rate limiting

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -61,8 +61,8 @@ type V3Client struct {
 	// waitForRateLimit determines whether or not the client will wait and retry a request if external rate limits are encountered
 	waitForRateLimit bool
 
-	// numRateLimitRetries determines how many times we retry requests due to rate limits
-	numRateLimitRetries int
+	// maxNumRateLimitRetries determines how many times we retry requests due to rate limits
+	maxNumRateLimitRetries int
 
 	// resource specifies which API this client is intended for.
 	// One of 'rest' or 'search'.
@@ -121,16 +121,16 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 				log.String("urn", urn),
 				log.String("resource", resource),
 			),
-		urn:                 urn,
-		apiURL:              apiURL,
-		githubDotCom:        urlIsGitHubDotCom(apiURL),
-		auth:                a,
-		httpClient:          cli,
-		internalRateLimiter: rl,
-		externalRateLimiter: rlm,
-		resource:            resource,
-		waitForRateLimit:    true,
-		numRateLimitRetries: 2,
+		urn:                    urn,
+		apiURL:                 apiURL,
+		githubDotCom:           urlIsGitHubDotCom(apiURL),
+		auth:                   a,
+		httpClient:             cli,
+		internalRateLimiter:    rl,
+		externalRateLimiter:    rlm,
+		resource:               resource,
+		waitForRateLimit:       true,
+		maxNumRateLimitRetries: 2,
 	}
 }
 
@@ -219,7 +219,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 	}
 
 	if c.waitForRateLimit {
-		c.externalRateLimiter.WaitForRateLimit(ctx) // We don't care whether we waited or not, this is a preventative measure.
+		c.externalRateLimiter.WaitForRateLimit(ctx, 1) // We don't care whether we waited or not, this is a preventative measure.
 	}
 
 	var resp *httpResponseState
@@ -231,10 +231,10 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 	// 1. We've exceeded the number of retries
 	// 2. The error returned is not a rate limit error
 	// 3. We succeed
-	for c.waitForRateLimit && err != nil && numRetries < c.numRateLimitRetries &&
+	for c.waitForRateLimit && err != nil && numRetries < c.maxNumRateLimitRetries &&
 		errors.As(err, &apiError) && apiError.Code == http.StatusForbidden {
 		// If we end up waiting because of an external rate limit, we need to retry the request.
-		if c.externalRateLimiter.WaitForRateLimit(ctx) {
+		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 			numRetries++
 		} else {

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -61,8 +61,8 @@ type V3Client struct {
 	// waitForRateLimit determines whether or not the client will wait and retry a request if external rate limits are encountered
 	waitForRateLimit bool
 
-	// maxNumRateLimitRetries determines how many times we retry requests due to rate limits
-	maxNumRateLimitRetries int
+	// maxRateLimitRetries determines how many times we retry requests due to rate limits
+	maxRateLimitRetries int
 
 	// resource specifies which API this client is intended for.
 	// One of 'rest' or 'search'.
@@ -121,16 +121,16 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 				log.String("urn", urn),
 				log.String("resource", resource),
 			),
-		urn:                    urn,
-		apiURL:                 apiURL,
-		githubDotCom:           urlIsGitHubDotCom(apiURL),
-		auth:                   a,
-		httpClient:             cli,
-		internalRateLimiter:    rl,
-		externalRateLimiter:    rlm,
-		resource:               resource,
-		waitForRateLimit:       true,
-		maxNumRateLimitRetries: 2,
+		urn:                 urn,
+		apiURL:              apiURL,
+		githubDotCom:        urlIsGitHubDotCom(apiURL),
+		auth:                a,
+		httpClient:          cli,
+		internalRateLimiter: rl,
+		externalRateLimiter: rlm,
+		resource:            resource,
+		waitForRateLimit:    true,
+		maxRateLimitRetries: 2,
 	}
 }
 
@@ -231,7 +231,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 	// 1. We've exceeded the number of retries
 	// 2. The error returned is not a rate limit error
 	// 3. We succeed
-	for c.waitForRateLimit && err != nil && numRetries < c.maxNumRateLimitRetries &&
+	for c.waitForRateLimit && err != nil && numRetries < c.maxRateLimitRetries &&
 		errors.As(err, &apiError) && apiError.Code == http.StatusForbidden {
 		// If we end up waiting because of an external rate limit, we need to retry the request.
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -1124,7 +1124,7 @@ func TestRateLimitRetry(t *testing.T) {
 
 	t.Run("retry maximum number of times", func(t *testing.T) {
 		test := buildNewtest(t, true, true)
-		test.client.numRateLimitRetries = 2
+		test.client.maxNumRateLimitRetries = 2
 
 		_, err := test.client.GetVersion(ctx)
 		require.NoError(t, err)

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -1124,7 +1124,7 @@ func TestRateLimitRetry(t *testing.T) {
 
 	t.Run("retry maximum number of times", func(t *testing.T) {
 		test := buildNewtest(t, true, true)
-		test.client.maxNumRateLimitRetries = 2
+		test.client.maxRateLimitRetries = 2
 
 		_, err := test.client.GetVersion(ctx)
 		require.NoError(t, err)

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -97,14 +97,16 @@ func NewV4Client(urn string, apiURL *url.URL, a auth.Authenticator, cli httpcli.
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V4Client{
-		log:                 log.Scoped("github.v4", "github v4 client"),
-		urn:                 urn,
-		apiURL:              apiURL,
-		githubDotCom:        urlIsGitHubDotCom(apiURL),
-		auth:                a,
-		httpClient:          cli,
-		internalRateLimiter: rl,
-		externalRateLimiter: rlm,
+		log:                    log.Scoped("github.v4", "github v4 client"),
+		urn:                    urn,
+		apiURL:                 apiURL,
+		githubDotCom:           urlIsGitHubDotCom(apiURL),
+		auth:                   a,
+		httpClient:             cli,
+		internalRateLimiter:    rl,
+		externalRateLimiter:    rlm,
+		waitForRateLimit:       true,
+		maxNumRateLimitRetries: 2,
 	}
 }
 

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -114,6 +114,10 @@ func TestV4Client_RateLimitRetry(t *testing.T) {
 			succeeded:          true,
 			numRequests:        2,
 		},
+		"no rate limit hit": {
+			succeeded:   true,
+			numRequests: 1,
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -241,7 +241,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 
 	if c.waitForRateLimit {
 		// We don't care whether this happens or not as it is a preventative measure.
-		_ = c.externalRateLimiter.WaitForRateLimit(ctx)
+		_ = c.externalRateLimiter.WaitForRateLimit(ctx, 1)
 	}
 
 	req.URL = c.baseURL.ResolveReference(req.URL)
@@ -250,7 +250,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 	// GitLab responds with a 429 Too Many Requests if rate limits are exceeded
 	numRetries := 0
 	for c.waitForRateLimit && numRetries < c.maxNumRateLimitRetries && respCode == http.StatusTooManyRequests {
-		if c.externalRateLimiter.WaitForRateLimit(ctx) {
+		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
 			respHeader, respCode, err = c.doWithBaseURL(ctx, req, result)
 			numRetries += 1
 		} else {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -180,7 +180,7 @@ func newGithubSource(
 
 	for resource, monitor := range map[string]*ratelimit.Monitor{
 		"rest":    v3Client.ExternalRateLimiter(),
-		"graphql": v4Client.RateLimitMonitor(),
+		"graphql": v4Client.ExternalRateLimiter(),
 		"search":  searchClient.ExternalRateLimiter(),
 	} {
 		// Copy the resource or funcs below will use the last one seen while iterating


### PR DESCRIPTION
Closes #48818 

This PR allows the GitHub V4 client to wait when rate limits are encountered. The V4 client uses the GraphQL API. Costs against the GraphQL API differ depending on the query.

We calculate the cost of the GraphQL query pre-emptively, as recommended by GitHub, and if the cost exceeds the number of tokens remaining, we wait until the tokens reset.

Secondary rate limits are handled as usual.

## Test plan

Added unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
