### PR TITLE
SCIM: Enable SCIM for existing users in case of PATCH or PUT

### DIFF
--- a/enterprise/internal/scim/mock_db.go
+++ b/enterprise/internal/scim/mock_db.go
@@ -85,7 +85,7 @@ func getMockDB(users []*types.UserForSCIM) *database.MockDB {
 		users = append(users, &userToCreate)
 		return &userToCreate.User, nil
 	})
-	userExternalAccountsStore.UpdateSCIMDataFunc.SetDefaultHook(func(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
+	userExternalAccountsStore.UpdateOrInsertSCIMDataFunc.SetDefaultHook(func(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
 		for _, user := range users {
 			if user.ID == userID {
 				var decrypted interface{}

--- a/enterprise/internal/scim/mock_db.go
+++ b/enterprise/internal/scim/mock_db.go
@@ -85,7 +85,7 @@ func getMockDB(users []*types.UserForSCIM) *database.MockDB {
 		users = append(users, &userToCreate)
 		return &userToCreate.User, nil
 	})
-	userExternalAccountsStore.UpdateOrInsertSCIMDataFunc.SetDefaultHook(func(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
+	userExternalAccountsStore.UpsertSCIMDataFunc.SetDefaultHook(func(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
 		for _, user := range users {
 			if user.ID == userID {
 				var decrypted interface{}

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -111,7 +111,7 @@ func updateUser(ctx context.Context, tx database.DB, oldUser *types.UserForSCIM,
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 	}
-	err = tx.UserExternalAccounts().UpdateSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
+	err = tx.UserExternalAccounts().UpdateOrInsertSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: errors.Wrap(err, "could not update").Error()}
 	}

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -86,11 +86,11 @@ func createUserResourceType(userResourceHandler *UserResourceHandler) scim.Resou
 }
 
 // updateUser updates a user in the database. This is meant to be used in a transaction.
-func updateUser(ctx context.Context, db database.DB, oldUser *types.UserForSCIM, attributes scim.ResourceAttributes) (err error) {
+func updateUser(ctx context.Context, tx database.DB, oldUser *types.UserForSCIM, attributes scim.ResourceAttributes) (err error) {
 	usernameUpdate := ""
 	requestedUsername := extractStringAttribute(attributes, AttrUserName)
 	if requestedUsername != oldUser.Username {
-		usernameUpdate, err = getUniqueUsername(ctx, db.Users(), requestedUsername)
+		usernameUpdate, err = getUniqueUsername(ctx, tx.Users(), requestedUsername)
 		if err != nil {
 			return scimerrors.ScimError{Status: http.StatusBadRequest, Detail: errors.Wrap(err, "invalid username").Error()}
 		}
@@ -102,7 +102,7 @@ func updateUser(ctx context.Context, db database.DB, oldUser *types.UserForSCIM,
 		DisplayName: displayNameUpdate,
 		AvatarURL:   avatarURLUpdate,
 	}
-	err = db.Users().Update(ctx, oldUser.ID, userUpdate)
+	err = tx.Users().Update(ctx, oldUser.ID, userUpdate)
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: errors.Wrap(err, "could not update").Error()}
 	}
@@ -111,7 +111,7 @@ func updateUser(ctx context.Context, db database.DB, oldUser *types.UserForSCIM,
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 	}
-	err = db.UserExternalAccounts().UpdateSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
+	err = tx.UserExternalAccounts().UpdateSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: errors.Wrap(err, "could not update").Error()}
 	}

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -111,7 +111,7 @@ func updateUser(ctx context.Context, tx database.DB, oldUser *types.UserForSCIM,
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
 	}
-	err = tx.UserExternalAccounts().UpdateOrInsertSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
+	err = tx.UserExternalAccounts().UpsertSCIMData(ctx, oldUser.ID, getUniqueExternalID(attributes), accountData)
 	if err != nil {
 		return scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: errors.Wrap(err, "could not update").Error()}
 	}

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -78,11 +78,11 @@ type UserExternalAccountsStore interface {
 	// CreateUserAndSave for that.
 	LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.AccountData) (userID int32, err error)
 
-	// UpdateOrInsertSCIMData updates the external account data for the given user's SCIM account.
+	// UpsertSCIMData updates the external account data for the given user's SCIM account.
 	// It looks up the existing user based on its ID, then sets its account ID and data.
 	// Account ID is the same as the external ID for SCIM.
 	// If the external account does not exist, it creates a new one.
-	UpdateOrInsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error)
+	UpsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error)
 
 	// TouchExpired sets the given user external accounts to be expired now.
 	TouchExpired(ctx context.Context, ids ...int32) error
@@ -164,7 +164,7 @@ RETURNING user_id
 	return userID, err
 }
 
-func (s *userExternalAccountsStore) UpdateOrInsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
+func (s *userExternalAccountsStore) UpsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
 	encryptedAuthData, encryptedAccountData, keyID, err := s.encryptData(ctx, data)
 	if err != nil {
 		return

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -78,10 +78,11 @@ type UserExternalAccountsStore interface {
 	// CreateUserAndSave for that.
 	LookupUserAndSave(ctx context.Context, spec extsvc.AccountSpec, data extsvc.AccountData) (userID int32, err error)
 
-	// UpdateSCIMData updates the external account data for the given user's SCIM account.
+	// UpdateOrInsertSCIMData updates the external account data for the given user's SCIM account.
 	// It looks up the existing user based on its ID, then sets its account ID and data.
 	// Account ID is the same as the external ID for SCIM.
-	UpdateSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error)
+	// If the external account does not exist, it creates a new one.
+	UpdateOrInsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error)
 
 	// TouchExpired sets the given user external accounts to be expired now.
 	TouchExpired(ctx context.Context, ids ...int32) error
@@ -163,27 +164,39 @@ RETURNING user_id
 	return userID, err
 }
 
-func (s *userExternalAccountsStore) UpdateSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
+func (s *userExternalAccountsStore) UpdateOrInsertSCIMData(ctx context.Context, userID int32, accountID string, data extsvc.AccountData) (err error) {
 	encryptedAuthData, encryptedAccountData, keyID, err := s.encryptData(ctx, data)
 	if err != nil {
 		return
 	}
 
-	_, err = s.Handle().ExecContext(ctx, `
+	res, err := s.ExecResult(ctx, sqlf.Sprintf(`
 UPDATE user_external_accounts
 SET
-	account_id = $4,
-	auth_data = $5,
-	account_data = $6,
-	encryption_key_id = $7,
+	account_id = %s,
+	auth_data = %s,
+	account_data = %s,
+	encryption_key_id = %s,
 	updated_at = now(),
 	expired_at = NULL
 WHERE
-	user_id = $1
-AND service_type = $2
-AND service_id = $3
+	user_id = %s
+AND service_type = %s
+AND service_id = %s
 AND deleted_at IS NULL
-`, userID, "scim", "scim", accountID, encryptedAuthData, encryptedAccountData, keyID)
+`, accountID, encryptedAuthData, encryptedAccountData, keyID, userID, "scim", "scim"))
+	if err != nil {
+		return
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return
+	}
+
+	if rowsAffected == 0 {
+		return s.Insert(ctx, userID, extsvc.AccountSpec{ServiceType: "scim", ServiceID: "scim", AccountID: accountID}, data)
+	}
+
 	return
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -56537,9 +56537,9 @@ type MockUserExternalAccountsStore struct {
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *UserExternalAccountsStoreTransactFunc
-	// UpdateSCIMDataFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateSCIMData.
-	UpdateSCIMDataFunc *UserExternalAccountsStoreUpdateSCIMDataFunc
+	// UpdateOrInsertSCIMDataFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateOrInsertSCIMData.
+	UpdateOrInsertSCIMDataFunc *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *UserExternalAccountsStoreWithFunc
@@ -56628,7 +56628,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 				return
 			},
 		},
-		UpdateSCIMDataFunc: &UserExternalAccountsStoreUpdateSCIMDataFunc{
+		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
 			defaultHook: func(context.Context, int32, string, extsvc.AccountData) (r0 error) {
 				return
 			},
@@ -56726,9 +56726,9 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Transact")
 			},
 		},
