### PR TITLE
docs: Add EventLogger to docs

### DIFF
--- a/doc/_resources/assets/docsite.js
+++ b/doc/_resources/assets/docsite.js
@@ -117,3 +117,40 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   })
 })
+
+// Promise to wait on for DOMContentLoaded
+const domContentLoadedPromise = new Promise(resolve => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', resolve)
+  } else {
+    resolve()
+  }
+})
+
+// Import Sourcegraph's EventLogger
+const importEventLoggerPromise = import('https://cdn.skypack.dev/@sourcegraph/event-logger')
+
+Promise.all([domContentLoadedPromise, importEventLoggerPromise]).then(([_, { EventLogger }]) => {
+  const eventLogger = new EventLogger('https://sourcegraph.com')
+
+  // Log a Docs page view event
+  const eventArguments = { path: window.location.pathname }
+  console.log('ViewStaticPage', eventArguments) // TODO: remove this console log
+  eventLogger.log('ViewStaticPage', eventArguments, eventArguments)
+
+  // Log download links which have a "data-download-name" attribute
+  // This is used to track Sourcegraph App download links
+  document.addEventListener('click', event => {
+    if (event.target.matches('a[data-download-name]')) {
+      const downloadName = event.target.getAttribute('data-download-name')
+      const eventArguments = {
+        path: window.location.pathname,
+        downloadSource: 'docs',
+        downloadName,
+      }
+
+      console.log('DownloadClick', eventArguments) // TODO: remove console log
+      eventLogger.log('DownloadClick', eventArguments, eventArguments)
+    }
+  })
+})

--- a/doc/_resources/assets/docsite.js
+++ b/doc/_resources/assets/docsite.js
@@ -147,6 +147,7 @@ Promise.all([domContentLoadedPromise, importEventLoggerPromise]).then(([_, { Eve
         path: window.location.pathname,
         downloadSource: 'docs',
         downloadName,
+        linkUrl: event.target.href,
       }
 
       console.log('DownloadClick', eventArguments) // TODO: remove console log

--- a/doc/_resources/assets/docsite.js
+++ b/doc/_resources/assets/docsite.js
@@ -135,7 +135,6 @@ Promise.all([domContentLoadedPromise, importEventLoggerPromise]).then(([_, { Eve
 
   // Log a Docs page view event
   const eventArguments = { path: window.location.pathname }
-  console.log('ViewStaticPage', eventArguments) // TODO: remove this console log
   eventLogger.log('ViewStaticPage', eventArguments, eventArguments)
 
   // Log download links which have a "data-download-name" attribute
@@ -147,10 +146,9 @@ Promise.all([domContentLoadedPromise, importEventLoggerPromise]).then(([_, { Eve
         path: window.location.pathname,
         downloadSource: 'docs',
         downloadName,
-        linkUrl: event.target.href,
+        downloadLinkUrl: event.target.href,
       }
 
-      console.log('DownloadClick', eventArguments) // TODO: remove console log
       eventLogger.log('DownloadClick', eventArguments, eventArguments)
     }
   })

--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -54,8 +54,8 @@ dpkg -i <file>.deb
 
 **Single-binary zip download:**
 
-* [linux (x64)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip)
 - <a data-download-name="app-download-zip-mac" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip">macOS (universal)</a>
+- <a data-download-name="app-download-zip-linux" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip" >linux (x64)</a>
 
 ## Usage
 

--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -46,7 +46,7 @@ Ensure you have `git` installed / on your path, then install.
 brew install sourcegraph/app/sourcegraph
 ```
 
-**Linux:** via [deb pkg](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.deb) installer:
+**Linux:** via <a data-download-name="app-download-deb" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.deb">deb pkg</a> installer:
 
 ```sh
 dpkg -i <file>.deb
@@ -54,8 +54,8 @@ dpkg -i <file>.deb
 
 **Single-binary zip download:**
 
-* [macOS (universal)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip)
 * [linux (x64)](https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip)
+- <a data-download-name="app-download-zip-mac" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip">macOS (universal)</a>
 
 ## Usage
 

--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -46,7 +46,7 @@ Ensure you have `git` installed / on your path, then install.
 brew install sourcegraph/app/sourcegraph
 ```
 
-**Linux:** via <a data-download-name="app-download-deb" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.deb">deb pkg</a> installer:
+**Linux:** via <a data-download-name="app-download-linux-deb" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.deb">deb pkg</a> installer:
 
 ```sh
 dpkg -i <file>.deb
@@ -54,8 +54,8 @@ dpkg -i <file>.deb
 
 **Single-binary zip download:**
 
-- <a data-download-name="app-download-zip-mac" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip">macOS (universal)</a>
-- <a data-download-name="app-download-zip-linux" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip" >linux (x64)</a>
+- <a data-download-name="app-download-mac-zip" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_darwin_all.zip">macOS (universal)</a>
+- <a data-download-name="app-download-linux-zip" href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+205301.ca3646/sourcegraph_2023.03.23+205301.ca3646_linux_amd64.zip" >linux (x64)</a>
 
 ## Usage
 
@@ -73,8 +73,8 @@ Your browser should automatically open to http://localhost:3080 - this is the ad
 
 Batch changes and precise code intel require the following optional dependencies be installed and on your PATH:
 
-* The `src` CLI ([installation](https://github.com/sourcegraph/src-cli))
-* `docker`
+- The `src` CLI ([installation](https://github.com/sourcegraph/src-cli))
+- `docker`
 
 ### Troubleshooting
 


### PR DESCRIPTION
Add EventLogger to the docs site. Co-authored with @akalia25 

- Log `ViewStaticPage` on every page view
  - event arguments:
    - `path` 
- Log `DownloadClick` on clicks on download links (which are defined as links with `data-download-name="name"` where the name is included in the event arguments
  - event arguments:
    - `downloadSource` = `docs`
    - `downloadName`: name of the download link, for example `app-download-linux-deb`
    - `downloadLinkUrl` is the clicked link URL

## Test plan

- Run docs site locally with `pnpm run docsite:serve`
- open docs at http://localhost:5080
- Navigate to pages
- Click on download links on `/app`
- Check the events logged (see network requests to debug)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
