### PR TITLE
inference: Fix pathspec vs glob paths

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
@@ -32,7 +32,7 @@ func (api patternAPI) LuaAPI() map[string]lua.LGFunction {
 
 	return map[string]lua.LGFunction{
 		"backdoor": util.WrapLuaFunction(func(state *lua.LState) error {
-			state.Push(luar.New(state, luatypes.NewPattern(state.CheckString(1))))
+			state.Push(luar.New(state, luatypes.NewPattern(state.CheckString(1), state.CheckString(2))))
 			return nil
 		}),
 		"path_combine": util.WrapLuaFunction(newPathPatternCombineConstructor(luatypes.NewCombinedPattern)),

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
@@ -2,24 +2,24 @@ local patterns = require "internal_patterns"
 
 local M = {}
 
-local new_pattern = function(prefix, pattern, suffix)
-    return patterns.backdoor(prefix .. pattern .. suffix)
+local new_pattern = function(glob, pathspec)
+    return patterns.backdoor(glob, pathspec)
 end
 
 M.new_path_literal = function(pattern)
-    return new_pattern("/", pattern, "")
+    return new_pattern("/" .. pattern, pattern)
 end
 
 M.new_path_segment = function(pattern)
-    return new_pattern("", pattern, "/")
+    return new_pattern(pattern .. "/", "**/" .. pattern .. "/**")
 end
 
 M.new_path_basename = function(pattern)
-    return new_pattern("", pattern, "")
+    return new_pattern(pattern, "**/" .. pattern)
 end
 
 M.new_path_extension = function(pattern)
-    return new_pattern("*.", pattern, "")
+    return new_pattern("*." .. pattern, "**/*." .. pattern)
 end
 
 M.new_path_combine = function(pattern)

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
@@ -6,18 +6,26 @@ local new_pattern = function(glob, pathspec)
     return patterns.backdoor(glob, pathspec)
 end
 
+-- glob:     /BUILD.bazel
+-- pathspec:  BUILD.bazel
 M.new_path_literal = function(pattern)
     return new_pattern("/" .. pattern, pattern)
 end
 
+-- glob:        web/
+-- pathspec: **/web/**
 M.new_path_segment = function(pattern)
     return new_pattern(pattern .. "/", "**/" .. pattern .. "/**")
 end
 
+-- glob:        gen.go
+-- pathspec: **/gen.go
 M.new_path_basename = function(pattern)
     return new_pattern(pattern, "**/" .. pattern)
 end
 
+-- glob:        *.md
+-- pathspec: **/*.md
 M.new_path_extension = function(pattern)
     return new_pattern("*." .. pattern, "**/*." .. pattern)
 end

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/luatypes/path_patterns.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/luatypes/path_patterns.go
@@ -9,14 +9,22 @@ import (
 // PathPattern is forms a tree of patterns to be matched against paths in an
 // associated git repository.
 type PathPattern struct {
-	pattern  string
+	pattern  GlobAndPathspecPattern
 	children []*PathPattern
 	invert   bool
 }
 
+type GlobAndPathspecPattern struct {
+	Glob     string
+	Pathspec string
+}
+
 // NewPattern returns a new path pattern instance that includes a single pattern.
-func NewPattern(pattern string) *PathPattern {
-	return &PathPattern{pattern: pattern}
+func NewPattern(glob, pathspec string) *PathPattern {
+	return &PathPattern{pattern: GlobAndPathspecPattern{
+		Glob:     glob,
+		Pathspec: pathspec,
+	}}
 }
 
 // NewCombinedPattern returns a new path pattern instance that includes the given
@@ -37,7 +45,7 @@ func NewExcludePattern(children []*PathPattern) *PathPattern {
 
 // FlattenPatterns returns a concatenation of results from calling the function
 // FlattenPattern on each of the inputs.
-func FlattenPatterns(pathPatterns []*PathPattern, inverted bool) (patterns []string) {
+func FlattenPatterns(pathPatterns []*PathPattern, inverted bool) (patterns []GlobAndPathspecPattern) {
 	for _, pathPattern := range pathPatterns {
 		patterns = append(patterns, FlattenPattern(pathPattern, inverted)...)
 	}
@@ -47,9 +55,9 @@ func FlattenPatterns(pathPatterns []*PathPattern, inverted bool) (patterns []str
 
 // FlattenPattern returns the set of patterns matching the given inverted flag on this
 // path pattern or any of its descendants.
-func FlattenPattern(pathPattern *PathPattern, inverted bool) (patterns []string) {
+func FlattenPattern(pathPattern *PathPattern, inverted bool) (patterns []GlobAndPathspecPattern) {
 	if pathPattern.invert == inverted {
-		if pathPattern.pattern != "" {
+		if pathPattern.pattern.Glob != "" {
 			patterns = append(patterns, pathPattern.pattern)
 		}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
@@ -335,10 +335,9 @@ func (s *Service) resolvePaths(
 		return nil, err
 	}
 
-	patterns := flattenPatterns(patternsForPaths, false)
-	pathspecs := make([]gitdomain.Pathspec, 0, len(patterns))
-	for _, pattern := range patterns {
-		pathspecs = append(pathspecs, gitdomain.Pathspec(pattern))
+	globs, pathspecs, err := flattenPatterns(patternsForPaths, false)
+	if err != nil {
+		return nil, err
 	}
 
 	// Ideally we can pass the globs we explicitly filter by below
@@ -347,12 +346,7 @@ func (s *Service) resolvePaths(
 		return nil, err
 	}
 
-	compiledPatterns, err := compileWildcards(patterns)
-	if err != nil {
-		return nil, err
-	}
-
-	return filterPaths(paths, compiledPatterns, nil), nil
+	return filterPaths(paths, globs, nil), nil
 }
 
 // resolveFileContents requests the content of the paths that match the given combined regular expression.


### PR DESCRIPTION
This PR breaks the patterns we construct internally into literal glob and pathspec patterns. It was difficult to translate one to the other, so we're going to construct both and carry them together.

## Test plan

Tested locally.
