### PR TITLE
[fix] source not being set correctly for explicit permissions

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -131,7 +131,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		AccountIDs:  pendingBindIDs,
 	}
 
-	if err = txs.SetRepoPerms(ctx, p.RepoID, perms); err != nil {
+	if err = txs.SetRepoPerms(ctx, p.RepoID, perms, authz.SourceAPI); err != nil {
 		return nil, errors.Wrap(err, "set user repo permissions")
 	} else if _, err = txs.SetRepoPermissions(ctx, p); err != nil {
 		return nil, errors.Wrap(err, "set repository permissions")

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -188,7 +188,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 			perms := edb.NewStrictMockPermsStore()
 			perms.TransactFunc.SetDefaultReturn(perms, nil)
 			perms.DoneFunc.SetDefaultReturn(nil)
-			perms.SetRepoPermsFunc.SetDefaultHook(func(_ context.Context, repoID int32, ids []authz.UserIDWithExternalAccountID) error {
+			perms.SetRepoPermsFunc.SetDefaultHook(func(_ context.Context, repoID int32, ids []authz.UserIDWithExternalAccountID, source authz.PermsSource) error {
 				expUserIDs := maps.Keys(test.expUserIDs)
 				userIDs := make([]int32, len(ids))
 				for i, u := range ids {
@@ -196,6 +196,9 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 				}
 				if diff := cmp.Diff(expUserIDs, userIDs); diff != "" {
 					return errors.Errorf("userIDs expected: %v, got: %v", expUserIDs, userIDs)
+				}
+				if source != authz.SourceAPI {
+					return errors.Errorf("source expected: %s, got: %s", authz.SourceAPI, source)
 				}
 
 				return nil

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -29,7 +29,7 @@ func addPerms(t *testing.T, s edb.PermsStore, userID, repoID int32) {
 	ctx := context.Background()
 
 	if conf.ExperimentalFeatures().UnifiedPermissions {
-		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{repoID})
+		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{repoID}, authz.SourceUserSync)
 		require.NoError(t, err)
 	} else {
 		_, err := s.SetUserPermissions(ctx, &authz.UserPermissions{

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -577,7 +577,7 @@ func (s *PermsSyncer) saveUserPermsForAccount(ctx context.Context, userID int32,
 	err := s.permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
 		UserID:            userID,
 		ExternalAccountID: acctID,
-	}, repoIDs)
+	}, repoIDs, authz.SourceUserSync)
 
 	if err != nil {
 		logger.Warn("saving perms to DB", log.Error(err))
@@ -824,7 +824,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	defer func() { err = txs.Done(err) }()
 
 	// write to new user_repo_permissions table by default
-	if err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs)); err != nil {
+	if err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
 		return result, providerStates, errors.Wrapf(err, "set user repo permissions for repository %q (id: %d)", repo.Name, repo.ID)
 	}
 	result, err = txs.SetRepoPermissions(ctx, p)

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -330,7 +330,7 @@ func (h *bitbucketProjectPermissionsHandler) setRepoPermissions(ctx context.Cont
 	}
 
 	// set repo permissions (and user permissions)
-	if err = txs.SetRepoPerms(ctx, int32(repoID), perms); err != nil {
+	if err = txs.SetRepoPerms(ctx, int32(repoID), perms, authz.SourceAPI); err != nil {
 		return errors.Wrapf(err, "failed to set user repo permissions for repo %d and users %v", repoID, perms)
 	} else if _, err = txs.SetRepoPermissions(ctx, &p); err != nil {
 		return errors.Wrapf(err, "failed to set repo permissions for repo %d", repoID)

--- a/enterprise/internal/batches/testing/mock_repo_perms.go
+++ b/enterprise/internal/batches/testing/mock_repo_perms.go
@@ -31,7 +31,7 @@ func MockRepoPermissions(t *testing.T, db database.DB, userID int32, repoIDs ...
 
 	err := permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
 		UserID: userID,
-	}, maps.Keys(repoIDMap))
+	}, maps.Keys(repoIDMap), authz.SourceUserSync)
 	require.NoError(t, err)
 
 	_, err = permsStore.SetUserPermissions(ctx,

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -332,7 +332,7 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 						UserID: userID,
 					}
 				}
-				if err := s.store.SetRepoPerms(ctx, update.repoID, userIDs); err != nil {
+				if err := s.store.SetRepoPerms(ctx, update.repoID, userIDs, authz.SourceAPI); err != nil {
 					t.Fatal(err)
 				}
 				_, err := s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{
@@ -373,7 +373,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	}
 
 	// Set both effective and pending permissions for a user
-	if err = s.store.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: user.ID}, []int32{int32(repo.ID)}); err != nil {
+	if err = s.store.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: user.ID}, []int32{int32(repo.ID)}, authz.SourceAPI); err != nil {
 		t.Fatal(err)
 	}
 	if _, err = s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -41,12 +41,10 @@ func TestIntegration_PermsStore(t *testing.T) {
 	}{
 		{"FetchReposByUserAndExternalService", testPermsStore_FetchReposByUserAndExternalService(db)},
 		{"FetchReposByExternalAccount", testPermsStore_FetchReposByExternalAccount(db)},
-		{"SetUserRepoPermissions", testPermsStore_SetUserRepoPermissions(db)},
 		{"LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
 		{"SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
-		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
 		{"MapUsers", testPermsStore_MapUsers(db)},
 	} {
 		t.Run(tc.name, tc.test)

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -14396,12 +14396,12 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		SetRepoPermsFunc: &PermsStoreSetRepoPermsFunc{
-			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID) (r0 error) {
+			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (r0 error) {
 				return
 			},
 		},
 		SetUserExternalAccountPermsFunc: &PermsStoreSetUserExternalAccountPermsFunc{
-			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32) (r0 error) {
+			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (r0 error) {
 				return
 			},
 		},
@@ -14548,12 +14548,12 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		SetRepoPermsFunc: &PermsStoreSetRepoPermsFunc{
-			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID) error {
+			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
 				panic("unexpected invocation of MockPermsStore.SetRepoPerms")
 			},
 		},
 		SetUserExternalAccountPermsFunc: &PermsStoreSetUserExternalAccountPermsFunc{
-			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32) error {
+			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
 				panic("unexpected invocation of MockPermsStore.SetUserExternalAccountPerms")
 			},
 		},
@@ -17094,24 +17094,24 @@ func (c PermsStoreSetRepoPermissionsUnrestrictedFuncCall) Results() []interface{
 // PermsStoreSetRepoPermsFunc describes the behavior when the SetRepoPerms
 // method of the parent MockPermsStore instance is invoked.
 type PermsStoreSetRepoPermsFunc struct {
-	defaultHook func(context.Context, int32, []authz.UserIDWithExternalAccountID) error
-	hooks       []func(context.Context, int32, []authz.UserIDWithExternalAccountID) error
+	defaultHook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error
+	hooks       []func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error
 	history     []PermsStoreSetRepoPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // SetRepoPerms delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockPermsStore) SetRepoPerms(v0 context.Context, v1 int32, v2 []authz.UserIDWithExternalAccountID) error {
-	r0 := m.SetRepoPermsFunc.nextHook()(v0, v1, v2)
-	m.SetRepoPermsFunc.appendCall(PermsStoreSetRepoPermsFuncCall{v0, v1, v2, r0})
+func (m *MockPermsStore) SetRepoPerms(v0 context.Context, v1 int32, v2 []authz.UserIDWithExternalAccountID, v3 authz.PermsSource) error {
+	r0 := m.SetRepoPermsFunc.nextHook()(v0, v1, v2, v3)
+	m.SetRepoPermsFunc.appendCall(PermsStoreSetRepoPermsFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the SetRepoPerms method
 // of the parent MockPermsStore instance is invoked and the hook queue is
 // empty.
-func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID) error) {
+func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error) {
 	f.defaultHook = hook
 }
 
@@ -17119,7 +17119,7 @@ func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, i
 // SetRepoPerms method of the parent MockPermsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID) error) {
+func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17128,19 +17128,19 @@ func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermsStoreSetRepoPermsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID) error {
+	f.SetDefaultHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermsStoreSetRepoPermsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID) error {
+	f.PushHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
 		return r0
 	})
 }
 
