### PR TITLE
Reset search text after user picks item in suggestions

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
@@ -52,6 +52,11 @@ export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = pro
         }
     )
 
+    const handleSelectedItemsChange = (orginaziations: string[]): void => {
+        setSearchTerm('')
+        onChange(orginaziations)
+    }
+
     const suggestions = (data?.externalServiceNamespaces?.nodes ?? []).map(item => item.name)
 
     // Render only non-selected organizations and orgs that match search term value
@@ -64,7 +69,7 @@ export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = pro
             selectedItems={organizations}
             getItemKey={identity}
             getItemName={identity}
-            onSelectedItemsChange={onChange}
+            onSelectedItemsChange={handleSelectedItemsChange}
         >
             <MultiComboboxInput
                 value={searchTerm}
@@ -146,6 +151,11 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
         },
     })
 
+    const handleSelectedItemsChange = (repositories: string[]): void => {
+        setSearchTerm('')
+        onChange(repositories)
+    }
+
     const data = currentData ?? previousData
     const suggestions = (data?.externalServiceRepositories?.nodes ?? []).map(item => formatRepositoryName(item.name))
 
@@ -159,7 +169,7 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
             selectedItems={repositories}
             getItemKey={identity}
             getItemName={identity}
-            onSelectedItemsChange={onChange}
+            onSelectedItemsChange={handleSelectedItemsChange}
         >
             <MultiComboboxInput
                 value={searchTerm}


### PR DESCRIPTION
Based on feedback here https://www.loom.com/share/c3c2371c94404e968a4ac17f53eaea76

## Test plan
- Open setup wizard
- Search for a repo or org in their pickers
- When you pick items in the suggestion panel, your input should be reset to an empty value 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-github-pickers.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
