### PR TITLE
Clarifying CLA form location

### DIFF
--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -4,7 +4,7 @@ This page outlines how to accept a contribution to the [Sourcegraph repository](
 
 ## CLA-bot
 
-1. If the `cla-bot` check fails, ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). You may have to wait up to 30 minutes for the form response to be synchronized to the [contributors list](https://github.com/sourcegraph/clabot-config).
+1. If the `cla-bot` check fails, ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing) by filling out the [form](https://forms.gle/YnmetmopXNxFxsDUA). You may have to wait up to 30 minutes for the form response to be synchronized to the [contributors list](https://github.com/sourcegraph/clabot-config).
    1. A sync can also be manually triggered from [the `sync` workflow](https://github.com/sourcegraph/clabot-config/actions/workflows/sync.yml).
 2. Comment on the pull request: `@cla-bot check`.
 3. The `verification/cla-signed` workflow should become green. 🎉


### PR DESCRIPTION

## Test plan
Use sg run docsite and navigate to the quickstart page.
Read the new documentation and click on the added link