### PR TITLE
Drop unused index on user_repo_permissions table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -18147,16 +18147,6 @@
           "ConstraintDefinition": ""
         },
         {
-          "Name": "package_repo_versions_fk_idx",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX package_repo_versions_fk_idx ON package_repo_versions USING btree (package_id)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
-        },
-        {
           "Name": "package_repo_versions_last_checked_at",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2740,7 +2740,6 @@ Indexes:
     "package_repo_versions_pkey" PRIMARY KEY, btree (id)
     "package_repo_versions_unique_version_per_package" UNIQUE, btree (package_id, version)
     "package_repo_versions_blocked" btree (blocked)
-    "package_repo_versions_fk_idx" btree (package_id)
     "package_repo_versions_last_checked_at" btree (last_checked_at)
 Foreign-key constraints:
     "package_id_fk" FOREIGN KEY (package_id) REFERENCES lsif_dependency_repos(id) ON DELETE CASCADE

--- a/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/down.sql
+++ b/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS package_repo_versions_fk_idx ON package_repo_versions USING btree (package_id);

--- a/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/metadata.yaml
+++ b/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/metadata.yaml
@@ -1,0 +1,2 @@
+name: Drop unused index package_repo_versions_fk_idx
+parents: [1677166643, 1678214530]

--- a/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/up.sql
+++ b/migrations/frontend/1678291831_drop_unused_index_package_repo_versions_fk_idx/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS package_repo_versions_fk_idx;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5313,8 +5313,6 @@ CREATE UNIQUE INDEX package_repo_filters_unique_matcher_per_scheme ON package_re
 
 CREATE INDEX package_repo_versions_blocked ON package_repo_versions USING btree (blocked);
 
-CREATE INDEX package_repo_versions_fk_idx ON package_repo_versions USING btree (package_id);
-
 CREATE INDEX package_repo_versions_last_checked_at ON package_repo_versions USING btree (last_checked_at);
 
 CREATE UNIQUE INDEX package_repo_versions_unique_version_per_package ON package_repo_versions USING btree (package_id, version);


### PR DESCRIPTION
package_repo_versions_fk_idx is covered by package_repo_versions_unique_version_per_package (package_id, version), so we don't need both.

## Test plan

Unused indexes, CI should tell if the SQL is broken.