### PR TITLE
SCIM: During create save all emails that are provided

### DIFF
--- a/enterprise/internal/scim/mock_db.go
+++ b/enterprise/internal/scim/mock_db.go
@@ -107,6 +107,20 @@ func getMockDB(users []*types.UserForSCIM) *database.MockDB {
 		return
 	})
 
+	userEmailsStore := database.NewMockUserEmailsStore()
+	userEmailsStore.AddFunc.SetDefaultHook(func(ctx context.Context, userID int32, email string, s2 *string) error {
+		for _, user := range users {
+			if user.ID == userID {
+				user.Emails = append(user.Emails, email)
+			}
+		}
+		return nil
+	})
+
+	userEmailsStore.SetVerifiedFunc.SetDefaultHook(func(ctx context.Context, i int32, s string, b bool) error {
+		return nil
+	})
+
 	// Create DB
 	db := database.NewMockDB()
 	db.WithTransactFunc.SetDefaultHook(func(ctx context.Context, tx func(database.DB) error) error {
@@ -114,6 +128,7 @@ func getMockDB(users []*types.UserForSCIM) *database.MockDB {
 	})
 	db.UsersFunc.SetDefaultReturn(userStore)
 	db.UserExternalAccountsFunc.SetDefaultReturn(userExternalAccountsStore)
+	db.UserEmailsFunc.SetDefaultReturn(userEmailsStore)
 	return db
 }
 

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -10,6 +10,7 @@ import (
 	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -125,8 +126,8 @@ func getUniqueExternalID(attributes scim.ResourceAttributes) string {
 	if attributes[AttrExternalId] != nil {
 		return attributes[AttrExternalId].(string)
 	}
-
-	return "no-external-id-" + extractPrimaryEmail(attributes)
+	primary, _ := extractPrimaryEmail(attributes)
+	return "no-external-id-" + primary
 }
 
 // getOptionalExternalID extracts the external identifier of the given attributes.

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -58,7 +58,6 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 			}
 			return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 		}
-
 		return nil
 	})
 	if err != nil {
@@ -70,7 +69,7 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 	}
 
 	// If there were additional emails provided, now that the user has been created
