### PR TITLE
Use uncached doer for downloading packages

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_python_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages_test.go
@@ -264,10 +264,7 @@ func newTestClient(t testing.TB, name string, update bool) *pypi.Client {
 		}
 	})
 
-	doer, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).Doer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	doer := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec))
 
 	c := pypi.NewClient("urn", []string{"https://pypi.org/simple"}, doer)
 	return c

--- a/cmd/gitserver/server/vcs_syncer_ruby_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_ruby_packages.go
@@ -57,20 +57,20 @@ func (rubyDependencySource) ParsePackageFromRepoName(repoName api.RepoName) (rep
 }
 
 func (s *rubyDependencySource) Download(ctx context.Context, dir string, dep reposource.VersionedPackage) error {
-	pkgContents, packageURL, err := s.client.GetPackageContents(ctx, dep)
+	pkgContents, err := s.client.GetPackageContents(ctx, dep)
 	if err != nil {
-		return errors.Wrapf(err, "error downloading RubyGem with URL '%s'", packageURL)
+		return errors.Wrapf(err, "error downloading RubyGem %q", dep.VersionedPackageSyntax())
 	}
 	defer pkgContents.Close()
 
-	if err = unpackRubyPackage(packageURL, pkgContents, dir); err != nil {
-		return errors.Wrapf(err, "failed to unzip ruby module from URL %s", packageURL)
+	if err = unpackRubyPackage(pkgContents, dir); err != nil {
+		return errors.Wrapf(err, "failed to unzip ruby module %q", dep.VersionedPackageSyntax())
 	}
 
 	return nil
 }
 
-func unpackRubyPackage(packageURL string, pkg io.Reader, workDir string) error {
+func unpackRubyPackage(pkg io.Reader, workDir string) error {
 	opts := unpack.Opts{
 		SkipInvalid:    true,
 		SkipDuplicates: true,
@@ -86,10 +86,10 @@ func unpackRubyPackage(packageURL string, pkg io.Reader, workDir string) error {
 	defer os.RemoveAll(tmpDir)
 
 	if err := unpack.Tar(pkg, tmpDir, opts); err != nil {
-		return errors.Wrapf(err, "failed to tar downloaded bytes from URL %s", packageURL)
+		return errors.Wrap(err, "failed to unpack downloaded tar")
 	}
 
-	err = unpackRubyDataTarGz(packageURL, filepath.Join(tmpDir, "data.tar.gz"), workDir)
+	err = unpackRubyDataTarGz(filepath.Join(tmpDir, "data.tar.gz"), workDir)
 	if err != nil {
 		return err
 	}
@@ -109,10 +109,10 @@ func unpackRubyPackage(packageURL string, pkg io.Reader, workDir string) error {
 }
 
 // unpackRubyDataTarGz unpacks the given `data.tar.gz` from a downloaded RubyGem.
-func unpackRubyDataTarGz(packageURL, path string, workDir string) error {
+func unpackRubyDataTarGz(path string, workDir string) error {
 	r, err := os.Open(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read file from downloaded URL %s", packageURL)
+		return errors.Wrapf(err, "failed to read data archive file %q", path)
 	}
 	defer r.Close()
 	opts := unpack.Opts{

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -491,7 +491,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := npm.NewHTTPClient(urn, c.Registry, c.Credentials, httpcli.ExternalDoer)
+		cli := npm.NewHTTPClient(urn, c.Registry, c.Credentials, httpcli.UncachedExternalDoer)
 		return server.NewNpmPackagesSyncer(c, depsSvc, cli), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
@@ -499,7 +499,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.ExternalDoer)
+		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.UncachedExternalDoer)
 		return server.NewGoModulesSyncer(&c, depsSvc, cli), nil
 	case extsvc.TypePythonPackages:
 		var c schema.PythonPackagesConnection
@@ -507,7 +507,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := pypi.NewClient(urn, c.Urls, httpcli.ExternalDoer)
+		cli := pypi.NewClient(urn, c.Urls, httpcli.UncachedExternalDoer)
 		return server.NewPythonPackagesSyncer(&c, depsSvc, cli, reposDir), nil
 	case extsvc.TypeRustPackages:
 		var c schema.RustPackagesConnection
@@ -515,7 +515,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := crates.NewClient(urn, httpcli.ExternalDoer)
+		cli := crates.NewClient(urn, httpcli.UncachedExternalDoer)
 		return server.NewRustPackagesSyncer(&c, depsSvc, cli), nil
 	case extsvc.TypeRubyPackages:
 		var c schema.RubyPackagesConnection
@@ -523,7 +523,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := rubygems.NewClient(urn, c.Repository, httpcli.ExternalDoer)
+		cli := rubygems.NewClient(urn, c.Repository, httpcli.UncachedExternalDoer)
 		return server.NewRubyPackagesSyncer(&c, depsSvc, cli), nil
 	}
 	return &server.GitRepoSyncer{}, nil

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -491,7 +491,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := npm.NewHTTPClient(urn, c.Registry, c.Credentials, httpcli.UncachedExternalDoer)
+		cli := npm.NewHTTPClient(urn, c.Registry, c.Credentials, httpcli.ExternalClientFactory)
 		return server.NewNpmPackagesSyncer(c, depsSvc, cli), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
@@ -499,7 +499,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.UncachedExternalDoer)
+		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.ExternalClientFactory)
 		return server.NewGoModulesSyncer(&c, depsSvc, cli), nil
 	case extsvc.TypePythonPackages:
 		var c schema.PythonPackagesConnection
@@ -507,7 +507,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := pypi.NewClient(urn, c.Urls, httpcli.UncachedExternalDoer)
+		cli := pypi.NewClient(urn, c.Urls, httpcli.ExternalClientFactory)
 		return server.NewPythonPackagesSyncer(&c, depsSvc, cli, reposDir), nil
 	case extsvc.TypeRustPackages:
 		var c schema.RustPackagesConnection
@@ -515,7 +515,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := crates.NewClient(urn, httpcli.UncachedExternalDoer)
+		cli := crates.NewClient(urn, httpcli.ExternalClientFactory)
 		return server.NewRustPackagesSyncer(&c, depsSvc, cli), nil
 	case extsvc.TypeRubyPackages:
 		var c schema.RubyPackagesConnection
@@ -523,7 +523,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		cli := rubygems.NewClient(urn, c.Repository, httpcli.UncachedExternalDoer)
+		cli := rubygems.NewClient(urn, c.Repository, httpcli.ExternalClientFactory)
 		return server.NewRubyPackagesSyncer(&c, depsSvc, cli), nil
 	}
 	return &server.GitRepoSyncer{}, nil

--- a/internal/extsvc/crates/client.go
+++ b/internal/extsvc/crates/client.go
@@ -35,10 +35,7 @@ func (c *Client) Get(ctx context.Context, url string) (io.ReadCloser, error) {
 	}
 	req.Header.Add("User-Agent", "sourcegraph-crates-syncer (sourcegraph.com)")
 
-	// WARN: The default external doer caches responses, meaning we will store
-	// entire package contents in redis! We switch to the UncachedExternalDoer for
-	// this specific method.
-	b, err := c.withDoer(httpcli.UncachedExternalDoer).do(req)
+	b, err := c.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -76,10 +73,4 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 	}
 
 	return resp.Body, nil
-}
-
-func (client *Client) withDoer(cli httpcli.Doer) *Client {
-	c := *client
-	c.cli = cli
-	return &c
 }

