### PR TITLE
bazel: fix setup to install ibazel and bazelisk for mac

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -42,8 +42,8 @@ var checks = map[string]check.CheckFunc{
 		check.Combine(check.InPath("docker"), check.CommandExitCode("docker info", 0)),
 		"Docker needs to be running",
 	),
-	"bazel":  check.WrapErrMessage(check.InPath("bazel"), "brew install bazel"),
-	"ibazel": check.WrapErrMessage(check.InPath("ibazel"), "brew install ibazel"),
+	"ibazel":   check.WrapErrMessage(check.InPath("ibazel"), "brew install ibazel"),
+	"bazelisk": check.WrapErrMessage(check.InPath("bazelisk"), "brew install bazelisk"),
 }
 
 func runChecksWithName(ctx context.Context, names []string) error {

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -92,6 +92,17 @@ var Mac = []category{
 				Fix:         cmdFix(`brew install nss`),
 			},
 			{
+				// bazelisk manages different bazel versions
+				Name:  "bazelisk",
+				Check: checkAction(check.InPath("bazelisk")),
+				Fix:   cmdFix(`brew install bazelisk`),
+			},
+			{
+				Name:  "ibazel",
+				Check: checkAction(check.InPath("ibazel")),
+				Fix:   cmdFix(`brew install ibazel`),
+			},
+			{
 				Name:  "asdf",
 				Check: checkAction(check.CommandOutputContains("asdf", "version")),
 				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {


### PR DESCRIPTION
* we're not installing raw `bazel` because `bazelisk` is the recommended way to install bazel according to the official docs

Only installing mac. I will do a follow up one for linux machines
## Test plan
* `brew uninstall bazel bazelisk ibazel`
* `go run ./dev/sg setup`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