-func (f *PermsStoreSetRepoPermsFunc) nextHook() func(context.Context, int32, []authz.UserIDWithExternalAccountID) error {
+func (f *PermsStoreSetRepoPermsFunc) nextHook() func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17182,6 +17182,9 @@ type PermsStoreSetRepoPermsFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 []authz.UserIDWithExternalAccountID
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 authz.PermsSource
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -17190,7 +17193,7 @@ type PermsStoreSetRepoPermsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermsStoreSetRepoPermsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
@@ -17203,24 +17206,24 @@ func (c PermsStoreSetRepoPermsFuncCall) Results() []interface{} {
 // SetUserExternalAccountPerms method of the parent MockPermsStore instance
 // is invoked.
 type PermsStoreSetUserExternalAccountPermsFunc struct {
-	defaultHook func(context.Context, authz.UserIDWithExternalAccountID, []int32) error
-	hooks       []func(context.Context, authz.UserIDWithExternalAccountID, []int32) error
+	defaultHook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error
+	hooks       []func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error
 	history     []PermsStoreSetUserExternalAccountPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // SetUserExternalAccountPerms delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) SetUserExternalAccountPerms(v0 context.Context, v1 authz.UserIDWithExternalAccountID, v2 []int32) error {
-	r0 := m.SetUserExternalAccountPermsFunc.nextHook()(v0, v1, v2)
-	m.SetUserExternalAccountPermsFunc.appendCall(PermsStoreSetUserExternalAccountPermsFuncCall{v0, v1, v2, r0})
+func (m *MockPermsStore) SetUserExternalAccountPerms(v0 context.Context, v1 authz.UserIDWithExternalAccountID, v2 []int32, v3 authz.PermsSource) error {
+	r0 := m.SetUserExternalAccountPermsFunc.nextHook()(v0, v1, v2, v3)
+	m.SetUserExternalAccountPermsFunc.appendCall(PermsStoreSetUserExternalAccountPermsFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // SetUserExternalAccountPerms method of the parent MockPermsStore instance
 // is invoked and the hook queue is empty.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32) error) {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error) {
 	f.defaultHook = hook
 }
 
@@ -17229,7 +17232,7 @@ func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32) error) {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17238,19 +17241,19 @@ func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.C
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32) error {
+	f.SetDefaultHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermsStoreSetUserExternalAccountPermsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32) error {
+	f.PushHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
 		return r0
 	})
 }
 
