### PR TITLE
[feat] make explicit perms API work alongside perms syncing

### DIFF
--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -27,7 +27,7 @@ func handleGitHubRepoAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions)
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}
-		if globals.PermissionsUserMapping().Enabled {
+		if globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions {
 			return nil
 		}
 

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -28,7 +28,7 @@ func handleGitHubUserAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions)
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}
-		if globals.PermissionsUserMapping().Enabled {
+		if globals.PermissionsUserMapping().Enabled || !conf.ExperimentalFeatures().UnifiedPermissions {
 			return nil
 		}
 

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -28,7 +28,7 @@ func handleGitHubUserAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions)
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}
-		if globals.PermissionsUserMapping().Enabled || !conf.ExperimentalFeatures().UnifiedPermissions {
+		if globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions {
 			return nil
 		}
 

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
@@ -310,11 +311,11 @@ func syncRepoBackoff() time.Duration {
 
 // PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
 // It is not enabled if:
-//   - Permissions user mapping (aka explicit permissions API) is enabled
+//   - Permissions user mapping (aka explicit permissions API) is enabled and unified permissions model is not enabled
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
 func permissionSyncingDisabled() bool {
-	return globals.PermissionsUserMapping().Enabled ||
+	return (globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
 		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -37,11 +37,11 @@ import (
 
 // PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
 // It is not enabled if:
-//   - Permissions user mapping (aka explicit permissions API) is enabled
+//   - Permissions user mapping (aka explicit permissions API) is enabled and unified permissions model is not enabled
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
 func PermissionSyncingDisabled() bool {
-	return globals.PermissionsUserMapping().Enabled ||
+	return (globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
 		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -431,6 +431,48 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 			expSeriousProblems:           []string{"The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when \"gitlab\" authorization providers are in use. Blocking access to all repositories until the conflict is resolved."},
 		},
 		{
+			description: "No conflict if unified perms is ON",
+			cfg: conf.Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					PermissionsUserMapping: &schema.PermissionsUserMapping{
+						Enabled: true,
+						BindID:  "email",
+					},
+					AuthProviders: []schema.AuthProviders{{
+						Gitlab: &schema.GitLabAuthProvider{
+							ClientID:     "clientID",
+							ClientSecret: "clientSecret",
+							DisplayName:  "GitLab",
+							Type:         extsvc.TypeGitLab,
+							Url:          "https://gitlab.mine",
+						},
+					}},
+					ExperimentalFeatures: &schema.ExperimentalFeatures{
+						UnifiedPermissions: true,
+					},
+				},
+			},
+			gitlabConnections: []*schema.GitLabConnection{
+				{
+					Authorization: &schema.GitLabAuthorization{
+						IdentityProvider: schema.IdentityProvider{Oauth: &schema.OAuthIdentity{Type: "oauth"}},
+					},
+					Url:   "https://gitlab.mine",
+					Token: "asdf",
+				},
+			},
+			expAuthzAllowAccessByDefault: true,
+			expAuthzProviders: providersEqual(
+				gitlabAuthzProviderParams{
+					OAuthOp: gitlab.OAuthProviderOp{
+						URN:     "extsvc:gitlab:0",
+						BaseURL: mustURLParse(t, "https://gitlab.mine"),
+						Token:   "asdf",
+					},
+				},
+			),
+		},
+		{
 			description: "Conflicted configuration between Sourcegraph and Bitbucket Server authz provider",
 			cfg: conf.Unified{
 				SiteConfiguration: schema.SiteConfiguration{

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -621,7 +620,6 @@ WHERE
 	}
 
 	q := sqlf.Sprintf(format, where, currentTime, whereSource)
-	fmt.Printf("Query: %v\n", q)
 	return s.Exec(ctx, q)
 }
 

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -619,7 +620,9 @@ WHERE
 		return errors.New("invalid entity for which to delete old permissions, need at least RepoID or UserID specified")
 	}
 
-	return s.Exec(ctx, sqlf.Sprintf(format, where, currentTime, whereSource))
+	q := sqlf.Sprintf(format, where, currentTime, whereSource)
+	fmt.Printf("Query: %v\n", q)
+	return s.Exec(ctx, q)
 }
 
 func (s *permsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermissions) (_ *database.SetPermissionsResult, err error) {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -1007,8 +1007,6 @@ func TestPermsStore_UnionExplicitAndSyncedPermissions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fmt.Printf("Test name %s\n", test.name)
-
 			s := perms(logger, db, clock)
 			t.Cleanup(func() {
 				cleanupPermsTables(t, s)
@@ -2784,7 +2782,6 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 				}
 			}
 
-			fmt.Printf("Test name: %s\n", test.name)
 			checkUserRepoPermissions(t, s, sqlf.Sprintf("TRUE"), test.expectUserRepoPerms)
 
 			err := checkRegularPermsTable(s, `SELECT user_id, object_ids_ints FROM user_permissions`, test.expectUserPerms)

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -910,6 +910,139 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 	}
 }
 
+func TestPermsStore_UnionExplicitAndSyncedPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+
+	testDb := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDb)
+
+	tests := []struct {
+		name                    string
+		origExplicitPermissions []authz.Permission
+		origSyncedPermissions   []authz.Permission
+		permissions             []authz.Permission
+		expectedPermissions     []authz.Permission
+		entity                  authz.PermissionEntity
+		source                  authz.PermsSource
+	}{
+		{
+			name: "add explicit permissions when synced are already there",
+			origSyncedPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, RepoID: 3},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 3, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceUserSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceUserSync},
+			},
+			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+			source: authz.SourceAPI,
+		},
+		{
+			name: "add synced permissions when explicit are already there",
+			origExplicitPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 1},
+				{UserID: 1, RepoID: 3},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 1, Source: authz.SourceAPI},
+				{UserID: 1, RepoID: 3, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceUserSync},
+			},
+			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+			source: authz.SourceUserSync,
+		},
+		{
+			name: "add, update and remove synced permissions, when explicit are already there",
+			origExplicitPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 2},
+				{UserID: 1, RepoID: 4},
+			},
+			origSyncedPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 5},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 2, Source: authz.SourceAPI},
+				{UserID: 1, RepoID: 4, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3, Source: authz.SourceUserSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 5, Source: authz.SourceUserSync},
+			},
+			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+			source: authz.SourceUserSync,
+		},
+		{
+			name: "add synced permission to same entity as explicit permission adds new row",
+			origExplicitPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 1},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, RepoID: 1, Source: authz.SourceAPI},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceUserSync},
+			},
+			entity: authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+			source: authz.SourceUserSync,
+		},
+	}
+
+	ctx := actor.WithInternalActor(context.Background())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fmt.Printf("Test name %s\n", test.name)
+
+			s := perms(logger, db, clock)
+			t.Cleanup(func() {
+				cleanupPermsTables(t, s)
+				cleanupUsersTable(t, s)
+				cleanupReposTable(t, s)
+			})
+
+			if len(test.origExplicitPermissions) > 0 {
+				setupPermsRelatedEntities(t, s, test.origExplicitPermissions)
+				err := s.setUserRepoPermissions(ctx, test.origExplicitPermissions, test.entity, authz.SourceAPI)
+				require.NoError(t, err)
+			}
+			if len(test.origSyncedPermissions) > 0 {
+				setupPermsRelatedEntities(t, s, test.origSyncedPermissions)
+				err := s.setUserRepoPermissions(ctx, test.origSyncedPermissions, test.entity, authz.SourceUserSync)
+				require.NoError(t, err)
+			}
+
+			if len(test.permissions) > 0 {
+				setupPermsRelatedEntities(t, s, test.permissions)
+			}
+			if err := s.setUserRepoPermissions(ctx, test.permissions, test.entity, test.source); err != nil {
+				t.Fatal("testing user repo permissions", err)
+			}
+
+			if test.entity.UserID > 0 {
+				checkUserRepoPermissions(t, s, sqlf.Sprintf("user_id = %d", test.entity.UserID), test.expectedPermissions)
+			} else if test.entity.RepoID > 0 {
+				checkUserRepoPermissions(t, s, sqlf.Sprintf("repo_id = %d", test.entity.RepoID), test.expectedPermissions)
+			}
+		})
+	}
+}
+
 func testPermsStore_FetchReposByExternalAccount(db database.DB) func(*testing.T) {
 	source := authz.SourceRepoSync
 

--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -46,8 +46,9 @@ func GetAuthzQueryParameters(ctx context.Context, db DB) (params *AuthzQueryPara
 
 	// 🚨 SECURITY: Blocking access to all repositories if both code host authz
 	// provider(s) and permissions user mapping are configured.
+	// But only if legacy permissions are used.
 	if params.UsePermissionsUserMapping {
-		if len(authzProviders) > 0 {
+		if len(authzProviders) > 0 && !params.UnifiedPermsEnabled {
 			return nil, errPermissionsUserMappingConflict
 		}
 		authzAllowByDefault = false


### PR DESCRIPTION
This is only done if the experimental feature unified permissions is ON

## Test plan

Tested locally + unit tests.
