### PR TITLE
Drop unused index on user_repo_permissions table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -23368,16 +23368,6 @@
           "IndexDefinition": "CREATE INDEX user_repo_permissions_user_external_account_id_idx ON user_repo_permissions USING btree (user_external_account_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
-        },
-        {
-          "Name": "user_repo_permissions_user_id_idx",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX user_repo_permissions_user_id_idx ON user_repo_permissions USING btree (user_id)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3582,7 +3582,6 @@ Indexes:
     "user_repo_permissions_source_idx" btree (source)
     "user_repo_permissions_updated_at_idx" btree (updated_at)
     "user_repo_permissions_user_external_account_id_idx" btree (user_external_account_id)
-    "user_repo_permissions_user_id_idx" btree (user_id)
 Foreign-key constraints:
     "user_repo_permissions_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     "user_repo_permissions_user_external_account_id_fkey" FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE

--- a/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/down.sql
+++ b/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS user_repo_permissions_user_id_idx ON user_repo_permissions(user_id);

--- a/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/metadata.yaml
+++ b/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/metadata.yaml
@@ -1,0 +1,2 @@
+name: Drop unused index on user_repo_permissions(user_id)
+parents: [1677166643, 1678214530]

--- a/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/up.sql
+++ b/migrations/frontend/1678291402_drop_unused_index_on_user_repo_permissionsuser_id/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS user_repo_permissions_user_id_idx;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5425,8 +5425,6 @@ CREATE INDEX user_repo_permissions_updated_at_idx ON user_repo_permissions USING
 
 CREATE INDEX user_repo_permissions_user_external_account_id_idx ON user_repo_permissions USING btree (user_external_account_id);
 
-CREATE INDEX user_repo_permissions_user_id_idx ON user_repo_permissions USING btree (user_id);
-
 CREATE UNIQUE INDEX users_billing_customer_id ON users USING btree (billing_customer_id) WHERE (deleted_at IS NULL);
 
 CREATE INDEX users_created_at_idx ON users USING btree (created_at);


### PR DESCRIPTION
user_repo_permissions_user_id_idx is covered by user_repo_permissions_perms_unique_idx (user_id, user_external_account_id, repo_id), so we don't need both.



## Test plan

Unused indexes, CI should tell if the SQL is broken.
