### PR TITLE
Setting all fields in the ADO update PR input to be pointers

### DIFF
--- a/enterprise/internal/batches/sources/azuredevops.go
+++ b/enterprise/internal/batches/sources/azuredevops.go
@@ -140,7 +140,8 @@ func (s AzureDevOpsSource) createChangeset(ctx context.Context, cs *Changeset, i
 // UndraftChangeset will update the Changeset on the source to be not in draft mode anymore.
 func (s AzureDevOpsSource) UndraftChangeset(ctx context.Context, cs *Changeset) error {
 	input := s.changesetToUpdatePullRequestInput(cs, false)
-	input.IsDraft = false
+	isDraft := false
+	input.IsDraft = &isDraft
 	repo := cs.TargetRepo.Metadata.(*azuredevops.Repository)
 	args, err := s.createCommonPullRequestArgs(*repo, *cs)
 	if err != nil {

--- a/internal/extsvc/azuredevops/pull_requests.go
+++ b/internal/extsvc/azuredevops/pull_requests.go
@@ -143,7 +143,7 @@ func (c *client) CompletePullRequest(ctx context.Context, args PullRequestCommon
 	completed := PullRequestStatusCompleted
 	pri := PullRequestUpdateInput{Status: &completed, LastMergeSourceCommit: &PullRequestCommit{CommitID: input.CommitID}}
 	if input.MergeStrategy != nil {
-		pri.CompletionOptions = PullRequestCompletionOptions{
+		pri.CompletionOptions = &PullRequestCompletionOptions{
 			MergeStrategy: *input.MergeStrategy,
 		}
 	}

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -149,14 +149,14 @@ type PullRequestCommit struct {
 }
 
 type PullRequestUpdateInput struct {
-	Status                *PullRequestStatus           `json:"status"`
-	Title                 *string                      `json:"title"`
-	Description           *string                      `json:"description"`
-	MergeOptions          *PullRequestMergeOptions     `json:"mergeOptions"`
-	LastMergeSourceCommit *PullRequestCommit           `json:"lastMergeSourceCommit"`
-	TargetRefName         *string                      `json:"targetRefName"`
-	IsDraft               bool                         `json:"isDraft"`
-	CompletionOptions     PullRequestCompletionOptions `json:"completionOptions"`
+	Status                *PullRequestStatus            `json:"status"`
+	Title                 *string                       `json:"title"`
+	Description           *string                       `json:"description"`
+	MergeOptions          *PullRequestMergeOptions      `json:"mergeOptions"`
+	LastMergeSourceCommit *PullRequestCommit            `json:"lastMergeSourceCommit"`
+	TargetRefName         *string                       `json:"targetRefName"`
+	IsDraft               *bool                         `json:"isDraft"`
+	CompletionOptions     *PullRequestCompletionOptions `json:"completionOptions"`
 	// ADO does not seem to support updating Source ref name, only TargetRefName which needs to be explicitly enabled.
 }
 


### PR DESCRIPTION
Setting all fields in the ADO update PR input to be pointers so we don't accidentally patch fields we don't mean to with go's default values.

## Test plan
updated tests, tested manually.