### PR TITLE
(experimental) search input: Explicitly blur input on repo pages

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -431,6 +431,9 @@ export function useUpdateEditorFromQueryState(
             if ((queryState.hint & EditorHint.ShowSuggestions) === EditorHint.ShowSuggestions) {
                 startCompletionRef.current(editor)
             }
+            if ((queryState.hint & EditorHint.Blur) === EditorHint.Blur) {
+                editor.contentDOM.blur()
+            }
         }
     }, [editorRef, queryState])
 }

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -585,6 +585,7 @@ function applyAction(view: EditorView, action: Action, option: Option, source: S
                 if (historyOrNavigate) {
                     notifySelectionListeners(view.state, option, action, source)
                     compatNavigate(historyOrNavigate, action.url)
+                    view.contentDOM.blur()
                 }
             }
             break

--- a/client/shared/src/search/helpers.ts
+++ b/client/shared/src/search/helpers.ts
@@ -44,6 +44,7 @@ export enum EditorHint {
      * Showing suggestions also implies focusing the input.
      */
     ShowSuggestions = 2 | Focus,
+    Blur = 4
 }
 
 /**

--- a/client/shared/src/search/helpers.ts
+++ b/client/shared/src/search/helpers.ts
@@ -44,7 +44,7 @@ export enum EditorHint {
      * Showing suggestions also implies focusing the input.
      */
     ShowSuggestions = 2 | Focus,
-    Blur = 4
+    Blur = 4,
 }
 
 /**

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -19,7 +19,7 @@ import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SearchContextProps } from '@sourcegraph/shared/src/search'
+import { EditorHint, SearchContextProps } from '@sourcegraph/shared/src/search'
 import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -276,6 +276,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         }
         onNavbarQueryChange({
             query,
+            hint: EditorHint.Blur,
         })
     }, [revision, filePath, repoName, onNavbarQueryChange, globbing, queryPrefix])
 


### PR DESCRIPTION
Currently when navigating to a repository page the search input continues to have focus. That's not a big problem in the current search input because it doesn't take up much space. The new input however will always show suggestions when focused, covering parts of the page.

This commit makes two changes:

- Blur the input when a "goto" action is executed
- Add a blur editor hint used by the repository page container to instruct the editor to blur

The latter is necessary because for unknown reasons the input regains focus when the repository page updates the input to reflect the currently opened repo/file.

Before / after video: 

https://user-images.githubusercontent.com/179026/224705360-28d5822c-049e-409d-8553-31b375dbac41.mp4



## Test plan

Go to search results page. Enter a repo name and use `Ctrl/cmd-enter` to go to the repository page. The search input should blur and stay blurred.

## App preview:

- [Web](https://sg-web-fkling-search-input-repo-page.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
