### PR TITLE
own: some copy changes to documentation and help banners

### DIFF
--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -44,7 +44,7 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                             <Alert variant="info" className="mb-3">
                                 This team is managed externally and cannot be modified from the UI except by site
                                 admins.{' '}
-                                <Link to="/help/admin/teams#configuring-teams">Read more about configuring teams.</Link>
+                                <Link to="/help/admin/teams#configuring-teams">Read more about configuring Teams.</Link>
                             </Alert>
                         )}
 

--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiAccountMultiple } from '@mdi/js'
 import { NavLink } from 'react-router-dom'
 
-import {Alert, Badge, Link, PageHeader, ProductStatusBadge} from '@sourcegraph/wildcard'
+import { Alert, Badge, Link, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import { TeamAreaRouteContext } from './TeamArea'
 
@@ -42,8 +42,9 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
 
                         {team.readonly && (
                             <Alert variant="info" className="mb-3">
-                                This team is managed externally and cannot be modified from the UI except by
-                                site admins. <Link to="/help/admin/teams#configuring-teams">Read more about configuring teams.</Link>
+                                This team is managed externally and cannot be modified from the UI except by site
+                                admins.{' '}
+                                <Link to="/help/admin/teams#configuring-teams">Read more about configuring teams.</Link>
                             </Alert>
                         )}
 

--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -42,8 +42,8 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
 
                         {team.readonly && (
                             <Alert variant="info" className="mb-3">
-                                This team is managed externally and can not be modified from the UI except by
-                                site-admins.
+                                This team is managed externally and cannot be modified from the UI except by
+                                site admins.
                             </Alert>
                         )}
 

--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiAccountMultiple } from '@mdi/js'
 import { NavLink } from 'react-router-dom'
 
-import { Alert, Badge, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
+import {Alert, Badge, Link, PageHeader, ProductStatusBadge} from '@sourcegraph/wildcard'
 
 import { TeamAreaRouteContext } from './TeamArea'
 
@@ -43,7 +43,7 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                         {team.readonly && (
                             <Alert variant="info" className="mb-3">
                                 This team is managed externally and cannot be modified from the UI except by
-                                site admins.
+                                site admins. <Link to="/help/admin/teams#configuring-teams">Read more about configuring teams.</Link>
                             </Alert>
                         )}
 

--- a/client/web/src/team/list/TeamListPage.tsx
+++ b/client/web/src/team/list/TeamListPage.tsx
@@ -47,8 +47,8 @@ export const TeamListPage: React.FunctionComponent<React.PropsWithChildren<TeamL
                 }
                 description={
                     <>
-                        A team is a set of users. See the <Link to="/help/admin/teams">Teams documentation</Link> for more
-                        information about configuring teams.
+                        A team is a set of users. See the <Link to="/help/admin/teams">Teams documentation</Link> for
+                        more information about configuring teams.
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/team/list/TeamListPage.tsx
+++ b/client/web/src/team/list/TeamListPage.tsx
@@ -47,7 +47,7 @@ export const TeamListPage: React.FunctionComponent<React.PropsWithChildren<TeamL
                 }
                 description={
                     <>
-                        A team is a set of users. See <Link to="/help/admin/teams">Teams documentation</Link> for more
+                        A team is a set of users. See the <Link to="/help/admin/teams">Teams documentation</Link> for more
                         information about configuring teams.
                     </>
                 }

--- a/doc/admin/teams/index.md
+++ b/doc/admin/teams/index.md
@@ -119,7 +119,7 @@ Removing a member from a read-only team|🟢|🔴|🔴
 
 ### GitHub teams
 
-Using the GitHub CLI, you can ingest teams data from GitHub into Sourcegraph. You may want to run this process regularly.
+Using the GitHub CLI along with Sourcegraph's CLI, you can ingest teams data from GitHub into Sourcegraph. You may want to run this process regularly.
 
 ```bash
 #!/usr/bin/env bash

--- a/doc/admin/teams/index.md
+++ b/doc/admin/teams/index.md
@@ -126,6 +126,9 @@ Using the GitHub CLI, you can ingest teams data from GitHub into Sourcegraph. Yo
 
 set -e
 
+ORG=<YOUR_ORG_NAME>
+export ORG 
+
 if [[ -z "${ORG}" ]]; then
   echo "ORG environment variable is required."
   exit 1

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -33,7 +33,7 @@ Navigating to any repository page, clicking the Ownership button will surface in
 
 ### Ingesting a file with src-cli
 
-There is the option to ingest data with the Sourcegraph [src-cli](../cli/quickstart.md). 
+There is the option to ingest data with the Sourcegraph [src-cli](../cli/quickstart.md).
 The CLI provides `add`, `update`, `delete`, and `list` functionality.
 
 ```bash

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -33,7 +33,7 @@ Navigating to any repository page, clicking the Ownership button will surface in
 
 ### Ingesting a file with src-cli
 
-There is the option to ingest data with the Sourcegraph [src-cli](../cli/quickstart.md).
+There is the option to ingest data with the Sourcegraph [src-cli](../cli/quickstart.md). 
 The CLI provides `add`, `update`, `delete`, and `list` functionality.
 
 ```bash

--- a/doc/own/index.md
+++ b/doc/own/index.md
@@ -1,5 +1,13 @@
 # Sourcegraph Own
 
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change in the future.
+</p>
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
 ## Requirements
 
 Sourcegraph Own is an enterprise feature in experimental state. 


### PR DESCRIPTION
Some copy changes I consider helpful after going through teams setup.

## Test plan

Docsite check/visual change check.

## App preview:

- [Web](https://sg-web-leo-copy-changes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
