### PR TITLE
[feat] Use new unified perms table in RepoIDsWithNoPerms

### DIFF
--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -58,7 +58,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
-		{"RepoIDsWithNoPerms", testPermsStore_RepoIDsWithNoPerms(db)},
 		{"UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
 		{"ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
 		{"Metrics", testPermsStore_Metrics(db)},


### PR DESCRIPTION
## Description

Use the new unified perms table in `RepoIDsWithNoPerms` in `perms_store.go`. Only use the new table if the feature flag is on.

## Test plan

Unit tests added/extended.