### PR TITLE
rbac: make pagination for roles optional and update ordering

### DIFF
--- a/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/roles.go
@@ -45,9 +45,11 @@ func (r *Resolver) Roles(ctx context.Context, args *gql.ListRoleArgs) (*graphqlu
 		&args.ConnectionResolverArgs,
 		&graphqlutil.ConnectionResolverOptions{
 			OrderBy: database.OrderBy{
-				{Field: "roles.id"},
+				{Field: "roles.system"},
+				{Field: "roles.created_at"},
 			},
-			Ascending: true,
+			Ascending:    false,
+			AllowNoLimit: true,
 		},
 	)
 }


### PR DESCRIPTION
We are making the pagination of roles optional so as to be able to render it in a couple of places such as the Profile page, where we currently don't have any rules for pagination.

<img width="908" alt="CleanShot 2023-03-09 at 21 45 48@2x" src="https://user-images.githubusercontent.com/25608335/224153450-714c6cdd-949a-43a1-8881-447dd0163aba.png">

This is only temporary and needed just to get through 5.0; #49038 has been created as a follow-up to make pagination for roles stricter.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested