### PR TITLE
rbac: hide roles on profile page on dotcom

### DIFF
--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -47,7 +47,7 @@ export const UserAreaGQLFragment = gql`
             email
             isPrimary
         }
-        roles {
+        roles @skip(if: $isSourcegraphDotCom) {
             nodes {
                 name
             }

--- a/client/web/src/user/profile/UserProfile.tsx
+++ b/client/web/src/user/profile/UserProfile.tsx
@@ -21,7 +21,7 @@ type UserData =
 
 export const UserProfile: FC<Pick<UserAreaRouteContext, 'user'>> = ({ user }) => {
     const primaryEmail = user.emails?.find(email => email.isPrimary)?.email
-    const roles = user.roles.nodes.map(role => toTitleCase(role.name))
+    const roles = user.roles?.nodes.map(role => toTitleCase(role.name))
 
     const userData: UserData[] = [
         {
@@ -50,8 +50,8 @@ export const UserProfile: FC<Pick<UserAreaRouteContext, 'user'>> = ({ user }) =>
         },
         {
             name: 'Roles',
-            value: roles,
-            visible: true,
+            value: roles || ['Not set'],
+            visible: !!roles,
             isList: true,
         },
     ]

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -482,10 +482,10 @@ func (r *UserResolver) BatchChangesCodeHosts(ctx context.Context, args *ListBatc
 }
 
 func (r *UserResolver) Roles(ctx context.Context, args *ListRoleArgs) (*graphqlutil.ConnectionResolver[RoleResolver], error) {
-	userID := r.user.ID
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
-		return nil, err
+	if envvar.SourcegraphDotComMode() {
+		return nil, errors.New("roles are not available on sourcegraph.com")
 	}
+	userID := r.user.ID
 	connectionStore := &roleConnectionStore{
 		db:     r.db,
 		userID: userID,


### PR DESCRIPTION
This PR hides the roles section on the User profile page when a user is accessing the profile page on Dotcom (for both unauthenticated and authenticated users).
It also allows user to view other's roles on customer instances.

<img width="1274" alt="CleanShot 2023-03-10 at 21 47 01@2x" src="https://user-images.githubusercontent.com/25608335/224434784-afaab3ec-7546-4b55-8989-5efd8d3bfa0f.png">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing
* Update unit tests