### PR TITLE
web: eliminate redundant history entries on sync

### DIFF
--- a/client/web/src/repo/blob/codemirror/react-interop.tsx
+++ b/client/web/src/repo/blob/codemirror/react-interop.tsx
@@ -46,7 +46,7 @@ const SyncInnerRouterWithParent: React.FC<{ navigate: NavigateFunction }> = ({ n
         ) {
             return
         }
-        navigate(location)
+        navigate(location, { replace: true })
     }, [location, navigate, initialLocation])
     return null
 }


### PR DESCRIPTION
## Context

When we sync the `CodeMirror` location with the parent router, we want to use `replace: true` to avoid creating duplicate history entries. Reported and discussed in [this Slack thread](https://sourcegraph.slack.com/archives/C04931KQVRC/p1678320592769639).

## Test plan

1. Use go to the definition in the CodeMirror blob
2. Press the back browser button to return to the previous location.

## App preview:

- [Web](https://sg-web-vb-sync-router.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
