### PR TITLE
experimental serch input: Add "last search context" suggestion

### DIFF
--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
@@ -1,0 +1,88 @@
+import { Extension, StateField } from '@codemirror/state'
+import { mdiFilterOutline } from '@mdi/js'
+import { inRange } from 'lodash'
+
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
+import { Filter } from '@sourcegraph/shared/src/search/query/token'
+import { isFilterType } from '@sourcegraph/shared/src/search/query/validate'
+
+import { getQueryInformation } from '../../codemirror/parsedQuery'
+import { filterValueRenderer } from '../optionRenderer'
+import { suggestionSources } from '../suggestionsExtension'
+
+export function lastUsedContextSuggestion(config: { getContext: () => string | undefined }): Extension {
+    return [
+        lastContextField,
+        suggestionSources.of({
+            query: (state, position) => {
+                const { token, tokens } = getQueryInformation(state, position)
+                const context = state.field(lastContextField) || config.getContext()
+                if (!context) {
+                    return null
+                }
+
+                // Only show suggestion if the query is empty or the query does not contain a context filter and
+                // the cursor is at a whitespace token
+                if (
+                    (token && token.type !== 'whitespace') ||
+                    tokens.some(token => isFilterType(token, FilterType.context))
+                ) {
+                    return null
+                }
+
+                const label = `context:${context}`
+                return {
+                    result: [
+                        {
+                            title: 'Search context',
+                            options: [
+                                {
+                                    label,
+                                    icon: mdiFilterOutline,
+                                    render: filterValueRenderer,
+                                    kind: 'context',
+                                    action: {
+                                        type: 'completion',
+                                        from: position,
+                                        insertValue: `${label} `,
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                }
+            },
+        }),
+    ]
+}
+
+function findSearchContext(query: string): Filter | undefined {
+    return findFilter(query, FilterType.context, FilterKind.Global)
+}
+
+const lastContextField = StateField.define<string | undefined>({
+    create(state) {
+        return findSearchContext(state.sliceDoc())?.value?.value
+    },
+    update(value, transaction) {
+        // We don't actually need to access the new query state we can just look for the first context: filter
+        // in the new document
+        if (transaction.docChanged) {
+            const searchContextFilter = findSearchContext(transaction.newDoc.sliceString(0))
+            if (
+                searchContextFilter?.value?.value &&
+                // Do not update the field while the user is still editing the filter value
+                // (determined by the fact that the cursor is in range of the filter value)
+                !inRange(
+                    transaction.newSelection.main.from,
+                    searchContextFilter.value.range.start - 1,
+                    searchContextFilter.value.range.end + 1
+                )
+            ) {
+                return searchContextFilter.value.value
+            }
+        }
+        return value
+    },
+})

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -12,10 +12,11 @@ export const filterDecoration = [
     EditorView.baseTheme({
         '.sg-query-token-filter-context': {
             borderRadius: '3px',
-            border: '1px solid var(--border-color)',
+            padding: '1px 0',
+            backgroundColor: '#eff2f5a0', // --gray-02 with transparency to make selection visible
         },
         '&dark .sg-query-token-filter-context': {
-            borderColor: 'var(--border-color-2)',
+            backgroundColor: '#343a4da0', // --gray-08 with transparency to make selection visible
         },
     }),
     EditorView.decorations.compute([decoratedTokens, 'selection'], state => {

--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -14,4 +14,5 @@ export { getEditorConfig, combineResults, selectionListener } from './suggestion
 export * from './optionRenderer'
 export * from './utils'
 export * from './codemirror/history'
+export * from './codemirror/searchcontext'
 export * from './filters'

--- a/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
+++ b/client/branded/src/search-ui/input/experimental/optionRenderer.tsx
@@ -25,7 +25,7 @@ const FilterValueOption: React.FunctionComponent<{ option: Option }> = ({ option
                 {field}
                 <span className={styles.separator}>:</span>
             </span>
-            {option.matches ? <HighlightedLabel label={value} matches={option.matches} /> : option.label}
+            {option.matches ? <HighlightedLabel label={value} matches={option.matches} /> : value}
         </span>
     )
 }

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -36,7 +36,7 @@ export function getEditorConfig(state: EditorState): EditorConfig {
  * A source for completion/suggestion results
  */
 export interface Source {
-    query: (state: EditorState, position: number, mode?: string) => SuggestionResult
+    query: (state: EditorState, position: number, mode?: string) => SuggestionResult | null
     mode?: string
 }
 

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -102,6 +102,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                     getUserSearchContextNamespaces={props.getUserSearchContextNamespaces}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                     submitSearch={submitSearchOnChange}
+                    selectedSearchContextSpec={props.selectedSearchContextSpec}
                 >
                     <Toggles
                         patternType={searchPatternType}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -139,6 +139,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             getUserSearchContextNamespaces={getUserSearchContextNamespaces}
             isSourcegraphDotCom={isSourcegraphDotCom}
             submitSearch={submitSearchOnChange}
+            selectedSearchContextSpec={selectedSearchContextSpec}
         >
             <Toggles
                 patternType={patternType}


### PR DESCRIPTION
We've gotten feedback that because the search context is not a separate dropdown anymore it's easy to "loose" your current search context e.g. by clearing out the query.

The changes here build on top of the refactor in #48924 and introduces a new suggestion source for the "last used search context".

The extension will show a suggestion if the query is empty or does not contain a `context:` filter and the cursor is at a whitespace token.

The suggested search context will either be 'globally' selected one or the one that was previously present in the query. A state field is used to keep track of the currently/most recently present search context value.


https://user-images.githubusercontent.com/179026/223855084-1a032e81-c334-4147-89cf-b00d26811935.mp4



## Test plan

- Clear search query -> context suggestion should be the first
- Select a different search context then clear query -> the just selected search context should be suggested

## App preview:

- [Web](https://sg-web-fkling-search-input-protect.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
