### PR TITLE
web: fix references panel links in the legacy blob

### DIFF
--- a/client/web/src/repo/blob/LegacyBlob.tsx
+++ b/client/web/src/repo/blob/LegacyBlob.tsx
@@ -196,10 +196,19 @@ export const LegacyBlob: FC<BlobProps> = props => {
         (lineOrPositionOrRange: LineOrPositionOrRange) => locationPositions.next(lineOrPositionOrRange),
         [locationPositions]
     )
-    const parsedHash = useMemo(
-        () => parseQueryAndHash(location.search, location.hash),
-        [location.search, location.hash]
-    )
+    const parsedHash = useMemo(() => {
+        // When an activeURL is passed, it takes presedence over the react
+        // router location API.
+        //
+        // This is needed to support the reference panel
+        if (props.activeURL) {
+            const url = new URL(props.activeURL, window.location.href)
+            return parseQueryAndHash(url.search, url.hash)
+        }
+
+        return parseQueryAndHash(location.search, location.hash)
+    }, [location.search, location.hash, props.activeURL])
+
     useDeepCompareEffect(() => {
         nextLocationPosition(parsedHash)
     }, [parsedHash])


### PR DESCRIPTION
## Context

Mirror [the fix](https://github.com/sourcegraph/sourcegraph/pull/47596) we already made for the `CodeMirrorBlob` in the `LegacyBlob`. Reported [here](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1678135164100079).

> The references panel needs a way to overwrite the react-router location for the blob view it renders.

## Test plan

CI