--- a/internal/extsvc/crates/client.go
+++ b/internal/extsvc/crates/client.go
@@ -35,7 +35,10 @@ func (c *Client) Get(ctx context.Context, url string) (io.ReadCloser, error) {
 	}
 	req.Header.Add("User-Agent", "sourcegraph-crates-syncer (sourcegraph.com)")
 
-	b, err := c.do(req)
+	// WARN: The default external doer caches responses, meaning we will store
+	// entire package contents in redis! We switch to the UncachedExternalDoer for
+	// this specific method.
+	b, err := c.withDoer(httpcli.UncachedExternalDoer).do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -73,4 +76,10 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 	}
 
 	return resp.Body, nil
+}
+
+func (client *Client) withDoer(cli httpcli.Doer) *Client {
+	c := *client
+	c.cli = cli
+	return &c
 }

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -21,18 +21,22 @@ import (
 
 // A Client to Go module proxies.
 type Client struct {
-	urls    []string // list of proxy URLs
-	cli     httpcli.Doer
-	limiter *ratelimit.InstrumentedLimiter
+	urls           []string // list of proxy URLs
+	uncachedClient httpcli.Doer
+	cachedClient   httpcli.Doer
+	limiter        *ratelimit.InstrumentedLimiter
 }
 
 // NewClient returns a new Client for the given urls. urn represents the
 // unique urn of the external service this client's config is from.
-func NewClient(urn string, urls []string, cli httpcli.Doer) *Client {
+func NewClient(urn string, urls []string, httpfactory *httpcli.Factory) *Client {
+	uncached, _ := httpfactory.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
+	cached, _ := httpfactory.Doer()
 	return &Client{
-		urls:    urls,
-		cli:     cli,
-		limiter: ratelimit.DefaultRegistry.Get(urn),
+		urls:           urls,
+		cachedClient:   cached,
+		uncachedClient: uncached,
+		limiter:        ratelimit.DefaultRegistry.Get(urn),
 	}
 }
 
@@ -49,13 +53,13 @@ func (c *Client) GetVersion(ctx context.Context, mod reposource.PackageName, ver
 		paths = []string{"@latest"}
 	}
 
-	respBody, err := c.get(ctx, mod, paths...)
+	respBody, err := c.get(ctx, c.cachedClient, mod, paths...)
 	if err != nil {
 		return nil, err
 	}
 
 	var v struct{ Version string }
-	if err = json.Unmarshal(respBody, &v); err != nil {
+	if err = json.NewDecoder(respBody).Decode(&v); err != nil {
 		return nil, err
 	}
 
@@ -69,7 +73,13 @@ func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version
 		return nil, errors.Wrap(err, "failed to escape version")
 	}
 
-	zipBytes, err := c.get(ctx, mod, "@v", escapedVersion+".zip")
+	zip, err := c.get(ctx, c.uncachedClient, mod, "@v", escapedVersion+".zip")
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove and return io.Reader
+	zipBytes, err := io.ReadAll(zip)
 	if err != nil {
 		return nil, err
 	}
@@ -77,51 +87,41 @@ func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version
 	return zipBytes, nil
 }
 
-func (c *Client) get(ctx context.Context, mod reposource.PackageName, paths ...string) (respBody []byte, err error) {
+func (c *Client) get(ctx context.Context, doer httpcli.Doer, mod reposource.PackageName, paths ...string) (respBody io.ReadCloser, err error) {
 	escapedMod, err := module.EscapePath(string(mod))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to escape module path")
 	}
-
-	var (
-		reqURL *url.URL
-		req    *http.Request
-	)
 
 	for _, baseURL := range c.urls {
 		if err = c.limiter.Wait(ctx); err != nil {
 			return nil, err
 		}
 
-		reqURL, err = url.Parse(baseURL)
+		reqURL, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, errors.Errorf("invalid go modules proxy URL %q", baseURL)
 		}
 		reqURL.Path = path.Join(escapedMod, path.Join(paths...))
 
-		req, err = http.NewRequestWithContext(ctx, "GET", reqURL.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL.String(), nil)
 		if err != nil {
 			return nil, err
 		}
 
-		respBody, err = c.do(req)
+		respBody, err = c.do(doer, req)
 		if err == nil || !errcode.IsNotFound(err) {
 			break
+		} else if respBody != nil {
+			respBody.Close()
 		}
 	}
 
 	return respBody, err
 }
 
