### PR TITLE
packages: add env var for coursier cache and proper fallback to src_repos_dir

### DIFF
--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -46,7 +45,9 @@ type jvmPackagesSource struct {
 
 var _ packagesSource = &jvmPackagesSource{}
 
-func (s *jvmPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
+// Commented out as importing 'internal/extsvc/jvmpackages/coursier' here includes it in the frontend and repo-updater binaries.
+// We don't want that due to the side-effects of importing that package.
+/* func (s *jvmPackagesSource) Get(ctx context.Context, name, version string) (reposource.VersionedPackage, error) {
 	mavenDependency, err := reposource.ParseMavenVersionedPackage(name + ":" + version)
 	if err != nil {
 		return nil, err
@@ -57,7 +58,7 @@ func (s *jvmPackagesSource) Get(ctx context.Context, name, version string) (repo
 		return nil, err
 	}
 	return mavenDependency, nil
-}
+} */
 
 func (jvmPackagesSource) ParseVersionedPackageFromConfiguration(dep string) (reposource.VersionedPackage, error) {
 	return reposource.ParseMavenVersionedPackage(dep)


### PR DESCRIPTION
If `COURSIER_CACHE_DIR` is set, it will be used directly. Else, if `SRC_REPOS_DIR` is set, we will use `$SRC_REPOS_DIR/coursier`. If neither are set, nothing will be created and gitserver will fail to start [anyways](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@857fd9349995709af2b3d55540da180059db61f8/-/blob/cmd/gitserver/shared/shared.go?L96%3A11-98%3A3).

Additionally, this package is no longer imported into the `frontend` or `repo-updater` binaries after commenting out an unused function.

Closes https://github.com/sourcegraph/sourcegraph/issues/48841

## Test plan

Ran locally to confirm the values of the env vars fallback properly