### PR TITLE
app: fix version parsing

### DIFF
--- a/cmd/worker/internal/migrations/version.go
+++ b/cmd/worker/internal/migrations/version.go
@@ -48,6 +48,8 @@ func currentVersion(logger log.Logger) (oobmigration.Version, error) {
 //
 // Tagged release format: `v1.2.3`
 // Continuous release format: `(ef-feat_)?12345_2006-01-02-1.2-deadbeefbabe(_patch)?`
+// App release format: `2023.03.23+204874.db2922`
+// App insiders format: `2023.03.23-insiders+204874.db2922`
 func parseVersion(rawVersion string) (oobmigration.Version, bool) {
 	version, ok := oobmigration.NewVersionFromString(rawVersion)
 	if ok {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -33,7 +33,7 @@ func newDevVersion(major, minor int) Version {
 	}
 }
 
-var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.(\d+))?$`)
+var versionPattern = lazyregexp.New(`^v?(\d+)\.(\d+)(?:\.(\d+))?(?:-\w*)?(?:\+[\w.]*)?$`)
 
 // NewVersionFromString parses the major and minor version from the given string. If
 // the string does not look like a parseable version, a false-valued flag is returned.

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -20,6 +20,8 @@ func TestNewVersionFromString(t *testing.T) {
 		{"3.50.3+dev", newDevVersion(3, 50), 3, true},
 		{"350", Version{}, 0, false},
 		{"350+dev", Version{}, 0, false},
+		{"2023.03.23+204874.db2922", NewVersion(2023, 03), 23, true},          // Sourcegraph App
+		{"2023.03.23-insiders+204874.db2922", NewVersion(2023, 03), 23, true}, // Sourcegraph App
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
I made Sourcegraph App use one of two version string formats: `2023.03.23+204874.db2922` or `2023.03.23-insiders+204874.db2922`. Both are valid semver strings; and the motivation for using a date version string like this is because App will be released much more frequently than the enterprise versions of Sourcegraph.

I forgot we relied on this in oobmigration, though. We're chatting about this in [this Slack thread](https://sourcegraph.slack.com/archives/C04F9E7GUDP/p1678243005165599) but more urgently is the issue that App won't start anymore due to failing to parse the new version strings:

```
Failed to initialize worker:\n  - out-of-band-migrations: failed to parse current version: \"2023.03.23+204874.db2922\"
```

This change adds tests which show this failure; and the subsequent commit fixes our version parsing regexp to accept valid semver strings with [pre-release](https://semver.org/#spec-item-9) and [metadata](https://semver.org/#spec-item-10) denotions in them.

## Test plan

Added tests.