### PR TITLE
Remove metadata comparison for checking if repository has been modified

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -271,11 +271,6 @@ func (r *Repo) Update(n *Repo) (modified RepoModified) {
 		modified |= RepoModifiedStars
 	}
 
-	if !reflect.DeepEqual(r.Metadata, n.Metadata) {
-		r.Metadata = n.Metadata
-		modified |= RepoModifiedMetadata
-	}
-
 	for urn, info := range n.Sources {
 		if old, ok := r.Sources[urn]; !ok || !reflect.DeepEqual(info, old) {
 			r.Sources[urn] = info

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -271,6 +271,10 @@ func (r *Repo) Update(n *Repo) (modified RepoModified) {
 		modified |= RepoModifiedStars
 	}
 
+	// We don't compare the Metadata fields to determine whether or not a repo
+	// has been modified. The reflect.DeepEqual always returns false for
+	// some code hosts (i.e. GitHub).
+
 	for urn, info := range n.Sources {
 		if old, ok := r.Sources[urn]; !ok || !reflect.DeepEqual(info, old) {
 			r.Sources[urn] = info


### PR DESCRIPTION
#47635 introduced repository topics as part of the GitHub repo metadata. However, this causes the `reflect.DeepEqual` we do on repo metadata to always return false, and thus all repositories are being marked as Modified. This, in turn, causes a repo permissions sync to be scheduled, making us do a massive amount of repo permission syncs.

## Test plan

I verified that this solves the issue locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
