### PR TITLE
syntax-highlighter: include libstdc++ in final image

### DIFF
--- a/docker-images/syntax-highlighter/Dockerfile
+++ b/docker-images/syntax-highlighter/Dockerfile
@@ -46,6 +46,9 @@ FROM sourcegraph/alpine-3.14:201280_2023-02-23_4.5-1071f8b97a60@sha256:c4970b211
 COPY --from=ss syntax_highlighter /
 COPY --from=hss http-server-stabilizer /
 
+# even with everything, we can't get this to statically link
+RUN apk add --no-cache libstdc++
+
 EXPOSE 9238
 ENV ROCKET_ENV "production"
 ENV ROCKET_LIMITS "{json=10485760}"


### PR DESCRIPTION
Because it is super insistent on not statically linking libstdc++

<details>
<summary>Details</summary>

```
Error loading shared library libstdc++.so.6: No such file or directory (needed by ./syntax_highlighter)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by ./syntax_highlighter)
Error relocating ./syntax_highlighter: __cxa_begin_catch: symbol not found
Error relocating ./syntax_highlighter: _ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE9_M_mutateEmmPKwm: symbol not found
Error relocating ./syntax_highlighter: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm: symbol not found
Error relocating ./syntax_highlighter: _ZdlPvm: symbol not found
Error relocating ./syntax_highlighter: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm: symbol not found
Error relocating ./syntax_highlighter: _Unwind_Resume: symbol not found
Error relocating ./syntax_highlighter: _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4copyEPcmm: symbol not found
Error relocating ./syntax_highlighter: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm: symbol not found
Error relocating ./syntax_highlighter: __cxa_rethrow: symbol not found
Error relocating ./syntax_highlighter: _Znwm: symbol not found
Error relocating ./syntax_highlighter: _ZSt20__throw_length_errorPKc: symbol not found
Error relocating ./syntax_highlighter: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_assignERKS4_: symbol not found
Error relocating ./syntax_highlighter: __cxa_end_catch: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetIPInfo: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetDataRelBase: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetRegionStart: symbol not found
Error relocating ./syntax_highlighter: _Unwind_SetGR: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetTextRelBase: symbol not found
Error relocating ./syntax_highlighter: _Unwind_DeleteException: symbol not found
Error relocating ./syntax_highlighter: _Unwind_RaiseException: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetIP: symbol not found
Error relocating ./syntax_highlighter: _Unwind_Backtrace: symbol not found
Error relocating ./syntax_highlighter: _Unwind_GetLanguageSpecificData: symbol not found
Error relocating ./syntax_highlighter: _Unwind_SetIP: symbol not found
Error relocating ./syntax_highlighter: __gxx_personality_v0: symbol not found
```

</details>

## Test plan

Ran `apk add libstdc++` in the from-CI-published docker image and it fixed it
