### PR TITLE
storm: use `cache-first`

### DIFF
--- a/client/web/src/storm/backend/route-loader.ts
+++ b/client/web/src/storm/backend/route-loader.ts
@@ -1,4 +1,4 @@
-import { OperationVariables } from '@apollo/client'
+import { OperationVariables, SuspenseQueryHookOptions } from '@apollo/client'
 import { useLoaderData } from 'react-router-dom'
 import * as uuid from 'uuid'
 
@@ -7,9 +7,7 @@ import { getDocumentNode, useSuspenseQuery } from '@sourcegraph/http-client'
 import { getWebGraphQLClient } from '../../backend/graphql'
 
 export type LoaderQuery = Parameters<typeof useSuspenseQuery>[0]
-export interface QueryReference {
-    variables: OperationVariables
-}
+export interface QueryReference extends SuspenseQueryHookOptions {}
 
 /**
  * TODO: Add explainers on how these things are connected.
@@ -17,6 +15,7 @@ export interface QueryReference {
 function createReference(variables: OperationVariables): QueryReference {
     return {
         variables,
+        fetchPolicy: 'cache-first',
     }
 }
 

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.loader.ts
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.loader.ts
@@ -41,6 +41,7 @@ const LAYOUT_PAGE_QUERY = gql`
         flag1: evaluateFeatureFlag(flagName: "contrast-compliant-syntax-highlighting")
         flag2: evaluateFeatureFlag(flagName: "cody")
         flag3: evaluateFeatureFlag(flagName: "search-ownership")
+        flag4: evaluateFeatureFlag(flagName: "blob-page-switch-areas-shortcuts")
     }
 
     ${siteFlagFieldsFragment}


### PR DESCRIPTION
## Context 

1. Use the `cache-first` strategy for page loaders to avoid redundant API requests.
2. Preload feature flag that was recently added to the nav bar.

## Test plan

1. Load the home page with Storm enabled.
3. Ensure that there's only one SearchPage query in the network tab.

## App preview:

- [Web](https://sg-web-vb-storm-6.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
