### PR TITLE
log rbac-related backend events

### DIFF
--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -69,7 +69,7 @@ func (r *Resolver) SetPermissions(ctx context.Context, args gql.SetPermissionsAr
 	}
 
 	eventArgs := &rolePermissionEventArgs{RoleID: roleID, PermissionIDs: opts.Permissions}
-	r.logBackendEvent(ctx, "RBACRolePermissionAssignment", eventArgs)
+	r.logBackendEvent(ctx, "RolePermissionAssignment", eventArgs)
 	return &gql.EmptyResponse{}, nil
 }
 
@@ -96,7 +96,7 @@ func (r *Resolver) DeleteRole(ctx context.Context, args *gql.DeleteRoleArgs) (_ 
 	}
 
 	eventArg := &roleEventArg{RoleID: roleID}
-	r.logBackendEvent(ctx, "RBACRoleDeleted", eventArg)
+	r.logBackendEvent(ctx, "RoleDeleted", eventArg)
 	return &gql.EmptyResponse{}, nil
 }
 
@@ -136,7 +136,7 @@ func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gq
 		return nil, err
 	}
 
-	r.logBackendEvent(ctx, "RBACRoleCreated", eventArg)
+	r.logBackendEvent(ctx, "RoleCreated", eventArg)
 	return gql.NewRoleResolver(r.db, role), nil
 }
 
@@ -167,7 +167,7 @@ func (r *Resolver) SetRoles(ctx context.Context, args *gql.SetRolesArgs) (*gql.E
 	}
 
 	eventArgs := &setRolesEventArgs{RoleIDs: opts.Roles, UserID: userID}
-	r.logBackendEvent(ctx, "RBACUserRoleAssignment", eventArgs)
+	r.logBackendEvent(ctx, "UserRoleAssignment", eventArgs)
 	return &gql.EmptyResponse{}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver.go
@@ -107,13 +107,14 @@ func (r *Resolver) CreateRole(ctx context.Context, args *gql.CreateRoleArgs) (gq
 	}
 
 	var role *types.Role
-	eventArg := &rolePermissionEventArgs{RoleID: role.ID}
+	eventArg := &rolePermissionEventArgs{}
 	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
 		role, err = tx.Roles().Create(ctx, args.Name, false)
 		if err != nil {
 			return err
 		}
 
+		eventArg.RoleID = role.ID
 		if len(args.Permissions) > 0 {
 			opts := database.BulkAssignPermissionsToRoleOpts{RoleID: role.ID}
 			for _, permissionID := range args.Permissions {

--- a/enterprise/cmd/frontend/internal/rbac/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/rbac/resolvers/resolver_test.go
@@ -28,10 +28,10 @@ func TestDeleteRole(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
 	userID := createTestUser(t, db, false).ID
-	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+	actorCtx := actor.WithActor(ctx, actor.FromMockUser(userID))
 
 	adminUserID := createTestUser(t, db, true).ID
-	adminActorCtx := actor.WithActor(ctx, actor.FromUser(adminUserID))
+	adminActorCtx := actor.WithActor(ctx, actor.FromMockUser(adminUserID))
 
 	r := &Resolver{logger: logger, db: db}
 	s, err := newSchema(db, r)
@@ -95,10 +95,10 @@ func TestCreateRole(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
 	userID := createTestUser(t, db, false).ID
-	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+	actorCtx := actor.WithActor(ctx, actor.FromMockUser(userID))
 
 	adminUserID := createTestUser(t, db, true).ID
-	adminActorCtx := actor.WithActor(ctx, actor.FromUser(adminUserID))
+	adminActorCtx := actor.WithActor(ctx, actor.FromMockUser(adminUserID))
 
 	r := &Resolver{logger: logger, db: db}
 	s, err := newSchema(db, r)
@@ -203,8 +203,8 @@ func TestSetPermissions(t *testing.T) {
 	admin := createTestUser(t, db, true)
 	user := createTestUser(t, db, false)
 
-	adminCtx := actor.WithActor(ctx, actor.FromUser(admin.ID))
-	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+	adminCtx := actor.WithActor(ctx, actor.FromMockUser(admin.ID))
+	userCtx := actor.WithActor(ctx, actor.FromMockUser(user.ID))
 
 	s, err := newSchema(db, &Resolver{logger: logger, db: db})
 	if err != nil {
@@ -318,10 +318,10 @@ func TestSetRoles(t *testing.T) {
 
 	uID := createTestUser(t, db, false).ID
 	userID := gql.MarshalUserID(uID)
-	userCtx := actor.WithActor(ctx, actor.FromUser(uID))
+	userCtx := actor.WithActor(ctx, actor.FromMockUser(uID))
 
 	aID := createTestUser(t, db, true).ID
-	adminCtx := actor.WithActor(ctx, actor.FromUser(aID))
+	adminCtx := actor.WithActor(ctx, actor.FromMockUser(aID))
 
 	s, err := newSchema(db, &Resolver{logger: logger, db: db})
 	if err != nil {


### PR DESCRIPTION
This PR adds a logger for events, so rbac-related events can be viewed in the `event_logs` table.
I also removed the constraint where a site admin can't assign a role to themselves.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual testing
* Update unit tests.