### PR TITLE
all: add deploy.IsApp and deploy.IsSingleBinary helpers

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -90,7 +90,7 @@ var disableSecurity, _ = strconv.ParseBool(env.Get("DISABLE_SECURITY", "false", 
 
 func init() {
 	conf.ContributeWarning(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
-		if deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) || deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+		if deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) || deploy.IsApp() {
 			return nil
 		}
 		if c.SiteConfig().ExternalURL == "" {
@@ -204,7 +204,7 @@ func storageLimitReachedAlert(args AlertFuncArgs) []*Alert {
 func updateAvailableAlert(args AlertFuncArgs) []*Alert {
 	// TODO(app): App Update Messaging
 	// See: https://github.com/sourcegraph/sourcegraph/issues/48851
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if deploy.IsApp() {
 		return nil
 	}
 
@@ -251,7 +251,7 @@ func isMinorUpdateAvailable(currentVersion, updateVersion string) bool {
 }
 
 func emailSendingNotConfiguredAlert(args AlertFuncArgs) []*Alert {
-	if !args.IsSiteAdmin || deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) || deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if !args.IsSiteAdmin || deploy.IsDeployTypeSingleDockerContainer(deploy.Type()) || deploy.IsApp() {
 		return nil
 	}
 	if conf.Get().EmailSmtp == nil || conf.Get().EmailSmtp.Host == "" {
@@ -274,7 +274,7 @@ func emailSendingNotConfiguredAlert(args AlertFuncArgs) []*Alert {
 func outOfDateAlert(args AlertFuncArgs) []*Alert {
 	// TODO(app): App Update Messaging
 	// See: https://github.com/sourcegraph/sourcegraph/issues/48851
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if deploy.IsApp() {
 		return nil
 	}
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -324,7 +324,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		DeployType:        deploy.Type(),
 
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
-		SourcegraphAppMode:    deploy.IsDeployTypeSingleProgram(deploy.Type()),
+		SourcegraphAppMode:    deploy.IsApp(),
 
 		BillingPublishableKey: BillingPublishableKey,
 
@@ -375,7 +375,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		RunningOnMacOS: runningOnMacOS,
 
-		LocalFilePickerAvailable: deploy.IsDeployTypeSingleProgram(deploy.Type()) && filepicker.Available(),
+		LocalFilePickerAvailable: deploy.IsApp() && filepicker.Available(),
 
 		SrcServeGitUrl: srcServeGitUrl,
 	}

--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -22,7 +22,7 @@ import (
 func serveHelp(w http.ResponseWriter, r *http.Request) {
 	page := strings.TrimPrefix(r.URL.Path, "/help")
 	versionStr := version.Version()
-	sourcegraphAppMode := deploy.IsDeployTypeSingleProgram(deploy.Type())
+	sourcegraphAppMode := deploy.IsApp()
 
 	// For release builds, use the version string. Otherwise, don't use any
 	// version string because:

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -765,8 +765,7 @@ func check(logger log.Logger, db database.DB) {
 
 	updateBodyFunc := updateBody
 	// In Sourcegraph App mode, use limited pings.
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsApp() {
 		updateBodyFunc = limitedUpdateBody
 	}
 	endpoint := updateCheckURL(logger)

--- a/cmd/frontend/internal/bg/app_ready.go
+++ b/cmd/frontend/internal/bg/app_ready.go
@@ -15,7 +15,7 @@ import (
 // AppReady is called once the frontend has reported it is ready to serve
 // requests. It contains tasks related to Sourcegraph App (single binary).
 func AppReady(logger log.Logger) {
-	if !deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if !deploy.IsApp() {
 		return
 	}
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -51,7 +51,7 @@ import (
 )
 
 var (
-	printLogo = env.MustGetBool("LOGO", deploy.IsDeployTypeSingleProgram(deploy.Type()), "print Sourcegraph logo upon startup")
+	printLogo = env.MustGetBool("LOGO", deploy.IsApp(), "print Sourcegraph logo upon startup")
 
 	httpAddr = env.Get("SRC_HTTP_ADDR", func() string {
 		if env.InsecureDev {
@@ -205,7 +205,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })
 	goroutine.Go(func() { users.StartUpdateAggregatedUsersStatisticsTable(context.Background(), db) })
 
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if deploy.IsApp() {
 		enterpriseServices.OptionalResolver.AppResolver = graphqlbackend.NewAppResolver(logger, db)
 	}
 

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -447,8 +447,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 	//    two separate binaries, and separate processes, to function semi-reliably.
 	//
 	// Instead, in Sourcegraph App we defer to Chroma for syntax highlighting.
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsApp() {
 		document, err := highlightWithChroma(code, p.Filepath)
 		if err != nil {
 			return unhighlightedCode(err, code)

--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -153,8 +153,7 @@ func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc) http.Handler
 
 func handleListLanguages(ctagsBinary string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-		if isSingleProgram && ctagsBinary == "" {
+		if deploy.IsSingleBinary() && ctagsBinary == "" {
 			// app: ctags is not available
 			var mapping map[string][]string
 			if err := json.NewEncoder(w).Encode(mapping); err != nil {

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -46,8 +46,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	// anything that tries to open a SQLite database.
 	sqlite.Init()
 
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram && config.Ctags.Command == "" {
+	if deploy.IsSingleBinary() && config.Ctags.Command == "" {
 		// app: ctags is not available
 		searchFunc := func(ctx context.Context, params search.SymbolsParameters) (result.Symbols, error) {
 			return nil, nil

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -60,10 +60,10 @@ func LoadCtagsConfig(baseConfig env.BaseConfig) CtagsConfig {
 	}
 
 	ctagsCommandDefault := "universal-ctags"
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsSingleBinary() {
 		ctagsCommandDefault = ""
 	}
+
 	return CtagsConfig{
 		Command:            baseConfig.Get("CTAGS_COMMAND", ctagsCommandDefault, "ctags command (should point to universal-ctags executable compiled with JSON and seccomp support)"),
 		PatternLengthLimit: baseConfig.GetInt("CTAGS_PATTERN_LENGTH_LIMIT", "250", "the maximum length of the patterns output by ctags"),

--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -54,8 +54,7 @@ type Config struct {
 func (c *Config) Load() {
 	c.FrontendURL = c.Get("EXECUTOR_FRONTEND_URL", "", "The external URL of the sourcegraph instance.")
 	c.FrontendAuthorizationToken = c.Get("EXECUTOR_FRONTEND_PASSWORD", "", "The authorization token supplied to the frontend.")
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsApp() {
 		// In App deployments, we respect the in-memory executor password only.
 		c.FrontendAuthorizationToken = confdefaults.AppInMemoryExecutorPassword
 	}

--- a/enterprise/cmd/executor/singlebinary/service.go
+++ b/enterprise/cmd/executor/singlebinary/service.go
@@ -30,8 +30,8 @@ func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready
 	// Always use the in-memory secret.
 	conf.FrontendAuthorizationToken = confdefaults.AppInMemoryExecutorPassword
 
-	// TODO(sqs) HACK(sqs): run executors for both queues
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	// TODO(sqs) HACK(sqs): TODO(app): run executors for both queues
+	if deploy.IsApp() {
 		otherConfig := *conf
 		if conf.QueueName == "batches" {
 			otherConfig.QueueName = "codeintel"

--- a/enterprise/cmd/frontend/internal/executorqueue/init.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/init.go
@@ -24,8 +24,7 @@ func Init(
 	batchesWorkspaceFileExistsHandler := enterpriseServices.BatchesChangesFileGetHandler
 
 	accessToken := func() string {
-		isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-		if isSingleProgram {
+		if deploy.IsApp() {
 			return confdefaults.AppInMemoryExecutorPassword
 		}
 		return conf.SiteConfig().ExecutorsAccessToken

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -24,8 +24,7 @@ import (
 var frontendInternal = env.Get("SRC_FRONTEND_INTERNAL", defaultFrontendInternal(), "HTTP address for internal frontend HTTP API.")
 
 func defaultFrontendInternal() string {
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsApp() {
 		return "localhost:3090"
 	}
 	return "sourcegraph-frontend-internal"

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -36,7 +36,7 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 		return confdefaults.DockerContainer
 	case deploy.IsDeployTypeKubernetes(deployType), deploy.IsDeployTypeDockerCompose(deployType), deploy.IsDeployTypePureDocker(deployType):
 		return confdefaults.KubernetesOrDockerComposeOrPureDocker
-	case deploy.IsDeployTypeSingleProgram(deployType):
+	case deploy.IsDeployTypeApp(deployType):
 		return confdefaults.App
 	default:
 		panic("deploy type did not register default configuration")
@@ -44,8 +44,7 @@ func defaultConfigForDeployment() conftypes.RawUnified {
 }
 
 func ExecutorsAccessToken() string {
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsApp() {
 		return confdefaults.AppInMemoryExecutorPassword
 	}
 	return Get().ExecutorsAccessToken

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -67,7 +67,7 @@ func getMode() configurationMode {
 }
 
 func getModeUncached() configurationMode {
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if deploy.IsApp() {
 		// App always uses the server mode because everything is running in the same process.
 		return modeServer
 	}

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -71,7 +71,7 @@ func IsDeployTypeSingleDockerContainer(deployType string) bool {
 }
 
 // IsDeployTypeSingleProgram tells if the given deployment type is a single Go program.
-func IsDeployTypeSingleProgram(deployType string) bool {
+func IsDeployTypeApp(deployType string) bool {
 	return deployType == App
 }
 
@@ -88,5 +88,33 @@ func IsValidDeployType(deployType string) bool {
 		IsDeployTypePureDocker(deployType) ||
 		IsDeployTypeSingleDockerContainer(deployType) ||
 		IsDev(deployType) ||
-		IsDeployTypeSingleProgram(deployType)
+		IsDeployTypeApp(deployType)
+}
+
+// IsApp tells if the running deployment is a Sourcegraph App deployment.
+//
+// Sourcegraph App is always a single-binary, but not all single-binary deployments are
+// a Sourcegraph app.
+//
+// In the future, all Sourcegraph deployments will be a single-binary. For example gitserver will
+// be `sourcegraph --as=gitserver` or similar. Use IsSingleBinary() for code that should always
+// run in a single-binary setting, and use IsApp() for code that should only run as part of the
+// Sourcegraph desktop app.
+func IsApp() bool {
+	return Type() == App
+}
+
+// IsSingleBinary tells if the running deployment is a single-binary or not.
+//
+// Sourcegraph App is always a single-binary, but not all single-binary deployments are
+// a Sourcegraph app.
+//
+// In the future, all Sourcegraph deployments will be a single-binary. For example gitserver will
+// be `sourcegraph --as=gitserver` or similar. Use IsSingleBinary() for code that should always
+// run in a single-binary setting, and use IsApp() for code that should only run as part of the
+// Sourcegraph desktop app.
+func IsSingleBinary() bool {
+	// TODO(single-binary): check in the future if this is any single-binary deployment, not just
+	// app.
+	return Type() == App
 }

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1467,8 +1467,7 @@ func ExternalRepoSpec(repo *Repository, baseURL *url.URL) api.ExternalRepoSpec {
 }
 
 func githubBaseURLDefault() string {
-	isSingleProgram := deploy.IsDeployTypeSingleProgram(deploy.Type())
-	if isSingleProgram {
+	if deploy.IsSingleBinary() {
 		return ""
 	}
 	return "http://github-proxy"

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -40,12 +40,10 @@ var addresses = func() struct {
 		return ""
 	}
 
-	deployType := deploy.Type()
-
 	for _, addr := range []string{
 		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),
 		fallback,
-		maybe(deploy.IsDeployTypeSingleProgram(deployType), MemoryKeyValueURI),
+		maybe(deploy.IsSingleBinary(), MemoryKeyValueURI),
 		"redis-cache:6379",
 	} {
 		if addr != "" {
@@ -58,7 +56,7 @@ var addresses = func() struct {
 	for _, addr := range []string{
 		env.Get("REDIS_STORE_ENDPOINT", "", "redis used for persistent stores (eg HTTP sessions). Default redis-store:6379"),
 		fallback,
-		maybe(deploy.IsDeployTypeSingleProgram(deployType), DBKeyValueURI("store")),
+		maybe(deploy.IsSingleBinary(), DBKeyValueURI("store")),
 		"redis-store:6379",
 	} {
 		if addr != "" {

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -42,7 +42,7 @@ func repoUpdaterURLDefault() string {
 		return u
 	}
 
-	if deploy.IsDeployTypeSingleProgram(deploy.Type()) {
+	if deploy.IsApp() {
 		return "http://127.0.0.1:3182"
 	}
 


### PR DESCRIPTION
Context: I am working towards us having two definitions in our codebase:

1. "App" -> the _deployment type_ of Sourcegraph you use on your local machine.
2. "Single binary" -> App is always single-binary, but not all single-binaries are App. In the future, all Sourcegraph services will be "single binary" and so this term will exist in our codebase to refer to code that is used when ran in a "single binary" setting.

---

Stacked on top of #49064

This change introduces `deploy.IsApp()` and `deploy.IsSingleBinary()` helpers that do not need to be fed the deployment type.

## Test plan

Existing tests