### PR TITLE
packages: fix hasNextPage and totalCounts in various places

### DIFF
--- a/cmd/frontend/graphqlbackend/package_repos.go
+++ b/cmd/frontend/graphqlbackend/package_repos.go
@@ -71,18 +71,19 @@ func (r *schemaResolver) PackageRepoReferences(ctx context.Context, args *Packag
 		}
 	}
 
-	deps, total, err := depsService.ListPackageRepoRefs(ctx, opts)
+	deps, total, hasMore, err := depsService.ListPackageRepoRefs(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &packageRepoReferenceConnectionResolver{r.db, deps, total}, err
+	return &packageRepoReferenceConnectionResolver{r.db, deps, hasMore, total}, err
 }
 
 type packageRepoReferenceConnectionResolver struct {
-	db    database.DB
-	deps  []dependencies.PackageRepoReference
-	total int
+	db      database.DB
+	deps    []dependencies.PackageRepoReference
+	hasMore bool
+	total   int
 }
 
 func (r *packageRepoReferenceConnectionResolver) Nodes(ctx context.Context) ([]*packageRepoReferenceResolver, error) {
@@ -123,7 +124,7 @@ func (r *packageRepoReferenceConnectionResolver) TotalCount(ctx context.Context)
 }
 
 func (r *packageRepoReferenceConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if len(r.deps) == 0 {
+	if len(r.deps) == 0 || !r.hasMore {
 		return graphqlutil.HasNextPage(false), nil
 	}
 
@@ -134,6 +135,7 @@ func (r *packageRepoReferenceConnectionResolver) PageInfo(ctx context.Context) (
 
 type packageRepoReferenceVersionConnectionResolver struct {
 	versions []dependencies.PackageRepoRefVersion
+	hasMore  bool
 	total    int
 }
 
@@ -151,7 +153,7 @@ func (r *packageRepoReferenceVersionConnectionResolver) TotalCount(ctx context.C
 }
 
 func (r *packageRepoReferenceVersionConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	if len(r.versions) == 0 {
+	if len(r.versions) == 0 || !r.hasMore {
 		return graphqlutil.HasNextPage(false), nil
 	}
 

--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -60,7 +60,7 @@ type packagesDownloadSource interface {
 // dependenciesService captures the methods we use of the codeintel/dependencies.Service,
 // used to make testing easier.
 type dependenciesService interface {
-	ListPackageRepoRefs(context.Context, dependencies.ListDependencyReposOpts) ([]dependencies.PackageRepoReference, int, error)
+	ListPackageRepoRefs(context.Context, dependencies.ListDependencyReposOpts) ([]dependencies.PackageRepoReference, int, bool, error)
 	InsertPackageRepoRefs(ctx context.Context, deps []dependencies.MinimalPackageRepoRef) ([]dependencies.PackageRepoReference, []dependencies.PackageRepoRefVersion, error)
 	IsPackageRepoVersionAllowed(ctx context.Context, scheme string, pkg reposource.PackageName, version string) (allowed bool, err error)
 }
@@ -343,7 +343,7 @@ func (s *vcsPackagesSyncer) versions(ctx context.Context, packageName reposource
 		}
 	}
 
-	listedPackages, _, err := s.svc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
+	listedPackages, _, _, err := s.svc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
 		Scheme:         s.scheme,
 		Name:           packageName,
 		ExactNameOnly:  true,

--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -250,8 +250,8 @@ func (s *fakeDepsService) IsPackageRepoVersionAllowed(ctx context.Context, schem
 	return true, nil
 }
 
-func (s *fakeDepsService) ListPackageRepoRefs(ctx context.Context, opts dependencies.ListDependencyReposOpts) ([]dependencies.PackageRepoReference, int, error) {
-	return []dependencies.PackageRepoReference{s.deps[opts.Name]}, 1, nil
+func (s *fakeDepsService) ListPackageRepoRefs(ctx context.Context, opts dependencies.ListDependencyReposOpts) ([]dependencies.PackageRepoReference, int, bool, error) {
+	return []dependencies.PackageRepoReference{s.deps[opts.Name]}, 1, false, nil
 }
 
 func (s *fakeDepsService) Add(deps ...string) {

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter.go
@@ -42,7 +42,7 @@ func (j *packagesFilterApplicatorJob) handle(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to check whether package repo filters need applying to anything")
 	}
 
-	filters, err := j.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{})
+	filters, _, err := j.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{})
 	if err != nil {
 		return errors.Wrap(err, "failed to list package repo filters")
 	}
@@ -59,7 +59,7 @@ func (j *packagesFilterApplicatorJob) handle(ctx context.Context) (err error) {
 	)
 
 	for lastID := 0; ; {
-		pkgs, _, err := j.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
+		pkgs, _, _, err := j.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
 			After:          lastID,
 			Limit:          1000,
 			IncludeBlocked: true,

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -58,13 +58,17 @@ func TestPackageRepoFilters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	have, count, err := s.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{Scheme: "npm"})
+	have, count, hasMore, err := s.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{Scheme: "npm"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if count != 1 {
 		t.Errorf("unexpected total count of package repos: want=%d got=%d", 1, count)
+	}
+
+	if hasMore {
+		t.Error("unexpected more-pages flag set, expected no more pages to follow")
 	}
 
 	for i, ref := range have {

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -27,12 +27,12 @@ import (
 type Store interface {
 	WithTransact(context.Context, func(Store) error) error
 
-	ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (dependencyRepos []shared.PackageRepoReference, total int, err error)
+	ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (dependencyRepos []shared.PackageRepoReference, total int, hasMore bool, err error)
 	InsertPackageRepoRefs(ctx context.Context, deps []shared.MinimalPackageRepoRef) (newDeps []shared.PackageRepoReference, newVersions []shared.PackageRepoRefVersion, err error)
 	DeletePackageRepoRefsByID(ctx context.Context, ids ...int) (err error)
 	DeletePackageRepoRefVersionsByID(ctx context.Context, ids ...int) (err error)
 
-	ListPackageRepoRefFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, error)
+	ListPackageRepoRefFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error)
 	CreatePackageRepoFilter(ctx context.Context, input shared.MinimalPackageFilter) (filter *shared.PackageRepoFilter, err error)
 	UpdatePackageRepoFilter(ctx context.Context, input shared.PackageRepoFilter) (err error)
 	DeletePacakgeRepoFilter(ctx context.Context, id int) (err error)
@@ -90,7 +90,7 @@ type ListDependencyReposOpts struct {
 }
 
 // ListDependencyRepos returns dependency repositories to be synced by gitserver.
-func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (dependencyRepos []shared.PackageRepoReference, total int, err error) {
+func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (dependencyRepos []shared.PackageRepoReference, total int, hasMore bool, err error) {
 	ctx, _, endObservation := s.operations.listPackageRepoRefs.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("scheme", opts.Scheme),
 	}})
@@ -110,7 +110,12 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	)
 	dependencyRepos, err = basestore.NewSliceScanner(scanDependencyRepoWithVersions)(s.db.Query(ctx, query))
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "error listing dependency repos")
+		return nil, 0, false, errors.Wrap(err, "error listing dependency repos")
+	}
+
+	if opts.Limit != 0 && len(dependencyRepos) > opts.Limit {
+		dependencyRepos = dependencyRepos[:opts.Limit]
+		hasMore = true
 	}
 
 	query = sqlf.Sprintf(
@@ -123,10 +128,10 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	)
 	totalCount, _, err := basestore.ScanFirstInt(s.db.Query(ctx, query))
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "error counting dependency repos")
+		return nil, 0, false, errors.Wrap(err, "error counting dependency repos")
 	}
 
-	return dependencyRepos, totalCount, err
+	return dependencyRepos, totalCount, hasMore, err
 }
 
 const listDependencyReposQuery = `
@@ -167,7 +172,8 @@ func makeLimit(limit int) *sqlf.Query {
 	if limit == 0 {
 		return sqlf.Sprintf("LIMIT ALL")
 	}
-	return sqlf.Sprintf("LIMIT %s", limit)
+	// + 1 to check if more pages
+	return sqlf.Sprintf("LIMIT %s", limit+1)
 }
 
 func makeOffset(id int) *sqlf.Query {
@@ -438,7 +444,7 @@ type ListPackageRepoRefFiltersOpts struct {
 	Limit          int
 }
 
-func (s *store) ListPackageRepoRefFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) (_ []shared.PackageRepoFilter, err error) {
+func (s *store) ListPackageRepoRefFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) (_ []shared.PackageRepoFilter, hasMore bool, err error) {
 	ctx, _, endObservation := s.operations.listPackageRepoFilters.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("numPackageRepoFilterIDs", len(opts.IDs)),
 		log.String("packageScheme", opts.PackageScheme),
@@ -476,7 +482,8 @@ func (s *store) ListPackageRepoRefFilters(ctx context.Context, opts ListPackageR
 
 	limit := sqlf.Sprintf("")
 	if opts.Limit != 0 {
-		limit = sqlf.Sprintf("LIMIT %s", opts.Limit)
+		// + 1 to check if more pages
+		limit = sqlf.Sprintf("LIMIT %s", opts.Limit+1)
 	}
 
 	filters, err := basestore.NewSliceScanner(scanPackageFilter)(
@@ -487,7 +494,12 @@ func (s *store) ListPackageRepoRefFilters(ctx context.Context, opts ListPackageR
 		)),
 	)
 
-	return filters, err
+	if opts.Limit != 0 && len(filters) > opts.Limit {
+		filters = filters[:opts.Limit]
+		hasMore = true
+	}
+
+	return filters, hasMore, err
 }
 
 const listPackageRepoRefFiltersQuery = `

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -54,7 +54,7 @@ type ListDependencyReposOpts struct {
 	IncludeBlocked bool
 }
 
