### PR TITLE
permissions-center: add permissions sync details modal.

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/Table.tsx
+++ b/client/web/src/site-admin/UserManagement/components/Table.tsx
@@ -219,17 +219,19 @@ export function Table<T>({
 
     return (
         <>
-            <div className="mb-4 d-flex justify-content-between">
-                {selectable && <SelectionActions<T> actions={bulkActions} position="top" selection={selection} />}
-                {pagination && (
-                    <Pagination
-                        {...pagination}
-                        onPrevious={onPreviousPage}
-                        onLimitChange={onLimitChange}
-                        onNext={onNextPage}
-                    />
-                )}
-            </div>
+            {(selectable || pagination) && (
+                <div className="mb-4 d-flex justify-content-between">
+                    {selectable && <SelectionActions<T> actions={bulkActions} position="top" selection={selection} />}
+                    {pagination && (
+                        <Pagination
+                            {...pagination}
+                            onPrevious={onPreviousPage}
+                            onLimitChange={onLimitChange}
+                            onNext={onNextPage}
+                        />
+                    )}
+                </div>
+            )}
             <table className={styles.table}>
                 <thead>
                     <tr>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -65,7 +65,7 @@ const JOB_REASON_TO_READABLE_REASON: Record<PermissionsSyncJobReason, string> = 
     REASON_USER_REMOVED_FROM_ORG: 'User removed from organization',
 }
 
-const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStateMetadata> = {
+export const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStateMetadata> = {
     QUEUED: {
         badgeVariant: 'secondary',
         temporalWording: 'Queued',

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -7,8 +7,8 @@ import { intervalToDuration } from 'date-fns'
 import formatDuration from 'date-fns/formatDuration'
 import { capitalize, noop } from 'lodash'
 
-import { useMutation } from '@sourcegraph/http-client'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import { useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -1,6 +1,12 @@
 import { gql } from '@sourcegraph/http-client'
 
 export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
+    fragment CodeHostState on CodeHostState {
+        providerID
+        providerType
+        status
+    }
+
     fragment PermissionsSyncJob on PermissionsSyncJob {
         id
         state
@@ -49,7 +55,7 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         noPerms
         invalidateCaches
         codeHostStates {
-            providerID
+            ...CodeHostState
         }
     }
 

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -54,3 +54,12 @@
         padding-bottom: var(--spacer);
     }
 }
+
+.modal {
+    &__grid {
+        display: grid;
+        grid-template-columns: max-content max-content;
+        column-gap: 1rem;
+        row-gap: 0.5rem;
+    }
+}


### PR DESCRIPTION
This commit also removes unnecessary padding from Table component when no selections/pagination is provided.

Test plan:
Local sg run and test.

### Demo

https://user-images.githubusercontent.com/94846361/224377086-68e72caa-fbda-42ac-b68c-a3ef5f0ac9a6.mp4

Closes https://github.com/sourcegraph/sourcegraph/issues/49073

## App preview:

- [Web](https://sg-web-ao-ui-pc-sync-info-modal.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
