### PR TITLE
[ranking] remove setting to true when undefined.

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -80,11 +80,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     // Use new ranking if the feature flag is enabled and the user has not explicitly disabled it
     const [rankingEnabled] = useFeatureFlag('search-ranking')
     const [rankingToggleEnabled, setRankingToggleEnabled] = useTemporarySetting('search.ranking.experimental')
-    useEffect(() => {
-        if (rankingEnabled && rankingToggleEnabled === undefined) {
-            setRankingToggleEnabled(rankingEnabled)
-        }
-    }, [rankingEnabled, rankingToggleEnabled, setRankingToggleEnabled])
 
     // Global state
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)


### PR DESCRIPTION
Removes functionality that sets the toggle to true when it is undefined. 

It was causing a bug where if you set it to false and clicked on a search result it would set it back to true when you navigated back to the page.

## Test plan
Tested manually and ran the test.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cesar-ranking-fix-enable-toggle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
