### PR TITLE
[Permissions] add filter for userID & repoID in permissions sync jobs api

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -193,6 +193,14 @@ extend type Query {
         Term used to search for permissions sync jobs.
         """
         query: String
+        """
+        Optional filter to find permissions sync jobs for a user.
+        """
+        userID: ID
+        """
+        Optional filter to find permissions sync jobs for a repository.
+        """
+        repoID: ID
     ): PermissionsSyncJobsConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -63,4 +63,6 @@ type ListPermissionsSyncJobsArgs struct {
 	State       *database.PermissionsSyncJobState
 	SearchType  *database.PermissionsSyncSearchType
 	Query       *string
+	UserID      *graphql.ID
+	RepoID      *graphql.ID
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -22,6 +22,11 @@ func NewPermissionsSyncJobsResolver(db database.DB, args graphqlbackend.ListPerm
 		db:   db,
 		args: args,
 	}
+
+	if args.UserID != nil && args.RepoID != nil {
+		return nil, errors.New("please provide either userID or repoID, but not both.")
+	}
+
 	return graphqlutil.NewConnectionResolver[graphqlbackend.PermissionsSyncJobResolver](store, &args.ConnectionResolverArgs, nil)
 }
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -108,6 +108,16 @@ func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.Pagin
 	if s.args.State != nil {
 		opts.State = *s.args.State
 	}
+	if s.args.UserID != nil {
+		if userID, err := graphqlbackend.UnmarshalUserID(*s.args.UserID); err == nil {
+			opts.UserID = int(userID)
+		}
+	}
+	if s.args.RepoID != nil {
+		if repoID, err := graphqlbackend.UnmarshalRepositoryID(*s.args.RepoID); err == nil {
+			opts.RepoID = int(repoID)
+		}
+	}
 	// First, we check for search type, because it can exist without search query,
 	// but not vice versa.
 	if s.args.SearchType != nil {


### PR DESCRIPTION
Add filter for userID & repoID in permissions sync jobs API to filter sync jobs for particular user/repo.

## Test plan

- [manually tested](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%20%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20id%5Cn%20%20%20%20username%5Cn%20%20%7D%5Cn%20%20%5Cn%20%20permissionsSyncJobs(first%3A%2010%2C%20userID%3A%20%5C%22VXNlcjoxMg%3D%3D%5C%22)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20subject%20%7B%5Cn%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%20%20...%20on%20User%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20%20%20%20%20username%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D)