### PR TITLE
Add Sourcegraph App limitation UI to setup wizard remote code step

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditingAppLimitInPlaceAlert.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditingAppLimitInPlaceAlert.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
+import { FC } from 'react'
 
 import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Alert, H4, Text, Link } from '@sourcegraph/wildcard'
 
-export const ExternalServiceEditingAppLimitInPlaceAlert: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
-    <Alert variant="info">
+export const ExternalServiceEditingAppLimitInPlaceAlert: FC<{ className?: string }> = props => (
+    <Alert variant="info" className={props.className}>
         <H4>Sourcegraph App limitations in place</H4>
         <Text className="mb-0">
             Only the first 10 remote repositories will be synchronized. For more,{' '}

--- a/client/web/src/components/externalServices/ExternalServiceEditingAppLimitReachedAlert.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditingAppLimitReachedAlert.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
+import { FC } from 'react'
 
 import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Alert, H4, Text, Link } from '@sourcegraph/wildcard'
 
-export const ExternalServiceEditingAppLimitAlert: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
-    <Alert variant="info">
+export const ExternalServiceEditingAppLimitAlert: FC<{ className?: string }> = props => (
+    <Alert variant="info" className={props.className}>
         <H4>Code host limit</H4>
         <Text className="mb-0">
             Sourcegraph App is limited to one remote code host and up to 10 remote repositories. For more,{' '}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -16,7 +16,7 @@ import { CodeHostsPicker } from './components/code-host-picker'
 import { CodeHostCreation, CodeHostEdit } from './components/code-hosts'
 import { CodeHostExternalServiceAlert } from './components/CodeHostExternalServiceAlert'
 import { CodeHostsNavigation } from './components/navigation'
-import { getNextButtonLabel, getNextButtonLogEvent, isAnyConnectedCodeHosts } from './helpers'
+import { getNextButtonLabel, getNextButtonLogEvent, getRemoteCodeHostCount, isAnyConnectedCodeHosts } from './helpers'
 import { GET_CODE_HOSTS } from './queries'
 
 import styles from './RemoteRepositoriesStep.module.scss'
@@ -51,6 +51,9 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
         }
     }
 
