### PR TITLE
Blob: Enable lazy syntax highlighting by default

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -126,7 +126,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, ..
     const { repoID, repoName, repoServiceType, revision, commitID, filePath, useBreadcrumb, mode } = props
     const { enableCodeMirror, enableLazyBlobSyntaxHighlighting } = useExperimentalFeatures(features => ({
         enableCodeMirror: features.enableCodeMirrorFileView ?? true,
-        enableLazyBlobSyntaxHighlighting: features.enableLazyBlobSyntaxHighlighting ?? false,
+        enableLazyBlobSyntaxHighlighting: features.enableLazyBlobSyntaxHighlighting ?? true,
     }))
     const isPackage = useMemo(() => isPackageServiceType(repoServiceType), [repoServiceType])
 

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -114,7 +114,7 @@ export const fetchBlob = memoizeObservable((options: FetchBlobOptions): Observab
 export const usePrefetchBlobFormat = (): HighlightResponseFormat => {
     const { enableCodeMirror, enableLazyHighlighting } = useExperimentalFeatures(features => ({
         enableCodeMirror: features.enableCodeMirrorFileView ?? true,
-        enableLazyHighlighting: features.enableLazyBlobSyntaxHighlighting ?? false,
+        enableLazyHighlighting: features.enableLazyBlobSyntaxHighlighting ?? true,
     }))
 
     /**


### PR DESCRIPTION
## Description

Enables `enableLazyBlobSyntaxHighlighting` by default. Can still be overriden by explicitly disabling the flag.

Considered removing the flag entirely as it's been enabled for customers for a few months now, but this gives us a little extra safety given we're close to a code freeze + release.

## Test plan

Tested locally:
- With no flag
- With flag set and enabled
- With flag set and disabled

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-enable-lazy-highlighting.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
