### PR TITLE
extsvc: add AbsFilePath to Other metadata

### DIFF
--- a/dev/internal/cmd/app-discover-repos/app-discover-repos.go
+++ b/dev/internal/cmd/app-discover-repos/app-discover-repos.go
@@ -67,9 +67,13 @@ func main() {
 		}
 	}
 
+	if *verbose {
+		fmt.Printf("%s\t%s\t%s\t%s\n", "Name", "URI", "ClonePath", "AbsFilePath")
+	}
+
 	printRepo := func(r servegit.Repo) {
 		if *verbose {
-			fmt.Printf("%s\t%s\t%s\n", r.Name, r.URI, r.ClonePath)
+			fmt.Printf("%s\t%s\t%s\t%s\n", r.Name, r.URI, r.ClonePath, r.AbsFilePath)
 		} else {
 			fmt.Println(r.Name)
 		}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -728,6 +728,11 @@ type OtherRepoMetadata struct {
 	// RelativePath is relative to ServiceID which is usually the host URL.
 	// Joining them gives you the clone url.
 	RelativePath string
+
+	// AbsFilePath is an optional field which is the absolute path to the
+	// repository on the src git-serve server. Notably this is only
+	// implemented for Sourcegraph App's implementation of src git-serve.
+	AbsFilePath string
 }
 
 func UniqueEncryptableCodeHostIdentifier(ctx context.Context, kind string, config *EncryptableConfig) (string, error) {

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -34,9 +34,10 @@ type (
 
 	// A srcExposeItem is the object model returned by src-cli when serving git repos
 	srcExposeItem struct {
-		URI       string `json:"uri"`
-		Name      string `json:"name"`
-		ClonePath string `json:"clonePath"`
+		URI         string `json:"uri"`
+		Name        string `json:"name"`
+		ClonePath   string `json:"clonePath"`
+		AbsFilePath string
 	}
 )
 
@@ -294,6 +295,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, bool, error)
 		}
 		repo.Metadata = &extsvc.OtherRepoMetadata{
 			RelativePath: strings.TrimPrefix(cloneURL, s.conn.Url),
+			AbsFilePath:  r.AbsFilePath,
 		}
 		// The only required field left is Name
 		name := r.Name

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -83,6 +83,28 @@ func TestSrcExpose_SrcExposeServer(t *testing.T) {
 			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/bar/baz/.git"},
 		}},
 	}, {
+		name: "abs-file-path",
+		body: `{"Items":[{"uri": "/repos/foo", "clonePath":"/repos/foo/.git", "AbsFilePath": "/src/foo"}]}`,
+		want: []*types.Repo{{
+			URI:  "/repos/foo",
+			Name: "/repos/foo",
+			ExternalRepo: api.ExternalRepoSpec{
+				ServiceID:   s.URL,
+				ServiceType: extsvc.TypeOther,
+				ID:          "/repos/foo",
+			},
+			Sources: map[string]*types.SourceInfo{
+				"extsvc:other:1": {
+					ID:       "extsvc:other:1",
+					CloneURL: s.URL + "/repos/foo/.git",
+				},
+			},
+			Metadata: &extsvc.OtherRepoMetadata{
+				RelativePath: "/repos/foo/.git",
+				AbsFilePath:  "/src/foo",
+			},
+		}},
+	}, {
 		name: "override",
 		body: `{"Items":[{"uri": "/repos/foo", "name": "foo", "description": "hi", "clonePath":"/repos/foo/.git"}]}`,
 		want: []*types.Repo{{

--- a/internal/service/servegit/serve.go
+++ b/internal/service/servegit/serve.go
@@ -109,9 +109,10 @@ var indexHTML = template.Must(template.New("").Parse(`<html>
 </html>`))
 
 type Repo struct {
-	Name      string
-	URI       string
-	ClonePath string
+	Name        string
+	URI         string
+	ClonePath   string
+	AbsFilePath string
 }
 
 func (s *Serve) handler() http.Handler {
@@ -307,9 +308,10 @@ func (s *Serve) Walk(root string, repoC chan<- Repo) error {
 		}
 
 		repoC <- Repo{
-			Name:      name,
-			URI:       cloneURI,
-			ClonePath: clonePath,
+			Name:        name,
+			URI:         cloneURI,
+			ClonePath:   clonePath,
+			AbsFilePath: path,
 		}
 
 		// At this point we know the directory is either a git repo or a bare git repo,

--- a/internal/service/servegit/serve_test.go
+++ b/internal/service/servegit/serve_test.go
@@ -39,10 +39,18 @@ func testRepoWithPaths(fixedEndpoint string, root string, pathWithName string) R
 		clonePath = sb.String()
 	}
 
+	// TODO(keegan) our test for an root="" is a bit confusing, for now just
+	// make it pass.
+	absFilePath := filepath.Join(root, filepath.FromSlash(pathWithName))
+	if root == "" {
+		absFilePath = ""
+	}
+
 	return Repo{
-		Name:      pathWithName,
-		URI:       uri,
-		ClonePath: clonePath,
+		Name:        pathWithName,
+		URI:         uri,
+		ClonePath:   clonePath,
+		AbsFilePath: absFilePath,
 	}
 }
 


### PR DESCRIPTION
This is an optional field only App will set which is the path to the repository on disk. The intention of this field is for the wizard to show where on disk a repository resides.

Test Plan: Ran app-discover-repos and validated the absolute paths printed. Otherwise updated unit tests.

``` shell
go run ./dev/internal/cmd/app-discover-repos -root ~/src/github.com/sourcegraph/ -v
```
 
Part of https://github.com/sourcegraph/sourcegraph/issues/48473
Stacked on https://github.com/sourcegraph/sourcegraph/pull/47779
