### PR TITLE
codeintel: bump indexer shas

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,13 +27,13 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/lsif-clang":      "sha256:99ca372c61b7cc5e32d5aedf87a7eb93a23443bd46d1e937dfa21b9ba2c6acd6",
-	"sourcegraph/lsif-go":         "sha256:cba76f5b3edb5d9af43e1dc59e27ecdb4b8b2fafda6a5d55d7e37def3b502775",
+	"sourcegraph/lsif-clang":      "sha256:ea814e5ab5c6e1e6ab4d001e4f4afddcc7b44128edbeeedf1d97da553813a4c8",
+	"sourcegraph/lsif-go":         "sha256:2194d2652862966f022b537ed81bccf5a9a535ab763534cb4e98a3083c8a1bc6",
 	"sourcegraph/lsif-rust":       "sha256:83cb769788987eb52f21a18b62d51ebb67c9436e1b0d2e99904c70fef424f9d1",
 	"sourcegraph/scip-rust":       "sha256:e9c400fd1d3146cd9a3d98f89c6d9a70e0a116618057e0dac452219b1c60b658",
 	"sourcegraph/scip-java":       "sha256:964a45ef06b7d914729b1c61b6907b662fc54545b188881c6d25e56fcc8dfb8c",
-	"sourcegraph/scip-python":     "sha256:5049c4598d03af542bde5e1254a17fa6d1eb794c1bdd14d0162fb39c604581b4",
-	"sourcegraph/scip-typescript": "sha256:37546e04763d6d1853fb6f32285ad630fc0d8671d4f1d2db40c6df272120f2f8",
+	"sourcegraph/scip-python":     "sha256:4cb64c4f62cfa611fcb217581073c2831fb9350bbb1c8e855f152cc4b3428a00",
+	"sourcegraph/scip-typescript": "sha256:2eb90bf6d52f86608b6a723e14079eafed54121419bfd0129bf61a09e1a0f293",
 	"sourcegraph/scip-ruby":       "sha256:e553fee039973cda8726d4c8c13cdbb851f82a6fca5daa15798a595ee4042906",
 }
 


### PR DESCRIPTION
Old docker images were being used, including a scip-typescript with a major bug with monikers.

## Test plan

N/A, semi-automated image SHA bumping
