### PR TITLE
jscontext: fix nil deref when fetching temp settings and user is nil.

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -265,8 +265,10 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		// Ignore err as we don't care if user does not exist
 		user, _ = a.User(ctx, db.Users())
 		licenseInfo = hooks.GetLicenseInfo(user != nil && user.SiteAdmin)
-		if settings, err := db.TemporarySettings().GetTemporarySettings(ctx, user.ID); err == nil {
-			temporarySettings = settings.Contents
+		if user != nil {
+			if settings, err := db.TemporarySettings().GetTemporarySettings(ctx, user.ID); err == nil {
+				temporarySettings = settings.Contents
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug when user nullability wasn't considered.

Test plan:
CI.

Found here: https://sourcegraph.slack.com/archives/CMBA8F926/p1678389506543419