### PR TITLE
Remove Felix from label notification bot

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -18,11 +18,10 @@ jobs:
                   team/cloud=@sourcegraph/cloud
                   team/search-product=@sourcegraph/search-product
                   team/search-core=@sourcegraph/search-core
-                  team/code-insights=@felixfbecker @vovakulikov
+                  team/code-insights=@vovakulikov
                   team/delivery=@sourcegraph/delivery
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
                   team/repo-management=@ryphil @mrnugget
                   team/devops=@sourcegraph/cloud-devops
                   team/iam=@sourcegraph/iam
-                  team/code-exploration=@felixfbecker


### PR DESCRIPTION
He left, so I assume he doesn't want the pings anymore 😬 

@sourcegraph/code-exploration if you still want those notifications, can you designate a new person / decide if your team handle should receive those instead? 
 
## Test plan

n/a