-func (c *Client) do(req *http.Request) ([]byte, error) {
-	resp, err := c.cli.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	bs, err := io.ReadAll(resp.Body)
+func (c *Client) do(doer httpcli.Doer, req *http.Request) (io.ReadCloser, error) {
+	resp, err := doer.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +134,14 @@ func (c *Client) do(req *http.Request) ([]byte, error) {
 	// Error responses should have content type text/plain with charset either utf-8 or us-ascii.
 
 	if resp.StatusCode != http.StatusOK {
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			bs = []byte(errors.Wrap(err, "failed to read body").Error())
+		}
 		return nil, &Error{Path: req.URL.Path, Code: resp.StatusCode, Message: string(bs)}
 	}
 
-	return bs, nil
+	return resp.Body, nil
 }
 
 // Error returned from an HTTP request to a Go module proxy.

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -69,10 +69,7 @@ func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version
 		return nil, errors.Wrap(err, "failed to escape version")
 	}
 
-	// WARN: The default external doer caches responses, meaning we will store
-	// entire package contents in redis! We switch to the UncachedExternalDoer for
-	// this specific method.
-	zipBytes, err := c.withDoer(httpcli.UncachedExternalDoer).get(ctx, mod, "@v", escapedVersion+".zip")
+	zipBytes, err := c.get(ctx, mod, "@v", escapedVersion+".zip")
 	if err != nil {
 		return nil, err
 	}