-func (f *PermsStoreSetUserExternalAccountPermsFunc) nextHook() func(context.Context, authz.UserIDWithExternalAccountID, []int32) error {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) nextHook() func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17294,6 +17297,9 @@ type PermsStoreSetUserExternalAccountPermsFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 []int32
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 authz.PermsSource
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -17302,7 +17308,7 @@ type PermsStoreSetUserExternalAccountPermsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermsStoreSetUserExternalAccountPermsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -321,8 +321,9 @@ func testPermsStore_FetchReposByUserAndExternalService(db database.DB) func(*tes
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				cleanupReposTable(t, s)
 				cleanupPermsTables(t, s)
+				cleanupUsersTable(t, s)
+				cleanupReposTable(t, s)
 			})
 
 			rp := &authz.RepoPermissions{
@@ -976,6 +977,8 @@ func testPermsStore_FetchReposByExternalAccount(db database.DB) func(*testing.T)
 				s := perms(logger, db, clock)
 				t.Cleanup(func() {
 					cleanupPermsTables(t, s)
+					cleanupUsersTable(t, s)
+					cleanupReposTable(t, s)
 				})
 
 				if test.origPermissions != nil && len(test.origPermissions) > 0 {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -96,7 +97,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 2, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -123,7 +124,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 2, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -155,7 +156,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 1, RepoID: 1}, {UserID: 2, RepoID: 1}, {UserID: 3, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 1}, {UserID: 2}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 1}, {UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -166,7 +167,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 				Perm:    authz.Read,
 				UserIDs: toMapset(2, 3),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}, {UserID: 3}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}, {UserID: 3}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -246,7 +247,7 @@ func TestPermsStore_LoadRepoPermissions(t *testing.T) {
 				Type:   authz.PermRepos,
 				IDs:    toMapset(1),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetUserPermissions(context.Background(), up); err != nil {
 				t.Fatal(err)
@@ -273,7 +274,7 @@ func TestPermsStore_LoadRepoPermissions(t *testing.T) {
 				Type:   authz.PermRepos,
 				IDs:    toMapset(1),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}); err != nil {
+			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetUserPermissions(context.Background(), up); err != nil {
 				t.Fatal(err)
@@ -743,7 +744,7 @@ func checkUserRepoPermissions(t *testing.T, s *permsStore, where *sqlf.Query, ex
 		return permissions[i].UserID < permissions[j].UserID
 	})
 
-	if diff := cmp.Diff(expectedPermissions, permissions, cmpopts.IgnoreFields(authz.Permission{}, "CreatedAt", "UpdatedAt", "Source")); diff != "" {
+	if diff := cmp.Diff(expectedPermissions, permissions, cmpopts.IgnoreFields(authz.Permission{}, "CreatedAt", "UpdatedAt")); diff != "" {
 		t.Fatalf("Expected permissions: %v do not match actual permissions: %v; diff %v", expectedPermissions, permissions, diff)
 	}
 }
@@ -778,8 +779,17 @@ func setupPermsRelatedEntities(t *testing.T, s *permsStore, permissions []authz.
 	}
 }
 
-func testPermsStore_SetUserRepoPermissions(db database.DB) func(*testing.T) {
-	source := "test"
+func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+
+	testDb := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDb)
+
+	source := authz.SourceUserSync
 
 	tests := []struct {
 		name                string
@@ -802,9 +812,9 @@ func testPermsStore_SetUserRepoPermissions(db database.DB) func(*testing.T) {
 				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
 			},
 			expectedPermissions: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3, Source: source},
 			},
 			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
 		},
