### PR TITLE
SCIM: Avoid auth warnings for SCIM requests

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/log"
@@ -25,6 +26,12 @@ import (
 func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Handler) http.Handler {
 	logger = logger.Scoped("accessTokenAuth", "Access token authentication middleware")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// SCIM uses an auth token which is checked separately in the SCIM package.
+		if strings.HasPrefix(r.URL.Path, "/.api/scim/v2") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		w.Header().Add("Vary", "Authorization")
 
 		var sudoUser string


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/48861

For SCIM's REST endpoint, we use custom auth. Our current validation isn't prepared to recognize it, and it fails because it has a different format.
The SCIM package has its own validation and error handling that's compatible with the SCIM format, so for that endpoint, we can safely avoid using our normal validation.
This is what this PR does.

## Test plan

Tested with SCIM requests. The warnings disappeared, but auth still fails with the wrong token, and passes with the correct one.