### PR TITLE
packages: misc postgres performance + correctness improvements

### DIFF
--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -64,21 +64,6 @@ func (s *store) WithTransact(ctx context.Context, f func(tx Store) error) error 
 	})
 }
 
-const (
-	groupedVersionedPackageReposColumns = `
-	lr.id,
-	lr.scheme,
-	lr.name,
-	lr.blocked,
-	lr.last_checked_at,
-	array_agg(prv.id ORDER BY prv.id) as vid,
-	array_agg(prv.version ORDER BY prv.id) as version,
-	array_agg(prv.blocked ORDER BY prv.id) as vers_blocked,
-	array_agg(prv.last_checked_at ORDER BY prv.id) as vers_last_checked_at
-`
-	packageReposColumns = "lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at"
-)
-
 // ListDependencyReposOpts are options for listing dependency repositories.
 type ListDependencyReposOpts struct {
 	Scheme         string
@@ -104,7 +89,7 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 		listDependencyReposQuery,
 		sqlf.Sprintf(groupedVersionedPackageReposColumns),
 		sqlf.Join([]*sqlf.Query{makeListDependencyReposConds(opts), makeOffset(opts.After)}, "AND"),
-		sqlf.Sprintf("GROUP BY lr.id, lr.scheme, lr.name"),
+		sqlf.Sprintf("GROUP BY lr.id"),
 		sqlf.Sprintf("ORDER BY lr.id ASC"),
 		makeLimit(opts.Limit),
 	)
@@ -134,10 +119,28 @@ func (s *store) ListPackageRepoRefs(ctx context.Context, opts ListDependencyRepo
 	return dependencyRepos, totalCount, hasMore, err
 }
 
+const groupedVersionedPackageReposColumns = `
+	lr.id,
+	lr.scheme,
+	lr.name,
+	lr.blocked,
+	lr.last_checked_at,
+	array_agg(prv.id ORDER BY prv.id) as vid,
+	array_agg(prv.version ORDER BY prv.id) as version,
+	array_agg(prv.blocked ORDER BY prv.id) as vers_blocked,
+	array_agg(prv.last_checked_at ORDER BY prv.id) as vers_last_checked_at
+`
+
 const listDependencyReposQuery = `
 SELECT %s
 FROM lsif_dependency_repos lr
-JOIN package_repo_versions prv ON lr.id = prv.package_id
+JOIN LATERAL (
+    SELECT id, package_id, version, blocked, last_checked_at
+    FROM package_repo_versions
+    WHERE package_id = lr.id
+    ORDER BY id
+) prv
+ON lr.id = prv.package_id
 WHERE %s
 %s -- group by
 %s -- order by

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -13109,6 +13109,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "lsif_dependency_repos_unique_scheme_name",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX lsif_dependency_repos_unique_scheme_name ON lsif_dependency_repos USING btree (scheme, name)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "lsif_dependency_repos_blocked",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -13129,12 +13139,22 @@
           "ConstraintDefinition": ""
         },
         {
-          "Name": "lsif_dependency_repos_name_idx",
+          "Name": "lsif_dependency_repos_name_id",
           "IsPrimaryKey": false,
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX lsif_dependency_repos_name_idx ON lsif_dependency_repos USING btree (name)",
+          "IndexDefinition": "CREATE INDEX lsif_dependency_repos_name_id ON lsif_dependency_repos USING btree (name, id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "lsif_dependency_repos_scheme_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_dependency_repos_scheme_id ON lsif_dependency_repos USING btree (scheme, id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1807,9 +1807,11 @@ Foreign-key constraints:
  last_checked_at | timestamp with time zone |           |          | 
 Indexes:
     "lsif_dependency_repos_pkey" PRIMARY KEY, btree (id)
+    "lsif_dependency_repos_unique_scheme_name" UNIQUE, btree (scheme, name)
     "lsif_dependency_repos_blocked" btree (blocked)
     "lsif_dependency_repos_last_checked_at" btree (last_checked_at)
-    "lsif_dependency_repos_name_idx" btree (name)
+    "lsif_dependency_repos_name_id" btree (name, id)
+    "lsif_dependency_repos_scheme_id" btree (scheme, id)
 Referenced by:
     TABLE "package_repo_versions" CONSTRAINT "package_id_fk" FOREIGN KEY (package_id) REFERENCES lsif_dependency_repos(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1678409821_package_repos_missing_indexes/down.sql
+++ b/migrations/frontend/1678409821_package_repos_missing_indexes/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS lsif_dependency_repos_unique_scheme_name;
+DROP INDEX IF EXISTS lsif_dependency_repos_scheme_id;
+DROP INDEX IF EXISTS lsif_dependency_repos_name_id;
+CREATE INDEX IF NOT EXISTS lsif_dependency_repos_name_idx ON lsif_dependency_repos USING btree (name);

--- a/migrations/frontend/1678409821_package_repos_missing_indexes/metadata.yaml
+++ b/migrations/frontend/1678409821_package_repos_missing_indexes/metadata.yaml
@@ -1,0 +1,2 @@
+name: package_repos_missing_indexes
+parents: [1678220614, 1678320579, 1678380933]

--- a/migrations/frontend/1678409821_package_repos_missing_indexes/up.sql
+++ b/migrations/frontend/1678409821_package_repos_missing_indexes/up.sql
@@ -1,0 +1,9 @@
+CREATE UNIQUE INDEX IF NOT EXISTS lsif_dependency_repos_unique_scheme_name
+ON lsif_dependency_repos USING btree (scheme, name);
+
+CREATE INDEX IF NOT EXISTS lsif_dependency_repos_scheme_id
+ON lsif_dependency_repos USING btree (scheme, id);
+
+DROP INDEX IF EXISTS lsif_dependency_repos_name_idx;
+CREATE INDEX IF NOT EXISTS lsif_dependency_repos_name_id
+ON lsif_dependency_repos USING btree (name, id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5227,7 +5227,11 @@ CREATE INDEX lsif_dependency_repos_blocked ON lsif_dependency_repos USING btree 
 
 CREATE INDEX lsif_dependency_repos_last_checked_at ON lsif_dependency_repos USING btree (last_checked_at);
 
-CREATE INDEX lsif_dependency_repos_name_idx ON lsif_dependency_repos USING btree (name);
+CREATE INDEX lsif_dependency_repos_name_id ON lsif_dependency_repos USING btree (name, id);
+
+CREATE INDEX lsif_dependency_repos_scheme_id ON lsif_dependency_repos USING btree (scheme, id);
+
+CREATE UNIQUE INDEX lsif_dependency_repos_unique_scheme_name ON lsif_dependency_repos USING btree (scheme, name);
 
 CREATE INDEX lsif_dependency_syncing_jobs_state ON lsif_dependency_syncing_jobs USING btree (state);
 


### PR DESCRIPTION
Changes include:
1. Reintroducing the unique index `(scheme,name)` that was originally `(scheme,name,version)` but was dropped when the `version` column was dropped. Not problematic as our insert query guaranteed no duplicates anyways, but nice-to-have
2. Improved query for listing package repo refs. The changes introduced [here](https://github.com/sourcegraph/sourcegraph/pull/48037/files#diff-6dff69941489dc9abde8669bfeaa09319bc712b1745e54c17da8f051e663ca4fR93-R131) caused performance to drop dramatically (see Grafana Screenshot below, after 03/09 00:00 less concentration in the 4th row from the bottom, instead spreading out further to higher rows where higher = slower)
3. Added indexes to `(scheme,id ASC)` and `(name,id ASC)`. Having `id` in these columns helps due to use always having `ORDER BY id`, skipping potential explicit sort steps, as well as the above in due to frequent filtering by scheme or name. Unique index above wouldnt be used due to the postgres preferring to use the primary key index for its sorted `id` column property and filtering on scheme/name instead.

See New Plan and Old Plan below for details.

<details>
<summary>Grafana Screenshot</summary>

![image](https://user-images.githubusercontent.com/18282288/224200497-d3c594a7-50f2-4a52-87cd-a8b33fc5a51e.png)

</details>

<details>
<summary>New Plan</summary>

[Visualize on explain.dalibo.com](https://explain.dalibo.com/plan/4c3g61g7hea992fh)

```sql
EXPLAIN (ANALYZE, BUFFERS, VERBOSE) SELECT
    lr.id,
    lr.scheme,
    lr.name,
    lr.blocked,
    lr.last_checked_at,
    array_agg(prv.id ORDER BY prv.id) as vid,
    array_agg(prv.version ORDER BY prv.id) as version,
    array_agg(prv.blocked ORDER BY prv.id) as vers_blocked,
    array_agg(prv.last_checked_at ORDER BY prv.id) as vers_last_checked_at
FROM lsif_dependency_repos lr
JOIN LATERAL (
    SELECT id, package_id, version, blocked, last_checked_at
    FROM package_repo_versions
    WHERE package_id = lr.id
    ORDER BY id
) prv
ON lr.id = prv.package_id
WHERE scheme = 'rust-analyzer'
GROUP BY lr.id
ORDER BY lr.id
LIMIT 500;
```

```
Limit  (cost=52.02..5985487.30 rows=18 width=170) (actual time=0.083..44.818 rows=500 loops=1)
"  Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, (array_agg(prv.id ORDER BY prv.id)), (array_agg(prv.version ORDER BY prv.id)), (array_agg(prv.blocked ORDER BY prv.id)), (array_agg(prv.last_checked_at ORDER BY prv.id))"
  Buffers: shared hit=33172
  ->  GroupAggregate  (cost=52.02..5985487.30 rows=18 width=170) (actual time=0.082..44.739 rows=500 loops=1)
"        Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, array_agg(prv.id ORDER BY prv.id), array_agg(prv.version ORDER BY prv.id), array_agg(prv.blocked ORDER BY prv.id), array_agg(prv.last_checked_at ORDER BY prv.id)"
        Group Key: lr.id
        Buffers: shared hit=33172
        ->  Nested Loop  (cost=52.02..5985486.72 rows=18 width=66) (actual time=0.042..26.712 rows=14969 loops=1)
