### PR TITLE
codeintel: Add docs for Lua inference configuration

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.module.scss
@@ -1,0 +1,17 @@
+.list {
+    display: inline;
+    list-style: none;
+    padding-left: .25rem;
+}
+
+.list li {
+    display:inline;
+}
+
+.list li::after {
+    content: ", ";
+}
+
+.list li:last-child::after {
+    content: ".";
+}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.module.scss
@@ -1,17 +1,17 @@
 .list {
     display: inline;
     list-style: none;
-    padding-left: .25rem;
+    padding-left: 0.25rem;
 }
 
 .list li {
-    display:inline;
+    display: inline;
 }
 
 .list li::after {
-    content: ", ";
+    content: ', ';
 }
 
 .list li:last-child::after {
-    content: ".";
+    content: '.';
 }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -19,6 +19,8 @@ import { InferenceScriptEditor } from '../components/inference-script/InferenceS
 import { InferenceScriptPreview } from '../components/inference-script/InferenceScriptPreview'
 import { useInferenceScript } from '../hooks/useInferenceScript'
 
+import styles from './CodeIntelInferenceConfigurationPage.module.scss'
+
 export interface CodeIntelInferenceConfigurationPageProps extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
 }
@@ -51,7 +53,18 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
                     <>
                         Lua script that emits complete and/or partial auto-indexing job specifications. See the{' '}
                         <Link to="/help/code_navigation/references/inference_configuration">reference guide</Link> for
-                        more information.
+                        more information. The following implementations can also be used as reference of the API:
+                        <ul className={styles.list}>
+                            {['Clang', 'Go', 'Java', 'Python', 'Ruby', 'Rust', 'TypeScript'].map(lang => (
+                                <li key={lang.toLowerCase()}>
+                                    <Link
+                                        to={`https://sourcegraph.com/github.com/sourcegraph/sourcegraph@5.0/-/blob/enterprise/internal/codeintel/autoindexing/internal/inference/lua/${lang.toLowerCase()}.lua`}
+                                    >
+                                        {lang}
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -1,7 +1,17 @@
 import { FunctionComponent, useState, useCallback } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { ErrorAlert, LoadingSpinner, PageHeader, Tab, TabList, TabPanel, TabPanels, Tabs } from '@sourcegraph/wildcard'
+import {
+    ErrorAlert,
+    Link,
+    LoadingSpinner,
+    PageHeader,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
+} from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { PageTitle } from '../../../../components/PageTitle'
@@ -37,7 +47,13 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
                         text: <>Code graph inference script</>,
                     },
                 ]}
-                description="Lua script that emits complete and/or partial auto-indexing job specifications."
+                description={
+                    <>
+                        Lua script that emits complete and/or partial auto-indexing job specifications. See the{' '}
+                        <Link to="/help/code_navigation/references/inference_configuration">reference guide</Link> for
+                        more information.
+                    </>
+                }
                 className="mb-3"
             />
             {fetchError && <ErrorAlert prefix="Error fetching inference script" error={fetchError} />}

--- a/doc/code_navigation/references/index.md
+++ b/doc/code_navigation/references/index.md
@@ -7,3 +7,4 @@
 - [Precise code navigation examples](precise_examples.md)
 - [Environment variables](envvars.md)
 - [Auto-indexing configuration](auto_indexing_configuration.md)
+- [Auto-indexing inference configuration](inference_configuration.md)

--- a/doc/code_navigation/references/inference_configuration.md
+++ b/doc/code_navigation/references/inference_configuration.md
@@ -3,76 +3,135 @@
 <aside class="beta">
 <p>
 <span class="badge badge-beta">Beta</span> This feature is in beta for self-hosted customers.
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
 </p>
 </aside>
 