@@ -820,8 +830,8 @@ func testPermsStore_SetUserRepoPermissions(db database.DB) func(*testing.T) {
 				{UserID: 1, ExternalAccountID: 1, RepoID: 4},
 			},
 			expectedPermissions: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 4},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 4, Source: source},
 			},
 			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
 		},
@@ -836,48 +846,71 @@ func testPermsStore_SetUserRepoPermissions(db database.DB) func(*testing.T) {
 			expectedPermissions: []authz.Permission{},
 			entity:              authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
 		},
+		{
+			name: "does not touch explicit permissions when source is sync",
+			origPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 4},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 4, Source: source},
+			},
+			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+		},
 	}
 
-	return func(t *testing.T) {
-		ctx := actor.WithInternalActor(context.Background())
-		logger := logtest.Scoped(t)
+	ctx := actor.WithInternalActor(context.Background())
 
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				s := perms(logger, db, clock)
-				t.Cleanup(func() {
-					cleanupPermsTables(t, s)
-					cleanupUsersTable(t, s)
-					cleanupReposTable(t, s)
-				})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := perms(logger, db, clock)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+				cleanupUsersTable(t, s)
+				cleanupReposTable(t, s)
+			})
 
-				if len(test.origPermissions) > 0 {
-					setupPermsRelatedEntities(t, s, test.origPermissions)
-					err := s.setUserRepoPermissions(ctx, test.origPermissions, test.entity, source)
-					if err != nil {
-						t.Fatal("setup test permissions before actual test", err)
+			if len(test.origPermissions) > 0 {
+				setupPermsRelatedEntities(t, s, test.origPermissions)
+				syncedPermissions := []authz.Permission{}
+				explicitPermissions := []authz.Permission{}
+				for _, p := range test.origPermissions {
+					if p.Source == authz.SourceAPI {
+						explicitPermissions = append(explicitPermissions, p)
+					} else {
+						syncedPermissions = append(syncedPermissions, p)
 					}
 				}
 
-				if len(test.permissions) > 0 {
-					setupPermsRelatedEntities(t, s, test.permissions)
-				}
-				if err := s.setUserRepoPermissions(ctx, test.permissions, test.entity, source); err != nil {
-					t.Fatal("testing user repo permissions", err)
-				}
+				err := s.setUserRepoPermissions(ctx, syncedPermissions, test.entity, source)
+				require.NoError(t, err)
+				err = s.setUserRepoPermissions(ctx, explicitPermissions, test.entity, authz.SourceAPI)
+				require.NoError(t, err)
+			}
 
-				if test.entity.UserID > 0 {
-					checkUserRepoPermissions(t, s, sqlf.Sprintf("user_id = %d", test.entity.UserID), test.expectedPermissions)
-				} else if test.entity.RepoID > 0 {
-					checkUserRepoPermissions(t, s, sqlf.Sprintf("repo_id = %d", test.entity.RepoID), test.expectedPermissions)
-				}
-			})
-		}
+			if len(test.permissions) > 0 {
+				setupPermsRelatedEntities(t, s, test.permissions)
+			}
+			if err := s.setUserRepoPermissions(ctx, test.permissions, test.entity, source); err != nil {
+				t.Fatal("testing user repo permissions", err)
+			}
+
+			if test.entity.UserID > 0 {
+				checkUserRepoPermissions(t, s, sqlf.Sprintf("user_id = %d", test.entity.UserID), test.expectedPermissions)
+			} else if test.entity.RepoID > 0 {
+				checkUserRepoPermissions(t, s, sqlf.Sprintf("repo_id = %d", test.entity.RepoID), test.expectedPermissions)
+			}
+		})
 	}
 }
 
 func testPermsStore_FetchReposByExternalAccount(db database.DB) func(*testing.T) {
-	source := "test"
+	source := authz.SourceRepoSync
 
 	tests := []struct {
 		name              string
@@ -994,8 +1027,19 @@ func TestPermsStore_SetRepoPermissionsUnrestricted(t *testing.T) {
 		t.Helper()
 		legacyUnrestricted(t, id, want)
 
-		q := sqlf.Sprintf("SELECT repo_id FROM user_repo_permissions WHERE repo_id = %d AND user_id IS NULL", id)
-		results, err := basestore.ScanInt32s(s.Handle().QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...))
+		type unrestrictedResult struct {
+			id     int32
+			source authz.PermsSource
+		}
+
+		scanResults := basestore.NewSliceScanner(func(s dbutil.Scanner) (unrestrictedResult, error) {
+			r := unrestrictedResult{}
+			err := s.Scan(&r.id, &r.source)
+			return r, err
+		})
+
+		q := sqlf.Sprintf("SELECT repo_id, source FROM user_repo_permissions WHERE repo_id = %d AND user_id IS NULL", id)
+		results, err := scanResults(s.Handle().QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...))
 		if err != nil {
 			t.Fatalf("loading user repo permissions for %d: %v", id, err)
 		}
@@ -1004,6 +1048,12 @@ func TestPermsStore_SetRepoPermissionsUnrestricted(t *testing.T) {
 		}
 		if !want && len(results) > 0 {
 			t.Fatalf("Want restricted, but found results for %d: %v", id, results)
+		}
+
+		if want {
+			for _, r := range results {
+				require.Equal(t, authz.SourceAPI, r.source)
+			}
 		}
 	}
 
