### PR TITLE
Fix local resolver for app

### DIFF
--- a/cmd/frontend/graphqlbackend/app.go
+++ b/cmd/frontend/graphqlbackend/app.go
@@ -92,16 +92,15 @@ func (r *localDirectoryResolver) Path() string {
 }
 
 func (r *localDirectoryResolver) Repositories() ([]LocalRepositoryResolver, error) {
-	var c servegit.Config
+	var c servegit.ServeConfig
 	c.Load()
-	c.Root = r.path
 
 	srv := &servegit.Serve{
-		Config: c,
-		Logger: log.Scoped("serve", ""),
+		ServeConfig: c,
+		Logger:      log.Scoped("serve", ""),
 	}
 
-	repos, err := srv.Repos()
+	repos, err := srv.Repos(r.path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Recently added instantiation of [servegit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/service/servegit/serve.go) in PR https://github.com/sourcegraph/sourcegraph/pull/48605 . Since I modified servegit the build breaks and so this new PR is fixing app.go to use the modified servegit.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a