### PR TITLE
Search suggestions: add file path to symbol suggestions

### DIFF
--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -289,7 +289,7 @@ function toSymbolSuggestion({ item, positions }: FzfResultItem<CodeSymbol>, from
         icon: getSymbolIconSVGPath(item.kind),
         action: {
             type: 'completion',
-            insertValue: item.name + ' type:symbol ',
+            insertValue: item.name + ' type:symbol file:' + item.path + ' ',
             from,
             to,
         },


### PR DESCRIPTION
Previously, when accepting a symbol suggestion we added `type:symbol` to the query and nothing more. This approach has surprising behavior when there are many symbol suggestions with the same name because it  doesn't matter which of the suggestions the user accepts, they all add the same `type:symbol` syntax, which produces the same search results. Now, we also add the file path so that the search results prioritize the accepted symbol even if there are other symbols with the same name that are defined in other files.

Fixes https://sourcegraph.slack.com/archives/CHEKCRWKV/p1678202639864099

## Test plan

Manually tested by typing the query `repo:^github\.com/sourcegraph/sourcegraph$ Store`, accepting one of the suggestions and verifying that it adds the appropriate `file:PATH` filter.

![CleanShot 2023-03-08 at 14 42 39](https://user-images.githubusercontent.com/1408093/223728505-9328abb9-3853-49e8-bc68-ba4d7e8b4945.gif)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-symbol-add-file-path.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
