### PR TITLE
Ranking: solidify ranking toggle

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -100,7 +100,7 @@ describe('StreamingSearchResults', () => {
             searchMode: SearchMode.SmartSearch,
             trace: undefined,
             chunkMatches: true,
-            featureOverrides: ['-search-ranking'],
+            featureOverrides: [],
         })
     })
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -77,29 +77,9 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
     const [sidebarCollapsed, setSidebarCollapsed] = useTemporarySetting('search.sidebar.collapsed', false)
 
-    // Use new ranking if the feature flag is enabled and the user has not explicitly disabled it
-    const [rankingEnabled] = useFeatureFlag('search-ranking')
-    const [rankingTemporarySettings, setRankingTemporarySettings] = useTemporarySetting(
-        'search.ranking.experimental',
-        true
-    )
-    const [rankingToggleEnabled, setRankingToggleEnabled] = useState(rankingTemporarySettings ?? rankingEnabled)
-    useEffect(() => {
-        if (rankingTemporarySettings !== undefined) {
-            setRankingTemporarySettings(rankingToggleEnabled)
-        }
-        // `rankingTemporarySettings` should not be a dependency, otherwise the
-        // observable would be recomputed if the caller used e.g. an object
-        // literal as default value. `useTemporarySetting` works more like
-        // `useState` in this regard.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [rankingToggleEnabled, setRankingTemporarySettings])
-
-    useEffect(() => {
-        if (rankingTemporarySettings !== undefined) {
-            setRankingToggleEnabled(rankingTemporarySettings)
-        }
-    }, [rankingTemporarySettings, setRankingToggleEnabled])
+    const [rankingFeatureEnabled] = useFeatureFlag('search-ranking')
+    // The toggle is only visible when the ranking feature flag is enabled, so we default it to true
+    const [rankingToggleEnabled, setRankingToggleEnabled] = useTemporarySetting('search.ranking.experimental', true)
 
     // Global state
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
@@ -120,13 +100,15 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [location.search])
     const featureOverrides = useDeepMemo(
         // Nested use memo here is used for avoiding extra object calculation step on each render
-        useMemo(
-            () => [
-                rankingToggleEnabled && rankingEnabled ? 'search-ranking' : '-search-ranking',
-                ...new URLSearchParams(location.search).getAll('feat'),
-            ],
-            [location.search, rankingToggleEnabled, rankingEnabled]
-        )
+        useMemo(() => {
+            // Only disable ranking if the feature flag is set and toggle is explicitly
+            // disabled. Otherwise, don't touch the search behavior.
+            const disableRanking = rankingFeatureEnabled && rankingToggleEnabled !== undefined && !rankingToggleEnabled
+            if (disableRanking) {
+                return ['-search-ranking', ...new URLSearchParams(location.search).getAll('feat')]
+            }
+            return new URLSearchParams(location.search).getAll('feat')
+        }, [location.search, rankingFeatureEnabled, rankingToggleEnabled])
     )
     const { addRecentSearch } = useRecentSearches()
 


### PR DESCRIPTION
This simplifies the approach to the ranking toggle and fixes a few bugs. Now, we only disable ranking if the `search-ranking` feature flag is set, and the toggle has been explicitly disabled. Otherwise we don't touch anything and use the standard backend behavior.

This fixes a bug where on page reload, the search would not use ranking even the toggle was enabled. I think this happened because feature flags are loaded asynchronously, so the feature flag was undefined which we interpreted as 'disable ranking'.

## Test plan

Existing tests, a lot of manual testing.

## App preview:

- [Web](https://sg-web-jtibs-ranking-toggle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
