### PR TITLE
admin users list: push up 'view permissions' in menu

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/UserManagement/components/UsersList.tsx
@@ -302,6 +302,14 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 condition: ([user]) => !user?.deletedAt && user?.locked,
                             },
                             {
+                                key: 'view-permissions',
+                                label: 'View Permissions',
+                                icon: mdiSecurity,
+                                href: ([user]) => `/users/${user.username}/settings/permissions`,
+                                target: '_blank',
+                                condition: ([user]) => !!user,
+                            },
+                            {
                                 key: 'delete',
                                 label: 'Delete',
                                 icon: mdiArchive,
@@ -326,14 +334,6 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 onClick: handleRecoverUsers,
                                 bulk: true,
                                 condition: users => users.some(user => user.deletedAt),
-                            },
-                            {
-                                key: 'view-permissions',
-                                label: 'View Permissions',
-                                icon: mdiSecurity,
-                                href: ([user]) => `/users/${user.username}/settings/permissions`,
-                                target: '_blank',
-                                condition: ([user]) => !!user,
                             },
                         ]}
                         columns={[


### PR DESCRIPTION
See Slack thread: https://sourcegraph.slack.com/archives/C0HMGV90V/p1678474466855269

Now 'Delete' and 'Delete forever' are always last.

## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-push-view-permissions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
