### PR TITLE
rbac: change role name to citext

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.5.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.5.0.json
@@ -43,5 +43,10 @@
     "path": "internal/database",
     "prefix": "TestRepos_List_LastChanged",
     "reason": "Changed format of table in a feature that wasn't enabled."
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/rbac/resolvers",
+    "prefix": "TestCreateRole",
+    "reason": "Changed the column type for role names from `text` to `citext` and introduced a new unique index for the column."
   }
 ]

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sourcegraph/log"
 
@@ -85,7 +86,7 @@ func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gq
 
 	var role *types.Role
 	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
-		role, err = tx.Roles().Create(ctx, args.Name, false)
+		role, err = tx.Roles().Create(ctx, strings.ToUpper(args.Name), false)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"strings"
 
 	"github.com/sourcegraph/log"
 
@@ -86,7 +85,7 @@ func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gq
 
 	var role *types.Role
 	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
-		role, err = tx.Roles().Create(ctx, strings.ToUpper(args.Name), false)
+		role, err = tx.Roles().Create(ctx, args.Name, false)
 		if err != nil {
 			return err
 		}

--- a/internal/database/roles.go
+++ b/internal/database/roles.go
@@ -252,7 +252,7 @@ func (r *roleStore) Create(ctx context.Context, name string, isSystemRole bool) 
 	role, err := scanRole(r.QueryRow(ctx, q))
 	if err != nil {
 		var e *pgconn.PgError
-		if errors.As(err, &e) && e.ConstraintName == "roles_name" {
+		if errors.As(err, &e) && e.ConstraintName == "unique_role_name" {
 			return nil, errCannotCreateRole{errorCodeRoleNameExists}
 		}
 		return nil, errors.Wrap(err, "scanning role")

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -20679,8 +20679,8 @@
         },
         {
           "Name": "name",
-          "Index": 2,
-          "TypeName": "text",
+          "Index": 6,
+          "TypeName": "citext",
           "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,
@@ -20688,7 +20688,7 @@
           "IdentityGeneration": "",
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
-          "Comment": "The uniquely identifying name of the role."
+          "Comment": ""
         },
         {
           "Name": "system",
@@ -20706,16 +20706,6 @@
       ],
       "Indexes": [
         {
-          "Name": "roles_name",
-          "IsPrimaryKey": false,
-          "IsUnique": true,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX roles_name ON roles USING btree (name)",
-          "ConstraintType": "u",
-          "ConstraintDefinition": "UNIQUE (name)"
-        },
-        {
           "Name": "roles_pkey",
           "IsPrimaryKey": true,
           "IsUnique": true,
@@ -20724,17 +20714,19 @@
           "IndexDefinition": "CREATE UNIQUE INDEX roles_pkey ON roles USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
-        }
-      ],
-      "Constraints": [
+        },
         {
-          "Name": "name_not_blank",
-          "ConstraintType": "c",
-          "RefTableName": "",
+          "Name": "unique_role_name",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
           "IsDeferrable": false,
-          "ConstraintDefinition": "CHECK (name \u003c\u003e ''::text)"
+          "IndexDefinition": "CREATE UNIQUE INDEX unique_role_name ON roles USING btree (name)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
+      "Constraints": null,
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3137,21 +3137,17 @@ Foreign-key constraints:
    Column   |           Type           | Collation | Nullable |              Default              
 ------------+--------------------------+-----------+----------+-----------------------------------
  id         | integer                  |           | not null | nextval('roles_id_seq'::regclass)
- name       | text                     |           | not null | 
  created_at | timestamp with time zone |           | not null | now()
  system     | boolean                  |           | not null | false
+ name       | citext                   |           | not null | 
 Indexes:
     "roles_pkey" PRIMARY KEY, btree (id)
-    "roles_name" UNIQUE CONSTRAINT, btree (name)
-Check constraints:
-    "name_not_blank" CHECK (name <> ''::text)
+    "unique_role_name" UNIQUE, btree (name)
 Referenced by:
     TABLE "role_permissions" CONSTRAINT "role_permissions_role_id_fkey" FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE DEFERRABLE
     TABLE "user_roles" CONSTRAINT "user_roles_role_id_fkey" FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE DEFERRABLE
 
 ```
-
-**name**: The uniquely identifying name of the role.
 
 **system**: This is used to indicate whether a role is read-only or can be modified.
 

--- a/migrations/frontend/1678456448_make_role_name_citext/down.sql
+++ b/migrations/frontend/1678456448_make_role_name_citext/down.sql
@@ -1,0 +1,20 @@
+-- we create a temporary column to store text for this migration
+ALTER TABLE roles ADD COLUMN IF NOT EXISTS name_text text;
+
+-- we then, update the created column to have the same values as `name`
+UPDATE roles SET name_text = name;
+
+DROP INDEX IF EXISTS unique_role_name;
+
+-- Drop the current `name` which is of type `citext`
+ALTER TABLE roles DROP COLUMN name;
+
+DO $$
+BEGIN
+    -- Rename the newly created column to `name`.
+    ALTER TABLE roles RENAME COLUMN name_text TO name;
+    ALTER TABLE roles ADD CONSTRAINT roles_name UNIQUE (name);
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column name_text does not exist in table roles';
+    WHEN duplicate_object THEN RAISE NOTICE 'constrant roles_name already exists';
+END $$;

--- a/migrations/frontend/1678456448_make_role_name_citext/metadata.yaml
+++ b/migrations/frontend/1678456448_make_role_name_citext/metadata.yaml
@@ -1,0 +1,2 @@
+name: make_role_name_citext
+parents: [1678220614, 1678320579, 1678380933]

--- a/migrations/frontend/1678456448_make_role_name_citext/up.sql
+++ b/migrations/frontend/1678456448_make_role_name_citext/up.sql
@@ -1,0 +1,24 @@
+-- we create a temporary column to store citext for this migration
+ALTER TABLE roles ADD COLUMN IF NOT EXISTS name_citext citext;
+
+-- we then, update the created column to have the same values as `name`
+UPDATE roles SET name_citext = name;
+
+-- remove the previous constraint on roles.name
+ALTER TABLE roles DROP CONSTRAINT IF EXISTS roles_name;
+
+-- Drop the current `name` which is of type `text`
+ALTER TABLE roles DROP COLUMN IF EXISTS name;
+
+DO $$
+BEGIN
+    -- Rename the newly created column to `name`.
+    ALTER TABLE roles RENAME COLUMN name_citext TO name;
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column name_text does not exist in table roles';
+END $$;
+
+ALTER TABLE roles ALTER COLUMN name SET NOT NULL;
+
+-- add a unique index
+CREATE UNIQUE INDEX IF NOT EXISTS unique_role_name ON roles (name);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3778,13 +3778,10 @@ CREATE TABLE role_permissions (
 
 CREATE TABLE roles (
     id integer NOT NULL,
-    name text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     system boolean DEFAULT false NOT NULL,
-    CONSTRAINT name_not_blank CHECK ((name <> ''::text))
+    name citext NOT NULL
 );
-
-COMMENT ON COLUMN roles.name IS 'The uniquely identifying name of the role.';
 
 COMMENT ON COLUMN roles.system IS 'This is used to indicate whether a role is read-only or can be modified.';
 
@@ -4896,9 +4893,6 @@ ALTER TABLE ONLY role_permissions
     ADD CONSTRAINT role_permissions_pkey PRIMARY KEY (permission_id, role_id);
 
 ALTER TABLE ONLY roles
-    ADD CONSTRAINT roles_name UNIQUE (name);
-
-ALTER TABLE ONLY roles
     ADD CONSTRAINT roles_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY saved_searches
@@ -5400,6 +5394,8 @@ CREATE INDEX sub_repo_perms_user_id ON sub_repo_permissions USING btree (user_id
 CREATE UNIQUE INDEX teams_name ON teams USING btree (name);
 
 CREATE UNIQUE INDEX unique_resource_permission ON namespace_permissions USING btree (namespace, resource_id, user_id);
+
+CREATE UNIQUE INDEX unique_role_name ON roles USING btree (name);
 
 CREATE INDEX user_credentials_credential_idx ON user_credentials USING btree (((encryption_key_id = ANY (ARRAY[''::text, 'previously-migrated'::text]))));
 
@@ -6010,7 +6006,7 @@ INSERT INTO lsif_configuration_policies VALUES (3, NULL, 'Default commit retenti
 
 SELECT pg_catalog.setval('lsif_configuration_policies_id_seq', 3, true);
 
-INSERT INTO roles VALUES (1, 'USER', '2023-01-04 16:29:41.195966+00', true);
-INSERT INTO roles VALUES (2, 'SITE_ADMINISTRATOR', '2023-01-04 16:29:41.195966+00', true);
+INSERT INTO roles VALUES (1, '2023-01-04 16:29:41.195966+00', true, 'USER');
+INSERT INTO roles VALUES (2, '2023-01-04 16:29:41.195966+00', true, 'SITE_ADMINISTRATOR');
 
 SELECT pg_catalog.setval('roles_id_seq', 3, true);


### PR DESCRIPTION
I am changing the column type for `roles.name` to `citext` so that case-insensitive uniqueness is enforced at the database level. 

In the previous implementation, as text, `Bob` and `BOB` was seen as two different values, while changing it to `citext` makes both the same because `citext` enforces case insensitive uniqueness.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing