### PR TITLE
ranking: Fix graph key misalignment

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/shared/keys.go
+++ b/enterprise/internal/codeintel/ranking/internal/shared/keys.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+// NewGraphKey creates a new root graph key. This key identifies all work related to ranking,
+// including the SCIP export tasks.
+func NewGraphKey(graphKey string) string {
+	return encode(graphKey)
+}
+
+// NewDerivativeGraphKeyKey creates a new derivative graph key. This key identifies work related
+// to ranking, excluding the SCIP export tasks, which are identified by the same root graph key
+// but with different bucket or derivative graph key prefix values.
+func NewDerivativeGraphKeyKey(graphKey, derivativeGraphKeyPrefix string, bucket int64) string {
+	return fmt.Sprintf("%s.%s-%d",
+		encode(graphKey),
+		encode(derivativeGraphKeyPrefix),
+		bucket,
+	)
+}
+
+// GraphKey returns a graph key from the configured root.
+func GraphKey() string {
+	return NewGraphKey(conf.CodeIntelRankingDocumentReferenceCountsGraphKey())
+}
+
+// DerivativeGraphKeyFromTime returns a derivative key from the configured root used for exports
+// as well as the current "bucket" of time containing the current instant. Each bucket of time is
+// the same configurable length, packed end-to-end since the Unix epoch.
+//
+// Constructing a graph key for the mapper and reducer jobs in this way ensures that begin a fresh
+// map/reduce job on a periodic cadence (equal to the bucket length). Changing the root graph key
+// will also create a new map/reduce job (without switching buckets).
+func DerivativeGraphKeyFromTime(now time.Time) string {
+	graphKey := conf.CodeIntelRankingDocumentReferenceCountsGraphKey()
+	derivativeGraphKeyPrefix := conf.CodeIntelRankingDocumentReferenceCountsDerivativeGraphKeyPrefix()
+	bucket := now.UTC().Unix() / int64(conf.CodeIntelRankingStaleResultAge().Seconds())
+
+	return NewDerivativeGraphKeyKey(graphKey, derivativeGraphKeyPrefix, bucket)
+}
+
+// GraphKeyFromDerivativeGraphKey returns the root of the given derivative graph key.
+func GraphKeyFromDerivativeGraphKey(derivativeGraphKey string) (string, bool) {
+	parts := strings.Split(derivativeGraphKey, ".")
+	if len(parts) != 2 {
+		return "", false
+	}
+
+	return parts[0], true
+}
+
+var replacer = strings.NewReplacer(
+	".", "_",
+	"-", "_",
+)
+
+func encode(s string) string {
+	return replacer.Replace(s)
+}

--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -2,13 +2,13 @@ package store
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	otlog "github.com/opentracing/opentracing-go/log"
 
+	rankingshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/ranking/internal/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
@@ -163,21 +163,19 @@ func (s *store) InsertPathCountInputs(
 	ctx, _, endObservation := s.operations.insertPathCountInputs.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	parts := strings.Split(derivativeGraphKey, "-")
-	if len(parts) < 2 {
-		return 0, 0, errors.Newf("unexpected graph key format %q", derivativeGraphKey)
+	graphKey, ok := rankingshared.GraphKeyFromDerivativeGraphKey(derivativeGraphKey)
+	if !ok {
+		return 0, 0, errors.Newf("unexpected derivative graph key %q", derivativeGraphKey)
 	}
-	// Remove last segment, which indicates the current time bucket
-	parentGraphKey := strings.Join(parts[:len(parts)-1], "-")
 
 	rows, err := s.db.Query(ctx, sqlf.Sprintf(
 		insertPathCountInputsQuery,
-		parentGraphKey,
+		graphKey,
 		derivativeGraphKey,
 		batchSize,
 		derivativeGraphKey,
 		derivativeGraphKey,
-		parentGraphKey,
+		graphKey,
 		derivativeGraphKey,
 	))
 	if err != nil {
@@ -304,9 +302,9 @@ func (s *store) InsertPathRanks(
 	)
 	defer endObservation(1, observation.Args{})
 
-	// Unused, but here for validation
-	if parts := strings.Split(derivativeGraphKey, "-"); len(parts) < 2 {
-		return 0, 0, errors.Newf("unexpected graph key format %q", derivativeGraphKey)
+	_, ok := rankingshared.GraphKeyFromDerivativeGraphKey(derivativeGraphKey)
+	if !ok {
+		return 0, 0, errors.Newf("unexpected derivative graph key %q", derivativeGraphKey)
 	}
 
 	rows, err := s.db.Query(ctx, sqlf.Sprintf(
@@ -546,17 +544,15 @@ func (s *store) VacuumStaleRanks(ctx context.Context, derivativeGraphKey string)
 	ctx, _, endObservation := s.operations.vacuumStaleRanks.With(ctx, &err, observation.Args{LogFields: []otlog.Field{}})
 	defer endObservation(1, observation.Args{})
 
-	parts := strings.Split(derivativeGraphKey, "-")
-	if len(parts) < 2 {
-		return 0, errors.Newf("unexpected graph key format %q", derivativeGraphKey)
+	graphKey, ok := rankingshared.GraphKeyFromDerivativeGraphKey(derivativeGraphKey)
+	if !ok {
+		return 0, errors.Newf("unexpected derivative graph key %q", derivativeGraphKey)
 	}
-	// Remove last segment, which indicates the current time bucket
-	parentGraphKey := strings.Join(parts[:len(parts)-1], "-")
 
 	count, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(
 		vacuumStaleRanksQuery,
 		derivativeGraphKey,
-		parentGraphKey,
+		graphKey,
 		derivativeGraphKey,
 	)))
 	return count, err
@@ -568,7 +564,7 @@ matching_graph_keys AS (
 	SELECT DISTINCT graph_key
 	FROM codeintel_path_ranks
 	-- Implicit delete anything with a different graph key root
-	WHERE graph_key != %s AND graph_key LIKE %s || '-%%'
+	WHERE graph_key != %s AND graph_key LIKE %s || '.%%'
 ),
 valid_graph_keys AS (
 	-- Select the current graph key as well as the highest graph key that


### PR DESCRIPTION
I messed up in #48774 and changed the format of graph keys so they didn't align properly between calls to the store. This PR standardizes it and fixes the issue (splitting on the wrong indicator after adding `.{prefix}` to the graph key).

## Test plan

Unit tests passed, tested full flow locally.
