### PR TITLE
[chore] delete from user_repo_permissions in DeleteAllUserPermissions

### DIFF
--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -54,7 +54,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},
 		{"GrantPendingPermissions", testPermsStore_GrantPendingPermissions(db)},
 		{"SetPendingPermissionsAfterGrant", testPermsStore_SetPendingPermissionsAfterGrant(db)},
-		{"DeleteAllUserPermissions", testPermsStore_DeleteAllUserPermissions(db)},
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1426,6 +1426,10 @@ func (s *permsStore) DeleteAllUserPermissions(ctx context.Context, userID int32)
 	ctx, save := s.observe(ctx, "DeleteAllUserPermissions", "")
 	defer func() { save(&err, otlog.Int32("userID", userID)) }()
 
+	// first delete from the unified table
+	if err = s.execute(ctx, sqlf.Sprintf(`DELETE FROM user_repo_permissions WHERE user_id = %d`, userID)); err != nil {
+		return errors.Wrap(err, "execute delete user repo permissions query")
+	}
 	// NOTE: Practically, we don't need to clean up "repo_permissions" table because the value of "id" column
 	// that is associated with this user will be invalidated automatically by deleting this row.
 	if err = s.execute(ctx, sqlf.Sprintf(`DELETE FROM user_permissions WHERE user_id = %s`, userID)); err != nil {
@@ -2367,20 +2371,20 @@ func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User,
 }
 
 const usersPermissionsInfoQueryFmt = `
-SELECT 
-	users.id, 
-	users.username, 
-	users.display_name, 
-	users.avatar_url, 
-	users.created_at, 
-	users.updated_at, 
-	users.site_admin, 
-	users.passwd IS NOT NULL, 
-	users.tags, 
-	users.invalidated_sessions_at, 
-	users.tos_accepted, 
+SELECT
+	users.id,
+	users.username,
+	users.display_name,
+	users.avatar_url,
+	users.created_at,
+	users.updated_at,
+	users.site_admin,
+	users.passwd IS NOT NULL,
+	users.tags,
+	users.invalidated_sessions_at,
+	users.tos_accepted,
 	users.searchable,
-	CASE 
+	CASE
 		WHEN user_permissions.object_ids_ints @> INTSET(repo.id) THEN user_permissions.updated_at
 		ELSE NULL
 	END AS permissions_updated_at
@@ -2411,7 +2415,7 @@ func (s *permsStore) isRepoUnrestricted(ctx context.Context, repoID api.RepoID, 
 }
 
 const isRepoUnrestrictedQueryFmt = `
-SELECT 
+SELECT
 	(%s) AS unrestricted
 FROM repo
 WHERE

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2650,19 +2650,14 @@ func TestPermsStore_DeleteAllUserPermissions(t *testing.T) {
 	}
 
 	// Set permissions for user 1 and 2
-	if _, err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-		RepoID:  1,
-		Perm:    authz.Read,
-		UserIDs: toMapset(1, 2),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-		RepoID:  2,
-		Perm:    authz.Read,
-		UserIDs: toMapset(1, 2),
-	}); err != nil {
-		t.Fatal(err)
+	for _, repoID := range []int32{1, 2} {
+		if _, err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
+			RepoID:  repoID,
+			Perm:    authz.Read,
+			UserIDs: toMapset(1, 2),
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Set unified permissions for user 1 and 2


### PR DESCRIPTION
## Description

Modifies the method `DeleteAllUserPermissions` of perms_store.go to delete from the new unified user_repo_permissions table as well as from the legacy table.

## Test plan

unit test modified
