### PR TITLE
App: Remove two options from feedback tab

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -260,12 +260,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                     target: '_blank',
                                 },
                                 {
-                                    content: 'Follow us on Twitter',
-                                    path: 'https://twitter.com/sourcegraph',
-                                    target: '_blank',
-                                },
-                                { content: 'Email us', path: 'mailto:taylor.sperry@sourcegraph.com', target: '_blank' },
-                                {
                                     content: 'File an issue',
                                     path: 'https://github.com/sourcegraph/app',
                                     target: '_blank',


### PR DESCRIPTION
Two last-minute changes from design, see [Figma](https://www.figma.com/file/tbM21yr4k9gJNKkjNc0a4m/UX%3A-Messaging%2FFeedback-in-App?node-id=4%3A11255&t=16CJqUOfURQmDCtv-0)

## Test plan

<img width="296" alt="Screenshot 2023-03-07 at 17 32 11" src="https://user-images.githubusercontent.com/458591/223486827-9b55e774-eedf-4f85-9664-b12f24fc0a4e.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-remove-feedback-options.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
