### PR TITLE
rbac: update role management modal UI

### DIFF
--- a/client/web/src/enterprise/rbac/backend.ts
+++ b/client/web/src/enterprise/rbac/backend.ts
@@ -29,7 +29,7 @@ const permissionFragment = gql`
     }
 `
 
-const roleFragment = gql`
+export const roleFragment = gql`
     fragment RoleFields on Role {
         __typename
         id

--- a/client/web/src/enterprise/rbac/mock.ts
+++ b/client/web/src/enterprise/rbac/mock.ts
@@ -21,6 +21,27 @@ export const mockPermissions: AllPermissionsResult = {
                 action: 'READ',
                 displayName: 'BATCH_CHANGES#READ',
             },
+            {
+                __typename: 'Permission',
+                id: 'perm-3',
+                namespace: 'CODE_INSIGHTS' as PermissionNamespace,
+                action: 'READ',
+                displayName: 'CODE_INSIGHTS#READ',
+            },
+            {
+                __typename: 'Permission',
+                id: 'perm-4',
+                namespace: 'CODE_INSIGHTS' as PermissionNamespace,
+                action: 'WRITE',
+                displayName: 'CODE_INSIGHTS#WRITE',
+            },
+            {
+                __typename: 'Permission',
+                id: 'perm-5',
+                namespace: 'REPO_MANAGEMENT' as PermissionNamespace,
+                action: 'ADD',
+                displayName: 'REPO_MANAGEMENT#ADD',
+            },
         ],
     },
 }

--- a/client/web/src/enterprise/site-admin/UserManagement/backend.ts
+++ b/client/web/src/enterprise/site-admin/UserManagement/backend.ts
@@ -9,6 +9,7 @@ import {
     SetRolesForUserResult,
     SetRolesForUserVariables,
 } from '../../../graphql-operations'
+import { roleFragment } from '../../rbac/backend'
 
 export const GET_ALL_ROLES_AND_USER_ROLES = gql`
     query GetAllRolesAndUserRoles($user: ID!) {
@@ -16,9 +17,7 @@ export const GET_ALL_ROLES_AND_USER_ROLES = gql`
             ... on User {
                 roles {
                     nodes {
-                        id
-                        name
-                        system
+                        ...RoleFields
                     }
                 }
             }
