### PR TITLE
Drop unused indexes on batch_changes rand_id columns

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -3405,16 +3405,6 @@
           "IndexDefinition": "CREATE UNIQUE INDEX batch_specs_unique_rand_id ON batch_specs USING btree (rand_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
-        },
-        {
-          "Name": "batch_specs_rand_id",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -4388,16 +4378,6 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX changeset_specs_head_ref ON changeset_specs USING btree (head_ref)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
-        },
-        {
-          "Name": "changeset_specs_rand_id",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX changeset_specs_rand_id ON changeset_specs USING btree (rand_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -294,7 +294,6 @@ Referenced by:
 Indexes:
     "batch_specs_pkey" PRIMARY KEY, btree (id)
     "batch_specs_unique_rand_id" UNIQUE, btree (rand_id)
-    "batch_specs_rand_id" btree (rand_id)
 Check constraints:
     "batch_specs_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
 Foreign-key constraints:
@@ -419,7 +418,6 @@ Indexes:
     "changeset_specs_created_at" btree (created_at)
     "changeset_specs_external_id" btree (external_id)
     "changeset_specs_head_ref" btree (head_ref)
-    "changeset_specs_rand_id" btree (rand_id)
     "changeset_specs_title" btree (title)
 Check constraints:
     "changeset_specs_published_valid_values" CHECK (published = 'true'::text OR published = 'false'::text OR published = '"draft"'::text OR published IS NULL)

--- a/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/down.sql
+++ b/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/down.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS batch_specs_rand_id ON batch_specs USING btree (rand_id);
+CREATE INDEX IF NOT EXISTS changeset_specs_rand_id ON changeset_specs USING btree (rand_id);

--- a/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/metadata.yaml
+++ b/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/metadata.yaml
@@ -1,0 +1,2 @@
+name: Drop unused indexes for Batch Changes rand_id columns
+parents: [1677166643, 1678214530]

--- a/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/up.sql
+++ b/migrations/frontend/1678291091_drop_unused_indexes_for_batch_changes_rand_id_columns/up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS batch_specs_rand_id;
+DROP INDEX IF EXISTS changeset_specs_rand_id;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5033,8 +5033,6 @@ CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING 
 
 CREATE INDEX batch_spec_workspaces_id_batch_spec_id ON batch_spec_workspaces USING btree (id, batch_spec_id);
 
-CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id);
-
 CREATE UNIQUE INDEX batch_specs_unique_rand_id ON batch_specs USING btree (rand_id);
 
 CREATE INDEX cached_available_indexers_num_events ON cached_available_indexers USING btree (num_events DESC) WHERE ((available_indexers)::text <> '{}'::text);
@@ -5052,8 +5050,6 @@ CREATE INDEX changeset_specs_created_at ON changeset_specs USING btree (created_
 CREATE INDEX changeset_specs_external_id ON changeset_specs USING btree (external_id);
 
 CREATE INDEX changeset_specs_head_ref ON changeset_specs USING btree (head_ref);
-
-CREATE INDEX changeset_specs_rand_id ON changeset_specs USING btree (rand_id);
 
 CREATE INDEX changeset_specs_title ON changeset_specs USING btree (title);
 


### PR DESCRIPTION
There are batch_specs_unique_rand_id (rand_id) and changeset_specs_unique_rand_id (rand_id) that have the same BTREE properties, so no need to keep both. We've probably forgotten to drop these when we added the new unique indexes for these columns.

## Test plan

Unused indexes, CI should tell if the SQL is broken.