### PR TITLE
chore: use devx bot token for tracking issue syncer Action

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - uses: docker://sourcegraph/tracking-issue:latest
         env:
-          GITHUB_TOKEN: ${{ secrets.TRACKING_ISSUE_SYNCER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRACKING_ISSUE_SYNCER_TOKEN_DEVX_BOT }}


### PR DESCRIPTION
The main bot account is hitting rate limits a lot, so switch to a token of the new devx bot.

## Test plan
No more rate limits pls

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
