### PR TITLE
Support compact mode for the new search box UI (search result and blob pages)

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -13,11 +13,11 @@
     }
 
     &--compact {
-        padding: 0.35rem;
-        margin: -0.35rem;
+        padding: 0.5rem;
+        margin: -0.5rem;
 
         .suggestions {
-            padding: 3rem 0.25rem 0.5rem 0.25rem;
+            padding: 3rem 0.5rem 0.5rem 0.5rem;
         }
     }
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -17,7 +17,8 @@
         margin: -0.5rem;
 
         .suggestions {
-            padding: 3rem 0.5rem 0.5rem 0.5rem;
+            // Set smaller paddings to the suggestion panel (see Suggestions.module.scss)
+            --suggestions-padding: 0.5rem;
         }
     }
 }
@@ -89,13 +90,12 @@
     top: 0;
     left: 0;
     right: 0;
-    // Hardcoded value in order to render border around
-    // input element but avoid suggestion content overlapping
-    // with input UI
-    padding: 3.5rem 0.75rem 0.75rem 0.75rem;
     border-radius: 8px;
     background-color: var(--color-bg-1);
     box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+
+    // Set a default paddings to the suggestion panel (see Suggestions.module.scss)
+    --suggestions-padding: 0.75rem;
 
     :global(.theme-dark) & {
         box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -1,52 +1,45 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .container {
-    flex: 1;
+    width: 100%;
     position: relative;
-
-    .spacer {
-        margin: 0.75rem;
-    }
-}
-
-.root {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    border-radius: 8px;
-    z-index: 100;
+    padding: 0.75rem;
 
     &:focus-within {
-        background-color: var(--color-bg-1);
-        box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
-
+        // Show suggestion if there is any focused element withing container
         .suggestions {
             display: block;
         }
+    }
 
-        :global(.theme-dark) & {
-            box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
+    &--compact {
+        padding: 0.35rem;
+        margin: -0.35rem;
+
+        .suggestions {
+            padding: 3rem 0.25rem 0.5rem 0.25rem;
         }
     }
 }
 
 .focus-container {
     display: flex;
-    background-color: var(--input-bg);
-    border-radius: 4px;
-    margin: 0.75rem;
-    border: 1px solid var(--border-color-2);
-    padding: 0 0.25rem;
-    min-height: 32px;
     align-items: center;
+    min-height: 32px;
+    padding: 0 0.25rem;
+    border-radius: 4px;
+    border: 1px solid var(--border-color-2);
+    background-color: var(--input-bg);
+    position: relative;
 
-    .show-when-focused {
-        display: none;
-    }
+    &:focus-within {
+        z-index: 1;
 
-    .hide-when-focused {
-        display: block;
+        @media (--sm-breakpoint-up) {
+            outline: 2px solid var(--primary-2);
+            outline-offset: 0;
+            border-color: var(--primary-2);
+        }
     }
 
     @media (--xs-breakpoint-down) {
@@ -54,37 +47,6 @@
         align-items: start;
         padding: 0.5rem;
         gap: 0.5rem;
-    }
-
-    &:focus-within {
-        @media (--sm-breakpoint-up) {
-            outline: 2px solid var(--primary-2);
-            outline-offset: 0;
-            border-color: var(--primary-2);
-        }
-
-        .hide-when-focused {
-            display: none;
-        }
-
-        .show-when-focused {
-            display: block;
-        }
-    }
-
-    .input-button {
-        display: none;
-        align-self: flex-start;
-        padding: 0.125rem 0.25rem;
-        margin: 0.125rem;
-        background-color: transparent;
-        border: 1px solid transparent;
-        border-radius: 4px;
-
-        &:focus {
-            outline: 2px solid rgba(163, 208, 255, 1);
-            outline-offset: 0;
-        }
     }
 
     :global(.cm-content) {
@@ -99,40 +61,48 @@
             flex-shrink: 1;
         }
     }
+}
 
-    .input {
-        display: contents;
+.input {
+    // We're using display contents here (not flex-grow: 1) because it prevents input
+    // element from uncontrolled growing if we have long string in the input
+    display: contents;
 
-        @media (--xs-breakpoint-down) {
-            display: block;
-            width: 100%;
-            border: 1px solid var(--border-color-2);
-            border-radius: 4px;
-            padding: 0.375rem 0.5rem;
+    @media (--xs-breakpoint-down) {
+        display: block;
+        width: 100%;
+        border: 1px solid var(--border-color-2);
+        border-radius: 4px;
+        padding: 0.375rem 0.5rem;
 
-            &:focus-within {
-                outline: 2px solid var(--primary-2);
-                outline-offset: 0;
-                border-color: var(--primary-2);
-            }
+        &:focus-within {
+            outline: 2px solid var(--primary-2);
+            outline-offset: 0;
+            border-color: var(--primary-2);
         }
     }
 }
 
 .suggestions {
-    position: relative;
     display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    // Hardcoded value in order to render border around
+    // input element but avoid suggestion content overlapping
+    // with input UI
+    padding: 3.5rem 0.75rem 0.75rem 0.75rem;
+    border-radius: 8px;
+    background-color: var(--color-bg-1);
+    box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+
+    :global(.theme-dark) & {
+        box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
+    }
 }
 
-.separator {
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    width: 1px;
-    height: 1.125rem;
-    margin-right: 0.5rem;
-    background-color: var(--border-color-2);
-}
-
-.mode-section {
+.mode {
     display: flex;
     align-items: center;
     padding-right: 0.1875rem;
@@ -150,7 +120,7 @@
         }
     }
 
-    &.active {
+    &--active {
         color: var(--logo-purple);
         padding: 0;
         border: 0;

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -480,7 +480,10 @@ const SearchModeSwitcher: FC<SearchModeSwitcherProps> = props => {
 
 function useMutableValue<T>(value: T): MutableRefObject<T> {
     const valueRef = useRef(value)
-    valueRef.current = value
+
+    useEffect(() => {
+        valueRef.current = value
+    }, [value])
 
     return valueRef
 }

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -19,6 +19,7 @@ import { mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
 import inRange from 'lodash/inRange'
 import { useNavigate } from 'react-router-dom'
+import useResizeObserver from 'use-resize-observer'
 
 import { HistoryOrNavigate } from '@sourcegraph/common'
 import { Editor, useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
@@ -430,8 +431,11 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
             }
         }, [setMode])
 
+        const { ref: inputContainerRef, height = 0 } = useResizeObserver({ box: 'border-box' })
+
         return (
             <div
+                ref={inputContainerRef}
                 className={classNames(styles.container, className, {
                     [styles.containerCompact]: visualMode === QueryInputVisualMode.Compact,
                 })}
@@ -441,7 +445,12 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                     <div ref={editorContainerRef} className={styles.input} />
                     {!mode && children}
                 </div>
-                <div ref={setSuggestionsContainer} className={styles.suggestions} />
+                <div
+                    ref={setSuggestionsContainer}
+                    className={styles.suggestions}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ paddingTop: height }}
+                />
                 <Shortcut ordered={['/']} onMatch={focus} />
             </div>
         )

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -24,7 +24,8 @@
 
         [role='rowgroup'] {
             border-bottom: 1px solid var(--border-color);
-            padding: 0.75rem;
+            padding-top: 0.75rem;
+            padding-bottom: 0.75rem;
 
             &:first-of-type {
                 padding-top: 0;
@@ -32,6 +33,7 @@
 
             &:last-of-type {
                 border: none;
+                padding-bottom: 0;
             }
 
             // group header
@@ -46,7 +48,7 @@
             /*
                 Layout of a row
                 The icon is always top aligned next to the label.
-                Label and description can wrap around if necessary, in which case the 
+                Label and description can wrap around if necessary, in which case the
                 action labels are centered.
                 On small screens the action labels are shown on a separate row.
 

--- a/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.module.scss
@@ -14,6 +14,13 @@
 
     .suggestions {
         overflow-y: auto;
+        margin: 0 var(--suggestions-padding) var(--suggestions-padding);
+
+        // Don't render the suggestions panel if we don't have any suggestions
+        // in order to avoid extra paddings appearance
+        &:empty {
+            display: none;
+        }
 
         ul {
             margin: 0;

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -12,7 +12,7 @@ export const filterDecoration = [
     EditorView.baseTheme({
         '.sg-query-token-filter-context': {
             borderRadius: '3px',
-            padding: '1px 0',
+            padding: '1px 4px',
             backgroundColor: '#eff2f5a0', // --gray-02 with transparency to make selection visible
         },
         '&dark .sg-query-token-filter-context': {

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -12,7 +12,7 @@ export const filterDecoration = [
     EditorView.baseTheme({
         '.sg-query-token-filter-context': {
             borderRadius: '3px',
-            padding: '1px 4px',
+            padding: '1px 0',
             backgroundColor: '#eff2f5a0', // --gray-02 with transparency to make selection visible
         },
         '&dark .sg-query-token-filter-context': {

--- a/client/branded/src/search-ui/input/experimental/index.ts
+++ b/client/branded/src/search-ui/input/experimental/index.ts
@@ -1,5 +1,5 @@
 export type { CodeMirrorQueryInputWrapperProps } from './CodeMirrorQueryInputWrapper'
-export { CodeMirrorQueryInputWrapper } from './CodeMirrorQueryInputWrapper'
+export { CodeMirrorQueryInputWrapper, QueryInputVisualMode } from './CodeMirrorQueryInputWrapper'
 export type {
     Group,
     Option,

--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -30,6 +30,6 @@
 .search-nav-bar {
     z-index: 1;
     width: 100%;
-    padding: 0.5rem 1rem;
+    padding: 0.75rem 1rem;
     border-bottom: 1px solid var(--border-color);
 }

--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -21,7 +21,15 @@
     border-width: 1px;
     border-color: var(--brand-secondary);
 }
+
 .fuzzy-finder-shortcut {
     position: relative;
     right: 2rem;
+}
+
+.search-nav-bar {
+    z-index: 1;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--border-color);
 }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -370,7 +370,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                 </NavActions>
             </NavBar>
             {showSearchBox && (
-                <div className="w-100 px-3 py-2 border-bottom">
+                <div className={styles.searchNavBar}>
                     <SearchNavbarItem
                         {...props}
                         isLightTheme={isLightTheme}

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`GlobalNavbar default 1`] = `
     </ul>
   </nav>
   <div
-    class="w-100 px-3 py-2 border-bottom"
+    class="searchNavBar"
   >
     <searchnavbaritem
       platformcontext="[object Object]"

--- a/client/web/src/search/input/ExperimentalSearchInput.tsx
+++ b/client/web/src/search/input/ExperimentalSearchInput.tsx
@@ -128,6 +128,7 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
     isSourcegraphDotCom,
     submitSearch,
     selectedSearchContextSpec,
+    visualMode,
     ...inputProps
 }) => {
     const { recentSearches } = useRecentSearches()
@@ -215,6 +216,8 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
             placeholder="Search for code or files..."
             suggestionSource={suggestionSource}
             extensions={extensions}
+            visualMode={visualMode}
+            className={inputProps.className}
         >
             {children}
         </CodeMirrorQueryInputWrapper>

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -89,6 +89,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 onSubmit={onSubmit}
             >
                 <LazyExperimentalSearchInput
+                    visualMode="compact"
                     telemetryService={props.telemetryService}
                     patternType={searchPatternType}
                     interpretComments={false}
@@ -103,6 +104,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                     submitSearch={submitSearchOnChange}
                     selectedSearchContextSpec={props.selectedSearchContextSpec}
+                    className="flex-grow-1"
                 >
                     <Toggles
                         patternType={searchPatternType}

--- a/client/web/src/search/results/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/StreamingSearchResults.module.scss
@@ -11,6 +11,7 @@
     column-gap: 1rem;
     height: min-content;
     padding: 0.5rem 1rem 0 1rem;
+    isolation: isolate;
 
     &--with-sidebar-hidden {
         grid-template-columns: minmax(0, 1fr);

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.module.scss
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.module.scss
@@ -20,6 +20,7 @@
 
 .search-container {
     position: relative;
+    z-index: 1;
     flex: 1 1 auto;
     width: 100%;
     flex-grow: 0;

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -140,6 +140,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             isSourcegraphDotCom={isSourcegraphDotCom}
             submitSearch={submitSearchOnChange}
             selectedSearchContextSpec={selectedSearchContextSpec}
+            className="flex-grow-1"
         >
             <Toggles
                 patternType={patternType}


### PR DESCRIPTION
Addresses search UI padding problem ([slack discussion](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1678548618527699?thread_ts=1678361542.292339&cid=C03CSAER9LK))

| | Before | After |
| ----- | -------- |  -------- |
| Initial state | <img width="1113" alt="Screenshot 2023-03-11 at 22 51 05" src="https://user-images.githubusercontent.com/18492575/224519899-60e75361-dea9-425c-891f-ca7efbfaeb68.png"> | <img width="1113" alt="Screenshot 2023-03-11 at 22 51 03" src="https://user-images.githubusercontent.com/18492575/224519888-1df65561-4540-4b01-82dd-33436e126e6c.png"> |
| Focused state | <img width="1113" alt="Screenshot 2023-03-11 at 22 51 07" src="https://user-images.githubusercontent.com/18492575/224519879-083605bc-7286-45f3-bcb3-64fefcd4e2cd.png"> | <img width="1113" alt="Screenshot 2023-03-11 at 22 50 42" src="https://user-images.githubusercontent.com/18492575/224519864-54a34cbf-3899-4f7c-91e2-97fc6ae6f286.png"> |

## Notes
- Home page search input isn't affected by this change (it still uses standard UI mode)
- @rrhyne I implemented this in the way you suggested in the thread (added a thin border around input in focus state), but let me know if you want to try the no around-border approach, No borders-approach in the image below
<img width="600" alt="Screenshot 2023-03-11 at 22 57 50" src="https://user-images.githubusercontent.com/18492575/224519986-756f897d-3266-4d09-82b3-aa75b8f0c8a2.png">

- @rrhyne, I'm not sure about the padding in the suggestion panel, I tried to keep alignment with the history icon buttons, but it may feels like it's too close to the borders in the compact mode. Let me know if we can ignore alignment with history icon and make the padding bigger there.
- @fkling I re-layout the previous version and tried to simplify styles and HTML in the search box UI, I didn't figure out why we had to use resize observer there if this input doesn't support multiple (and always has the same height value) but let me know if there is a case for this, I think we could bring back resize observer and don't use hardcoded values for padding in CSS) 

## Test plan
- Check the Home page old/new search UI 
- Check the search result page old/new search UI 
- Check file page old/new search UI


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-search-box-paddings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
