### PR TITLE
[Bugfix] permissions center bug fixes

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -111,17 +111,9 @@ func (r *UserResolver) DatabaseID() int32 { return r.user.ID }
 // Email returns the user's oldest email, if one exists.
 // Deprecated: use Emails instead.
 func (r *UserResolver) Email(ctx context.Context) (string, error) {
-	// 🚨 SECURITY: Only the authenticated user can view their email on
-	// Sourcegraph.com.
-	if envvar.SourcegraphDotComMode() {
-		if err := auth.CheckSameUser(ctx, r.user.ID); err != nil {
-			return "", err
-		}
-	} else {
-		// 🚨 SECURITY: Only the user and admins are allowed to access the email address.
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return "", err
-		}
+	// 🚨 SECURITY: Only the user and admins are allowed to access the email address.
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return "", err
 	}
 
 	email, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, r.user.ID)

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -146,9 +146,13 @@ func TestUser_Email(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(orig)
 
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, database.ErrNoCurrentUser)
+		db.UsersFunc.SetDefaultReturn(users)
+
 		_, err := NewUserResolver(db, &types.User{ID: 1}).Email(context.Background())
 		got := fmt.Sprintf("%v", err)
-		want := "must be authenticated as user with id 1"
+		want := "must be authenticated as the authorized user or site admin"
 		assert.Equal(t, want, got)
 	})
 }

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -155,6 +155,44 @@ func TestUser_Email(t *testing.T) {
 		want := "must be authenticated as the authorized user or site admin"
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("allowed by authenticated site admin user on Sourcegraph.com", func(t *testing.T) {
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		defer envvar.MockSourcegraphDotComMode(orig)
+
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, SiteAdmin: true}, nil)
+		db.UsersFunc.SetDefaultReturn(users)
+
+		userEmails := database.NewMockUserEmailsStore()
+		userEmails.GetPrimaryEmailFunc.SetDefaultReturn("john@doe.com", true, nil)
+		db.UserEmailsFunc.SetDefaultReturn(userEmails)
+
+		email, _ := NewUserResolver(db, &types.User{ID: 1}).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 2}))
+		got := fmt.Sprintf("%v", email)
+		want := "john@doe.com"
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
+		orig := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		defer envvar.MockSourcegraphDotComMode(orig)
+
+		users := database.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+		db.UsersFunc.SetDefaultReturn(users)
+
+		userEmails := database.NewMockUserEmailsStore()
+		userEmails.GetPrimaryEmailFunc.SetDefaultReturn("john@doe.com", true, nil)
+		db.UserEmailsFunc.SetDefaultReturn(userEmails)
+
+		email, _ := NewUserResolver(db, &types.User{ID: 1}).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 1}))
+		got := fmt.Sprintf("%v", email)
+		want := "john@doe.com"
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestUser_LatestSettings(t *testing.T) {


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/49168
closes: https://github.com/sourcegraph/sourcegraph/issues/49285

- Allow non admin users to view their permissions sync jobs
- Allow site admins on dotcom to view user's email via `User` gql type. They already can view that from `SiteUser` gql type used in user management.

## Test plan

- added unit tests