### PR TITLE
sg: remove unecessary check from oss command set

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1039,8 +1039,6 @@ commandsets:
       - redis
       - postgres
       - git
-      - bazel
-      - ibazel
     commands:
       - oss-frontend
       - oss-worker


### PR DESCRIPTION
@leonore spotted that I wrongly added a bazel check on the normal `oss` command set. This PR fixes this.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 