### PR TITLE
incoming webhooks: normalize webhook configuration URNs

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -29,6 +29,7 @@ import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 import { ClosedNotice } from './ClosedNotice'
 import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
 import { UnpublishedNotice } from './UnpublishedNotice'
+import { WebhookAlert } from './WebhookAlert'
 
 export interface BatchChangeDetailsPageProps extends BatchChangeDetailsProps, SettingsCascadeProps<Settings> {
     /** The namespace ID. */
@@ -162,9 +163,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
                 />
             )}
             <ChangesetsArchivedNotice />
-            {/* Temporarily disabled due to bug with discovery. */}
-            {/* See https://github.com/sourcegraph/sourcegraph/issues/45919 */}
-            {/* <WebhookAlert batchChange={batchChange} /> */}
+            <WebhookAlert batchChange={batchChange} />
             <BatchChangeStatsCard batchChange={batchChange} className="mb-3" />
             <Description description={batchChange.description} />
             <BatchChangeDetailsTabs batchChange={batchChange} refetchBatchChange={refetch} {...props} />

--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -38,7 +38,11 @@ func (ws *webhookService) CreateWebhook(ctx context.Context, name, codeHostKind,
 	if secretStr != nil {
 		secret = types.NewUnencryptedSecret(*secretStr)
 	}
-	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, name, codeHostKind, codeHostURN, actor.FromContext(ctx).UID, secret)
+	urn, err := extsvc.NewCodeHostBaseURL(codeHostURN)
+	if err != nil {
+		return nil, err
+	}
+	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, name, codeHostKind, urn.String(), actor.FromContext(ctx).UID, secret)
 }
 
 func (ws *webhookService) DeleteWebhook(ctx context.Context, id int32) error {

--- a/migrations/frontend/1678320579_normalize_webhook_urns/down.sql
+++ b/migrations/frontend/1678320579_normalize_webhook_urns/down.sql
@@ -1,0 +1,1 @@
+-- Up migration only changes data, no down migration necessary.

--- a/migrations/frontend/1678320579_normalize_webhook_urns/metadata.yaml
+++ b/migrations/frontend/1678320579_normalize_webhook_urns/metadata.yaml
@@ -1,0 +1,2 @@
+name: normalize webhook urns
+parents: [1677166643, 1678214530]

--- a/migrations/frontend/1678320579_normalize_webhook_urns/up.sql
+++ b/migrations/frontend/1678320579_normalize_webhook_urns/up.sql
@@ -1,0 +1,5 @@
+UPDATE webhooks
+-- Add a trailing slash to URNs that don't have one. This mimics the effect of the
+-- extsvc.NormalizeBaseURL method in Go
+SET code_host_urn = CONCAT(code_host_urn, '/')
+WHERE code_host_urn NOT LIKE '%/';


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/45919.

It turns out we typically call an `extsvc` helper method to normalize URLs for external services to include the trailing "/", but we weren't doing anything for that when creating new webhooks. So if an external service configuration didn't include the slash, the webhook wouldn't either, hence the mismatch between the repo `external_service_id` and the webhook `code_host_urn`.

This PR does two things, then:
- Adds a migration to update existing webhooks to append the trailing slash, if it's missing one.
- Updates the `CreateWebhook` method to use the `extsvc` helper method to prepare a URN before inserting the entry in the DB.

## Test plan

- Tested running the migration locally and verified webhooks without the trailing slash were updated.
- Added a unit test case for `CreateWebhook`.
- Verified in the UI that the alert banner appeared for a batch change where I did not have webhooks configured for all or some of the changeset code hosts and did not appear for a batch change where I did have webhooks configured

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
