### PR TITLE
Fix notebook embed page

### DIFF
--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -2,19 +2,20 @@ import { FC, Suspense, useEffect, useLayoutEffect, useMemo } from 'react'
 
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
-import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/createSyncLoadedController'
 import { useTheme, Theme, ThemeSetting } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Alert, LoadingSpinner, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import '../../SourcegraphWebApp.scss'
 
-import { GlobalContributions } from '../../contributions'
 import { createPlatformContext } from '../../platform/context'
 
 import { OpenNewTabAnchorLink } from './OpenNewTabAnchorLink'
 
 import styles from './EmbeddedWebApp.module.scss'
+import { SettingsProvider } from '@sourcegraph/shared/src/settings/settings'
+import { ApolloProvider } from '@apollo/client'
+import { GraphQLClient } from '@sourcegraph/http-client'
 
 // Since we intend to embed the EmbeddedWebApp component within an iframe,
 // we want to open all links in a new tab instead of the current iframe window.
@@ -32,7 +33,10 @@ const EmbeddedNotebookPage = lazyComponent(
 
 const EMPTY_SETTINGS_CASCADE = { final: {}, subjects: [] }
 
-export const EmbeddedWebApp: FC = () => {
+interface Props {
+    graphqlClient: GraphQLClient
+}
+export const EmbeddedWebApp: FC<Props> = ({ graphqlClient }) => {
     const { theme, setThemeSetting } = useTheme()
 
     useLayoutEffect(() => {
@@ -52,7 +56,6 @@ export const EmbeddedWebApp: FC = () => {
     }, [setThemeSetting])
 
     const platformContext = useMemo(() => createPlatformContext(), [])
-    const extensionsController = useMemo(() => createExtensionsController(platformContext), [platformContext])
 
     // 🚨 SECURITY: The `EmbeddedWebApp` is intended to be embedded into 3rd party sites where we do not have total control.
     // That is why it is essential to be mindful when adding new routes that may be vulnerable to clickjacking or similar exploits.
@@ -62,45 +65,45 @@ export const EmbeddedWebApp: FC = () => {
     // IMPORTANT: Please consult with the security team if you are unsure whether your changes could introduce security exploits.
     return (
         <BrowserRouter>
-            <WildcardThemeContext.Provider value={WILDCARD_THEME}>
-                <div className={styles.body}>
-                    <Suspense
-                        fallback={
-                            <div className="d-flex justify-content-center p-3">
-                                <LoadingSpinner />
-                            </div>
-                        }
-                    >
-                        <Routes>
-                            <Route
-                                path="/embed/notebooks/:notebookId"
-                                element={
-                                    <EmbeddedNotebookPage
-                                        searchContextsEnabled={true}
-                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                        authenticatedUser={null}
-                                        settingsCascade={EMPTY_SETTINGS_CASCADE}
-                                        platformContext={platformContext}
+            <ApolloProvider client={graphqlClient}>
+                <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                    <SettingsProvider settingsCascade={EMPTY_SETTINGS_CASCADE}>
+                        <div className={styles.body}>
+                            <Suspense
+                                fallback={
+                                    <div className="d-flex justify-content-center p-3">
+                                        <LoadingSpinner />
+                                    </div>
+                                }
+                            >
+                                <Routes>
+                                    <Route
+                                        path="/embed/notebooks/:notebookId"
+                                        element={
+                                            <EmbeddedNotebookPage
+                                                searchContextsEnabled={true}
+                                                isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                                authenticatedUser={null}
+                                                settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                                platformContext={platformContext}
+                                            />
+                                        }
                                     />
-                                }
-                            />
-                            Ï
-                            <Route
-                                path="*"
-                                element={
-                                    <Alert variant="danger">
-                                        Invalid embedding route, please check the embedding URL.
-                                    </Alert>
-                                }
-                            />
-                        </Routes>
-                    </Suspense>
-                    <GlobalContributions
-                        extensionsController={extensionsController}
-                        platformContext={platformContext}
-                    />
-                </div>
-            </WildcardThemeContext.Provider>
+                                    Ï
+                                    <Route
+                                        path="*"
+                                        element={
+                                            <Alert variant="danger">
+                                                Invalid embedding route, please check the embedding URL.
+                                            </Alert>
+                                        }
+                                    />
+                                </Routes>
+                            </Suspense>
+                        </div>
+                    </SettingsProvider>
+                </WildcardThemeContext.Provider>
+            </ApolloProvider>
         </BrowserRouter>
     )
 }

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,7 +1,10 @@
 import { FC, Suspense, useEffect, useLayoutEffect, useMemo } from 'react'
 
+import { ApolloProvider } from '@apollo/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
+import { GraphQLClient } from '@sourcegraph/http-client'
+import { SettingsProvider } from '@sourcegraph/shared/src/settings/settings'
 import { useTheme, Theme, ThemeSetting } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Alert, LoadingSpinner, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
@@ -13,9 +16,6 @@ import { createPlatformContext } from '../../platform/context'
 import { OpenNewTabAnchorLink } from './OpenNewTabAnchorLink'
 
 import styles from './EmbeddedWebApp.module.scss'
-import { SettingsProvider } from '@sourcegraph/shared/src/settings/settings'
-import { ApolloProvider } from '@apollo/client'
-import { GraphQLClient } from '@sourcegraph/http-client'
 
 // Since we intend to embed the EmbeddedWebApp component within an iframe,
 // we want to open all links in a new tab instead of the current iframe window.

--- a/client/web/src/enterprise/embed/main.tsx
+++ b/client/web/src/enterprise/embed/main.tsx
@@ -2,12 +2,24 @@ import '@sourcegraph/shared/src/polyfills'
 
 import { createRoot } from 'react-dom/client'
 
+import { logger } from '@sourcegraph/common'
+
+import { initAppShell } from '../../storm/app-shell-init'
+
 import { EmbeddedWebApp } from './EmbeddedWebApp'
+
+const appShellPromise = initAppShell()
 
 // It's important to have a root component in a separate file to create a react-refresh boundary and avoid page reload.
 // https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#edits-always-lead-to-full-reload
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
     const root = createRoot(document.querySelector('#root')!)
 
-    root.render(<EmbeddedWebApp />)
+    try {
+        const { graphqlClient } = await appShellPromise
+
+        root.render(<EmbeddedWebApp graphqlClient={graphqlClient} />)
+    } catch (error) {
+        logger.error('Failed to initialize the app shell', error)
+    }
 })


### PR DESCRIPTION
This adds some of the changes that we brought to the `<(Legacy)SourcegraphWebApp/>` over to the embed endpoint as well to fix it (we probably need to find time to add a test for this to avoid regressions in the future).

The fix here was to:

- Remove the outdated extension API initializations. We no longer render hover tooltip for notbooks IIRC which means that this won't need extensions add all
- Add the Apollo client (since we need it for feature flags now) and settings provider 


I noticed a weird issue that happens on my local machine where notebooks aren't syntax highlighted 😕  This repros on main as well but it seems to work fine on S2 and it's unrelated to this fix.

## Test plan

Verify that the embed endpoint works again

<img width="1702" alt="Screenshot 2023-03-08 at 13 20 36" src="https://user-images.githubusercontent.com/458591/223712687-4dc23102-7234-4517-9139-9372ae8c0aea.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-embed.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