-		UpdateSCIMDataFunc: &UserExternalAccountsStoreUpdateSCIMDataFunc{
+		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
 			defaultHook: func(context.Context, int32, string, extsvc.AccountData) error {
-				panic("unexpected invocation of MockUserExternalAccountsStore.UpdateSCIMData")
+				panic("unexpected invocation of MockUserExternalAccountsStore.UpdateOrInsertSCIMData")
 			},
 		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
@@ -56794,8 +56794,8 @@ func NewMockUserExternalAccountsStoreFrom(i UserExternalAccountsStore) *MockUser
 		TransactFunc: &UserExternalAccountsStoreTransactFunc{
 			defaultHook: i.Transact,
 		},
-		UpdateSCIMDataFunc: &UserExternalAccountsStoreUpdateSCIMDataFunc{
-			defaultHook: i.UpdateSCIMData,
+		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
+			defaultHook: i.UpdateOrInsertSCIMData,
 		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
 			defaultHook: i.With,
@@ -58459,37 +58459,37 @@ func (c UserExternalAccountsStoreTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// UserExternalAccountsStoreUpdateSCIMDataFunc describes the behavior when
-// the UpdateSCIMData method of the parent MockUserExternalAccountsStore
-// instance is invoked.
-type UserExternalAccountsStoreUpdateSCIMDataFunc struct {
+// UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc describes the
+// behavior when the UpdateOrInsertSCIMData method of the parent
+// MockUserExternalAccountsStore instance is invoked.
+type UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc struct {
 	defaultHook func(context.Context, int32, string, extsvc.AccountData) error
 	hooks       []func(context.Context, int32, string, extsvc.AccountData) error
-	history     []UserExternalAccountsStoreUpdateSCIMDataFuncCall
+	history     []UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall
 	mutex       sync.Mutex
 }
 
-// UpdateSCIMData delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) UpdateSCIMData(v0 context.Context, v1 int32, v2 string, v3 extsvc.AccountData) error {
-	r0 := m.UpdateSCIMDataFunc.nextHook()(v0, v1, v2, v3)
-	m.UpdateSCIMDataFunc.appendCall(UserExternalAccountsStoreUpdateSCIMDataFuncCall{v0, v1, v2, v3, r0})
+// UpdateOrInsertSCIMData delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockUserExternalAccountsStore) UpdateOrInsertSCIMData(v0 context.Context, v1 int32, v2 string, v3 extsvc.AccountData) error {
+	r0 := m.UpdateOrInsertSCIMDataFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateOrInsertSCIMDataFunc.appendCall(UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the UpdateSCIMData
-// method of the parent MockUserExternalAccountsStore instance is invoked
-// and the hook queue is empty.
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) SetDefaultHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
+// SetDefaultHook sets function that is called when the
+// UpdateOrInsertSCIMData method of the parent MockUserExternalAccountsStore
+// instance is invoked and the hook queue is empty.
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) SetDefaultHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateSCIMData method of the parent MockUserExternalAccountsStore
+// UpdateOrInsertSCIMData method of the parent MockUserExternalAccountsStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) PushHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) PushHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -58497,20 +58497,20 @@ func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) SetDefaultReturn(r0 error) {
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int32, string, extsvc.AccountData) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) PushReturn(r0 error) {
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int32, string, extsvc.AccountData) error {
 		return r0
 	})
 }
 
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) nextHook() func(context.Context, int32, string, extsvc.AccountData) error {
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) nextHook() func(context.Context, int32, string, extsvc.AccountData) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -58523,28 +58523,28 @@ func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) nextHook() func(context.Co
 	return hook
 }
 
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) appendCall(r0 UserExternalAccountsStoreUpdateSCIMDataFuncCall) {
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) appendCall(r0 UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UserExternalAccountsStoreUpdateSCIMDataFuncCall objects describing the
-// invocations of this function.
-func (f *UserExternalAccountsStoreUpdateSCIMDataFunc) History() []UserExternalAccountsStoreUpdateSCIMDataFuncCall {
+// UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall objects
+// describing the invocations of this function.
+func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) History() []UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall {
 	f.mutex.Lock()
-	history := make([]UserExternalAccountsStoreUpdateSCIMDataFuncCall, len(f.history))
+	history := make([]UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UserExternalAccountsStoreUpdateSCIMDataFuncCall is an object that
-// describes an invocation of method UpdateSCIMData on an instance of
-// MockUserExternalAccountsStore.
-type UserExternalAccountsStoreUpdateSCIMDataFuncCall struct {
+// UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall is an object that
+// describes an invocation of method UpdateOrInsertSCIMData on an instance
+// of MockUserExternalAccountsStore.
+type UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -58564,13 +58564,13 @@ type UserExternalAccountsStoreUpdateSCIMDataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UserExternalAccountsStoreUpdateSCIMDataFuncCall) Args() []interface{} {
+func (c UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UserExternalAccountsStoreUpdateSCIMDataFuncCall) Results() []interface{} {
+func (c UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -56537,9 +56537,9 @@ type MockUserExternalAccountsStore struct {
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *UserExternalAccountsStoreTransactFunc
-	// UpdateOrInsertSCIMDataFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateOrInsertSCIMData.
-	UpdateOrInsertSCIMDataFunc *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc
+	// UpsertSCIMDataFunc is an instance of a mock function object
+	// controlling the behavior of the method UpsertSCIMData.
+	UpsertSCIMDataFunc *UserExternalAccountsStoreUpsertSCIMDataFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *UserExternalAccountsStoreWithFunc
@@ -56628,7 +56628,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 				return
 			},
 		},
-		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
+		UpsertSCIMDataFunc: &UserExternalAccountsStoreUpsertSCIMDataFunc{
 			defaultHook: func(context.Context, int32, string, extsvc.AccountData) (r0 error) {
 				return
 			},
@@ -56726,9 +56726,9 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Transact")
 			},
 		},
-		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
+		UpsertSCIMDataFunc: &UserExternalAccountsStoreUpsertSCIMDataFunc{
 			defaultHook: func(context.Context, int32, string, extsvc.AccountData) error {
-				panic("unexpected invocation of MockUserExternalAccountsStore.UpdateOrInsertSCIMData")
+				panic("unexpected invocation of MockUserExternalAccountsStore.UpsertSCIMData")
 			},
 		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
@@ -56794,8 +56794,8 @@ func NewMockUserExternalAccountsStoreFrom(i UserExternalAccountsStore) *MockUser
 		TransactFunc: &UserExternalAccountsStoreTransactFunc{
 			defaultHook: i.Transact,
 		},
-		UpdateOrInsertSCIMDataFunc: &UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc{
-			defaultHook: i.UpdateOrInsertSCIMData,
+		UpsertSCIMDataFunc: &UserExternalAccountsStoreUpsertSCIMDataFunc{
+			defaultHook: i.UpsertSCIMData,
 		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
 			defaultHook: i.With,
@@ -58459,37 +58459,37 @@ func (c UserExternalAccountsStoreTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc describes the
-// behavior when the UpdateOrInsertSCIMData method of the parent
-// MockUserExternalAccountsStore instance is invoked.
-type UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc struct {
+// UserExternalAccountsStoreUpsertSCIMDataFunc describes the behavior when
+// the UpsertSCIMData method of the parent MockUserExternalAccountsStore
+// instance is invoked.
+type UserExternalAccountsStoreUpsertSCIMDataFunc struct {
 	defaultHook func(context.Context, int32, string, extsvc.AccountData) error
 	hooks       []func(context.Context, int32, string, extsvc.AccountData) error
-	history     []UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall
+	history     []UserExternalAccountsStoreUpsertSCIMDataFuncCall
 	mutex       sync.Mutex
 }
 
-// UpdateOrInsertSCIMData delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) UpdateOrInsertSCIMData(v0 context.Context, v1 int32, v2 string, v3 extsvc.AccountData) error {
-	r0 := m.UpdateOrInsertSCIMDataFunc.nextHook()(v0, v1, v2, v3)
-	m.UpdateOrInsertSCIMDataFunc.appendCall(UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall{v0, v1, v2, v3, r0})
+// UpsertSCIMData delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUserExternalAccountsStore) UpsertSCIMData(v0 context.Context, v1 int32, v2 string, v3 extsvc.AccountData) error {
+	r0 := m.UpsertSCIMDataFunc.nextHook()(v0, v1, v2, v3)
+	m.UpsertSCIMDataFunc.appendCall(UserExternalAccountsStoreUpsertSCIMDataFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the
-// UpdateOrInsertSCIMData method of the parent MockUserExternalAccountsStore
-// instance is invoked and the hook queue is empty.
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) SetDefaultHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
+// SetDefaultHook sets function that is called when the UpsertSCIMData
+// method of the parent MockUserExternalAccountsStore instance is invoked
+// and the hook queue is empty.
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) SetDefaultHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateOrInsertSCIMData method of the parent MockUserExternalAccountsStore
+// UpsertSCIMData method of the parent MockUserExternalAccountsStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) PushHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) PushHook(hook func(context.Context, int32, string, extsvc.AccountData) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -58497,20 +58497,20 @@ func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) PushHook(hook func
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) SetDefaultReturn(r0 error) {
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int32, string, extsvc.AccountData) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) PushReturn(r0 error) {
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int32, string, extsvc.AccountData) error {
 		return r0
 	})
 }
 
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) nextHook() func(context.Context, int32, string, extsvc.AccountData) error {
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) nextHook() func(context.Context, int32, string, extsvc.AccountData) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -58523,28 +58523,28 @@ func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) nextHook() func(co
 	return hook
 }
 
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) appendCall(r0 UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) {
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) appendCall(r0 UserExternalAccountsStoreUpsertSCIMDataFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall objects
-// describing the invocations of this function.
-func (f *UserExternalAccountsStoreUpdateOrInsertSCIMDataFunc) History() []UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall {
+// UserExternalAccountsStoreUpsertSCIMDataFuncCall objects describing the
+// invocations of this function.
+func (f *UserExternalAccountsStoreUpsertSCIMDataFunc) History() []UserExternalAccountsStoreUpsertSCIMDataFuncCall {
 	f.mutex.Lock()
-	history := make([]UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall, len(f.history))
+	history := make([]UserExternalAccountsStoreUpsertSCIMDataFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall is an object that
-// describes an invocation of method UpdateOrInsertSCIMData on an instance
-// of MockUserExternalAccountsStore.
-type UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall struct {
+// UserExternalAccountsStoreUpsertSCIMDataFuncCall is an object that
+// describes an invocation of method UpsertSCIMData on an instance of
+// MockUserExternalAccountsStore.
+type UserExternalAccountsStoreUpsertSCIMDataFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -58564,13 +58564,13 @@ type UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) Args() []interface{} {
+func (c UserExternalAccountsStoreUpsertSCIMDataFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UserExternalAccountsStoreUpdateOrInsertSCIMDataFuncCall) Results() []interface{} {
+func (c UserExternalAccountsStoreUpsertSCIMDataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/48441

**Context:** Some users are **already in the DB** with the same email address as in the IdP. GET requests return non-SCIM-enabled users, so IdPs can know that these users already exist, despite them not having a SCIM entry in `user_external_accounts`. `CREATE` requests correctly respond with `409` in case the IdP tries to create an existing user. In case of `PATCH` and `PUT` requests, we expect these to change user data _and_ enable SCIM for these users.

**Problem:** `PATCH` and `PUT` requests return a valid response, but they fail to change the user in the DB, and they leave `user_external_accounts` intact.

**Solution:** With the changes in this PR, we'll notice if there is no entry in `user_external_accounts` when modifying/replacing the user, and create one.

## Test plan

Tested with Postman, both with SCIM-enabled users (to avoid a regression) and non-SCIM-enabled users (to test the new feature) and it worked smoothly.
