### PR TITLE
Wildcard [Combobox]: Fix border radius in Combobox item UI

### DIFF
--- a/client/branded/src/search-ui/input/__snapshots__/SearchContextMenu.test.tsx.snap
+++ b/client/branded/src/search-ui/input/__snapshots__/SearchContextMenu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SearchContextMenu should filter list by spec when searching 1`] = `
 Array [
   <li
     aria-selected="false"
-    class="item item"
+    class="item"
     data-reach-combobox-option=""
     data-search-context-spec="@username/test-version-1.5"
     data-testid="search-context-menu-item"

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.module.scss
@@ -4,3 +4,7 @@
     min-height: 20rem;
     margin-top: 0.5rem;
 }
+
+.item {
+    border-radius: 3px;
+}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubEntityPickers.tsx
@@ -88,7 +88,7 @@ export const GithubOrganizationsPicker: FC<GithubOrganizationsPickerProps> = pro
             <MultiComboboxList items={filteredSuggestions} className="mt-2">
                 {items =>
                     items.map((item, index) => (
-                        <MultiComboboxOption key={item} value={item} index={index}>
+                        <MultiComboboxOption key={item} value={item} index={index} className={styles.item}>
                             <Icon aria-hidden={true} svgPath={mdiGithub} /> <MultiComboboxOptionText />
                         </MultiComboboxOption>
                     ))
@@ -191,7 +191,7 @@ export const GithubRepositoriesPicker: FC<GithubRepositoriesPickerProps> = props
             >
                 {items =>
                     items.map((item, index) => (
-                        <MultiComboboxOption key={item} value={item} index={index}>
+                        <MultiComboboxOption key={item} value={item} index={index} className={styles.item}>
                             <Icon aria-hidden={true} svgPath={mdiGithub} /> <MultiComboboxOptionText />
                         </MultiComboboxOption>
                     ))

--- a/client/wildcard/src/components/Combobox/Combobox.module.scss
+++ b/client/wildcard/src/components/Combobox/Combobox.module.scss
@@ -45,8 +45,6 @@
 }
 
 .item {
-    border-radius: 3px;
-
     &--disabled {
         cursor: not-allowed;
     }

--- a/client/wildcard/src/components/Combobox/Combobox.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.tsx
@@ -240,7 +240,7 @@ export const ComboboxOption = forwardRef((props, ref) => {
             <li
                 ref={mergedRef}
                 data-option-disabled={true}
-                className={classNames(className, styles.item, styles.itemDisabled)}
+                className={classNames(className, styles.itemDisabled)}
                 {...attributes}
             >
                 {typeof children === 'function' ? children(context) : children ?? value}
@@ -249,12 +249,7 @@ export const ComboboxOption = forwardRef((props, ref) => {
     }
 
     return (
-        <ReachComboboxOption
-            ref={mergedRef}
-            value={value}
-            className={classNames(styles.item, className)}
-            {...attributes}
-        >
+        <ReachComboboxOption ref={mergedRef} value={value} className={className} {...attributes}>
             {children}
         </ReachComboboxOption>
     )


### PR DESCRIPTION

For the setup wizard I added a border radius to a common combobox item (bad idea), this PR makes shared combobox items with no border-radius but adds specific border-radius styles for setup UI pickers

| Before | After |
| --------- | ------- |
| <img width="600" alt="Screenshot 2023-03-11 at 12 44 26" src="https://user-images.githubusercontent.com/18492575/224494015-e59f6a44-437e-4295-be75-52d0d165457c.png"> | <img width="594" alt="Screenshot 2023-03-11 at 12 55 53" src="https://user-images.githubusercontent.com/18492575/224494408-5830cbb4-8bb9-47f8-b3c8-1162a4795fee.png"> | 

## Test plan
- N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-border-radius-at-combobox.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
