### PR TITLE
packages: sync pkgrepo extsvc's after applying filters in background job

### DIFF
--- a/internal/codeintel/dependencies/internal/background/job_packages_filter.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/packagefilters"
@@ -13,8 +14,9 @@ import (
 )
 
 type packagesFilterApplicatorJob struct {
-	store      store.Store
-	operations *operations
+	store       store.Store
+	extsvcStore ExternalServiceStore
+	operations  *operations
 }
 
 func NewPackagesFilterApplicator(
@@ -22,8 +24,9 @@ func NewPackagesFilterApplicator(
 	db database.DB,
 ) goroutine.BackgroundRoutine {
 	job := packagesFilterApplicatorJob{
-		store:      store.New(obsctx, db),
-		operations: newOperations(obsctx),
+		store:       store.New(obsctx, db),
+		extsvcStore: db.ExternalServices(),
+		operations:  newOperations(obsctx),
 	}
 
 	return goroutine.NewPeriodicGoroutine(
@@ -93,5 +96,23 @@ func (j *packagesFilterApplicatorJob) handle(ctx context.Context) (err error) {
 	j.operations.versionsUpdated.Add(float64(totalVersionsUpdated))
 	j.operations.packagesUpdated.Add(float64(totalPkgsUpdated))
 
-	return err
+	// now we want to mark all package repo extsvcs to sync so any (un)blocked pacakge repo references will be picked up
+
+	nextSyncAt := time.Now()
+
+	extsvcs, err := j.extsvcStore.List(ctx, database.ExternalServicesListOptions{
+		Kinds: []string{extsvc.KindJVMPackages, extsvc.KindNpmPackages, extsvc.KindGoPackages, extsvc.KindRustPackages, extsvc.KindRubyPackages, extsvc.KindPythonPackages},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list package repo external services")
+	}
+
+	for _, extsvc := range extsvcs {
+		extsvc.NextSyncAt = nextSyncAt
+	}
+	if err := j.extsvcStore.Upsert(ctx, extsvcs...); err != nil {
+		return errors.Wrap(err, "failed to update next_sync_at for package repo external services")
+	}
+
+	return nil
 }

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -50,8 +50,9 @@ func TestPackageRepoFilters(t *testing.T) {
 	}
 
 	job := packagesFilterApplicatorJob{
-		store:      s,
-		operations: newOperations(&observation.TestContext),
+		store:       s,
+		extsvcStore: db.ExternalServices(),
+		operations:  newOperations(&observation.TestContext),
 	}
 
 	if err := job.handle(ctx); err != nil {


### PR DESCRIPTION
Package repo references rely on repo-updater in order to add/remove package repos as theyre listed from `lsif_dependency_repos`.  To make this happen sooner rather than later, we need to set the next_sync_at in the external_services table. We could alternatively call a synchronous endpoint on repo-updater directly, but this asynchronous version is good enough.

## Test plan

Tested locally in a full-run of adding/updating a filter.
