### PR TITLE
migration: take dynamic list of schema names for checking drift

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -15,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 )
@@ -187,31 +184,6 @@ func BatchChangesEnabledForUser(ctx context.Context, db database.DB) error {
 		return ErrBatchChangesDisabledForUser{}
 	}
 	return nil
-}
-
-// IsCodeInsightsEnabled tells if code insights are enabled or not.
-func IsCodeInsightsEnabled() bool {
-	if envvar.SourcegraphDotComMode() {
-		return false
-	}
-	if v, _ := strconv.ParseBool(os.Getenv("DISABLE_CODE_INSIGHTS")); v {
-		// Code insights can always be disabled. This can be a helpful escape hatch if e.g. there
-		// are issues with (or connecting to) the codeinsights-db deployment and it is preventing
-		// the Sourcegraph frontend or repo-updater from starting.
-		//
-		// It is also useful in dev environments if you do not wish to spend resources running Code
-		// Insights.
-		return false
-	}
-	if deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) {
-		// Code insights is not supported in single-container Docker demo deployments unless
-		// explicity allowed, (for example by backend integration tests.)
-		if v, _ := strconv.ParseBool(os.Getenv("ALLOW_SINGLE_DOCKER_CODE_INSIGHTS")); v {
-			return true
-		}
-		return false
-	}
-	return true
 }
 
 type stubRankingService struct{}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -12,6 +12,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
@@ -20,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
@@ -234,6 +236,31 @@ func canUpdateSiteConfiguration() bool {
 	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
 }
 
