### PR TITLE
[feat] migrate perms_store scheduling functions to use perms_sync_jobs_history

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -29,7 +29,7 @@ func addPerms(t *testing.T, s edb.PermsStore, userID, repoID int32) {
 	ctx := context.Background()
 
 	if conf.ExperimentalFeatures().UnifiedPermissions {
-		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{int32(repoID)})
+		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{repoID})
 		require.NoError(t, err)
 	} else {
 		_, err := s.SetUserPermissions(ctx, &authz.UserPermissions{

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -8,39 +8,47 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func execQuery(t *testing.T, ctx context.Context, h basestore.TransactableHandle, q *sqlf.Query) {
+func addPerms(t *testing.T, s edb.PermsStore, userID, repoID int32) {
 	t.Helper()
-	if t.Failed() {
-		return
-	}
 
-	_, err := h.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	if err != nil {
-		t.Fatalf("Error executing query %v, err: %v", q, err)
+	ctx := context.Background()
+
+	if conf.ExperimentalFeatures().UnifiedPermissions {
+		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{int32(repoID)})
+		require.NoError(t, err)
+	} else {
+		_, err := s.SetUserPermissions(ctx, &authz.UserPermissions{
+			UserID: userID,
+			IDs:    map[int32]struct{}{repoID: {}},
+			Perm:   authz.Read,
+			Type:   authz.PermRepos,
+		})
+		require.NoError(t, err)
 	}
 }
 
-func addSyncJobHistoryRecord(t *testing.T, h basestore.TransactableHandle, userID int32, repoID api.RepoID, updatedAt time.Time) {
-	t.Helper()
-	if userID > 0 {
-		execQuery(t, context.Background(), h, sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, %s)`, userID, updatedAt))
-	}
-	if repoID > 0 {
-		execQuery(t, context.Background(), h, sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id, updated_at) VALUES(%d, %s)`, repoID, updatedAt))
-	}
+func mockUnifiedPermsConfig(val bool) {
+	cfg := &conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+		ExperimentalFeatures: &schema.ExperimentalFeatures{
+			UnifiedPermissions: val,
+		},
+	}}
+	conf.Mock(cfg)
 }
 
 func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
@@ -49,138 +57,175 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 	}
 
 	zeroBackoffDuringTest = true
