### PR TITLE
Bring back padding between git blame annotations and content

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -219,7 +219,7 @@ const showGitBlameDecorations = Facet.define<BlameDecorationsFacetProps, BlameDe
                 // Move the start of the line to after the blame decoration.
                 // This is necessary because the start of the line is used for
                 // aligning tab characters.
-                paddingLeft: 'var(--blame-decoration-width) !important',
+                paddingLeft: 'calc(var(--blame-decoration-width) + 1rem) !important',
             },
             '.blame-decoration': {
                 // Remove the blame decoration from the content flow so that


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C04931KQVRC/p1678375235273069

This seems to have regressed [with this change](https://github.com/sourcegraph/sourcegraph/pull/47463/files#diff-2d61af119dd9616e1813972bead6f814021fa3abb73bc21e559775318f7d23b9L154-L156).

I couldn't find any issues with this approach no matter if blame annotations are shown or hidden. 

## Test plan

<img width="1254" alt="Screenshot 2023-03-09 at 17 02 02" src="https://user-images.githubusercontent.com/458591/224081918-6da5c033-5565-4462-a0ed-a8ac677df0a9.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-git-blame-bring-back-padding.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
