### PR TITLE
Move dash in regular expression

### DIFF
--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -59,7 +59,7 @@
           "name": {
             "description": "The name of an Azure DevOps Services organization, project, and repository (\"orgName/projectName/repositoryName\") to exclude from mirroring.",
             "type": "string",
-            "pattern": "^[\\w.-/ ]*?$"
+            "pattern": "^[\\w./ -]*?$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of an Azure DevOps Services repo.",


### PR DESCRIPTION
The location of the dash was causing the regex to be parsed like a range, so moved it to the end.
## Test plan

Manual.