-	t.Cleanup(func() { zeroBackoffDuringTest = false })
+	t.Cleanup(func() {
+		conf.Mock(nil)
+		zeroBackoffDuringTest = false
+	})
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	store := database.PermissionSyncJobsWith(logger, db)
-	usersStore := database.UsersWith(logger, db)
-	reposStore := database.ReposWith(logger, db)
+	runTest := func(t *testing.T) {
+		t.Helper()
 
-	// Creating site-admin.
-	_, err := usersStore.Create(ctx, database.NewUser{Username: "admin"})
-	require.NoError(t, err)
+		db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	// Creating non-private repo.
-	nonPrivateRepo := types.Repo{Name: "test-public-repo"}
-	err = reposStore.Create(ctx, &nonPrivateRepo)
-	require.NoError(t, err)
+		store := database.PermissionSyncJobsWith(logger, db)
+		usersStore := database.UsersWith(logger, db)
+		externalAccountStore := database.ExternalAccountsWith(logger, db)
+		reposStore := database.ReposWith(logger, db)
+		permsStore := edb.Perms(logger, db, clock)
 
-	// We should have no jobs scheduled
-	runJobsTest(t, ctx, logger, db, store, []testJob{})
+		// Creating site-admin.
+		_, err := usersStore.Create(ctx, database.NewUser{Username: "admin"})
+		require.NoError(t, err)
 
-	// Creating a user.
-	user1, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-1"})
-	require.NoError(t, err)
+		// Creating non-private repo.
+		nonPrivateRepo := types.Repo{Name: "test-public-repo"}
+		err = reposStore.Create(ctx, &nonPrivateRepo)
+		require.NoError(t, err)
 
-	// Creating a repo.
-	repo1 := types.Repo{Name: "test-repo-1", Private: true}
-	err = reposStore.Create(ctx, &repo1)
-	require.NoError(t, err)
+		// We should have no jobs scheduled
+		runJobsTest(t, ctx, logger, db, store, []testJob{})
 
-	// We should have 2 jobs scheduled.
-	wantJobs := []testJob{
-		{
-			UserID:       int(user1.ID),
-			RepositoryID: 0,
-			Reason:       database.ReasonUserNoPermissions,
-			Priority:     database.MediumPriorityPermissionsSync,
-			NoPerms:      true,
-		},
-		{
-			UserID:       0,
-			RepositoryID: int(repo1.ID),
-			Reason:       database.ReasonRepoNoPermissions,
-			Priority:     database.MediumPriorityPermissionsSync,
-			NoPerms:      true,
-		},
+		// Creating a user.
+		user1, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-1"})
+		require.NoError(t, err)
+
+		// Creating an external account
+		err = externalAccountStore.Insert(ctx, user1.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user1.Username}, extsvc.AccountData{})
+		require.NoError(t, err)
+
+		// Creating a repo.
+		repo1 := types.Repo{Name: "test-repo-1", Private: true}
+		err = reposStore.Create(ctx, &repo1)
+		require.NoError(t, err)
+
+		// We should have 2 jobs scheduled.
+		wantJobs := []testJob{
+			{
+				UserID:       int(user1.ID),
+				RepositoryID: 0,
+				Reason:       database.ReasonUserNoPermissions,
+				Priority:     database.MediumPriorityPermissionsSync,
+				NoPerms:      true,
+			},
+			{
+				UserID:       0,
+				RepositoryID: int(repo1.ID),
+				Reason:       database.ReasonRepoNoPermissions,
+				Priority:     database.MediumPriorityPermissionsSync,
+				NoPerms:      true,
+			},
+		}
+		runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+		// Add permissions for user and repo
+		addPerms(t, permsStore, user1.ID, int32(repo1.ID))
+
+		// We should have same 2 jobs because jobs with higher priority already exists.
+		runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+		// Creating a user.
+		user2, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-2"})
+		require.NoError(t, err)
+
+		// Creating an external account
+		err = externalAccountStore.Insert(ctx, user2.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user2.Username}, extsvc.AccountData{})
+		require.NoError(t, err)
+
+		// Creating a repo.
+		repo2 := types.Repo{Name: "test-repo-2", Private: true}
+		err = reposStore.Create(ctx, &repo2)
+		require.NoError(t, err)
+
+		// Add permissions and sync jobs for the user and repo.
+		addPerms(t, permsStore, user2.ID, int32(repo2.ID))
+		store.CreateUserSyncJob(ctx, user2.ID, database.PermissionSyncJobOpts{
+			Priority: database.LowPriorityPermissionsSync,
+			Reason:   database.ReasonUserOutdatedPermissions,
+		})
+		store.CreateRepoSyncJob(ctx, repo2.ID, database.PermissionSyncJobOpts{
+			Priority: database.LowPriorityPermissionsSync,
+			Reason:   database.ReasonRepoOutdatedPermissions,
+		})
+
+		// We should have 4 jobs scheduled including new jobs for user2 and repo2.
+		wantJobs = []testJob{
+			{
+				UserID:       int(user1.ID),
+				RepositoryID: 0,
+				Reason:       database.ReasonUserNoPermissions,
+				Priority:     database.MediumPriorityPermissionsSync,
+				NoPerms:      true,
+			},
+			{
+				UserID:       0,
+				RepositoryID: int(repo1.ID),
+				Reason:       database.ReasonRepoNoPermissions,
+				Priority:     database.MediumPriorityPermissionsSync,
+				NoPerms:      true,
+			},
+			{
+				UserID:       int(user2.ID),
+				RepositoryID: 0,
+				Reason:       database.ReasonUserOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+			{
+				UserID:       0,
+				RepositoryID: int(repo2.ID),
+				Reason:       database.ReasonRepoOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+		}
+		runJobsTest(t, ctx, logger, db, store, wantJobs)
+
+		// Set user1 and repo1 schedule jobs to completed.
+		_, err = db.ExecContext(ctx, fmt.Sprintf(`UPDATE permission_sync_jobs SET state = 'completed' WHERE user_id=%d OR repository_id=%d`, user1.ID, repo1.ID))
+		require.NoError(t, err)
+
+		// We should have 4 jobs including new jobs for user1 and repo1.
+		wantJobs = []testJob{
+			{
+				UserID:       int(user2.ID),
+				RepositoryID: 0,
+				Reason:       database.ReasonUserOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+			{
+				UserID:       0,
+				RepositoryID: int(repo2.ID),
+				Reason:       database.ReasonRepoOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+			{
+				UserID:       int(user1.ID),
+				RepositoryID: 0,
+				Reason:       database.ReasonUserOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+			{
+				UserID:       0,
+				RepositoryID: int(repo1.ID),
+				Reason:       database.ReasonRepoOutdatedPermissions,
+				Priority:     database.LowPriorityPermissionsSync,
+			},
+		}
+		runJobsTest(t, ctx, logger, db, store, wantJobs)
 	}
-	runJobsTest(t, ctx, logger, db, store, wantJobs)
 
-	// Add sync job history record for the user and repo.
-	addSyncJobHistoryRecord(t, db.Handle(), user1.ID, repo1.ID, clock())
+	t.Run("with legacy permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(false)
 
-	// We should have same 2 jobs because jobs with higher priority already exists.
-	runJobsTest(t, ctx, logger, db, store, wantJobs)
+		runTest(t)
+	})
 
-	// Creating a user.
-	user2, err := usersStore.Create(ctx, database.NewUser{Username: "test-user-2"})
-	require.NoError(t, err)
+	t.Run("with unified permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(true)
 
-	// Creating a repo.
-	repo2 := types.Repo{Name: "test-repo-2", Private: true}
-	err = reposStore.Create(ctx, &repo2)
-	require.NoError(t, err)
-
-	// Touch perms for the user and repo.
-	// Add sync job history record for the user and repo.
-	addSyncJobHistoryRecord(t, db.Handle(), user2.ID, repo2.ID, clock())
-
-	// We should have same 4 jobs scheduled including new jobs for user2 and repo2.
-	wantJobs = []testJob{
-		{
-			UserID:       int(user1.ID),
-			RepositoryID: 0,
-			Reason:       database.ReasonUserNoPermissions,
-			Priority:     database.MediumPriorityPermissionsSync,
-			NoPerms:      true,
-		},
-		{
-			UserID:       0,
-			RepositoryID: int(repo1.ID),
-			Reason:       database.ReasonRepoNoPermissions,
-			Priority:     database.MediumPriorityPermissionsSync,
-			NoPerms:      true,
-		},
-		{
-			UserID:       int(user2.ID),
-			RepositoryID: 0,
-			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-		{
-			UserID:       0,
-			RepositoryID: int(repo2.ID),
-			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-	}
-	runJobsTest(t, ctx, logger, db, store, wantJobs)
-
-	// Set user1 and repo1 schedule jobs to completed.
-	_, err = db.ExecContext(ctx, fmt.Sprintf(`UPDATE permission_sync_jobs SET state = 'completed' WHERE user_id=%d OR repository_id=%d`, user1.ID, repo1.ID))
-	require.NoError(t, err)
-
-	// We should have 4 jobs including new jobs for user1 and repo1.
-	wantJobs = []testJob{
-		{
-			UserID:       int(user2.ID),
-			RepositoryID: 0,
-			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-		{
-			UserID:       0,
-			RepositoryID: int(repo2.ID),
-			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-		{
-			UserID:       int(user1.ID),
-			RepositoryID: 0,
-			Reason:       database.ReasonUserOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-		{
-			UserID:       0,
-			RepositoryID: int(repo1.ID),
-			Reason:       database.ReasonRepoOutdatedPermissions,
-			Priority:     database.LowPriorityPermissionsSync,
-		},
-	}
-	runJobsTest(t, ctx, logger, db, store, wantJobs)
+		runTest(t)
+	})
 }
 
 type testJob struct {

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -56,8 +56,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
-		{"UserIDsWithOldestPerms", testPermsStore_UserIDsWithOldestPerms(db)},
-		{"ReposIDsWithOldestPerms", testPermsStore_ReposIDsWithOldestPerms(db)},
 		{"Metrics", testPermsStore_Metrics(db)},
 		{"MapUsers", testPermsStore_MapUsers(db)},
 		{"ListUserPermissions", testPermsStore_ListUserPermissions(db)},

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1774,25 +1774,11 @@ func UnifiedPermsEnabled() bool {
 	return conf.ExperimentalFeatures().UnifiedPermissions
 }
 
-const legacyUsersWithNoPermsQuery = `
-SELECT users.id, NULL
-FROM users
-LEFT OUTER JOIN user_permissions AS rp ON rp.user_id = users.id
-WHERE
-	users.deleted_at IS NULL
-AND %s
-AND rp.user_id IS NULL
-`
-
-const unifiedUsersWithNoPermsQuery = `
+const usersWithNoPermsQuery = `
 WITH rp AS (
-	-- Filter out users with permissions
-	SELECT DISTINCT user_id FROM user_repo_permissions
-	UNION
-	-- Filter out users with completed sync jobs
-	SELECT user_id FROM permission_sync_jobs WHERE user_id IS NOT NULL
+	SELECT user_id FROM perms_sync_jobs_history WHERE user_id IS NOT NULL
 )
-SELECT users.id, NULL
+SELECT users.id
 FROM users
 LEFT OUTER JOIN rp ON rp.user_id = users.id
 WHERE
@@ -1809,50 +1795,15 @@ func (s *permsStore) UserIDsWithNoPerms(ctx context.Context) ([]int32, error) {
 		filterSiteAdmins = sqlf.Sprintf("TRUE")
 	}
 
-	query := unifiedUsersWithNoPermsQuery
-	// check if we should read from legacy permissions table or not
-	if !UnifiedPermsEnabled() {
-		query = legacyUsersWithNoPermsQuery
-	}
-
-	q := sqlf.Sprintf(query, filterSiteAdmins)
-	results, err := s.loadIDsWithTime(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]int32, 0, len(results))
-	for id := range results {
-		ids = append(ids, id)
-	}
-	return ids, nil
+	q := sqlf.Sprintf(usersWithNoPermsQuery, filterSiteAdmins)
+	return basestore.ScanInt32s(s.Query(ctx, q))
 }
 
-const legacyRepoIDsWithNoPermsQuery = `
+const repoIDsWithNoPermsQuery = `
 WITH rp AS (
-	SELECT perms.repo_id FROM repo_permissions AS perms
-	UNION
-	SELECT pending.repo_id FROM repo_pending_permissions AS pending
-)
-SELECT r.id, NULL
-FROM repo AS r
-LEFT OUTER JOIN rp ON rp.repo_id = r.id
-WHERE r.deleted_at IS NULL
-AND r.private = TRUE
-AND rp.repo_id IS NULL
-`
-
-const unifiedRepoIDsWithNoPermsQuery = `
-WITH rp AS (
-	-- Filter out repos with permissions
-	SELECT DISTINCT perms.repo_id FROM user_repo_permissions AS perms
-	UNION
-	-- Filter out repos with pending permissions
-	SELECT pending.repo_id FROM repo_pending_permissions AS pending
-	UNION
 	-- Filter out repos with sync jobs
-	SELECT syncs.repository_id AS repo_id FROM permission_sync_jobs AS syncs
-		WHERE syncs.repository_id IS NOT NULL
+	SELECT syncs.repo_id FROM perms_sync_jobs_history AS syncs
+		WHERE syncs.repo_id IS NOT NULL
 )
 SELECT r.id, NULL
 FROM repo AS r
@@ -1863,69 +1814,53 @@ AND rp.repo_id IS NULL
 `
 
 func (s *permsStore) RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, error) {
-	query := unifiedRepoIDsWithNoPermsQuery
-	// check if we should read from legacy permissions table or not
-	if !UnifiedPermsEnabled() {
-		query = legacyRepoIDsWithNoPermsQuery
-	}
+	q := sqlf.Sprintf(repoIDsWithNoPermsQuery)
+	return scanRepoIDs(s.Query(ctx, q))
+}
 
-	q := sqlf.Sprintf(query)
+const usersWithOldestPermsQuery = `
+SELECT user_id, updated_at FROM perms_sync_jobs_history
+WHERE user_id IS NOT NULL
+	AND %s
+ORDER BY updated_at ASC
+LIMIT %s;
+`
 
-	results, err := s.loadIDsWithTime(ctx, q)
-	if err != nil {
-		return nil, err
+func (s *permsStore) getCutoffClause(age time.Duration) *sqlf.Query {
+	if age == 0 {
+		return sqlf.Sprintf("TRUE")
 	}
-
-	ids := make([]api.RepoID, 0, len(results))
-	for id := range results {
-		ids = append(ids, api.RepoID(id))
-	}
-	return ids, nil
+	cutoff := s.clock().Add(-1 * age)
+	return sqlf.Sprintf("updated_at < %s", cutoff)
 }
 
 // UserIDsWithOldestPerms lists the users with the oldest synced perms, limited
 // to limit. If age is non-zero, users that have synced within "age" since now
 // will be filtered out.
 func (s *permsStore) UserIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[int32]time.Time, error) {
-	cutoffClause := sqlf.Sprintf("TRUE")
-	if age > 0 {
-		cutoff := s.clock().Add(-1 * age)
-		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR perms.synced_at < %s)", cutoff)
-	}
-	q := sqlf.Sprintf(`
-SELECT perms.user_id, perms.synced_at FROM user_permissions AS perms
-WHERE perms.user_id IN
-	(SELECT users.id FROM users
-	 WHERE users.deleted_at IS NULL)
-AND %s
-ORDER BY perms.synced_at ASC NULLS FIRST
-LIMIT %s
-`, cutoffClause, limit)
+	cutoffClause := s.getCutoffClause(age)
+	q := sqlf.Sprintf(usersWithOldestPermsQuery, cutoffClause, limit)
 	return s.loadIDsWithTime(ctx, q)
 }
 
+const reposWithOldestPermsQuery = `
+SELECT repo_id, updated_at FROM perms_sync_jobs_history
+WHERE repo_id IS NOT NULL
+	AND %s
+ORDER BY updated_at ASC
+LIMIT %s;
+`
+
 func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[api.RepoID]time.Time, error) {
-	cutoffClause := sqlf.Sprintf("TRUE")
-	if age > 0 {
-		cutoff := s.clock().Add(-1 * age)
-		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR perms.synced_at < %s)", cutoff)
-	}
-	q := sqlf.Sprintf(`
-SELECT perms.repo_id, perms.synced_at FROM repo_permissions AS perms
-WHERE perms.repo_id IN
-	(SELECT repo.id FROM repo
-	 WHERE repo.deleted_at IS NULL
-	 AND repo.private = TRUE)
-AND %s
-ORDER BY perms.synced_at ASC NULLS FIRST
-LIMIT %s
-`, cutoffClause, limit)
+	cutoffClause := s.getCutoffClause(age)
+	q := sqlf.Sprintf(reposWithOldestPermsQuery, cutoffClause, limit)
 
 	pairs, err := s.loadIDsWithTime(ctx, q)
 	if err != nil {
 		return nil, err
 	}
 
+	// convert the map[int32]time.Time to map[api.RepoID]time.Time
 	results := make(map[api.RepoID]time.Time, len(pairs))
 	for id, t := range pairs {
 		results[api.RepoID(id)] = t
@@ -1933,29 +1868,16 @@ LIMIT %s
 	return results, nil
 }
 
+var scanIDsWithTime = basestore.NewMapScanner(func(s dbutil.Scanner) (int32, time.Time, error) {
+	var id int32
+	var t time.Time
+	err := s.Scan(&id, &dbutil.NullTime{Time: &t})
+	return id, t, err
+})
+
 // loadIDsWithTime runs the query and returns a list of ID and nullable time pairs.
 func (s *permsStore) loadIDsWithTime(ctx context.Context, q *sqlf.Query) (map[int32]time.Time, error) {
-	rows, err := s.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	results := make(map[int32]time.Time)
-	for rows.Next() {
-		var id int32
-		var t time.Time
-		if err = rows.Scan(&id, &dbutil.NullTime{Time: &t}); err != nil {
-			return nil, err
-		}
-
-		results[id] = t
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return results, nil
+	return scanIDsWithTime(s.Query(ctx, q))
 }
 
 // PermsMetrics contains metrics values calculated by querying the database.

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1805,7 +1805,7 @@ WITH rp AS (
 	SELECT syncs.repo_id FROM perms_sync_jobs_history AS syncs
 		WHERE syncs.repo_id IS NOT NULL
 )
-SELECT r.id, NULL
+SELECT r.id
 FROM repo AS r
 LEFT OUTER JOIN rp ON rp.repo_id = r.id
 WHERE r.deleted_at IS NULL

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1859,6 +1859,14 @@ func (s *permsStore) RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, erro
 	return scanRepoIDs(s.Query(ctx, sqlf.Sprintf(query)))
 }
 
+func (s *permsStore) getCutoffClause(age time.Duration) *sqlf.Query {
+	if age == 0 {
+		return sqlf.Sprintf("TRUE")
+	}
+	cutoff := s.clock().Add(-1 * age)
+	return sqlf.Sprintf("finished_at < %s", cutoff)
+}
+
 const usersWithOldestPermsQuery = `
 WITH us AS (
 	SELECT DISTINCT ON(user_id) user_id, finished_at FROM permission_sync_jobs
@@ -1869,14 +1877,6 @@ SELECT user_id, finished_at FROM us
 WHERE %s
 LIMIT %d;
 `
-
-func (s *permsStore) getCutoffClause(age time.Duration) *sqlf.Query {
-	if age == 0 {
-		return sqlf.Sprintf("TRUE")
-	}
-	cutoff := s.clock().Add(-1 * age)
-	return sqlf.Sprintf("finished_at < %s", cutoff)
-}
 
 // UserIDsWithOldestPerms lists the users with the oldest synced perms, limited
 // to limit. If age is non-zero, users that have synced within "age" since now

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -3120,9 +3120,9 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 	}
 
 	// mark sync jobs as completed for "private_repo" and "private_repo_2"
-	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repository_id) VALUES(%d)`, 1)
+	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id) VALUES(%d)`, 1)
 	execQuery(t, ctx, s, q)
-	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repository_id) VALUES(%d)`, 3)
+	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id) VALUES(%d)`, 3)
 	execQuery(t, ctx, s, q)
 
 	// No private repositories have any permissions at this point
@@ -3131,10 +3131,7 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expIDs = []api.RepoID{}
-	if diff := cmp.Diff(expIDs, ids); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.Nil(t, ids)
 }
 
 func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
@@ -3225,7 +3222,7 @@ func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
 		}
 	})
 
-	t.Run("Ignore userse that have synced recently", func(t *testing.T) {
+	t.Run("Ignore users that have synced recently", func(t *testing.T) {
 		// Should get no results, since the and age is 1 hour
 		results, err := s.UserIDsWithOldestPerms(ctx, 1, 1*time.Hour)
 		if err != nil {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2770,7 +2770,7 @@ func testPermsStore_DeleteAllUserPendingPermissions(db database.DB) func(*testin
 			AccountIDs:  []string{"alice", "bob"},
 		}
 
-		// Set pending permissions for alice and bob
+		// Set pending permissions for "alice" and "bob"
 		if err := s.SetRepoPendingPermissions(ctx, accounts, &authz.RepoPermissions{
 			RepoID: 1,
 			Perm:   authz.Read,
@@ -2778,7 +2778,7 @@ func testPermsStore_DeleteAllUserPendingPermissions(db database.DB) func(*testin
 			t.Fatal(err)
 		}
 
-		// Remove all pending permissions for alice
+		// Remove all pending permissions for "alice"
 		accounts.AccountIDs = []string{"alice"}
 		if err := s.DeleteAllUserPendingPermissions(ctx, accounts); err != nil {
 			t.Fatal(err)
@@ -3070,7 +3070,7 @@ func TestPermsStore_UserIDsWithNoPerms(t *testing.T) {
 	t.Run("unified user_repo_permissions table", func(t *testing.T) {
 		mockUnifiedPermsConfig(true)
 
-		// mark sync jobs as completed for alice and add permissions for bob
+		// mark sync jobs as completed for "alice" and add permissions for "bob"
 		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(user_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonUserNoPermissions)
 		execQuery(t, ctx, s, q)
 

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -40,7 +40,7 @@ import (
 func cleanupPermsTables(t *testing.T, s *permsStore) {
 	t.Helper()
 
-	q := `TRUNCATE TABLE perms_sync_jobs_history, user_permissions, repo_permissions, user_pending_permissions, repo_pending_permissions, user_repo_permissions;`
+	q := `TRUNCATE TABLE permission_sync_jobs, user_permissions, repo_permissions, user_pending_permissions, repo_pending_permissions, user_repo_permissions;`
 	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 }
 
@@ -3049,22 +3049,45 @@ func TestPermsStore_UserIDsWithNoPerms(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	// mark sync jobs as completed for alice and bob
-	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, NOW())`, 1)
-	execQuery(t, ctx, s, q)
-	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, NOW())`, 2)
-	execQuery(t, ctx, s, q)
+	t.Run("legacy user_permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(false)
 
-	// Only "david" has no permissions at this point
-	ids, err = s.UserIDsWithNoPerms(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+		s.SetUserPermissions(ctx, &authz.UserPermissions{UserID: 1, IDs: map[int32]struct{}{1: {}}})
+		s.SetUserPermissions(ctx, &authz.UserPermissions{UserID: 2, IDs: make(map[int32]struct{})})
 
-	expIDs = []int32{4}
-	if diff := cmp.Diff(expIDs, ids); diff != "" {
-		t.Fatal(diff)
-	}
+		// Only "david" has no permissions at this point
+		ids, err = s.UserIDsWithNoPerms(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expIDs = []int32{4}
+		if diff := cmp.Diff(expIDs, ids); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("unified user_repo_permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(true)
+
+		// mark sync jobs as completed for alice and add permissions for bob
+		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(user_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonUserNoPermissions)
+		execQuery(t, ctx, s, q)
+
+		s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: 2, ExternalAccountID: 1}, []int32{1})
+
+		// Only "david" has no permissions at this point
+		ids, err = s.UserIDsWithNoPerms(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expIDs = []int32{4}
+		if diff := cmp.Diff(expIDs, ids); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
 }
 
 func cleanupReposTable(t *testing.T, s *permsStore) {
@@ -3119,19 +3142,41 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	// mark sync jobs as completed for "private_repo" and "private_repo_2"
-	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id) VALUES(%d)`, 1)
-	execQuery(t, ctx, s, q)
-	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id) VALUES(%d)`, 3)
-	execQuery(t, ctx, s, q)
+	t.Run("legacy user_permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(false)
 
-	// No private repositories have any permissions at this point
-	ids, err = s.RepoIDsWithNoPerms(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+		s.SetRepoPermissions(ctx, &authz.RepoPermissions{RepoID: 1, UserIDs: map[int32]struct{}{1: {}}})
+		s.SetRepoPermissions(ctx, &authz.RepoPermissions{RepoID: 3, UserIDs: make(map[int32]struct{})})
 
-	assert.Nil(t, ids)
+		// No private repositories have any permissions at this point
+		ids, err = s.RepoIDsWithNoPerms(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Nil(t, ids)
+	})
+
+	t.Run("unified user_repo_permissions table", func(t *testing.T) {
+		mockUnifiedPermsConfig(true)
+
+		// mark sync jobs as completed for "private_repo" and add permissions for "private_repo_2"
+		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(repository_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonRepoNoPermissions)
+		execQuery(t, ctx, s, q)
+
+		err := s.SetRepoPerms(ctx, 3, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// No private repositories have any permissions at this point
+		ids, err = s.RepoIDsWithNoPerms(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Nil(t, ids)
+	})
 }
 
 func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
@@ -3165,9 +3210,9 @@ func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
 	// mark sync jobs as completed for users 1 and 2
 	user1UpdatedAt := clock().Add(-15 * time.Minute)
 	user2UpdatedAt := clock().Add(-5 * time.Minute)
-	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, %s)`, 1, user1UpdatedAt)
+	q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(user_id, finished_at, reason) VALUES(%d, %s, %s)`, 1, user1UpdatedAt, database.ReasonUserOutdatedPermissions)
 	execQuery(t, ctx, s, q)
-	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, %s)`, 2, user2UpdatedAt)
+	q = sqlf.Sprintf(`INSERT INTO permission_sync_jobs(user_id, finished_at, reason) VALUES(%d, %s, %s)`, 2, user2UpdatedAt, database.ReasonUserOutdatedPermissions)
 	execQuery(t, ctx, s, q)
 
 	t.Run("One result when limit is 1", func(t *testing.T) {
@@ -3265,9 +3310,9 @@ func TestPermsStore_ReposIDsWithOldestPerms(t *testing.T) {
 	// mark sync jobs as completed for private_repo_1 and private_repo_2
 	repo1UpdatedAt := clock().Add(-15 * time.Minute)
 	repo2UpdatedAt := clock().Add(-5 * time.Minute)
-	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id, updated_at) VALUES(%d, %s)`, 1, repo1UpdatedAt)
+	q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(repository_id, finished_at, reason) VALUES(%d, %s, %s)`, 1, repo1UpdatedAt, database.ReasonRepoOutdatedPermissions)
 	execQuery(t, ctx, s, q)
-	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id, updated_at) VALUES(%d, %s)`, 2, repo2UpdatedAt)
+	q = sqlf.Sprintf(`INSERT INTO permission_sync_jobs(repository_id, finished_at, reason) VALUES(%d, %s, %s)`, 2, repo2UpdatedAt, database.ReasonRepoOutdatedPermissions)
 	execQuery(t, ctx, s, q)
 
 	t.Run("One result when limit is 1", func(t *testing.T) {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -38,14 +38,10 @@ import (
 )
 
 func cleanupPermsTables(t *testing.T, s *permsStore) {
-	if t.Failed() {
-		return
-	}
+	t.Helper()
 
-	q := `TRUNCATE TABLE user_permissions, repo_permissions, user_pending_permissions, repo_pending_permissions, user_repo_permissions;`
-	if err := s.execute(context.Background(), sqlf.Sprintf(q)); err != nil {
-		t.Fatal(err)
-	}
+	q := `TRUNCATE TABLE perms_sync_jobs_history, user_permissions, repo_permissions, user_pending_permissions, repo_pending_permissions, user_repo_permissions;`
+	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 }
 
 func mapsetToArray(ms map[int32]struct{}) []int {
@@ -2914,19 +2910,13 @@ func testPermsStore_DatabaseDeadlocks(db database.DB) func(*testing.T) {
 }
 
 func cleanupUsersTable(t *testing.T, s *permsStore) {
-	if t.Failed() {
-		return
-	}
+	t.Helper()
 
 	q := `DELETE FROM user_external_accounts;`
-	if err := s.execute(context.Background(), sqlf.Sprintf(q)); err != nil {
-		t.Fatal(err)
-	}
+	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 
 	q = `TRUNCATE TABLE users RESTART IDENTITY CASCADE;`
-	if err := s.execute(context.Background(), sqlf.Sprintf(q)); err != nil {
-		t.Fatal(err)
-	}
+	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 }
 
 func testPermsStore_GetUserIDsByExternalAccounts(db database.DB) func(*testing.T) {
@@ -3004,6 +2994,9 @@ func mockUnifiedPermsConfig(val bool) {
 
 func execQuery(t *testing.T, ctx context.Context, s *permsStore, q *sqlf.Query) {
 	t.Helper()
+	if t.Failed() {
+		return
+	}
 
 	err := s.execute(ctx, q)
 	if err != nil {
@@ -3020,111 +3013,65 @@ func TestPermsStore_UserIDsWithNoPerms(t *testing.T) {
 
 	testDb := dbtest.NewDB(logger, t)
 	db := database.NewDB(logger, testDb)
+	s := perms(logger, db, time.Now)
 
-	runTest := func(t *testing.T) {
-		t.Helper()
+	t.Cleanup(func() {
+		cleanupPermsTables(t, s)
+		cleanupUsersTable(t, s)
+		cleanupReposTable(t, s)
+	})
 
-		logger := logtest.Scoped(t)
-		s := perms(logger, db, time.Now)
-		t.Cleanup(func() {
-			cleanupPermsTables(t, s)
-			cleanupUsersTable(t, s)
-			cleanupReposTable(t, s)
-		})
+	ctx := context.Background()
 
-		ctx := context.Background()
-
-		// Create test users "alice" and "bob", test repo and test external account
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),                    // ID=1
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),                      // ID=2
-			sqlf.Sprintf(`INSERT INTO users(username, deleted_at) VALUES('cindy', NOW())`), // ID=3
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('david')`),                    // ID=4
-			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo', TRUE)`),   // ID=1
-			sqlf.Sprintf(`INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
+	// Create test users "alice" and "bob", test repo and test external account
+	qs := []*sqlf.Query{
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),                    // ID=1
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),                      // ID=2
+		sqlf.Sprintf(`INSERT INTO users(username, deleted_at) VALUES('cindy', NOW())`), // ID=3
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('david')`),                    // ID=4
+		sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo', TRUE)`),   // ID=1
+		sqlf.Sprintf(`INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
 				VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)`, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil, nil), // ID=1
