### PR TITLE
experimental search input: Fix keyboard shortcut display

### DIFF
--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -162,9 +162,7 @@ const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
             {!option.info && (
                 <>
                     <ActionInfo action={option.action} shortcut="Enter" />{' '}
-                    {option.alternativeAction && (
-                        <ActionInfo action={option.alternativeAction} shortcut="Shift+Enter" />
-                    )}
+                    {option.alternativeAction && <ActionInfo action={option.alternativeAction} shortcut="Mod+Enter" />}
                 </>
             )}
         </span>


### PR DESCRIPTION
I forgot to update the help text in https://github.com/sourcegraph/sourcegraph/pull/49079


## Test plan

Footer now displays `Ctrl+Enter` on Linux.

## App preview:

- [Web](https://sg-web-fkling-search-input-keyboard-info.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
