### PR TITLE
graphqlbackend: workaround not injecting servegit service

### DIFF
--- a/cmd/frontend/graphqlbackend/app.go
+++ b/cmd/frontend/graphqlbackend/app.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"path/filepath"
+	"time"
 
 	"github.com/sourcegraph/log"
 
@@ -92,12 +93,14 @@ func (r *localDirectoryResolver) Path() string {
 }
 
 func (r *localDirectoryResolver) Repositories() ([]LocalRepositoryResolver, error) {
-	var c servegit.ServeConfig
-	c.Load()
-
+	// TODO(keegan) this should be injected from the global instance. For now
+	// we are hardcoding the relevant defaults for ServeConfig.
 	srv := &servegit.Serve{
-		ServeConfig: c,
-		Logger:      log.Scoped("serve", ""),
+		ServeConfig: servegit.ServeConfig{
+			Timeout:  5 * time.Second,
+			MaxDepth: 10,
+		},
+		Logger: log.Scoped("serve", ""),
 	}
 
 	repos, err := srv.Repos(r.path)


### PR DESCRIPTION
Without this we panic due to calling Load after init. This is a temporary workaround to unblock frontend dev. It is correct, but is fragile to changes that may happen to servegit. Will work on a proper fix soon.

Test Plan: graphql call against Repositories.
