### PR TITLE
experimental search input: Fix cursor position in Chrome

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react'
 
 import { defaultKeymap, historyKeymap, history as codemirrorHistory } from '@codemirror/commands'
-import { Compartment, EditorState, Extension, Prec } from '@codemirror/state'
+import { Compartment, EditorSelection, EditorState, Extension, Prec } from '@codemirror/state'
 import { EditorView, keymap, drawSelection } from '@codemirror/view'
 import { mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -171,7 +171,34 @@ function configureQueryExtensions({
 
 // Creates extensions that don't depend on props
 function createStaticExtensions({ popoverID }: { popoverID: string }): Extension {
+    const position0 = EditorSelection.single(0)
     return [
+        EditorState.transactionFilter.of(transaction => {
+            // This is a hacky way to "fix" the cursor position when the input receives
+            // focus by clicking outside of it in Chrome.
+            // Debugging has revealed that in such a case the transaction has a user event
+            // 'select', the new selection is set to `0` and 'scrollIntoView' is 'false'.
+            // This is different from other events that change the cursor position:
+            // - Clicking on text inside the input (whether focused or not) will be a 'select.pointer'
+            //   user event.
+            // - Moving the cursor with arrow keys will be a 'select' user event but will also set
+            //   'scrollIntoView' to 'true'
+            // - Entering new characters will be of user type 'input'
+            // - Selecting a text range will be of user type 'select.pointer'
+            // - Tabbing to the input seems to only trigger a 'select' user event transaction when
+            //   the user clicked outside the input (also only in Chrome, this transaction doesn't
+            //   occur in Firefox)
+
+            if (
+                !transaction.isUserEvent('select.pointer') &&
+                transaction.isUserEvent('select') &&
+                !transaction.scrollIntoView &&
+                transaction.selection?.eq(position0)
+            ) {
+                return [transaction, { selection: EditorSelection.single(transaction.newDoc.length) }]
+            }
+            return transaction
+        }),
         singleLine,
         drawSelection(),
         EditorView.contentAttributes.of({


### PR DESCRIPTION
Addresses [this slack thread](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1678463340977319)

Chrome moves focus to the input even when clicking on the container element around it. Clicking above the input will put the cursor at the beginning of the input.
This isn't useful because with the context: filter being present by default because the user most likely wants to position the cursor after the context: filter to type the query.

It's reasonable to assume that it's not uncommon for users to click slightly outside the input.

Debugging revealed that we can identify such transactions (not 100% uniquely but close enough). This PR adds a transaction filter to adjust the cursor position to the end of the input in this case.

See code for more comments.

Before/after video: 

https://user-images.githubusercontent.com/179026/224445816-72eaacfd-bd1a-4ee3-a5d8-aba410655436.mp4



## Test plan

- Click slightly outside of input in Chrome -> input gets focus with cursor being positioned at the end of the input.
- Click on text inside the input -> cursor is positioned where the click happened
- Move cursor with arrow keys -> cursor moves as expected

## App preview:

- [Web](https://sg-web-fkling-search-input-smart-focus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
