### PR TITLE
Setup Wizard: Add debounce to github repositories picker

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
@@ -12,6 +12,7 @@ import {
     MultiComboboxList,
     MultiComboboxOption,
     MultiComboboxOptionText,
+    useDebounce,
 } from '@sourcegraph/wildcard'
 
 import {
@@ -134,6 +135,7 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
     const { token, disabled, repositories, externalServiceId, onChange } = props
 
     const [searchTerm, setSearchTerm] = useState('')
+
     const {
         data: currentData,
         previousData,
@@ -145,7 +147,7 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
         variables: {
             token,
             first: 10,
-            query: searchTerm,
+            query: useDebounce(searchTerm, 500),
             id: externalServiceId ?? null,
             excludeRepositories: repositories,
         },


### PR DESCRIPTION
Prior to this PR, we called github repositories query too often during user typing in the input, and this led to slow query and slow backend response. 

This PR adds debounce logic, and by this, we're avoiding many query calls problem 
 
## Test plan
- Check the repositories picker, make sure that this still provides repositories as you type

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
