### PR TITLE
release-tool: add patches to calendar for minor / major versions

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -4,11 +4,19 @@
     "slackAnnounceChannel": "announce-engineering"
   },
   "scheduledReleases": {
-    "4.6.0": {
+    "5.0.0": {
       "codeFreezeDate": "2023-03-13T10:00:00.000-07:00",
       "securityApprovalDate": "2023-03-15T10:00:00.000-07:00",
       "releaseDate": "2023-03-22T10:00:00.000-07:00",
-      "current": "4.6.0",
+      "patches": [
+        "2023-04-05T10:00:00.000-07:00",
+        "2023-04-19T10:00:00.000-07:00",
+        "2023-05-03T10:00:00.000-07:00",
+        "2023-05-17T10:00:00.000-07:00",
+        "2023-05-31T10:00:00.000-07:00",
+        "2023-06-14T10:00:00.000-07:00"
+      ],
+      "current": "5.0.0",
       "captainGitHubUsername": "coury-clark",
       "captainSlackUsername": "coury"
     }

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -138,8 +138,8 @@ function releaseDates(releaseDate: DateTime, includePatches?: boolean): ReleaseD
 
 function generatePatchDates(start: DateTime, end: DateTime, intervalWeeks: number): DateTime[] {
     const patches = []
-    let current: DateTime = start.plus({weeks: intervalWeeks})
-    while (current < end.minus({weeks: 1})) {
+    let current: DateTime = start.plus({ weeks: intervalWeeks })
+    while (current < end.minus({ weeks: 1 })) {
         patches.push(current)
         current = current.plus({ weeks: intervalWeeks })
     }

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -83,7 +83,7 @@ export function newRelease(
     captainSlack: string
 ): ScheduledReleaseDefinition {
     return {
-        ...releaseDates(releaseDate),
+        ...releaseDates(releaseDate, version.patch === 0),
         current: version.version,
         captainGitHubUsername: captainGithub,
         captainSlackUsername: captainSlack,
@@ -124,13 +124,26 @@ export async function newReleaseFromInput(versionOverride?: SemVer): Promise<Sch
     return rel
 }
 
-function releaseDates(releaseDate: DateTime): ReleaseDates {
+function releaseDates(releaseDate: DateTime, includePatches?: boolean): ReleaseDates {
     releaseDate = releaseDate.set({ hour: 10 })
     return {
         codeFreezeDate: releaseDate.plus({ days: -7 }).toString(),
         securityApprovalDate: releaseDate.plus({ days: -7 }).toString(),
         releaseDate: releaseDate.toString(),
+        patches: includePatches
+            ? generatePatchDates(releaseDate, releaseDate.plus({ months: 3 }), 2).map(rdate => rdate.toString())
+            : undefined,
     }
+}
+
+function generatePatchDates(start: DateTime, end: DateTime, intervalWeeks: number): DateTime[] {
+    const patches = []
+    let current: DateTime = start
+    while (current < end.minus({ weeks: intervalWeeks })) {
+        current = current.plus({ weeks: intervalWeeks })
+        patches.push(current)
+    }
+    return patches
 }
 
 export function addScheduledRelease(config: ReleaseConfig, release: ScheduledReleaseDefinition): ReleaseConfig {
@@ -147,6 +160,7 @@ export interface ReleaseDates {
     releaseDate: string
     codeFreezeDate: string
     securityApprovalDate: string
+    patches?: string[]
 }
 
 export interface ActiveRelease extends ReleaseCaptainInformation, ReleaseDates {

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -138,10 +138,10 @@ function releaseDates(releaseDate: DateTime, includePatches?: boolean): ReleaseD
 
 function generatePatchDates(start: DateTime, end: DateTime, intervalWeeks: number): DateTime[] {
     const patches = []
-    let current: DateTime = start
-    while (current < end.minus({ weeks: intervalWeeks })) {
-        current = current.plus({ weeks: intervalWeeks })
+    let current: DateTime = start.plus({weeks: intervalWeeks})
+    while (current < end.minus({weeks: 1})) {
         patches.push(current)
+        current = current.plus({ weeks: intervalWeeks })
     }
     return patches
 }

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -5,11 +5,12 @@ import { addMinutes } from 'date-fns'
 import { Credentials } from 'google-auth-library'
 import { google, calendar_v3 } from 'googleapis'
 import { OAuth2Client } from 'googleapis-common'
+import { DateTime } from 'luxon'
 import { readFile, writeFile } from 'mz/fs'
 import open from 'open'
 
 import { readLine, cacheFolder } from './util'
-import { DateTime } from 'luxon'
+
 
 export interface Installed {
     client_id?: string

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -11,7 +11,6 @@ import open from 'open'
 
 import { readLine, cacheFolder } from './util'
 
-
 export interface Installed {
     client_id?: string
     client_secret?: string

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -9,6 +9,7 @@ import { readFile, writeFile } from 'mz/fs'
 import open from 'open'
 
 import { readLine, cacheFolder } from './util'
+import { DateTime } from 'luxon'
 
 export interface Installed {
     client_id?: string
@@ -148,11 +149,12 @@ export async function ensureEvent(
     })
 }
 
-async function listEvents(auth: OAuth2Client): Promise<calendar_v3.Schema$Event[] | undefined> {
+export async function listEvents(auth: OAuth2Client): Promise<calendar_v3.Schema$Event[] | undefined> {
     const calendar = google.calendar({ version: 'v3', auth })
     const result = await calendar.events.list({
         calendarId: 'primary',
         timeMin: new Date().toISOString(),
+        timeMax: DateTime.now().plus({ year: 1 }).toJSDate().toISOString(), // this ends up returning a lot of events, so filtering down to the next year should be fine
         maxResults: 2500,
         singleEvents: true,
         orderBy: 'startTime',


### PR DESCRIPTION
Creates calendar events for scheduled patches for minor / major releases.

## Test plan

This can be tested by running `pnpm run release _test:patch-dates`. I also generated the 5.0 patch calendar invites using this locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-add-patches-to-cal.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
