### PR TITLE
Fix user permissions page not loading

### DIFF
--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -41,7 +41,7 @@ func (edb *enterpriseDB) CodeMonitors() CodeMonitorStore {
 }
 
 func (edb *enterpriseDB) Perms() PermsStore {
-	return &permsStore{Store: basestore.NewWithHandle(edb.Handle()), clock: time.Now}
+	return &permsStore{Store: basestore.NewWithHandle(edb.Handle()), clock: time.Now, ossDB: edb.DB}
 }
 
 func (edb *enterpriseDB) SubRepoPerms() SubRepoPermsStore {


### PR DESCRIPTION
This PR: https://github.com/sourcegraph/sourcegraph/pull/48608

Introduced an `ossDB` field to the perms store but the perms store is being created without populating the field. This leads to null pointer access in certain code paths.

## Test plan

Confirmed to work locally now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
