### PR TITLE
SCIM: Restrict user fields on the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a dashboard with information about user and repository background permissions sync jobs. [#46317](https://github.com/sourcegraph/sourcegraph/issues/46317)
 - When encountering GitHub or GitLab rate limits, Sourcegraph will now wait the recommended amount of time and retry the request. This prevents sync jobs from failing prematurely due to external rate limits. [#48423](https://github.com/sourcegraph/sourcegraph/pull/48423), [#48616](https://github.com/sourcegraph/sourcegraph/pull/48616)
 - Added "SCIM" badges for SCIM-controlled users on the User admin page. [#48727](https://github.com/sourcegraph/sourcegraph/pull/48727)
+- Added feature to disable some fields on user profiles for SCIM-controlled users. [#48816](https://github.com/sourcegraph/sourcegraph/pull/48816)
 
 ### Changed
 

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -346,6 +346,7 @@ function mockCommonGraphQLResponses(
                 organizations: { nodes: [] },
                 permissionsInfo: null,
                 tags: [],
+                scimControlled: false,
             },
         }),
         BatchChangeByNamespace: () => ({

--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -31,6 +31,7 @@ const USER: UserSettingsAreaUserFields = {
     emails: [{ email: 'test@example.com', verified: true, isPrimary: true }],
     organizations: { nodes: [] },
     tags: [],
+    scimControlled: false,
 }
 describe('User profile page', () => {
     let driver: Driver
@@ -170,6 +171,7 @@ describe('User Different Settings Page', () => {
                     organizations: { nodes: [] },
                     permissionsInfo: null,
                     tags: [],
+                    scimControlled: false,
                 },
             }),
         })

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -94,6 +94,7 @@ describe('Settings', () => {
                         organizations: { nodes: [] },
                         permissionsInfo: null,
                         tags: [],
+                        scimControlled: false,
                     },
                 }),
             })

--- a/client/web/src/user/settings/ScimAlert.tsx
+++ b/client/web/src/user/settings/ScimAlert.tsx
@@ -1,0 +1,12 @@
+import { Alert, Link, Text } from '@sourcegraph/wildcard'
+
+export const ScimAlert = (): JSX.Element => (
+    <Alert className="mb-4" variant="info">
+        <Text className="mb-0">
+            This profile is managed by the organization's identity provider through SCIM. Some fields are disabled.{' '}
+            <Link to="/help/admin/scim" className="text-nowrap">
+                Learn more about SCIM
+            </Link>
+        </Text>
+    </Alert>
+)

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -9,11 +9,11 @@ import { screenReaderAnnounce, Input, Label, ErrorAlert } from '@sourcegraph/wil
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { LoaderButton } from '../../../components/LoaderButton'
-import { AddUserEmailResult, AddUserEmailVariables } from '../../../graphql-operations'
+import { AddUserEmailResult, AddUserEmailVariables, UserSettingsAreaUserFields } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
 interface Props {
-    user: string
+    user: Pick<UserSettingsAreaUserFields, 'id' | 'scimControlled'>
     onDidAdd: () => void
 
     className?: string
@@ -57,7 +57,7 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
                                 }
                             }
                         `,
-                        { user, email: emailState.value }
+                        { user: user.id, email: emailState.value }
                     ).toPromise()
                 )
 
@@ -104,13 +104,14 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
                     spellCheck={false}
                     readOnly={false}
                     status={InputState[emailState.kind]}
+                    disabled={user.scimControlled}
                     className={classNames(deriveInputClassName(emailState), 'mr-sm-2')}
                 />
                 <LoaderButton
                     loading={statusOrError === 'loading'}
                     label="Add"
                     type="submit"
-                    disabled={statusOrError === 'loading' || emailState.kind !== 'VALID'}
+                    disabled={statusOrError === 'loading' || emailState.kind !== 'VALID' || user.scimControlled}
                     variant="primary"
                 />
                 {emailState.kind === 'INVALID' && (

--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -8,7 +8,12 @@ import { Select, ErrorAlert, Form } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { LoaderButton } from '../../../components/LoaderButton'
-import { SetUserEmailPrimaryResult, SetUserEmailPrimaryVariables, UserEmailsResult } from '../../../graphql-operations'
+import {
+    SetUserEmailPrimaryResult,
+    SetUserEmailPrimaryVariables,
+    UserEmailsResult,
+    UserSettingsAreaUserFields,
+} from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
 import styles from './SetUserPrimaryEmailForm.module.scss'
@@ -16,7 +21,7 @@ import styles from './SetUserPrimaryEmailForm.module.scss'
 type UserEmail = (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
 
 interface Props {
-    user: string
+    user: Pick<UserSettingsAreaUserFields, 'id' | 'scimControlled'>
     emails: UserEmail[]
     onDidSet: () => void
 
@@ -60,7 +65,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
                                 }
                             }
                         `,
