### PR TITLE
experimental search input: Use Mod-Enter to trigger alternative action

### DIFF
--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -68,7 +68,7 @@ export interface Option {
     action: Action
     /**
      * Options can have perform an alternative action when applied via
-     * Shift+Enter.
+     * Mod-Enter.
      */
     alternativeAction?: Action
     /**
@@ -615,7 +615,10 @@ const defaultKeyboardBindings: KeyBinding[] = [
             applyAction(view, option.action, option)
             return true
         },
-        shift(view) {
+    },
+    {
+        key: 'Mod-Enter',
+        run(view) {
             const state = view.state.field(suggestionsStateField)
             const option = state.result.at(state.selectedOption)
             if (!state.open || !option || !option.alternativeAction) {


### PR DESCRIPTION
By popular demand.

## Test plan

Select suggestion and press Ctrl-Enter (or Cmd-Enter on macOS)

## App preview:

- [Web](https://sg-web-fkling-search-input-mod-enter.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
