### PR TITLE
bext: fix code-intel popover actions

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
@@ -71,6 +71,7 @@ const createMockPlatformContext = (
     settings: NEVER,
     refreshSettings: () => Promise.resolve(),
     sourcegraphURL: '',
+    clientApplication: 'other',
     ...partialMocks,
 })
 

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -288,7 +288,7 @@ export interface FileInfoWithContent extends FileInfoWithRepoName {
 export interface CodeIntelligenceProps extends TelemetryProps {
     platformContext: Pick<
         BrowserPlatformContext,
-        'urlToFile' | 'requestGraphQL' | 'settings' | 'refreshSettings' | 'sourcegraphURL'
+        'urlToFile' | 'requestGraphQL' | 'settings' | 'refreshSettings' | 'sourcegraphURL' | 'clientApplication'
     >
     codeHost: CodeHost
     extensionsController: Controller

--- a/client/shared/src/api/client/connection.ts
+++ b/client/shared/src/api/client/connection.ts
@@ -12,7 +12,7 @@ import { InitData } from '../extension/extensionHost'
 import { registerComlinkTransferHandlers } from '../util'
 
 import { ClientAPI } from './api/api'
-import { initMainThreadAPI } from './mainthread-api'
+import { ExposedToClient, initMainThreadAPI } from './mainthread-api'
 
 export interface ExtensionHostClientConnection {
     /**
@@ -50,6 +50,7 @@ export async function createExtensionHostClientConnection(
     subscription: Unsubscribable
     api: comlink.Remote<FlatExtensionHostAPI>
     mainThreadAPI: MainThreadAPI
+    exposedToClient: ExposedToClient
 }> {
     const subscription = new Subscription()
 
@@ -70,7 +71,7 @@ export async function createExtensionHostClientConnection(
         initialSettings: isSettingsValid(initialSettings) ? initialSettings : { final: {}, subjects: [] },
     })
 
-    const { api: newAPI, subscription: apiSubscriptions } = initMainThreadAPI(proxy, platformContext)
+    const { api: newAPI, exposedToClient, subscription: apiSubscriptions } = initMainThreadAPI(proxy, platformContext)
 
     subscription.add(apiSubscriptions)
 
@@ -86,5 +87,5 @@ export async function createExtensionHostClientConnection(
 
     // TODO(tj): return MainThreadAPI and add to Controller interface
     // to allow app to interact with APIs whose state lives in the main thread
-    return { subscription, api: proxy, mainThreadAPI: newAPI }
+    return { subscription, api: proxy, mainThreadAPI: newAPI, exposedToClient }
 }

--- a/client/shared/src/extensions/createSyncLoadedController.ts
+++ b/client/shared/src/extensions/createSyncLoadedController.ts
@@ -2,6 +2,7 @@ import { Subscription } from 'rxjs'
 
 import { createExtensionHostClientConnection } from '../api/client/connection'
 import type { InitData } from '../api/extension/extensionHost'
+import { syncPromiseSubscription } from '../api/util'
 import type { PlatformContext } from '../platform/context'
 
 import type { Controller } from './controller'
@@ -45,12 +46,14 @@ export function createController(
     // TODO: Debug helpers, logging
 
     return {
-        executeCommand: () => {
-            throw new Error('not implemented')
-        },
-        registerCommand: () => {
-            throw new Error('not implemented')
-        },
+        executeCommand: parameters =>
+            extensionHostClientPromise.then(({ exposedToClient }) => exposedToClient.executeCommand(parameters)),
+        registerCommand: entryToRegister =>
+            syncPromiseSubscription(
+                extensionHostClientPromise.then(({ exposedToClient }) =>
+                    exposedToClient.registerCommand(entryToRegister)
+                )
+            ),
         extHostAPI: extensionHostClientPromise.then(({ api }) => api),
         unsubscribe: () => subscriptions.unsubscribe(),
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48918

1. Registers "Find implementations" contributions only when the client application is Sourcegraph. Browser and VSCode extensions use code-intel extensions bundles that register "Find implementations" action during activation. Without this change two "Find implementations" actions were registered for the browser extension: one by the [code-intel extension](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions@c66e756d3d68a1e19048c3f7515ba42a7e793767/-/blob/template/package.json?L78-88) with `findImplementations` id and one by [`registerHoverContributions`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0fb71ce95adf8d9791fcb6826ef348fae7d8458e/-/blob/client/shared/src/hover/actions.ts?L490-531) with `findImplementations_typescript` id for example. See also https://github.com/sourcegraph/sourcegraph/issues/48918#issuecomment-1462372597. 
2. Reverts change introduced by https://github.com/sourcegraph/sourcegraph/pull/48688 causing "Find references" link not to render in the browser extension code-intel popover. See also https://github.com/sourcegraph/sourcegraph/issues/48918#issuecomment-1462084580.

https://user-images.githubusercontent.com/25318659/224171976-af7b6cc7-3f64-4dff-b43f-5bcf6cc40a1b.mov




## Test plan
- CI passes
- browser extension code-intel popover has "Find references" action
- browser extension code-intel popover has single "Find implementations" action
- Sourcegraph web app code-intel popover has "Find implementations" action 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-code-intel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

