### PR TITLE
experimental search input: Fix filter value completion when cursor is not at the end

### DIFF
--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -465,7 +465,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
             }
 
             case 'path': {
-                const predicates = staticFilterPredicateOptions('file', token.value, position)
+                const predicates = staticFilterPredicateOptions('file', token, from, to)
                 return caches.file.query(
                     value,
                     entries => {

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -26,7 +26,7 @@ import { FILTERS, FilterType, isNegatableFilter, ResolvedFilter } from '@sourceg
 import { Node, OperatorKind } from '@sourcegraph/shared/src/search/query/parser'
 import { predicateCompletion } from '@sourcegraph/shared/src/search/query/predicates'
 import { selectorHasFields } from '@sourcegraph/shared/src/search/query/selectFilter'
-import { CharacterRange, Filter, Literal, PatternKind, Token } from '@sourcegraph/shared/src/search/query/token'
+import { CharacterRange, Filter, PatternKind, Token } from '@sourcegraph/shared/src/search/query/token'
 import { isFilterOfType, resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
 import { getSymbolIconSVGPath } from '@sourcegraph/shared/src/symbols/symbolIcons'
 
@@ -426,12 +426,13 @@ function filterValueSuggestions(caches: Caches): InternalSource {
         }
 
         const value = token.value?.value ?? ''
+        // The value is always inserted after the filter field
         const from = token.value?.range.start ?? token.range.end
-        const to = token.value?.range.end
+        const to = token.value?.range.end ?? token.range.end
 
         switch (resolvedFilter.definition.suggestions) {
             case 'repo': {
-                const predicates = staticFilterPredicateOptions('repo', token.value, position)
+                const predicates = staticFilterPredicateOptions('repo', token, from, to)
                 return caches.repo.query(
                     value,
                     entries => {
@@ -538,8 +539,9 @@ function staticFilterValueOptions(
     }
 
     const value = token.value?.value ?? ''
+    // The value is always inserted after the filter field
     const from = token.value?.range.start ?? token.range.end
-    const to = token.value?.range.end
+    const to = token.value?.range.end ?? token.range.end
 
     let options: Option[]
     if (resolvedFilter.type === FilterType.select) {
@@ -620,16 +622,16 @@ const predicateFzfOption: PredicateFzfOptions = {
 /**
  * Returns predicate options for the provided filter type.
  */
-function staticFilterPredicateOptions(type: 'repo' | 'file', value: Literal | undefined, position: number): Option[] {
+function staticFilterPredicateOptions(type: 'repo' | 'file', filter: Filter, from: number, to: number): Option[] {
     const fzf = new Fzf(predicateCompletion(type), predicateFzfOption)
-    return fzf.find(value?.value || '').map(({ item, positions }) => ({
+    return fzf.find(filter.value?.value || '').map(({ item, positions }) => ({
         label: item.label,
         description: item.description,
         matches: positions,
         action: {
             type: 'completion',
-            from: value?.range.start ?? position,
-            to: value?.range.end,
+            from,
+            to,
             // insertText is always set for prediction completions
             insertValue: item.insertText! + ' ${}',
             asSnippet: item.asSnippet,


### PR DESCRIPTION

For better or worse we are showing filter value completions for a filter as long as the cursor is anywhere inside the filter. But if the filter doesn't have a value then we are inserting the value at [filter.end, current cursor position] which only works if the cursor is at the end of the cursor.

This change ensures that the value is always correctly inserted after the field.


https://user-images.githubusercontent.com/179026/223786914-e7667943-ab37-4f5d-a183-8ff93d07f735.mp4



## Test plan
Manual testing (see video)

## App preview:

- [Web](https://sg-web-fkling-search-input-fix-filter.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
