### PR TITLE
update to use sourcegraph/backport@v2

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,6 +21,6 @@ jobs:
         )
       )
     steps:
-      - uses: sourcegraph/backport@v2.0.3
+      - uses: sourcegraph/backport@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using sourcegraph/backport@v2 prevents us from having to update this version tag every time a new minor version is released in sourcegraph/backport



## Test plan
GH action ran in sourcegraph/test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
