### PR TITLE
experimental search input: Blur input on submission

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -406,18 +406,21 @@ export function useUpdateEditorFromQueryState(
             return
         }
 
+        const changes =
+            editor.state.sliceDoc() !== queryState.query
+                ? { from: 0, to: editor.state.doc.length, insert: queryState.query }
+                : undefined
         editor.dispatch({
             // Update value if it's different
-            changes:
-                editor.state.sliceDoc() !== queryState.query
-                    ? { from: 0, to: editor.state.doc.length, insert: queryState.query }
-                    : undefined,
+            changes,
             selection: queryState.selectionRange
                 ? // Select the specified range (most of the time this will be a
                   // placeholder filter value).
                   EditorSelection.range(queryState.selectionRange.start, queryState.selectionRange.end)
-                : // Place the cursor at the end of the query.
-                  EditorSelection.cursor(queryState.query.length),
+                : // Place the cursor at the end of the query if it changed.
+                changes
+                ? EditorSelection.cursor(queryState.query.length)
+                : undefined,
             scrollIntoView: true,
         })
 

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+    forwardRef,
+    PropsWithChildren,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
 
 import { defaultKeymap, historyKeymap, history as codemirrorHistory } from '@codemirror/commands'
 import { Compartment, EditorState, Extension, Prec } from '@codemirror/state'
@@ -11,7 +20,7 @@ import useResizeObserver from 'use-resize-observer'
 import * as uuid from 'uuid'
 
 import { HistoryOrNavigate } from '@sourcegraph/common'
