### PR TITLE
setup wizard: remove space after "Syncing" status

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -89,7 +89,7 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                                 {codeHost.lastSyncAt !== null && <>Synced, {codeHost.repoCount} repositories found</>}
                                 {codeHost.lastSyncAt === null && (
                                     <>
-                                        Syncing{' '}
+                                        Syncing
                                         {codeHost.repoCount > 0 && (
                                             <>
                                                 , so far {codeHost.repoCount}{' '}


### PR DESCRIPTION
With the space the text would end up as "Syncing , so far". Correct is "Syncing, so far"

## Test plan

- N/A