### PR TITLE
SCIM: Add existing user matching by email

### DIFF
--- a/enterprise/internal/scim/mock_db.go
+++ b/enterprise/internal/scim/mock_db.go
@@ -164,6 +164,17 @@ func getMockDB(users []*types.UserForSCIM, userEmails map[int32][]*database.User
 		}
 		return toReturn, nil
 	})
+	userEmailsStore.GetVerifiedEmailsFunc.SetDefaultHook(func(ctx context.Context, emails ...string) ([]*database.UserEmail, error) {
+		toReturn := make([]*database.UserEmail, 0)
+		for _, email := range emails {
+			for _, userEmail := range userEmails {
+				if userEmail[0].Email == email && userEmail[0].VerifiedAt != nil {
+					toReturn = append(toReturn, userEmail[0])
+				}
+			}
+		}
+		return toReturn, nil
+	})
 
 	// Create DB
 	db := database.NewMockDB()

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -30,6 +30,9 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 	// Try to match emails to existing users
 	allEmails := append([]string{primaryEmail}, otherEmails...)
 	existingEmails, err := h.db.UserEmails().GetVerifiedEmails(r.Context(), allEmails...)
+	if err != nil {
+		return scim.Resource{}, scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
+	}
 	existingUserIDs := make(map[int32]struct{})
 	for _, email := range existingEmails {
 		existingUserIDs[email.UserID] = struct{}{}

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -7,15 +7,19 @@ import (
 
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Create stores given attributes. Returns a resource with the attributes that are stored and a (new) unique identifier.
 func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {
+	if err := checkBodyNotEmpty(r); err != nil {
+		return scim.Resource{}, err
+	}
+
 	// Extract external ID, primary email, username, and display name from attributes to variables
 	primaryEmail, otherEmails := extractPrimaryEmail(attributes)
 	if primaryEmail == "" {
@@ -23,9 +27,44 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 	}
 	displayName := extractDisplayName(attributes)
 
+	// Try to match emails to existing users
+	allEmails := append([]string{primaryEmail}, otherEmails...)
+	existingEmails, err := h.db.UserEmails().GetVerifiedEmails(r.Context(), allEmails...)
+	existingUserIDs := make(map[int32]struct{})
+	for _, email := range existingEmails {
+		existingUserIDs[email.UserID] = struct{}{}
+	}
+	if len(existingUserIDs) > 1 {
+		return scim.Resource{}, scimerrors.ScimError{Status: http.StatusConflict, Detail: "Emails match to multiple users"}
+	}
+	if len(existingUserIDs) == 1 {
+		userID := int32(0)
+		for id := range existingUserIDs {
+			userID = id
+		}
+		// A user with the email(s) already exists → check if the user is not SCIM-controlled
+		user, err := h.db.Users().GetByID(r.Context(), userID)
+		if err != nil {
+			return scim.Resource{}, scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: err.Error()}
+		}
+		if user == nil {
+			return scim.Resource{}, scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: "User not found"}
+		}
+		if user.SCIMControlled {
+			// This user creation would fail based on the email address, so we'll return a conflict error
+			return scim.Resource{}, scimerrors.ScimError{Status: http.StatusConflict, Detail: "User already exists based on email address"}
+		}
+
+		// The user exists, but is not SCIM-controlled, so we'll update the user with the new attributes,
+		// and make the user SCIM-controlled (which is the same as a replace)
+		return h.Replace(r, strconv.FormatInt(int64(userID), 10), attributes)
+	}
+
+	// At this point we know that the user does not exist yet, so we'll create a new user
+
 	// Make sure the username is unique, then create user with/without an external account ID
 	var user *types.User
-	err := h.db.WithTransact(r.Context(), func(tx database.DB) error {
+	err = h.db.WithTransact(r.Context(), func(tx database.DB) error {
 		uniqueUsername, err := getUniqueUsername(r.Context(), tx.Users(), extractStringAttribute(attributes, AttrUserName))
 		if err != nil {
 			return err

--- a/enterprise/internal/scim/user_create_test.go
+++ b/enterprise/internal/scim/user_create_test.go
@@ -2,7 +2,7 @@ package scim
 
 import (
 	"context"
-	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/elimity-com/scim"
@@ -17,26 +17,36 @@ func TestUserResourceHandler_Create(t *testing.T) {
 	t.Parallel()
 
 	db := getMockDB([]*types.UserForSCIM{
-		{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
+		{User: types.User{ID: 1, Username: "user1", DisplayName: "Yay Scim", SCIMControlled: true}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
+		{User: types.User{ID: 2, Username: "user2", DisplayName: "Nay Scim", SCIMControlled: false}, Emails: []string{"b@example.com"}},
+		{User: types.User{ID: 3, Username: "user3", DisplayName: "Also Yay Scim", SCIMControlled: true}, Emails: []string{"c@example.com"}, SCIMExternalID: "id3"},
+		{User: types.User{ID: 4, Username: "user4", DisplayName: "Double No Scim", SCIMControlled: false}, Emails: []string{"d@example.com", "dd@example.com"}},
 	},
-		map[int32][]*database.UserEmail{})
+		map[int32][]*database.UserEmail{
+			1: {&database.UserEmail{UserID: 1, Email: "a@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			2: {&database.UserEmail{UserID: 2, Email: "b@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			3: {&database.UserEmail{UserID: 3, Email: "c@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			4: {&database.UserEmail{UserID: 4, Email: "d@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			5: {&database.UserEmail{UserID: 4, Email: "dd@example.com", VerifiedAt: &verifiedDate, Primary: false}},
+		})
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
 	testCases := []struct {
-		name     string
-		username string
-		testFunc func(t *testing.T, usernameInDB string, usernameInResource string, err error)
+		name       string
+		username   string
+		attrEmails []interface{}
+		testFunc   func(t *testing.T, usernameInDB string, usernameInResource string, err error)
 	}{
 		{
-			name:     "create user with new username",
-			username: "user2",
+			name:     "usernames - create user with new username",
+			username: "user5",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "user2", usernameInDB)
-				assert.Equal(t, "user2", usernameInResource)
+				assert.Equal(t, "user5", usernameInDB)
+				assert.Equal(t, "user5", usernameInResource)
 			},
 		},
 		{
-			name:     "create user with existing username",
+			name:     "usernames - create user with existing username",
 			username: "user1",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
@@ -45,7 +55,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			},
 		},
 		{
-			name:     "create user with email address as the username",
+			name:     "usernames - create user with email address as the username",
 			username: "test@company.com",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
@@ -54,7 +64,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			},
 		},
 		{
-			name:     "create user with email address as a duplicate username",
+			name:     "usernames - create user with email address as a duplicate username",
 			username: "user1@company.com",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
@@ -63,7 +73,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			},
 		},
 		{
-			name:     "create user with empty username",
+			name:     "usernames - create user with empty username",
 			username: "",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
@@ -71,21 +81,96 @@ func TestUserResourceHandler_Create(t *testing.T) {
 				assert.Equal(t, "", usernameInResource)
 			},
 		},
+		{
+			name:     "usernames - create user with empty username",
+			username: "",
+			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
+				assert.NoError(t, err)
+				assert.Len(t, usernameInDB, 5) // abcde
+				assert.Equal(t, "", usernameInResource)
+			},
+		},
+		{
+			name:     "existing email - fail for scim-controlled user",
+			username: "updated-user1",
+			attrEmails: []interface{}{
+				map[string]interface{}{"value": "a@example.com", "primary": false},
+			},
+			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, "409 - User already exists based on email address", err.Error())
+			},
+		},
+		{
+			name:     "existing email - pass for non-scim-controlled user",
+			username: "updated-user2",
+			attrEmails: []interface{}{
+				map[string]interface{}{"value": "b@example.com", "primary": false},
+			},
+			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "updated-user2", usernameInDB)
+				assert.Equal(t, "updated-user2", usernameInResource)
+			},
+		},
+		{
+			name:     "existing email - fail for multiple users",
+			username: "updated-user3",
+			attrEmails: []interface{}{
+				map[string]interface{}{"value": "c@example.com", "primary": false},
+				map[string]interface{}{"value": "dd@example.com", "primary": true},
+			},
+			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, "409 - Emails match to multiple users", err.Error())
+			},
+		},
+		{
+			name:     "existing email - pass for multiple emails for same user",
+			username: "updated-user4",
+			attrEmails: []interface{}{
+				map[string]interface{}{"value": "d@example.com", "primary": false},
+				map[string]interface{}{"value": "dd@example.com", "primary": true},
+			},
+			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "updated-user4", usernameInDB)
+				assert.Equal(t, "updated-user4", usernameInResource)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			userRes, err := userResourceHandler.Create(&http.Request{}, createUserResourceAttributes(tc.username))
-			newUser, _ := db.Users().GetByID(context.Background(), 2)
-			tc.testFunc(t, newUser.Username, userRes.Attributes[AttrUserName].(string), err)
-			_ = db.Users().Delete(context.Background(), 2)
+			userRes, err := userResourceHandler.Create(createDummyRequest(), createUserResourceAttributes(tc.username, tc.attrEmails))
+			id, _ := strconv.Atoi(userRes.ID)
+			newUser, _ := db.Users().GetByID(context.Background(), int32(id))
+			usernameInDB := ""
+			usernameInResource := ""
+			if err == nil {
+				usernameInDB = newUser.Username
+				usernameInResource = userRes.Attributes[AttrUserName].(string)
+			}
+			tc.testFunc(t, usernameInDB, usernameInResource, err)
+			if id > 4 {
+				_ = db.Users().Delete(context.Background(), int32(id))
+			}
 		})
 	}
 
 }
 
 // createUserResourceAttributes creates a scim.ResourceAttributes object with the given username.