-func (s *Service) ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (_ []PackageRepoReference, total int, err error) {
+func (s *Service) ListPackageRepoRefs(ctx context.Context, opts ListDependencyReposOpts) (_ []PackageRepoReference, total int, hasMore bool, err error) {
 	ctx, _, endObservation := s.operations.listPackageRepos.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("scheme", opts.Scheme),
 		log.String("name", string(opts.Name)),
@@ -110,7 +110,7 @@ func deref(s *string) string {
 	return *s
 }
 
-func (s *Service) ListPackageRepoFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) (_ []shared.PackageRepoFilter, err error) {
+func (s *Service) ListPackageRepoFilters(ctx context.Context, opts ListPackageRepoRefFiltersOpts) (_ []shared.PackageRepoFilter, hasMore bool, err error) {
 	ctx, _, endObservation := s.operations.listPackageRepoFilters.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("numPackageRepoFilterIDs", len(opts.IDs)),
 		log.String("packageScheme", opts.PackageScheme),
@@ -165,7 +165,7 @@ func (s *Service) IsPackageRepoVersionAllowed(ctx context.Context, scheme string
 	}})
 	defer endObservation(1, observation.Args{})
 
-	filters, err := s.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{
+	filters, _, err := s.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{
 		PackageScheme:  scheme,
 		IncludeDeleted: false,
 	})
@@ -188,7 +188,7 @@ func (s *Service) IsPackageRepoAllowed(ctx context.Context, scheme string, pkg r
 	}})
 	defer endObservation(1, observation.Args{})
 
