### PR TITLE
own: document codeowners ingestion

### DIFF
--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -1,0 +1,1 @@
+## Codeowners ingestion

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -1,1 +1,24 @@
 ## Codeowners ingestion
+
+Sourcegraph Own allows you to surface ownership data using `CODEOWNERS` files. 
+This is done automatically if there is a committed `CODEOWNERS` file in your repository at any of the following locations:
+
+```md
+CODEOWNERS
+.github/CODEOWNERS
+.gitlab/CODEOWNERS
+docs/CODEOWNERS
+```
+
+However, it might be you do not want to have a CODEOWNERS file committed to your repository (for example, to avoid automatic review requests), or you would like to overwrite the existing one.
+
+Sourcegraph provides a UI and CLI to ingest a CODEOWNERS file per-repository, that overwrites any committed file.
+
+### Ingesting a file through the UI
+
+### Ingesting a file with src-cli
+
+### Limitations 
+
+- Only site admins can add, update or delete a `CODEOWNERS` file through the ingestion API.
+- Ingested CODEOWNERS files are limited to a size of 10Mb if uploaded through the client.

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -18,7 +18,7 @@ Sourcegraph provides a UI and CLI to ingest a `CODEOWNERS` file per-repository, 
 
 Navigating to any repository page, clicking the Ownership button will surface information about any ingested `CODEOWNERS` file, and will allow you to upload or update an existing one.
 
-[img]
+![img](pending)
 
 ### Ingesting a file with src-cli
 

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -10,15 +10,42 @@ CODEOWNERS
 docs/CODEOWNERS
 ```
 
-However, it might be you do not want to have a CODEOWNERS file committed to your repository (for example, to avoid automatic review requests), or you would like to overwrite the existing one.
+However, it might be you do not want to have a `CODEOWNERS` file committed to your repository (for example, to avoid automatic review requests), or you would like to overwrite the existing one.
 
-Sourcegraph provides a UI and CLI to ingest a CODEOWNERS file per-repository, that overwrites any committed file.
+Sourcegraph provides a UI and CLI to ingest a `CODEOWNERS` file per-repository, that overrides any existing committed file.
 
 ### Ingesting a file through the UI
 
+Navigating to any repository page, clicking the Ownership button will surface information about any ingested `CODEOWNERS` file, and will allow you to upload or update an existing one.
+
+[img]
+
 ### Ingesting a file with src-cli
+
+There is the option to ingest data with the Sourcegraph [src-cli](../cli/quickstart.md).
+The CLI provides `add`, `update`, `delete`, and `list` functionality.
+
+```bash
+'src codeowners' is a tool that manages ingested code ownership data in a Sourcegraph instance.
+
+Usage:
+
+	src codeowners command [command options]
+
+The commands are:
+
+	get	returns the codeowners file for a repository, if exists
+	create	create a codeowners file
+	update	update a codeowners file
+	delete	delete a codeowners file
+
+Use "src codeowners [command] -h" for more information about a command.
+```
+
+The input file can be written inline or passed in. 
 
 ### Limitations 
 
+- The file should respect `CODEOWNERS` formatting for Sourcegraph Own to surface useful information. No formatting validation is done at upload time.
 - Only site admins can add, update or delete a `CODEOWNERS` file through the ingestion API.
-- Ingested CODEOWNERS files are limited to a size of 10Mb if uploaded through the client.
+- Ingested `CODEOWNERS` files are limited to a size of 10Mb if uploaded through the client.

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -14,6 +14,9 @@ However, it might be you do not want to have a `CODEOWNERS` file committed to yo
 
 Sourcegraph provides a UI and CLI to ingest a `CODEOWNERS` file per-repository, that overrides any existing committed file.
 
+You can ingest one `CODEOWNERS` file per repository. 
+At this time the same ingested `CODEOWNERS` file applies to all revisions.
+
 ### Ingesting a file through the UI
 
 Navigating to any repository page, clicking the Ownership button will surface information about any ingested `CODEOWNERS` file, and will allow you to upload or update an existing one.

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -18,7 +18,7 @@ Sourcegraph provides a UI and CLI to ingest a `CODEOWNERS` file per-repository, 
 
 Navigating to any repository page, clicking the Ownership button will surface information about any ingested `CODEOWNERS` file, and will allow you to upload or update an existing one.
 
-![img](pending)
+![Codeowners ingestion UI on sourcegraph/sourcegraph](https://storage.googleapis.com/sourcegraph-assets/docs/images/own/codeowners_ingestion_ui.png)
 
 ### Ingesting a file with src-cli
 

--- a/doc/own/index.md
+++ b/doc/own/index.md
@@ -1,3 +1,11 @@
 # Sourcegraph Own
 
+
+## Requirements
+
+Sourcegraph Own is an enterprise feature in experimental state. 
+A site admin needs to add the feature flag `search-ownership` to enable it.
+
+## References
+
 - [Codeowners ingestion](codeowners_ingestion.md)

--- a/doc/own/index.md
+++ b/doc/own/index.md
@@ -1,1 +1,3 @@
 # Sourcegraph Own
+
+- [Codeowners ingestion](codeowners_ingestion.md)


### PR DESCRIPTION
closes #48587 

<img width="1454" alt="Screenshot 2023-03-09 at 17 30 52" src="https://user-images.githubusercontent.com/29406849/224109682-aa4e08cd-5ec3-421b-9d72-1e2d5e24b93d.png">

## Test plan

`sg run docsite`