### PR TITLE
Add a hash to the esbuild prod output and include it in the manifest

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -17,7 +17,7 @@ import {
 } from '@sourcegraph/build-config'
 import { isDefined } from '@sourcegraph/common'
 
-import { ENVIRONMENT_CONFIG } from '../utils'
+import { ENVIRONMENT_CONFIG, IS_PRODUCTION } from '../utils'
 
 import { manifestPlugin } from './manifestPlugin'
 
@@ -39,6 +39,7 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     jsxDev: true, // we're only using esbuild for dev server right now
     splitting: true,
     chunkNames: 'chunks/chunk-[name]-[hash]',
+    entryNames: IS_PRODUCTION ? 'scripts/[name]-[hash]' : undefined,
     outdir: STATIC_ASSETS_PATH,
     plugins: [
         stylePlugin,

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -20,7 +20,7 @@
     "task:gulp": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
     "dev": "pnpm task:gulp dev",
     "unsafeDev": "pnpm task:gulp unsafeDev",
-    "build": "pnpm task:gulp build",
+    "build": "NODE_ENV=production pnpm task:gulp build",
     "watch": "pnpm task:gulp watch",
     "watch-webpack": "pnpm task:gulp watchWebpack",
     "webpack": "pnpm task:gulp webpack",


### PR DESCRIPTION
Closes #49008

In production, we want to be able to use an immutable caching strategy.

This, however, requires our assets to have a filename that contains the file hash so that whenever we update the assets, we naturally evict the cache.

With esbuild, this was not the case and even for production builds, assets were outputted as `app.js`. This broke the app deployment but it might also break a web build in the future if we ever want to publish with esbuild.

This fixes it by giving the entrypoint asset a name and then using the `metafile` to find what the file resolves to, after the build.

```
// The bug https://github.com/evanw/esbuild/issues/1384 means that onEnd isn't called in
// serve mode, so write it here instead of waiting for onEnd. This is OK because we
// don't actually need any information that's only available in onEnd.
```

This bug was resolved and we can now use the `onEnd` callback properly. We need this because we now need to inspect the build output.

## Test plan

- Run `DEV_WEB_BUILDER=esbuild sg start` and observe that dev still works:
  <img width="1322" alt="Screenshot 2023-03-09 at 15 48 49" src="https://user-images.githubusercontent.com/458591/224060858-a9c8db3f-fe61-43b6-86c2-33d8cde8ee2d.png">
- Run ` ENTERPRISE=1 DEV_WEB_BUILDER=esbuild pnpm run build-web && cat ui/assets/webpack.manifest.json` to see the prod build working:
  ```
  {
    "app.js": "/.assets/scripts/app-WMT5UEXE.js",
    "app.css": "/.assets/scripts/app-5LIWIKBX.css",
    "isModule": true
  }%
  ```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-esbuild-entrypoint-contenthash.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