-	filters, err := s.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{
+	filters, _, err := s.store.ListPackageRepoRefFilters(ctx, store.ListPackageRepoRefFiltersOpts{
 		PackageScheme:  scheme,
 		IncludeDeleted: false,
 	})
@@ -204,7 +204,7 @@ func (s *Service) IsPackageRepoAllowed(ctx context.Context, scheme string, pkg r
 	return packagefilters.IsPackageAllowed(pkg, allowlist, blocklist), nil
 }
 
-func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter shared.MinimalPackageFilter, limit, after int) (_ []shared.PackageRepoReference, _ int, err error) {
+func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter shared.MinimalPackageFilter, limit, after int) (_ []shared.PackageRepoReference, _ int, hasMore bool, err error) {
 	ctx, _, endObservation := s.operations.pkgsOrVersionsMatchingFilter.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("packageScheme", filter.PackageScheme),
 		log.String("versionFilter", fmt.Sprintf("%+v", filter.VersionFilter)),
@@ -223,7 +223,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 		nameToMatch = filter.VersionFilter.PackageName
 	}
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to compile glob")
+		return nil, 0, false, errors.Wrap(err, "failed to compile glob")
 	}
 
 	var (
@@ -234,7 +234,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 	if filter.NameFilter != nil {
 		var lastID int
 		for {
-			pkgs, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
+			pkgs, _, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
 				Scheme: filter.PackageScheme,
 				// doing this so we don't have to load everything in at once
 				Limit:          500,
@@ -242,7 +242,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 				IncludeBlocked: true,
 			})
 			if err != nil {
-				return nil, 0, errors.Wrap(err, "failed to list package repo references")
+				return nil, 0, false, errors.Wrap(err, "failed to list package repo references")
 			}
 
 			if len(pkgs) == 0 {
@@ -258,6 +258,8 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 						continue
 					}
 					if len(matchingPkgs) == limit {
+						// once we've reached the limit but are hitting more, we know theres more
+						hasMore = true
 						continue
 					}
 					pkg.Versions = nil
@@ -266,7 +268,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 			}
 		}
 	} else {
-		pkgs, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
+		pkgs, _, _, err := s.store.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{
 			Scheme:        filter.PackageScheme,
 			Name:          reposource.PackageName(nameToMatch),
 			ExactNameOnly: true,
@@ -275,11 +277,11 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 			IncludeBlocked: true,
 		})
 		if err != nil {
-			return nil, 0, errors.Wrap(err, "failed to list package repo references")
+			return nil, 0, false, errors.Wrap(err, "failed to list package repo references")
 		}
 
 		if len(pkgs) == 0 {
-			return nil, 0, errors.Newf("package repo reference not found for name %q", nameToMatch)
+			return nil, 0, false, errors.Newf("package repo reference not found for name %q", nameToMatch)
 		}
 
 		pkg := pkgs[0]
