### PR TITLE
Revert changes to permissions_info.unrestricted resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -46,9 +46,7 @@ func (r *permissionsInfoResolver) UpdatedAt() gqlutil.DateTime {
 }
 
 func (r *permissionsInfoResolver) Unrestricted(ctx context.Context) bool {
-	unrestricted, _ := r.db.Perms().IsRepoUnrestricted(ctx, r.repoID)
-
-	return unrestricted
+	return r.unrestricted
 }
 
 var permissionsInfoRepositoryConnectionMaxPageSize = 100


### PR DESCRIPTION
Partial revert of changes in https://github.com/sourcegraph/sourcegraph/pull/48902/files#diff-cc3ab4699f245179cfe1ee550a0a538ba414af1630e04520eabfcfe702e75dfbL48 which broke CI integration tests. 

The partial revert should work and won't introduce regression bugs. 

Originally permissionsInfo.unrestricted gql api field only checked for repo_permissions.unrestricted column in the DB to find if the repo is unrestricted.

But a repo can generally be unrestricted for other reasons as well.

In the last PR, I updated the resolver for the gql API field to use IsRepoUnrestriced, which checks for both external service tables & repo_permissions tables to check if the repo is unrestricted.

This broke the test, and the correct config for the external service repo was not set, or some other config was wrong.
We tried but couldn't fix the config in the test.

For now, I decided to revert the change specific to the gql field resolver, which won't break anything else, and the test will still work.

## Test plan

- ran CI integration tests locally. 
- doing main dry run
