### PR TITLE
Add BasicAuthWithSSH as an auth type for ADO and use it in BC

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1247,9 +1247,11 @@ func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, exter
 			Passphrase: keypair.Passphrase,
 		}
 	} else if externalServiceType == extsvc.TypeAzureDevOps {
-		a = &extsvcauth.BasicAuth{
-			Username: *username,
-			Password: credential,
+		a = &extsvcauth.BasicAuthWithSSH{
+			BasicAuth:  extsvcauth.BasicAuth{Username: *username, Password: credential},
+			PrivateKey: keypair.PrivateKey,
+			PublicKey:  keypair.PublicKey,
+			Passphrase: keypair.Passphrase,
 		}
 	} else {
 		a = &extsvcauth.OAuthBearerTokenWithSSH{

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -144,7 +144,10 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 // unexpected behaviour, or (more likely) errors. At present, only BasicAuth is
 // supported.
 func (c *client) WithAuthenticator(a auth.Authenticator) (Client, error) {
-	if _, ok := a.(*auth.BasicAuth); !ok {
+	switch a.(type) {
+	case *auth.BasicAuth, *auth.BasicAuthWithSSH:
+		break
+	default:
 		return nil, errors.Errorf("authenticator type unsupported for Azure DevOps clients: %s", a)
 	}
 

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -141,8 +141,8 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 // the given authenticator instance.
 //
 // Note that using an unsupported Authenticator implementation may result in
-// unexpected behaviour, or (more likely) errors. At present, only BasicAuth is
-// supported.
+// unexpected behaviour, or (more likely) errors. At present, only BasicAuth and
+// BasicAuthWithSSH are supported.
 func (c *client) WithAuthenticator(a auth.Authenticator) (Client, error) {
 	switch a.(type) {
 	case *auth.BasicAuth, *auth.BasicAuthWithSSH:


### PR DESCRIPTION
Added BasicAuthWithSSH as an auth type for the ADO client, set it for BC to avoid potential future migration issues.


## Test plan

Manual.