### PR TITLE
codeintel: Navigate to correct project root

### DIFF
--- a/enterprise/internal/codeintel/codenav/transport/graphql/utils.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/utils.go
@@ -140,7 +140,7 @@ func resolveLocations(ctx context.Context, locationResolver *sharedresolvers.Cac
 // resolveLocation creates a LocationResolver for the given adjusted location. This function may return a
 // nil resolver if the location's commit is not known by gitserver.
 func resolveLocation(ctx context.Context, locationResolver *sharedresolvers.CachedLocationResolver, location types.UploadLocation) (resolverstubs.LocationResolver, error) {
-	treeResolver, err := locationResolver.Path(ctx, api.RepoID(location.Dump.RepositoryID), location.TargetCommit, location.Path)
+	treeResolver, err := locationResolver.Path(ctx, api.RepoID(location.Dump.RepositoryID), location.TargetCommit, location.Path, false)
 	if err != nil || treeResolver == nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver_test.go
+++ b/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver_test.go
@@ -104,7 +104,7 @@ func TestCachedLocationResolver(t *testing.T) {
 			for _, repositoryID := range repositoryIDs {
 				for _, commit := range commits {
 					for _, path := range paths {
-						treeResolver, err := locationResolver.Path(context.Background(), repositoryID, commit, path)
+						treeResolver, err := locationResolver.Path(context.Background(), repositoryID, commit, path, false)
 						if err != nil {
 							errs <- err
 							return
@@ -171,7 +171,7 @@ func TestCachedLocationResolverUnknownRepository(t *testing.T) {
 	}
 
 	// Ensure no dereference in child resolvers either
-	pathResolver, err := locationResolver.Path(context.Background(), 50, "deadbeef", "main.go")
+	pathResolver, err := locationResolver.Path(context.Background(), 50, "deadbeef", "main.go", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -202,7 +202,7 @@ func TestCachedLocationResolverUnknownCommit(t *testing.T) {
 	}
 
 	// Ensure no dereference in child resolvers either
-	pathResolver, err := locationResolver.Path(context.Background(), 50, "deadbeef", "main.go")
+	pathResolver, err := locationResolver.Path(context.Background(), 50, "deadbeef", "main.go", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
@@ -118,7 +118,7 @@ func (r *indexResolver) ShouldReindex(ctx context.Context) bool {
 func (r *indexResolver) ProjectRoot(ctx context.Context) (_ resolverstubs.GitTreeEntryResolver, err error) {
 	defer r.traceErrs.Collect(&err, log.String("indexResolver.field", "projectRoot"))
 
-	resolver, err := r.locationResolver.Path(ctx, api.RepoID(r.index.RepositoryID), r.index.Commit, r.index.Root)
+	resolver, err := r.locationResolver.Path(ctx, api.RepoID(r.index.RepositoryID), r.index.Commit, r.index.Root, true)
 	if err != nil || resolver == nil {
 		// Do not return typed nil interface
 		return nil, err

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver.go
@@ -109,7 +109,7 @@ func (r *UploadResolver) AssociatedIndex(ctx context.Context) (_ resolverstubs.L
 func (r *UploadResolver) ProjectRoot(ctx context.Context) (_ resolverstubs.GitTreeEntryResolver, err error) {
 	defer r.traceErrs.Collect(&err, log.String("uploadResolver.field", "projectRoot"))
 
-	resolver, err := r.locationResolver.Path(ctx, api.RepoID(r.upload.RepositoryID), r.upload.Commit, r.upload.Root)
+	resolver, err := r.locationResolver.Path(ctx, api.RepoID(r.upload.RepositoryID), r.upload.Commit, r.upload.Root, true)
 	if err != nil || resolver == nil {
 		// Do not return typed nil interface
 		return nil, err


### PR DESCRIPTION
We are always returning `/blob/` paths, which means we get a 404 for `/tree/` paths for project root. This PR adds an isDir method and chains it up to the point where we know if it's a project root or a specific blob location.

## Test plan

Tested in UI locally.