### PR TITLE
Highlighthing: make tree-sitter the default engine

### DIFF
--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -129,25 +129,8 @@ var engineConfig = syntaxEngineConfig{
 // Eventually, we will switch from having `Default` be EngineSyntect and move
 // to having it be EngineTreeSitter.
 var baseEngineConfig = syntaxEngineConfig{
-	Default: EngineSyntect,
+	Default: EngineTreeSitter,
 	Overrides: map[string]EngineType{
-		// Languages enabled for tree-sitter highlighting
-		"c":          EngineTreeSitter,
-		"c#":         EngineTreeSitter,
-		"c++":        EngineTreeSitter,
-		"cpp":        EngineTreeSitter,
-		"go":         EngineTreeSitter,
-		"java":       EngineTreeSitter,
-		"javascript": EngineTreeSitter,
-		"jsonnet":    EngineTreeSitter,
-		"jsx":        EngineTreeSitter,
-		"nickel":     EngineTreeSitter,
-		"rust":       EngineTreeSitter,
-		"scala":      EngineTreeSitter,
-		"tsx":        EngineTreeSitter,
-		"typescript": EngineTreeSitter,
-		"xlsg":       EngineTreeSitter,
-
 		// Languages enabled for advanced syntax features
 		"perl": EngineScipSyntax,
 	},

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -160,7 +160,7 @@ func normalizeFiletype(filetype string) string {
 }
 
 func IsTreesitterSupported(filetype string) bool {
-	_, contained := supportedFiletypes[normalizeFiletype(filetype)]
+	_, contained := treesitterSupportedFiletypes[normalizeFiletype(filetype)]
 	return contained
 }
 

--- a/internal/gosyntect/languages.go
+++ b/internal/gosyntect/languages.go
@@ -7,7 +7,7 @@ var enryLanguageMappings = map[string]string{
 	"c#": "c_sharp",
 }
 
-var supportedFiletypes = map[string]struct{}{
+var treesitterSupportedFiletypes = map[string]struct{}{
 	"c":          {},
 	"c++":        {},
 	"c_sharp":    {},


### PR DESCRIPTION
Previously, we had to manually override each language for new tree-sitter supported language. This was error prone and resulted in Ruby and Python not having tree-sitter highlighting enabled by default. With this change, there's one less place we have to update when we add a new tree-sitter highlighter.

## Test plan

Manually opened all files in this directory and verified they are using tree-sitter highlighting https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/typescript.ts


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