@@ -1027,7 +1077,7 @@ func TestPermsStore_SetRepoPermissionsUnrestricted(t *testing.T) {
 		if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.SetRepoPerms(context.Background(), int32(i+1), []authz.UserIDWithExternalAccountID{{UserID: 2}}); err != nil {
+		if err := s.SetRepoPerms(context.Background(), int32(i+1), []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2153,9 +2203,9 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				},
 			},
 			expectUserRepoPerms: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
-				{UserID: 2, ExternalAccountID: 2, RepoID: 2},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceRepoSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceRepoSync},
+				{UserID: 2, ExternalAccountID: 2, RepoID: 2, Source: authz.SourceRepoSync},
 			},
 			expectUserPerms: map[int32][]uint32{
 				1: {1, 2},
@@ -2200,7 +2250,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				AccountID:             "alice",
 			}},
 			expectUserRepoPerms: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceUserSync},
 			},
 			expectUserPerms: map[int32][]uint32{
 				1: {1},
@@ -2280,11 +2330,11 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				},
 			},
 			expectUserRepoPerms: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
-				{UserID: 2, ExternalAccountID: 2, RepoID: 2},
-				{UserID: 3, ExternalAccountID: 3, RepoID: 1},
-				{UserID: 3, ExternalAccountID: 4, RepoID: 2},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceRepoSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceRepoSync},
+				{UserID: 2, ExternalAccountID: 2, RepoID: 2, Source: authz.SourceRepoSync},
+				{UserID: 3, ExternalAccountID: 3, RepoID: 1, Source: authz.SourceUserSync},
+				{UserID: 3, ExternalAccountID: 4, RepoID: 2, Source: authz.SourceUserSync},
 			},
 			expectUserPerms: map[int32][]uint32{
 				1: {1, 2},
@@ -2360,11 +2410,11 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				},
 			},
 			expectUserRepoPerms: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
