### PR TITLE
App: Add support to pass-through destination in app token creation flow

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -156,7 +156,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                         if (requester) {
                             onDidCreateAccessToken(result)
                             setNewToken(result.token)
-                            const uri = requester?.redirectURL.replace('$TOKEN', result.token)
+                            const uri = replaceToken(requester?.redirectURL, result.token)
                             switch (requester.callbackType) {
                                 case 'new-tab':
                                     window.open(uri, '_blank')
@@ -212,7 +212,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                         {requester.showRedirectButton && (
                             <Button
                                 className="mr-2"
-                                to={requester.redirectURL.replace('$TOKEN', newToken)}
+                                to={replaceToken(requester.redirectURL, newToken)}
                                 disabled={creationOrError === 'loading'}
                                 variant="primary"
                                 as={Link}
@@ -234,4 +234,9 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
             {isErrorLike(creationOrError) && <ErrorAlert className="my-3" error={creationOrError} />}
         </div>
     )
+}
+
+function replaceToken(url: string, token: string): string {
+    // %24 is the URL encoded version of $
+    return url.replace('$TOKEN', token).replace('%24TOKEN', token)
 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -132,6 +132,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
 
         if (nextRequester.forwardDestination) {
             const destination = new URLSearchParams(location.search).get('destination')
+            // SECURITY: only destinations starting with a "/" are allowed to prevent an open redirect vulnerability.
             if (destination?.startsWith('/')) {
                 const redirectURL = new URL(nextRequester.redirectURL)
                 redirectURL.searchParams.set('destination', destination)


### PR DESCRIPTION
Part of #47998

For the App flow to "Connect your Sourcegraph account" we want to be able to pass-through a destination parameters to the callback page. This way we can redirect the user to the correct page after they have generated a token.

We only support this for the App flow, and only when the destination parameter starts with a `/` (to prevent open redirects).

## Test plan

- Go to `https://sourcegraph.test:3443/user/settings/tokens/new/callback?requestFrom=APP&destination=%2Ffoo%2Fbar%2Fbaz%27` 
- See the proper redirect happening
<img width="707" alt="Screenshot 2023-03-10 at 16 09 02" src="https://user-images.githubusercontent.com/458591/224351488-9763e824-09dd-4477-bd3a-f10640788141.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-token-destination.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
