### PR TITLE
Setup Wizard: Fix wizard paper cuts (3 round)

### DIFF
--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -40,29 +40,29 @@ export const ProgressBar: FC<{}> = () => {
     const items = useMemo(
         () => [
             {
-                value: data?.repositoryStats.total,
+                value: Math.max(data?.repositoryStats.total ?? 0, 0),
                 description: 'Repositories',
                 color: 'text-merged',
             },
             {
-                value: data?.repositoryStats.notCloned,
+                value: Math.max(data?.repositoryStats.notCloned ?? 0, 0),
                 description: 'Not cloned',
             },
             {
-                value: data?.repositoryStats.cloning,
+                value: Math.max(data?.repositoryStats.cloning ?? 0, 0),
                 description: 'Cloning',
             },
             {
-                value: data?.repositoryStats.cloned,
+                value: Math.max(data?.repositoryStats.cloned ?? 0, 0),
                 description: 'Cloned',
                 color: 'text-success',
             },
             {
-                value: data?.repositoryStats.indexed,
+                value: Math.max(data?.repositoryStats.indexed ?? 0, 0),
                 description: 'Indexed',
             },
             {
-                value: data?.repositoryStats.failedFetch,
+                value: Math.max(data?.repositoryStats.failedFetch ?? 0, 0),
                 description: 'Failed',
                 color: 'text-danger',
             },
@@ -116,7 +116,7 @@ export const ProgressBar: FC<{}> = () => {
 
             {items.map(item => (
                 <Text className="mb-0 mr-3" size="small" key={item.description}>
-                    <span className={classNames('font-weight-bold', item?.color)}>{formatNumber(item.value ?? 0)}</span>{' '}
+                    <span className={classNames('font-weight-bold', item?.color)}>{formatNumber(item.value)}</span>{' '}
                     {item.description}
                 </Text>
             ))}

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -23,8 +23,8 @@ export const ProgressBar: FC<{}> = () => {
     )
 
     const { data: statusData } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
-        fetchPolicy: 'no-cache',
-        pollInterval: 5000,
+        fetchPolicy: 'cache-and-network',
+        pollInterval: 2000,
     })
 
     useEffect(() => {
@@ -77,10 +77,17 @@ export const ProgressBar: FC<{}> = () => {
         if (
             !statusData ||
             statusData.statusMessages?.some(
-                ({ __typename: type }) => type === 'CloningProgress' || type === 'IndexingProgress'
+                ({ __typename: type }) => type === 'CloningProgress'
             )
         ) {
             codeHostMessage = 'Syncing'
+            iconProps = { as: CloudSyncIconRefresh }
+        } else if (
+            statusData.statusMessages?.some(
+                ({ __typename: type }) => type === 'IndexingProgress'
+            )
+        ) {
+            codeHostMessage = 'Indexing'
             iconProps = { as: CloudSyncIconRefresh }
         } else if (
             statusData.statusMessages?.some(
@@ -99,7 +106,7 @@ export const ProgressBar: FC<{}> = () => {
         return (
             <div className="d-flex align-items-center mr-2">
                 <Icon {...iconProps} size="md" aria-label={codeHostMessage} className="mr-1" />
-                <Text className={classNames(codeHostMessage === 'Syncing' && styles.loading, 'mb-0')} size="small">
+                <Text className={classNames((codeHostMessage === 'Syncing' || codeHostMessage === 'Indexing') && styles.loading, 'mb-0')} size="small">
                     {codeHostMessage}
                 </Text>
             </div>

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -74,19 +74,10 @@ export const ProgressBar: FC<{}> = () => {
         let codeHostMessage
         let iconProps
 
-        if (
-            !statusData ||
-            statusData.statusMessages?.some(
-                ({ __typename: type }) => type === 'CloningProgress'
-            )
-        ) {
+        if (!statusData || statusData.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Syncing'
             iconProps = { as: CloudSyncIconRefresh }
-        } else if (
-            statusData.statusMessages?.some(
-                ({ __typename: type }) => type === 'IndexingProgress'
-            )
-        ) {
+        } else if (statusData.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
             codeHostMessage = 'Indexing'
             iconProps = { as: CloudSyncIconRefresh }
         } else if (
@@ -106,7 +97,13 @@ export const ProgressBar: FC<{}> = () => {
         return (
             <div className="d-flex align-items-center mr-2">
                 <Icon {...iconProps} size="md" aria-label={codeHostMessage} className="mr-1" />
-                <Text className={classNames((codeHostMessage === 'Syncing' || codeHostMessage === 'Indexing') && styles.loading, 'mb-0')} size="small">
+                <Text
+                    className={classNames(
+                        (codeHostMessage === 'Syncing' || codeHostMessage === 'Indexing') && styles.loading,
+                        'mb-0'
+                    )}
+                    size="small"
+                >
                     {codeHostMessage}
                 </Text>
             </div>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -1,15 +1,14 @@
-import { FC, ReactNode } from 'react'
+import { FC, ReactNode, useMemo } from 'react'
 
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
-import { Alert, H4, Link, Button } from '@sourcegraph/wildcard'
+import { Alert, Button, FormChangeEvent, H4, Link, useLocalStorage } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../../../components/externalServices/externalServices'
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import {
-    AddExternalServiceInput,
     AddRemoteCodeHostResult,
     AddRemoteCodeHostVariables,
     GetCodeHostsResult,
@@ -17,7 +16,7 @@ import {
 import { getCodeHostKindFromURLParam } from '../../helpers'
 import { ADD_CODE_HOST, CODE_HOST_FRAGMENT } from '../../queries'
 
-import { CodeHostJSONForm, CodeHostJSONFormState } from './common'
+import { CodeHostConnectFormFields, CodeHostJSONForm, CodeHostJSONFormState } from './common'
 import { GithubConnectView } from './github/GithubConnectView'
 
 import styles from './CodeHostCreation.module.scss'
@@ -77,11 +76,32 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
     const { codeHostKind, children } = props
 
     const navigate = useNavigate()
+    const externalServiceOptions = defaultExternalServices[codeHostKind]
+
+    const defaultConnectionValues = useMemo(
+        () => ({
+            displayName: externalServiceOptions.defaultDisplayName,
+            config: getDefaultConfiguration(externalServiceOptions.defaultConfig, externalServiceOptions.kind),
+        }),
+        [externalServiceOptions.defaultConfig, externalServiceOptions.defaultDisplayName, externalServiceOptions.kind]
+    )
+
+    const [localValues, setLocalValues] = useLocalStorage<CodeHostConnectFormFields>(
+        `${codeHostKind}-connect-form`,
+        defaultConnectionValues
+    )
+
     const [addRemoteCodeHost] = useMutation<AddRemoteCodeHostResult, AddRemoteCodeHostVariables>(ADD_CODE_HOST)
 
-    const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
+    const handleFormChange = (event: FormChangeEvent<CodeHostConnectFormFields>): void => {
+        if (event.valid) {
+            setLocalValues(event.values)
+        }
+    }
+
+    const handleFormSubmit = async (values: CodeHostConnectFormFields): Promise<void> => {
         await addRemoteCodeHost({
-            variables: { input },
+            variables: { input: { ...values, kind: codeHostKind } },
             refetchQueries: ['RepositoryStats', 'StatusMessages'],
             update: (cache, result) => {
                 const { data } = result
@@ -107,17 +127,46 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
             },
         })
 
+        // Reset local storage values
+        setLocalValues(defaultConnectionValues)
         navigate('/setup/remote-repositories')
         // TODO show notification UI that code host has been added successfully
     }
 
     if (codeHostKind === ExternalServiceKind.GITHUB) {
-        return <GithubConnectView onSubmit={handleSubmit}>{children}</GithubConnectView>
+        return (
+            <GithubConnectView initialValues={localValues} onChange={handleFormChange} onSubmit={handleFormSubmit}>
+                {children}
+            </GithubConnectView>
+        )
     }
 
     return (
-        <CodeHostJSONForm externalServiceOptions={defaultExternalServices[codeHostKind]} onSubmit={handleSubmit}>
+        <CodeHostJSONForm
+            initialValues={localValues}
+            externalServiceOptions={defaultExternalServices[codeHostKind]}
+            onChange={handleFormChange}
+            onSubmit={handleFormSubmit}
+        >
             {children}
         </CodeHostJSONForm>
     )
+}
+
+const DEFAULT_GITHUB_CONNECTION_CONFIG = `
+{
+    "url": "https://github.com",
+    "token": ""
+}
+`.trim()
+
+function getDefaultConfiguration(defaultConfig: string, kind: ExternalServiceKind): string {
+    // GitHub's connection form should have no orgs field by default
+    // because it opens orgs option by default which should be hided in
+    // setup wizard until user clicks the checkbox for organizations.
+    if (kind === ExternalServiceKind.GITHUB) {
+        return DEFAULT_GITHUB_CONNECTION_CONFIG
+    }
+
+    return defaultConfig
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -10,7 +10,6 @@ import { Alert, Button, ErrorAlert, H4, Link, LoadingSpinner } from '@sourcegrap
 import { defaultExternalServices } from '../../../../../components/externalServices/externalServices'
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import {
-    AddExternalServiceInput,
     GetExternalServiceByIdResult,
     GetExternalServiceByIdVariables,
     UpdateRemoteCodeHostResult,
@@ -52,7 +51,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
     const { data, loading, error, refetch } = useQuery<GetExternalServiceByIdResult, GetExternalServiceByIdVariables>(
         GET_CODE_HOST_BY_ID,
         {
-            fetchPolicy: 'network-only',
+            fetchPolicy: 'cache-and-network',
             variables: { id: codehostId! },
         }
     )
@@ -139,9 +138,9 @@ const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
         UPDATE_CODE_HOST
     )
 
-    const handleSubmit = async (input: AddExternalServiceInput): Promise<void> => {
+    const handleSubmit = async (values: CodeHostConnectFormFields): Promise<void> => {
         await updateRemoteCodeHost({
-            variables: { input: { id: codeHostId, ...input } },
+            variables: { input: { id: codeHostId, ...values } },
             refetchQueries: ['RepositoryStats', 'StatusMessages'],
         })
 

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, ReactNode, useState, useMemo } from 'react'
+import { FC, ReactElement, ReactNode, useState } from 'react'
 
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
@@ -12,7 +12,6 @@ import {
     Icon,
     Input,
     Text,
-    useLocalStorage,
     FormGroup,
     getDefaultInputProps,
     SubmissionErrors,
@@ -21,10 +20,10 @@ import {
     useForm,
     ErrorAlert,
     FORM_ERROR,
+    FormChangeEvent,
 } from '@sourcegraph/wildcard'
 
 import { AddExternalServiceOptions } from '../../../../../../components/externalServices/externalServices'
-import { AddExternalServiceInput } from '../../../../../../graphql-operations'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../../../../../settings/DynamicallyImportedMonacoSettingsEditor'
 
 import styles from './CodeHostConnection.module.scss'
@@ -40,33 +39,17 @@ export interface CodeHostJSONFormState {
 }
 
 interface CodeHostJSONFormProps {
-    externalServiceOptions: AddExternalServiceOptions
-    initialValues?: CodeHostConnectFormFields
+    initialValues: CodeHostConnectFormFields
     children: (state: CodeHostJSONFormState) => ReactNode
-    onSubmit: (values: AddExternalServiceInput) => Promise<void>
+    externalServiceOptions: AddExternalServiceOptions
+    onSubmit: (values: CodeHostConnectFormFields) => Promise<void>
+    onChange?: (event: FormChangeEvent<CodeHostConnectFormFields>) => void
 }
 
 export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
-    const { externalServiceOptions, initialValues, onSubmit, children } = props
+    const { initialValues, children, externalServiceOptions, onSubmit, onChange } = props
 
-    const initialValue = useMemo(
-        () => ({
-            displayName: externalServiceOptions.defaultDisplayName,
-            config: externalServiceOptions.defaultConfig,
-        }),
-        [externalServiceOptions.defaultConfig, externalServiceOptions.defaultDisplayName]
-    )
-
-    const [localValues, setLocalValues] = useLocalStorage<CodeHostConnectFormFields>(
-        `${externalServiceOptions.kind}-connect-form`,
-        initialValue
-    )
-
-    const form = useForm<CodeHostConnectFormFields>({
-        initialValues: initialValues ?? localValues,
-        onSubmit: values => onSubmit({ ...values, kind: externalServiceOptions.kind }),
-        onChange: event => setLocalValues(event.values),
-    })
+    const form = useForm<CodeHostConnectFormFields>({ initialValues, onChange, onSubmit })
 
     const displayName = useField({
         formApi: form.formAPI,

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -227,7 +227,9 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
         const repoQueryWithNoAffiliated = reposQuery.filter(token => token !== 'affiliated')
         const nextReposQuery = event.target.checked
             ? [...reposQuery, 'affiliated']
-            : repoQueryWithNoAffiliated.length > 0 ? repoQueryWithNoAffiliated : undefined
+            : repoQueryWithNoAffiliated.length > 0
+            ? repoQueryWithNoAffiliated
+            : undefined
 
         configurationField.input.onChange(modify(configurationField.input.value, ['repositoryQuery'], nextReposQuery))
     }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -224,9 +224,10 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
         const reposQuery: string[] =
             typeof parsedConfiguration === 'object' ? [...(parsedConfiguration.reposQuery ?? [])] : []
 
+        const repoQueryWithNoAffiliated = reposQuery.filter(token => token !== 'affiliated')
         const nextReposQuery = event.target.checked
             ? [...reposQuery, 'affiliated']
-            : reposQuery.filter(token => token !== 'affiliated')
+            : repoQueryWithNoAffiliated.length > 0 ? repoQueryWithNoAffiliated : undefined
 
         configurationField.input.onChange(modify(configurationField.input.value, ['repositoryQuery'], nextReposQuery))
     }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
@@ -73,7 +73,7 @@ export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = pro
                 status={loading ? 'loading' : 'initial'}
                 onChange={event => setSearchTerm(event.target.value)}
             />
-            <small className="text-muted pl-2">
+            <small className="d-block text-muted pl-2 mt-2">
                 Pick at least one organization and we clone all repositories that this organization has
             </small>
 
@@ -168,7 +168,7 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
                 status={loading ? 'loading' : 'initial'}
                 onChange={event => setSearchTerm(event.target.value)}
             />
-            <small className="text-muted pl-2">Pick at least one repository</small>
+            <small className="d-block text-muted pl-2 mt-2">Pick at least one repository</small>
 
             <MultiComboboxList items={filteredSuggestions} className="mt-2">
                 {items =>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -58,6 +58,12 @@
         background-color: var(--secondary-2);
     }
 
+    &--title {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+    }
+
     &--creation {
         display: flex;
         justify-content: flex-start;

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -4,6 +4,7 @@ import { QueryResult } from '@apollo/client'
 import { mdiInformationOutline, mdiDelete, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 
+import { pluralize } from '@sourcegraph/common'
 import { ErrorAlert, Icon, LoadingSpinner, Button, Tooltip, Link } from '@sourcegraph/wildcard'
 
 import { CodeHost, GetCodeHostsResult } from '../../../../../graphql-operations'
@@ -11,7 +12,7 @@ import { CodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../.
 
 import styles from './CodeHostsNavigation.module.scss'
 
-interface CodeHostsNavigationProps {
+interface CodeHostsNavigationProps {Ï
     codeHostQueryResult: QueryResult<GetCodeHostsResult>
     activeConnectionId: string | undefined
     createConnectionType: string | undefined
@@ -76,14 +77,13 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                             <CodeHostIcon codeHostType={codeHost.kind} aria-hidden={true} />
                         </span>
                         <span className={styles.itemDescription}>
-                            <span>{codeHost.displayName}</span>
+                            <span className={styles.itemTitle}>{codeHost.displayName} <small><LoadingSpinner /></small></span>
                             <small className={styles.itemDescriptionStatus}>
                                 {codeHost.lastSyncAt !== null && <>Synced, {codeHost.repoCount} repositories found</>}
                                 {codeHost.lastSyncAt === null && (
                                     <>
-                                        <LoadingSpinner />, Syncing{' '}
-                                        {codeHost.repoCount > 0 && (
-                                            <>, so far {codeHost.repoCount} repositories found</>
+                                       Syncing {codeHost.repoCount > 0 && (
+                                            <>, so far {codeHost.repoCount} {pluralize('repository', codeHost.repoCount ?? 0, 'repositories')} found</>
                                         )}
                                     </>
                                 )}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -79,14 +79,22 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                         <span className={styles.itemDescription}>
                             <span className={styles.itemTitle}>
                                 {codeHost.displayName}
-                                { codeHost.lastSyncAt === null &&  <small><LoadingSpinner /></small> }
+                                {codeHost.lastSyncAt === null && (
+                                    <small>
+                                        <LoadingSpinner />
+                                    </small>
+                                )}
                             </span>
                             <small className={styles.itemDescriptionStatus}>
                                 {codeHost.lastSyncAt !== null && <>Synced, {codeHost.repoCount} repositories found</>}
                                 {codeHost.lastSyncAt === null && (
                                     <>
-                                       Syncing {codeHost.repoCount > 0 && (
-                                            <>, so far {codeHost.repoCount} {pluralize('repository', codeHost.repoCount ?? 0, 'repositories')} found</>
+                                        Syncing{' '}
+                                        {codeHost.repoCount > 0 && (
+                                            <>
+                                                , so far {codeHost.repoCount}{' '}
+                                                {pluralize('repository', codeHost.repoCount ?? 0, 'repositories')} found
+                                            </>
                                         )}
                                     </>
                                 )}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -12,7 +12,7 @@ import { CodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../.
 
 import styles from './CodeHostsNavigation.module.scss'
 
-interface CodeHostsNavigationProps {Ï
+interface CodeHostsNavigationProps {
     codeHostQueryResult: QueryResult<GetCodeHostsResult>
     activeConnectionId: string | undefined
     createConnectionType: string | undefined
@@ -77,7 +77,10 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                             <CodeHostIcon codeHostType={codeHost.kind} aria-hidden={true} />
                         </span>
                         <span className={styles.itemDescription}>
-                            <span className={styles.itemTitle}>{codeHost.displayName} <small><LoadingSpinner /></small></span>
+                            <span className={styles.itemTitle}>
+                                {codeHost.displayName}
+                                { codeHost.lastSyncAt === null &&  <small><LoadingSpinner /></small> }
+                            </span>
                             <small className={styles.itemDescriptionStatus}>
                                 {codeHost.lastSyncAt !== null && <>Synced, {codeHost.repoCount} repositories found</>}
                                 {codeHost.lastSyncAt === null && (


### PR DESCRIPTION
This PR fixes
- Bug that affiliated token wasn't deleted from configuration when you uncheck affiliated with me repositories checkbox
- It looks like there is a bug on the backend, and it's possible to get negative values from the backend about repositories stats. I added some `Math.max` checks to avoid negative values on the client
- Fix loading layout for aside code host item (there was a comma after loading spinner, I put a loading right after the title to make the layout a bit better looking)
- Adds indexing status to the progress bar

## Test plan
- Make sure that you can connect a code host in the wizard
- Check layout changes by points above

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-wizard-paper-cuts-3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
