### PR TITLE
own: Fix matching for input paths without leading /

### DIFF
--- a/enterprise/internal/own/codeowners/file.go
+++ b/enterprise/internal/own/codeowners/file.go
@@ -29,6 +29,11 @@ func (r *Ruleset) GetFile() *codeownerspb.File {
 // Rules are evaluated in order: Returned owners come from the rule which pattern matches
 // given path, that is the furthest down the file.
 func (x *Ruleset) FindOwners(path string) []*codeownerspb.Owner {
+	// For pattern matching, we expect paths to start with a `/`. Several internal
+	// systems don't use leading `/` though, so we ensure it's always there here.
+	if path[0] != '/' {
+		path = "/" + path
+	}
 	for i := len(x.rules) - 1; i >= 0; i-- {
 		rule := x.rules[i]
 		if rule.match(path) {

--- a/enterprise/internal/own/codeowners/find_owners_test.go
+++ b/enterprise/internal/own/codeowners/find_owners_test.go
@@ -88,6 +88,20 @@ func TestFileOwnersMatch(t *testing.T) {
 				"/main/src/foo/bar/README.md",
 			},
 		},
+		// Literal absolute match.
+		{
+			pattern: "/main/src/README.md",
+			paths: []string{
+				"/main/src/README.md",
+			},
+		},
+		// Without a leading `/` still matches correctly.
+		{
+			pattern: "/main/src/README.md",
+			paths: []string{
+				"main/src/README.md",
+			},
+		},
 	}
 	for _, c := range cases {
 		for _, path := range c.paths {


### PR DESCRIPTION
The matcher expects paths to be absolute, like patterns would be. Search and the blob resolver don't use absolute paths though, and it's easy to miss and get wrong results, so I've added some logic to ensure paths are absolute before we match them against rules.

## Test plan

Added tests, those failed before this change.