### PR TITLE
experimental search input: "Stronger" popover shadow

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -19,10 +19,14 @@
 
     &:focus-within {
         background-color: var(--color-bg-1);
-        box-shadow: var(--box-shadow);
+        box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
 
         .suggestions {
             display: block;
+        }
+
+        :global(.theme-dark) & {
+            box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
         }
     }
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -208,6 +208,9 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
             '.cm-line': {
                 padding: 0,
             },
+            '.cm-selectionLayer .cm-selectionBackground': {
+                backgroundColor: 'var(--gray-08)',
+            },
             '.sg-decorated-token-hover': {
                 borderRadius: '3px',
             },


### PR DESCRIPTION
We got feedback that the search input kind of blends in with the rest of the page on the search results page. This change changes the shadow to make it "pop out" more.


| before | after|
|--------|------|
|![2023-03-10_17-40](https://user-images.githubusercontent.com/179026/224373106-e16549a2-828a-434c-9439-7ff37a2600e0.png)| ![2023-03-10_17-39](https://user-images.githubusercontent.com/179026/224373184-46fe0225-3049-4722-b1d0-24f65493f11a.png)


## Test plan

Focus search input on home page, search results page and file page.

## App preview:

- [Web](https://sg-web-fkling-search-input-dropshadown.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