-		}
-		for _, q := range qs {
-			execQuery(t, ctx, s, q)
-		}
-
-		// "alice", "bob" and "david" have no permissions
-		ids, err := s.UserIDsWithNoPerms(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-
-		expIDs := []int32{1, 2, 4}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
-
-		// Give "alice" some permissions, give bob no permissions
-		if UnifiedPermsEnabled() {
-			err = s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: 1, ExternalAccountID: 1}, []int32{1})
-			if err != nil {
-				t.Fatal(err)
-			}
-			q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(state, reason, user_id) VALUES(%s, %s, %d)`, database.PermissionsSyncJobStateCompleted, database.ReasonUserNoPermissions, 2)
-			execQuery(t, ctx, s, q)
-		} else {
-			_, err = s.SetUserPermissions(ctx, &authz.UserPermissions{
-				UserID: 1,
-				Perm:   authz.Read,
-				Type:   authz.PermRepos,
-				IDs:    toMapset(1),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = s.SetUserPermissions(ctx, &authz.UserPermissions{
-				Perm:   authz.Read,
-				Type:   authz.PermRepos,
-				UserID: 2,
-				IDs:    make(map[int32]struct{}),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		// Only "david" has no permissions at this point
-		ids, err = s.UserIDsWithNoPerms(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		expIDs = []int32{4}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+	}
+	for _, q := range qs {
+		execQuery(t, ctx, s, q)
 	}
 
-	t.Run("With legacy permissions table", func(t *testing.T) {
-		t.Cleanup(func() { conf.Mock(nil) })
-		mockUnifiedPermsConfig(false)
+	// "alice", "bob" and "david" have no permissions
+	ids, err := s.UserIDsWithNoPerms(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 
-		runTest(t)
-	})
+	expIDs := []int32{1, 2, 4}
+	if diff := cmp.Diff(expIDs, ids); diff != "" {
+		t.Fatal(diff)
+	}
 
-	t.Run("With new permissions tables", func(t *testing.T) {
-		t.Cleanup(func() { conf.Mock(nil) })
-		mockUnifiedPermsConfig(true)
+	// mark sync jobs as completed for alice and bob
+	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, NOW())`, 1)
+	execQuery(t, ctx, s, q)
+	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, NOW())`, 2)
+	execQuery(t, ctx, s, q)
 
-		runTest(t)
-	})
+	// Only "david" has no permissions at this point
+	ids, err = s.UserIDsWithNoPerms(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expIDs = []int32{4}
+	if diff := cmp.Diff(expIDs, ids); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func cleanupReposTable(t *testing.T, s *permsStore) {
-	if t.Failed() {
-		return
-	}
+	t.Helper()
 
 	q := `TRUNCATE TABLE repo RESTART IDENTITY CASCADE;`
-	if err := s.execute(context.Background(), sqlf.Sprintf(q)); err != nil {
-		t.Fatal(err)
-	}
+	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 }
 
 func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
@@ -3136,340 +3083,260 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 
 	testDb := dbtest.NewDB(logger, t)
 	db := database.NewDB(logger, testDb)
+	s := perms(logger, db, time.Now)
 
-	runTest := func(t *testing.T) {
-		t.Helper()
+	t.Cleanup(func() {
+		cleanupPermsTables(t, s)
+		cleanupReposTable(t, s)
+		cleanupUsersTable(t, s)
+	})
 
-		logger := logtest.Scoped(t)
-		s := perms(logger, db, time.Now)
-		t.Cleanup(func() {
-			cleanupReposTable(t, s)
-			cleanupPermsTables(t, s)
-			cleanupUsersTable(t, s)
-		})
+	ctx := context.Background()
 
-		ctx := context.Background()
-
-		// Create three test repositories
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo', TRUE)`),                      // ID=1
-			sqlf.Sprintf(`INSERT INTO repo(name) VALUES('public_repo')`),                                      // ID=2
-			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo_2', TRUE)`),                    // ID=3
-			sqlf.Sprintf(`INSERT INTO repo(name, private, deleted_at) VALUES('private_repo_3', TRUE, NOW())`), // ID=4
-			sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo_4', TRUE)`),                    // ID=5
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),                                       // ID=1
-			sqlf.Sprintf(`INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
+	// Create three test repositories
+	qs := []*sqlf.Query{
+		sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo', TRUE)`),                      // ID=1
+		sqlf.Sprintf(`INSERT INTO repo(name) VALUES('public_repo')`),                                      // ID=2
+		sqlf.Sprintf(`INSERT INTO repo(name, private) VALUES('private_repo_2', TRUE)`),                    // ID=3
+		sqlf.Sprintf(`INSERT INTO repo(name, private, deleted_at) VALUES('private_repo_3', TRUE, NOW())`), // ID=4
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),                                       // ID=1
+		sqlf.Sprintf(`INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
 				VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)`, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil, nil), // ID=1
