### PR TITLE
internal/extsvc/bitbucketserver: Wrap json unmarshal error

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -986,7 +986,11 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 	if s, ok := result.(*[]byte); ok {
 		*s = bs
 	} else if result != nil {
-		return resp, json.Unmarshal(bs, result)
+		err := json.Unmarshal(bs, result)
+		if err != nil {
+			return resp, errors.Wrap(err, "failed to unmarshal response to JSON")
+		}
+		return resp, nil
 	}
 
 	return resp, nil

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -986,11 +986,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 	if s, ok := result.(*[]byte); ok {
 		*s = bs
 	} else if result != nil {
-		err := json.Unmarshal(bs, result)
-		if err != nil {
-			return resp, errors.Wrap(err, "failed to unmarshal response to JSON")
-		}
-		return resp, nil
+		return resp, errors.Wrap(json.Unmarshal(bs, result), "failed to unmarshal response to JSON")
 	}
 
 	return resp, nil


### PR DESCRIPTION
The bare bones error message is confusing. Wrapping it to provide more context to the user.. Originally reported in [Slack](https://sourcegraph.slack.com/archives/C04M5M8GWCX/p1678239526686919).

**Current behaviour**

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/2682729/223958359-4ccaa58e-10f0-451b-a67a-c5d40dc0a782.png">

**With the fix**

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/2682729/223957923-aae9b4d9-c583-4ee6-bfb7-2450cc3d9428.png">

## Test plan

- No functional change
- Tested locally
- Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
