### PR TITLE
app: better warning if src-cli is not installed

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -149,6 +149,14 @@ func Init(logger log.Logger) {
 		)
 	}
 
+	if _, err := exec.LookPath("src"); err != nil {
+		printStatusCheckError(
+			"src-cli is unavailable",
+			"Sourcegraph is better when src-cli is available; batch changes may not work.",
+			"Installation: https://github.com/sourcegraph/src-cli#sourcegraph-cli--",
+		)
+	}
+
 	// generate a shell script to run a ctags Docker image
 	// unless the environment is already set up to find ctags
 	ctagsPath := os.Getenv("CTAGS_COMMAND")

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -153,7 +153,7 @@ func Init(logger log.Logger) {
 		printStatusCheckError(
 			"src-cli is unavailable",
 			"Sourcegraph is better when src-cli is available; batch changes may not work.",
-			"Installation: https://github.com/sourcegraph/src-cli#sourcegraph-cli--",
+			"Installation: https://github.com/sourcegraph/src-cli",
 		)
 	}
 


### PR DESCRIPTION
Sourcegraph already runs best-effort if `src` is not on your path. However, the errors are not very clear about the impact or how to install it. This simply adds a better error message for it:

![](https://user-images.githubusercontent.com/3173176/223589485-ea9da879-0a72-46ef-a9c0-deec5e3ad46f.png)

Fixes #46543

## Test plan

Manually tested by removing `src` from my path and running `sg start app`
