### PR TITLE
Replace `p4 ping` with `p4 login -s`

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1932,7 +1932,7 @@ func (s *Server) handleP4Exec(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err := p4pingWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
+	err := p4testWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/cmd/gitserver/server/vcs_syncer_perforce_test.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce_test.go
@@ -99,7 +99,7 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 			name:     "empty error message",
 			errorMsg: "",
 			command: &exec.Cmd{
-				Args: []string{"p4", "ping", "-c", "1"},
+				Args: []string{"p4", "login", "-s"},
 			},
 			expectedMsg: "",
 		},
@@ -107,7 +107,7 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 			name:     "error message without phrase to replace",
 			errorMsg: "Some error",
 			command: &exec.Cmd{
-				Args: []string{"p4", "ping", "-c", "1"},
+				Args: []string{"p4", "login", "-s"},
 			},
 			expectedMsg: "Some error",
 		},
@@ -125,11 +125,11 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 		},
 		{
 			name:     "error message with phrase to replace, valid input Cmd",
-			errorMsg: "error cloning repo: repo perforce/path/to/depot not cloneable: exit status 1 (output follows)\n\nYou don't have permission for this operation.",
+			errorMsg: "error cloning repo: repo perforce/path/to/depot not cloneable: exit status 1 (output follows)\n\nPerforce password (P4PASSWD) invalid or unset.",
 			command: &exec.Cmd{
-				Args: []string{"p4", "ping", "-c", "1"},
+				Args: []string{"p4", "login", "-s"},
 			},
-			expectedMsg: "error cloning repo: repo perforce/path/to/depot not cloneable: exit status 1 (output follows)\n\nYou don't have permission for `p4 ping -c 1`.",
+			expectedMsg: "error cloning repo: repo perforce/path/to/depot not cloneable: exit status 1 (output follows)\n\nPerforce password (P4PASSWD) invalid or unset.",
 		},
 	}
 

--- a/dev/perforce-testing-helpers/p4-setup-protections.sh
+++ b/dev/perforce-testing-helpers/p4-setup-protections.sh
@@ -70,12 +70,12 @@ my_chronic() {
 export -f my_chronic
 
 # ensure that user is logged into the Perforce server
-if ! p4 ping &>/dev/null; then
+if ! p4 login -s &>/dev/null; then
   handbook_link="https://handbook.sourcegraph.com/departments/ce-support/support/process/p4-enablement/#generate-a-session-ticket"
   address="${P4USER}:${P4PORT}"
 
   cat <<END
-'p4 ping' command failed. This indicates that you might not be logged into '$address'.
+'p4 login -s' command failed. This indicates that you might not be logged into '$address'.
 Try using 'p4 -u ${P4USER} login -a' to generate a session ticket.
 See '${handbook_link}' for more information.
 END

--- a/dev/perforce-testing-helpers/p4-upload.sh
+++ b/dev/perforce-testing-helpers/p4-upload.sh
@@ -109,12 +109,12 @@ delete_perforce_client() {
 }
 
 # ensure that user is logged into the Perforce server
-if ! p4 ping &>/dev/null; then
+if ! p4 login -s &>/dev/null; then
   handbook_link="https://handbook.sourcegraph.com/departments/ce-support/support/process/p4-enablement/#generate-a-session-ticket"
   address="${P4USER}:${P4PORT}"
 
   cat <<END
-'p4 ping' command failed. This indicates that you might not be logged into '$address'.
+'p4 login -s' command failed. This indicates that you might not be logged into '$address'.
 Try using 'p4 -u ${P4USER} login -a' to generate a session ticket.
 See '${handbook_link}' for more information.
 END

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -41,7 +41,6 @@ To enable Perforce code host connections, a site admin must:
     - [`p4.user`](perforce.md#p4-user)
       
       The user to be authenticated for `p4` CLI, and should be capable of performing:
-      - `p4 ping`
       - `p4 login`
       - `p4 trust`
       - and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`.


### PR DESCRIPTION
Addresses issue #49066 by swapping out `p4 ping` in `repo-updater` and elsewhere with `p4 login -s`.

## Test plan

Add a Perforce repository and verify that it behaves as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
