### PR TITLE
Add request retrying for Bitbucket Cloud when we encounter a 429

### DIFF
--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -230,6 +230,9 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		return err
 	}
 
+	// Because we have no external rate limiting data for Bitbucket Cloud, we do an exponential
+	// back-off and retry for requests where we recieve a 429 Too Many Requests.
+	// If we still don't succeed after waiting a total of 5 min, we give up.
 	var resp *http.Response
 	var err error
 	sleepTime := 10 * time.Second

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -228,9 +230,24 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		return err
 	}
 
-	resp, err := oauthutil.DoRequest(ctx, nil, c.httpClient, req, c.Auth)
-	if err != nil {
-		return err
+	var resp *http.Response
+	var err error
+	sleepTime := 10 * time.Second
+	for {
+		resp, err = oauthutil.DoRequest(ctx, nil, c.httpClient, req, c.Auth)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			break
+		}
+
+		timeutil.SleepWithContext(ctx, sleepTime)
+		sleepTime = sleepTime * 2
+		if sleepTime.Seconds() > 160 {
+			break
+		}
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Bitbucket Cloud does not provide us with any information when it comes to rate limits. The API has a rate limit of 1000 requests per hour per user, and that hour is a rolling window (i.e. if you exceed 1000 requests in any 60 min window, you will receive 429 responses).

So what this PR does is add an exponential back-off and retry, with a total retry time of ~5 minutes. If the request still does not succeed after that, we give up.

## Test plan

Existing tests should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
