### PR TITLE
SCIM: Adjust badge design

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/UserManagement/components/UsersList.tsx
@@ -1,41 +1,41 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import {
-    mdiLogoutVariant,
+    mdiAccountReactivate,
     mdiArchive,
-    mdiDelete,
-    mdiLockReset,
     mdiChevronDown,
     mdiClipboardMinus,
     mdiClipboardPlus,
     mdiClose,
+    mdiDelete,
     mdiLock,
     mdiLockOpen,
-    mdiAccountReactivate,
+    mdiLockReset,
+    mdiLogoutVariant,
     mdiSecurity,
 } from '@mdi/js'
 import classNames from 'classnames'
-import { formatDistanceToNowStrict, startOfDay, endOfDay } from 'date-fns'
+import { endOfDay, formatDistanceToNowStrict, startOfDay } from 'date-fns'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import {
-    H2,
-    LoadingSpinner,
-    Text,
-    Button,
     Alert,
-    useDebounce,
-    Link,
-    Icon,
-    PopoverTrigger,
-    PopoverContent,
-    Popover,
-    Position,
-    PopoverOpenEvent,
-    Tooltip,
-    ErrorAlert,
     Badge,
+    Button,
+    ErrorAlert,
+    H2,
+    Icon,
+    Link,
+    LoadingSpinner,
+    Popover,
+    PopoverContent,
+    PopoverOpenEvent,
+    PopoverTrigger,
+    Position,
+    Text,
+    Tooltip,
+    useDebounce,
 } from '@sourcegraph/wildcard'
 
 import {
@@ -54,6 +54,7 @@ import styles from '../index.module.scss'
 export type SiteUser = UsersManagementUsersListResult['site']['users']['nodes'][0]
 
 const LIMIT = 25
+
 interface UsersListProps {
     onActionEnd?: () => void
 }
@@ -507,64 +508,59 @@ function RenderUsernameAndEmail({
 
     return (
         <div
-            className={classNames('d-flex p-2 align-items-center', styles.usernameColumn, {
+            className={classNames('d-flex p-2 align-items-center justify-content-between', styles.usernameColumn, {
                 [styles.visibleActionsOnHover]: !isOpen,
             })}
         >
-            {!deletedAt ? (
-                <>
-                    {locked && (
-                        <Tooltip content="This user is locked and cannot sign in.">
-                            <Icon aria-label="Account locked" svgPath={mdiLock} />
-                        </Tooltip>
-                    )}{' '}
-                    {scimControlled && (
-                        <Tooltip
-                            content={
-                                <Text>
-                                    This user is{' '}
-                                    <Link to="/help/admin/scim" target="_blank" rel="noopener">
-                                        SCIM
-                                    </Link>
-                                    -controlled—an external system controls some of its attributes.
-                                </Text>
-                            }
-                        >
-                            <Badge variant="primary" className="mr-1">
-                                SCIM
-                            </Badge>
-                        </Tooltip>
-                    )}
-                    <Link to={`/users/${username}`} className="text-truncate">
-                        @{username}
-                    </Link>
-                </>
-            ) : (
-                <>
-                    {scimControlled && (
-                        <Badge variant="primary" className="mr-1">
-                            SCIM
-                        </Badge>
-                    )}
+            <div className="d-flex align-items-center text-truncate">
+                {!deletedAt ? (
+                    <>
+                        {locked && (
+                            <Tooltip content="This user is locked and cannot sign in.">
+                                <Icon aria-label="Account locked" svgPath={mdiLock} />
+                            </Tooltip>
+                        )}{' '}
+                        <Link to={`/users/${username}`} className="text-truncate">
+                            @{username}
+                        </Link>
+                    </>
+                ) : (
                     <Text className="mb-0 text-truncate">@{username}</Text>
-                </>
-            )}
-            <Popover isOpen={isOpen} onOpenChange={handleOpenChange}>
-                <PopoverTrigger
-                    as={Button}
-                    className={classNames('ml-1 border-0 p-1', styles.actionsButton)}
-                    variant="secondary"
-                    outline={true}
+                )}
+                <Popover isOpen={isOpen} onOpenChange={handleOpenChange}>
+                    <PopoverTrigger
+                        as={Button}
+                        className={classNames('ml-1 border-0 p-1', styles.actionsButton)}
+                        variant="secondary"
+                        outline={true}
+                    >
+                        <Icon aria-label="Show details" svgPath={mdiChevronDown} />
+                    </PopoverTrigger>
+                    <PopoverContent position={Position.bottom} focusLocked={false}>
+                        <div className="p-2">
+                            <Text className="mb-0">{displayName}</Text>
+                            <Text className="mb-0">{email}</Text>
+                        </div>
+                    </PopoverContent>
+                </Popover>
+            </div>
+            {scimControlled && (
+                <Tooltip
+                    content={
+                        <Text>
+                            This user is{' '}
+                            <Link to="/help/admin/scim" target="_blank" rel="noopener">
+                                SCIM
+                            </Link>
+                            -controlled—an external system controls some of its attributes.
+                        </Text>
+                    }
                 >
-                    <Icon aria-label="Show details" svgPath={mdiChevronDown} />
-                </PopoverTrigger>
-                <PopoverContent position={Position.bottom} focusLocked={false}>
-                    <div className="p-2">
-                        <Text className="mb-0">{displayName}</Text>
-                        <Text className="mb-0">{email}</Text>
-                    </div>
-                </PopoverContent>
-            </Popover>
+                    <Badge variant="secondary" className="mr-1">
+                        SCIM
+                    </Badge>
+                </Tooltip>
+            )}
         </div>
     )
 }

--- a/client/web/src/site-admin/UserManagement/index.module.scss
+++ b/client/web/src/site-admin/UserManagement/index.module.scss
@@ -9,7 +9,7 @@
 }
 
 .username-column {
-    max-width: 10rem;
+    max-width: 12rem;
 }
 
 .visible-actions-on-hover {


### PR DESCRIPTION
Fixes design issues based on @rrhyne's and @danielmarquespt's feedback on https://github.com/sourcegraph/sourcegraph/pull/48727

It **used to look like** this:

![image](https://user-images.githubusercontent.com/2552265/224358016-9a72a384-255f-406a-bec4-37181652c233.png)

It **now looks like** this:

<img width="1154" alt="CleanShot 2023-03-10 at 17 03 38@2x" src="https://user-images.githubusercontent.com/2552265/224364776-f2eadbdd-2a85-4467-8597-cd8aaf7271e9.png">

Not exactly the colors Rob used in his draft, but he suggested using the "secondary" style which I did, and I think this more faded color makes sense.

I also widened the column from 10rem to 12rem. It overflows in [an ugly way](https://share.cleanshot.com/YlcYLQ04) at smaller widths, but it's not a regression, it was like this before the PR (I tested on S2).

## Test plan

Pass design review

## App preview:

- [Web](https://sg-web-dv-scim-adjust-user-list-scim.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
