### PR TITLE
Precise indexes: Pass through filtered connection args

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
@@ -202,7 +202,13 @@ export const CodeIntelPreciseIndexesPage: FunctionComponent<CodeIntelPreciseInde
             setArgs(stashArgs)
             setSelection(new Set())
 
-            return queryPreciseIndexes(stashArgs, apolloClient).pipe(
+            return queryPreciseIndexes(
+                {
+                    ...args,
+                    ...stashArgs,
+                },
+                apolloClient
+            ).pipe(
                 tap(connection => {
                     setTotalCount(connection.totalCount ?? undefined)
                 })


### PR DESCRIPTION
## Description

Previously we didn't pass through additional `args` that are automatically set from `FilteredConnection` (`first`, `after`, `query`). This PR fixes that.

## Test plan

`SOURCEGRAPH_API_URL=https://sourcegraph.sourcegraph.com sg start web-standalone`

Go to precise indexes

Check pagination works

Check pagination works with filters/query etc

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-index-pagination.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
