### PR TITLE
Fix frontend showing Sourcegraph Enterprise when Free

### DIFF
--- a/cmd/frontend/graphqlbackend/product_license_info.go
+++ b/cmd/frontend/graphqlbackend/product_license_info.go
@@ -29,7 +29,7 @@ type ProductLicenseInfo struct {
 }
 
 func (r ProductLicenseInfo) ProductNameWithBrand() string {
-	return GetProductNameWithBrand(true, r.TagsValue)
+	return GetProductNameWithBrand(IsFreePlan(&r), r.TagsValue)
 }
 
 func (r ProductLicenseInfo) Tags() []string { return r.TagsValue }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services.go
@@ -58,8 +58,9 @@ func NewBeforeCreateExternalServiceHook() func(ctx context.Context, store databa
 				return presentationError
 			}
 
+		// Free plan can have unlimited number of code host connections for now
 		case licensing.PlanFree0:
-			// Free plan can have unlimited number of code host connections for now
+		case licensing.PlanFree1:
 		default:
 			// Default to unlimited number of code host connections
 		}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -60,7 +60,7 @@ func Init(
 			return nil
 		}
 
-		if info.Plan() == licensing.PlanFree0 {
+		if info.Plan().IsFree() {
 			// We don't enforce anything on the free plan
 			return nil
 		}
@@ -136,7 +136,7 @@ func Init(
 
 	graphqlbackend.IsFreePlan = func(info *graphqlbackend.ProductLicenseInfo) bool {
 		for _, tag := range info.Tags() {
-			if tag == fmt.Sprintf("plan:%s", licensing.PlanFree0) {
+			if tag == fmt.Sprintf("plan:%s", licensing.PlanFree0) || tag == fmt.Sprintf("plan:%s", licensing.PlanFree1) {
 				return true
 			}
 		}


### PR DESCRIPTION
The initial switch to the new free plan missed a few frontend checks where we determine if the frontend is using the free plan. This PR fixes those checks.

## Test plan

Verified locally:

**BEFORE WITHOUT LICENSE KEY**

<img width="611" alt="image" src="https://user-images.githubusercontent.com/6427795/224625678-882b7b73-4cb3-4c81-a1c2-a799f5cddc5e.png">

**AFTER WITHOUT LICENSE KEY**

<img width="572" alt="image" src="https://user-images.githubusercontent.com/6427795/224626969-82c96fa9-d2cb-4819-9ee1-1b3cab283816.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
