### PR TITLE
packages: include blocked packages for testing filters

### DIFF
--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -236,9 +236,10 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 
 		for {
 			pkgs, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
-				Scheme: filter.PackageScheme,
-				After:  lastID,
-				Limit:  limit,
+				Scheme:         filter.PackageScheme,
+				After:          lastID,
+				Limit:          limit,
+				IncludeBlocked: true,
 			})
 			if err != nil {
 				return nil, 0, errors.Wrap(err, "failed to list package repo references")
@@ -263,10 +264,11 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 		}
 	} else {
 		pkgs, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
-			Scheme:        filter.PackageScheme,
-			Name:          reposource.PackageName(nameToMatch),
-			ExactNameOnly: true,
-			Limit:         1,
+			Scheme:         filter.PackageScheme,
+			Name:           reposource.PackageName(nameToMatch),
+			ExactNameOnly:  true,
+			Limit:          1,
+			IncludeBlocked: true,
 		})
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "failed to list package repo references")


### PR DESCRIPTION
Previously, blocked packages would not show results in both name and version filters when testing for matches. We should show matches even if theyre covered by another filter

## Test plan

Minor change to return more of the same, covers existing tested codepaths