@@ -291,6 +293,8 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 					continue
 				}
 				if len(versions) == limit {
+					// once we've reached the limit but are hitting more, we know theres more
+					hasMore = true
 					continue
 				}
 				versions = append(versions, version)
@@ -300,5 +304,5 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 		matchingPkgs = append(matchingPkgs, pkg)
 	}
 
-	return matchingPkgs, totalCount, nil
+	return matchingPkgs, totalCount, hasMore, nil
 }

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -35,13 +35,17 @@ func TestGetNpmDependencyRepos(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		deps, _, err := depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
+		deps, _, hasMore, err := depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
 			Scheme:        dependencies.NpmPackagesScheme,
 			Name:          reposource.PackageName(testCase.pkgName),
 			ExactNameOnly: true,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error listing package repos: %v", err)
+		}
+
+		if hasMore {
+			t.Error("unexpected more-pages flag set, expected no more pages to follow")
 		}
 
 		depStrs := []string{}
@@ -67,7 +71,7 @@ func TestGetNpmDependencyRepos(t *testing.T) {
 
 	for _, testCase := range testCases {
 		var depStrs []string
-		deps, _, err := depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
+		deps, _, _, err := depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
 			Scheme:        dependencies.NpmPackagesScheme,
 			Name:          reposource.PackageName(testCase.pkgName),
 			ExactNameOnly: true,

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -92,7 +92,7 @@ func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResul
 	const batchLimit = 100
 	var lastID int
 	for {
-		depRepos, _, err := s.depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
+		depRepos, _, _, err := s.depsSvc.ListPackageRepoRefs(ctx, dependencies.ListDependencyReposOpts{
 			Scheme: s.scheme,
 			After:  lastID,
 			Limit:  batchLimit,


### PR DESCRIPTION
`hasNextPage` was broken in all connection resoleers, and `totalCount`  additionally in `packageRepoReferencesMatchingFilter` endpoint. 

Will change base branch after https://github.com/sourcegraph/sourcegraph/pull/49023 lands

## Test plan

Added unit tests and tested in API console
