### PR TITLE
blob: show experimental keyboard shortcuts in help

### DIFF
--- a/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
@@ -18,6 +18,24 @@ type KEYBOARD_SHORTCUT_IDENTIFIERS =
 
 export type KEYBOARD_SHORTCUT_MAPPING = Record<KEYBOARD_SHORTCUT_IDENTIFIERS, KeyboardShortcut>
 
+export const EXPERIMENTAL_BLOB_PAGE_SHORTCUTS: Record<
+    'focusCodeEditor' | 'focusFileTree' | 'focusSymbols',
+    KeyboardShortcut
+> = {
+    focusCodeEditor: {
+        title: 'Focus editor',
+        keybindings: [{ ordered: ['c'] }],
+    },
+    focusFileTree: {
+        title: 'Focus file tree',
+        keybindings: [{ ordered: ['f'] }],
+    },
+    focusSymbols: {
+        title: 'Focus symbols',
+        keybindings: [{ ordered: ['s'] }],
+    },
+}
+
 export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
     switchTheme: {
         title: 'Switch color theme',
@@ -33,6 +51,7 @@ export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
         title: 'Focus search bar',
         keybindings: [{ ordered: ['/'] }],
     },
+    ...EXPERIMENTAL_BLOB_PAGE_SHORTCUTS,
     fuzzyFinder: {
         title: 'Fuzzy finder',
         keybindings: [{ held: ['Mod'], ordered: ['k'] }],
@@ -60,20 +79,5 @@ export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
     copyFullQuery: {
         title: 'Copy full query',
         keybindings: [{ held: ['Mod', 'Shift'], ordered: ['c'] }],
-    },
-    focusCodeEditor: {
-        title: 'Focus editor',
-        keybindings: [{ ordered: ['c'] }],
-        hideInHelp: true,
-    },
-    focusFileTree: {
-        title: 'Focus file tree',
-        keybindings: [{ ordered: ['f'] }],
-        hideInHelp: true,
-    },
-    focusSymbols: {
-        title: 'Focus symbols',
-        keybindings: [{ ordered: ['s'] }],
-        hideInHelp: true,
     },
 }

--- a/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.test.tsx
+++ b/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 
 import { Shortcut, ShortcutProvider } from '@sourcegraph/shared/src/react-shortcuts'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp'
@@ -13,10 +14,12 @@ const showHelpShortcut = 'Y'
 const ShortcutTriggerExample = () => {
     const [isOpen, setIsOpen] = useState(false)
     return (
-        <ShortcutProvider>
-            <Shortcut ordered={[showHelpShortcut]} onMatch={() => setIsOpen(true)} />
-            <KeyboardShortcutsHelp isOpen={isOpen} onDismiss={() => setIsOpen(false)} />
-        </ShortcutProvider>
+        <MockedTestProvider mocks={[]}>
+            <ShortcutProvider>
+                <Shortcut ordered={[showHelpShortcut]} onMatch={() => setIsOpen(true)} />
+                <KeyboardShortcutsHelp isOpen={isOpen} onDismiss={() => setIsOpen(false)} />
+            </ShortcutProvider>
+        </MockedTestProvider>
     )
 }
 

--- a/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
+++ b/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
 
 import { mdiClose } from '@mdi/js'
+import { omit } from 'lodash'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { isMacPlatform } from '@sourcegraph/common'
 import { Keybinding, KeyboardShortcut, shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
-import { KEYBOARD_SHORTCUTS } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
+import {
+    KEYBOARD_SHORTCUTS,
+    EXPERIMENTAL_BLOB_PAGE_SHORTCUTS,
+} from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { Button, Modal, Icon, H4, Label } from '@sourcegraph/wildcard'
+
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 
 import styles from './KeyboardShortcutsHelp.module.scss'
 
@@ -36,6 +42,7 @@ export const KeyboardShortcutsHelp: React.FunctionComponent<React.PropsWithChild
         'characterKeyShortcuts.enabled',
         true
     )
+    const [enableBlobPageSwitchAreasShortcuts] = useFeatureFlag('blob-page-switch-areas-shortcuts')
     return (
         <Modal
             position="center"
@@ -52,7 +59,12 @@ export const KeyboardShortcutsHelp: React.FunctionComponent<React.PropsWithChild
             </div>
             <div>
                 <ul className="list-group list-group-flush">
-                    {Object.values({ ...KEYBOARD_SHORTCUTS, ...LEGACY_KEYBOARD_SHORTCUTS })
+                    {Object.values({
+                        ...(enableBlobPageSwitchAreasShortcuts
+                            ? KEYBOARD_SHORTCUTS
+                            : omit(KEYBOARD_SHORTCUTS, Object.keys(EXPERIMENTAL_BLOB_PAGE_SHORTCUTS))),
+                        ...LEGACY_KEYBOARD_SHORTCUTS,
+                    })
                         .filter(({ hideInHelp }) => !hideInHelp)
                         .map(({ title, keybindings }, index) => (
                             <li


### PR DESCRIPTION
Show experimental blob page shortcuts based on `blob-page-switch-areas-shortcuts` feature flag value.
See [this thread](https://sourcegraph.slack.com/archives/C0HMGV90V/p1678197149771269) for more context.

|Feature flag enabled|Feature flag disabled|
|--|--|
|<img width="581" alt="Screenshot 2023-03-08 at 23 14 15" src="https://user-images.githubusercontent.com/25318659/223851938-d8ca8690-e44c-4bef-9c3d-94b080d4c890.png">|<img width="594" alt="Screenshot 2023-03-08 at 23 13 42" src="https://user-images.githubusercontent.com/25318659/223851941-c5a47631-dd22-4291-8e59-19b5428bfb50.png">|

## Test plan
Tested manually (screenshots attached).
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-show-blob-page.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
