### PR TITLE
codeintel: Make sure indexer key uses indexer _name_, not the raw input

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -297,7 +297,7 @@ func (r *autoIndexJobDescriptionResolver) Indexer() resolverstubs.CodeIntelIndex
 }
 
 func (r *autoIndexJobDescriptionResolver) ComparisonKey() string {
-	return comparisonKey(r.indexJob.Root, r.indexJob.Indexer)
+	return comparisonKey(r.indexJob.Root, r.Indexer().Name())
 }
 
 func comparisonKey(root, indexer string) string {


### PR DESCRIPTION
Fixes indexer key mismatch.

## Test plan

Tested by hand in API console locally.