-				{UserID: 2, ExternalAccountID: 2, RepoID: 2},
-				{UserID: 3, ExternalAccountID: 3, RepoID: 1},
-				{UserID: 3, ExternalAccountID: 4, RepoID: 2},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceRepoSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceRepoSync},
+				{UserID: 2, ExternalAccountID: 2, RepoID: 2, Source: authz.SourceRepoSync},
+				{UserID: 3, ExternalAccountID: 3, RepoID: 1, Source: authz.SourceUserSync},
+				{UserID: 3, ExternalAccountID: 4, RepoID: 2, Source: authz.SourceUserSync},
 			},
 			expectUserPerms: map[int32][]uint32{
 				1: {1, 2},
@@ -2428,9 +2478,9 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				AccountID:             "alice",
 			}},
 			expectUserRepoPerms: []authz.Permission{
-				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
-				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceUserSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceUserSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3, Source: authz.SourceUserSync},
 			},
 			expectUserPerms: map[int32][]uint32{
 				1: {1, 2, 3},
@@ -2489,6 +2539,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 						UserID:            1,
 						ExternalAccountID: 1,
 						RepoID:            int32(i),
+						Source:            authz.SourceUserSync,
 					})
 				}
 				return perms
@@ -2575,7 +2626,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 						})
 					}
 
-					if err := s.SetRepoPerms(ctx, repoID, users); err != nil {
+					if err := s.SetRepoPerms(ctx, repoID, users, authz.SourceRepoSync); err != nil {
 						t.Fatal(err)
 					}
 
@@ -2597,6 +2648,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				}
 			}
 
+			fmt.Printf("Test name: %s\n", test.name)
 			checkUserRepoPermissions(t, s, sqlf.Sprintf("TRUE"), test.expectUserRepoPerms)
 
 			err := checkRegularPermsTable(s, `SELECT user_id, object_ids_ints FROM user_permissions`, test.expectUserPerms)
@@ -2751,7 +2803,7 @@ func TestPermsStore_DeleteAllUserPermissions(t *testing.T) {
 	// Set unified permissions for user 1 and 2
 	for _, userID := range []int32{1, 2} {
 		for _, repoID := range []int32{1, 2} {
-			if err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: repoID}, []int32{repoID}); err != nil {
+			if err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: repoID}, []int32{repoID}, authz.SourceUserSync); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -2970,68 +3022,74 @@ func cleanupUsersTable(t *testing.T, s *permsStore) {
 	execQuery(t, context.Background(), s, sqlf.Sprintf(q))
 }
 
