### PR TITLE
Remove mention of Azure DevOps Server

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1304,9 +1304,7 @@ const AZUREDEVOPS: AddExternalServiceOptions = {
             <ol>
                 <li>
                     In the configuration below, set <Field>url</Field> to the URL of Azure DevOps Services:{' '}
-                    <Link to="https://dev.azure.com">
-                        https://dev.azure.com
-                    </Link>.
+                    <Link to="https://dev.azure.com">https://dev.azure.com</Link>.
                 </li>
                 <li>
                     In the configuration below, set <Field>username</Field> to the authenticated username for Azure

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1303,15 +1303,18 @@ const AZUREDEVOPS: AddExternalServiceOptions = {
         <div>
             <ol>
                 <li>
-                    In the configuration below, set <Field>url</Field> to the URL of Azure DevOps Services/Server.
+                    In the configuration below, set <Field>url</Field> to the URL of Azure DevOps Services:{' '}
+                    <Link to="https://dev.azure.com">
+                        https://dev.azure.com
+                    </Link>.
                 </li>
                 <li>
-                    In the configuration below, set <Field>username</Field> to the authenticated username for the Azure
-                    DevOps Services/Server instance.
+                    In the configuration below, set <Field>username</Field> to the authenticated username for Azure
+                    DevOps Services.
                 </li>
                 <li>
-                    In the configuration below, set <Field>token</Field> to the authenticated token for the Azure DevOps
-                    Services/Server instance. See the{' '}
+                    In the configuration below, set <Field>token</Field> to the authenticated token for Azure DevOps
+                    Services. See the{' '}
                     <Link to="https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#create-a-pat">
                         Azure DevOps documentation
                     </Link>{' '}

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -9,7 +9,7 @@
   "required": ["url", "username", "token"],
   "properties": {
     "url": {
-      "description": "URL of a Azure DevOps Services/Server instance, such as https://dev.azure.com.",
+      "description": "URL for Azure DevOps Services, set to https://dev.azure.com.",
       "type": "string",
       "pattern": "^https?://",
       "not": {
@@ -47,7 +47,7 @@
       "examples": [["name"], ["kubernetes", "golang", "facebook"]]
     },
     "exclude": {
-      "description": "A list of repositories to never mirror from this Azure DevOps Services/Server instance.",
+      "description": "A list of repositories to never mirror from Azure DevOps Services.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -57,12 +57,12 @@
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
         "properties": {
           "name": {
-            "description": "The name of an Azure DevOps Services/Server project and repository (\"projectName/repositoryName\") to exclude from mirroring.",
+            "description": "The name of an Azure DevOps Services project and repository (\"projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
             "pattern": "^~?[\\w.-]+([ ]*[\\w.-]+)*/[\\w.-]+([ ]*[\\w.-]+)*?$"
           },
           "pattern": {
-            "description": "Regular expression which matches against the name of an Azure DevOps Services/Server repo.",
+            "description": "Regular expression which matches against the name of an Azure DevOps Services repo.",
             "type": "string",
             "format": "regex"
           }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -203,7 +203,7 @@ type AzureDevOpsAuthProvider struct {
 type AzureDevOpsConnection struct {
 	// EnforcePermissions description: A flag to enforce Azure DevOps repository access permissions
 	EnforcePermissions bool `json:"enforcePermissions,omitempty"`
-	// Exclude description: A list of repositories to never mirror from this Azure DevOps Services/Server instance.
+	// Exclude description: A list of repositories to never mirror from Azure DevOps Services.
 	Exclude []*ExcludedAzureDevOpsServerRepo `json:"exclude,omitempty"`
 	// Orgs description: An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.
 	Orgs []string `json:"orgs,omitempty"`
@@ -211,7 +211,7 @@ type AzureDevOpsConnection struct {
 	Projects []string `json:"projects,omitempty"`
 	// Token description: The Personal Access Token associated with the Azure DevOps username used for authentication.
 	Token string `json:"token"`
-	// Url description: URL of a Azure DevOps Services/Server instance, such as https://dev.azure.com.
+	// Url description: URL for Azure DevOps Services, set to https://dev.azure.com.
 	Url string `json:"url"`
 	// Username description: A username for authentication with the Azure DevOps code host.
 	Username string `json:"username"`
@@ -669,9 +669,9 @@ type ExcludedAWSCodeCommitRepo struct {
 	Name string `json:"name,omitempty"`
 }
 type ExcludedAzureDevOpsServerRepo struct {
-	// Name description: The name of an Azure DevOps Services/Server project and repository ("projectName/repositoryName") to exclude from mirroring.
+	// Name description: The name of an Azure DevOps Services project and repository ("projectName/repositoryName") to exclude from mirroring.
 	Name string `json:"name,omitempty"`
-	// Pattern description: Regular expression which matches against the name of an Azure DevOps Services/Server repo.
+	// Pattern description: Regular expression which matches against the name of an Azure DevOps Services repo.
 	Pattern string `json:"pattern,omitempty"`
 }
 type ExcludedBitbucketCloudRepo struct {


### PR DESCRIPTION
The first release of Azure DevOps support won't include Azure DevOps Server (on-prem), just Azure DevOps Services (cloud).

## Test plan
Just small description changes.