### PR TITLE
[ranking] fix mapper to not mark upload as processed

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -239,7 +239,8 @@ processable_symbols AS (
 				rrp.graph_key = %s AND
 				u.repository_id = u2.repository_id AND
 				u.root = u2.root AND
-				u.indexer = u2.indexer
+				u.indexer = u2.indexer AND
+				u.id != u2.id
 		) AND
 		-- For multiple references for the same repository/root/indexer in THIS batch, we want to
 		-- process the one associated with the most recently processed upload record. This should


### PR DESCRIPTION
Fix query to not mark the entire upload as processed when we've only processed a subset of the references for the upload.

## Test plan
Tested manually.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
