### PR TITLE
[Permissions] improve permissions syncing polling

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -110,15 +110,21 @@ export const PermissionsSyncJobsTable: React.FunctionComponent<React.PropsWithCh
                 repoID,
             } as PermissionsSyncJobsVariables,
             getConnection: ({ data }) => data?.permissionsSyncJobs || undefined,
+            // always do polling if minimal
+            options: { pollInterval: minimal ? PERMISSIONS_SYNC_JOBS_POLL_INTERVAL : undefined },
         })
 
     useEffect(() => {
+        if (minimal) {
+            return
+        }
+
         if (polling) {
             startPolling(PERMISSIONS_SYNC_JOBS_POLL_INTERVAL)
         } else {
             stopPolling()
         }
-    }, [polling, stopPolling, startPolling])
+    }, [polling, stopPolling, startPolling, minimal])
 
     const setReason = useCallback(
         (reasonGroup: PermissionsSyncJobReasonGroup | null) => setFilters({ reason: reasonGroup?.toString() || '' }),


### PR DESCRIPTION
Right now, polling of perms syncing a table is integrated with localstorage. 

The same table is used in perms info pages. There we always need to do polling and not based on the local storage. 

This PR implements the required change. 

## Test plan

manually tested.

## App preview:

- [Web](https://sg-web-naman-improve-perms-sync-polling.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
