### PR TITLE
App: Add access token callback page for App

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -12,7 +12,9 @@ import { UserSettingsCreateAccessTokenCallbackPage } from './UserSettingsCreateA
 import { UserSettingsCreateAccessTokenPage } from './UserSettingsCreateAccessTokenPage'
 import { UserSettingsTokensPage } from './UserSettingsTokensPage'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>, TelemetryProps {}
+interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>, TelemetryProps {
+    isSourcegraphDotCom: boolean
+}
 
 export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     const [newToken, setNewToken] = useState<CreateAccessTokenResult['createAccessToken'] | undefined>()


### PR DESCRIPTION
Part of #47998

This adds a new allowed requestor to the user access token callback page that will allow App to make a request to dotcom to "sign in" a user.

Under the hood this uses the same logic that we added for the VS Code extension: The user is redirected to a page on Sourcegraph that will create an access token automatically and redirect the user back to App.

🚨 SECURITY: This flow currently does not need a user to accept the token. This means that if a user has malware installed on their local machine that intercepts `vscode://` links or listens on `localhost:3080` they can create an access token for the user without any user input.

Should we update the step to require the user to confirm the creation of the token?

To make sure we do not cause any additional security issues, the new App requestor is only allowed on dotcom.

## Test plan

- Go to `https://sourcegraph.test:3443/user/settings/tokens/new/callback?requestFrom=APP`
- Observe that a new token is created and the user sees this page briefly before being redirected:

<img width="1031" alt="Screenshot 2023-03-09 at 12 49 44" src="https://user-images.githubusercontent.com/458591/224016125-85b64c4b-946a-4d0b-a404-69b27334dae0.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-sign-in-via-dotcom.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
