### PR TITLE
Setup wizard: Support controlled mode in json component

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -29,6 +29,7 @@ interface Props<T extends object>
     saving?: boolean
 
     canEdit?: boolean
+    controlled?: boolean
 
     className?: string
 
@@ -79,10 +80,18 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
     }
 
     private get effectiveValue(): string {
+        if (this.props.controlled) {
+            return this.props.value
+        }
+
         return this.state.value === undefined ? this.props.value : this.state.value
     }
 
     private get isDirty(): boolean {
+        if (this.props.controlled) {
+            return true
+        }
+
         return this.effectiveValue !== this.props.value
     }
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
@@ -128,6 +128,7 @@ export function CodeHostJSONFormContent(props: CodeHostJSONFormContentProps): Re
                     actions={externalServiceOptions.editorActions}
                     jsonSchema={externalServiceOptions.jsonSchema}
                     canEdit={false}
+                    controlled={true}
                     loading={true}
                     height={400}
                     readOnly={false}


### PR DESCRIPTION
In the setup wizard, JSON editor should have no state because all state is handled on the parent level in the form state hooks. This PR extends editor UI with controlled mode when we use only prop value and ignore the internal JSON editor value state.

Prior to this PR, it was possible that the setup wizard form UI has one value, and JSON editor had old values because the JSON editor didn't pick up any new values since it used its own internal value state.

## Test plan
- Check the github connection form in the setup wizard
- Use the form and add some values, repositories, orgs, and affiliated checkbox.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
