### PR TITLE
gosyntect: try to prefer shebangs to force correct syntax highlighting

### DIFF
--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -264,7 +264,7 @@ func getLanguage(path string, contents string) (string, bool) {
 		return lang, true
 	}
 
-	// Use the shebang if possible, sometimes enry is doesn't use the shebang...
+	// Force the use of the shebang.
 	if shebangLang, ok := overrideViaShebang(path, contents); ok {
 		return shebangLang, false
 	}
@@ -280,6 +280,10 @@ func getLanguage(path string, contents string) (string, bool) {
 // It also covers some edge cases when enry eagerly returns more languages
 // than necessary, which ends up overriding the shebang completely (which,
 // IMO is the highest priority match we can have).
+//
+// For example, enry will return "Perl" and "Pod" for a shebang of `#!/usr/bin/env perl`.
+// This is actually unhelpful, because then enry will *not* select "Perl" as the
+// language (which is our desired behavior).
 func overrideViaShebang(path, content string) (lang string, ok bool) {
 	shebangs := enry.GetLanguagesByShebang(path, []byte(content), []string{})
 	if len(shebangs) == 0 {

--- a/cmd/frontend/internal/highlight/language_test.go
+++ b/cmd/frontend/internal/highlight/language_test.go
@@ -1,6 +1,7 @@
 package highlight
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/grafana/regexp"
@@ -72,6 +73,56 @@ func TestGetLanguageFromConfig(t *testing.T) {
 
 		if language != testCase.Expected {
 			t.Fatalf("Got: %s, Expected: %s", testCase.Expected, language)
+		}
+	}
+}
+
+func TestShebagn(t *testing.T) {
+	type testCase struct {
+		Contents string
+		Expected string
+	}
+
+	cases := []testCase{
+		{
+			Contents: "#!/usr/bin/env python",
+			Expected: "python",
+		},
+		{
+			Contents: "#!/usr/bin/env node",
+			Expected: "javascript",
+		},
+		{
+			Contents: "#!/usr/bin/env ruby",
+			Expected: "ruby",
+		},
+		{
+			Contents: "#!/usr/bin/env perl",
+			Expected: "perl",
+		},
+		{
+			Contents: "#!/usr/bin/env php",
+			Expected: "php",
+		},
+		{
+			Contents: "#!/usr/bin/env lua",
+			Expected: "lua",
+		},
+		{
+			Contents: "#!/usr/bin/env tclsh",
+			Expected: "tcl",
+		},
+		{
+			Contents: "#!/usr/bin/env fish",
+			Expected: "fish",
+		},
+	}
+
+	for _, testCase := range cases {
+		language, _ := getLanguage("", testCase.Contents)
+		language = strings.ToLower(language)
+		if language != testCase.Expected {
+			t.Fatalf("%s\nGot: %s, Expected: %s", testCase.Contents, testCase.Expected, language)
 		}
 	}
 }


### PR DESCRIPTION

## Test plan

- [ ] Open up a file like: https://sourcegraph.com/github.com/openssl/openssl/-/blob/ms/cmp.pl and confirm you are now seeing perl
- [ ] Can also search with other files w/ shebangs and check those out.
