### PR TITLE
Log `filePage:ownershipPanel:viewOwnerDetail:clicked` on ownership panel accordion expand

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -65,7 +65,13 @@ export const FileOwnershipPanel: React.FunctionComponent<
         return (
             <div className={styles.contents}>
                 <OwnExplanation />
-                <Accordion as="table" collapsible={true} multiple={true} className={styles.table}>
+                <Accordion
+                    as="table"
+                    collapsible={true}
+                    multiple={true}
+                    className={styles.table}
+                    onChange={() => telemetryService.log('filePage:ownershipPanel:viewOwnerDetail:clicked')}
+                >
                     <thead className="sr-only">
                         <tr>
                             <th>Show details</th>


### PR DESCRIPTION
Part of #47062

## Test plan

https://www.loom.com/share/6aa4fcc75eb04895a0cf443191a0c417

## App preview:

- [Web](https://sg-web-cb-own-amplitude-viewownerdetails.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
