### PR TITLE
Add org as part o the name of excluded Azure DevOps repos

### DIFF
--- a/internal/repos/azuredevops.go
+++ b/internal/repos/azuredevops.go
@@ -110,7 +110,11 @@ func (s *AzureDevOpsSource) processReposFromProjectOrOrg(ctx context.Context, na
 	}
 
 	for _, repo := range repos {
-		if s.exclude(fmt.Sprintf("%s/%s", repo.Project.Name, repo.Name)) {
+		org, err := repo.GetOrganization()
+		if err != nil {
+			results <- SourceResult{Source: s, Err: err}
+		}
+		if s.exclude(fmt.Sprintf("%s/%s/%s", org, repo.Project.Name, repo.Name)) {
 			continue
 		}
 		repo, err := s.makeRepo(repo)

--- a/internal/repos/azuredevops.go
+++ b/internal/repos/azuredevops.go
@@ -113,6 +113,7 @@ func (s *AzureDevOpsSource) processReposFromProjectOrOrg(ctx context.Context, na
 		org, err := repo.GetOrganization()
 		if err != nil {
 			results <- SourceResult{Source: s, Err: err}
+			continue
 		}
 		if s.exclude(fmt.Sprintf("%s/%s/%s", org, repo.Project.Name, repo.Name)) {
 			continue

--- a/internal/repos/azuredevops_test.go
+++ b/internal/repos/azuredevops_test.go
@@ -23,10 +23,10 @@ func TestAzureDevOpsSource_ListRepos(t *testing.T) {
 		Projects: []string{"sgtestazure/sgtestazure", "sgtestazure/sg test with spaces"},
 		Exclude: []*schema.ExcludedAzureDevOpsServerRepo{
 			{
-				Name: "sg test with spaces/sg test with spaces",
+				Name: "sgtestazure/sg test with spaces/sg test with spaces",
 			},
 			{
-				Pattern: "^sgtestazure/sgtestazure[3-9]",
+				Pattern: "^sgtestazure/sgtestazure/sgtestazure[3-9]",
 			},
 		},
 	}

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -69,8 +69,8 @@
         }
       },
       "examples": [
-        [{ "name": "myproject/myrepo" }],
-        [{ "name": "myproject/myrepo" }, { "name": "myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
+        [{ "name": "myorg/myproject/myrepo" }],
+        [{ "name": "myorg/myproject/myrepo" }, { "name": "myorg/myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
       ]
     }
   }

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -35,7 +35,7 @@
       "minLength": 1
     },
     "projects": {
-      "description": "An array of projects \"org/project\" strings specifying which Azure DevOps whose repositories should be mirrored on Sourcegraph.",
+      "description": "An array of projects \"org/project\" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.",
       "type": "array",
       "items": { "type": "string", "pattern": "^[\\w-]+/[\\w.-]+([ ]*[\\w.-]+)*$" },
       "examples": [["org/project"]]
@@ -57,9 +57,9 @@
         "anyOf": [{ "required": ["name"] }, { "required": ["id"] }, { "required": ["pattern"] }],
         "properties": {
           "name": {
-            "description": "The name of an Azure DevOps Services project and repository (\"projectName/repositoryName\") to exclude from mirroring.",
+            "description": "The name of an Azure DevOps Services organization, project, and repository (\"orgName/projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^~?[\\w.-]+([ ]*[\\w.-]+)*/[\\w.-]+([ ]*[\\w.-]+)*?$"
+            "pattern": "^[\\w.-\/ ]*?$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of an Azure DevOps Services repo.",

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -59,7 +59,7 @@
           "name": {
             "description": "The name of an Azure DevOps Services organization, project, and repository (\"orgName/projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w.-\/ ]*?$"
+            "pattern": "^[\\w.-/ ]*?$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of an Azure DevOps Services repo.",
@@ -70,7 +70,11 @@
       },
       "examples": [
         [{ "name": "myorg/myproject/myrepo" }],
-        [{ "name": "myorg/myproject/myrepo" }, { "name": "myorg/myproject/myotherrepo" }, { "pattern": "^topsecretproject/.*" }]
+        [
+          { "name": "myorg/myproject/myrepo" },
+          { "name": "myorg/myproject/myotherrepo" },
+          { "pattern": "^topsecretproject/.*" }
+        ]
       ]
     }
   }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -207,7 +207,7 @@ type AzureDevOpsConnection struct {
 	Exclude []*ExcludedAzureDevOpsServerRepo `json:"exclude,omitempty"`
 	// Orgs description: An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.
 	Orgs []string `json:"orgs,omitempty"`
-	// Projects description: An array of projects "org/project" strings specifying which Azure DevOps whose repositories should be mirrored on Sourcegraph.
+	// Projects description: An array of projects "org/project" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.
 	Projects []string `json:"projects,omitempty"`
 	// Token description: The Personal Access Token associated with the Azure DevOps username used for authentication.
 	Token string `json:"token"`
@@ -669,7 +669,7 @@ type ExcludedAWSCodeCommitRepo struct {
 	Name string `json:"name,omitempty"`
 }
 type ExcludedAzureDevOpsServerRepo struct {
-	// Name description: The name of an Azure DevOps Services project and repository ("projectName/repositoryName") to exclude from mirroring.
+	// Name description: The name of an Azure DevOps Services organization, project, and repository ("orgName/projectName/repositoryName") to exclude from mirroring.
 	Name string `json:"name,omitempty"`
 	// Pattern description: Regular expression which matches against the name of an Azure DevOps Services repo.
 	Pattern string `json:"pattern,omitempty"`


### PR DESCRIPTION
Changed up the Azure DevOps exclude by name to process excludes using org name as well, as the name for the repos are: org/project/repo.

Changed the regex string to be something much more readable, it was basically unreadable after this change if I kept it how it is.

## Test plan
Manual.