### PR TITLE
Add support for Azure DevOps for the setup wizard

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
@@ -15,6 +15,7 @@ const SUPPORTED_CODE_HOSTS = [
     ExternalServiceKind.BITBUCKETSERVER,
     ExternalServiceKind.AWSCODECOMMIT,
     ExternalServiceKind.GITOLITE,
+    ExternalServiceKind.AZUREDEVOPS
 ]
 
 export const CodeHostsPicker: FC = () => (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
@@ -15,7 +15,7 @@ const SUPPORTED_CODE_HOSTS = [
     ExternalServiceKind.BITBUCKETSERVER,
     ExternalServiceKind.AWSCODECOMMIT,
     ExternalServiceKind.GITOLITE,
-    ExternalServiceKind.AZUREDEVOPS
+    ExternalServiceKind.AZUREDEVOPS,
 ]
 
 export const CodeHostsPicker: FC = () => (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import {mdiAws, mdiBitbucket, mdiGit, mdiGithub, mdiGitlab, mdiMicrosoftAzure} from '@mdi/js'
+import { mdiAws, mdiBitbucket, mdiGit, mdiGithub, mdiGitlab, mdiMicrosoftAzure } from '@mdi/js'
 import { MdiReactIconComponentType } from 'mdi-react'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { mdiAws, mdiBitbucket, mdiGit, mdiGithub, mdiGitlab } from '@mdi/js'
+import {mdiAws, mdiBitbucket, mdiGit, mdiGithub, mdiGitlab, mdiMicrosoftAzure} from '@mdi/js'
 import { MdiReactIconComponentType } from 'mdi-react'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
@@ -43,7 +43,7 @@ export const getCodeHostIconPath = (codeHostType: ExternalServiceKind | null): s
         case ExternalServiceKind.AWSCODECOMMIT:
             return mdiAws
         case ExternalServiceKind.AZUREDEVOPS:
-            return mdiGit
+            return mdiMicrosoftAzure
         default:
             // TODO: Add support for other code host
             return null
@@ -66,7 +66,8 @@ export const getCodeHostName = (codeHostType: ExternalServiceKind | null): strin
             return 'Gitolite'
         case ExternalServiceKind.GERRIT:
             return 'Gerrit'
-
+        case ExternalServiceKind.AZUREDEVOPS:
+            return 'Azure DevOps'
         default:
             // TODO: Add support for other code host
             return 'Unknown'


### PR DESCRIPTION
Add support for Azure DevOps in the setup wizard.
## Test plan

📺  Loom: https://www.loom.com/share/a1e7769a4bfc42a981c45b0ac9fd0772

## App preview:

- [Web](https://sg-web-iv-ado-setup-wizard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
