### PR TITLE
permissions-center: add `cancelPermissionsSyncJob` mutation.

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -11,15 +11,16 @@ import (
 )
 
 type AuthzResolver interface {
-	// Mutations
+	// SetRepositoryPermissionsForUsers and functions below are GraphQL Mutations.
 	SetRepositoryPermissionsForUsers(ctx context.Context, args *RepoPermsArgs) (*EmptyResponse, error)
 	SetRepositoryPermissionsUnrestricted(ctx context.Context, args *RepoUnrestrictedArgs) (*EmptyResponse, error)
 	ScheduleRepositoryPermissionsSync(ctx context.Context, args *RepositoryIDArgs) (*EmptyResponse, error)
 	ScheduleUserPermissionsSync(ctx context.Context, args *UserPermissionsSyncArgs) (*EmptyResponse, error)
 	SetSubRepositoryPermissionsForUsers(ctx context.Context, args *SubRepoPermsArgs) (*EmptyResponse, error)
 	SetRepositoryPermissionsForBitbucketProject(ctx context.Context, args *RepoPermsBitbucketProjectArgs) (*EmptyResponse, error)
+	CancelPermissionsSyncJob(ctx context.Context, args *CancelPermissionsSyncJobArgs) (*EmptyResponse, error)
 
-	// Queries
+	//AuthorizedUserRepositories and functions below are GraphQL Queries.
 	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
@@ -27,7 +28,7 @@ type AuthzResolver interface {
 	AuthzProviderTypes(ctx context.Context) ([]string, error)
 	PermissionsSyncJobs(ctx context.Context, args ListPermissionsSyncJobsArgs) (*graphqlutil.ConnectionResolver[PermissionsSyncJobResolver], error)
 
-	// Helpers
+	// RepositoryPermissionsInfo and UserPermissionsInfo are helpers functions.
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
 	UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error)
 }
@@ -79,6 +80,11 @@ type RepoPermsBitbucketProjectArgs struct {
 	CodeHost        graphql.ID
 	UserPermissions []types.UserPermission
 	Unrestricted    *bool
+}
+
+type CancelPermissionsSyncJobArgs struct {
+	Job    graphql.ID
+	Reason *string
 }
 
 type BitbucketProjectPermissionJobsArgs struct {

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -93,6 +93,22 @@ extend type Mutation {
         """
         unrestricted: Boolean
     ): EmptyResponse!
+
+    """
+    Cancel permissions sync job with given ID.
+    No error is returned when the job is not in `queued` state or there is no such job
+    with the given ID (latter means that most probably, the job has already been cleaned up).
+    """
+    cancelPermissionsSyncJob(
+        """
+        ID of the job to be canceled.
+        """
+        job: ID!
+        """
+        Optional cancellation reason.
+        """
+        reason: String
+    ): EmptyResponse!
 }
 
 extend type Query {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -12,7 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+const permissionsSyncJobIDKind = "PermissionsSyncJob"
 
 func NewPermissionsSyncJobsResolver(db database.DB, args graphqlbackend.ListPermissionsSyncJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsSyncJobResolver], error) {
 	store := &permissionsSyncJobConnectionStore{
@@ -278,10 +281,14 @@ func (s subject) ToUser() (*graphqlbackend.UserResolver, bool) {
 }
 
 func marshalPermissionsSyncJobID(id int) graphql.ID {
-	return relay.MarshalID("PermissionsSyncJob", id)
+	return relay.MarshalID(permissionsSyncJobIDKind, id)
 }
 
 func unmarshalPermissionsSyncJobID(id graphql.ID) (jobID int, err error) {
+	if kind := relay.UnmarshalKind(id); kind != permissionsSyncJobIDKind {
+		err = errors.Errorf("expected graphql ID to have kind %q; got %q", permissionsSyncJobIDKind, kind)
+		return
+	}
 	err = relay.UnmarshalSpec(id, &jobID)
 	return
 }

--- a/internal/database/mockerr.go
+++ b/internal/database/mockerr.go
@@ -5,4 +5,5 @@ var (
 	MockCannotCreateUserEmailExistsErr    = ErrCannotCreateUser{ErrorCodeEmailExists}
 	MockUserNotFoundErr                   = userNotFoundErr{}
 	MockUserEmailNotFoundErr              = userEmailNotFoundError{}
+	MockPermissionsSyncJobNotFoundErr     = notFoundError{}
 )


### PR DESCRIPTION
Test plan:
Unit tests added.
GraphQL tests added.
Local sg run and API tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/48894