### PR TITLE
Revert "Use distroless grafana image (#48930)"

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -8,12 +8,10 @@ RUN GRAFANA_DIR='/generated/grafana' PROMETHEUS_DIR='' DOCS_DIR='' NO_PRUNE=true
 RUN ls '/generated/grafana'
 
 # Prepare final image
-# When upgrading the Grafana version, please refer to https://docs.sourcegraph.com/dev/background-information/observability/grafana#upgrading-grafana
+# when upgrading the Grafana version, please refer to https://docs.sourcegraph.com/dev/background-information/observability/grafana#upgrading-grafana
 # DO NOT UPGRADE to AGPL Grafana without consulting Stephen+legal, Grafana >= 8.0 is AGPLv3 Licensed
 # See https://docs.google.com/document/d/1nSmz1ChL_rBvX8FAKTB-CNzgcff083sUlIpoXEz6FHE/edit#heading=h.69clsrno4211
-# We use a Grafana base image built by Chainguard
-# TODO(@willdollman): This image was manually uploaded to our registry 2023-03-08
-FROM us.gcr.io/sourcegraph-dev/wolfi-grafana@sha256:e46d29f56d30911ee9995d81b8bfc0590586e1e7f39b4e8ed933ece19d7e4da1 as production
+FROM grafana/grafana:7.5.17@sha256:15abb652aa82eeb9f45589278b34ae6ef0e96f74c389cadde31831eb0b1ce228 as production
 LABEL com.sourcegraph.grafana.version=7.5.17
 
 ARG COMMIT_SHA="unknown"
@@ -27,22 +25,33 @@ LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
-# This removes the Chainguard-supplied config and replaces it with our own
-# TODO: Ask Chainguard to remove this from the base image
-USER root
-RUN rm -rf /sg_config_grafana/provisioning/dashboards/sourcegraph/
 # hadolint ignore=DL3020
 ADD config /sg_config_grafana
 COPY --from=monitoring_builder /generated/grafana/home.json /usr/share/grafana/public/dashboards/home.json
 COPY --from=monitoring_builder /generated/grafana/* /sg_config_grafana/provisioning/dashboards/sourcegraph/
 
-# Overwrite default entrypoint with the local one
-COPY entry.sh /opt/grafana/
+# hadolint ignore=DL3020
+ADD entry.sh /
+
+
+USER root
 
 # Create optional folders to avoid error logs about missing dirs
-RUN chown grafana:root /sg_config_grafana/provisioning/plugins
+RUN mkdir /sg_grafana_additional_dashboards
+RUN mkdir /sg_config_grafana/provisioning/plugins && chown grafana:root /sg_config_grafana/provisioning/plugins
 
+# @FIXME: Update redis image
+# Pin busybox=1.32.1-r7 https://github.com/sourcegraph/sourcegraph/issues/27965
+RUN apk add --upgrade --no-cache \
+    'apk-tools>=2.12' \
+    'krb5-libs>=1.18.4' \
+    'libssl1.1>=1.1.1s-r0' \
+    'openssl>=1.1.1s-r0' \
+    'busybox>=1.32.1' \
+    'ncurses-libs>=6.2_p20210109-r1' \
+    'ncurses-terminfo-base>=6.2_p20210109-r1' \
+    'libtirpc>=1.3.1-r1'
 
 EXPOSE 3370
 USER grafana
-ENTRYPOINT ["/opt/grafana/entry.sh"]
+ENTRYPOINT ["/entry.sh"]

--- a/docker-images/grafana/build.sh
+++ b/docker-images/grafana/build.sh
@@ -37,7 +37,7 @@ if [[ "$CACHE" == "true" ]]; then
 fi
 
 # shellcheck disable=SC2086
-docker build ${BUILD_CACHE} -f Dockerfile -t "${IMAGE:-sourcegraph/grafana}" . \
+docker build ${BUILD_CACHE} -t "${IMAGE:-sourcegraph/grafana}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \

--- a/docker-images/grafana/entry.sh
+++ b/docker-images/grafana/entry.sh
@@ -4,4 +4,4 @@ set -e
 export GF_PATHS_PROVISIONING=/sg_config_grafana/provisioning
 export GF_PATHS_CONFIG=/sg_config_grafana/grafana.ini
 
-exec "/opt/grafana/run.sh"
+exec "/run.sh"


### PR DESCRIPTION
This reverts commit ad31e14b5080790045aea7cfc02b3c9e2159f512.

As always, should've run end to end tests before merging 😁 
I think this has an unexpected interaction with the server image, which pulls some resources from the grafana image. Will investigate further tomorrow.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Reverting previous commit so manual testing of previous version
