### PR TITLE
scim: don't run tests in parallel

### DIFF
--- a/enterprise/internal/scim/user_create_test.go
+++ b/enterprise/internal/scim/user_create_test.go
@@ -17,8 +17,6 @@ import (
 
 func TestUserResourceHandler_Create(t *testing.T) {
 	txemail.DisableSilently()
-	t.Parallel()
-
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "Yay Scim", SCIMControlled: true}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
 		{User: types.User{ID: 2, Username: "user2", DisplayName: "Nay Scim", SCIMControlled: false}, Emails: []string{"b@example.com"}},

--- a/enterprise/internal/scim/user_get_test.go
+++ b/enterprise/internal/scim/user_get_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestUserResourceHandler_Get(t *testing.T) {
-	t.Parallel()
-
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
 		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Middle Last"}, Emails: []string{"b@example.com"}},

--- a/enterprise/internal/scim/user_patch_test.go
+++ b/enterprise/internal/scim/user_patch_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/scim2/filter-parser/v2"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -52,8 +53,6 @@ func makeEmail(userID int32, address string, primary, verified bool) *database.U
 }
 
 func Test_UserResourceHandler_Patch(t *testing.T) {
-	t.Parallel()
-
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1}},
 		{User: types.User{ID: 2, Username: "test-user2", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id2"},
@@ -298,8 +297,6 @@ func Test_UserResourceHandler_Patch(t *testing.T) {
 }
 
 func Test_UserResourceHandler_Patch_ReplaceStrategies(t *testing.T) {
-	t.Parallel()
-
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "test-user1"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData},
 		{User: types.User{ID: 2, Username: "test-user2"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData},

--- a/enterprise/internal/scim/user_replace_test.go
+++ b/enterprise/internal/scim/user_replace_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func Test_UserResourceHandler_Replace(t *testing.T) {
-	t.Parallel()
-
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
 		{User: types.User{ID: 2, Username: "user2", DisplayName: "First Last"}, Emails: []string{"b@example.com"}, SCIMExternalID: "id2"},


### PR DESCRIPTION
SCIM tests now depend on configuration and running in parallel causes inconsistent results.
## Test plan
n/a tests only 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