@@ -156,10 +153,4 @@ func (e *Error) Error() string {
 
 func (e *Error) NotFound() bool {
 	return e.Code == http.StatusNotFound || e.Code == http.StatusGone
-}
-
-func (c *Client) withDoer(cli httpcli.Doer) *Client {
-	cpy := *c
-	cpy.cli = cli
-	return &cpy
 }

--- a/internal/extsvc/gomodproxy/client_test.go
+++ b/internal/extsvc/gomodproxy/client_test.go
@@ -15,8 +15,9 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"golang.org/x/mod/module"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
@@ -131,10 +132,7 @@ func newTestClient(t testing.TB, name string, update bool) *Client {
 		}
 	})
 
-	hc, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).Doer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	hc := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec))
 
 	c := &schema.GoModulesConnection{
 		Urls: []string{"https://proxy.golang.org"},

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -189,5 +189,15 @@ func (client *HTTPClient) FetchTarball(ctx context.Context, dep *reposource.NpmV
 	if dep.TarballURL == "" {
 		return nil, errors.New("empty TarballURL")
 	}
-	return client.makeGetRequest(ctx, dep.TarballURL)
+
+	// WARN: The default external doer caches responses, meaning we will store
+	// entire package contents in redis! We switch to the UncachedExternalDoer for
+	// this specific method.
+	return client.withDoer(httpcli.UncachedExternalDoer).makeGetRequest(ctx, dep.TarballURL)
+}
+
+func (client *HTTPClient) withDoer(cli httpcli.Doer) *HTTPClient {
+	c := *client
+	c.doer = cli
+	return &c
 }

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -190,14 +190,5 @@ func (client *HTTPClient) FetchTarball(ctx context.Context, dep *reposource.NpmV
 		return nil, errors.New("empty TarballURL")
 	}
 
-	// WARN: The default external doer caches responses, meaning we will store
-	// entire package contents in redis! We switch to the UncachedExternalDoer for
-	// this specific method.
-	return client.withDoer(httpcli.UncachedExternalDoer).makeGetRequest(ctx, dep.TarballURL)
-}
-
-func (client *HTTPClient) withDoer(cli httpcli.Doer) *HTTPClient {
-	c := *client
-	c.doer = cli
-	return &c
+	return client.makeGetRequest(ctx, dep.TarballURL)
 }

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -34,10 +34,7 @@ func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
 
-	doer, err := recorderFactory.Doer()
-	require.Nil(t, err)
-
-	client = NewHTTPClient("urn", "https://registry.npmjs.org", "", doer)
+	client = NewHTTPClient("urn", "https://registry.npmjs.org", "", recorderFactory)
 	return client, stop
 }
 
