### PR TITLE
azureoauth: Update default scope to include vso.project

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
@@ -105,7 +105,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 // if they are not set in the config.
 func setProviderDefaults(p *schema.AzureDevOpsAuthProvider) {
 	if p.ApiScope == "" {
-		p.ApiScope = "vso.code,vso.identity"
+		p.ApiScope = "vso.code,vso.identity,vso.project"
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider_test.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider_test.go
@@ -38,9 +38,7 @@ func TestParseConfig(t *testing.T) {
 		name          string
 		config        conf.Unified
 		wantProviders []Provider
-
-		// TODO: use this
-		wantProblems []string
+		wantProblems  []string
 	}{
 		{
 			name:          "empty config",
@@ -67,7 +65,7 @@ func TestParseConfig(t *testing.T) {
 						ClientSecret: "myclientsecret",
 						DisplayName:  "Azure Dev Ops",
 						Type:         extsvc.TypeAzureDevOps,
-						ApiScope:     "vso.code,vso.identity",
+						ApiScope:     "vso.code,vso.identity,vso.project",
 					},
 					Provider: newOauthProvider(oauth2.Config{
 						ClientID:     "myclientid",
@@ -77,7 +75,7 @@ func TestParseConfig(t *testing.T) {
 							TokenURL:  "https://app.vssps.visualstudio.com/oauth2/token",
 							AuthStyle: oauth2.AuthStyleInParams,
 						},
-						Scopes:      []string{"vso.code", "vso.identity"},
+						Scopes:      []string{"vso.code", "vso.identity", "vso.project"},
 						RedirectURL: "https://example.com/.auth/azuredevops/callback",
 					}),
 				},
@@ -150,7 +148,7 @@ func TestParseConfig(t *testing.T) {
 						ClientSecret: "myclientsecret",
 						DisplayName:  "Azure Dev Ops",
 						Type:         extsvc.TypeAzureDevOps,
-						ApiScope:     "vso.code,vso.identity",
+						ApiScope:     "vso.code,vso.identity,vso.project",
 					},
 					Provider: newOauthProvider(oauth2.Config{
 						ClientID:     "myclientid",
@@ -160,7 +158,7 @@ func TestParseConfig(t *testing.T) {
 							TokenURL:  "https://app.vssps.visualstudio.com/oauth2/token",
 							AuthStyle: oauth2.AuthStyleInParams,
 						},
-						Scopes:      []string{"vso.code", "vso.identity"},
+						Scopes:      []string{"vso.code", "vso.identity", "vso.project"},
 						RedirectURL: "https://example.com/.auth/azuredevops/callback",
 					}),
 				},

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2300,7 +2300,7 @@
         "apiScope": {
           "type": "string",
           "description": "The OAuth API scope that should be used",
-          "default": "vso.code,vso.identity"
+          "default": "vso.code,vso.identity,vso.project"
         },
         "allowOrgs": {
           "description": "Restricts new logins and signups (if allowSignup is true) to members of these Azure DevOps organizations only. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.",


### PR DESCRIPTION
This is the minimal list of scopes required. Adding it in the default is a nice UX when a site admin is configuring the auth.providers.

## Test plan

- Updated tests
- main-dry-run should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
