### PR TITLE
chore: Remove backdoor access to stores

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -31,7 +31,7 @@ func NewService(
 	repoUpdater := repoupdater.DefaultClient
 	inferenceSvc := inference.NewService()
 
-	svc := newService(scopedContext("service", observationCtx), store, inferenceSvc, repoUpdater, gitserver, symbolsClient)
+	svc := newService(scopedContext("service", observationCtx), store, inferenceSvc, repoUpdater, db.Repos(), gitserver, symbolsClient)
 
 	return svc
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
@@ -3760,9 +3760,6 @@ type MockStore struct {
 	// GetRepoNameFunc is an instance of a mock function object controlling
 	// the behavior of the method GetRepoName.
 	GetRepoNameFunc *StoreGetRepoNameFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *StoreGetUnsafeDBFunc
 	// InsertDependencyIndexingJobFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// InsertDependencyIndexingJob.
@@ -3906,11 +3903,6 @@ func NewMockStore() *MockStore {
 		},
 		GetRepoNameFunc: &StoreGetRepoNameFunc{
 			defaultHook: func(context.Context, int) (r0 string, r1 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -4091,11 +4083,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetRepoName")
 			},
 		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockStore.GetUnsafeDB")
-			},
-		},
 		InsertDependencyIndexingJobFunc: &StoreInsertDependencyIndexingJobFunc{
 			defaultHook: func(context.Context, int, string, time.Time) (int, error) {
 				panic("unexpected invocation of MockStore.InsertDependencyIndexingJob")
@@ -4242,9 +4229,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetRepoNameFunc: &StoreGetRepoNameFunc{
 			defaultHook: i.GetRepoName,
-		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		InsertDependencyIndexingJobFunc: &StoreInsertDependencyIndexingJobFunc{
 			defaultHook: i.InsertDependencyIndexingJob,
@@ -5948,104 +5932,6 @@ func (c StoreGetRepoNameFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetRepoNameFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetUnsafeDBFunc describes the behavior when the GetUnsafeDB method
-// of the parent MockStore instance is invoked.
-type StoreGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []StoreGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(StoreGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *StoreGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetUnsafeDBFunc) appendCall(r0 StoreGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetUnsafeDBFuncCall objects describing
-// the invocations of this function.
-func (f *StoreGetUnsafeDBFunc) History() []StoreGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetUnsafeDBFuncCall is an object that describes an invocation of
-// method GetUnsafeDB on an instance of MockStore.
-type StoreGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreInsertDependencyIndexingJobFunc describes the behavior when the

--- a/enterprise/internal/codeintel/autoindexing/internal/store/store.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store.go
@@ -56,8 +56,6 @@ type Store interface {
 	GetLanguagesRequestedBy(ctx context.Context, userID int) (_ []string, err error)
 	SetRequestLanguageSupport(ctx context.Context, userID int, language string) (err error)
 
-	GetUnsafeDB() database.DB
-
 	GetRepoName(ctx context.Context, repositoryID int) (_ string, err error)
 	NumRepositoriesWithCodeIntelligence(ctx context.Context) (int, error)
 	RepositoryIDsWithErrors(ctx context.Context, offset, limit int) (_ []shared.RepositoryWithCount, totalCount int, err error)
@@ -105,10 +103,4 @@ func (s *store) transact(ctx context.Context) (*store, error) {
 
 func (s *store) Done(err error) error {
 	return s.db.Done(err)
-}
-
-// GetUnsafeDB returns the underlying database handle. This is used by the
-// resolvers that have the old convention of using the database handle directly.
-func (s *store) GetUnsafeDB() database.DB {
-	return database.NewDBWith(s.logger, s.db)
 }

--- a/enterprise/internal/codeintel/autoindexing/service.go
+++ b/enterprise/internal/codeintel/autoindexing/service.go
@@ -41,6 +41,7 @@ func newService(
 	store store.Store,
 	inferenceSvc InferenceService,
 	repoUpdater RepoUpdaterClient,
+	repoStore database.RepoStore,
 	gitserver GitserverClient,
 	symbolsClient *symbols.Client,
 ) *Service {
@@ -62,6 +63,7 @@ func newService(
 		observationCtx,
 		store,
 		repoUpdater,
+		repoStore,
 		gitserver,
 		jobSelector,
 	)
@@ -168,10 +170,6 @@ func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int,
 
 func (s *Service) UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, data []byte) error {
 	return s.store.UpdateIndexConfigurationByRepositoryID(ctx, repositoryID, data)
-}
-
-func (s *Service) GetUnsafeDB() database.DB {
-	return s.store.GetUnsafeDB()
 }
 
 func (s *Service) ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error) {

--- a/enterprise/internal/codeintel/autoindexing/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/service_test.go
@@ -60,6 +60,7 @@ func TestQueueIndexesExplicit(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		nil, // repoUpdater
+		nil, // repoStore
 		mockGitserverClient,
 		nil, // symbolsClient
 	)
@@ -156,6 +157,7 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		nil, // repoUpdater
+		nil, // repoStore
 		mockGitserverClient,
 		nil, // symbolsClient
 	)
@@ -260,6 +262,7 @@ func TestQueueIndexesInRepository(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		nil, // repoUpdater
+		nil, // repoStore
 		mockGitserverClient,
 		nil, // symbolsClient
 	)
@@ -353,6 +356,7 @@ func TestQueueIndexesInferred(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		nil, // repoUpdater
+		nil, // repoStore
 		mockGitserverClient,
 		nil, // symbolsClient
 	)
@@ -422,6 +426,7 @@ func TestQueueIndexesInferredTooLarge(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		nil, // repoUpdater
+		nil, // repoStore
 		mockGitserverClient,
 		nil, //
 	)
@@ -479,6 +484,7 @@ func TestQueueIndexesForPackage(t *testing.T) {
 		mockDBStore,
 		inferenceService,
 		mockRepoUpdater, // repoUpdater
+		nil,             // repoStore
 		mockGitserverClient,
 		nil, //
 	)

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/mocks_test.go
@@ -16,7 +16,6 @@ import (
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	shared1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	config "github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
@@ -64,9 +63,6 @@ type MockAutoIndexingService struct {
 	// GetSupportedByCtagsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetSupportedByCtags.
 	GetSupportedByCtagsFunc *AutoIndexingServiceGetSupportedByCtagsFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *AutoIndexingServiceGetUnsafeDBFunc
 	// InferIndexConfigurationFunc is an instance of a mock function object
 	// controlling the behavior of the method InferIndexConfiguration.
 	InferIndexConfigurationFunc *AutoIndexingServiceInferIndexConfigurationFunc
@@ -172,11 +168,6 @@ func NewMockAutoIndexingService() *MockAutoIndexingService {
 		},
 		GetSupportedByCtagsFunc: &AutoIndexingServiceGetSupportedByCtagsFunc{
 			defaultHook: func(context.Context, string, api.RepoName) (r0 bool, r1 string, r2 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -308,11 +299,6 @@ func NewStrictMockAutoIndexingService() *MockAutoIndexingService {
 				panic("unexpected invocation of MockAutoIndexingService.GetSupportedByCtags")
 			},
 		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockAutoIndexingService.GetUnsafeDB")
-			},
-		},
 		InferIndexConfigurationFunc: &AutoIndexingServiceInferIndexConfigurationFunc{
 			defaultHook: func(context.Context, int, string, string, bool) (*config.IndexConfiguration, []config.IndexJobHint, error) {
 				panic("unexpected invocation of MockAutoIndexingService.InferIndexConfiguration")
@@ -416,9 +402,6 @@ func NewMockAutoIndexingServiceFrom(i AutoIndexingService) *MockAutoIndexingServ
 		},
 		GetSupportedByCtagsFunc: &AutoIndexingServiceGetSupportedByCtagsFunc{
 			defaultHook: i.GetSupportedByCtags,
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		InferIndexConfigurationFunc: &AutoIndexingServiceInferIndexConfigurationFunc{
 			defaultHook: i.InferIndexConfiguration,
@@ -1821,107 +1804,6 @@ func (c AutoIndexingServiceGetSupportedByCtagsFuncCall) Args() []interface{} {
 // invocation.
 func (c AutoIndexingServiceGetSupportedByCtagsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// AutoIndexingServiceGetUnsafeDBFunc describes the behavior when the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance is
-// invoked.
-type AutoIndexingServiceGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []AutoIndexingServiceGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockAutoIndexingService) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(AutoIndexingServiceGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockAutoIndexingService instance is invoked and the hook
-// queue is empty.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) appendCall(r0 AutoIndexingServiceGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of AutoIndexingServiceGetUnsafeDBFuncCall
-// objects describing the invocations of this function.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) History() []AutoIndexingServiceGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]AutoIndexingServiceGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// AutoIndexingServiceGetUnsafeDBFuncCall is an object that describes an
-// invocation of method GetUnsafeDB on an instance of
-// MockAutoIndexingService.
-type AutoIndexingServiceGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // AutoIndexingServiceInferIndexConfigurationFunc describes the behavior

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_test.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_test.go
@@ -39,7 +39,6 @@ func TestDeleteLSIFIndex(t *testing.T) {
 	mockUploadsService := NewMockUploadsService()
 	mockPolicyService := NewMockPolicyService()
 	mockAutoIndexingService := NewMockAutoIndexingService()
-	mockAutoIndexingService.GetUnsafeDBFunc.SetDefaultReturn(db)
 
 	siteAdminChecker := sharedresolvers.NewSiteAdminChecker(db)
 	locationResolverFactory := sharedresolvers.NewCachedLocationResolverFactory(nil, repos, gitserver.NewClient())
@@ -66,7 +65,6 @@ func TestDeleteLSIFIndexUnauthenticated(t *testing.T) {
 	mockUploadsService := NewMockUploadsService()
 	mockPolicyService := NewMockPolicyService()
 	mockAutoIndexingService := NewMockAutoIndexingService()
-	mockAutoIndexingService.GetUnsafeDBFunc.SetDefaultReturn(db)
 
 	siteAdminChecker := sharedresolvers.NewSiteAdminChecker(db)
 	locationResolverFactory := sharedresolvers.NewCachedLocationResolverFactory(nil, repos, gitserver.NewClient())

--- a/enterprise/internal/codeintel/codenav/internal/store/store.go
+++ b/enterprise/internal/codeintel/codenav/internal/store/store.go
@@ -10,7 +10,6 @@ import (
 
 // Store provides the interface for codenav storage.
 type Store interface {
-	GetUnsafeDB() database.DB
 }
 
 // store manages the codenav store.
@@ -27,10 +26,4 @@ func New(observationCtx *observation.Context, db database.DB) Store {
 		logger:     logger.Scoped("codenav.store", ""),
 		operations: newOperations(observationCtx),
 	}
-}
-
-// GetUnsafeDB returns the underlying database handle. This is used by the
-// resolvers that have the old convention of using the database handle directly.
-func (s *store) GetUnsafeDB() database.DB {
-	return database.NewDBWith(s.logger, s.db)
 }

--- a/enterprise/internal/codeintel/codenav/mocks_test.go
+++ b/enterprise/internal/codeintel/codenav/mocks_test.go
@@ -18,7 +18,6 @@ import (
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	authz "github.com/sourcegraph/sourcegraph/internal/authz"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	precise "github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -26,142 +25,24 @@ import (
 // package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/store)
 // used for unit testing.
-type MockStore struct {
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *StoreGetUnsafeDBFunc
-}
+type MockStore struct{}
 
 // NewMockStore creates a new mock of the Store interface. All methods
 // return zero values for all results, unless overwritten.
 func NewMockStore() *MockStore {
-	return &MockStore{
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
-				return
-			},
-		},
-	}
+	return &MockStore{}
 }
 
 // NewStrictMockStore creates a new mock of the Store interface. All methods
 // panic on invocation, unless overwritten.
 func NewStrictMockStore() *MockStore {
-	return &MockStore{
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockStore.GetUnsafeDB")
-			},
-		},
-	}
+	return &MockStore{}
 }
 
 // NewMockStoreFrom creates a new mock of the MockStore interface. All
 // methods delegate to the given implementation, unless overwritten.
 func NewMockStoreFrom(i store.Store) *MockStore {
-	return &MockStore{
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
-		},
-	}
-}
-
-// StoreGetUnsafeDBFunc describes the behavior when the GetUnsafeDB method
-// of the parent MockStore instance is invoked.
-type StoreGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []StoreGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(StoreGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *StoreGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetUnsafeDBFunc) appendCall(r0 StoreGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetUnsafeDBFuncCall objects describing
-// the invocations of this function.
-func (f *StoreGetUnsafeDBFunc) History() []StoreGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetUnsafeDBFuncCall is an object that describes an invocation of
-// method GetUnsafeDB on an instance of MockStore.
-type StoreGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return &MockStore{}
 }
 
 // MockLsifStore is a mock implementation of the LsifStore interface (from

--- a/enterprise/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -20,7 +20,6 @@ import (
 	shared2 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	authz "github.com/sourcegraph/sourcegraph/internal/authz"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -38,9 +37,6 @@ type MockAutoIndexingService struct {
 	// GetListTagsFunc is an instance of a mock function object controlling
 	// the behavior of the method GetListTags.
 	GetListTagsFunc *AutoIndexingServiceGetListTagsFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *AutoIndexingServiceGetUnsafeDBFunc
 	// NumRepositoriesWithCodeIntelligenceFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
@@ -74,11 +70,6 @@ func NewMockAutoIndexingService() *MockAutoIndexingService {
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: func(context.Context, api.RepoName, ...string) (r0 []*gitdomain.Tag, r1 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -125,11 +116,6 @@ func NewStrictMockAutoIndexingService() *MockAutoIndexingService {
 				panic("unexpected invocation of MockAutoIndexingService.GetListTags")
 			},
 		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockAutoIndexingService.GetUnsafeDB")
-			},
-		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockAutoIndexingService.NumRepositoriesWithCodeIntelligence")
@@ -166,9 +152,6 @@ func NewMockAutoIndexingServiceFrom(i AutoIndexingService) *MockAutoIndexingServ
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: i.GetListTags,
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
@@ -534,107 +517,6 @@ func (c AutoIndexingServiceGetListTagsFuncCall) Args() []interface{} {
 // invocation.
 func (c AutoIndexingServiceGetListTagsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// AutoIndexingServiceGetUnsafeDBFunc describes the behavior when the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance is
-// invoked.
-type AutoIndexingServiceGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []AutoIndexingServiceGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockAutoIndexingService) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(AutoIndexingServiceGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockAutoIndexingService instance is invoked and the hook
-// queue is empty.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) appendCall(r0 AutoIndexingServiceGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of AutoIndexingServiceGetUnsafeDBFuncCall
-// objects describing the invocations of this function.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) History() []AutoIndexingServiceGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]AutoIndexingServiceGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// AutoIndexingServiceGetUnsafeDBFuncCall is an object that describes an
-// invocation of method GetUnsafeDB on an instance of
-// MockAutoIndexingService.
-type AutoIndexingServiceGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc describes the

--- a/enterprise/internal/codeintel/policies/internal/store/store.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store.go
@@ -27,7 +27,6 @@ type Store interface {
 	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
 
 	// Utilities
-	GetUnsafeDB() database.DB
 	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []types.ConfigurationPolicy, err error)
 }
 
@@ -45,10 +44,4 @@ func New(observationCtx *observation.Context, db database.DB) Store {
 		logger:     logger.Scoped("policies.store", ""),
 		operations: newOperations(observationCtx),
 	}
-}
-
-// GetUnsafeDB returns the underlying database handle. This is used by the
-// resolvers that have the old convention of using the database handle directly.
-func (s *store) GetUnsafeDB() database.DB {
-	return database.NewDBWith(s.logger, s.db)
 }

--- a/enterprise/internal/codeintel/policies/mocks_test.go
+++ b/enterprise/internal/codeintel/policies/mocks_test.go
@@ -14,7 +14,6 @@ import (
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store"
 	shared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -41,9 +40,6 @@ type MockStore struct {
 	// GetRepoIDsByGlobPatternsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRepoIDsByGlobPatterns.
 	GetRepoIDsByGlobPatternsFunc *StoreGetRepoIDsByGlobPatternsFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *StoreGetUnsafeDBFunc
 	// RepoCountFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoCount.
 	RepoCountFunc *StoreRepoCountFunc
@@ -87,11 +83,6 @@ func NewMockStore() *MockStore {
 		},
 		GetRepoIDsByGlobPatternsFunc: &StoreGetRepoIDsByGlobPatternsFunc{
 			defaultHook: func(context.Context, []string, int, int) (r0 []int, r1 int, r2 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -147,11 +138,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetRepoIDsByGlobPatterns")
 			},
 		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockStore.GetUnsafeDB")
-			},
-		},
 		RepoCountFunc: &StoreRepoCountFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockStore.RepoCount")
@@ -193,9 +179,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetRepoIDsByGlobPatternsFunc: &StoreGetRepoIDsByGlobPatternsFunc{
 			defaultHook: i.GetRepoIDsByGlobPatterns,
-		},
-		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		RepoCountFunc: &StoreRepoCountFunc{
 			defaultHook: i.RepoCount,
@@ -774,104 +757,6 @@ func (c StoreGetRepoIDsByGlobPatternsFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetRepoIDsByGlobPatternsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetUnsafeDBFunc describes the behavior when the GetUnsafeDB method
-// of the parent MockStore instance is invoked.
-type StoreGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []StoreGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(StoreGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *StoreGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetUnsafeDBFunc) appendCall(r0 StoreGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetUnsafeDBFuncCall objects describing
-// the invocations of this function.
-func (f *StoreGetUnsafeDBFunc) History() []StoreGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetUnsafeDBFuncCall is an object that describes an invocation of
-// method GetUnsafeDB on an instance of MockStore.
-type StoreGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreRepoCountFunc describes the behavior when the RepoCount method of

--- a/enterprise/internal/codeintel/policies/service.go
+++ b/enterprise/internal/codeintel/policies/service.go
@@ -9,7 +9,6 @@ import (
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -259,10 +258,6 @@ func (s *Service) GetPreviewGitObjectFilter(
 	}
 
 	return gitObjects, totalCount, totalCountYoungerThanThreshold, nil
-}
-
-func (s *Service) GetUnsafeDB() database.DB {
-	return s.store.GetUnsafeDB()
 }
 
 func (s *Service) getCommitsVisibleToUpload(ctx context.Context, upload types.Upload) (commits []string, err error) {

--- a/enterprise/internal/codeintel/policies/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/iface.go
@@ -7,7 +7,6 @@ import (
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 type PoliciesService interface {
@@ -19,7 +18,6 @@ type PoliciesService interface {
 	UpdateConfigurationPolicy(ctx context.Context, policy types.ConfigurationPolicy) (err error)
 	DeleteConfigurationPolicyByID(ctx context.Context, id int) error
 	GetPreviewRepositoryFilter(ctx context.Context, patterns []string, limit int) (_ []int, totalCount int, matchesAll bool, repositoryMatchLimit *int, err error)
-	GetUnsafeDB() database.DB
 
 	GetPreviewGitObjectFilter(
 		ctx context.Context,

--- a/enterprise/internal/codeintel/shared/resolvers/iface.go
+++ b/enterprise/internal/codeintel/shared/resolvers/iface.go
@@ -9,14 +9,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	uploadsShared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type AutoIndexingService interface {
 	GetIndexes(ctx context.Context, opts autoindexingShared.GetIndexesOptions) (_ []types.Index, _ int, err error)
 	GetIndexesByIDs(ctx context.Context, ids ...int) (_ []types.Index, err error)
-	GetUnsafeDB() database.DB
 	GetListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) (_ []*gitdomain.Tag, err error)
 
 	NumRepositoriesWithCodeIntelligence(ctx context.Context) (int, error)

--- a/enterprise/internal/codeintel/shared/resolvers/mocks_test.go
+++ b/enterprise/internal/codeintel/shared/resolvers/mocks_test.go
@@ -14,7 +14,6 @@ import (
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	shared1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -32,9 +31,6 @@ type MockAutoIndexingService struct {
 	// GetListTagsFunc is an instance of a mock function object controlling
 	// the behavior of the method GetListTags.
 	GetListTagsFunc *AutoIndexingServiceGetListTagsFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *AutoIndexingServiceGetUnsafeDBFunc
 	// NumRepositoriesWithCodeIntelligenceFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
@@ -65,11 +61,6 @@ func NewMockAutoIndexingService() *MockAutoIndexingService {
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: func(context.Context, api.RepoName, ...string) (r0 []*gitdomain.Tag, r1 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -111,11 +102,6 @@ func NewStrictMockAutoIndexingService() *MockAutoIndexingService {
 				panic("unexpected invocation of MockAutoIndexingService.GetListTags")
 			},
 		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockAutoIndexingService.GetUnsafeDB")
-			},
-		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockAutoIndexingService.NumRepositoriesWithCodeIntelligence")
@@ -147,9 +133,6 @@ func NewMockAutoIndexingServiceFrom(i AutoIndexingService) *MockAutoIndexingServ
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: i.GetListTags,
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
@@ -512,107 +495,6 @@ func (c AutoIndexingServiceGetListTagsFuncCall) Args() []interface{} {
 // invocation.
 func (c AutoIndexingServiceGetListTagsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// AutoIndexingServiceGetUnsafeDBFunc describes the behavior when the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance is
-// invoked.
-type AutoIndexingServiceGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []AutoIndexingServiceGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockAutoIndexingService) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(AutoIndexingServiceGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockAutoIndexingService instance is invoked and the hook
-// queue is empty.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) appendCall(r0 AutoIndexingServiceGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of AutoIndexingServiceGetUnsafeDBFuncCall
-// objects describing the invocations of this function.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) History() []AutoIndexingServiceGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]AutoIndexingServiceGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// AutoIndexingServiceGetUnsafeDBFuncCall is an object that describes an
-// invocation of method GetUnsafeDB on an instance of
-// MockAutoIndexingService.
-type AutoIndexingServiceGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc describes the

--- a/enterprise/internal/codeintel/uploads/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/mocks_test.go
@@ -15,7 +15,6 @@ import (
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	shared1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -33,9 +32,6 @@ type MockAutoIndexingService struct {
 	// GetListTagsFunc is an instance of a mock function object controlling
 	// the behavior of the method GetListTags.
 	GetListTagsFunc *AutoIndexingServiceGetListTagsFunc
-	// GetUnsafeDBFunc is an instance of a mock function object controlling
-	// the behavior of the method GetUnsafeDB.
-	GetUnsafeDBFunc *AutoIndexingServiceGetUnsafeDBFunc
 	// NumRepositoriesWithCodeIntelligenceFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
@@ -66,11 +62,6 @@ func NewMockAutoIndexingService() *MockAutoIndexingService {
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: func(context.Context, api.RepoName, ...string) (r0 []*gitdomain.Tag, r1 error) {
-				return
-			},
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() (r0 database.DB) {
 				return
 			},
 		},
@@ -112,11 +103,6 @@ func NewStrictMockAutoIndexingService() *MockAutoIndexingService {
 				panic("unexpected invocation of MockAutoIndexingService.GetListTags")
 			},
 		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: func() database.DB {
-				panic("unexpected invocation of MockAutoIndexingService.GetUnsafeDB")
-			},
-		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockAutoIndexingService.NumRepositoriesWithCodeIntelligence")
@@ -148,9 +134,6 @@ func NewMockAutoIndexingServiceFrom(i AutoIndexingService) *MockAutoIndexingServ
 		},
 		GetListTagsFunc: &AutoIndexingServiceGetListTagsFunc{
 			defaultHook: i.GetListTags,
-		},
-		GetUnsafeDBFunc: &AutoIndexingServiceGetUnsafeDBFunc{
-			defaultHook: i.GetUnsafeDB,
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
@@ -513,107 +496,6 @@ func (c AutoIndexingServiceGetListTagsFuncCall) Args() []interface{} {
 // invocation.
 func (c AutoIndexingServiceGetListTagsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// AutoIndexingServiceGetUnsafeDBFunc describes the behavior when the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance is
-// invoked.
-type AutoIndexingServiceGetUnsafeDBFunc struct {
-	defaultHook func() database.DB
-	hooks       []func() database.DB
-	history     []AutoIndexingServiceGetUnsafeDBFuncCall
-	mutex       sync.Mutex
-}
-
-// GetUnsafeDB delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockAutoIndexingService) GetUnsafeDB() database.DB {
-	r0 := m.GetUnsafeDBFunc.nextHook()()
-	m.GetUnsafeDBFunc.appendCall(AutoIndexingServiceGetUnsafeDBFuncCall{r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the GetUnsafeDB method
-// of the parent MockAutoIndexingService instance is invoked and the hook
-// queue is empty.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultHook(hook func() database.DB) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetUnsafeDB method of the parent MockAutoIndexingService instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushHook(hook func() database.DB) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) SetDefaultReturn(r0 database.DB) {
-	f.SetDefaultHook(func() database.DB {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) PushReturn(r0 database.DB) {
-	f.PushHook(func() database.DB {
-		return r0
-	})
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) nextHook() func() database.DB {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *AutoIndexingServiceGetUnsafeDBFunc) appendCall(r0 AutoIndexingServiceGetUnsafeDBFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of AutoIndexingServiceGetUnsafeDBFuncCall
-// objects describing the invocations of this function.
-func (f *AutoIndexingServiceGetUnsafeDBFunc) History() []AutoIndexingServiceGetUnsafeDBFuncCall {
-	f.mutex.Lock()
-	history := make([]AutoIndexingServiceGetUnsafeDBFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// AutoIndexingServiceGetUnsafeDBFuncCall is an object that describes an
-// invocation of method GetUnsafeDB on an instance of
-// MockAutoIndexingService.
-type AutoIndexingServiceGetUnsafeDBFuncCall struct {
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 database.DB
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Args() []interface{} {
-	return []interface{}{}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c AutoIndexingServiceGetUnsafeDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // AutoIndexingServiceNumRepositoriesWithCodeIntelligenceFunc describes the

--- a/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_test.go
@@ -29,7 +29,6 @@ func TestDeleteLSIFUpload(t *testing.T) {
 	mockUploadService := NewMockUploadService()
 	mockPolicyService := NewMockPolicyService()
 	mockAutoIndexingService := NewMockAutoIndexingService()
-	mockAutoIndexingService.GetUnsafeDBFunc.SetDefaultReturn(db)
 
 	rootResolver := NewRootResolver(&observation.TestContext, mockUploadService, mockAutoIndexingService, mockPolicyService, siteAdminChecker, nil, nil, nil)
 
@@ -55,7 +54,6 @@ func TestDeleteLSIFUploadUnauthenticated(t *testing.T) {
 	mockUploadService := NewMockUploadService()
 	mockPolicyService := NewMockPolicyService()
 	mockAutoIndexingService := NewMockAutoIndexingService()
-	mockAutoIndexingService.GetUnsafeDBFunc.SetDefaultReturn(db)
 
 	rootResolver := NewRootResolver(&observation.TestContext, mockUploadService, mockAutoIndexingService, mockPolicyService, siteAdminChecker, nil, nil, nil)
 


### PR DESCRIPTION
Remove mostly unused access to underlying db handle via service/store. Replaced only location where it was effectively used with an explicitly passed-in `database.RepoStore`, which is what it ultimately constructed.

## Test plan

Existing unit tests.