### PR TITLE
Log `repoPage:ownerTab:viewed`

### DIFF
--- a/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../components/WebStory'
 import { createFlagMock } from '../../featureFlags/createFlagMock'
@@ -64,7 +65,12 @@ const searchOwnershipFlagMock = createFlagMock('search-ownership', true)
 export const EmptyNonAdmin: Story = () => (
     <WebStory mocks={[empyResponse, searchOwnershipFlagMock]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
+            <RepositoryOwnPage
+                repo={repo}
+                authenticatedUser={{ siteAdmin: false }}
+                useBreadcrumb={useBreadcrumb}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+            />
         )}
     </WebStory>
 )
@@ -73,7 +79,12 @@ EmptyNonAdmin.storyName = 'Empty (non-admin)'
 export const EmptyAdmin: Story = () => (
     <WebStory mocks={[empyResponse, searchOwnershipFlagMock]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />
+            <RepositoryOwnPage
+                repo={repo}
+                authenticatedUser={{ siteAdmin: true }}
+                useBreadcrumb={useBreadcrumb}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+            />
         )}
     </WebStory>
 )
@@ -104,7 +115,12 @@ const populatedResponse: MockedResponse<GetIngestedCodeownersResult, GetIngested
 export const PopulatedNonAdmin: Story = () => (
     <WebStory mocks={[populatedResponse, searchOwnershipFlagMock]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
+            <RepositoryOwnPage
+                repo={repo}
+                authenticatedUser={{ siteAdmin: false }}
+                useBreadcrumb={useBreadcrumb}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+            />
         )}
     </WebStory>
 )
@@ -113,7 +129,12 @@ PopulatedNonAdmin.storyName = 'Populated (non-admin)'
 export const PopulatedAdmin: Story = () => (
     <WebStory mocks={[populatedResponse, searchOwnershipFlagMock]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />
+            <RepositoryOwnPage
+                repo={repo}
+                authenticatedUser={{ siteAdmin: true }}
+                useBreadcrumb={useBreadcrumb}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+            />
         )}
     </WebStory>
 )

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { mdiAccount } from '@mdi/js'
 import { Navigate } from 'react-router-dom'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import { LoadingSpinner, PageHeader, Icon, H1, ProductStatusBadge, Link } from '@sourcegraph/wildcard'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { H1, Icon, Link, LoadingSpinner, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -18,7 +19,7 @@ import { RepositoryOwnPageContents } from './RepositoryOwnPageContents'
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'> {
+export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'> | null
@@ -29,10 +30,17 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
     useBreadcrumb,
     repo,
     authenticatedUser,
+    telemetryService,
 }) => {
     useBreadcrumb(BREADCRUMB)
 
     const [ownEnabled, status] = useFeatureFlag('search-ownership')
+
+    useEffect(() => {
+        if (status !== 'initial' && ownEnabled) {
+            telemetryService.log('repoPage:ownerTab:viewed')
+        }
+    }, [status, ownEnabled, telemetryService])
 
     if (status === 'initial') {
         return (


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/47062

Log event on displaying the ownership tab on repo page

## Test plan

Manually. Awaiting loom to record.