-func testPermsStore_GetUserIDsByExternalAccounts(db database.DB) func(*testing.T) {
-	return func(t *testing.T) {
-		logger := logtest.Scoped(t)
-		s := perms(logger, db, time.Now)
-		t.Cleanup(func() {
-			cleanupUsersTable(t, s)
-		})
+func TestPermsStore_GetUserIDsByExternalAccounts(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 
-		ctx := context.Background()
+	logger := logtest.Scoped(t)
 
-		// Set up test users and external accounts
-		extSQL := `
+	testDb := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDb)
+
+	s := perms(logger, db, time.Now)
+	t.Cleanup(func() {
+		cleanupUsersTable(t, s)
+	})
+
+	ctx := context.Background()
+
+	// Set up test users and external accounts
+	extSQL := `
 INSERT INTO user_external_accounts(user_id, service_type, service_id, account_id, client_id, created_at, updated_at, deleted_at, expired_at)
 	VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)
 `
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),  // ID=1
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),    // ID=2
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('cindy')`),  // ID=3
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('denise')`), // ID=4
+	qs := []*sqlf.Query{
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`),  // ID=1
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),    // ID=2
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('cindy')`),  // ID=3
+		sqlf.Sprintf(`INSERT INTO users(username) VALUES('denise')`), // ID=4
 
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil, nil), // ID=1
-			sqlf.Sprintf(extSQL, 1, "github", "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil, nil),          // ID=2
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil, nil),     // ID=3
-			sqlf.Sprintf(extSQL, 3, extsvc.TypeGitLab, "https://gitlab.com/", "cindy_gitlab", "cindy_gitlab_client_id", clock(), clock(), nil, nil), // ID=4
-			sqlf.Sprintf(extSQL, 3, "github", "https://github.com/", "cindy_github", "cindy_github_client_id", clock(), clock(), clock(), nil),      // ID=5, deleted
-			sqlf.Sprintf(extSQL, 4, "github", "https://github.com/", "denise_github", "denise_github_client_id", clock(), clock(), nil, clock()),    // ID=6, expired
-		}
-		for _, q := range qs {
-			if err := s.execute(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		accounts := &extsvc.Accounts{
-			ServiceType: "gitlab",
-			ServiceID:   "https://gitlab.com/",
-			AccountIDs:  []string{"alice_gitlab", "bob_gitlab", "david_gitlab"},
-		}
-		userIDs, err := s.GetUserIDsByExternalAccounts(ctx, accounts)
-		if err != nil {
+		sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", clock(), clock(), nil, nil), // ID=1
+		sqlf.Sprintf(extSQL, 1, "github", "https://github.com/", "alice_github", "alice_github_client_id", clock(), clock(), nil, nil),          // ID=2
+		sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", clock(), clock(), nil, nil),     // ID=3
+		sqlf.Sprintf(extSQL, 3, extsvc.TypeGitLab, "https://gitlab.com/", "cindy_gitlab", "cindy_gitlab_client_id", clock(), clock(), nil, nil), // ID=4
+		sqlf.Sprintf(extSQL, 3, "github", "https://github.com/", "cindy_github", "cindy_github_client_id", clock(), clock(), clock(), nil),      // ID=5, deleted
+		sqlf.Sprintf(extSQL, 4, "github", "https://github.com/", "denise_github", "denise_github_client_id", clock(), clock(), nil, clock()),    // ID=6, expired
+	}
+	for _, q := range qs {
+		if err := s.execute(ctx, q); err != nil {
 			t.Fatal(err)
 		}
-
-		if len(userIDs) != 2 {
-			t.Fatalf("len(userIDs): want 2 but got %v", userIDs)
-		}
-
-		assert.Equal(t, int32(1), userIDs["alice_gitlab"].UserID)
-		assert.Equal(t, int32(1), userIDs["alice_gitlab"].ExternalAccountID)
-		assert.Equal(t, int32(2), userIDs["bob_gitlab"].UserID)
-		assert.Equal(t, int32(3), userIDs["bob_gitlab"].ExternalAccountID)
-
-		accounts = &extsvc.Accounts{
-			ServiceType: "github",
-			ServiceID:   "https://github.com/",
-			AccountIDs:  []string{"cindy_github", "denise_github"},
-		}
-		userIDs, err = s.GetUserIDsByExternalAccounts(ctx, accounts)
-		require.Nil(t, err)
-		assert.Empty(t, userIDs)
 	}
+
+	accounts := &extsvc.Accounts{
+		ServiceType: "gitlab",
+		ServiceID:   "https://gitlab.com/",
+		AccountIDs:  []string{"alice_gitlab", "bob_gitlab", "david_gitlab"},
+	}
+	userIDs, err := s.GetUserIDsByExternalAccounts(ctx, accounts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(userIDs) != 2 {
+		t.Fatalf("len(userIDs): want 2 but got %v", userIDs)
+	}
+
+	assert.Equal(t, int32(1), userIDs["alice_gitlab"].UserID)
+	assert.Equal(t, int32(1), userIDs["alice_gitlab"].ExternalAccountID)
+	assert.Equal(t, int32(2), userIDs["bob_gitlab"].UserID)
+	assert.Equal(t, int32(3), userIDs["bob_gitlab"].ExternalAccountID)
+
+	accounts = &extsvc.Accounts{
+		ServiceType: "github",
+		ServiceID:   "https://github.com/",
+		AccountIDs:  []string{"cindy_github", "denise_github"},
+	}
+	userIDs, err = s.GetUserIDsByExternalAccounts(ctx, accounts)
+	require.Nil(t, err)
+	assert.Empty(t, userIDs)
 }
 
 func mockUnifiedPermsConfig(val bool) {
@@ -3125,7 +3183,7 @@ func TestPermsStore_UserIDsWithNoPerms(t *testing.T) {
 		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(user_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonUserNoPermissions)
 		execQuery(t, ctx, s, q)
 
-		s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: 2, ExternalAccountID: 1}, []int32{1})
+		s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: 2, ExternalAccountID: 1}, []int32{1}, authz.SourceUserSync)
 
 		// Only "david" has no permissions at this point
 		ids, err = s.UserIDsWithNoPerms(ctx)
@@ -3215,7 +3273,7 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(repository_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonRepoNoPermissions)
 		execQuery(t, ctx, s, q)
 
-		err := s.SetRepoPerms(ctx, 3, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}})
+		err := s.SetRepoPerms(ctx, 3, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}}, authz.SourceRepoSync)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/authz/perms.go
+++ b/internal/authz/perms.go
@@ -93,12 +93,12 @@ func (e ErrStalePermissions) Error() string {
 // Permission determines if a user with a specific id
 // can read a repository with a specific id
 type Permission struct {
-	UserID            int32     // The internal database ID of a user
-	ExternalAccountID int32     // The internal database ID of a user external account
-	RepoID            int32     // The internal database ID of a repo
-	CreatedAt         time.Time // The creation time
-	UpdatedAt         time.Time // The last updated time
-	Source            string    // source of the permission
+	UserID            int32       // The internal database ID of a user
+	ExternalAccountID int32       // The internal database ID of a user external account
+	RepoID            int32       // The internal database ID of a repo
+	CreatedAt         time.Time   // The creation time
+	UpdatedAt         time.Time   // The last updated time
+	Source            PermsSource // source of the permission
 }
 
 // A struct that holds the entity we are updating the permissions for
@@ -114,9 +114,13 @@ type UserIDWithExternalAccountID struct {
 	ExternalAccountID int32
 }
 
-const SourceRepoSync = "repo_sync"
-const SourceUserSync = "user_sync"
-const SourceAPI = "api"
+type PermsSource string
+
+const (
+	SourceRepoSync PermsSource = "repo_sync"
+	SourceUserSync PermsSource = "user_sync"
+	SourceAPI      PermsSource = "api"
+)
 
 // TracingFields returns tracing fields for the opentracing log.
 func (p *Permission) TracingFields() []otlog.Field {
@@ -126,7 +130,7 @@ func (p *Permission) TracingFields() []otlog.Field {
 		otlog.Int32("SrcPermissions.ExternalAccountID", p.ExternalAccountID),
 		otlog.String("SrcPermissions.CreatedAt", p.CreatedAt.String()),
 		otlog.String("SrcPermissions.UpdatedAt", p.UpdatedAt.String()),
-		otlog.String("SrcPermissions.UpdatedAt", p.Source),
+		otlog.String("SrcPermissions.Source", string(p.Source)),
 	}
 	return fs
 }


### PR DESCRIPTION
It is important that we set the correct source for the permissions in the new data model.

This was not done properly for the explicit permissions. 

Also, the OOB migration should take explicit permissions into account. If explicit permissions are enabled, all permissions transformed with the OOB migration should be set to the api source.

## Test plan

unit tests added / modified
