### PR TITLE
packages: fix version filters not applying

### DIFF
--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -91,7 +91,7 @@ func scanPackageFilter(s dbutil.Scanner) (shared.PackageRepoFilter, error) {
 
 	if err := d.Decode(&filter.NameFilter); err != nil {
 		// d.Decode will set NameFilter to != nil even if theres an error, meaning we potentially
-		// have both NameFilter and VersionFilter set to nil
+		// have both NameFilter and VersionFilter set to not nil
 		filter.NameFilter = nil
 		b.Seek(0, 0)
 		return filter, d.Decode(&filter.VersionFilter)

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -90,6 +90,9 @@ func scanPackageFilter(s dbutil.Scanner) (shared.PackageRepoFilter, error) {
 	d.DisallowUnknownFields()
 
 	if err := d.Decode(&filter.NameFilter); err != nil {
+		// d.Decode will set NameFilter to != nil even if theres an error, meaning we potentially
+		// have both NameFilter and VersionFilter set to nil
+		filter.NameFilter = nil
 		b.Seek(0, 0)
 		return filter, d.Decode(&filter.VersionFilter)
 	}


### PR DESCRIPTION
When scanning package filters from the database, there was a bug whereby both VersionFilter and NameFilter would be set (as `json.Unmarshal` will set passed in field to nil even if deserializing is ultimately unsuccessfuly). This caused the VersionFilter to be shadowed by the non-nil but empty NameFilter, resulting in the version filter never applying.

## Test plan

Added additional unit testing, tested locally too
