### PR TITLE
Delete dashboard from apollo cache after delete on the backend

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
@@ -159,6 +159,12 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                     }
                 `,
                 variables: { id },
+                update(cache: ApolloCache<DeleteDashboardResult>) {
+                    const deletedDashboardReference = cache.identify({ __typename: 'InsightsDashboard', id })
+
+                    // Remove deleted insights from the apollo cache
+                    cache.evict({ id: deletedDashboardReference })
+                },
             })
         ).pipe(mapTo(undefined))
     }


### PR DESCRIPTION
Originally filed by @philipp-spiess [here](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1678188121556159)

## Test plan
- Try to remove the code insights dashboard, you should be redirected to the first dashboard in the list. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-dashboard-delete-flow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
