### PR TITLE
bazel: remove unnecessary jest commonjs workaround

### DIFF
--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -6,10 +6,6 @@ load("//client/shared/dev:generate_schema.bzl", "generate_schema")
 load("//client/shared/dev:generate_graphql_operations.bzl", "generate_graphql_operations")
 load("//client/shared/dev:tools.bzl", "module_style_typings")
 
-# TODO(bazel): @sourcegraph/shared is currently used by jest setup scripts and must be compiled to commonjs.
-# This should be changed to esm once jest setup scripts are moved to a separate package that can be
-# compiled to commonjs specifically and only for jest.
-
 # TODO(bazel): storybook build
 # gazelle:exclude **/*.story.{ts,tsx}
 

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -74,8 +74,6 @@ const config = {
   // Include the pnpm-style rules_js.
   // See pnpm notes at https://jestjs.io/docs/configuration#transformignorepatterns-arraystring
   transformIgnorePatterns: [
-    // TODO(bazel): remove when @sourcegraph/shared is no longer compiled as commonjs. See client/common/BUILD.bazel
-    '@sourcegraph/shared',
     // packages within the root pnpm/rules_js package store
     `<rootDir>/node_modules/.(aspect_rules_js|pnpm)/(?!(${ESM_NPM_DEPS.replace('/', '\\+')})@)`,
     // files under a subdir: eg. '/packages/lib-a/'


### PR DESCRIPTION

## Test plan

locally:
```
bazel test //client/...
```