### PR TITLE
web: fix routes for not found pages

### DIFF
--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -84,7 +84,7 @@ export const GlobalBatchChangesArea: React.FunctionComponent<React.PropsWithChil
                     }
                 />
             )}
-            <Route element={<NotFoundPage pageType="batch changes" />} key="hardcoded-key" />
+            <Route path="*" element={<NotFoundPage pageType="batch changes" />} key="hardcoded-key" />
         </Routes>
     </div>
 )

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -171,7 +171,7 @@ export const RepositoryCodeIntelArea: FC<RepositoryCodeIntelAreaPageProps> = pro
                             )
                     )}
 
-                    <Route element={<NotFoundPage pageType="repository" />} />
+                    <Route path="*" element={<NotFoundPage pageType="repository" />} />
                 </Routes>
             </div>
         </div>

--- a/client/web/src/enterprise/executors/ExecutorsSiteAdminArea.tsx
+++ b/client/web/src/enterprise/executors/ExecutorsSiteAdminArea.tsx
@@ -24,6 +24,6 @@ export const ExecutorsSiteAdminArea: FC = () => (
     <Routes>
         <Route index={true} element={<ExecutorsListPage />} />
         <Route path="secrets" element={<GlobalExecutorSecretsListPage />} />
-        <Route element={<NotFoundPage pageType="settings" />} />
+        <Route path="*" element={<NotFoundPage pageType="settings" />} />
     </Routes>
 )

--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -86,7 +86,7 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                 />
                 <Route path=":insightId" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
 
-                <Route element={<NotFoundPage pageType="code insights" />} />
+                <Route path="*" element={<NotFoundPage pageType="code insights" />} />
             </Routes>
         </CodeInsightsBackendContext.Provider>
     )

--- a/client/web/src/org/OrgsArea.tsx
+++ b/client/web/src/org/OrgsArea.tsx
@@ -46,7 +46,7 @@ const AuthenticatedOrgsArea: React.FunctionComponent<React.PropsWithChildren<Pro
         )}
         <Route path="invitation/:token" element={<OrgInvitationPage {...props} />} />
         <Route path=":orgName/*" element={<OrgAreaWithRouteProps {...props} />} />
-        <Route element={<NotFoundPage pageType="organization" />} />
+        <Route path="*" element={<NotFoundPage pageType="organization" />} />
     </Routes>
 )
 

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -283,7 +283,7 @@ export class OrgArea extends React.Component<OrgAreaProps> {
                                 />
                             )
                     )}
-                    <Route element={<NotFoundPage />} />
+                    <Route path="*" element={<NotFoundPage />} />
                 </Routes>
             </React.Suspense>
         )

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -62,7 +62,7 @@ export const AuthenticatedOrgSettingsArea: FC<OrgSettingsAreaProps> = props => {
                                     />
                                 )
                         )}
-                        <Route element={<NotFoundPage />} />
+                        <Route path="*" element={<NotFoundPage />} />
                     </Routes>
                 </React.Suspense>
             </div>

--- a/client/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -40,7 +40,7 @@ export const RepositoryBranchesArea: FC<Props> = props => {
             <Routes>
                 <Route path="all" element={<RepositoryBranchesAllPage repo={repo} />} />
                 <Route path="" element={<RepositoryBranchesOverviewPage repo={repo} />} />
-                <Route element={<NotFoundPage pageType="repository branches" />} />
+                <Route path="*" element={<NotFoundPage pageType="repository branches" />} />
             </Routes>
         </div>
     )

--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -93,7 +93,7 @@ export const RepoSettingsArea: React.FunctionComponent<React.PropsWithChildren<P
                         ({ render, path, condition = () => true }) =>
                             condition(context) && <Route key="hardcoded-key" path={path} element={render(context)} />
                     )}
-                    <Route element={<NotFoundPage pageType="repository" />} />
+                    <Route path="*" element={<NotFoundPage pageType="repository" />} />
                 </Routes>
             </div>
         </div>

--- a/client/web/src/team/TeamsArea.tsx
+++ b/client/web/src/team/TeamsArea.tsx
@@ -50,7 +50,7 @@ const AuthenticatedTeamsArea: React.FunctionComponent<React.PropsWithChildren<Pr
                 <Route path="new" element={<NewTeamPage />} errorElement={<RouteError />} />
                 <Route path="" element={<TeamListPage {...props} />} errorElement={<RouteError />} />
                 <Route path=":teamName/*" element={<TeamArea {...props} />} errorElement={<RouteError />} />
-                <Route element={<NotFoundPage pageType="team" />} errorElement={<RouteError />} />
+                <Route path="*" element={<NotFoundPage pageType="team" />} errorElement={<RouteError />} />
             </Routes>
         </React.Suspense>
     )

--- a/client/web/src/team/area/TeamArea.tsx
+++ b/client/web/src/team/area/TeamArea.tsx
@@ -92,7 +92,7 @@ export const TeamArea: React.FunctionComponent<TeamAreaProps> = ({ authenticated
                 <Route path="" element={<TeamProfilePage {...context} />} errorElement={<RouteError />} />
                 <Route path="members" element={<TeamMembersPage {...context} />} errorElement={<RouteError />} />
                 <Route path="child-teams" element={<TeamChildTeamsPage {...context} />} errorElement={<RouteError />} />
-                <Route element={<NotFoundPage />} />
+                <Route path="*" element={<NotFoundPage />} />
             </Routes>
         </React.Suspense>
     )

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -215,7 +215,7 @@ export const UserArea: FC<UserAreaProps> = ({
                             />
                         )
                 )}
-                <Route element={<NotFoundPage pageType="user" />} />
+                <Route path="*" element={<NotFoundPage pageType="user" />} />
             </Routes>
         </Suspense>
     )

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -163,7 +163,7 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
                                         />
                                     )
                             )}
-                            <Route element={<NotFoundPage pageType="settings" />} />
+                            <Route path="*" element={<NotFoundPage pageType="settings" />} />
                         </Routes>
                     </React.Suspense>
                 </div>

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -43,7 +43,7 @@ export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChil
                     />
                 }
             />
-            <Route element={<NotFoundPage pageType="settings" />} />
+            <Route path="*" element={<NotFoundPage pageType="settings" />} />
         </Routes>
     )
 }


### PR DESCRIPTION
I'm not sure if this is related to the react-router upgrade or not, but it seems like at some point the fallback catch-all routes that render a `<NotFoundPage />` stopped, well, catching all. 😅

It seems that explicitly passing them a `path` prop with a wildcard will restore the fallback behavior. I've tried in this PR to locate all places where a catch-all route was not providing this prop and update them accordingly.

Below are a couple collected examples, with `main` (S2) on the left and this branch on the right.

**Site admin - executors**

<img width="1709" alt="image" src="https://user-images.githubusercontent.com/8942601/224238421-b280b0fe-7495-4d0b-9eaf-649489760219.png">

**Batch changes**

<img width="1716" alt="image" src="https://user-images.githubusercontent.com/8942601/224238902-0ccc5774-68e4-4c10-82d5-31ebf9b7b268.png">

**User settings**

<img width="1715" alt="image" src="https://user-images.githubusercontent.com/8942601/224239250-3c918bca-5a59-46aa-927d-be31ee70c75e.png">


## Test plan

Manual testing for several routes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