+// IsCodeInsightsEnabled tells if code insights are enabled or not.
+func IsCodeInsightsEnabled() bool {
+	if envvar.SourcegraphDotComMode() {
+		return false
+	}
+	if v, _ := strconv.ParseBool(os.Getenv("DISABLE_CODE_INSIGHTS")); v {
+		// Code insights can always be disabled. This can be a helpful escape hatch if e.g. there
+		// are issues with (or connecting to) the codeinsights-db deployment and it is preventing
+		// the Sourcegraph frontend or repo-updater from starting.
+		//
+		// It is also useful in dev environments if you do not wish to spend resources running Code
+		// Insights.
+		return false
+	}
+	if deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) {
+		// Code insights is not supported in single-container Docker demo deployments unless
+		// explicity allowed, (for example by backend integration tests.)
+		if v, _ := strconv.ParseBool(os.Getenv("ALLOW_SINGLE_DOCKER_CODE_INSIGHTS")); v {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
 func (r *siteResolver) UpgradeReadiness(ctx context.Context) (*upgradeReadinessResolver, error) {
 	// 🚨 SECURITY: Only site admins may view upgrade readiness information.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
@@ -250,10 +277,11 @@ type upgradeReadinessResolver struct {
 	logger log.Logger
 	db     database.DB
 
-	initOnce sync.Once
-	initErr  error
-	runner   cliutil.Runner
-	version  string
+	initOnce    sync.Once
+	initErr     error
+	runner      cliutil.Runner
+	version     string
+	schemaNames []string
 }
 
 var devSchemaFactory = cliutil.NewExpectedSchemaFactory(
@@ -271,45 +299,51 @@ var schemaFactories = append(
 
 var insidersVersionPattern = lazyregexp.New(`^[\w-]+_\d{4}-\d{2}-\d{2}_\d+\.\d+-(\w+)$`)
 
-func (r *upgradeReadinessResolver) init(ctx context.Context) (_ cliutil.Runner, version string, _ error) {
+func (r *upgradeReadinessResolver) init(ctx context.Context) (_ cliutil.Runner, version string, schemaNames []string, _ error) {
 	r.initOnce.Do(func() {
-		r.runner, r.version, r.initErr = func() (cliutil.Runner, string, error) {
+		r.runner, r.version, r.schemaNames, r.initErr = func() (cliutil.Runner, string, []string, error) {
+			schemaNames := []string{schemas.Frontend.Name, schemas.CodeIntel.Name}
+			schemaList := []*schemas.Schema{schemas.Frontend, schemas.CodeIntel}
+			if IsCodeInsightsEnabled() {
+				schemaNames = append(schemaNames, schemas.CodeInsights.Name)
+				schemaList = append(schemaList, schemas.CodeInsights)
+			}
 			observationCtx := observation.NewContext(r.logger)
-			runner, err := migratorshared.NewRunnerWithSchemas(observationCtx, r.logger, schemas.SchemaNames, schemas.Schemas)
+			runner, err := migratorshared.NewRunnerWithSchemas(observationCtx, r.logger, schemaNames, schemaList)
 			if err != nil {
-				return nil, "", errors.Wrap(err, "new runner")
+				return nil, "", nil, errors.Wrap(err, "new runner")
 			}
 
 			versionStr, ok, err := cliutil.GetRawServiceVersion(ctx, runner)
 			if err != nil {
-				return nil, "", errors.Wrap(err, "get service version")
+				return nil, "", nil, errors.Wrap(err, "get service version")
 			} else if !ok {
-				return nil, "", errors.New("invalid service version")
+				return nil, "", nil, errors.New("invalid service version")
 			}
 
 			// Return abbreviated commit hash from insiders version
 			if matches := insidersVersionPattern.FindStringSubmatch(versionStr); len(matches) > 0 {
-				return runner, matches[1], nil
+				return runner, matches[1], schemaNames, nil
 			}
 
 			v, patch, ok := oobmigration.NewVersionAndPatchFromString(versionStr)
 			if !ok {
-				return nil, "", errors.Newf("cannot parse version: %q - expected [v]X.Y[.Z]", versionStr)
+				return nil, "", nil, errors.Newf("cannot parse version: %q - expected [v]X.Y[.Z]", versionStr)
 			}
 
 			if v.Dev {
-				return runner, "dev", nil
+				return runner, "dev", schemaNames, nil
 			}
 
-			return runner, v.GitTagWithPatch(patch), nil
+			return runner, v.GitTagWithPatch(patch), schemaNames, nil
 		}()
 	})
 
-	return r.runner, r.version, r.initErr
+	return r.runner, r.version, r.schemaNames, r.initErr
 }
 
 func (r *upgradeReadinessResolver) SchemaDrift(ctx context.Context) (string, error) {
-	runner, version, err := r.init(ctx)
+	runner, version, schemaNames, err := r.init(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -317,7 +351,7 @@ func (r *upgradeReadinessResolver) SchemaDrift(ctx context.Context) (string, err
 
 	var drift bytes.Buffer
 	out := output.NewOutput(&drift, output.OutputOpts{Verbose: true})
-	err = cliutil.CheckDrift(ctx, runner, version, out, true, schemaFactories)
+	err = cliutil.CheckDrift(ctx, runner, version, out, true, schemaNames, schemaFactories)
 	if err == cliutil.ErrDatabaseDriftDetected {
 		return drift.String(), nil
 	} else if err != nil {

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -334,7 +334,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),
 		CodeIntelAutoIndexingAllowGlobalPolicies: conf.CodeIntelAutoIndexingAllowGlobalPolicies(),
 
-		CodeInsightsEnabled: enterprise.IsCodeInsightsEnabled(),
+		CodeInsightsEnabled: graphqlbackend.IsCodeInsightsEnabled(),
 
 		EmbeddingsEnabled: conf.EmbeddingsEnabled(),
 

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -1,7 +1,7 @@
 package insights
 
 import (
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -11,7 +11,7 @@ import (
 )
 
 func IsEnabled() bool {
-	return enterprise.IsCodeInsightsEnabled()
+	return graphqlbackend.IsCodeInsightsEnabled()
 }
 
 // InitializeCodeInsightsDB connects to and initializes the Code Insights Postgres DB, running

--- a/internal/database/connections/live/runner.go
+++ b/internal/database/connections/live/runner.go
@@ -25,10 +25,6 @@ func RunnerFromDSNsWithSchemas(logger log.Logger, dsns map[string]string, appNam
 	if !ok {
 		return nil, errors.Newf("no available schema matches %q", "codeintel")
 	}
-	codeinsightsSchema, ok := schemaByName(availableSchemas, "codeinsights")
-	if !ok {
-		return nil, errors.Newf("no available schema matches %q", "codeinsights")
-	}
 
 	makeFactory := func(
 		name string,
@@ -45,11 +41,14 @@ func RunnerFromDSNsWithSchemas(logger log.Logger, dsns map[string]string, appNam
 		}
 	}
 	storeFactoryMap := map[string]runner.StoreFactory{
-		"frontend":     makeFactory("frontend", frontendSchema, RawNewFrontendDB),
-		"codeintel":    makeFactory("codeintel", codeintelSchema, RawNewCodeIntelDB),
-		"codeinsights": makeFactory("codeinsights", codeinsightsSchema, RawNewCodeInsightsDB),
+		"frontend":  makeFactory("frontend", frontendSchema, RawNewFrontendDB),
+		"codeintel": makeFactory("codeintel", codeintelSchema, RawNewCodeIntelDB),
 	}
 
+	codeinsightsSchema, ok := schemaByName(availableSchemas, "codeinsights")
+	if ok {
+		storeFactoryMap["codeinsights"] = makeFactory("codeinsights", codeinsightsSchema, RawNewCodeInsightsDB)
+	}
 	return runner.NewRunnerWithSchemas(logger, storeFactoryMap, availableSchemas), nil
 }
 

--- a/internal/database/migration/cliutil/multiversion.go
+++ b/internal/database/migration/cliutil/multiversion.go
@@ -158,7 +158,7 @@ func runMigration(
 	}
 
 	if !skipDriftCheck {
-		if err := CheckDrift(ctx, r, plan.from.GitTagWithPatch(patch), out, false, expectedSchemaFactories); err != nil {
+		if err := CheckDrift(ctx, r, plan.from.GitTagWithPatch(patch), out, false, schemas.SchemaNames, expectedSchemaFactories); err != nil {
 			return err
 		}
 	}
@@ -319,15 +319,16 @@ var ErrDatabaseDriftDetected = errors.New("database drift detected")
 // exists, and nil error when not.
 //
 //   - The `verbose` indicates whether to collect drift details in the output.
-//   - The `expectedSchemaFactories` is the means to retrieve the schema
+//   - The `schemaNames` is the list of schema names to check for drift.
+//   - The `expectedSchemaFactories` is the means to retrieve the schema.
 //     definitions at the target version.
-func CheckDrift(ctx context.Context, r Runner, version string, out *output.Output, verbose bool, expectedSchemaFactories []ExpectedSchemaFactory) error {
+func CheckDrift(ctx context.Context, r Runner, version string, out *output.Output, verbose bool, schemaNames []string, expectedSchemaFactories []ExpectedSchemaFactory) error {
 	type schemaWithDrift struct {
 		name  string
 		drift *bytes.Buffer
 	}
-	schemasWithDrift := make([]*schemaWithDrift, 0, len(schemas.SchemaNames))
-	for _, schemaName := range schemas.SchemaNames {
+	schemasWithDrift := make([]*schemaWithDrift, 0, len(schemaNames))
+	for _, schemaName := range schemaNames {
 		store, err := r.Store(ctx, schemaName)
 		if err != nil {
 			return errors.Wrap(err, "get migration store")


### PR DESCRIPTION
This PR makes the `CheckDrfit` helper take a dynamic list of schema names to check for drift instead of always a hardcoded global list. Thus being able to skip checking drift for code insights DB when it's actually not available:

![image](https://user-images.githubusercontent.com/2946214/223441843-1b8bd464-8f90-4c7a-aab9-0384aab8d09f.png)


**NOTE**: I had to move the `IsCodeInsightsEnabled` to `graphqlbackend` package to avoid circular imports. @sourcegraph/code-insights  Feel free to suggest a better place!

## Test plan

Toggle the `DISABLE_CODE_INSIGHTS: <true|false>` in `sg.config.yaml` and both work when visiting **Site admin > Updates** page.
