### PR TITLE
Replace null characters in GitHub repo descriptions

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -412,6 +412,7 @@ func (s *GitHubSource) GetRepo(ctx context.Context, nameWithOwner string) (*type
 }
 
 func (s *GitHubSource) makeRepo(r *github.Repository) *types.Repo {
+	r.Description = strings.ReplaceAll(r.Description, "\x00", "") // Postgres does not support the NULL character in text fields
 	urn := s.svc.URN()
 	metadata := *r
 	// This field flip flops depending on which token was used to retrieve the repo

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -412,7 +412,6 @@ func (s *GitHubSource) GetRepo(ctx context.Context, nameWithOwner string) (*type
 }
 
 func (s *GitHubSource) makeRepo(r *github.Repository) *types.Repo {
-	r.Description = strings.ReplaceAll(r.Description, "\x00", "") // Postgres does not support the NULL character in text fields
 	urn := s.svc.URN()
 	metadata := *r
 	// This field flip flops depending on which token was used to retrieve the repo
@@ -430,7 +429,7 @@ func (s *GitHubSource) makeRepo(r *github.Repository) *types.Repo {
 			r.NameWithOwner,
 		)),
 		ExternalRepo: github.ExternalRepoSpec(r, s.baseURL),
-		Description:  r.Description,
+		Description:  strings.ReplaceAll(r.Description, "\x00", ""), // Postgres does not support the NULL character in text fields
 		Fork:         r.IsFork,
 		Archived:     r.IsArchived,
 		Stars:        r.StargazerCount,

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -243,6 +244,26 @@ func TestGithubSource_GetRepo_Enterprise(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMakeRepo_NullCharacter(t *testing.T) {
+	r := &github.Repository{
+		Description: "Fun nulls \x00\x00\x00",
+	}
+
+	svc := types.ExternalService{
+		ID:     1,
+		Kind:   extsvc.KindGitHub,
+		Config: extsvc.NewEmptyConfig(),
+	}
+	schema := &schema.GitHubConnection{
+		Url: "https://github.com",
+	}
+	s, err := newGithubSource(logtest.Scoped(t), database.NewMockExternalServiceStore(), &svc, schema, nil)
+	require.NoError(t, err)
+	repo := s.makeRepo(r)
+
+	require.Equal(t, "Fun nulls ", repo.Description)
 }
 
 func TestGithubSource_makeRepo(t *testing.T) {


### PR DESCRIPTION
GitHub repo descriptions can contain NULL characters, but Postgres does not support this for text fields. We now remove them before attempting to store the repo.

## Test plan

Verified manually by cloning https://github.com/Phr33d0m/NW-Profession-Bot , which has the following description:

```
"Automatically selects professions for empty slots\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
