### PR TITLE
SCIM: Optimize user queries: Use WITH and JOIN rather than subqueries

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1241,7 +1241,7 @@ WITH scim_accounts AS (
         account_data
     FROM user_external_accounts
     WHERE service_type = 'scim'
-      AND deleted_at IS NULL
+        AND deleted_at IS NULL
 )
 SELECT u.id,
        u.username,

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1241,7 +1241,7 @@ WITH scim_accounts AS (
         account_data
     FROM user_external_accounts
     WHERE service_type = 'scim'
-        AND deleted_at IS NULL
+    AND deleted_at IS NULL
 )
 SELECT u.id,
        u.username,

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1205,9 +1205,7 @@ SELECT u.id,
        u.tos_accepted,
        u.searchable,
        EXISTS (SELECT 1 FROM user_external_accounts WHERE service_type = 'scim' AND user_id = u.id AND deleted_at IS NULL) AS scim_controlled
-FROM users u
-LEFT JOIN user_external_accounts AS sa ON u.id = sa.user_id
- %s`, query)
+FROM users u %s`, query)
 	rows, err := u.Query(ctx, q)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Set out to solve https://github.com/sourcegraph/sourcegraph/issues/48899, as per @pjlast's [suggestion](https://github.com/sourcegraph/sourcegraph/pull/48816/files#r1129187068)

Just adding a "LEFT JOIN" doesn't work because a field called `deleted_at` exists both in `users` and `user_external_accounts`, and they clash after JOINing.
Aliasing doesn't work either, as discussed [here](https://github.com/sourcegraph/sourcegraph/pull/48291#discussion_r1119175162).
To solve it, I used @chwarwick's solution (see the same discussion linked above) and used a `WITH` subquery.

This _works_ 🚀 , BUT the new problem is the `EXPLAIN ANALYZE` result I got when I ran it on dotcom (based on [this guide](https://handbook.sourcegraph.com/departments/engineering/dev/process/deployments/postgresql/#sourcegraphcom-specific)):

My original query that included a subquery, plus the `EXPLAIN ANALYZE` results:

```
EXPLAIN ANALYZE SELECT u.id,
       u.username,
       u.display_name,
       u.avatar_url,
       u.created_at,
       u.updated_at,
       u.site_admin,
       u.passwd IS NOT NULL,
       u.tags,
       u.invalidated_sessions_at,
       u.tos_accepted,
       u.searchable,
       (SELECT COUNT(user_id) FROM user_external_accounts WHERE user_id=u.id AND service_type = 'scim') >= 1 AS scim_controlled
FROM users u;

Seq Scan on users u  (cost=0.00..308122.63 rows=128233 width=119) (actual time=0.015..90.713 rows=53176 loops=1)
   SubPlan 1
     ->  Aggregate  (cost=2.35..2.35 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=53176)
           ->  Index Only Scan using user_external_accounts_user_id_scim_service_type on user_external_accounts  (cost=0.12..2.34 rows=1 width=4) (actual time=0.000..0.000 rows=0 loops=53176)
                 Index Cond: (user_id = u.id)
                 Heap Fetches: 0
 Planning Time: 0.126 ms
 Execution Time: 93.453 ms
(8 rows)
```

The new one that uses `WITH` and `JOIN`, plus the `EXPLAIN ANALYZE` results:

```
EXPLAIN ANALYZE WITH scim_accounts AS (SELECT user_id FROM user_external_accounts WHERE service_type = 'scim')
SELECT u.id,
       u.username,
       u.display_name,
       u.avatar_url,
       u.created_at,
       u.updated_at,
       u.site_admin,
       u.passwd IS NOT NULL,
       u.tags,
       u.invalidated_sessions_at,
       u.tos_accepted,
       u.searchable,
       (SELECT COUNT(user_id) FROM scim_accounts WHERE user_id=u.id) >= 1 AS scim_controlled
FROM users u
LEFT JOIN scim_accounts sa ON u.id = sa.user_id;

Hash Left Join  (cost=2.37..11105.32 rows=128233 width=119) (actual time=0.345..87.601 rows=53176 loops=1)
   Hash Cond: (u.id = sa.user_id)
   CTE scim_accounts
     ->  Index Only Scan using user_external_accounts_user_id_scim_service_type on user_external_accounts  (cost=0.12..2.34 rows=1 width=4) (actual time=0.321..0.321 rows=0 loops=1)
           Heap Fetches: 0
   ->  Seq Scan on users u  (cost=0.00..5813.33 rows=128233 width=178) (actual time=0.008..28.870 rows=53176 loops=1)
   ->  Hash  (cost=0.02..0.02 rows=1 width=4) (actual time=0.322..0.322 rows=0 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 8kB
         ->  CTE Scan on scim_accounts sa  (cost=0.00..0.02 rows=1 width=4) (actual time=0.321..0.322 rows=0 loops=1)
   SubPlan 2
     ->  Aggregate  (cost=0.02..0.03 rows=1 width=8) (actual time=0.000..0.000 rows=1 loops=53176)
           ->  CTE Scan on scim_accounts  (cost=0.00..0.02 rows=1 width=4) (actual time=0.000..0.000 rows=0 loops=53176)
                 Filter: (user_id = u.id)
 Planning Time: 0.183 ms
 Execution Time: 90.410 ms
(15 rows)
```

The time difference is smaller than what I'd expect, plus the seq scans in both cases make me worry. Am I looking at it wrong? → ✅  solved in comments.

Note on the priority of this PR: It's not a dealbreaker to have the subqueries there, but using a JOIN would be just much nicer.

## Test plan

- Tested it for functionality, it works!
- Tested that both queries use indexes all around.
