### PR TITLE
packages: fix handling of + allow page cursor in packageRepoReferencesMatchingFilter

### DIFF
--- a/cmd/frontend/graphqlbackend/package_repo_filters.go
+++ b/cmd/frontend/graphqlbackend/package_repo_filters.go
@@ -55,7 +55,7 @@ func (r *schemaResolver) PackageRepoReferencesMatchingFilter(ctx context.Context
 
 	var after int
 	if args.After != nil {
-		if after, err = graphqlutil.DecodeIntCursor(args.After); err != nil {
+		if err = relay.UnmarshalSpec(graphql.ID(*args.After), &after); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/graphqlbackend/package_repos.go
+++ b/cmd/frontend/graphqlbackend/package_repos.go
@@ -130,7 +130,7 @@ func (r *packageRepoReferenceConnectionResolver) PageInfo(ctx context.Context) (
 
 	next := r.deps[len(r.deps)-1].ID
 	cursor := string(relay.MarshalID("PackageRepoReference", next))
-	return graphqlutil.EncodeCursor(&cursor), nil
+	return graphqlutil.NextPageCursor(cursor), nil
 }
 
 type packageRepoReferenceVersionConnectionResolver struct {
@@ -159,7 +159,7 @@ func (r *packageRepoReferenceVersionConnectionResolver) PageInfo(ctx context.Con
 
 	next := r.versions[len(r.versions)-1].ID
 	cursor := string(relay.MarshalID("PackageRepoReferenceVersion", next))
-	return graphqlutil.EncodeCursor(&cursor), nil
+	return graphqlutil.NextPageCursor(cursor), nil
 }
 
 type packageRepoReferenceResolver struct {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1526,6 +1526,10 @@ type Query {
         Returns the first n package/package version matches from the list.
         """
         first: Int
+        """
+        Opaque pagination cursor.
+        """
+        after: String
     ): PackageRepoOrVersionConnection!
 
     """

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -71,10 +71,10 @@ const (
 	lr.name,
 	lr.blocked,
 	lr.last_checked_at,
-	array_agg(prv.id) as vid,
-	array_agg(prv.version) as version,
-	array_agg(prv.blocked) as vers_blocked,
-	array_agg(prv.last_checked_at) as vers_last_checked_at
+	array_agg(prv.id ORDER BY prv.id) as vid,
+	array_agg(prv.version ORDER BY prv.id) as version,
+	array_agg(prv.blocked ORDER BY prv.id) as vers_blocked,
+	array_agg(prv.last_checked_at ORDER BY prv.id) as vers_last_checked_at
 `
 	packageReposColumns = "lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at"
 )

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -254,7 +254,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 			for _, pkg := range pkgs {
 				if matcher.Matches(string(pkg.Name), "") {
 					totalCount++
-					if pkg.ID < after {
+					if pkg.ID <= after {
 						continue
 					}
 					if len(matchingPkgs) == limit {
@@ -289,7 +289,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 		for _, version := range pkg.Versions {
 			if matcher.Matches(string(pkg.Name), version.Version) {
 				totalCount++
-				if version.ID < after {
+				if version.ID <= after {
 					continue
 				}
 				if len(versions) == limit {


### PR DESCRIPTION
We werent actually handling the new cursor format properly :upside_down_face: and there was a hidden bug in paginating. That has been FIXED

## Test plan

Tested in graphql API console with _actual_ pagination
