### PR TITLE
App: Hide more items in site-admin page and make it an "advanced settings" section

### DIFF
--- a/client/web/src/enterprise/namespaces/navitems.ts
+++ b/client/web/src/enterprise/namespaces/navitems.ts
@@ -6,6 +6,6 @@ export const enterpriseNamespaceAreaHeaderNavItems: readonly NamespaceAreaNavIte
         to: '/batch-changes',
         label: 'Batch Changes',
         icon: BatchChangesIconNamespaceNav,
-        condition: ({ batchChangesEnabled }) => batchChangesEnabled,
+        condition: ({ batchChangesEnabled, isSourcegraphApp }) => batchChangesEnabled && !isSourcegraphApp,
     },
 ]

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -22,6 +22,8 @@ const configurationGroup: SiteAdminSideBarGroup = {
         {
             label: 'License',
             to: '/site-admin/license',
+
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],
 }
@@ -81,7 +83,7 @@ export const batchChangesGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/outbound-webhooks',
         },
     ],
-    condition: ({ batchChangesEnabled }) => batchChangesEnabled,
+    condition: ({ batchChangesEnabled, isSourcegraphApp }) => batchChangesEnabled && !isSourcegraphApp,
 }
 
 const businessGroup: SiteAdminSideBarGroup = {
@@ -108,6 +110,7 @@ const businessGroup: SiteAdminSideBarGroup = {
 
 const codeIntelGroup: SiteAdminSideBarGroup = {
     header: { label: 'Code graph', icon: BrainIcon },
+    condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
     items: [
         {
             to: '/site-admin/code-graph/dashboard',
@@ -135,6 +138,7 @@ const repositoriesGroup: SiteAdminSideBarGroup = {
         {
             label: 'Incoming webhooks',
             to: '/site-admin/webhooks',
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],
 }

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -197,7 +197,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 </>
                             )}
                             <MenuDivider className={styles.dropdownDivider} />
-                            {authenticatedUser.siteAdmin && (
+                            {authenticatedUser.siteAdmin && !isSourcegraphApp && (
                                 <MenuLink as={Link} to="/site-admin">
                                     Site admin
                                 </MenuLink>

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -85,7 +85,9 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         <Page>
             <PageHeader>
                 <PageHeader.Heading as="h2" styleAs="h1">
-                    <PageHeader.Breadcrumb>Admin</PageHeader.Breadcrumb>
+                    <PageHeader.Breadcrumb>
+                        {props.isSourcegraphApp ? 'Advanced Settings' : 'Admin'}
+                    </PageHeader.Breadcrumb>
                 </PageHeader.Heading>
             </PageHeader>
             <div className="d-flex my-3 flex-column flex-sm-row" ref={reference}>

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -214,6 +214,7 @@ const quickConfigureActions: {
 interface Props extends TelemetryProps {
     isLightTheme: boolean
     client: ApolloClient<{}>
+    isSourcegraphApp: boolean
 }
 
 interface State {
@@ -229,7 +230,7 @@ interface State {
 
 const EXPECTED_RELOAD_WAIT = 7 * 1000 // 7 seconds
 
-export const SiteAdminConfigurationPage: FC<TelemetryProps> = props => {
+export const SiteAdminConfigurationPage: FC<TelemetryProps & { isSourcegraphApp: boolean }> = props => {
     const client = useApolloClient()
     return <SiteAdminConfigurationContent {...props} isLightTheme={useIsLightTheme()} client={client} />
 }
@@ -430,7 +431,7 @@ class SiteAdminConfigurationContent extends React.Component<Props, State> {
                                 height={600}
                                 isLightTheme={this.props.isLightTheme}
                                 onSave={this.onSave}
-                                actions={quickConfigureActions}
+                                actions={this.props.isSourcegraphApp ? [] : quickConfigureActions}
                                 telemetryService={this.props.telemetryService}
                                 explanation={
                                     <Text className="form-text text-muted">

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -38,9 +38,7 @@ import { SITE_UPDATE_CHECK, SITE_UPGRADE_READINESS } from './backend'
 
 import styles from './SiteAdminUpdatesPage.module.scss'
 
-interface Props extends TelemetryProps {
-    isSourcegraphApp: boolean
-}
+interface Props extends TelemetryProps {}
 
 const SiteUpdateCheck: React.FC = () => {
     const { data, loading, error } = useQuery<SiteUpdateCheckResult, SiteUpdateCheckVariables>(SITE_UPDATE_CHECK, {})
@@ -203,23 +201,19 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
 /**
  * A page displaying information about available updates for the server.
  */
-export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService, isSourcegraphApp }) => {
+export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminUpdates')
     }, [telemetryService])
 
     return (
         <div>
-            <PageTitle title={`${isSourcegraphApp ? 'Overview' : 'Updates'} - Admin`} />
+            <PageTitle title="Updates - Admin" />
 
-            {!isSourcegraphApp ? (
-                <>
-                    <PageHeader path={[{ text: 'Updates' }]} headingElement="h2" className="mb-3" />
-                    <Container className="mb-3">
-                        <SiteUpdateCheck />
-                    </Container>
-                </>
-            ) : null}
+            <PageHeader path={[{ text: 'Updates' }]} headingElement="h2" className="mb-3" />
+            <Container className="mb-3">
+                <SiteUpdateCheck />
+            </Container>
 
             <PageHeader path={[{ text: 'Readiness' }]} headingElement="h2" className="mb-3" />
             <Container className="mb-3">

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -11,6 +11,7 @@ import { isPackagesEnabled } from './flags'
 import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from './SiteAdminSidebar'
 
 export const analyticsGroup: SiteAdminSideBarGroup = {
+    condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
     header: {
         label: 'Analytics',
         icon: ChartLineVariantIcon,
@@ -70,11 +71,11 @@ export const configurationGroup: SiteAdminSideBarGroup = {
         {
             label: 'Global settings',
             to: '/site-admin/global-settings',
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Feature flags',
             to: '/site-admin/feature-flags',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],
 }
@@ -139,9 +140,10 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
         label: 'Maintenance',
         icon: MonitorStarIcon,
     },
+    condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
     items: [
         {
-            label: window.context.sourcegraphAppMode ? 'Overview' : 'Updates',
+            label: 'Updates',
             to: '/site-admin/updates',
         },
         {
@@ -151,7 +153,6 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
         {
             label: 'Pings',
             to: '/site-admin/pings',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Report a bug',

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -123,11 +123,16 @@ export const UserSettingsSidebar: FC<UserSettingsSidebarProps> = props => {
                             API console
                         </SidebarNavItem>
                     )}
-                    {props.authenticatedUser.siteAdmin && (
-                        <SidebarNavItem to="/site-admin" onClick={collapseMobileSidebar}>
-                            Site admin
-                        </SidebarNavItem>
-                    )}
+                    {props.authenticatedUser.siteAdmin &&
+                        (props.isSourcegraphApp ? (
+                            <SidebarNavItem to="/site-admin/configuration" onClick={collapseMobileSidebar}>
+                                Advanced settings
+                            </SidebarNavItem>
+                        ) : (
+                            <SidebarNavItem to="/site-admin" onClick={collapseMobileSidebar}>
+                                Site admin
+                            </SidebarNavItem>
+                        ))}
                 </SidebarGroup>
                 <div>Version: {window.context.version}</div>
             </div>


### PR DESCRIPTION
Closes #48402

This PR adds the remaining changes that were discussed in [this doc](https://docs.google.com/document/d/1DH-hlcTMs5GOUXPcqy9nJ9RIgP4gmlrMn6GD5pxq5Bc/edit).

Namely:

- We hide even more items in the site-admin area. There's not a lot going on there anymore.
- Changed the title of site admin area to "Advanced settings" for app
- Reverted a change to the update page, we now hide it instead.
- Removed additional options in the Site config page
- Removed site-admin from the dropdown menu
- Renamed site-admin in the user menu to "Advanced settings" and link it to the first page for app.
- Removed batch changes from the user dropdown. The entrypoint from the app header is enough.

## Test plan

Tested locally, here are some screenshots:

<table>
<tr>
	<td><img width="1165" alt="Screenshot 2023-03-10 at 12 44 00" src="https://user-images.githubusercontent.com/458591/224308503-f09725c3-7344-4663-86f5-abefe31fd731.png">
	<td><img width="1267" alt="Screenshot 2023-03-10 at 12 43 54" src="https://user-images.githubusercontent.com/458591/224308512-200e3f69-01e0-4f23-8787-29d4c8209ea8.png">
	<td><img width="299" alt="Screenshot 2023-03-10 at 12 17 34" src="https://user-images.githubusercontent.com/458591/224308514-011513cc-8743-46d8-9847-db833415c0f8.png">
</table>


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-site-admin-changes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
