### PR TITLE
SCIM: Let new users set a password

### DIFF
--- a/cmd/frontend/auth/auth.go
+++ b/cmd/frontend/auth/auth.go
@@ -4,11 +4,9 @@ package auth
 import (
 	"math/rand"
 	"net/http"
-	"strings"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/suspiciousnames"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // AuthURLPrefix is the URL path prefix under which to attach authentication handlers
@@ -59,52 +57,10 @@ func composeMiddleware(middlewares ...*Middleware) *Middleware {
 }
 
 // NormalizeUsername normalizes a proposed username into a format that meets Sourcegraph's
-// username formatting rules (based on, but not identical to
-// https://web.archive.org/web/20180215000330/https://help.github.com/enterprise/2.11/admin/guides/user-management/using-ldap):
-//
-// - Any characters not in `[a-zA-Z0-9-._]` are replaced with `-`
-// - Usernames with exactly one `@` character are interpreted as an email address, so the username will be extracted by truncating at the `@` character.
-// - Usernames with two or more `@` characters are not considered an email address, so the `@` will be treated as a non-standard character and be replaced with `-`
-// - Usernames with consecutive `-` or `.` characters are not allowed, so they are replaced with a single `-` or `.`
-// - Usernames that start with `.` or `-` are not allowed, starting periods and dashes are removed
-// - Usernames that end with `.` are not allowed, ending periods are removed
-//
-// Usernames that could not be converted return an error.
-//
-// Note: Do not forget to change database constraints on "users" and "orgs" tables.
+// username formatting rules.
 func NormalizeUsername(name string) (string, error) {
-	origName := name
-
-	// If the username is an email address, extract the username part.
-	if i := strings.Index(name, "@"); i != -1 && i == strings.LastIndex(name, "@") {
-		name = name[:i]
-	}
-
-	// Replace all non-alphanumeric characters with a dash.
-	name = disallowedCharacter.ReplaceAllString(name, "-")
-
-	// Replace all consecutive dashes and periods with a single dash.
-	name = consecutivePeriodsDashes.ReplaceAllString(name, "-")
-
-	// Trim leading and trailing dashes and periods.
-	name = sequencesToTrim.ReplaceAllString(name, "")
-
-	if name == "" {
-		return "", errors.Errorf("username %q could not be normalized to acceptable format", origName)
-	}
-
-	if err := suspiciousnames.CheckNameAllowedForUserOrOrganization(name); err != nil {
-		return "", err
-	}
-
-	return name, nil
+	return userpasswd.NormalizeUsername(name)
 }
-
-var (
-	disallowedCharacter      = lazyregexp.New(`[^\w\-\.]`)
-	consecutivePeriodsDashes = lazyregexp.New(`[\-\.]{2,}`)
-	sequencesToTrim          = lazyregexp.New(`(^[\-\.])|(\.$)|`)
-)
 
 // AddRandomSuffix appends a random 5-character lowercase alphabetical suffix (like "-lbwwt")
 // to the username to avoid collisions. If the username already ends with a dash, it is not

--- a/cmd/frontend/auth/reset_password.go
+++ b/cmd/frontend/auth/reset_password.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// ResetPasswordURL modifies the DB when it generates reset URLs, which is somewhat
+// counterintuitive for a "value" type from an implementation POV. Its behavior is
+// justified because it is convenient and intuitive from the POV of the API consumer.
+func ResetPasswordURL(ctx context.Context, db database.DB, logger log.Logger, user *types.User, email string, emailVerified bool) (*string, error) {
+	if !userpasswd.ResetPasswordEnabled() {
+		return nil, nil
+	}
+
+	if email != "" && conf.CanSendEmail() {
+		// HandleSetPasswordEmail will send a special password reset email that also
+		// verifies the primary email address.
+		ru, err := userpasswd.HandleSetPasswordEmail(ctx, db, user.ID, user.Username, email, emailVerified)
+		if err != nil {
+			msg := "failed to send set password email"
+			logger.Error(msg, log.Error(err))
+			return nil, errors.Wrap(err, msg)
+		}
+		return &ru, nil
+	}
+
+	resetURL, err := backend.MakePasswordResetURL(ctx, db, user.ID)
+	if err != nil {
+		msg := "failed to generate reset URL"
+		logger.Error(msg, log.Error(err))
+		return nil, errors.Wrap(err, msg)
+	}
+
+	ru := globals.ExternalURL().ResolveReference(resetURL).String()
+	return &ru, nil
+}

--- a/cmd/frontend/auth/sign_out_cookie.go
+++ b/cmd/frontend/auth/sign_out_cookie.go
@@ -2,27 +2,19 @@ package auth
 
 import (
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 )
 
-const SignoutCookie = "sg-signout"
-
+// HasSignOutCookie returns true if the given request has a sign-out cookie.
 func HasSignOutCookie(r *http.Request) bool {
-	ck, err := r.Cookie(SignoutCookie)
-	if err != nil {
-		return false
-	}
-	return ck != nil
+	return session.HasSignOutCookie(r)
 }
 
-func RemoveSignOutCookieIfSet(r *http.Request, w http.ResponseWriter) {
-	if HasSignOutCookie(r) {
-		http.SetCookie(w, &http.Cookie{Name: SignoutCookie, Value: "", MaxAge: -1})
-	}
-}
-
-func SetSignoutCookie(w http.ResponseWriter) {
+// SetSignOutCookie sets a sign-out cookie on the given response.
+func SetSignOutCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
-		Name:   SignoutCookie,
+		Name:   session.SignOutCookie,
 		Value:  "true",
 		Secure: true,
 		Path:   "/",

--- a/cmd/frontend/auth/sign_out_cookie.go
+++ b/cmd/frontend/auth/sign_out_cookie.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 )
 
+const SignOutCookie = session.SignOutCookie
+
 // HasSignOutCookie returns true if the given request has a sign-out cookie.
 func HasSignOutCookie(r *http.Request) bool {
 	return session.HasSignOutCookie(r)
@@ -14,7 +16,7 @@ func HasSignOutCookie(r *http.Request) bool {
 // SetSignOutCookie sets a sign-out cookie on the given response.
 func SetSignOutCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
-		Name:   session.SignOutCookie,
+		Name:   SignOutCookie,
 		Value:  "true",
 		Secure: true,
 		Path:   "/",

--- a/cmd/frontend/internal/app/sign_out.go
+++ b/cmd/frontend/internal/app/sign_out.go
@@ -49,7 +49,7 @@ func serveSignOutHandler(db database.DB) http.HandlerFunc {
 			log15.Error("serveSignOutHandler", "err", err)
 		}
 
-		auth.SetSignoutCookie(w)
+		auth.SetSignOutCookie(w)
 
 		if ssoSignOutHandler != nil {
 			ssoSignOutHandler(w, r)

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
@@ -61,7 +61,7 @@ func TestMiddleware(t *testing.T) {
 	}
 
 	t.Run("unauthenticated homepage visit, sign-out cookie present -> sg sign-in", func(t *testing.T) {
-		cookie := &http.Cookie{Name: auth.SignoutCookie, Value: "true"}
+		cookie := &http.Cookie{Name: auth.SignOutCookie, Value: "true"}
 
 		resp := doRequest("GET", "http://example.com/", "", []*http.Cookie{cookie}, false)
 		if want := http.StatusOK; resp.StatusCode != want {

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -64,7 +64,7 @@ func TestMiddleware(t *testing.T) {
 	}
 
 	t.Run("unauthenticated homepage visit, sign-out cookie present -> sg sign-in", func(t *testing.T) {
-		cookie := &http.Cookie{Name: auth.SignoutCookie, Value: "true"}
+		cookie := &http.Cookie{Name: auth.SignOutCookie, Value: "true"}
 
 		resp := doRequest("GET", "http://example.com/", "", []*http.Cookie{cookie}, false)
 		if want := http.StatusOK; resp.StatusCode != want {

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -83,7 +83,7 @@ func TestMiddleware(t *testing.T) {
 		}
 	})
 	t.Run("unauthenticated homepage visit, sign-out cookie present -> sg sign-in", func(t *testing.T) {
-		cookie := &http.Cookie{Name: auth.SignoutCookie, Value: "true"}
+		cookie := &http.Cookie{Name: auth.SignOutCookie, Value: "true"}
 
 		resp := doRequest("GET", "http://example.com/", "", []*http.Cookie{cookie}, false)
 		if want := http.StatusOK; resp.StatusCode != want {

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -205,7 +205,7 @@ func TestMiddleware(t *testing.T) {
 	}
 
 	t.Run("unauthenticated homepage visit, sign-out cookie present -> sg sign-in", func(t *testing.T) {
-		cookie := &http.Cookie{Name: auth.SignoutCookie, Value: "true"}
+		cookie := &http.Cookie{Name: auth.SignOutCookie, Value: "true"}
 
 		resp := doRequest("GET", "http://example.com/", "", []*http.Cookie{cookie}, false)
 		if want := http.StatusOK; resp.StatusCode != want {

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
@@ -292,7 +292,7 @@ func TestMiddleware(t *testing.T) {
 		}
 	})
 	t.Run("unauthenticated homepage visit, sign-out cookie present -> sg login", func(t *testing.T) {
-		cookie := &http.Cookie{Name: auth.SignoutCookie, Value: "true"}
+		cookie := &http.Cookie{Name: auth.SignOutCookie, Value: "true"}
 
 		resp := doRequest("GET", "http://example.com/", "", []*http.Cookie{cookie}, false, nil)
 		if want := http.StatusOK; resp.StatusCode != want {

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -45,9 +45,9 @@ type UserResourceHandler struct {
 	schemaExtensions []scim.SchemaExtension
 }
 
-func (u *UserResourceHandler) getLogger() log.Logger {
-	if u.observationCtx != nil && u.observationCtx.Logger != nil {
-		return u.observationCtx.Logger.Scoped("scim.user", "resource handler for scim user")
+func (h *UserResourceHandler) getLogger() log.Logger {
+	if h.observationCtx != nil && h.observationCtx.Logger != nil {
+		return h.observationCtx.Logger.Scoped("scim.user", "resource handler for scim user")
 	}
 	return log.Scoped("scim.user", "resource handler for scim user")
 }

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 
 	"github.com/sourcegraph/log"
 
@@ -139,6 +140,11 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 			})
 		}
 	}
+
+	// Email user to ask to set up a password
+	// This internally checks whether username/password login is enabled, whether we have an SMTP in place, etc.
+	_, err = auth.ResetPasswordURL(r.Context(), h.db, h.observationCtx.Logger, user, primaryEmail, true)
+
 	var now = time.Now()
 	// Attempt to send welcome email in the background.
 	goroutine.Go(func() {

--- a/enterprise/internal/scim/user_create.go
+++ b/enterprise/internal/scim/user_create.go
@@ -130,7 +130,7 @@ func (h *UserResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 	// the error because they are not required.
 	if len(otherEmails) > 0 {
 		for _, email := range otherEmails {
-			h.db.WithTransact(r.Context(), func(tx database.DB) error {
+			_ = h.db.WithTransact(r.Context(), func(tx database.DB) error {
 				err := tx.UserEmails().Add(r.Context(), user.ID, email, nil)
 				if err != nil {
 					return err


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/48425

This PR includes three commits:
1. A one-liner code warning fix
2. A bunch of reorg across packages to make `ResetPasswordURL` accessible from outside `frontend`
3. A single-line call to `ResetPasswordURL` at user creation

## Test plan

- If CI passes, I'm quite confident that the existing code works. The reorg was quite trivial, I just moved stuff around. I also think I managed to minimize code duplication and bureaucracy of call chains.
- I tested with creating a user. It got created without warnings, I got the email, and the password reset link worked and I could follow through with the password setting and could log in.

Email screenshot:

<img width="816" alt="CleanShot 2023-03-13 at 16 31 22@2x" src="https://user-images.githubusercontent.com/2552265/224749587-1d50ea1c-d083-4b5d-9d3b-121f65cf5340.png">

