### PR TITLE
own: disable codeowners ingestion on dotcom

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	own2 "github.com/sourcegraph/sourcegraph/enterprise/internal/own"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/own"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -34,12 +34,12 @@ func TestCodeownersIngestionGuarding(t *testing.T) {
 	db := database.NewMockDB()
 	fs.Wire(db)
 	git := fakeGitserver{}
-	own := own2.NewService(git, db)
+	svc := own.NewService(git, db)
 
 	ctx := context.Background()
 	adminUser := fs.AddUser(types.User{SiteAdmin: false})
 
-	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: New(db, git, own)})
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: New(db, git, svc)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
@@ -1,1 +1,91 @@
 package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go/errors"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	own2 "github.com/sourcegraph/sourcegraph/enterprise/internal/own"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+type fakeOwnService struct {
+}
+
+type fakeGitserver struct {
+	gitserver.Client
+}
+
+func TestCodeownersIngestionGuarding(t *testing.T) {
+	db := database.NewMockDB()
+	git := fakeGitserver{}
+	own := own2.NewService(git, db)
+
+	ctx := context.Background()
+
+	//ctx := userCtx(fs.AddUser(types.User{SiteAdmin: true}))
+
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: New(db, git, own)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pathToQueries := map[string]string{
+		"addCodeownersFile": `
+		mutation add {
+		  addCodeownersFile(input: {fileContents: "* @admin", repoName: "github.com/sourcegraph/sourcegraph"}) {
+			id
+		  }
+		}`,
+		"updateCodeownersFile": `
+		mutation update {
+		 updateCodeownersFile(input: {fileContents: "* @admin", repoName: "github.com/sourcegraph/sourcegraph"}) {
+			id
+		 }
+		}`,
+		"deleteCodeownersFiles": `
+		mutation delete {
+		 deleteCodeownersFiles(repositories:{repoName: "test"}) {
+			alwaysNil
+		 }
+		}`,
+	}
+	for path, query := range pathToQueries {
+		t.Run("feature flag guarding is respected for "+path, func(t *testing.T) {
+			t.Cleanup(func() {
+				ctx = context.TODO()
+			})
+			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": false}, nil, nil))
+			expectedResult := `null`
+			if path == "deleteCodeownersFiles" {
+				expectedResult = `
+					{
+						"deleteCodeownersFiles": null
+					}
+				`
+			}
+			graphqlbackend.RunTest(t, &graphqlbackend.Test{
+				Schema:         schema,
+				Context:        ctx,
+				Query:          query,
+				ExpectedResult: expectedResult,
+				ExpectedErrors: []*errors.QueryError{
+					{Message: "own is not available yet", Path: []any{path}},
+				},
+			})
+		})
+		t.Run("dotcom guarding is respected for "+path, func(t *testing.T) {
+			orig := envvar.SourcegraphDotComMode()
+			envvar.MockSourcegraphDotComMode(true)
+			t.Cleanup(func() {
+				envvar.MockSourcegraphDotComMode(orig)
+			})
+		})
+	}
+
+}

--- a/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
@@ -9,12 +9,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	own2 "github.com/sourcegraph/sourcegraph/enterprise/internal/own"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/fakedb"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-type fakeOwnService struct {
+// userCtx returns a context where give user ID identifies logged in user.
+func userCtx(userID int32) context.Context {
+	ctx := context.Background()
+	a := actor.FromUser(userID)
+	return actor.WithActor(ctx, a)
 }
 
 type fakeGitserver struct {
@@ -22,13 +30,14 @@ type fakeGitserver struct {
 }
 
 func TestCodeownersIngestionGuarding(t *testing.T) {
+	fs := fakedb.New()
 	db := database.NewMockDB()
+	fs.Wire(db)
 	git := fakeGitserver{}
 	own := own2.NewService(git, db)
 
 	ctx := context.Background()
-
-	//ctx := userCtx(fs.AddUser(types.User{SiteAdmin: true}))
+	adminUser := fs.AddUser(types.User{SiteAdmin: false})
 
 	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: New(db, git, own)})
 	if err != nil {
@@ -54,26 +63,26 @@ func TestCodeownersIngestionGuarding(t *testing.T) {
 			alwaysNil
 		 }
 		}`,
+		"codeownersIngestedFiles": `
+		query files {
+		 codeownersIngestedFiles(first:1) {
+			nodes {
+				id
+			}
+		 }
+		}`,
 	}
 	for path, query := range pathToQueries {
 		t.Run("feature flag guarding is respected for "+path, func(t *testing.T) {
+			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": false}, nil, nil))
 			t.Cleanup(func() {
 				ctx = context.TODO()
 			})
-			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": false}, nil, nil))
-			expectedResult := `null`
-			if path == "deleteCodeownersFiles" {
-				expectedResult = `
-					{
-						"deleteCodeownersFiles": null
-					}
-				`
-			}
 			graphqlbackend.RunTest(t, &graphqlbackend.Test{
 				Schema:         schema,
 				Context:        ctx,
 				Query:          query,
-				ExpectedResult: expectedResult,
+				ExpectedResult: nullOrAlwaysNil(t, path),
 				ExpectedErrors: []*errors.QueryError{
 					{Message: "own is not available yet", Path: []any{path}},
 				},
@@ -85,7 +94,44 @@ func TestCodeownersIngestionGuarding(t *testing.T) {
 			t.Cleanup(func() {
 				envvar.MockSourcegraphDotComMode(orig)
 			})
+			graphqlbackend.RunTest(t, &graphqlbackend.Test{
+				Schema:         schema,
+				Context:        ctx,
+				Query:          query,
+				ExpectedResult: nullOrAlwaysNil(t, path),
+				ExpectedErrors: []*errors.QueryError{
+					{Message: "codeownership ingestion is not available on sourcegraph.com", Path: []any{path}},
+				},
+			})
+		})
+		t.Run("site admin guarding is respected for "+path, func(t *testing.T) {
+			ctx = userCtx(adminUser)
+			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
+			t.Cleanup(func() {
+				ctx = context.TODO()
+			})
+			graphqlbackend.RunTest(t, &graphqlbackend.Test{
+				Schema:         schema,
+				Context:        ctx,
+				Query:          query,
+				ExpectedResult: nullOrAlwaysNil(t, path),
+				ExpectedErrors: []*errors.QueryError{
+					{Message: auth.ErrMustBeSiteAdmin.Error(), Path: []any{path}},
+				},
+			})
 		})
 	}
+}
 
+func nullOrAlwaysNil(t *testing.T, endpoint string) string {
+	t.Helper()
+	expectedResult := `null`
+	if endpoint == "deleteCodeownersFiles" {
+		expectedResult = `
+					{
+						"deleteCodeownersFiles": null
+					}
+				`
+	}
+	return expectedResult
 }


### PR DESCRIPTION
part of [#48847](https://github.com/sourcegraph/sourcegraph/issues/48847) - API is now disabled

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/29406849/223999330-be0a7dcb-6988-4d68-89c5-93fb87c18b9e.png">

## Test plan

Added unit tests for feature flag, dotcom and site admin guarding.

Tested manually with `sg start dotcom` on the UI and through the graphQL API.