### PR TITLE
experimental search input: Fix text selection color dark mode

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -216,7 +216,7 @@ function createStaticExtensions({ popoverID }: { popoverID: string }): Extension
             '.cm-line': {
                 padding: 0,
             },
-            '.cm-selectionLayer .cm-selectionBackground': {
+            '.theme-dark .cm-selectionLayer .cm-selectionBackground': {
                 backgroundColor: 'var(--gray-08)',
             },
             '.sg-decorated-token-hover': {


### PR DESCRIPTION
Addresses [Slack](https://sourcegraph.slack.com/archives/C04931KQVRC/p1678501868123139)
The text selection color should only be overwritten when dark mode is enabled.


## Test plan

:eyes:

## App preview:

- [Web](https://sg-web-fkling-search-input-fix-selection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
