### PR TITLE
permissions-center: make cancel permissions sync job result typed.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -24,6 +24,7 @@ import { ConnectionError, ConnectionLoading } from '../../components/FilteredCon
 import { PageTitle } from '../../components/PageTitle'
 import {
     CancelPermissionsSyncJobResult,
+    CancelPermissionsSyncJobResultMessage,
     CancelPermissionsSyncJobVariables,
     PermissionsSyncJob,
     PermissionsSyncJobReasonGroup,
@@ -168,7 +169,7 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
             cancelSyncJob({
                 variables: { job: syncJob.id },
                 onCompleted: ({ cancelPermissionsSyncJob }) =>
-                    setNotification({ text: prettyPrintCancelSyncJobMessage(cancelPermissionsSyncJob || undefined) }),
+                    setNotification({ text: prettyPrintCancelSyncJobMessage(cancelPermissionsSyncJob) }),
                 onError,
             }).catch(
                 // noop here is used because an error is handled in `onError` option of `useMutation` above.
@@ -416,7 +417,13 @@ const EmptyList: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
 const finalState = (state: PermissionsSyncJobState): boolean =>
     state !== PermissionsSyncJobState.QUEUED && state !== PermissionsSyncJobState.PROCESSING
 
-const prettyPrintCancelSyncJobMessage = (message: string = 'Permissions sync job canceled.'): string =>
-    message === 'No job that can be canceled found.'
-        ? 'Permissions sync job is already dequeued and cannot be canceled.'
-        : message
+const prettyPrintCancelSyncJobMessage = (message: CancelPermissionsSyncJobResultMessage): string => {
+    switch (message) {
+        case CancelPermissionsSyncJobResultMessage.SUCCESS:
+            return 'Permissions sync job canceled.'
+        case CancelPermissionsSyncJobResultMessage.NOT_FOUND:
+            return 'Permissions sync job is already dequeued and cannot be canceled.'
+        case CancelPermissionsSyncJobResultMessage.ERROR:
+            return 'Error during permissions sync job cancelling.'
+    }
+}

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -18,7 +18,7 @@ type AuthzResolver interface {
 	ScheduleUserPermissionsSync(ctx context.Context, args *UserPermissionsSyncArgs) (*EmptyResponse, error)
 	SetSubRepositoryPermissionsForUsers(ctx context.Context, args *SubRepoPermsArgs) (*EmptyResponse, error)
 	SetRepositoryPermissionsForBitbucketProject(ctx context.Context, args *RepoPermsBitbucketProjectArgs) (*EmptyResponse, error)
-	CancelPermissionsSyncJob(ctx context.Context, args *CancelPermissionsSyncJobArgs) (*string, error)
+	CancelPermissionsSyncJob(ctx context.Context, args *CancelPermissionsSyncJobArgs) (CancelPermissionsSyncJobResultMessage, error)
 
 	//AuthorizedUserRepositories and functions below are GraphQL Queries.
 	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
@@ -151,3 +151,11 @@ type PermissionsInfoUsersArgs struct {
 	graphqlutil.ConnectionResolverArgs
 	Query *string
 }
+
+const (
+	CancelPermissionsSyncJobResultMessageSuccess  CancelPermissionsSyncJobResultMessage = "SUCCESS"
+	CancelPermissionsSyncJobResultMessageNotFound CancelPermissionsSyncJobResultMessage = "NOT_FOUND"
+	CancelPermissionsSyncJobResultMessageError    CancelPermissionsSyncJobResultMessage = "ERROR"
+)
+
+type CancelPermissionsSyncJobResultMessage string

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -108,7 +108,13 @@ extend type Mutation {
         Optional cancellation reason.
         """
         reason: String
-    ): String
+    ): CancelPermissionsSyncJobResultMessage!
+}
+
+enum CancelPermissionsSyncJobResultMessage {
+    SUCCESS
+    NOT_FOUND
+    ERROR
 }
 
 extend type Query {

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -111,6 +111,9 @@ extend type Mutation {
     ): CancelPermissionsSyncJobResultMessage!
 }
 
+"""
+A status message of a permissions sync job cancellation.
+"""
 enum CancelPermissionsSyncJobResultMessage {
     SUCCESS
     NOT_FOUND

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -342,19 +342,19 @@ func (r *Resolver) SetRepositoryPermissionsForBitbucketProject(
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
-func (r *Resolver) CancelPermissionsSyncJob(ctx context.Context, args *graphqlbackend.CancelPermissionsSyncJobArgs) (*string, error) {
+func (r *Resolver) CancelPermissionsSyncJob(ctx context.Context, args *graphqlbackend.CancelPermissionsSyncJobArgs) (graphqlbackend.CancelPermissionsSyncJobResultMessage, error) {
 	if err := r.checkLicense(licensing.FeatureACLs); err != nil {
-		return nil, err
+		return graphqlbackend.CancelPermissionsSyncJobResultMessageError, err
 	}
 
 	// 🚨 SECURITY: Only site admins can cancel permissions sync jobs.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
+		return graphqlbackend.CancelPermissionsSyncJobResultMessageError, err
 	}
 
 	syncJobID, err := unmarshalPermissionsSyncJobID(args.Job)
 	if err != nil {
-		return nil, err
+		return graphqlbackend.CancelPermissionsSyncJobResultMessageError, err
 	}
 
 	reason := ""
@@ -367,11 +367,11 @@ func (r *Resolver) CancelPermissionsSyncJob(ctx context.Context, args *graphqlba
 	// by ID (might already be cleaned up).
 	if err != nil {
 		if errcode.IsNotFound(err) {
-			return strPtr("No job that can be canceled found."), nil
+			return graphqlbackend.CancelPermissionsSyncJobResultMessageNotFound, nil
 		}
-		return nil, err
+		return graphqlbackend.CancelPermissionsSyncJobResultMessageError, err
 	}
-	return strPtr("Permissions sync job canceled."), nil
+	return graphqlbackend.CancelPermissionsSyncJobResultMessageSuccess, nil
 }
 
 func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphqlbackend.AuthorizedRepoArgs) (graphqlbackend.RepositoryConnectionResolver, error) {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -667,10 +667,10 @@ func TestResolver_CancelPermissionsSyncJob(t *testing.T) {
 		r := &Resolver{db: db, logger: logger}
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := r.SetRepositoryPermissionsForBitbucketProject(ctx, nil)
+		result, err := r.CancelPermissionsSyncJob(ctx, nil)
 
 		require.EqualError(t, err, auth.ErrMustBeSiteAdmin.Error())
-		require.Nil(t, result)
+		require.Equal(t, graphqlbackend.CancelPermissionsSyncJobResultMessageError, result)
 	})
 
 	t.Run("invalid sync job ID", func(t *testing.T) {
@@ -690,7 +690,7 @@ func TestResolver_CancelPermissionsSyncJob(t *testing.T) {
 		)
 
 		require.Error(t, err)
-		require.Nil(t, result)
+		require.Equal(t, graphqlbackend.CancelPermissionsSyncJobResultMessageError, result)
 	})
 
 	t.Run("sync job not found", func(t *testing.T) {
@@ -715,7 +715,7 @@ func TestResolver_CancelPermissionsSyncJob(t *testing.T) {
 		)
 
 		require.NoError(t, err)
-		require.Equal(t, "No job that can be canceled found.", *result)
+		require.Equal(t, graphqlbackend.CancelPermissionsSyncJobResultMessageNotFound, result)
 	})
 
 	t.Run("SQL error", func(t *testing.T) {
@@ -741,7 +741,7 @@ func TestResolver_CancelPermissionsSyncJob(t *testing.T) {
 		)
 
 		require.EqualError(t, err, errorText)
-		require.Nil(t, result)
+		require.Equal(t, graphqlbackend.CancelPermissionsSyncJobResultMessageError, result)
 	})
 
 	t.Run("sync job successfully cancelled", func(t *testing.T) {
@@ -765,7 +765,7 @@ func TestResolver_CancelPermissionsSyncJob(t *testing.T) {
 			},
 		)
 
-		require.Equal(t, "Permissions sync job canceled.", *result)
+		require.Equal(t, graphqlbackend.CancelPermissionsSyncJobResultMessageSuccess, result)
 		require.NoError(t, err)
 	})
 }
@@ -801,7 +801,7 @@ func TestResolver_CancelPermissionsSyncJob_GraphQLQuery(t *testing.T) {
 			`, marshalPermissionsSyncJobID(1)),
 			ExpectedResult: `
 				{
-					"cancelPermissionsSyncJob": "Permissions sync job canceled."
+					"cancelPermissionsSyncJob": "SUCCESS"
 				}
 			`,
 		})
@@ -820,7 +820,7 @@ func TestResolver_CancelPermissionsSyncJob_GraphQLQuery(t *testing.T) {
 			`, marshalPermissionsSyncJobID(42)),
 			ExpectedResult: `
 				{
-					"cancelPermissionsSyncJob": "No job that can be canceled found."
+					"cancelPermissionsSyncJob": "NOT_FOUND"
 				}
 			`,
 		})


### PR DESCRIPTION
This commit introduces `CancelPermissionsSyncJobResultMessage` type which is used instead of plain strings to resolve a message which is shown to the user on UI.

Test plan:
Unit tests updated.
GraphQL tests updated.
Local sg run and tests.

@mrnugget now this is less brittle than raw strings comparison :)