### PR TITLE
Search: Fix submitted URL observer

### DIFF
--- a/client/web/src/SearchQueryStateObserver.tsx
+++ b/client/web/src/SearchQueryStateObserver.tsx
@@ -1,4 +1,4 @@
-import {FC, useLayoutEffect, useRef, useState } from 'react'
+import { FC, useLayoutEffect, useRef, useState } from 'react'
 
 import { Location, useLocation } from 'react-router-dom'
 import { BehaviorSubject } from 'rxjs'

--- a/client/web/src/SearchQueryStateObserver.tsx
+++ b/client/web/src/SearchQueryStateObserver.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef, useState } from 'react'
+import {FC, useLayoutEffect, useRef, useState } from 'react'
 
 import { Location, useLocation } from 'react-router-dom'
 import { BehaviorSubject } from 'rxjs'
@@ -36,11 +36,11 @@ export const SearchQueryStateObserver: FC<SearchQueryStateObserverProps> = props
 
     const [locationSubject] = useState(() => new BehaviorSubject<Location>(location))
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         locationSubject.next(location)
     }, [location, locationSubject])
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         const subscription = getQueryStateFromLocation({
             location: locationSubject,
             isSearchContextAvailable: (searchContext: string) =>


### PR DESCRIPTION
Prior to this, PR we had the following flow 
- We navigate to the search result page from the home page by clicking submit in the search box
- We render search result page 
- We run the search result page `searchStream`
- We run global `SearchQueryStateObserver`, which syncs URL and global Zustand store

So you can see that we sync URL and global store after we run the search stream.
In this PR, we just change the order by making syncs in useLayoutEffect that make the syncing happens before running  `searchStream`

## Test plan
- Go to [sourcegraph.sourcegraph.com](http://sourcegraph.sourcegraph.com/) and search for UseDocumentRanks (global context)
-Without clicking on anything, hit the "back" button. Search for TODO
- Make sure that you see related results 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-submitted-url-state.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
