### PR TITLE
web: make readiness error look more scary

### DIFF
--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -1,13 +1,6 @@
 import React, { FunctionComponent, useMemo, useState } from 'react'
 
-import {
-    mdiOpenInNew,
-    mdiCheckCircle,
-    mdiChevronUp,
-    mdiChevronDown,
-    mdiCheckBold,
-    mdiAlertCircleOutline,
-} from '@mdi/js'
+import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown, mdiCheckBold, mdiAlertOctagram } from '@mdi/js'
 import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'
@@ -142,20 +135,21 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                     <H3 as={H4}>Schema drift</H3>
                     {data.site.upgradeReadiness.schemaDrift.length > 0 ? (
                         <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded} openByDefault={false}>
+                            <span>
+                                <Icon aria-hidden={true} svgPath={mdiAlertOctagram} className="text-danger" /> There are
+                                schema drifts detected, please contact{' '}
+                                <Link to="mailto:support@sourcegraph.com" target="_blank" rel="noopener noreferrer">
+                                    Sourcegraph support
+                                </Link>{' '}
+                                for assistance.
+                            </span>
                             <CollapseHeader
                                 as={Button}
                                 variant="secondary"
                                 outline={true}
                                 className="p-0 m-0 mb-2 border-0 w-100 font-weight-normal d-flex justify-content-between align-items-center"
                             >
-                                <span>
-                                    <Icon aria-hidden={true} svgPath={mdiAlertCircleOutline} className="text-danger" />{' '}
-                                    There are schema drifts detected, please contact{' '}
-                                    <Link to="mailto:support@sourcegraph.com" target="_blank" rel="noopener noreferrer">
-                                        Sourcegraph support
-                                    </Link>{' '}
-                                    for assistance.
-                                </span>
+                                Click to view the drift output:
                                 <Icon
                                     aria-hidden={true}
                                     svgPath={isExpanded ? mdiChevronUp : mdiChevronDown}
@@ -182,8 +176,8 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                     {data.site.upgradeReadiness.requiredOutOfBandMigrations.length > 0 ? (
                         <>
                             <span>
-                                <Icon aria-hidden={true} svgPath={mdiAlertCircleOutline} className="text-danger" />{' '}
-                                There are pending out-of-band migrations that need to complete, please go to{' '}
+                                <Icon aria-hidden={true} svgPath={mdiAlertOctagram} className="text-danger" /> There are
+                                pending out-of-band migrations that need to complete, please go to{' '}
                                 <Link to="/site-admin/migrations?filters=pending">migrations</Link> to check details.
                             </span>
                             <ul className="mt-2 pl-3">


### PR DESCRIPTION



## Test plan


![CleanShot 2023-03-08 at 11 04 43](https://user-images.githubusercontent.com/2946214/223609486-8876452e-fe19-4c88-92a9-11ef5bd7ecd7.gif)

## App preview:

- [Web](https://sg-web-jc-scary-readiness.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
