### PR TITLE
CSIM: Welcome email when new scim user created

### DIFF
--- a/enterprise/internal/scim/user_create_test.go
+++ b/enterprise/internal/scim/user_create_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestUserResourceHandler_Create(t *testing.T) {
+	txemail.DisableSilently()
 	t.Parallel()
 
 	db := getMockDB([]*types.UserForSCIM{


### PR DESCRIPTION
Adds a new welcome email that is based on the invitation email when a new user is automatically create from SCIM (via an IDP such as Okta).

The **_Come experience the power of great code search_** links the user to the main site url.
The **_Learn more about Sourcegraph_** links the user to [https://about.sourcegraph.com/](https://about.sourcegraph.com/)
<img width="899" alt="image" src="https://user-images.githubusercontent.com/6098507/224169015-b1d96f54-4177-443b-b207-42c05e96ce4d.png">
## Test plan
tdb
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