@@ -26,12 +25,12 @@ export const GET_ALL_ROLES_AND_USER_ROLES = gql`
 
         roles {
             nodes {
-                id
-                name
-                system
+                ...RoleFields
             }
         }
     }
+
+    ${roleFragment}
 `
 
 export const SET_ROLES_FOR_USER = gql`

--- a/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.module.scss
+++ b/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.module.scss
@@ -1,0 +1,92 @@
+.modal {
+    display: flex;
+    flex-direction: column;
+    width: 80vw;
+    height: 80vh;
+    max-height: 850px;
+    max-width: 900px;
+    background-color: var(--body-bg);
+    padding: 1rem;
+}
+
+.header-top-line {
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.close-button:hover {
+    svg {
+        color: var(--icon-color);
+    }
+}
+
+.role-combobox {
+    // Reserve all available area for the role picker UI
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    height: 100%;
+    min-height: 0;
+}
+
+.suggestions-list {
+    flex-grow: 1;
+    margin-top: 1rem;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    width: unset;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.suggestion-card {
+    // Compensate list negative x margin
+    padding: 0.25rem 1rem;
+    display: flex;
+    flex-direction: column;
+
+    &--icon {
+        margin-right: 0.5rem;
+    }
+
+    &--description {
+        color: var(--text-muted);
+    }
+
+    &[data-highlighted] &--description {
+        color: unset;
+    }
+
+    [data-user-value] {
+        background-color: var(--mark-bg);
+    }
+}
+
+.zero-state-message {
+    margin-left: 1rem;
+    display: block;
+    color: var(--text-muted);
+}
+
+.footer {
+    display: flex;
+    align-items: center;
+    margin-top: 1rem;
+}
+
+.keyboard-explanation {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}

--- a/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.tsx
+++ b/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.tsx
@@ -18,6 +18,7 @@ import {
     Link,
     MultiComboboxOptionText,
     Code,
+    joinWithAnd,
 } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../components/LoaderButton'
@@ -186,5 +187,18 @@ const RoleSuggestionCard: React.FunctionComponent<PropsWithChildren<RoleSuggesti
         <span>
             <MultiComboboxOptionText />
         </span>
+        <small>
+            {item.permissions.nodes.length === 0 && 'No permissions granted to this role.'}
+            {joinWithAnd(
+                item.permissions.nodes,
+                item => (
+                    <Code>
+                        {item.namespace.toLowerCase()}:{item.action.toLowerCase()}
+                    </Code>
+                ),
+                item => item.id,
+                5
+            )}
+        </small>
     </MultiComboboxOption>
 )

--- a/client/wildcard/src/utils/index.ts
+++ b/client/wildcard/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { screenReaderAnnounce, screenReaderClearAnnouncements } from './screenReaderAnnounce'
 export { createLinkClickHandler } from './linkClickHandler'
+export { joinWithAnd } from './joinWithAnd'

--- a/client/wildcard/src/utils/joinWithAnd.tsx
+++ b/client/wildcard/src/utils/joinWithAnd.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+/**
+ * Returns a ReactNode where all the items in the provided array have been visually joined
+ * with commas, and an "and" is inserted before the last item.
+ *
+ * @param array The array to format as a list with commas and an "and" before the last
+ * item
+ * @param formatItem Function to call to format each item in the array before joining
+ * @param getKey Function to call to get a unique key for each item in the array
+ * @param maxItems Optionally, the maximum number of items to show. If the array has more
+ * items than this, the last item will be followed with "and N more".
+ */
+export function joinWithAnd<T>(
+    array: T[],
+    formatItem: (original: T) => React.ReactNode,
+    getKey: (original: T) => string,
+    maxItems?: number
+): React.ReactNode {
+    if (array.length === 0) {
+        return null
+    }
+    if (array.length <= 1) {
+        return formatItem(array[0])
+    }
+    if (array.length === 2) {
+        return (
+            <>
+                {formatItem(array[0])} and {formatItem(array[1])}
+            </>
+        )
+    }
+    if (maxItems && array.length > maxItems) {
+        return (
+            <>
+                {array.slice(0, maxItems).map(item => (
+                    <React.Fragment key={getKey(item)}>{formatItem(item)}, </React.Fragment>
+                ))}
+                and {array.length - maxItems} more
+            </>
+        )
+    }
+    return (
+        <>
+            {array.slice(0, -1).map(item => (
+                <React.Fragment key={getKey(item)}>{formatItem(item)}, </React.Fragment>
+            ))}
+            and {formatItem(array[array.length - 1])}
+        </>
+    )
+}


### PR DESCRIPTION
Updates the `RoleAssignmentModal` to follow more patterns of the `AddInsightModal`, most notably, showing the suggestions list inline as a plain list rather than as a popover.

Here's a demonstration of the whole role management flow, where you can see the new modal and `MultiCombobox` suggestions list in action:

<video src="https://user-images.githubusercontent.com/8942601/224806021-9cebf107-efb0-4514-b6aa-65ae1e137eb7.mov"></video>

The modal can accommodate many more roles, though of course we don't expect customers to create this many in the near term while the scope of RBAC is limited to Batch Changes:

<video src="https://user-images.githubusercontent.com/8942601/224806063-7874d35a-f4ed-4c9f-b29f-71e8c31d2376.mov"></video>

Last of all, the permissions shown inline can be limited to just the first N if we desire it. Though, again, at the present there are only 2 total types of permissions:

<img width="463" alt="image" src="https://user-images.githubusercontent.com/8942601/224805962-5ac55f1d-640f-462c-87e6-a15e4159357a.png">


## Test plan

Storybook coverage. Verified manually the whole flow works as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-manage-roles-modal-list.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
