### PR TITLE
SCIM: Add docs beta warnings

### DIFF
--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -37,7 +37,7 @@ Administration is usually handled by site administrators are the admins responsi
   - [Adding SSL (HTTPS) to Sourcegraph with a self-signed certificate](ssl_https_self_signed_cert_nginx.md)
 - [User authentication](auth/index.md)
   - [User data deletion](user_data_deletion.md)
-- [Provision users through SCIM](scim.md)
+- <span class="badge badge-beta">Beta</span> [Provision users through SCIM](scim.md)
 - [Setting the URL for your instance](url.md)
 - [Repository permissions](permissions/index.md)
   - [Row-level security](repo/row_level_security.md)

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -12,7 +12,7 @@ SCIM (System for Cross-domain Identity Management) is a standard for provisionin
 
 Sourcegraph supports SCIM 2.0 for provisioning and de-provisioning _users_.
 
-You can use any IdP that supports SCIM, but we’ve only tested the endpoint with Okta and Azure Active Directory.
+> WARNING: We’ve only tested the endpoint with Okta and Azure Active Directory. Be cautious when using our SCIM server with other IdPs.
 
 ## How to use
 
@@ -77,3 +77,4 @@ We support the following SCIM 2.0 features:
 - ❌ Entity tags (ETags)
 - ❌ Multi-tenancy – you can only have 1 SCIM client configured at a time.
 - ❌ Soft delete – Currently, we do not support soft deletion through SCIM. When a user is deleted (typically, when removed from a group of users who can access Sourcegraph), we **permanently delete** their user in Sourcegraph. This means that if the user is re-added to such a group, their settings will be reset.
+- ❌ Tests with many IdPs – we’ve only validated the endpoint with Okta and Azure AD.

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -1,5 +1,13 @@
 # SCIM
 
+<aside class="beta">
+<p>
+<span class="badge badge-beta">Beta</span> This feature is in beta and might change in the future.
+</p>
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
 SCIM (System for Cross-domain Identity Management) is a standard for provisioning and deprovisioning users and groups in an organization. IdPs (identity providers) like Okta, OneLogin, and Azure Active Directory support provisioning users through SCIM.
 
 Sourcegraph supports SCIM 2.0 for provisioning and de-provisioning _users_.

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -2,7 +2,7 @@
 
 <aside class="beta">
 <p>
-<span class="badge badge-beta">Beta</span> This feature is in beta and might change in the future.
+<span class="badge badge-beta">Beta</span> This feature is in beta while we're testing it with more IdPs. Our implementation complies with the SCIM 2.0 specification, and passes the validator for Okta and Azure AD. But implementations might differ on the side of IdPs and validators don't give a 100% coverage, so we can't guarantee that our solution works with all IdPs in every case.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
@@ -12,7 +12,7 @@ SCIM (System for Cross-domain Identity Management) is a standard for provisionin
 
 Sourcegraph supports SCIM 2.0 for provisioning and de-provisioning _users_.
 
-> WARNING: We’ve only tested the endpoint with Okta and Azure Active Directory. Be cautious when using our SCIM server with other IdPs.
+> NOTE: While our implementation of SCIM 2.0 is compliant with the specification, we’ve only tested it against two IdPs: Okta and Azure Active Directory. We can't guarantee it works with every IdP if the provider doesn't fully comply with the specification.
 
 ## How to use
 


### PR DESCRIPTION
- Added "Beta" badge to admin page
- Added beta disclaimer to the top of the SCIM page
- Saying "only tested for Okta and Azure AD" twice: as a warning at the top, and as a listed limitation at the bottom.

## Test plan

Only docs change