+    const hasCodeHostCountReachedLimit =
+        window.context.sourcegraphAppMode && getRemoteCodeHostCount(codeHostQueryResult.data) > 0
+
     return (
         <div {...attributes} className={classNames(className, styles.root)}>
             <Text className="mb-2">Connect remote code hosts where your source code lives.</Text>
@@ -70,7 +73,10 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = props => 
 
                 <Container className={styles.contentMain}>
                     <Routes>
-                        <Route index={true} element={<CodeHostsPicker />} />
+                        <Route
+                            index={true}
+                            element={<CodeHostsPicker isLimitReached={hasCodeHostCountReachedLimit} />}
+                        />
                         <Route
                             path=":codeHostType/create"
                             element={<CodeHostCreation telemetryService={telemetryService} />}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/CodeHostExternalServiceAlert.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/CodeHostExternalServiceAlert.tsx
@@ -3,6 +3,8 @@ import { FC } from 'react'
 import {
     ExternalServiceEditingDisabledAlert,
     ExternalServiceEditingTemporaryAlert,
+    ExternalServiceEditingAppLimitInPlaceAlert,
+    ExternalServiceEditingAppLimitReachedAlert,
 } from '../../../../components/externalServices'
 
 export const CodeHostExternalServiceAlert: FC = () => {
@@ -21,5 +23,25 @@ export const CodeHostExternalServiceAlert: FC = () => {
 
     // If nothing is specified that means everything is available manually
     // in site admin or setup wizard UI
+    return null
+}
+
+export const CodeHostRepositoriesAppLimitAlert: FC<{ className?: string }> = props => {
+    const { sourcegraphAppMode } = window.context
+
+    if (sourcegraphAppMode) {
+        return <ExternalServiceEditingAppLimitInPlaceAlert className={props.className} />
+    }
+
+    return null
+}
+
+export const CodeHostAppLimit: FC<{ className?: string }> = props => {
+    const { sourcegraphAppMode } = window.context
+
+    if (sourcegraphAppMode) {
+        return <ExternalServiceEditingAppLimitReachedAlert className={props.className} />
+    }
+
     return null
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-host-picker/CodeHostsPicker.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
-import { Button, Link } from '@sourcegraph/wildcard'
+import { Button, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { CodeHostIcon, getCodeHostName, getCodeHostURLParam } from '../../helpers'
+import { CodeHostAppLimit } from '../CodeHostExternalServiceAlert'
 
 import styles from './CodeHostsPicker.module.scss'
 
@@ -18,26 +19,43 @@ const SUPPORTED_CODE_HOSTS = [
     ExternalServiceKind.AZUREDEVOPS,
 ]
 
-export const CodeHostsPicker: FC = () => (
+interface CodeHostsPickerProps {
+    /**
+     * Turns on/off code host picker buttons, originally it's used to disable
+     * code host connection UI buttons when user already has 1 remote code host
+     * in Sourcegraph App mode.
+     */
+    isLimitReached: boolean
+}
+
+export const CodeHostsPicker: FC<CodeHostsPickerProps> = props => (
     <section>
         <header className={styles.header}>
             <span>Add another remote code host</span>
             <small className="text-muted">Choose a provider from the list below</small>
         </header>
 
+        <CodeHostAppLimit className="mb-2" />
+
         <ul className={styles.list}>
             {SUPPORTED_CODE_HOSTS.map(codeHostType => (
                 <li key={codeHostType}>
-                    <Button
-                        as={Link}
-                        to={`/setup/remote-repositories/${getCodeHostURLParam(codeHostType)}/create`}
-                        variant="secondary"
-                        outline={true}
-                        className={styles.item}
+                    <Tooltip
+                        content={props.isLimitReached ? 'You have reached remote code host limit' : ''}
+                        placement="left"
                     >
-                        <CodeHostIcon codeHostType={codeHostType} aria-hidden={true} />
-                        <span>{getCodeHostName(codeHostType)}</span>
-                    </Button>
+                        <Button
+                            as={Link}
+                            to={`/setup/remote-repositories/${getCodeHostURLParam(codeHostType)}/create`}
+                            variant="secondary"
+                            outline={true}
+                            disabled={props.isLimitReached}
+                            className={styles.item}
+                        >
+                            <CodeHostIcon codeHostType={codeHostType} aria-hidden={true} />
+                            <span>{getCodeHostName(codeHostType)}</span>
+                        </Button>
+                    </Tooltip>
                 </li>
             ))}
         </ul>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
@@ -25,6 +25,7 @@ import {
 
 import { AddExternalServiceOptions } from '../../../../../../components/externalServices/externalServices'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../../../../../settings/DynamicallyImportedMonacoSettingsEditor'
+import { CodeHostRepositoriesAppLimitAlert } from '../../CodeHostExternalServiceAlert'
 
 import styles from './CodeHostConnection.module.scss'
 
@@ -95,6 +96,8 @@ export function CodeHostJSONFormContent(props: CodeHostJSONFormContentProps): Re
     // Fragment to avoid nesting since it's rendered within TabPanel fieldset
     return (
         <>
+            <CodeHostRepositoriesAppLimitAlert className="mb-2" />
+
             <Input label="Display name" {...getDefaultInputProps(displayNameField)} />
 
             <FormGroup

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -34,6 +34,7 @@ import {
     ValidateAccessTokenResult,
     ValidateAccessTokenVariables,
 } from '../../../../../../graphql-operations'
+import { CodeHostRepositoriesAppLimitAlert } from '../../CodeHostExternalServiceAlert'
 import { CodeHostJSONFormContent, RadioGroupSection, CodeHostConnectFormFields, CodeHostJSONFormState } from '../common'
 
 import { GithubOrganizationsPicker, GithubRepositoriesPicker } from './GithubEntityPickers'
@@ -140,6 +141,7 @@ export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
                     JSONC editor
                 </Tab>
             </TabList>
+
             <TabPanels className={styles.tabPanels}>
                 <TabPanel as="fieldset" tabIndex={-1} className={styles.formView}>
                     <GithubFormView
@@ -240,6 +242,8 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
     // Fragment to avoid nesting since it's rendered within TabPanel fieldset
     return (
         <>
+            <CodeHostRepositoriesAppLimitAlert className="mb-2" />
+
             <Input label="Display name" placeholder="Github (Personal)" {...getDefaultInputProps(displayNameField)} />
 
             <Input

--- a/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/helpers.tsx
@@ -135,3 +135,15 @@ export const getNextButtonLogEvent = (data?: GetCodeHostsResult): string | null 
 
     return null
 }
+
+export const getRemoteCodeHostCount = (data?: GetCodeHostsResult): number => {
+    if (!data) {
+        return 0
+    }
+
+    const nonOtherExternalServices = data.externalServices.nodes.filter(
+        service => service.kind !== ExternalServiceKind.OTHER
+    )
+
+    return nonOtherExternalServices.length
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/48883

| Main menu | Connection form |
| -------- | -------- |
| <img width="1141" alt="Screenshot 2023-03-10 at 17 06 30" src="https://user-images.githubusercontent.com/18492575/224417692-56e0aef9-4e22-42fa-b195-bc07e91addf5.png"> | <img width="1141" alt="Screenshot 2023-03-10 at 17 06 39" src="https://user-images.githubusercontent.com/18492575/224417740-5ae4c9f3-415b-455c-9568-2cbb7cc11f74.png"> | 

## Test plan
- Run `EXTSVC_CONFIG_FILE='' sg start app`
- Check that you can see an alert on the remote code host step about the code host count limitation 
- Connect one code host
- Check that during creation, there is an alert about the max count for repositories
- Check that after connection buttons on the main page are disabled

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-app-limit-ui-to-setup.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
