### PR TITLE
Clean up GitLab docs

### DIFF
--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -43,5 +43,3 @@ The [Sourcegraph browser extension](browser_extension.md) supports GitLab. When 
     - Click "Enable Sourcegraph on this domain".
     - Click "Allow" in the permissions request popup.
 1. Visit any file or merge request on GitLab. Hover over code or click the "View file" and "View repository" buttons.
-
-![Sourcegraph for GitLab](https://cl.ly/7916fe1453a4/download/sourcegraph-for-gitLab.gif)


### PR DESCRIPTION
Remove old gif link from docs page

## Test plan

Docs only. Deploy preview test.