@@ -76,7 +73,7 @@ func TestCredentials(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	client := NewHTTPClient("urn", server.URL, credentials, httpcli.ExternalDoer)
+	client := NewHTTPClient("urn", server.URL, credentials, httpcli.ExternalClientFactory)
 
 	presentDep, err := reposource.ParseNpmVersionedPackage("left-pad@1.3.0")
 	require.NoError(t, err)

--- a/internal/extsvc/pypi/client.go
+++ b/internal/extsvc/pypi/client.go
@@ -278,7 +278,7 @@ func (c *Client) Download(ctx context.Context, url string) (io.ReadCloser, error
 	// WARN: The default external doer caches responses, meaning we will store
 	// entire package contents in redis! We switch to the UncachedExternalDoer for
 	// this specific method.
-	b, err := c.withDoer(httpcli.UncachedExternalDoer).do(req)
+	b, err := c.do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "PyPI")
 	}
@@ -479,10 +479,4 @@ var normalizer = lazyregexp.New("[-_.]+")
 
 func normalize(path string) string {
 	return strings.ToLower(normalizer.ReplaceAllLiteralString(path, "-"))
-}
-
-func (client *Client) withDoer(cli httpcli.Doer) *Client {
-	c := *client
-	c.cli = cli
-	return &c
 }

--- a/internal/extsvc/pypi/client.go
+++ b/internal/extsvc/pypi/client.go
@@ -275,9 +275,6 @@ func (c *Client) Download(ctx context.Context, url string) (io.ReadCloser, error
 		return nil, err
 	}
 
-	// WARN: The default external doer caches responses, meaning we will store
-	// entire package contents in redis! We switch to the UncachedExternalDoer for
-	// this specific method.
 	b, err := c.do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "PyPI")

--- a/internal/extsvc/pypi/client_test.go
+++ b/internal/extsvc/pypi/client_test.go
@@ -446,10 +446,7 @@ func newTestClient(t testing.TB, name string, update bool) *Client {
 		}
 	})
 
-	doer, err := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec)).Doer()
-	if err != nil {
-		t.Fatal(err)
-	}
+	doer := httpcli.NewFactory(nil, httptestutil.NewRecorderOpt(rec))
 
 	c := NewClient("urn", []string{"https://pypi.org/simple"}, doer)
 	return c

--- a/internal/extsvc/rubygems/BUILD.bazel
+++ b/internal/extsvc/rubygems/BUILD.bazel
@@ -14,9 +14,9 @@ go_library(
 )
 
 go_test(
-    name = "rubygems_test",
+    name = "client_test",
     timeout = "short",
-    srcs = ["rubygems_test.go"],
+    srcs = ["client_test.go"],
     data = glob(["testdata/**"]),
     embed = [":rubygems"],
     deps = [

--- a/internal/extsvc/rubygems/client.go
+++ b/internal/extsvc/rubygems/client.go
@@ -43,10 +43,7 @@ func (c *Client) GetPackageContents(ctx context.Context, dep reposource.Versione
 	}
 	req.Header.Add("User-Agent", "sourcegraph-rubygems-syncer (sourcegraph.com)")
 
-	// WARN: The default external doer caches responses, meaning we will store
-	// entire package contents in redis! We switch to the UncachedExternalDoer for
-	// this specific method.
-	body, err = c.withDoer(httpcli.UncachedExternalDoer).do(req)
+	body, err = c.do(req)
 	if err != nil {
 		return nil, url, err
 	}
@@ -80,10 +77,4 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 		return nil, &Error{path: req.URL.Path, code: resp.StatusCode, message: string(bs)}
 	}
 	return resp.Body, nil
-}
-
-func (client *Client) withDoer(cli httpcli.Doer) *Client {
-	c := *client
-	c.cli = cli
-	return &c
 }

--- a/internal/extsvc/rubygems/client.go
+++ b/internal/extsvc/rubygems/client.go
@@ -43,7 +43,10 @@ func (c *Client) GetPackageContents(ctx context.Context, dep reposource.Versione
 	}
 	req.Header.Add("User-Agent", "sourcegraph-rubygems-syncer (sourcegraph.com)")
 
-	body, err = c.do(req)
+	// WARN: The default external doer caches responses, meaning we will store
+	// entire package contents in redis! We switch to the UncachedExternalDoer for
+	// this specific method.
+	body, err = c.withDoer(httpcli.UncachedExternalDoer).do(req)
 	if err != nil {
 		return nil, url, err
 	}
