### PR TITLE
Ignore key presses when modifier is held but shortcut has no modifier defined

### DIFF
--- a/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.test.tsx
@@ -273,5 +273,20 @@ describe('ShortcutManager', () => {
 
             platform.reset()
         })
+
+        it("doesn't match shortcut when any modifier key is held, but no modifier key is defined for the shortcut", () => {
+            const fooSpy = sinon.spy()
+
+            render(
+                <ShortcutProvider>
+                    <Shortcut ordered={['/']} onMatch={fooSpy} />
+                </ShortcutProvider>
+            )
+
+            for (const key of ['Alt', 'Control', 'Meta', 'Shift']) {
+                userEvent.keyboard(`{${key}>}/{/${key}}`)
+                sinon.assert.notCalled(fooSpy)
+            }
+        })
     })
 })

--- a/client/shared/src/react-shortcuts/ShortcutManager.tsx
+++ b/client/shared/src/react-shortcuts/ShortcutManager.tsx
@@ -1,6 +1,6 @@
 import { isMacPlatform } from '@sourcegraph/common'
 
-import { Key, ModifierKey } from './keys'
+import { Key, MODIFIER_KEYS, ModifierKey } from './keys'
 
 const ON_MATCH_DELAY = 500
 
@@ -73,6 +73,10 @@ export class ShortcutManager {
                 return false
             }
 
+            if (!held && isAnyModifierKeyHeld(event)) {
+                return false
+            }
+
             const partiallyMatching = arraysMatch(this.keysPressed, ordered.slice(0, this.keysPressed.length))
 
             if (node) {
@@ -114,6 +118,10 @@ function isModifierHeld(held: Exclude<Data['held'], undefined>, event: KeyboardE
     // calling it here makes the code easier to test
     const modKey = getModKey()
     return held.every(key => event.getModifierState(key === 'Mod' ? modKey : key))
+}
+
+function isAnyModifierKeyHeld(event: KeyboardEvent): boolean {
+    return MODIFIER_KEYS.some(key => event.getModifierState(key))
 }
 
 /**

--- a/client/shared/src/react-shortcuts/keys.ts
+++ b/client/shared/src/react-shortcuts/keys.ts
@@ -75,21 +75,24 @@ export type AlphabetKey =
 
 export type NumericKey = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 
-export type ModifierKey =
-    | 'Alt'
-    | 'AltGraph'
-    | 'CapsLock'
-    | 'Control'
-    | 'Fn'
-    | 'FnLock'
-    | 'Hyper'
-    | 'Meta'
-    | 'NumLock'
-    | 'ScrollLock'
-    | 'Shift'
-    | 'Super'
-    | 'Symbol'
-    | 'SymbolLock'
+export const MODIFIER_KEYS = [
+    'Alt',
+    'AltGraph',
+    'CapsLock',
+    'Control',
+    'Fn',
+    'FnLock',
+    'Hyper',
+    'Meta',
+    'NumLock',
+    'ScrollLock',
+    'Shift',
+    'Super',
+    'Symbol',
+    'SymbolLock',
+] as const
+
+export type ModifierKey = typeof MODIFIER_KEYS[number]
 
 export type SymbolKey =
     | '~'

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { openSearchPanel } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { isEqual } from 'lodash'
+import { isEqual, noop } from 'lodash'
 import { createPath, NavigateFunction, useLocation, useNavigate, Location } from 'react-router-dom'
 
 import {
@@ -437,17 +437,21 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             {overrideBrowserSearchKeybinding && useFileSearch && (
                 <Shortcut ordered={['f']} held={['Mod']} onMatch={openSearch} ignoreInput={true} />
             )}
-            {enableBlobPageSwitchAreasShortcuts &&
-                focusCodeEditorShortcut?.keybindings.map((keybinding, index) => (
-                    <Shortcut
-                        key={index}
-                        {...keybinding}
-                        allowDefault={true}
-                        onMatch={() => {
-                            editorRef.current?.contentDOM.focus()
-                        }}
-                    />
-                ))}
+            {enableBlobPageSwitchAreasShortcuts && focusCodeEditorShortcut && (
+                <>
+                    <Shortcut ordered={['c']} held={['Mod']} allowDefault={true} onMatch={noop} />
+                    {focusCodeEditorShortcut.keybindings.map((keybinding, index) => (
+                        <Shortcut
+                            key={index}
+                            {...keybinding}
+                            allowDefault={containerRef.current?.contains(document.activeElement)}
+                            onMatch={() => {
+                                editorRef.current?.contentDOM.focus()
+                            }}
+                        />
+                    ))}
+                </>
+            )}
         </>
     )
 }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { openSearchPanel } from '@codemirror/search'
 import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { isEqual, noop } from 'lodash'
+import { isEqual } from 'lodash'
 import { createPath, NavigateFunction, useLocation, useNavigate, Location } from 'react-router-dom'
 
 import {
@@ -437,21 +437,17 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             {overrideBrowserSearchKeybinding && useFileSearch && (
                 <Shortcut ordered={['f']} held={['Mod']} onMatch={openSearch} ignoreInput={true} />
             )}
-            {enableBlobPageSwitchAreasShortcuts && focusCodeEditorShortcut && (
-                <>
-                    <Shortcut ordered={['c']} held={['Mod']} allowDefault={true} onMatch={noop} />
-                    {focusCodeEditorShortcut.keybindings.map((keybinding, index) => (
-                        <Shortcut
-                            key={index}
-                            {...keybinding}
-                            allowDefault={containerRef.current?.contains(document.activeElement)}
-                            onMatch={() => {
-                                editorRef.current?.contentDOM.focus()
-                            }}
-                        />
-                    ))}
-                </>
-            )}
+            {enableBlobPageSwitchAreasShortcuts &&
+                focusCodeEditorShortcut?.keybindings.map((keybinding, index) => (
+                    <Shortcut
+                        key={index}
+                        {...keybinding}
+                        allowDefault={true}
+                        onMatch={() => {
+                            editorRef.current?.contentDOM.focus()
+                        }}
+                    />
+                ))}
         </>
     )
 }


### PR DESCRIPTION
Previously if the shortcut had no held modifier key defined, is was matched regardless of whether any modifier key was held.
This logic had an undesired side-effect: depending on the shortcut, the default browser/OS behavior was overridden or tweaked. For example, https://github.com/sourcegraph/sourcegraph/pull/46829 added `C` key shortcut to focus the code editor on the blob page. Selecting some text outside the code editor and pressing `Cmd+C` on Mac not only copied text to the clipboard (expected behavior) but also focused the code editor (unexpected part).
This PR changes the ShortcutManager logic to match shortcuts with no modifiers defined only if no modifier keys were pressed along with the shortcut key.

## Test plan
- CI passes
- Shortcuts with no modifier keys defined should not be matched if any modifier key was pressed along with the shortcut key. For example: 
  - ensure `blob-page-switch-areas-shortcuts` feature flag is enabled
  - select any text outside the code editor and press `Cmd+C` - text should be copied, and the active element shouldn't change
  - `C` key press (without a modifier) should focus the code editor

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-focus-blob.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