-		}
-		for _, q := range qs {
-			execQuery(t, ctx, s, q)
-		}
-
-		// Should get back two private repos that are not deleted
-		ids, err := s.RepoIDsWithNoPerms(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-
-		expIDs := []api.RepoID{1, 3, 5}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
-
-		// Give "private_repo" regular permissions and "private_repo_2" pending permissions and "private_repo_4" no permissions
-		if UnifiedPermsEnabled() {
-			err = s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}})
-			if err != nil {
-				t.Fatal(err)
-			}
-			q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(state, reason, repository_id) VALUES(%s, %s, %d)`, database.PermissionsSyncJobStateCompleted, database.ReasonUserNoPermissions, 5)
-			execQuery(t, ctx, s, q)
-		} else {
-			_, err = s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-				RepoID:  1,
-				Perm:    authz.Read,
-				UserIDs: toMapset(1),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-				RepoID:  5,
-				Perm:    authz.Read,
-				UserIDs: make(map[int32]struct{}),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		err = s.SetRepoPendingPermissions(ctx,
-			&extsvc.Accounts{
-				ServiceType: authz.SourcegraphServiceType,
-				ServiceID:   authz.SourcegraphServiceID,
-				AccountIDs:  []string{"alice"},
-			},
-			&authz.RepoPermissions{
-				RepoID: 3,
-				Perm:   authz.Read,
-			},
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// No private repositories have any permissions at this point
-		ids, err = s.RepoIDsWithNoPerms(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		expIDs = []api.RepoID{}
-		if diff := cmp.Diff(expIDs, ids); diff != "" {
-			t.Fatal(diff)
-		}
+	}
+	for _, q := range qs {
+		execQuery(t, ctx, s, q)
 	}
 
-	t.Run("With legacy permissions table", func(t *testing.T) {
-		mockUnifiedPermsConfig(false)
-		t.Cleanup(func() { conf.Mock(nil) })
+	// Should get back two private repos that are not deleted
+	ids, err := s.RepoIDsWithNoPerms(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 
-		runTest(t)
-	})
+	expIDs := []api.RepoID{1, 3}
+	if diff := cmp.Diff(expIDs, ids); diff != "" {
+		t.Fatal(diff)
+	}
 
-	t.Run("With unified permissions table", func(t *testing.T) {
-		mockUnifiedPermsConfig(true)
-		t.Cleanup(func() { conf.Mock(nil) })
+	// mark sync jobs as completed for "private_repo" and "private_repo_2"
+	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repository_id) VALUES(%d)`, 1)
+	execQuery(t, ctx, s, q)
+	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repository_id) VALUES(%d)`, 3)
+	execQuery(t, ctx, s, q)
 
-		runTest(t)
-	})
+	// No private repositories have any permissions at this point
+	ids, err = s.RepoIDsWithNoPerms(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expIDs = []api.RepoID{}
+	if diff := cmp.Diff(expIDs, ids); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
-func testPermsStore_UserIDsWithOldestPerms(db database.DB) func(*testing.T) {
-	return func(t *testing.T) {
-		logger := logtest.Scoped(t)
-		s := perms(logger, db, clock)
-		ctx := context.Background()
-		t.Cleanup(func() {
-			cleanupPermsTables(t, s)
+func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 
-			if t.Failed() {
-				return
-			}
+	logger := logtest.Scoped(t)
 
-			if err := s.execute(ctx, sqlf.Sprintf(`DELETE FROM users`)); err != nil {
-				t.Fatal(err)
-			}
-		})
+	testDb := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDb)
+	s := perms(logger, db, clock)
+	ctx := context.Background()
 
-		// Set up some users and permissions
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(1, 'alice')`),
-			sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(2, 'bob')`),
-			sqlf.Sprintf(`INSERT INTO users(id, username, deleted_at) VALUES(3, 'cindy', NOW())`),
-		}
-		for _, q := range qs {
-			if err := s.execute(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
+	t.Cleanup(func() {
+		cleanupPermsTables(t, s)
+		cleanupReposTable(t, s)
+		cleanupUsersTable(t, s)
+	})
 
-		// Set up some permissions
-		_, err := s.SetRepoPermissions(ctx, &authz.RepoPermissions{
-			RepoID:  1,
-			Perm:    authz.Read,
-			UserIDs: toMapset(1, 2),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
+	// Set up some users and permissions
+	qs := []*sqlf.Query{
+		sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(1, 'alice')`),
+		sqlf.Sprintf(`INSERT INTO users(id, username) VALUES(2, 'bob')`),
+		sqlf.Sprintf(`INSERT INTO users(id, username, deleted_at) VALUES(3, 'cindy', NOW())`),
+	}
+	for _, q := range qs {
+		execQuery(t, ctx, s, q)
+	}
 
