### PR TITLE
Fix link in code monitoring to user email settings

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
@@ -110,8 +110,8 @@ export const EmailAction: React.FunctionComponent<React.PropsWithChildren<Action
         )
     ) : !userPrimaryEmail?.verified ? (
         <>
-            Please <Link to={`${authenticatedUser.settingsURL!}/settings/emails`}>verify your email</Link> to enable
-            this feature.
+            Please <Link to={`${authenticatedUser.settingsURL!}/emails`}>verify your email</Link> to enable this
+            feature.
         </>
     ) : undefined
 


### PR DESCRIPTION
The settings URL already contains `/settings`, so this was linking to `/settings/settings/emails` which doesn't exist.

## Test plan

Link now links to a working page.

## App preview:

- [Web](https://sg-web-es-fix-email-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
