### PR TITLE
Drop unused index on event_logs table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -9119,16 +9119,6 @@
           "ConstraintDefinition": ""
         },
         {
-          "Name": "event_logs_user_id",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
-        },
-        {
           "Name": "event_logs_user_id_name",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1151,7 +1151,6 @@ Indexes:
     "event_logs_source" btree (source)
     "event_logs_timestamp" btree ("timestamp")
     "event_logs_timestamp_at_utc" btree (date(timezone('UTC'::text, "timestamp")))
-    "event_logs_user_id" btree (user_id)
     "event_logs_user_id_name" btree (user_id, name)
     "event_logs_user_id_timestamp" btree (user_id, "timestamp")
 Check constraints:

--- a/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/down.sql
+++ b/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS event_logs_user_id ON event_logs USING btree (user_id);

--- a/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/metadata.yaml
+++ b/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/metadata.yaml
@@ -1,0 +1,2 @@
+name: Drop unused index event_logs_user_id
+parents: [1678214530]

--- a/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/up.sql
+++ b/migrations/frontend/1678290792_drop_unused_index_event_logs_user_id/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS event_logs_user_id;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5104,8 +5104,6 @@ CREATE INDEX event_logs_timestamp ON event_logs USING btree ("timestamp");
 
 CREATE INDEX event_logs_timestamp_at_utc ON event_logs USING btree (date(timezone('UTC'::text, "timestamp")));
 
-CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
-
 CREATE INDEX event_logs_user_id_name ON event_logs USING btree (user_id, name);
 
 CREATE INDEX event_logs_user_id_timestamp ON event_logs USING btree (user_id, "timestamp");


### PR DESCRIPTION
event_logs_user_id (user_id) is covered by event_logs_user_id_name (user_id, name).

## Test plan

Just dropping a redundant index, CI should find if the migration is borked.