### PR TITLE
Revert forced NODE_ENV to fix app build

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -17,10 +17,11 @@ import {
 } from '@sourcegraph/build-config'
 import { isDefined } from '@sourcegraph/common'
 
-import { ENVIRONMENT_CONFIG, IS_PRODUCTION } from '../utils'
+import { ENVIRONMENT_CONFIG } from '../utils'
 
 import { manifestPlugin } from './manifestPlugin'
 
+const hashedEntrypoint = Boolean(process.env.ESBUILD_HASHED_ENTRYPOINT)
 const isEnterpriseBuild = ENVIRONMENT_CONFIG.ENTERPRISE
 const omitSlowDeps = ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
 
@@ -39,7 +40,7 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     jsxDev: true, // we're only using esbuild for dev server right now
     splitting: true,
     chunkNames: 'chunks/chunk-[name]-[hash]',
-    entryNames: IS_PRODUCTION ? 'scripts/[name]-[hash]' : undefined,
+    entryNames: hashedEntrypoint ? 'scripts/[name]-[hash]' : undefined,
     outdir: STATIC_ASSETS_PATH,
     plugins: [
         stylePlugin,

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -20,7 +20,7 @@
     "task:gulp": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
     "dev": "pnpm task:gulp dev",
     "unsafeDev": "pnpm task:gulp unsafeDev",
-    "build": "NODE_ENV=production pnpm task:gulp build",
+    "build": "ESBUILD_HASHED_ENTRYPOINT=1 pnpm task:gulp build",
     "watch": "pnpm task:gulp watch",
     "watch-webpack": "pnpm task:gulp watchWebpack",
     "webpack": "pnpm task:gulp webpack",


### PR DESCRIPTION
After merging #49019, we started seeing broken App builds because
apparently part of the compiled assets still think that they are in dev
mode and some parts are not.

I assume this meant that a previous version was running React in
development mode, which is something that we actually need to fix up in
the future.

For now, to unblock the soft-launch, we're reverting the change that
forced a NODE_ENV in the `package.json` and instead add a new env
variable to ensure that the fix still works.

## Test plan

- Verify that the test build works.
- Verify that `ENTERPRISE=1 DEV_WEB_BUILDER=esbuild pnpm run build-web && cat ui/assets/webpack.manifest.json` still works

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-revert-forced-node-env.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
