### PR TITLE
fix: move musl config to .cargo/config.toml and now it works

### DIFF
--- a/docker-images/syntax-highlighter/.cargo/config.toml
+++ b/docker-images/syntax-highlighter/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-Clink-arg=-Wl,--dynamic-linker=/lib/ld-musl-aarch64.so.1"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-Ctarget-feature=-crt-static"]

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-languages/build.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-languages/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    #[cfg(target_arch = "x86_64")]
-    {
-        println!("cargo:rustc-link-lib=static=stdc++");
-        println!("cargo:rustc-link-search=/usr/lib");
-    }
-}

--- a/docker-images/syntax-highlighter/crates/sg-syntax/build.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    #[cfg(target_arch = "x86_64")]
-    {
-        println!("cargo:rustc-link-lib=static=stdc++");
-        println!("cargo:rustc-link-search=/usr/lib");
-    }
-}


### PR DESCRIPTION
Previously, syntect_server ran and linked against C++ correctly in "standard" build environments (read: non-musl envs). It also was able to link (at least a compile time?) to C++ in musl environments. However(!) When running this in the docker image, it was possible that syntect_server would segfault when using a C++ grammar (often, it would seg fault immediately).

This segfault is "uncatchable", not like the panics from `syntect` that http-stablizer was designed to restart. So, this meant that whenever a C++ grammar'd language would run, we'd lose a syntax highlighter service. Well... when you refresh, you kill another one. Rinse and repeat til even the other languages are affected.

Now, with the new build, we don't have that happen (you can verify this by running the docker image locally and checking against C++ grammars) and now syntax highlighting continues to work.

## Test plan

- [ ] Run this locally after rebuilding the docker image, and using the docker image to supply highlighting (NOT your local cargo instance)
- [ ] Do it again, but now with your local cargo instance
