### PR TITLE
doc: app: bump to latest version

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -46,7 +46,7 @@ Ensure you have `git` installed / on your path, then install.
 brew install sourcegraph/app/sourcegraph
 ```
 
-**Linux:** via [deb pkg](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+204957.f499bb/sourcegraph_2023.03.23+204957.f499bb_linux_amd64.deb) installer:
+**Linux:** via [deb pkg](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.deb) installer:
 
 ```sh
 dpkg -i <file>.deb
@@ -54,8 +54,8 @@ dpkg -i <file>.deb
 
 **Single-binary zip download:**
 
-* [macOS (universal)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+204957.f499bb/sourcegraph_2023.03.23+204957.f499bb_darwin_all.zip)
-* [linux (x64)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+204957.f499bb/sourcegraph_2023.03.23+204957.f499bb_linux_amd64.zip)
+* [macOS (universal)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip)
+* [linux (x64)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip)
 
 ## Usage
 


### PR DESCRIPTION
Bump docs to latest App version, which fixes a browser caching issue.

## Test plan

Docs change only.