"              Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, prv.id, prv.version, prv.blocked, prv.last_checked_at"
              Buffers: shared hit=33172
              ->  Index Scan using noah_test_lsif_dependency_repos_scheme_id on public.lsif_dependency_repos lr  (cost=0.42..27979.76 rows=114057 width=42) (actual time=0.020..0.718 rows=501 loops=1)
"                    Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at"
                    Index Cond: (lr.scheme = 'rust-analyzer'::text)
                    Buffers: shared hit=1004
              ->  Subquery Scan on prv  (cost=51.59..52.22 rows=1 width=32) (actual time=0.034..0.042 rows=30 loops=501)
"                    Output: prv.id, prv.package_id, prv.version, prv.blocked, prv.last_checked_at"
                    Filter: (lr.id = prv.package_id)
                    Buffers: shared hit=32168
                    ->  Sort  (cost=51.59..51.70 rows=42 width=32) (actual time=0.033..0.036 rows=30 loops=501)
"                          Output: package_repo_versions.id, package_repo_versions.package_id, package_repo_versions.version, package_repo_versions.blocked, package_repo_versions.last_checked_at"
                          Sort Key: package_repo_versions.id
                          Sort Method: quicksort  Memory: 25kB
                          Buffers: shared hit=32168
                          ->  Index Scan using package_repo_versions_unique_version_per_package on public.package_repo_versions  (cost=0.43..50.46 rows=42 width=32) (actual time=0.003..0.025 rows=30 loops=501)
"                                Output: package_repo_versions.id, package_repo_versions.package_id, package_repo_versions.version, package_repo_versions.blocked, package_repo_versions.last_checked_at"
                                Index Cond: (package_repo_versions.package_id = lr.id)
                                Buffers: shared hit=32168
Planning Time: 0.227 ms
Execution Time: 44.908 ms

```

</details>

<details>
<summary>Old Plan</summary>

[Visualize on explain.dalibo.com](https://explain.dalibo.com/plan/d2709418e14e89e7)

```sql
EXPLAIN (ANALYZE, VERBOSE, BUFFERS) SELECT
      lr.id,
      lr.scheme,
      lr.name,
      lr.blocked,
      lr.last_checked_at,
      array_agg(prv.id ORDER BY prv.id) as vid,
      array_agg(prv.version ORDER BY prv.id) as version,
      array_agg(prv.blocked ORDER BY prv.id) as vers_blocked,
      array_agg(prv.last_checked_at ORDER BY prv.id) as vers_last_checked_at
FROM lsif_dependency_repos lr
JOIN package_repo_versions prv
ON lr.id = prv.package_id
WHERE scheme = 'rust-analyzer' AND TRUE
GROUP BY lr.id, lr.scheme, lr.name
ORDER BY lr.id ASC
LIMIT 500;
```

```
Limit  (cost=0.85..1093.56 rows=500 width=170) (actual time=294.329..413.149 rows=500 loops=1)
"  Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, (array_agg(prv.id ORDER BY prv.id)), (array_agg(prv.version ORDER BY prv.id)), (array_agg(prv.blocked ORDER BY prv.id)), (array_agg(prv.last_checked_at ORDER BY prv.id))"
  Buffers: shared hit=903886
  ->  GroupAggregate  (cost=0.85..249784.56 rows=114295 width=170) (actual time=294.328..413.072 rows=500 loops=1)
"        Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, array_agg(prv.id ORDER BY prv.id), array_agg(prv.version ORDER BY prv.id), array_agg(prv.blocked ORDER BY prv.id), array_agg(prv.last_checked_at ORDER BY prv.id)"
        Group Key: lr.id
        Buffers: shared hit=903886
        ->  Merge Join  (cost=0.85..240311.37 rows=574983 width=66) (actual time=294.270..392.733 rows=14969 loops=1)
"              Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at, prv.id, prv.version, prv.blocked, prv.last_checked_at"
              Merge Cond: (lr.id = prv.package_id)
              Buffers: shared hit=903886
              ->  Index Scan using noah_test_lsif_dependency_repos_scheme_id on public.lsif_dependency_repos lr  (cost=0.42..27826.97 rows=114295 width=42) (actual time=0.019..0.360 rows=501 loops=1)
"                    Output: lr.id, lr.scheme, lr.name, lr.blocked, lr.last_checked_at"
                    Index Cond: (lr.scheme = 'rust-analyzer'::text)
                    Buffers: shared hit=226
              ->  Index Scan using package_repo_versions_unique_version_per_package on public.package_repo_versions prv  (cost=0.43..203194.13 rows=1329133 width=32) (actual time=0.004..334.291 rows=484029 loops=1)
"                    Output: prv.id, prv.version, prv.blocked, prv.last_checked_at, prv.package_id"
                    Buffers: shared hit=903660
Planning Time: 0.382 ms
Execution Time: 413.239 ms
```

</details>

## Test plan

Lots of querying on dotcom data, back n forth with the Eri{c,k}s, additional unit test coverage
