### PR TITLE
rbac: allow site admins to manage their own roles

### DIFF
--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Resolver is the GraphQL resolver of all things related to batch changes.
@@ -124,15 +123,6 @@ func (r *Resolver) SetRoles(ctx context.Context, args *gql.SetRolesArgs) (*gql.E
 	userID, err := gql.UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err
-	}
-
-	user, err := auth.CurrentUser(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
-
-	if user.ID == userID {
-		return nil, errors.New("cannot assign role to self")
 	}
 
 	opts := database.SetRolesForUserOpts{UserID: userID}

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver_test.go
@@ -321,7 +321,6 @@ func TestSetRoles(t *testing.T) {
 	userCtx := actor.WithActor(ctx, actor.FromUser(uID))
 
 	aID := createTestUser(t, db, true).ID
-	adminID := gql.MarshalUserID(aID)
 	adminCtx := actor.WithActor(ctx, actor.FromUser(aID))
 
 	s, err := newSchema(db, &Resolver{logger: logger, db: db})
@@ -358,15 +357,6 @@ func TestSetRoles(t *testing.T) {
 
 		require.Len(t, errs, 1)
 		require.ErrorContains(t, errs[0], "must be site admin")
-	})
-
-	t.Run("as self", func(t *testing.T) {
-		input := map[string]any{"user": adminID, "roles": marshalledRoles}
-		var response struct{ AssignRolesToUser apitest.EmptyResponse }
-		errs := apitest.Exec(adminCtx, t, s, input, &response, setRolesQuery)
-
-		require.Len(t, errs, 1)
-		require.ErrorContains(t, errs[0], "cannot assign role to self")
 	})
 
 	t.Run("as site-admin", func(t *testing.T) {


### PR DESCRIPTION
I think this was just an oversight that neither of us thought all the way through. Site admins can do whatever the heck they want, including change the roles assigned to themselves. This already excludes system roles, so it's not like assigning themselves other roles really matters anyway.

## Test plan

Unit test coverage still passes. Manually confirmed I can assign or revoke roles from myself as a site admin.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
