### PR TITLE
app: set default log format to Console

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -3,10 +3,12 @@ package svcmain
 
 import (
 	"context"
+	"os"
 	"sync"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/output"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
@@ -28,6 +30,13 @@ type Config struct {
 
 // Main is called from the `main` function of the `sourcegraph-oss` and `sourcegraph` commands.
 func Main(services []sgservice.Service, config Config) {
+	// Unlike other sourcegraph binaries we expect Sourcegraph App to be run
+	// by a user instead of deployed to a cloud. So adjust the default output
+	// format before initializing log.
+	if _, ok := os.LookupEnv(log.EnvLogFormat); !ok {
+		os.Setenv(log.EnvLogFormat, string(output.FormatConsole))
+	}
+
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/log/output"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
@@ -33,7 +34,7 @@ func Main(services []sgservice.Service, config Config) {
 	// Unlike other sourcegraph binaries we expect Sourcegraph App to be run
 	// by a user instead of deployed to a cloud. So adjust the default output
 	// format before initializing log.
-	if _, ok := os.LookupEnv(log.EnvLogFormat); !ok {
+	if _, ok := os.LookupEnv(log.EnvLogFormat); !ok && deploy.IsApp() {
 		os.Setenv(log.EnvLogFormat, string(output.FormatConsole))
 	}
 


### PR DESCRIPTION
This improves the readability of logs when running the binary.

Test Plan: directly run .bin/sourcegraph without the influence of sg and have readable logs.