### PR TITLE
rbac: skip user roles on dotcom

### DIFF
--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -66,7 +66,7 @@ const UserSettingsAreaGQLFragment = gql`
                 name
             }
         }
-        roles {
+        roles @skip(if: $isSourcegraphDotCom) {
             nodes {
                 name
             }


### PR DESCRIPTION
This is an oversight on #49146 for hiding user roles on Dotcom.

[Context](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1678698421031709) - we don't fetch a user's role on Dotcom.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested

## App preview:

- [Web](https://sg-web-bo-fix-roles-on-dotcom.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
