### PR TITLE
chore: clean up how licensing mocks are used.

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -58,14 +58,13 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 }
 
 func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
-
-		licensing.MockCheckFeatureError("")
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		result, err := (&Resolver{db: db}).SetRepositoryPermissionsForUsers(ctx, &graphqlbackend.RepoPermsArgs{})
@@ -233,6 +232,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 
 func TestResolver_SetRepositoryPermissionsUnrestricted(t *testing.T) {
 	// TODO: Factor out this common check
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
@@ -294,7 +294,7 @@ func TestResolver_SetRepositoryPermissionsUnrestricted(t *testing.T) {
 }
 
 func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
-	licensing.MockCheckFeatureError("")
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
@@ -348,8 +348,7 @@ func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
 }
 
 func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
-	reset := licensing.TestingSkipFeatureChecks()
-	t.Cleanup(reset)
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 123})
 
 	t.Run("authenticated as non-admin and not the same user", func(t *testing.T) {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -35,9 +35,10 @@ func init() {
 
 func TestPermsSyncer_ScheduleUsers(t *testing.T) {
 	authz.SetProviders(true, []authz.Provider{&mockProvider{}})
-	defer authz.SetProviders(true, nil)
-
-	licensing.MockCheckFeatureError("")
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	s := NewPermsSyncer(logtest.Scoped(t), nil, nil, nil, nil, nil)
 	s.ScheduleUsers(context.Background(), authz.FetchPermsOptions{}, 1)
 
@@ -55,9 +56,10 @@ func TestPermsSyncer_ScheduleUsers(t *testing.T) {
 
 func TestPermsSyncer_ScheduleRepos(t *testing.T) {
 	authz.SetProviders(true, []authz.Provider{&mockProvider{}})
-	defer authz.SetProviders(true, nil)
-
-	licensing.MockCheckFeatureError("")
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	s := NewPermsSyncer(logtest.Scoped(t), nil, nil, nil, nil, nil)
 	s.ScheduleRepos(context.Background(), 1)
 
@@ -112,7 +114,9 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 		serviceID:   "https://gitlab.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -196,7 +200,9 @@ func TestPermsSyncer_syncUserPerms_touchUserPermissions(t *testing.T) {
 		serviceID:   "https://gitlab.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	users := database.NewMockUserStore()
 	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
@@ -267,7 +273,9 @@ func TestPermsSyncer_syncUserPermsTemporaryProviderError(t *testing.T) {
 		serviceID:   "https://gitlab.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -353,7 +361,9 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 		serviceID:   "https://gitlab.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -437,7 +447,9 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 		serviceID:   "https://github.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -528,7 +540,9 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 		serviceID:   "ssl:111.222.333.444:1666",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -597,7 +611,9 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 		serviceID:   "ssl:111.222.333.444:1666",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	extAccount := extsvc.Account{
 		AccountSpec: extsvc.AccountSpec{
@@ -736,7 +752,9 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			},
 		}
 		authz.SetProviders(false, []authz.Provider{p1, p2})
-		defer authz.SetProviders(true, nil)
+		t.Cleanup(func() {
+			authz.SetProviders(true, nil)
+		})
 
 		mockRepos.ListFunc.SetDefaultReturn(
 			[]*types.Repo{
@@ -812,7 +830,9 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		serviceID:   "https://gitlab.com/",
 	}
 	authz.SetProviders(false, []authz.Provider{p})
-	defer authz.SetProviders(true, nil)
+	t.Cleanup(func() {
+		authz.SetProviders(true, nil)
+	})
 
 	mockRepos.ListFunc.SetDefaultReturn(
 		[]*types.Repo{

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -65,6 +65,7 @@ func (m gitlabAuthzProviderParams) FetchRepoPerms(context.Context, *extsvc.Repos
 }
 
 func TestAuthzProvidersFromConfig(t *testing.T) {
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 	gitlab.NewOAuthProvider = func(op gitlab.OAuthProviderOp) authz.Provider {
 		return gitlabAuthzProviderParams{OAuthOp: op}
 	}
@@ -496,7 +497,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				}
 				return svcs, nil
 			})
-			licensing.MockCheckFeatureError("")
 			allowAccessByDefault, authzProviders, seriousProblems, _, _ := ProvidersFromConfig(
 				context.Background(),
 				staticConfig(test.cfg.SiteConfiguration),
@@ -514,6 +514,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 }
 
 func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
+	t.Cleanup(licensing.MockCheckFeatureError("failed"))
 	tests := []struct {
 		description                string
 		cfg                        conf.Unified
@@ -741,7 +742,6 @@ func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
 				return svcs, nil
 			})
 
-			licensing.MockCheckFeatureError("failed")
 			_, _, seriousProblems, _, invalidConnections := ProvidersFromConfig(
 				context.Background(),
 				staticConfig(test.cfg.SiteConfiguration),

--- a/enterprise/internal/authz/bitbucketcloud/authz_test.go
+++ b/enterprise/internal/authz/bitbucketcloud/authz_test.go
@@ -35,7 +35,7 @@ func TestNewAuthzProviders(t *testing.T) {
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {
-		licensing.MockCheckFeatureError("")
+		t.Cleanup(licensing.TestingSkipFeatureChecks())
 		initResults := NewAuthzProviders(
 			db,
 			[]*types.BitbucketCloudConnection{
@@ -61,7 +61,7 @@ func TestNewAuthzProviders(t *testing.T) {
 
 	t.Run("matching auth provider found", func(t *testing.T) {
 		t.Run("default case", func(t *testing.T) {
-			licensing.MockCheckFeatureError("")
+			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
 				db,
 				[]*types.BitbucketCloudConnection{
@@ -84,7 +84,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		})
 
 		t.Run("license does not have ACLs feature", func(t *testing.T) {
-			licensing.MockCheckFeatureError("failed")
+			t.Cleanup(licensing.MockCheckFeatureError("failed"))
 			initResults := NewAuthzProviders(
 				db,
 				[]*types.BitbucketCloudConnection{

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -46,7 +46,7 @@ func TestNewAuthzProviders(t *testing.T) {
 	})
 
 	t.Run("no matching auth provider", func(t *testing.T) {
-		licensing.MockCheckFeatureError("")
+		t.Cleanup(licensing.TestingSkipFeatureChecks())
 		initResults := NewAuthzProviders(
 			db,
 			[]*ExternalConnection{
@@ -80,7 +80,7 @@ func TestNewAuthzProviders(t *testing.T) {
 
 	t.Run("matching auth provider found", func(t *testing.T) {
 		t.Run("default case", func(t *testing.T) {
-			licensing.MockCheckFeatureError("")
+			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
 				db,
 				[]*ExternalConnection{
@@ -110,7 +110,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		})
 
 		t.Run("license does not have ACLs feature", func(t *testing.T) {
-			licensing.MockCheckFeatureError("failed")
+			t.Cleanup(licensing.MockCheckFeatureError("failed"))
 			initResults := NewAuthzProviders(
 				db,
 				[]*ExternalConnection{
@@ -139,7 +139,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		})
 
 		t.Run("groups cache enabled, but not allowGroupsPermissionsSync", func(t *testing.T) {
-			licensing.MockCheckFeatureError("")
+			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
 				db,
 				[]*ExternalConnection{
@@ -176,6 +176,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		})
 
 		t.Run("groups cache and allowGroupsPermissionsSync enabled", func(t *testing.T) {
+			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			github.MockGetAuthenticatedOAuthScopes = func(context.Context) ([]string, error) {
 				return []string{"read:org"}, nil
 			}
@@ -215,6 +216,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		})
 
 		t.Run("github app installation id available", func(t *testing.T) {
+			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			const bogusKey = `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBUEpIaWprdG1UMUlLYUd0YTVFZXAzQVo5Q2VPZUw4alBESUZUN3dRZ0tabXQzRUZxRGhCCk93bitRVUhKdUs5Zm92UkROSmVWTDJvWTVCT0l6NHJ3L0cwQ0F3RUFBUUpCQU1BK0o5Mks0d2NQVllsbWMrM28KcHU5NmlKTkNwMmp5Nm5hK1pEQlQzK0VvSUo1VFJGdnN3R2kvTHUzZThYUWwxTDNTM21ub0xPSlZNcTF0bUxOMgpIY0VDSVFEK3daeS83RlYxUEFtdmlXeWlYVklETzJnNWJOaUJlbmdKQ3hFa3Nia1VtUUloQVBOMlZaczN6UFFwCk1EVG9vTlJXcnl0RW1URERkamdiOFpzTldYL1JPRGIxQWlCZWNKblNVQ05TQllLMXJ5VTFmNURTbitoQU9ZaDkKWDFBMlVnTDE3bWhsS1FJaEFPK2JMNmRDWktpTGZORWxmVnRkTUtxQnFjNlBIK01heFU2VzlkVlFvR1dkQWlFQQptdGZ5cE9zYTFiS2hFTDg0blovaXZFYkJyaVJHalAya3lERHYzUlg0V0JrPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
 
 			conf.Mock(&conf.Unified{

--- a/enterprise/internal/database/external_services_test.go
+++ b/enterprise/internal/database/external_services_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -22,6 +22,7 @@ import (
 // super-set of the validation performed by the OSS version.
 func TestValidateExternalServiceConfig(t *testing.T) {
 	t.Parallel()
+	t.Cleanup(licensing.TestingSkipFeatureChecks())
 
 	// Assertion helpers
 	equals := func(want ...string) func(testing.TB, []string) {
@@ -1291,7 +1292,6 @@ func TestValidateExternalServiceConfig(t *testing.T) {
 			assert: equals("<nil>"),
 		},
 	} {
-		licensing.MockCheckFeatureError("")
 		tc := tc
 		t.Run(tc.kind+"/"+tc.desc, func(t *testing.T) {
 			var have []string

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -12,11 +12,12 @@ type Feature interface {
 	FeatureName() string
 	// Check checks whether the feature is activated on the provided license info.
 	// If applicable, it is recommended that Check modifies the feature in-place
-	// to reflect the license info (e.g., to set a limit on the number of changesets)
+	// to reflect the license info (e.g., to set a limit on the number of changesets).
 	Check(*Info) error
 }
 
-// BasicFeature is a product feature that is selectively activated based on the current license key.
+// BasicFeature is a product feature that is selectively activated based on the
+// current license key.
 type BasicFeature string
 
 func (f BasicFeature) FeatureName() string {
@@ -32,7 +33,7 @@ func (f BasicFeature) Check(info *Info) error {
 
 	// Check if the feature is explicitly allowed via license tag.
 	hasFeature := func(want Feature) bool {
-		// if license is expired, do not look at tags anymore
+		// If license is expired, do not look at tags anymore.
 		if info.IsExpired() {
 			return false
 		}
@@ -57,7 +58,8 @@ func (f BasicFeature) Check(info *Info) error {
 type FeatureBatchChanges struct {
 	// If true, there is no limit to the number of changesets that can be created.
 	Unrestricted bool
-	// Maximum number of changesets that can be created per batch change. If Unrestricted is true, this is ignored.
+	// Maximum number of changesets that can be created per batch change.
+	// If Unrestricted is true, this is ignored.
 	MaxNumChangesets int
 }
 
@@ -70,19 +72,20 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", f.FeatureName()))
 	}
 
-	// If the deprecated campaigns are enabled, use unrestricted batch changes
+	// If the deprecated campaigns are enabled, use unrestricted batch changes.
 	if FeatureCampaigns.Check(info) == nil {
 		f.Unrestricted = true
 		return nil
 	}
 
-	// If the batch changes tag exists on the license, use unrestricted batch changes
+	// If the batch changes tag exists on the license, use unrestricted batch
+	// changes.
 	if info.HasTag(f.FeatureName()) {
 		f.Unrestricted = true
 		return nil
 	}
 
-	// Otherwise, check the default batch changes feature
+	// Otherwise, check the default batch changes feature.
 	if info.Plan().HasFeature(f, info.IsExpired()) {
 		return nil
 	}
@@ -91,9 +94,11 @@ func (f *FeatureBatchChanges) Check(info *Info) error {
 }
 
 type FeaturePrivateRepositories struct {
-	// If true, there is no limit to the number of private repositories that can be added.
+	// If true, there is no limit to the number of private repositories that can be
+	// added.
 	Unrestricted bool
-	// Maximum number of private repositories that can be added. If Unrestricted is true, this is ignored.
+	// Maximum number of private repositories that can be added. If Unrestricted is
+	// true, this is ignored.
 	MaxNumPrivateRepos int
 }
 
@@ -106,13 +111,14 @@ func (f *FeaturePrivateRepositories) Check(info *Info) error {
 		return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated because it requires a valid Sourcegraph license. Purchase a Sourcegraph subscription to activate this feature.", f.FeatureName()))
 	}
 
-	// If the private repositories tag exists on the license, use unrestricted private repositories
+	// If the private repositories tag exists on the license, use unrestricted
+	// private repositories.
 	if info.HasTag(f.FeatureName()) {
 		f.Unrestricted = true
 		return nil
 	}
 
-	// Otherwise, check the defaultprivate repositories feature
+	// Otherwise, check the default private repositories feature.
 	if info.Plan().HasFeature(f, info.IsExpired()) {
 		return nil
 	}
@@ -120,11 +126,12 @@ func (f *FeaturePrivateRepositories) Check(info *Info) error {
 	return NewFeatureNotActivatedError(fmt.Sprintf("The feature %q is not activated in your Sourcegraph license. Upgrade your Sourcegraph subscription to use this feature.", f.FeatureName()))
 }
 
-// Check checks whether the feature is activated based on the current license. If it is
-// disabled, it returns a non-nil error.
+// Check checks whether the feature is activated based on the current license. If
+// it is disabled, it returns a non-nil error.
 //
-// The returned error may implement errcode.PresentationError to indicate that it can be displayed
-// directly to the user. Use IsFeatureNotActivated to distinguish between the error reasons.
+// The returned error may implement errcode.PresentationError to indicate that it
+// can be displayed directly to the user. Use IsFeatureNotActivated to
+// distinguish between the error reasons.
 func Check(feature Feature) error {
 	if MockCheckFeature != nil {
 		return MockCheckFeature(feature)
@@ -137,25 +144,31 @@ func Check(feature Feature) error {
 	return feature.Check(info)
 }
 
-func MockCheckFeatureError(expectedError string) {
+// MockCheckFeatureError is for tests that want to mock Check to return a
+// specific error or nil (in case of empty string argument).
+//
+// It returns a cleanup func so callers can use
+// `t.Cleanup(licensing.TestingSkipFeatureChecks())` in a test body.
+func MockCheckFeatureError(expectedError string) func() {
 	MockCheckFeature = func(feature Feature) error {
 		if expectedError == "" {
 			return nil
 		}
 		return errors.New(expectedError)
 	}
+	return func() { MockCheckFeature = nil }
 }
 
 // MockCheckFeature is for mocking Check in tests.
 var MockCheckFeature func(feature Feature) error
 
-// TestingSkipFeatureChecks is for tests that want to mock Check to always return nil (i.e.,
-// behave as though the current license enables all features).
+// TestingSkipFeatureChecks is for tests that want to mock Check to always return
+// nil (i.e., behave as though the current license enables all features).
 //
-// It returns a cleanup func so callers can use `defer TestingSkipFeatureChecks()()` in a test body.
+// It returns a cleanup func so callers can use
+// `t.Cleanup(licensing.TestingSkipFeatureChecks())` in a test body.
 func TestingSkipFeatureChecks() func() {
-	MockCheckFeature = func(feature Feature) error { return nil }
-	return func() { MockCheckFeature = nil }
+	return MockCheckFeatureError("")
 }
 
 func NewFeatureNotActivatedError(message string) featureNotActivatedError {
@@ -165,23 +178,24 @@ func NewFeatureNotActivatedError(message string) featureNotActivatedError {
 
 type featureNotActivatedError struct{ errcode.PresentationError }
 
-// IsFeatureNotActivated reports whether err indicates that the license is valid but does not
-// activate the feature.
+// IsFeatureNotActivated reports whether err indicates that the license is valid
+// but does not activate the feature.
 //
-// It is used to distinguish between the multiple reasons for errors from Check: either
-// failed license verification, or a valid license that does not activate a feature (e.g.,
-// Enterprise Starter not including an Enterprise-only feature).
+// It is used to distinguish between the multiple reasons for errors from Check:
+// either failed license verification, or a valid license that does not activate
+// a feature (e.g., Enterprise Starter not including an Enterprise-only feature).
 func IsFeatureNotActivated(err error) bool {
 	// Also check for the pointer type to guard against stupid mistakes.
 	return errors.HasType(err, featureNotActivatedError{}) || errors.HasType(err, &featureNotActivatedError{})
 }
 
-// IsFeatureEnabledLenient reports whether the current license enables the given feature. If there
-// is an error reading the license, it is lenient and returns true.
+// IsFeatureEnabledLenient reports whether the current license enables the given
+// feature. If there is an error reading the license, it is lenient and returns
+// true.
 //
-// This is useful for callers who don't want to handle errors (usually because the user would be
-// prevented from getting to this point if license verification had failed, so it's not necessary to
-// handle license verification errors here).
+// This is useful for callers who don't want to handle errors (usually because
+// the user would be prevented from getting to this point if license verification
+// had failed, so it's not necessary to handle license verification errors here).
 func IsFeatureEnabledLenient(feature Feature) bool {
 	return !IsFeatureNotActivated(Check(feature))
 }


### PR DESCRIPTION
Noticed it during writing another test and couldn't help cleaning this thing up.

Test plan:
Unit tests should not be broken after changes.