-func createUserResourceAttributes(username string) scim.ResourceAttributes {
+func createUserResourceAttributes(username string, attrEmails []interface{}) scim.ResourceAttributes {
+	emails := []interface{}{}
+	if attrEmails == nil {
+		emails = []interface{}{
+			map[string]interface{}{"value": "a@b.c", "primary": true},
+			map[string]interface{}{"value": "b@b.c", "primary": false},
+		}
+	} else {
+		emails = attrEmails
+	}
 	return scim.ResourceAttributes{
 		AttrUserName: username,
 		AttrName: map[string]interface{}{
@@ -93,15 +178,6 @@ func createUserResourceAttributes(username string) scim.ResourceAttributes {
 			AttrNameMiddle: "Middle",
 			AttrNameFamily: "Last",
 		},
-		AttrEmails: []interface{}{
-			map[string]interface{}{
-				"value":   "a@b.c",
-				"primary": true,
-			},
-			map[string]interface{}{
-				"value":   "b@b.c",
-				"primary": false,
-			},
-		},
+		AttrEmails: emails,
 	}
 }

--- a/enterprise/internal/scim/user_create_test.go
+++ b/enterprise/internal/scim/user_create_test.go
@@ -162,7 +162,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 
 // createUserResourceAttributes creates a scim.ResourceAttributes object with the given username.
 func createUserResourceAttributes(username string, attrEmails []interface{}) scim.ResourceAttributes {
-	emails := []interface{}{}
+	var emails []interface{}
 	if attrEmails == nil {
 		emails = []interface{}{
 			map[string]interface{}{"value": "a@b.c", "primary": true},

--- a/enterprise/internal/scim/user_replace_test.go
+++ b/enterprise/internal/scim/user_replace_test.go
@@ -18,15 +18,15 @@ func Test_UserResourceHandler_Replace(t *testing.T) {
 
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
-		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id2"},
-		{User: types.User{ID: 3, Username: "user3", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id3"},
-		{User: types.User{ID: 4, Username: "user4", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id4"},
+		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Last"}, Emails: []string{"b@example.com"}, SCIMExternalID: "id2"},
+		{User: types.User{ID: 3, Username: "user3", DisplayName: "First Last"}, Emails: []string{"c@example.com"}, SCIMExternalID: "id3"},
+		{User: types.User{ID: 4, Username: "user4", DisplayName: "First Last"}, Emails: []string{"d@example.com"}, SCIMExternalID: "id4"},
 	},
 		map[int32][]*database.UserEmail{
 			1: {&database.UserEmail{UserID: 1, Email: "a@example.com", VerifiedAt: &verifiedDate, Primary: true}},
-			2: {&database.UserEmail{UserID: 2, Email: "a@example.com", VerifiedAt: &verifiedDate, Primary: true}},
-			3: {&database.UserEmail{UserID: 3, Email: "a@example.com", VerifiedAt: &verifiedDate, Primary: true}},
-			4: {&database.UserEmail{UserID: 4, Email: "a@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			2: {&database.UserEmail{UserID: 2, Email: "b@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			3: {&database.UserEmail{UserID: 3, Email: "c@example.com", VerifiedAt: &verifiedDate, Primary: true}},
+			4: {&database.UserEmail{UserID: 4, Email: "d@example.com", VerifiedAt: &verifiedDate, Primary: true}},
 		})
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
 


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/49016

**Problem:** Okta identifies users by userName rather than email address. Our expectation was matching by email address.

**Old behavior** in case of an existing user is this:
- Okta lists users through GET
- Okta notices that there is no matching user by username
- It tries to create the user with a POST
- The POST fails with 409 because the user already exists: creation would conflict with our “unique validated email address” constraint

**New behavior:** The POST doesn't fail. We handle request like a PUT and convert the existing user to SCIM-controlled, save the SCIM data, and return 200.

## Test plan

Added four new unit tests to cover the new cases.