-                        { user, email: primaryEmail }
+                        { user: user.id, email: primaryEmail }
                     ).toPromise()
                 )
 
@@ -91,7 +96,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
                             value={primaryEmail}
                             onChange={onPrimaryEmailSelect}
                             required={true}
-                            disabled={options.length === 1 || statusOrError === 'loading'}
+                            disabled={options.length === 1 || statusOrError === 'loading' || user.scimControlled}
                         >
                             {options.map(email => (
                                 <option key={email} value={email}>
@@ -105,7 +110,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<React.PropsWithChildren<
                             loading={statusOrError === 'loading'}
                             label="Save"
                             type="submit"
-                            disabled={options.length === 1 || statusOrError === 'loading'}
+                            disabled={options.length === 1 || statusOrError === 'loading' || user.scimControlled}
                             variant="primary"
                         />
                     </div>

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -1,4 +1,4 @@
-import { useState, FunctionComponent } from 'react'
+import { FunctionComponent, useState } from 'react'
 
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
@@ -6,13 +6,13 @@ import { Badge, Button, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import {
-    UserEmailsResult,
     RemoveUserEmailResult,
     RemoveUserEmailVariables,
-    SetUserEmailVerifiedResult,
-    SetUserEmailVerifiedVariables,
     ResendVerificationEmailResult,
     ResendVerificationEmailVariables,
+    SetUserEmailVerifiedResult,
+    SetUserEmailVerifiedVariables,
+    UserEmailsResult,
 } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
@@ -21,8 +21,8 @@ import styles from './UserEmail.module.scss'
 interface Props {
     user: string
     email: (NonNullable<UserEmailsResult['node']> & { __typename: 'User' })['emails'][number]
+    disableControls: boolean
     onError: (error: ErrorLike) => void
-
     onDidRemove?: (email: string) => void
     onEmailVerify?: () => void
     onEmailResendVerification?: () => void
@@ -31,6 +31,7 @@ interface Props {
 export const UserEmail: FunctionComponent<React.PropsWithChildren<Props>> = ({
     user,
     email: { email, isPrimary, verified, verificationPending, viewerCanManuallyVerify },
+    disableControls,
     onError,
     onDidRemove,
     onEmailVerify,
@@ -162,7 +163,7 @@ export const UserEmail: FunctionComponent<React.PropsWithChildren<Props>> = ({
                             <Button
                                 className="p-0"
                                 onClick={() => resendEmailVerification(email)}
-                                disabled={isLoading}
+                                disabled={isLoading || disableControls}
                                 variant="link"
                             >
                                 Resend verification email
@@ -175,14 +176,19 @@ export const UserEmail: FunctionComponent<React.PropsWithChildren<Props>> = ({
                         <Button
                             className="p-0"
                             onClick={() => updateEmailVerification(!verified)}
-                            disabled={isLoading}
+                            disabled={isLoading || disableControls}
                             variant="link"
                         >
                             {verified ? 'Mark as unverified' : 'Mark as verified'}
                         </Button>
                     )}{' '}
                     {!isPrimary && (
-                        <Button className="text-danger p-0" onClick={removeEmail} disabled={isLoading} variant="link">
+                        <Button
+                            className="text-danger p-0"
+                            onClick={removeEmail}
+                            disabled={isLoading || disableControls}
+                            variant="link"
+                        >
                             Remove
                         </Button>
                     )}

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useState, useCallback } from 'react'
+import React, { FunctionComponent, useEffect, useState, useCallback } from 'react'
 
 import classNames from 'classnames'
 
@@ -17,6 +17,7 @@ import {
     UserSettingsEmailsSiteFlagsVariables,
 } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
+import { ScimAlert } from '../ScimAlert'
 
 import { AddUserEmailForm } from './AddUserEmailForm'
 import { SetUserPrimaryEmailForm } from './SetUserPrimaryEmailForm'
@@ -92,6 +93,7 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
 
     return (
         <div className={styles.userSettingsEmailsPage} data-testid="user-settings-emails-page">
+            {user.scimControlled && <ScimAlert />}
             <PageTitle title="Emails" />
             <PageHeader headingElement="h2" path={[{ text: 'Emails' }]} className="mb-3" />
 
@@ -116,6 +118,7 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
                                 onEmailResendVerification={fetchEmails}
                                 onDidRemove={onEmailRemove}
                                 onError={setEmailActionError}
+                                disableControls={user.scimControlled}
                             />
                         </li>
                     ))}
@@ -125,9 +128,9 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
                 </ul>
             </Container>
             {/* re-fetch emails on onDidAdd to guarantee correct state */}
-            <AddUserEmailForm className={styles.emailForm} user={user.id} onDidAdd={fetchEmails} />
+            <AddUserEmailForm className={styles.emailForm} user={user} onDidAdd={fetchEmails} />
             <hr className="my-4" aria-hidden="true" />
-            <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} />
+            <SetUserPrimaryEmailForm user={user} emails={emails} onDidSet={fetchEmails} />
         </div>
     )
 }

--- a/client/web/src/user/settings/profile/EditUserProfileForm.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.tsx
@@ -23,7 +23,7 @@ export const UPDATE_USER = gql`
 `
 
 interface Props {
-    user: Pick<EditUserProfilePage, 'id' | 'viewerCanChangeUsername'>
+    user: Pick<EditUserProfilePage, 'id' | 'viewerCanChangeUsername' | 'scimControlled'>
     initialValue: UserProfileFormFieldsValue
     after?: React.ReactNode
 }
@@ -74,13 +74,16 @@ export const EditUserProfileForm: React.FunctionComponent<React.PropsWithChildre
         [updateUser, user.id, userFields]
     )
 
+    const isUserScimControlled = user.scimControlled
+
     return (
         <Container>
             <Form className="w-100" onSubmit={onSubmit}>
                 <UserProfileFormFields
                     value={userFields}
                     onChange={onChange}
-                    usernameFieldDisabled={!user.viewerCanChangeUsername}
+                    usernameFieldDisabled={!user.viewerCanChangeUsername || isUserScimControlled}
+                    displayNameFieldDisabled={isUserScimControlled}
                     disabled={loading}
                 />
                 <Button type="submit" disabled={loading} id="test-EditUserProfileForm__save" variant="primary">

--- a/client/web/src/user/settings/profile/UserProfileFormFields.tsx
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.tsx
@@ -17,6 +17,7 @@ interface Props {
     value: UserProfileFormFieldsValue
     onChange: (newValue: UserProfileFormFieldsValue) => void
     usernameFieldDisabled?: boolean
+    displayNameFieldDisabled?: boolean
     disabled?: boolean
 }
 
@@ -24,6 +25,7 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
     value,
     onChange,
     usernameFieldDisabled,
+    displayNameFieldDisabled,
     disabled,
 }) => {
     const onUsernameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
@@ -62,7 +64,7 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
                 data-testid="test-UserProfileFormFields__displayName"
                 value={value.displayName || ''}
                 onChange={onDisplayNameChange}
-                disabled={disabled}
+                disabled={displayNameFieldDisabled || disabled}
                 spellCheck={false}
                 placeholder="Display name"
                 maxLength={USER_DISPLAY_NAME_MAX_LENGTH}

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
@@ -15,6 +15,7 @@ const mockUser = {
     avatarURL: 'https://example.com/image.jpg',
     viewerCanChangeUsername: true,
     createdAt: new Date().toISOString(),
+    scimControlled: false,
 }
 
 const newUserValues = {

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.tsx
@@ -2,11 +2,12 @@ import React, { useEffect } from 'react'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { gql } from '@sourcegraph/http-client'
-import { PageHeader, Link, Text } from '@sourcegraph/wildcard'
+import { Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
 import { EditUserProfilePage as EditUserProfilePageFragment } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
+import { ScimAlert } from '../ScimAlert'
 
 import { EditUserProfileForm } from './EditUserProfileForm'
 
@@ -20,6 +21,7 @@ export const EditUserProfilePageGQLFragment = gql`
         avatarURL
         viewerCanChangeUsername
         createdAt
+        scimControlled
     }
 `
 
@@ -27,10 +29,7 @@ interface Props {
     user: EditUserProfilePageFragment
 }
 
-export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    user,
-    ...props
-}) => {
+export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ user }) => {
     useEffect(() => eventLogger.logViewEvent('UserProfile'), [])
 
     return (
@@ -53,6 +52,7 @@ export const UserSettingsProfilePage: React.FunctionComponent<React.PropsWithChi
                 }
                 className={styles.heading}
             />
+            {user.scimControlled && <ScimAlert />}
             {user && (
                 <EditUserProfileForm
                     user={user}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6187,6 +6187,11 @@ type User implements Node & SettingsSubject & Namespace {
     namespaceName: String!
 
     """
+    Whether the user is controlled externally through SCIM.
+    """
+    scimControlled: Boolean!
+
+    """
     EXPERIMENTAL: Collaborators who can be invited to Sourcegraph. This typically comes from a few
     repositories this user has access to, and is derived from recent commit history of those.
     """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -353,6 +353,8 @@ func (r *UserResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 
 func (r *UserResolver) NamespaceName() string { return r.user.Username }
 
+func (r *UserResolver) SCIMControlled() bool { return r.user.SCIMControlled }
+
 func (r *UserResolver) PermissionsInfo(ctx context.Context) (PermissionsInfoResolver, error) {
 	return EnterpriseResolvers.authzResolver.UserPermissionsInfo(ctx, r.ID())
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -825,6 +825,7 @@ type User struct {
 	InvalidatedSessionsAt time.Time
 	TosAccepted           bool
 	Searchable            bool
+	SCIMControlled        bool
 }
 
 // UserForSCIM extends user with email addresses and SCIM external ID.


### PR DESCRIPTION
- Builds on https://github.com/sourcegraph/sourcegraph/pull/48727
- Closes https://github.com/sourcegraph/sourcegraph/issues/48427

There are three user attributes on the [profile](https://sourcegraph.sourcegraph.com/users/vrto/settings/profile) and [emails](https://sourcegraph.sourcegraph.com/users/vrto/settings/emails) pages that SCIM interferes with:
 - username
 - display name
 - email addresses
 
These fields are currently editable. But for SCIM-controlled users, the **identity provider** is the source of truth, and these fields shouldn't be editable on the UI.
This PR disables these fields for SCIM-controlled users and adds a note that that attributes are SCIM-controlled.

**For the design reviewer:** check out the screenshots below. I want to make sure that I'd using the right style of a notification (blue/info, rather than yellow/warning or other), that the text sounds right, and that the disabled fields are fine. I can include more screenshots or a short vid to show the cursors, etc.

Profile page for a non-SCIM-controlled vs. SCIM-controlled user—left side: (unchanged) enabled controls, right side: disabled controls:

<table><tr>
<td><img width="1116" alt="CleanShot 2023-03-07 at 14 10 22@2x" src="https://user-images.githubusercontent.com/2552265/223431708-8064e972-6cbd-4bdc-88d9-2193431cfa0a.png"></td>
<td><img width="1112" alt="CleanShot 2023-03-07 at 14 10 47@2x" src="https://user-images.githubusercontent.com/2552265/223431753-ca3e9d91-3c92-412c-b49b-f9b0bf86c331.png"></td>
</tr></table>

Emails page for a non-SCIM-controlled vs. SCIM-controlled user—left side: (unchanged) enabled controls, right side: disabled controls:

<table><tr>
<td>
<img width="1123" alt="CleanShot 2023-03-07 at 14 51 59@2x" src="https://user-images.githubusercontent.com/2552265/223442143-fb7b0c84-b407-4920-aa95-1121f173cb44.png">
</td>
<td>
<img width="1114" alt="CleanShot 2023-03-07 at 14 51 29@2x" src="https://user-images.githubusercontent.com/2552265/223442022-41291bf6-c7ee-490e-a313-975fa1193191.png">
</td>
</tr></table>

The changes:
- Added a `SCIMControlled` (`bool`) field on the user model
- Populating the field based on the `user_external_accounts` content
- Added new field to the GraphQL query
- Requesting the new field in the user admin page query
- Disabling the UI based on the value

## Test plan

- Design review
- CI should pass