### PR TITLE
packages: properly handle filter scheme everywhere 

### DIFF
--- a/internal/codeintel/dependencies/internal/background/job_packages_filter.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter.go
@@ -50,7 +50,7 @@ func (j *packagesFilterApplicatorJob) handle(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to list package repo filters")
 	}
 
-	allowlist, blocklist, err := packagefilters.NewFilterLists(filters)
+	packageFilters, err := packagefilters.NewFilterLists(filters)
 	if err != nil {
 		return err
 	}
@@ -78,9 +78,9 @@ func (j *packagesFilterApplicatorJob) handle(ctx context.Context) (err error) {
 		lastID = pkgs[len(pkgs)-1].ID
 
 		for i, pkg := range pkgs {
-			pkg.Blocked = !packagefilters.IsPackageAllowed(pkg.Name, allowlist, blocklist)
+			pkg.Blocked = !packagefilters.IsPackageAllowed(pkg.Scheme, pkg.Name, packageFilters)
 			for j, version := range pkg.Versions {
-				pkg.Versions[j].Blocked = !packagefilters.IsVersionedPackageAllowed(pkg.Name, version.Version, allowlist, blocklist)
+				pkg.Versions[j].Blocked = !packagefilters.IsVersionedPackageAllowed(pkg.Scheme, pkg.Name, version.Version, packageFilters)
 			}
 			pkgs[i] = pkg
 		}

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -180,8 +180,8 @@ func TestPackageRepoFiltersBlockAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 3 {
-		t.Errorf("unexpected total count of package repos: want=%d got=%d", 3, count)
+	if count != 4 {
+		t.Errorf("unexpected total count of package repos: want=%d got=%d", 4, count)
 	}
 
 	if hasMore {

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -29,6 +29,8 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 		{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
 		{Scheme: "npm", Name: "banana", Versions: []string{"2.0.0"}},
 		{Scheme: "rust-analyzer", Name: "burger", Versions: []string{"1.0.0", "1.0.1", "1.0.2"}},
+		// make sure filters only apply to their respective scheme
+		{Scheme: "semanticdb", Name: "burger", Versions: []string{"1.0.3"}},
 	}
 
 	if _, _, err := s.InsertPackageRepoRefs(ctx, deps); err != nil {
@@ -73,8 +75,8 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 2 {
-		t.Errorf("unexpected total count of package repos: want=%d got=%d", 2, count)
+	if count != 3 {
+		t.Errorf("unexpected total count of package repos: want=%d got=%d", 3, count)
 	}
 
 	if hasMore {
@@ -96,7 +98,114 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 
 	want := []shared.PackageRepoReference{
 		{ID: 3, Scheme: "rust-analyzer", Name: "burger", Versions: []shared.PackageRepoRefVersion{{ID: 6, PackageRefID: 3, Version: "1.0.1"}}},
-		{ID: 4, Scheme: "npm", Name: "foo", Versions: []shared.PackageRepoRefVersion{{ID: 8, PackageRefID: 4, Version: "1.0.0"}}},
+		{ID: 4, Scheme: "semanticdb", Name: "burger", Versions: []shared.PackageRepoRefVersion{{ID: 8, PackageRefID: 4, Version: "1.0.3"}}},
+		{ID: 5, Scheme: "npm", Name: "foo", Versions: []shared.PackageRepoRefVersion{{ID: 9, PackageRefID: 5, Version: "1.0.0"}}},
+	}
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Errorf("mismatch (-want, +got): %s", diff)
+	}
+}
+
+func TestPackageRepoFiltersBlockAllow(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	s := store.New(&observation.TestContext, db)
+
+	deps := []shared.MinimalPackageRepoRef{
+		{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0", "2.0.1", "3.0.0"}},
+		{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
+		{Scheme: "npm", Name: "banana", Versions: []string{"2.0.0"}},
+		{Scheme: "rust-analyzer", Name: "burger", Versions: []string{"1.0.0", "1.0.1", "1.0.2"}},
+		{Scheme: "rust-analyzer", Name: "frogger", Versions: []string{"4.1.2", "3.0.0"}},
+		{Scheme: "semanticdb", Name: "burger", Versions: []string{"1.0.3"}},
+	}
+
+	if _, _, err := s.InsertPackageRepoRefs(ctx, deps); err != nil {
+		t.Fatal(err)
+	}
+
+	block := "BLOCK"
+	allow := "ALLOW"
+	for _, filter := range []shared.MinimalPackageFilter{
+		{
+			Behaviour:     &block,
+			PackageScheme: "npm",
+			NameFilter:    &struct{ PackageGlob string }{PackageGlob: "ba*"},
+		},
+		{
+			Behaviour:     &allow,
+			PackageScheme: "rust-analyzer",
+			VersionFilter: &struct {
+				PackageName string
+				VersionGlob string
+			}{
+				PackageName: "burger",
+				VersionGlob: "1.0.[!1]",
+			},
+		},
+		{
+			Behaviour:     &allow,
+			PackageScheme: "rust-analyzer",
+			VersionFilter: &struct {
+				PackageName string
+				VersionGlob string
+			}{
+				PackageName: "frogger",
+				VersionGlob: "3*",
+			},
+		},
+	} {
+		if _, err := s.CreatePackageRepoFilter(ctx, filter); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	job := packagesFilterApplicatorJob{
+		store:       s,
+		extsvcStore: db.ExternalServices(),
+		operations:  newOperations(&observation.TestContext),
+	}
+
+	if err := job.handle(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	have, count, hasMore, err := s.ListPackageRepoRefs(ctx, store.ListDependencyReposOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 3 {
+		t.Errorf("unexpected total count of package repos: want=%d got=%d", 3, count)
+	}
+
+	if hasMore {
+		t.Error("unexpected more-pages flag set, expected no more pages to follow")
+	}
+
+	for i, ref := range have {
+		if ref.LastCheckedAt == nil {
+			t.Errorf("unexpected nil last_checked_at for package (%s, %s)", ref.Scheme, ref.Name)
+		}
+		for i, version := range ref.Versions {
+			if version.LastCheckedAt == nil {
+				t.Errorf("unexpected nil last_checked_at for package version (%s, %s, [%s])", ref.Scheme, ref.Name, version.Version)
+			}
+			ref.Versions[i].LastCheckedAt = nil
+		}
+		have[i].LastCheckedAt = nil
+	}
+
+	want := []shared.PackageRepoReference{
+		{ID: 3, Scheme: "rust-analyzer", Name: "burger", Versions: []shared.PackageRepoRefVersion{{ID: 5, PackageRefID: 3, Version: "1.0.0"}, {ID: 7, PackageRefID: 3, Version: "1.0.2"}}},
+		{ID: 4, Scheme: "semanticdb", Name: "burger", Versions: []shared.PackageRepoRefVersion{{ID: 8, PackageRefID: 4, Version: "1.0.3"}}},
+		{ID: 5, Scheme: "npm", Name: "foo", Versions: []shared.PackageRepoRefVersion{{ID: 9, PackageRefID: 5, Version: "1.0.0"}}},
+		{ID: 6, Scheme: "rust-analyzer", Name: "frogger", Versions: []shared.PackageRepoRefVersion{{ID: 10, PackageRefID: 6, Version: "3.0.0"}}},
 	}
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Errorf("mismatch (-want, +got): %s", diff)

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -173,12 +173,12 @@ func (s *Service) IsPackageRepoVersionAllowed(ctx context.Context, scheme string
 		return false, err
 	}
 
-	allowlist, blocklist, err := packagefilters.NewFilterLists(filters)
+	packageFilters, err := packagefilters.NewFilterLists(filters)
 	if err != nil {
 		return false, err
 	}
 
-	return packagefilters.IsVersionedPackageAllowed(pkg, version, allowlist, blocklist), nil
+	return packagefilters.IsVersionedPackageAllowed(scheme, pkg, version, packageFilters), nil
 }
 
 func (s *Service) IsPackageRepoAllowed(ctx context.Context, scheme string, pkg reposource.PackageName) (allowed bool, err error) {
@@ -196,12 +196,12 @@ func (s *Service) IsPackageRepoAllowed(ctx context.Context, scheme string, pkg r
 		return false, err
 	}
 
-	allowlist, blocklist, err := packagefilters.NewFilterLists(filters)
+	packageFilters, err := packagefilters.NewFilterLists(filters)
 	if err != nil {
 		return false, err
 	}
 
-	return packagefilters.IsPackageAllowed(pkg, allowlist, blocklist), nil
+	return packagefilters.IsPackageAllowed(scheme, pkg, packageFilters), nil
 }
 
 func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter shared.MinimalPackageFilter, limit, after int) (_ []shared.PackageRepoReference, _ int, hasMore bool, err error) {
@@ -252,7 +252,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 			lastID = pkgs[len(pkgs)-1].ID
 
 			for _, pkg := range pkgs {
-				if matcher.Matches(string(pkg.Name), "") {
+				if matcher.Matches(pkg.Name, "") {
 					totalCount++
 					if pkg.ID <= after {
 						continue
@@ -287,7 +287,7 @@ func (s *Service) PackagesOrVersionsMatchingFilter(ctx context.Context, filter s
 		pkg := pkgs[0]
 		versions := pkg.Versions[:0]
 		for _, version := range pkg.Versions {
-			if matcher.Matches(string(pkg.Name), version.Version) {
+			if matcher.Matches(pkg.Name, version.Version) {
 				totalCount++
 				if version.ID <= after {
 					continue


### PR DESCRIPTION
In most existing places, filter schemes were handled correctly as the specific scheme was known and only filters with that scheme were requested. In the background job, we list every filter and every package repo, while applying every filter to every package repo instead of matching filter scheme to package scheme.

This PR fixed this as well as some correctness improvements to the unversioned package matcher

## Test plan

additional unit tests added and existing ones still pass
