### PR TITLE
app: Add app_version to outbound link params in App

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -606,6 +606,10 @@ export const addSourcegraphAppOutboundUrlParameters = (url: string, campaign?: s
         urlObject.searchParams.append('app_os', os)
     }
 
+    const version = window.context?.version as string | undefined
+    if (version) {
+        urlObject.searchParams.append('app_version', version)
+    }
     return urlObject.toString()
 }
 


### PR DESCRIPTION
Add `app_version` to the URL parameters that are added to outbound links in Sourcegraph App.

This change is in `addSourcegraphAppOutboundUrlParameters()`

## Test plan

- Check URL params in Sourcegraph App mode, presence of `app_version=` value

## App preview:

- [Web](https://sg-web-marek-app-add-version-to-outbound.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