@@ -77,4 +80,10 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 		return nil, &Error{path: req.URL.Path, code: resp.StatusCode, message: string(bs)}
 	}
 	return resp.Body, nil
+}
+
+func (client *Client) withDoer(cli httpcli.Doer) *Client {
+	c := *client
+	c.cli = cli
+	return &c
 }

--- a/internal/extsvc/rubygems/client_test.go
+++ b/internal/extsvc/rubygems/client_test.go
@@ -28,10 +28,7 @@ func newTestHTTPClient(t *testing.T) (client *Client, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
 
-	doer, err := recorderFactory.Doer()
-	require.Nil(t, err)
-
-	return NewClient("rubygems_urn", "https://rubygems.org", doer), stop
+	return NewClient("rubygems_urn", "https://rubygems.org", recorderFactory), stop
 }
 
 func TestGetPackageContents(t *testing.T) {
@@ -39,7 +36,7 @@ func TestGetPackageContents(t *testing.T) {
 	client, stop := newTestHTTPClient(t)
 	defer stop()
 	dep := reposource.ParseRubyVersionedPackage("hola@0.1.0")
-	readCloser, _, err := client.GetPackageContents(ctx, dep)
+	readCloser, err := client.GetPackageContents(ctx, dep)
 	require.Nil(t, err)
 	defer readCloser.Close()
 

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -169,14 +169,6 @@ var ExternalDoer, _ = ExternalClientFactory.Doer()
 // downloading arbitrarily sized files! See UncachedExternalClient instead.
 var ExternalClient, _ = ExternalClientFactory.Client()
 
-// UncachedExternalDoer is a shared client for external communication with caching
-// disabled. This is a convenience for existing uses of http.DefaultClient.
-var UncachedExternalDoer, _ = UncachedExternalClientFactory.Doer()
-
-// UncachedExternalClient returns a shared client for external communication with
-// caching disabled. This is a convenience for existing uses of http.DefaultClient.
-var UncachedExternalClient, _ = UncachedExternalClientFactory.Client()
-
 // InternalClientFactory is a httpcli.Factory with common options
 // and middleware pre-set for communicating with internal services.
 var InternalClientFactory = NewInternalClientFactory("internal")
@@ -558,7 +550,6 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 			if retry || a.Error == nil || a.Index == 0 {
 				return
 			}
-
 		}()
 
 		if a.Response != nil {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -93,7 +93,15 @@ var CachedTransportOpt = NewCachedTransportOpt(redisCache, true)
 
 // ExternalClientFactory is a httpcli.Factory with common options
 // and middleware pre-set for communicating with external services.
+// WARN: Clients from this factory cache entire responses for etag matching. Do not
+// use them for one-off requests if possible, and definitely not for larger payloads,
+// like downloading arbitrarily sized files! See UncachedExternalClientFactory instead.
 var ExternalClientFactory = NewExternalClientFactory()
+
+// UncachedExternalClientFactory is a httpcli.Factory with common options
+// and middleware pre-set for communicating with external services, but with caching
+// responses disabled.
+var UncachedExternalClientFactory = newExternalClientFactory(false)
 
 var (
 	externalTimeout, _          = time.ParseDuration(env.Get("SRC_HTTP_CLI_EXTERNAL_TIMEOUT", "5m", "Timeout for external HTTP requests"))
@@ -105,7 +113,19 @@ var (
 // NewExternalClientFactory returns a httpcli.Factory with common options
 // and middleware pre-set for communicating with external services. Additional
 // middleware can also be provided to e.g. enable logging with NewLoggingMiddleware.
+// WARN: Clients from this factory cache entire responses for etag matching. Do not
+// use them for one-off requests if possible, and definitely not for larger payloads,
+// like downloading arbitrarily sized files!
 func NewExternalClientFactory(middleware ...Middleware) *Factory {
+	return newExternalClientFactory(true, middleware...)
+}
+
+// NewExternalClientFactory returns a httpcli.Factory with common options
+// and middleware pre-set for communicating with external services. Additional
+// middleware can also be provided to e.g. enable logging with NewLoggingMiddleware.
+// If cache is true, responses will be cached in redis for improved rate limiting
+// and reduced byte transfer sizes.
+func newExternalClientFactory(cache bool, middleware ...Middleware) *Factory {
 	mw := []Middleware{
 		ContextErrorMiddleware,
 		HeadersMiddleware("User-Agent", "Sourcegraph-Bot"),
@@ -113,8 +133,7 @@ func NewExternalClientFactory(middleware ...Middleware) *Factory {
 	}
 	mw = append(mw, middleware...)
 
-	return NewFactory(
-		NewMiddleware(mw...),
+	opts := []Opt{
 		NewTimeoutOpt(externalTimeout),
 		// ExternalTransportOpt needs to be before TracedTransportOpt and
 		// NewCachedTransportOpt since it wants to extract a http.Transport,
@@ -125,17 +144,38 @@ func NewExternalClientFactory(middleware ...Middleware) *Factory {
 			ExpJitterDelay(externalRetryDelayBase, externalRetryDelayMax),
 		),
 		TracedTransportOpt,
-		CachedTransportOpt,
+	}
+	if cache {
+		opts = append(opts, CachedTransportOpt)
+	}
+
+	return NewFactory(
+		NewMiddleware(mw...),
+		opts...,
 	)
 }
 
 // ExternalDoer is a shared client for external communication. This is a
 // convenience for existing uses of http.DefaultClient.
+// WARN: This client caches entire responses for etag matching. Do not use it for
+// one-off requests if possible, and definitely not for larger payloads, like
+// downloading arbitrarily sized files! See UncachedExternalClient instead.
 var ExternalDoer, _ = ExternalClientFactory.Doer()
 
 // ExternalClient returns a shared client for external communication. This is
 // a convenience for existing uses of http.DefaultClient.
+// WARN: This client caches entire responses for etag matching. Do not use it for
+// one-off requests if possible, and definitely not for larger payloads, like
+// downloading arbitrarily sized files! See UncachedExternalClient instead.
 var ExternalClient, _ = ExternalClientFactory.Client()
+
+// UncachedExternalDoer is a shared client for external communication with caching
+// disabled. This is a convenience for existing uses of http.DefaultClient.
+var UncachedExternalDoer, _ = UncachedExternalClientFactory.Doer()
+
+// UncachedExternalClient returns a shared client for external communication with
+// caching disabled. This is a convenience for existing uses of http.DefaultClient.
+var UncachedExternalClient, _ = UncachedExternalClientFactory.Client()
 
 // InternalClientFactory is a httpcli.Factory with common options
 // and middleware pre-set for communicating with internal services.

--- a/internal/httpcli/noop_response_cache.go
+++ b/internal/httpcli/noop_response_cache.go
@@ -1,0 +1,7 @@
+package httpcli
+
+type NoopCache struct{}
+
+func (c NoopCache) Get(key string) (responseBytes []byte, ok bool) { return nil, false }
+func (c NoopCache) Set(key string, responseBytes []byte)           {}
+func (c NoopCache) Delete(key string)                              {}

--- a/internal/repos/go_packages.go
+++ b/internal/repos/go_packages.go
@@ -25,17 +25,12 @@ func NewGoPackagesSource(ctx context.Context, svc *types.ExternalService, cf *ht
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
-	if err != nil {
-		return nil, err
-	}
-
 	return &PackagesSource{
 		svc:        svc,
 		configDeps: c.Dependencies,
 		scheme:     dependencies.GoPackagesScheme,
 		src: &goPackagesSource{
-			client: gomodproxy.NewClient(svc.URN(), c.Urls, cli),
+			client: gomodproxy.NewClient(svc.URN(), c.Urls, cf),
 		},
 	}, nil
 }

--- a/internal/repos/go_packages.go
+++ b/internal/repos/go_packages.go
@@ -25,7 +25,7 @@ func NewGoPackagesSource(ctx context.Context, svc *types.ExternalService, cf *ht
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer()
+	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -27,18 +27,13 @@ func NewNpmPackagesSource(ctx context.Context, svc *types.ExternalService, cf *h
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
-	if err != nil {
-		return nil, err
-	}
-
 	return &PackagesSource{
 		svc:        svc,
 		configDeps: c.Dependencies,
 		scheme:     dependencies.NpmPackagesScheme,
 		/* depsSvc initialized in SetDependenciesService */
 		src: &npmPackagesSource{
-			client: npm.NewHTTPClient(svc.URN(), c.Registry, c.Credentials, cli),
+			client: npm.NewHTTPClient(svc.URN(), c.Registry, c.Credentials, cf),
 		},
 	}, nil
 }

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -27,7 +27,7 @@ func NewNpmPackagesSource(ctx context.Context, svc *types.ExternalService, cf *h
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer()
+	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/python_packages.go
+++ b/internal/repos/python_packages.go
@@ -25,16 +25,11 @@ func NewPythonPackagesSource(ctx context.Context, svc *types.ExternalService, cf
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
-	if err != nil {
-		return nil, err
-	}
-
 	return &PackagesSource{
 		svc:        svc,
 		configDeps: c.Dependencies,
 		scheme:     dependencies.PythonPackagesScheme,
-		src:        &pythonPackagesSource{client: pypi.NewClient(svc.URN(), c.Urls, cli)},
+		src:        &pythonPackagesSource{client: pypi.NewClient(svc.URN(), c.Urls, cf)},
 	}, nil
 }
 

--- a/internal/repos/python_packages.go
+++ b/internal/repos/python_packages.go
@@ -25,7 +25,7 @@ func NewPythonPackagesSource(ctx context.Context, svc *types.ExternalService, cf
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer()
+	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/ruby_packages.go
+++ b/internal/repos/ruby_packages.go
@@ -25,7 +25,7 @@ func NewRubyPackagesSource(ctx context.Context, svc *types.ExternalService, cf *
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer()
+	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/ruby_packages.go
+++ b/internal/repos/ruby_packages.go
@@ -25,16 +25,11 @@ func NewRubyPackagesSource(ctx context.Context, svc *types.ExternalService, cf *
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
-	if err != nil {
-		return nil, err
-	}
-
 	return &PackagesSource{
 		svc:        svc,
 		configDeps: c.Dependencies,
 		scheme:     dependencies.RubyPackagesScheme,
-		src:        &rubyPackagesSource{client: rubygems.NewClient(svc.URN(), c.Repository, cli)},
+		src:        &rubyPackagesSource{client: rubygems.NewClient(svc.URN(), c.Repository, cf)},
 	}, nil
 }
 

--- a/internal/repos/rust_packages.go
+++ b/internal/repos/rust_packages.go
@@ -25,7 +25,7 @@ func NewRustPackagesSource(ctx context.Context, svc *types.ExternalService, cf *
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer()
+	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/rust_packages.go
+++ b/internal/repos/rust_packages.go
@@ -25,16 +25,11 @@ func NewRustPackagesSource(ctx context.Context, svc *types.ExternalService, cf *
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
 
-	cli, err := cf.Doer(httpcli.NewCachedTransportOpt(httpcli.NoopCache{}, false))
-	if err != nil {
-		return nil, err
-	}
-
 	return &PackagesSource{
 		svc:        svc,
 		configDeps: c.Dependencies,
 		scheme:     dependencies.RustPackagesScheme,
-		src:        &rustPackagesSource{client: crates.NewClient(svc.URN(), cli)},
+		src:        &rustPackagesSource{client: crates.NewClient(svc.URN(), cf)},
 	}, nil
 }
 


### PR DESCRIPTION
We've encountered that all our external requests are cached in redis, which means (1) that we need to read the entire body into memory so we can serialize it for redis, and (2) that we store potentially gigantic binary files in redis, which we never need to fetch again. This introduces an uncached version of the external doer, adds comments on when to use which, and modifies each of the packages clients to use that doer for the Download operation.



## Test plan

The unit tests