-	// we can try to add and verify them each in a seperate trx so that if it fails we can ignore
+	// we can try to add and verify them each in a separate trx so that if it fails we can ignore
 	// the error because they are not required.
 	if len(otherEmails) > 0 {
 		for _, email := range otherEmails {

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -16,7 +17,7 @@ import (
 // Create stores given attributes. Returns a resource with the attributes that are stored and a (new) unique identifier.
 func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {
 	// Extract external ID, primary email, username, and display name from attributes to variables
-	primaryEmail := extractPrimaryEmail(attributes)
+	primaryEmail, otherEmails := extractPrimaryEmail(attributes)
 	if primaryEmail == "" {
 		return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{"emails missing"})
 	}
@@ -46,7 +47,7 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 		if err != nil {
 			return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 		}
-		user, err = h.db.UserExternalAccounts().CreateUserAndSave(r.Context(), newUser, accountSpec, accountData)
+		user, err = tx.UserExternalAccounts().CreateUserAndSave(r.Context(), newUser, accountSpec, accountData)
 
 		if err != nil {
 			if dbErr, ok := containsErrCannotCreateUserError(err); ok {
@@ -57,6 +58,7 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 			}
 			return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -65,6 +67,21 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 			return scim.Resource{}, err
 		}
 		return scim.Resource{}, multiErr.Errors()[len(multiErr.Errors())-1]
+	}
+
+	// If there were additional emails provided, now that the user has been created
+	// we can try to add and verify them each in a seperate trx so that if it fails we can ignore
+	// the error because they are not required.
+	if len(otherEmails) > 0 {
+		for _, email := range otherEmails {
+			h.db.WithTransact(r.Context(), func(tx database.DB) error {
+				err := tx.UserEmails().Add(r.Context(), user.ID, email, nil)
+				if err != nil {
+					return err
+				}
+				return tx.UserEmails().SetVerified(r.Context(), user.ID, email, true)
+			})
+		}
 	}
 
 	var now = time.Now()
@@ -82,20 +99,22 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 
 // extractPrimaryEmail extracts the primary email address from the given attributes.
 // Tries to get the (first) email address marked as primary, otherwise uses the first email address it finds.
-func extractPrimaryEmail(attributes scim.ResourceAttributes) (primaryEmail string) {
+func extractPrimaryEmail(attributes scim.ResourceAttributes) (primaryEmail string, otherEmails []string) {
 	if attributes[AttrEmails] == nil {
 		return
 	}
 	emails := attributes[AttrEmails].([]interface{})
+	otherEmails = make([]string, 0, len(emails))
 	for _, emailRaw := range emails {
 		email := emailRaw.(map[string]interface{})
 		if email["primary"] == true {
 			primaryEmail = email["value"].(string)
-			break
+			continue
 		}
+		otherEmails = append(otherEmails, email["value"].(string))
 	}
-	if primaryEmail == "" && len(emails) > 0 {
-		primaryEmail = emails[0].(map[string]interface{})["value"].(string)
+	if primaryEmail == "" && len(otherEmails) > 0 {
+		primaryEmail, otherEmails = otherEmails[0], otherEmails[1:]
 	}
 	return
 }

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -106,7 +106,7 @@ func extractPrimaryEmail(attributes scim.ResourceAttributes) (primaryEmail strin
 	otherEmails = make([]string, 0, len(emails))
 	for _, emailRaw := range emails {
 		email := emailRaw.(map[string]interface{})
-		if email["primary"] == true {
+		if email["primary"] == true && primaryEmail == "" {
 			primaryEmail = email["value"].(string)
 			continue
 		}

--- a/enterprise/internal/scim/user_create_test.go
+++ b/enterprise/internal/scim/user_create_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/elimity-com/scim"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUserResourceHandler_Create(t *testing.T) {
@@ -94,6 +95,10 @@ func createUserResourceAttributes(username string) scim.ResourceAttributes {
 			map[string]interface{}{
 				"value":   "a@b.c",
 				"primary": true,
+			},
+			map[string]interface{}{
+				"value":   "b@b.c",
+				"primary": false,
 			},
 		},
 	}


### PR DESCRIPTION
This ensures that all emails provided by SCIM attempt to be added and set as verified in the `user_emails` table.  I say attempted because as long as we have a primary email address we can allow the creation to complete successfully.  If adding any secondary emails fails this error is ignored, however they are still captured in external account_data.

I will address changes need for PATCH requests for replace/remove separately. 

Part of https://github.com/sourcegraph/sourcegraph/issues/48720
## Test plan
<img width="593" alt="image" src="https://user-images.githubusercontent.com/6098507/223507811-b797abd4-9de9-4d9c-b6ac-3d64361368c1.png">

POST - 200 response
```json
{
  "displayName": "Test User",
  "emails": [
    {
      "type": "work",
      "value": "secondary@example.com",
      "primary": false
    },
    {
      "type": "work",
      "value": "primary@example.com",
      "primary": true
    }
  ],
  "name": {
    "formatted": "Test Name",
    "familyName": "LastName",
    "givenName": "FirstName",
    "middleName": "Middle"
  },
  "nickName": "shortname",
  "schemas": [
    "urn:ietf:params:scim:schemas:core:2.0:User",
    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
  ],
  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
    "employeeNumber": "ABC123",
    "organization": "DEF987"
  },
  "userName": "test_account"
}
```

| user\_id | email | created\_at | verification\_code | verified\_at | last\_verification\_sent\_at | is\_primary |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 231 | primary@example.com | 2023-03-07 17:55:37.836786 +00:00 | NULL | 2023-03-07 17:55:37.836786 +00:00 | NULL | true |
| 231 | secondary@example.com | 2023-03-07 17:55:37.849496 +00:00 | NULL | 2023-03-07 17:55:37.849496 +00:00 | NULL | false |


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