-		// Mock user user 2's permissions to be synced in the future
-		q := sqlf.Sprintf(`
-UPDATE user_permissions
-SET synced_at = %s
-WHERE user_id = 2`, clock().AddDate(1, 0, 0))
-		if err := s.execute(ctx, q); err != nil {
-			t.Fatal(err)
-		}
+	// mark sync jobs as completed for users 1 and 2
+	user1UpdatedAt := clock().Add(-15 * time.Minute)
+	user2UpdatedAt := clock().Add(-5 * time.Minute)
+	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, %s)`, 1, user1UpdatedAt)
+	execQuery(t, ctx, s, q)
+	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(user_id, updated_at) VALUES(%d, %s)`, 2, user2UpdatedAt)
+	execQuery(t, ctx, s, q)
 
-		// Should only get user 1 back (NULL FIRST)
+	t.Run("One result when limit is 1", func(t *testing.T) {
+		// Should only get user 1 back, because limit is 1
 		results, err := s.UserIDsWithOldestPerms(ctx, 1, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults := map[int32]time.Time{1: {}}
+		wantResults := map[int32]time.Time{1: user1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
 			t.Fatal(diff)
 		}
+	})
 
-		// Should get both users back
-		results, err = s.UserIDsWithOldestPerms(ctx, 2, 0)
+	t.Run("One result when limit is 10 and age is 10 minutes", func(t *testing.T) {
+		// Should only get user 1 back, because age is 10 minutes
+		results, err := s.UserIDsWithOldestPerms(ctx, 1, 10*time.Minute)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults = map[int32]time.Time{
-			1: {},
-			2: clock().AddDate(1, 0, 0),
-		}
+		wantResults := map[int32]time.Time{1: user1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
 			t.Fatal(diff)
 		}
+	})
 
-		// Ignore users that have synced recently (or in the future)
-		results, err = s.UserIDsWithOldestPerms(ctx, 5, 1*time.Hour)
+	t.Run("Both users are returned when limit is 10 and age is 1 minute", func(t *testing.T) {
+		// Should get both users, since the limit is 10 and age is 1 minute only
+		results, err := s.UserIDsWithOldestPerms(ctx, 1, 1*time.Minute)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults = map[int32]time.Time{
-			1: {},
-			// User 2 should be filtered out since it synced in the future
-		}
+		wantResults := map[int32]time.Time{1: user1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
 			t.Fatal(diff)
 		}
+	})
 
-		// Hard-delete user 2
-		if err := s.execute(ctx, sqlf.Sprintf(`DELETE FROM users WHERE id = 2`)); err != nil {
-			t.Fatal(err)
-		}
-
-		// Should only get user 1 back with limit=2
-		results, err = s.UserIDsWithOldestPerms(ctx, 2, 0)
+	t.Run("Both users are returned when limit is 10 and age is 0", func(t *testing.T) {
+		// Should get both users, since the limit is 10 and age is 0
+		results, err := s.UserIDsWithOldestPerms(ctx, 1, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults = map[int32]time.Time{1: {}}
+		wantResults := map[int32]time.Time{1: user1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
-			t.Fatalf("Results mismatch (-want +got):\n%s", diff)
+			t.Fatal(diff)
 		}
-	}
+	})
+
+	t.Run("Ignore userse that have synced recently", func(t *testing.T) {
+		// Should get no results, since the and age is 1 hour
+		results, err := s.UserIDsWithOldestPerms(ctx, 1, 1*time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantResults := make(map[int32]time.Time)
+		if diff := cmp.Diff(wantResults, results); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }
 
-func testPermsStore_ReposIDsWithOldestPerms(db database.DB) func(*testing.T) {
-	return func(t *testing.T) {
-		logger := logtest.Scoped(t)
-		s := perms(logger, db, clock)
-		ctx := context.Background()
-		t.Cleanup(func() {
-			cleanupPermsTables(t, s)
+func TestPermsStore_ReposIDsWithOldestPerms(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 
-			if t.Failed() {
-				return
-			}
+	logger := logtest.Scoped(t)
 
-			q := `TRUNCATE TABLE external_services, repo CASCADE`
-			if err := s.execute(ctx, sqlf.Sprintf(q)); err != nil {
-				t.Fatal(err)
-			}
-		})
+	testDb := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDb)
+	s := perms(logger, db, clock)
+	ctx := context.Background()
+	t.Cleanup(func() {
+		cleanupPermsTables(t, s)
+		cleanupReposTable(t, s)
+	})
 
-		// Set up some repositories and permissions
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(1, 'private_repo_1', TRUE)`),
-			sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(2, 'private_repo_2', TRUE)`),
-			sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(3, 'private_repo_3', TRUE, NOW())`),
-			sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config) VALUES(1, 'GitHub #1', 'GITHUB', '{}')`),
-			sqlf.Sprintf(`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url)
-                                 VALUES(1, 1, ''), (2, 1, ''), (3, 1, '')`),
-		}
+	// Set up some repositories and permissions
+	qs := []*sqlf.Query{
+		sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(1, 'private_repo_1', TRUE)`),                    // id=1
+		sqlf.Sprintf(`INSERT INTO repo(id, name, private) VALUES(2, 'private_repo_2', TRUE)`),                    // id=2
+		sqlf.Sprintf(`INSERT INTO repo(id, name, private, deleted_at) VALUES(3, 'private_repo_3', TRUE, NOW())`), // id=3
+	}
+	for _, q := range qs {
+		execQuery(t, ctx, s, q)
+	}
 
-		for _, q := range qs {
-			if err := s.execute(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
+	// mark sync jobs as completed for private_repo_1 and private_repo_2
+	repo1UpdatedAt := clock().Add(-15 * time.Minute)
+	repo2UpdatedAt := clock().Add(-5 * time.Minute)
+	q := sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id, updated_at) VALUES(%d, %s)`, 1, repo1UpdatedAt)
+	execQuery(t, ctx, s, q)
+	q = sqlf.Sprintf(`INSERT INTO perms_sync_jobs_history(repo_id, updated_at) VALUES(%d, %s)`, 2, repo2UpdatedAt)
+	execQuery(t, ctx, s, q)
 
-		perms := []*authz.RepoPermissions{
-			{
-				RepoID:  1,
-				Perm:    authz.Read,
-				UserIDs: toMapset(1),
-			}, {
-				RepoID:  2,
-				Perm:    authz.Read,
-				UserIDs: toMapset(1),
-			}, {
-				RepoID:  3,
-				Perm:    authz.Read,
-				UserIDs: toMapset(1),
-			},
-		}
-		for _, perm := range perms {
-			_, err := s.SetRepoPermissions(ctx, perm)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		// Mock repo 2's permissions to be synced in the past
-		q := sqlf.Sprintf(`
-UPDATE repo_permissions
-SET synced_at = %s
-WHERE repo_id = 2`, clock().AddDate(-1, 0, 0))
-		if err := s.execute(ctx, q); err != nil {
-			t.Fatal(err)
-		}
-
-		// Should only get repo 1 back
+	t.Run("One result when limit is 1", func(t *testing.T) {
+		// Should only get private_repo_1 back, because limit is 1
 		results, err := s.ReposIDsWithOldestPerms(ctx, 1, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults := map[api.RepoID]time.Time{2: clock().AddDate(-1, 0, 0)}
-		if diff := cmp.Diff(wantResults, results); diff != "" {
-			t.Fatalf("Results mismatch (-want +got):\n%s", diff)
-		}
-
-		// Should get two repos back
-		results, err = s.ReposIDsWithOldestPerms(ctx, 2, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		wantResults = map[api.RepoID]time.Time{
-			1: clock(),
-			2: clock().AddDate(-1, 0, 0),
-		}
-		if diff := cmp.Diff(wantResults, results); diff != "" {
-			t.Fatalf("Results mismatch (-want +got):\n%s", diff)
-		}
-
-		// Ignore repos that have synced recently (or in the future)
-		results, err = s.ReposIDsWithOldestPerms(ctx, 2, 1*time.Hour)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		wantResults = map[api.RepoID]time.Time{
-			// Only repo 2 should appear since it was synced a long time in the past
-			2: clock().AddDate(-1, 0, 0),
-		}
+		wantResults := map[api.RepoID]time.Time{1: repo1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
 			t.Fatal(diff)
 		}
+	})
 
-		// Hard-delete repo 2
-		if err := s.execute(ctx, sqlf.Sprintf(`DELETE FROM repo WHERE id = 2`)); err != nil {
-			t.Fatal(err)
-		}
-
-		// Should only get repo 1 back with limit=2
-		results, err = s.ReposIDsWithOldestPerms(ctx, 2, 0)
+	t.Run("One result when limit is 10 and age is 10 minutes", func(t *testing.T) {
+		// Should only get private_repo_1 back, because age is 10 minutes
+		results, err := s.ReposIDsWithOldestPerms(ctx, 1, 10*time.Minute)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wantResults = map[api.RepoID]time.Time{1: clock()}
+		wantResults := map[api.RepoID]time.Time{1: repo1UpdatedAt}
 		if diff := cmp.Diff(wantResults, results); diff != "" {
-			t.Fatalf("Results mismatch (-want +got):\n%s", diff)
+			t.Fatal(diff)
 		}
-	}
+	})
+
+	t.Run("Both users are returned when limit is 10 and age is 1 minute", func(t *testing.T) {
+		// Should get both private_repo_1 and private_repo_2, since the limit is 10 and age is 1 minute only
+		results, err := s.ReposIDsWithOldestPerms(ctx, 1, 1*time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantResults := map[api.RepoID]time.Time{1: repo1UpdatedAt}
+		if diff := cmp.Diff(wantResults, results); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("Both users are returned when limit is 10 and age is 0", func(t *testing.T) {
+		// Should get both private_repo_1 and private_repo_2, since the limit is 10 and age is 0
+		results, err := s.ReposIDsWithOldestPerms(ctx, 1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantResults := map[api.RepoID]time.Time{1: repo1UpdatedAt}
+		if diff := cmp.Diff(wantResults, results); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("Ignore repos that have synced recently", func(t *testing.T) {
+		// Should get no results, since the and age is 1 hour
+		results, err := s.ReposIDsWithOldestPerms(ctx, 1, 1*time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantResults := make(map[api.RepoID]time.Time)
+		if diff := cmp.Diff(wantResults, results); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }
 
 func testPermsStore_MapUsers(db database.DB) func(*testing.T) {


### PR DESCRIPTION
## Related to

This is the same code as here, that was already approved, but merging to main instead:
- https://github.com/sourcegraph/sourcegraph/pull/48915

## Description
This change changes the way we schedule permission sync jobs.

We will follow these rules now:

- For the high priority schedule for entities with no permissions: List all users who do not have permissions or do not have a job in perms_sync_jobs_history table. And similar for the orthogonal repo case.
- For the medium priority schedue for entities with oldest permissions: Take x amount of user_ids from perms_sync_jobs_history with the oldest updated_at timestamps. Similar for orthogonal repo case.

This way, we simplify the logic for scheduling.
A nice side effect is also, that the scheduling of oldest perms is now completely decoupled from the permissions themselves.

## Test plan
Added/modified unit tests. Tested locally that it works.