-This document details SOMETHING.
+This document details how a site administrator can supply a Lua script to customize the way [Sourcegraph detects precise code intelligence indexing jobs from repository contents](http://localhost:5080/code_navigation/explanations/auto_indexing_inference).
 
-Default indexers:
+By default, Sourcegraph will attempt to infer (or hint) index jobs for the following languages:
 
-- `clang`
-- `go`
-- `java`
-- `python`
-- `ruby`
-- `rust`
-- `test`
-- `typescript`
+- `C++`
+- [`Go`](../explanations/auto_indexing_inference#go)
+- [`Java`/`Scala`/`Kotlin`](../explanations/auto_indexing_inference#java)
+- `Python`
+- `Ruby`
+- [`Rust`](../explanations/auto_indexing_inference#rust)
+- [`TypeScript`/`JavaScript`](../explanations/auto_indexing_inference#typescript)
+
+Inference logic can be disabled or altered in the case when the target repositories do not conform to a pattern that the Sourcegraph default inference logic recognizes. Inference logic is controlled by a **Lua override script** that can be supplied in the UI under `Admin > Code graph > Inference`.
+
+> NOTE: While the change is self-service, **Sourcegraph support is more than happy to help write custom behaviors with you**. Do not hesitate to contact us to get the inference logic behaving how you would expect for **your** repositories.
 
 ## Example
 
-TODO
+The **Lua override script** ultimately must return an _auto-indexing config object_. An empty configuration does not change the default behavior.
+
+```lua
+return require("sg.autoindex.config").new({
+  -- Empty configuration
+})
+```
+
+To **disable** default behaviors, you can re-assign a recognizer value to `false`. Each of the built-in recognizers are prefixed with `sg.` (and are the only ones allowed to be).
+
+```lua
+return require("sg.autoindex.config").new({
+  -- Disable default Python inference
+  ["sg.python"] = false
+})
+```
+
+To **add** additional behaviors, you can create and register a new **recognizer**. A recognizer is an interface that requests some set of files from a repository, and returns a set of auto-indexing job configurations that could produce a precise code intelligence index.
+
+A _path recognizer_ is a concrete recognizer that advertises a set of path _globs_ it is interested in, then invokes its `generate` function with matching paths from a repository. In the following, all files matching `Snek.module` (`Snek.module`, `proj/Snek.module`, `proj/sub/Snek.module`, etc) are passed to a call to `generate` (if non-empty). The generate function will then return a list of indexing job descriptions. The [guide for auto-indexing jobs configuration](auto_indexing_configuration#keys-1) gives detailed descriptions on the fields of this object.
 
 ```lua
 local path = require("path")
 local pattern = require("sg.autoindex.patterns")
 local recognizer = require("sg.autoindex.recognizer")
 
-local custom_recognizer = recognizer.new_path_recognizer {
-  patterns = { pattern.new_path_basename("sg-test") },
+local snek_recognizer = recognizer.new_path_recognizer {
+  patterns = {
+    -- Look for Snek.module files
+    pattern.new_path_basename("Snek.module"),
 
-  -- Invoked when go.mod files exist
+    -- Ignore any files in test or vendor directories
+    pattern.new_path_exclude(pattern.new_path_combine {
+      pattern.new_path_segment("test"),
+      pattern.new_path_segment("vendor"),
+    }),
+  },
+
+  -- Called with list of matching Snek.module files
   generate = function(_, paths)
     local jobs = {}
     for i = 1, #paths do
+      -- Create indexing job description for each matching file
       table.insert(jobs, {
+        indexer = "acme/snek:latest",  -- Run this indexer...
+        root = path.dirname(paths[i]), -- ...in this directory
         steps = {},
-        root = path.dirname(paths[i]),
-        indexer = "test-override",
         indexer_args = {},
         outfile = "",
       })
     end
 
     return jobs
-  end,
+  end
 }
 
 return require("sg.autoindex.config").new({
-  ["custom.test"] = custom_recognizer,
+  -- Register new recognizer
+  ["acme.snek"] = snek_recognizer,
 })
 ```
 
-## Libraries
+## Available libraries
 
-TODO
+There are a number of specific and general-purpose Lua libraries made accessible via the built-in `require`.
 
 ### `sg.autoindex.recognizer`
 
-TODO
+This auto-indexing-specific library defines the following two functions.
 
-```
-M.new_path_recognizer = function(config)
-M.new_fallback_recognizer = function(config)
-```
+<!-- TODO - document paths_for_content;api.register -->
+- `new_path_recognizer` creates a recognizer from a config object containing `patterns` and `generate` fields. See the [example](#example) above for basic usage.
+- `new_fallback_recognizer` creates a recognizer from an ordered list of recognizers. Each recognizer is called sequentially, and halts after the recognizer emitting the first non-empty set of results.
 
 ### `sg.autoindex.patterns`
 
-TODO
+This auto-indexing-specific library defines the following four path pattern constructors.
 
-```
-M.new_path_literal = function(pattern)
-M.new_path_segment = function(pattern)
-M.new_path_basename = function(pattern)
-M.new_path_extension = function(pattern)
-```
+- `new_path_literal(pattern)` creates a pattern that matches an exact filepath.
+- `new_path_segment(pattern)` creates a pattern that matches a directory name.
+- `new_path_basename(pattern)` creates a pattern that matches a basename exactly.
+- `new_path_extension(ext_no_dot)` creates a pattern that matches files with a given extension.
+
+This library also defines the following two pattern collection constructors.
+
+- `new_path_combine(patterns)` creates a pattern collection object (to be used with [recognizers](#sg-autoindex-recognizers)) from the given set of path patterns.
+- `new_path_exclude(patterns)` creates a new _inverted_ pattern collection object. Paths matching these patterns are filtered out from the set of matching filepaths given to a recognizer's `generate` function.
+
+### `paths`
+
+This library defines the following five path utility functions:
+
+- `ancestors(path)` returns a path's parent, grandparent, etc as a list.
+- `basename(path)` returns the basename of the given path.
+- `dirname(path)` returns the dirname of the given path.
+- `join(paths)` returns a filepath created by joining the given path segments via filepath separator.
+- `split(path)` split a path into an ordered sequence of path segments.
+
+### `json`
+
+This library defines the following two JSON utility functions:
+
+- `encode(val)` returns a JSON-ified version of the given Lua object.
+- `decode(json)` returns a Lua table representation of the given JSON text.
+
+### `fun`
+
+[Lua Functional](https://github.com/luafun/luafun/tree/cb6a7e25d4b55d9578fd371d1474b00e47bd29f3#lua-functional) is a high-performance functional programming library accessible via `local fun = requrie("fun")`. This library has a number of functional utilities to help make recognizer code a bit more expressive.

--- a/doc/code_navigation/references/inference_configuration.md
+++ b/doc/code_navigation/references/inference_configuration.md
@@ -1,0 +1,9 @@
+# Auto-indexing inference configuration reference
+
+<aside class="beta">
+<p>
+<span class="badge badge-beta">Beta</span> This feature is in beta for self-hosted customers.
+</p>
+</aside>
+
+This document details SOMETHING.

--- a/doc/code_navigation/references/inference_configuration.md
+++ b/doc/code_navigation/references/inference_configuration.md
@@ -9,7 +9,7 @@
 </p>
 </aside>
 
-This document details how a site administrator can supply a Lua script to customize the way [Sourcegraph detects precise code intelligence indexing jobs from repository contents](http://localhost:5080/code_navigation/explanations/auto_indexing_inference).
+This document details how a site administrator can supply a Lua script to customize the way [Sourcegraph detects precise code intelligence indexing jobs from repository contents](../explanations/auto_indexing_inference).
 
 By default, Sourcegraph will attempt to infer (or hint) index jobs for the following languages:
 
@@ -27,11 +27,11 @@ Inference logic can be disabled or altered in the case when the target repositor
 
 ## Example
 
-The **Lua override script** ultimately must return an _auto-indexing config object_. An empty configuration does not change the default behavior.
+The **Lua override script** ultimately must return an _auto-indexing config object_. A configuration that neither disables or adds new recognizers does not change the default inference behavior.
 
 ```lua
 return require("sg.autoindex.config").new({
-  -- Empty configuration
+  -- Empty configuration (see below for usage)
 })
 ```
 
@@ -55,7 +55,8 @@ local recognizer = require("sg.autoindex.recognizer")
 
 local snek_recognizer = recognizer.new_path_recognizer {
   patterns = {
-    -- Look for Snek.module files
+    -- Look for Snek.module files 
+    -- (would match Snek.module; proj/Snek.module, proj/sub/Snek.module, etc)
     pattern.new_path_basename("Snek.module"),
 
     -- Ignore any files in test or vendor directories
@@ -98,22 +99,22 @@ There are a number of specific and general-purpose Lua libraries made accessible
 This auto-indexing-specific library defines the following two functions.
 
 <!-- TODO - document paths_for_content;api.register -->
-- `new_path_recognizer` creates a recognizer from a config object containing `patterns` and `generate` fields. See the [example](#example) above for basic usage.
-- `new_fallback_recognizer` creates a recognizer from an ordered list of recognizers. Each recognizer is called sequentially, and halts after the recognizer emitting the first non-empty set of results.
+- `new_path_recognizer` creates a `recognizer` from a config object containing `patterns` and `generate` fields. See the [example](#example) above for basic usage.
+- `new_fallback_recognizer` creates a `recognizer` from an ordered list of `recognizer`s. Each `recognizer` is called sequentially, until one of them emits non-empty results.
 
 ### `sg.autoindex.patterns`
 
 This auto-indexing-specific library defines the following four path pattern constructors.
 
-- `new_path_literal(pattern)` creates a pattern that matches an exact filepath.
-- `new_path_segment(pattern)` creates a pattern that matches a directory name.
-- `new_path_basename(pattern)` creates a pattern that matches a basename exactly.
-- `new_path_extension(ext_no_dot)` creates a pattern that matches files with a given extension.
+- `new_path_literal(pattern)` creates a `pattern` that matches an exact filepath.
+- `new_path_segment(pattern)` creates a `pattern` that matches a directory name.
+- `new_path_basename(pattern)` creates a `pattern` that matches a basename exactly.
+- `new_path_extension(ext_no_dot)` creates a `pattern` that matches files with a given extension.
 
 This library also defines the following two pattern collection constructors.
 
-- `new_path_combine(patterns)` creates a pattern collection object (to be used with [recognizers](#sg-autoindex-recognizers)) from the given set of path patterns.
-- `new_path_exclude(patterns)` creates a new _inverted_ pattern collection object. Paths matching these patterns are filtered out from the set of matching filepaths given to a recognizer's `generate` function.
+- `new_path_combine(patterns)` creates a pattern collection object (to be used with [recognizers](#sg-autoindex-recognizers)) from the given set of path `pattern`s.
+- `new_path_exclude(patterns)` creates a new _inverted_ pattern collection object. Paths matching these `pattern`s are filtered out from the set of matching filepaths given to a recognizer's `generate` function.
 
 ### `paths`
 

--- a/doc/code_navigation/references/inference_configuration.md
+++ b/doc/code_navigation/references/inference_configuration.md
@@ -134,4 +134,4 @@ This library defines the following two JSON utility functions:
 
 ### `fun`
 
-[Lua Functional](https://github.com/luafun/luafun/tree/cb6a7e25d4b55d9578fd371d1474b00e47bd29f3#lua-functional) is a high-performance functional programming library accessible via `local fun = requrie("fun")`. This library has a number of functional utilities to help make recognizer code a bit more expressive.
+[Lua Functional](https://github.com/luafun/luafun/tree/cb6a7e25d4b55d9578fd371d1474b00e47bd29f3#lua-functional) is a high-performance functional programming library accessible via `local fun = require("fun")`. This library has a number of functional utilities to help make recognizer code a bit more expressive.

--- a/doc/code_navigation/references/inference_configuration.md
+++ b/doc/code_navigation/references/inference_configuration.md
@@ -7,3 +7,72 @@
 </aside>
 
 This document details SOMETHING.
+
+Default indexers:
+
+- `clang`
+- `go`
+- `java`
+- `python`
+- `ruby`
+- `rust`
+- `test`
+- `typescript`
+
+## Example
+
+TODO
+
+```lua
+local path = require("path")
+local pattern = require("sg.autoindex.patterns")
+local recognizer = require("sg.autoindex.recognizer")
+
+local custom_recognizer = recognizer.new_path_recognizer {
+  patterns = { pattern.new_path_basename("sg-test") },
+
+  -- Invoked when go.mod files exist
+  generate = function(_, paths)
+    local jobs = {}
+    for i = 1, #paths do
+      table.insert(jobs, {
+        steps = {},
+        root = path.dirname(paths[i]),
+        indexer = "test-override",
+        indexer_args = {},
+        outfile = "",
+      })
+    end
+
+    return jobs
+  end,
+}
+
+return require("sg.autoindex.config").new({
+  ["custom.test"] = custom_recognizer,
+})
+```
+
+## Libraries
+
+TODO
+
+### `sg.autoindex.recognizer`
+
+TODO
+
+```
+M.new_path_recognizer = function(config)
+M.new_fallback_recognizer = function(config)
+```
+
+### `sg.autoindex.patterns`
+
+TODO
+
+```
+M.new_path_literal = function(pattern)
+M.new_path_segment = function(pattern)
+M.new_path_basename = function(pattern)
+M.new_path_extension = function(pattern)
+```


### PR DESCRIPTION
Fixes #44120.

## Test plan

Docs update :)

## App preview:

- [Web](https://sg-web-ef-lua-docs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
