### PR TITLE
app: implement notifications sent by sourcegraph.com to Sourcegraph App users

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -122,6 +122,18 @@ func init() {
 		log15.Warn("WARNING: possibly misconfigured Prometheus", "error", err)
 	}
 
+	AlertFuncs = append(AlertFuncs, func(args AlertFuncArgs) []*Alert {
+		var alerts []*Alert
+		for _, notification := range conf.Get().Notifications {
+			alerts = append(alerts, &Alert{
+				TypeValue:                 AlertTypeInfo,
+				MessageValue:              notification.Message,
+				IsDismissibleWithKeyValue: notification.Key,
+			})
+		}
+		return alerts
+	})
+
 	// Warn about invalid site configuration.
 	AlertFuncs = append(AlertFuncs, func(args AlertFuncArgs) []*Alert {
 		// 🚨 SECURITY: Only the site admin should care about the site configuration being invalid, as they

--- a/cmd/frontend/internal/app/updatecheck/build.go
+++ b/cmd/frontend/internal/app/updatecheck/build.go
@@ -11,8 +11,9 @@ import (
 
 // pingResponse is the JSON shape of the update check handler's response body.
 type pingResponse struct {
-	Version       semver.Version `json:"version"`
-	Notifications []Notification `json:"notifications,omitempty"`
+	Version         semver.Version `json:"version"`
+	UpdateAvailable bool           `json:"updateAvailable"`
+	Notifications   []Notification `json:"notifications,omitempty"`
 }
 
 func newPingResponse(version string) pingResponse {

--- a/cmd/frontend/internal/app/updatecheck/build.go
+++ b/cmd/frontend/internal/app/updatecheck/build.go
@@ -1,14 +1,65 @@
 package updatecheck
 
-import "github.com/coreos/go-semver/semver"
+import (
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
 
 // pingResponse is the JSON shape of the update check handler's response body.
 type pingResponse struct {
-	Version semver.Version `json:"version"`
+	Version       semver.Version `json:"version"`
+	Notifications []Notification `json:"notifications,omitempty"`
 }
 
 func newPingResponse(version string) pingResponse {
 	return pingResponse{
 		Version: *semver.New(version),
 	}
+}
+
+type Notification struct {
+	Key     string
+	Message string
+}
+
+func getNotifications(clientVersionString string) []Notification {
+	calcNotifications(clientVersionString, conf.Get().Dotcom.AppNotifications)
+}
+
+func calcNotifications(clientVersionString string, notifications []*schema.AppNotifications) []Notification {
+	clientVersionString = strings.TrimPrefix(clientVersionString, "v")
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		return nil
+	}
+	var results []Notification
+	for _, notification := range notifications {
+		if notification.VersionMin != "" && notification.VersionMax != "" {
+			versionMin, err := semver.NewVersion(notification.VersionMin)
+			if err != nil {
+				continue
+			}
+			if clientVersion.LessThan(*versionMin) {
+				continue
+			}
+
+			versionMax, err := semver.NewVersion(notification.VersionMax)
+			if err != nil {
+				continue
+			}
+			if !clientVersion.LessThan(*versionMax) && !clientVersion.Equal(*versionMax) {
+				continue
+			}
+		}
+		results = append(results, Notification{
+			Key:     notification.Key,
+			Message: notification.Message,
+		})
+	}
+	return results
+
 }

--- a/cmd/frontend/internal/app/updatecheck/build.go
+++ b/cmd/frontend/internal/app/updatecheck/build.go
@@ -46,7 +46,7 @@ func calcNotifications(clientVersionString string, notifications []*schema.AppNo
 			// TODO(app): this is a poor/approximate check for "YYYY-MM-DD-" prefix that we mandate
 			continue
 		}
-		if notification.VersionMin != "" && notification.VersionMax != "" {
+		if notification.VersionMin != "" {
 			versionMin, err := semver.NewVersion(notification.VersionMin)
 			if err != nil {
 				continue
@@ -54,7 +54,8 @@ func calcNotifications(clientVersionString string, notifications []*schema.AppNo
 			if clientVersion.LessThan(*versionMin) {
 				continue
 			}
-
+		}
+		if notification.VersionMax != "" {
 			versionMax, err := semver.NewVersion(notification.VersionMax)
 			if err != nil {
 				continue

--- a/cmd/frontend/internal/app/updatecheck/build.go
+++ b/cmd/frontend/internal/app/updatecheck/build.go
@@ -2,13 +2,13 @@ package updatecheck
 
 import "github.com/coreos/go-semver/semver"
 
-// build is the JSON shape of the update check handler's response body.
-type build struct {
+// pingResponse is the JSON shape of the update check handler's response body.
+type pingResponse struct {
 	Version semver.Version `json:"version"`
 }
 
-func newBuild(version string) build {
-	return build{
+func newPingResponse(version string) pingResponse {
+	return pingResponse{
 		Version: *semver.New(version),
 	}
 }

--- a/cmd/frontend/internal/app/updatecheck/build.go
+++ b/cmd/frontend/internal/app/updatecheck/build.go
@@ -42,6 +42,10 @@ func calcNotifications(clientVersionString string, notifications []*schema.AppNo
 	}
 	var results []Notification
 	for _, notification := range notifications {
+		if len(strings.Split(notification.Key, "-")) < 4 {
+			// TODO(app): this is a poor/approximate check for "YYYY-MM-DD-" prefix that we mandate
+			continue
+		}
 		if notification.VersionMin != "" && notification.VersionMax != "" {
 			versionMin, err := semver.NewVersion(notification.VersionMin)
 			if err != nil {

--- a/cmd/frontend/internal/app/updatecheck/build_test.go
+++ b/cmd/frontend/internal/app/updatecheck/build_test.go
@@ -1,0 +1,63 @@
+package updatecheck
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func Test_calcNotifications(t *testing.T) {
+	clientVersionString := "2023.03.23+205275.dd37e7"
+	got := calcNotifications(clientVersionString, []*schema.AppNotifications{
+		{
+			Key:     "2023-03-10-foo",
+			Message: "Hello world",
+		},
+		{
+			Key:        "2023-03-10-foo1",
+			Message:    "max-included",
+			VersionMax: "2023.03.23",
+		},
+		{
+			Key:        "2023-03-10-foo1",
+			Message:    "max-excluded",
+			VersionMax: "2023.03.22",
+		},
+		{
+			Key:        "2023-03-10-foo1",
+			Message:    "min-included",
+			VersionMin: "2023.03.23",
+		},
+		{
+			Key:        "2023-03-10-foo1",
+			Message:    "min-excluded",
+			VersionMin: "2023.03.24",
+		},
+		{
+			Key:        "2023-03-10-foo1",
+			Message:    "range-inclusion",
+			VersionMin: "2023.01.01",
+			VersionMax: "2023.09.30",
+		},
+	})
+	autogold.Expect([]Notification{
+		{
+			Key:     "2023-03-10-foo",
+			Message: "Hello world",
+		},
+		{
+			Key:     "2023-03-10-foo1",
+			Message: "max-included",
+		},
+		{
+			Key:     "2023-03-10-foo1",
+			Message: "min-included",
+		},
+		{
+			Key:     "2023-03-10-foo1",
+			Message: "range-inclusion",
+		},
+	}).Equal(t, got)
+}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -818,7 +818,7 @@ func check(logger log.Logger, db database.DB) {
 			return "", nil // no update available
 		}
 
-		var latestBuild build
+		var latestBuild pingResponse
 		if err := json.NewDecoder(resp.Body).Decode(&latestBuild); err != nil {
 			return "", err
 		}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -814,6 +814,19 @@ func check(logger log.Logger, db database.DB) {
 			return "", errors.Errorf("update endpoint returned HTTP error %d: %s", resp.StatusCode, description)
 		}
 
+		// Sourcegraph App: we always get ping responses back, as they may contain notification messages for us.
+		if deploy.IsApp() {
+			var response pingResponse
+			if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+				return "", err
+			}
+			response.handleNotifications()
+			if response.UpdateAvailable {
+				return response.Version.String(), nil
+			}
+			return "", nil // no update available
+		}
+
 		if resp.StatusCode == http.StatusNoContent {
 			return "", nil // no update available
 		}

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -103,8 +103,8 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	latestReleaseBuild := getLatestRelease(pr.DeployType)
-	hasUpdate, err := canUpdate(pr.ClientVersionString, latestReleaseBuild, pr.DeployType)
+	pingResponse := getLatestRelease(pr.DeployType)
+	hasUpdate, err := canUpdate(pr.ClientVersionString, pingResponse, pr.DeployType)
 
 	// Always log, even on malformed version strings
 	logPing(logger, r, pr, hasUpdate)
@@ -121,7 +121,7 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("content-type", "application/json; charset=utf-8")
-	body, err := json.Marshal(latestReleaseBuild)
+	body, err := json.Marshal(pingResponse)
 	if err != nil {
 		logger.Error("error preparing update check response", log.Error(err))
 		http.Error(w, "", http.StatusInternalServerError)

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -97,7 +97,7 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no version specified", http.StatusBadRequest)
 		return
 	}
-	if pr.ClientVersionString == "dev" {
+	if pr.ClientVersionString == "dev" && !deploy.IsDeployTypeApp(pr.DeployType) {
 		// No updates for dev servers.
 		w.WriteHeader(http.StatusNoContent)
 		return
@@ -115,6 +115,7 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 	}
 	if deploy.IsDeployTypeApp(pr.DeployType) {
 		pingResponse.Notifications = getNotifications(pr.ClientVersionString)
+		pingResponse.UpdateAvailable = hasUpdate
 	}
 	body, err := json.Marshal(pingResponse)
 	if err != nil {

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -113,20 +113,19 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, pr.ClientVersionString+" is a bad version string: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	if !hasUpdate {
-		// No newer version.
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	w.Header().Set("content-type", "application/json; charset=utf-8")
 	body, err := json.Marshal(pingResponse)
 	if err != nil {
 		logger.Error("error preparing update check response", log.Error(err))
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}
+
+	if !hasUpdate {
+		// No newer version.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("content-type", "application/json; charset=utf-8")
 	requestHasUpdateCounter.Inc()
 	_, _ = w.Write(body)
 }

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -35,20 +35,20 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	// version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newBuild("4.5.1")
+	latestReleaseDockerServerImageBuild = newPingResponse("4.5.1")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newBuild("4.5.1")
+	latestReleaseKubernetesBuild = newPingResponse("4.5.1")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newBuild("4.5.1")
+	latestReleaseDockerComposeOrPureDocker = newPingResponse("4.5.1")
 )
 
-func getLatestRelease(deployType string) build {
+func getLatestRelease(deployType string) pingResponse {
 	switch {
 	case deploy.IsDeployTypeKubernetes(deployType):
 		return latestReleaseKubernetesBuild
@@ -125,7 +125,7 @@ func handler(logger log.Logger, w http.ResponseWriter, r *http.Request) {
 }
 
 // canUpdate returns true if the latestReleaseBuild is newer than the clientVersionString.
-func canUpdate(clientVersionString string, latestReleaseBuild build) (bool, error) {
+func canUpdate(clientVersionString string, latestReleaseBuild pingResponse) (bool, error) {
 	// Check for a date in the version string to handle developer builds that don't have a semver.
 	// If there is an error parsing a date out of the version string, then we ignore the error
 	// and parse it as a semver.
@@ -139,7 +139,7 @@ func canUpdate(clientVersionString string, latestReleaseBuild build) (bool, erro
 
 // canUpdateVersion returns true if the latest released build is newer than
 // the clientVersionString. It returns an error if clientVersionString is not a semver.
-func canUpdateVersion(clientVersionString string, latestReleaseBuild build) (bool, error) {
+func canUpdateVersion(clientVersionString string, latestReleaseBuild pingResponse) (bool, error) {
 	clientVersionString = strings.TrimPrefix(clientVersionString, "v")
 	clientVersion, err := semver.NewVersion(clientVersionString)
 	if err != nil {

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -73,41 +73,41 @@ func TestCanUpdate(t *testing.T) {
 		name                string
 		now                 time.Time
 		clientVersionString string
-		latestReleaseBuild  build
+		latestReleaseBuild  pingResponse
 		hasUpdate           bool
 		err                 error
 	}{
 		{
 			name:                "no version update",
 			clientVersionString: "v1.2.3",
-			latestReleaseBuild:  newBuild("1.2.3"),
+			latestReleaseBuild:  newPingResponse("1.2.3"),
 			hasUpdate:           false,
 		},
 		{
 			name:                "version update",
 			clientVersionString: "v1.2.3",
-			latestReleaseBuild:  newBuild("1.2.4"),
+			latestReleaseBuild:  newPingResponse("1.2.4"),
 			hasUpdate:           true,
 		},
 		{
 			name:                "no date update clock skew",
 			now:                 time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC),
 			clientVersionString: "19272_2018-08-02_f7dec47",
-			latestReleaseBuild:  newBuild("1.2.3"),
+			latestReleaseBuild:  newPingResponse("1.2.3"),
 			hasUpdate:           false,
 		},
 		{
 			name:                "no date update",
 			now:                 time.Date(2018, time.September, 1, 0, 0, 0, 0, time.UTC),
 			clientVersionString: "19272_2018-08-01_f7dec47",
-			latestReleaseBuild:  newBuild("1.2.3"),
+			latestReleaseBuild:  newPingResponse("1.2.3"),
 			hasUpdate:           false,
 		},
 		{
 			name:                "date update",
 			now:                 time.Date(2018, time.August, 42, 0, 0, 0, 0, time.UTC),
 			clientVersionString: "19272_2018-08-01_f7dec47",
-			latestReleaseBuild:  newBuild("1.2.3"),
+			latestReleaseBuild:  newPingResponse("1.2.3"),
 			hasUpdate:           true,
 		},
 	}

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -74,6 +74,7 @@ func TestCanUpdate(t *testing.T) {
 		now                 time.Time
 		clientVersionString string
 		latestReleaseBuild  pingResponse
+		deployType          string
 		hasUpdate           bool
 		err                 error
 	}{
@@ -110,6 +111,12 @@ func TestCanUpdate(t *testing.T) {
 			latestReleaseBuild:  newPingResponse("1.2.3"),
 			hasUpdate:           true,
 		},
+		{
+			name:                "app version update",
+			clientVersionString: "2023.03.23+205275.dd37e7",
+			latestReleaseBuild:  newPingResponse("2023.03.24+205301.ca3646"),
+			hasUpdate:           true,
+		},
 	}
 
 	for _, test := range tests {
@@ -123,7 +130,10 @@ func TestCanUpdate(t *testing.T) {
 				timeNow = time.Now
 			}()
 
-			hasUpdate, err := canUpdate(test.clientVersionString, test.latestReleaseBuild)
+			if test.deployType == "" {
+				test.deployType = "kubernetes"
+			}
+			hasUpdate, err := canUpdate(test.clientVersionString, test.latestReleaseBuild, test.deployType)
 			if err != test.err {
 				t.Fatalf("expected error %s; got %s", test.err, err)
 			}

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -666,9 +666,9 @@ cc @${release.captainGitHubUsername}
                                 : `comby -in-place 'currentReleaseRevspec := ":[1]"' 'currentReleaseRevspec := "v${release.version.version}"' doc/_resources/templates/document.html`,
 
                             // Update references to Sourcegraph deployment versions
-                            `comby -in-place 'latestReleaseKubernetesBuild = newBuild(":[1]")' "latestReleaseKubernetesBuild = newBuild(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
-                            `comby -in-place 'latestReleaseDockerServerImageBuild = newBuild(":[1]")' "latestReleaseDockerServerImageBuild = newBuild(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
-                            `comby -in-place 'latestReleaseDockerComposeOrPureDocker = newBuild(":[1]")' "latestReleaseDockerComposeOrPureDocker = newBuild(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
+                            `comby -in-place 'latestReleaseKubernetesBuild = newPingResponse(":[1]")' "latestReleaseKubernetesBuild = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
+                            `comby -in-place 'latestReleaseDockerServerImageBuild = newPingResponse(":[1]")' "latestReleaseDockerServerImageBuild = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
+                            `comby -in-place 'latestReleaseDockerComposeOrPureDocker = newPingResponse(":[1]")' "latestReleaseDockerComposeOrPureDocker = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
 
                             // Support current release as the "previous release" going forward
                             notPatchRelease

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -65,6 +65,16 @@ type ApiRatelimit struct {
 	// PerUser description: Limit granted per user per hour
 	PerUser int `json:"perUser"`
 }
+type AppNotifications struct {
+	// Key description: e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.
+	Key string `json:"key"`
+	// Message description: The Markdown message to display
+	Message string `json:"message"`
+	// VersionMax description: If present, this message will only be shown to Sourcegraph App instances in this inclusive version range.
+	VersionMax string `json:"version.max,omitempty"`
+	// VersionMin description: If present, this message will only be shown to Sourcegraph App instances in this inclusive version range.
+	VersionMin string `json:"version.min,omitempty"`
+}
 
 // AuditLog description: EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)
 type AuditLog struct {
@@ -569,6 +579,8 @@ type DebugLog struct {
 
 // Dotcom description: Configuration options for Sourcegraph.com only.
 type Dotcom struct {
+	// AppNotifications description: Notifications to display in the Sourcegraph app.
+	AppNotifications []*AppNotifications `json:"app.notifications,omitempty"`
 	// SlackLicenseExpirationWebhook description: Slack webhook for upcoming license expiration notifications.
 	SlackLicenseExpirationWebhook string `json:"slackLicenseExpirationWebhook,omitempty"`
 	// SrcCliVersionCache description: Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1411,6 +1411,12 @@ type Notice struct {
 	// Message description: The message to display. Markdown formatting is supported.
 	Message string `json:"message"`
 }
+type Notifications struct {
+	// Key description: e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.
+	Key string `json:"key"`
+	// Message description: The Markdown message to display
+	Message string `json:"message"`
+}
 type Notifier struct {
 	Slack     *NotifierSlack
 	Pagerduty *NotifierPagerduty
@@ -2485,6 +2491,8 @@ type SiteConfiguration struct {
 	LsifEnforceAuth bool `json:"lsifEnforceAuth,omitempty"`
 	// MaxReposToSearch description: DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
 	MaxReposToSearch int `json:"maxReposToSearch,omitempty"`
+	// Notifications description: Notifications recieved from Sourcegraph.com to display in Sourcegraph.
+	Notifications []*Notifications `json:"notifications,omitempty"`
 	// ObservabilityAlerts description: Configure notifications for Sourcegraph's built-in alerts.
 	ObservabilityAlerts []*ObservabilityAlerts `json:"observability.alerts,omitempty"`
 	// ObservabilityCaptureSlowGraphQLRequestsLimit description: (debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.
@@ -2663,6 +2671,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "log")
 	delete(m, "lsifEnforceAuth")
 	delete(m, "maxReposToSearch")
+	delete(m, "notifications")
 	delete(m, "observability.alerts")
 	delete(m, "observability.captureSlowGraphQLRequestsLimit")
 	delete(m, "observability.client")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1543,10 +1543,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "key",
-              "message"
-            ],
+            "required": ["key", "message"],
             "properties": {
               "key": {
                 "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -1638,10 +1635,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "key",
-          "message"
-        ],
+        "required": ["key", "message"],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1538,6 +1538,39 @@
       "description": "Configuration options for Sourcegraph.com only.",
       "type": "object",
       "properties": {
+        "app.notifications": {
+          "description": "Notifications to display in the Sourcegraph app.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "message"
+            ],
+            "properties": {
+              "key": {
+                "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
+                "type": "string",
+                "minLength": 1
+              },
+              "message": {
+                "description": "The Markdown message to display",
+                "type": "string",
+                "minLength": 1
+              },
+              "version.min": {
+                "description": "If present, this message will only be shown to Sourcegraph App instances in this inclusive version range.",
+                "type": "string",
+                "minLength": 1
+              },
+              "version.max": {
+                "description": "If present, this message will only be shown to Sourcegraph App instances in this inclusive version range.",
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
         "slackLicenseExpirationWebhook": {
           "description": "Slack webhook for upcoming license expiration notifications.",
           "type": "string",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1633,6 +1633,29 @@
       },
       "group": "Sourcegraph.com"
     },
+    "notifications": {
+      "description": "Notifications recieved from Sourcegraph.com to display in Sourcegraph.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "message"
+        ],
+        "properties": {
+          "key": {
+            "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "description": "The Markdown message to display",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "auth.providers": {
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",


### PR DESCRIPTION
This gives us the ability to add notifications for Sourcegraph App users to the Sourcegraph.com site configuration (under `dotcom.app.notifications`) with Markdown messages including text, links & more.

When the App sends a telemetry ping, the response now includes these notifications, which the app then stores in the site config `notifications` field. They are then rendered as dismissible alerts:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/3173176/224429630-f00d012b-118d-4dab-9a08-9ad2c54d237f.png">

Each notification has a unique key, and so once dismissed the user will never see it again (unless we add a new one in the sourcegraph.com site config.)

Additionally, we can specify a version range in the sourcegraph.com site config to make the notification target specific Sourcegraph App versions. For example, if we release a broken version we could notify those users specifically and inform them.

## Test plan

Because this hinges on a sourcegraph.com change, this is hard to test. What I've done to de-risk it is:

1. Made each commit individually clear/transparent; most of the changes to the `updatecheck` code are VERY low risk and easily verified.
2. Every change only affects App; there is near-zero risk to other deployment types.
3. Once merged; we can test this further (post-code-freeze) and confirm it works. We still have time to land bug fixes should any issue pop up.
4. I used VERY defensive coding; so if it doesn't work the notifications will just not appear (rather than e.g. crash the app, or cause pings to stop working.)

I think this is worth the risk in terms of value it gives us, and because it makes pings more defensible to users, and gives us a better way to communicate with these early adopters. I suggest we land this before code freeze as a result - even if it's not 100% perfect.