### PR TITLE
run protector when release branch exists

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -26,14 +26,16 @@ jobs:
   protect-pr:
     runs-on: ubuntu-latest
     needs: validate_release_branch
-    if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'false' }}
+    # We're manually updating the release protector for now, so we only want to run it when the branch exists. If the branch doesn't exist,
+    # we do not need to run it.
+    if: ${{ needs.validate_release_branch.outputs.releaseBranchExists == 'true' }}
     steps:
       - name: Check backport labels during code freeze
         id: check-backport-labels-during-code-freeze
         run: |
           # Does this PR have the acknowledgement label?
           has_label="${{contains(github.event.pull_request.labels.*.name, 'confirm-no-backport') || contains(github.event.pull_request.labels.*.name, 'backport 5.0')}}"
-          
+
           enabled="true"
           if [ ${enabled} = "true" ]; then
             if [ "${has_label}" = "true" ]; then


### PR DESCRIPTION

<img width="1798" alt="CleanShot 2023-03-13 at 21 55 23@2x" src="https://user-images.githubusercontent.com/25608335/224830194-604b2c3a-f85d-45b7-9ecb-dd7ba681d698.png">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested locally using the `act` library and it worked.

```sh
act --container-architecture linux/amd64 -W .github/workflows/release-protector.yml
[Release protector/validate_release_branch] 🚀  Start image=catthehacker/ubuntu:act-latest
[Release protector/validate_release_branch]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
[Release protector/validate_release_branch]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Release protector/validate_release_branch]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Release protector/validate_release_branch] ⭐ Run Main Check if latest release branch exists
[Release protector/validate_release_branch]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/checkout] user= workdir=
| HTTP/2 200
[Release protector/validate_release_branch]   ⚙  ::set-output:: exists=true
[Release protector/validate_release_branch]   ✅  Success - Main Check if latest release branch exists
[Release protector/validate_release_branch] 🏁  Job succeeded
[Release protector/protect-pr             ] 🚀  Start image=catthehacker/ubuntu:act-latest
[Release protector/protect-pr             ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
[Release protector/protect-pr             ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Release protector/protect-pr             ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Release protector/protect-pr             ] ⭐ Run Main Check backport labels during code freeze
[Release protector/protect-pr             ]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/check-backport-labels-during-code-freeze] user= workdir=
| ❌ Label 'confirm-no-backport' or 'backport 5.0' is absent
| 👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the 'backport 5.0' label your PR. If you don't want to include this change, add 'confirm-no-backport' to merge into main without backport.
| To learn more about backporting, see the handbook https://handbook.sourcegraph.com/departments/engineering/dev/tools/backport/#how-should-i-use-the-backporting-tool
[Release protector/protect-pr             ]   ❌  Failure - Main Check backport labels during code freeze
[Release protector/protect-pr             ] exitcode '1': failure
[Release protector/protect-pr             ] 🏁  Job failed
Error: Job 'protect-pr' failed
```