-import { useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { Editor, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { QueryChangeSource, QueryState } from '@sourcegraph/shared/src/search'
@@ -28,7 +37,7 @@ import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
 import { filterDecoration } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
-import { editorConfigFacet, Source, suggestions, startCompletion } from './suggestionsExtension'
+import { Source, suggestions, startCompletion } from './suggestionsExtension'
 
 import styles from './CodeMirrorQueryInputWrapper.module.scss'
 
@@ -109,7 +118,6 @@ function configureExtensions({
 
     if (onSubmit) {
         extensions.push(
-            editorConfigFacet.of({ onSubmit }),
             Prec.high(
                 keymap.of([
                     {
@@ -248,145 +256,168 @@ export interface CodeMirrorQueryInputWrapperProps {
     extensions?: Extension
 }
 
-export const CodeMirrorQueryInputWrapper: React.FunctionComponent<
-    React.PropsWithChildren<CodeMirrorQueryInputWrapperProps>
-> = ({
-    queryState,
-    onChange,
-    onSubmit,
-    isLightTheme,
-    interpretComments,
-    patternType,
-    placeholder,
-    suggestionSource,
-    extensions: externalExtensions = empty,
-    children,
-}) => {
-    const navigate = useNavigate()
-    const editorContainerRef = useRef<HTMLDivElement | null>(null)
-    const focusContainerRef = useRef<HTMLDivElement | null>(null)
-    const [suggestionsContainer, setSuggestionsContainer] = useState<HTMLDivElement | null>(null)
-    const popoverID = useMemo(() => uuid.v4(), [])
-    const [mode, setMode, modeNotifierExtension] = useInputMode()
+export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<CodeMirrorQueryInputWrapperProps>>(
+    (
+        {
+            queryState,
+            onChange,
+            onSubmit,
+            isLightTheme,
+            interpretComments,
+            patternType,
+            placeholder,
+            suggestionSource,
+            extensions: externalExtensions = empty,
+            children,
+        },
+        ref
+    ) => {
+        const navigate = useNavigate()
+        const editorContainerRef = useRef<HTMLDivElement | null>(null)
+        const focusContainerRef = useRef<HTMLDivElement | null>(null)
+        const [suggestionsContainer, setSuggestionsContainer] = useState<HTMLDivElement | null>(null)
+        const popoverID = useMemo(() => uuid.v4(), [])
+        const [mode, setMode, modeNotifierExtension] = useInputMode()
 
-    const onSubmitRef = useRef(onSubmit)
-    useEffect(() => {
-        onSubmitRef.current = onSubmit
-    }, [onSubmit])
-    const hasSubmitHandler = !!onSubmit
+        const onSubmitRef = useRef(onSubmit)
+        useEffect(() => {
+            onSubmitRef.current = onSubmit
+        }, [onSubmit])
+        const hasSubmitHandler = !!onSubmit
 
-    const onChangeRef = useRef(onChange)
-    useEffect(() => {
-        onChangeRef.current = onChange
-    }, [onChange])
+        const onChangeRef = useRef(onChange)
+        useEffect(() => {
+            onChangeRef.current = onChange
+        }, [onChange])
 
-    const staticExtensions = useMemo(() => createStaticExtensions({ popoverID }), [popoverID])
-    // Update extensions whenever any of these props change
-    const dynamicExtensions = useMemo(
-        () => [
-            configureExtensions({
+        const staticExtensions = useMemo(() => createStaticExtensions({ popoverID }), [popoverID])
+        // Update extensions whenever any of these props change
+        const dynamicExtensions = useMemo(
+            () => [
+                configureExtensions({
+                    popoverID,
+                    isLightTheme,
+                    placeholder,
+                    onChange: (...args) => onChangeRef.current(...args),
+                    onSubmit: hasSubmitHandler
+                        ? (): void => {
+                              if (onSubmitRef.current) {
+                                  onSubmitRef.current()
+                                  editorRef.current?.contentDOM.blur()
+                              }
+                          }
+                        : undefined,
+                    suggestionsContainer,
+                    suggestionSource,
+                    historyOrNavigate: navigate,
+                }),
+                externalExtensions,
+                modeNotifierExtension,
+            ],
+            [
                 popoverID,
                 isLightTheme,
                 placeholder,
-                onChange: (...args) => onChangeRef.current(...args),
-                onSubmit: hasSubmitHandler ? (): void => onSubmitRef.current?.() : undefined,
+                hasSubmitHandler,
                 suggestionsContainer,
                 suggestionSource,
-                historyOrNavigate: navigate,
+                navigate,
+                externalExtensions,
+                modeNotifierExtension,
+            ]
+        )
+
+        // Update query extensions whenever any of these props change
+        const queryExtensions = useMemo(
+            () => configureQueryExtensions({ patternType, interpretComments }),
+            [patternType, interpretComments]
+        )
+
+        const editorRef = useRef<EditorView | null>(null)
+
+        // Update editor state whenever query state changes
+        useUpdateEditorFromQueryState(editorRef, queryState, startCompletion)
+
+        // Update editor configuration whenever extensions change
+        useEffect(() => updateExtensions(editorRef.current, dynamicExtensions), [dynamicExtensions])
+        useEffect(() => updateQueryExtensions(editorRef.current, queryExtensions), [queryExtensions])
+
+        // Create editor
+        useCodeMirror(
+            editorRef,
+            editorContainerRef,
+            queryState.query,
+            useMemo(
+                () => [
+                    staticExtensions,
+                    extensionsCompartment.of(dynamicExtensions),
+                    querySettingsCompartment.of(queryExtensions),
+                ],
+                // Only set extensions during initialization. dynamicExtensions and queryExtensions
+                // are updated separately.
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                []
+            )
+        )
+
+        useImperativeHandle(
+            ref,
+            () => ({
+                focus() {
+                    editorRef.current?.focus()
+                },
+                blur() {
+                    editorRef.current?.contentDOM.blur()
+                },
             }),
-            externalExtensions,
-            modeNotifierExtension,
-        ],
-        [
-            popoverID,
-            isLightTheme,
-            placeholder,
-            hasSubmitHandler,
-            suggestionsContainer,
-            suggestionSource,
-            navigate,
-            externalExtensions,
-            modeNotifierExtension,
-        ]
-    )
-
-    // Update query extensions whenever any of these props change
-    const queryExtensions = useMemo(
-        () => configureQueryExtensions({ patternType, interpretComments }),
-        [patternType, interpretComments]
-    )
-
-    const editorRef = useRef<EditorView | null>(null)
-
-    // Update editor state whenever query state changes
-    useUpdateEditorFromQueryState(editorRef, queryState, startCompletion)
-
-    // Update editor configuration whenever extensions change
-    useEffect(() => updateExtensions(editorRef.current, dynamicExtensions), [dynamicExtensions])
-    useEffect(() => updateQueryExtensions(editorRef.current, queryExtensions), [queryExtensions])
-
-    // Create editor
-    useCodeMirror(
-        editorRef,
-        editorContainerRef,
-        queryState.query,
-        useMemo(
-            () => [
-                staticExtensions,
-                extensionsCompartment.of(dynamicExtensions),
-                querySettingsCompartment.of(queryExtensions),
-            ],
-            // Only set extensions during initialization. dynamicExtensions and queryExtensions
-            // are updated separately.
-            // eslint-disable-next-line react-hooks/exhaustive-deps
             []
         )
-    )
 
-    // Position cursor at the end of the input when it is initialized
-    useEffect(() => {
-        if (editorRef.current) {
-            editorRef.current.dispatch({
-                selection: { anchor: editorRef.current.state.doc.length },
-            })
-        }
-    }, [])
+        // Position cursor at the end of the input when it is initialized
+        useEffect(() => {
+            if (editorRef.current) {
+                editorRef.current.dispatch({
+                    selection: { anchor: editorRef.current.state.doc.length },
+                })
+            }
+        }, [])
 
-    const focus = useCallback(() => {
-        editorRef.current?.contentDOM.focus()
-    }, [])
+        const focus = useCallback(() => {
+            editorRef.current?.focus()
+        }, [])
 
-    const toggleHistoryMode = useCallback(() => {
-        if (editorRef.current) {
-            setMode(editorRef.current, mode => (mode === 'History' ? null : 'History'))
-            editorRef.current.focus()
-        }
-    }, [setMode])
+        const toggleHistoryMode = useCallback(() => {
+            if (editorRef.current) {
+                setMode(editorRef.current, mode => (mode === 'History' ? null : 'History'))
+                editorRef.current.focus()
+            }
+        }, [setMode])
 
-    const { ref: spacerRef, height: spacerHeight } = useResizeObserver({
-        ref: focusContainerRef,
-    })
+        const { ref: spacerRef, height: spacerHeight } = useResizeObserver({
+            ref: focusContainerRef,
+        })
 
-    return (
-        <div className={styles.container}>
-            {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div className={styles.spacer} style={{ height: `${spacerHeight}px` }} />
-            <div className={styles.root}>
-                <div ref={spacerRef} className={styles.focusContainer}>
-                    <div className={classNames(styles.modeSection, !!mode && styles.active)}>
-                        <Tooltip content="Recent searches">
-                            <Button variant="icon" onClick={toggleHistoryMode} aria-label="Open search history">
-                                <Icon svgPath={mdiClockOutline} aria-hidden="true" />
-                            </Button>
-                        </Tooltip>
-                        {mode && <span className="ml-1">{mode}:</span>}
+        return (
+            <div className={styles.container}>
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <div className={styles.spacer} style={{ height: `${spacerHeight}px` }} />
+                <div className={styles.root}>
+                    <div ref={spacerRef} className={styles.focusContainer}>
+                        <div className={classNames(styles.modeSection, !!mode && styles.active)}>
+                            <Tooltip content="Recent searches">
+                                <Button variant="icon" onClick={toggleHistoryMode} aria-label="Open search history">
+                                    <Icon svgPath={mdiClockOutline} aria-hidden="true" />
+                                </Button>
+                            </Tooltip>
+                            {mode && <span className="ml-1">{mode}:</span>}
+                        </div>
+                        <div ref={editorContainerRef} className={styles.input} />
+                        {!mode && children}
                     </div>
-                    <div ref={editorContainerRef} className={styles.input} />
-                    {!mode && children}
+                    <div ref={setSuggestionsContainer} className={styles.suggestions} />
                 </div>
-                <div ref={setSuggestionsContainer} className={styles.suggestions} />
+                <Shortcut ordered={['/']} onMatch={focus} />
             </div>
-            <Shortcut ordered={['/']} onMatch={focus} />
-        </div>
-    )
-}
+        )
+    }
+)

--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -10,7 +10,7 @@ export type {
     Source,
     SuggestionResult,
 } from './suggestionsExtension'
-export { getEditorConfig, combineResults, selectionListener } from './suggestionsExtension'
+export { combineResults, selectionListener } from './suggestionsExtension'
 export * from './optionRenderer'
 export * from './utils'
 export * from './codemirror/history'

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -21,19 +21,6 @@ import { Suggestions } from './Suggestions'
 
 const ASYNC_THROTTLE_TIME = 300
 
-// Temporary solution to make some editor settings available to other extensions
-interface EditorConfig {
-    onSubmit: () => void
-}
-export const editorConfigFacet = Facet.define<EditorConfig, EditorConfig>({
-    combine(configs) {
-        return configs[0] ?? { onSubmit: () => {} }
-    },
-})
-export function getEditorConfig(state: EditorState): EditorConfig {
-    return state.facet(editorConfigFacet)
-}
-
 /**
  * A source for completion/suggestion results
  */

--- a/client/shared/src/components/CodeMirrorEditor.tsx
+++ b/client/shared/src/components/CodeMirrorEditor.tsx
@@ -94,6 +94,7 @@ export function useCodeMirror(
 
 export interface Editor {
     focus(): void
+    blur(): void
 }
 
 /**
@@ -119,6 +120,9 @@ export const CodeMirrorEditor = React.memo(
                                 scrollIntoView: true,
                             })
                         }
+                    },
+                    blur() {
+                        editorRef.current?.contentDOM.blur()
                     },
                 }),
                 []


### PR DESCRIPTION
**NOTE:** Depends on #48924. Review with whitespace changes hidden.

Currently the search input stays focused when the query is submitted, which implies showing suggestions. This is a problem on the search results page because it covers up part of the page. While the input will be blurred automatically as soon as the results arrived, the input itself shouldn't assume that it will be blurred via an external event.

This PR updates the code to blur the input when the query is submitted. It also fixes a bug where the input is refocused (and therefore the suggestions are shown again) after the query is submitted when the cursor is not positioned at the end of the input.
I wasn't able to find out _why_ this happens but I know it's related to the fact that we update the selection in
`useUpdateEditorFromQueryState` (if I comment out the `selection` change in line 416 the input is not focused again).
To avoid this behavior I simply avoid changing the selection when the query hasn't changed and when the selection is not explicitly set.


Before/after video: 

https://user-images.githubusercontent.com/179026/224158472-fefe36a3-99cf-4a6d-99ff-50beab091468.mp4



## Test plan

Go to search results via an arbitrary search. Position the cursor within the query (not at the end!). Press enter to submit the query
  -> The query input blurs and stays blurred.

## App preview:

- [Web](https://sg-web-fkling-search-input-blur-on-submit.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
