### PR TITLE
[ranking] update ranking toggle

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -85,7 +85,12 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         if (rankingTemporarySettings !== undefined) {
             setRankingTemporarySettings(rankingToggleEnabled)
         }
-    }, [rankingToggleEnabled, rankingTemporarySettings, setRankingTemporarySettings])
+        // `rankingTemporarySettings` should not be a dependency, otherwise the
+        // observable would be recomputed if the caller used e.g. an object
+        // literal as default value. `useTemporarySetting` works more like
+        // `useState` in this regard.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [rankingToggleEnabled, setRankingTemporarySettings])
 
     useEffect(() => {
         if (rankingTemporarySettings !== undefined) {

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -79,7 +79,10 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
     // Use new ranking if the feature flag is enabled and the user has not explicitly disabled it
     const [rankingEnabled] = useFeatureFlag('search-ranking')
-    const [rankingTemporarySettings, setRankingTemporarySettings] = useTemporarySetting('search.ranking.experimental')
+    const [rankingTemporarySettings, setRankingTemporarySettings] = useTemporarySetting(
+        'search.ranking.experimental',
+        true
+    )
     const [rankingToggleEnabled, setRankingToggleEnabled] = useState(rankingTemporarySettings ?? rankingEnabled)
     useEffect(() => {
         if (rankingTemporarySettings !== undefined) {

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -88,7 +88,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     }, [rankingToggleEnabled, rankingTemporarySettings, setRankingTemporarySettings])
 
     useEffect(() => {
-        if (rankingTemporarySettings != undefined) {
+        if (rankingTemporarySettings !== undefined) {
             setRankingToggleEnabled(rankingTemporarySettings)
         }
     }, [rankingTemporarySettings, setRankingToggleEnabled])

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -79,7 +79,19 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
     // Use new ranking if the feature flag is enabled and the user has not explicitly disabled it
     const [rankingEnabled] = useFeatureFlag('search-ranking')
-    const [rankingToggleEnabled, setRankingToggleEnabled] = useTemporarySetting('search.ranking.experimental')
+    const [rankingTemporarySettings, setRankingTemporarySettings] = useTemporarySetting('search.ranking.experimental')
+    const [rankingToggleEnabled, setRankingToggleEnabled] = useState(rankingTemporarySettings ?? rankingEnabled)
+    useEffect(() => {
+        if (rankingTemporarySettings != undefined) {
+            setRankingTemporarySettings(rankingToggleEnabled)
+        }
+    }, [rankingToggleEnabled, setRankingTemporarySettings])
+
+    useEffect(() => {
+        if (rankingTemporarySettings != undefined) {
+            setRankingToggleEnabled(rankingTemporarySettings)
+        }
+    }, [rankingTemporarySettings, setRankingToggleEnabled])
 
     // Global state
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -82,10 +82,10 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const [rankingTemporarySettings, setRankingTemporarySettings] = useTemporarySetting('search.ranking.experimental')
     const [rankingToggleEnabled, setRankingToggleEnabled] = useState(rankingTemporarySettings ?? rankingEnabled)
     useEffect(() => {
-        if (rankingTemporarySettings != undefined) {
+        if (rankingTemporarySettings !== undefined) {
             setRankingTemporarySettings(rankingToggleEnabled)
         }
-    }, [rankingToggleEnabled, setRankingTemporarySettings])
+    }, [rankingToggleEnabled, rankingTemporarySettings, setRankingTemporarySettings])
 
     useEffect(() => {
         if (rankingTemporarySettings != undefined) {


### PR DESCRIPTION
Updating ranking toggle to be set automatically when temporary settings are undefined and then update when temporary settings update.
## Test plan
Tested manually
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cesar-ranking-update-toggle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
