### PR TITLE
search input: Do not show token information during text selection

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -1,4 +1,4 @@
-import { Extension, MapMode, StateEffect, StateField } from '@codemirror/state'
+import { type Extension, Facet, MapMode, type SelectionRange, StateEffect, StateField } from '@codemirror/state'
 import { Decoration, EditorView, hoverTooltip, TooltipView } from '@codemirror/view'
 
 import { renderMarkdown } from '@sourcegraph/common'
@@ -60,6 +60,12 @@ const hoverStyle = [
     }),
 ]
 
+const tooltipInformationFacet = Facet.define<TooltipInformation | null, TooltipInformation | null>({
+    combine(values) {
+        return values[0] ?? null
+    },
+})
+
 /**
  * Extension for providing token information. This includes showing a popover
  * on hover and highlighting the hovered token.
@@ -94,34 +100,47 @@ export function tokenInfo(): Extension {
             return position
         },
         provide(field) {
-            return EditorView.decorations.compute([field, decoratedTokens], state => {
-                const position = state.field(field)
-                if (!position) {
-                    return Decoration.none
-                }
-
-                const tooltipInfo = getTokensTooltipInformation(state.facet(decoratedTokens), position)
-                if (!tooltipInfo) {
-                    return Decoration.none
-                }
-                let { range } = tooltipInfo
-
-                const token = tooltipInfo.tokensAtCursor[0]
-                switch (token.type) {
-                    case 'keyword': {
-                        // Find operator (AND and OR are supported) and
-                        // highlight its operands too if possible
-                        const operator = findOperatorNode(position, state.facet(parsedQuery))
-                        if (operator) {
-                            range = operator.groupRange ?? operator.range
-                        }
-                        // Highlight operator keyword only
-                        break
+            return [
+                tooltipInformationFacet.compute([field, decoratedTokens], state => {
+                    const position = state.field(field)
+                    if (!position) {
+                        return null
                     }
-                }
 
-                return Decoration.set([tokenHoverDecoration.range(range.start, range.end)])
-            })
+                    return getTokensTooltipInformation(state.facet(decoratedTokens), position)
+                }),
+
+                EditorView.decorations.compute([field, tooltipInformationFacet, 'selection'], state => {
+                    const position = state.field(field)
+                    const tooltipInfo = state.facet(tooltipInformationFacet)
+                    const selection = state.selection.main
+                    if (
+                        !position ||
+                        !tooltipInfo ||
+                        (isTextSelection(selection) &&
+                            intersects(selection.from, selection.to, tooltipInfo.range.start, tooltipInfo.range.end))
+                    ) {
+                        return Decoration.none
+                    }
+                    let { range } = tooltipInfo
+
+                    const token = tooltipInfo.tokensAtCursor[0]
+                    switch (token.type) {
+                        case 'keyword': {
+                            // Find operator (AND and OR are supported) and
+                            // highlight its operands too if possible
+                            const operator = findOperatorNode(position, state.facet(parsedQuery))
+                            if (operator) {
+                                range = operator.groupRange ?? operator.range
+                            }
+                            // Highlight operator keyword only
+                            break
+                        }
+                    }
+
+                    return Decoration.set([tokenHoverDecoration.range(range.start, range.end)])
+                }),
+            ]
         },
     })
 
@@ -132,8 +151,18 @@ export function tokenInfo(): Extension {
         EditorView.domEventHandlers({
             mousemove(event, view) {
                 const position = view.posAtCoords(event)
-                if (position && position !== view.state.field(highlightedTokenPosition)) {
-                    view.dispatch({ effects: setHighlighedTokenPosition.of(position) })
+                let effects: StateEffect<any> | null = null
+
+                // event.buttons === 0 means no button is pressed
+                if (event.buttons > 0) {
+                    // Clear/prevent token highlight while selecting text
+                    effects = setHighlighedTokenPosition.of(null)
+                } else if (position !== null && position !== view.state.field(highlightedTokenPosition)) {
+                    effects = setHighlighedTokenPosition.of(position)
+                }
+
+                if (effects) {
+                    view.dispatch({ effects })
                 }
             },
             mouseleave(_event, view) {
@@ -144,9 +173,14 @@ export function tokenInfo(): Extension {
         }),
         // Shows information about the hovered token
         hoverTooltip(
-            (view, position) => {
-                const tooltipInfo = getTokensTooltipInformation(view.state.facet(decoratedTokens), position)
-                if (!tooltipInfo) {
+            view => {
+                const selection = view.state.selection.main
+                const tooltipInfo = view.state.facet(tooltipInformationFacet)
+                if (
+                    !tooltipInfo ||
+                    (isTextSelection(selection) &&
+                        intersects(selection.from, selection.to, tooltipInfo.range.start, tooltipInfo.range.end))
+                ) {
                     return null
                 }
 
@@ -181,10 +215,27 @@ export function tokenInfo(): Extension {
     ]
 }
 
-function getTokensTooltipInformation(
-    tokens: readonly DecoratedToken[],
-    position: number
-): { tokensAtCursor: readonly DecoratedToken[]; range: { start: number; end: number }; value: string } | null {
+/**
+ * Returns true if both ranges intersect.
+ */
+function intersects(rangeAFrom: number, rangeATo: number, rangeBFrom: number, rangeBTo: number): boolean {
+    return rangeAFrom < rangeBFrom ? rangeBFrom < rangeATo : rangeAFrom < rangeBTo
+}
+
+/**
+ * Returns true of the selection spans mutiple characters.
+ */
+function isTextSelection(range: SelectionRange): boolean {
+    return range.from !== range.to
+}
+
+interface TooltipInformation {
+    tokensAtCursor: readonly DecoratedToken[]
+    range: { start: number; end: number }
+    value: string
+}
+
+function getTokensTooltipInformation(tokens: readonly DecoratedToken[], position: number): TooltipInformation | null {
     const tokensAtCursor = tokens.filter(token => {
         let { start, end } = token.range
         switch (token.type) {


### PR DESCRIPTION
**NOTE:** Hide whitespace changes for review

This commit avoids highlighting tokens and showing hover tooltips during text selection by

- ignoring mouse events when a button is pressed
- checking whether text is selected and intersection with the hovered token

Even if the user is not actively selecting text, text selection and token highlighting a somewhat at odds with each other (I think text selection and _dynamic_ background colors don't work well together). So with this update no hover information will be shown for tokens that are intersection the text selection (hover information is still shown for tokens outside the text selection).

The biggest change in the implementation is that the tooltip extension and the token decoration extension both use the `tooltipInformationFacet` facet to determine what to show instead computing the tooltip information based on their own positioning information. 

Before/after video: 

https://user-images.githubusercontent.com/179026/224833008-7493b557-1865-41a5-b63d-5bc5047a4d53.mp4


## Test plan

- Enter query.
- Hover over tokens -> token highlighted and tooltip shown
- Slowly select text -> no token highlighting or tooltips
- Hover over tokens outside of text selection -> token highlighted and tooltip shown
- Hover over tokens intersecting with text selection -> no token highlighting or tooltips
- Place cursor at the end of a token and hover hover token -> token highlighted and tooltip shown
- Place cursor at the beginning of a token and hover over token -> token highlighted and tooltip shown

## App preview:

- [Web](https://sg-web-fkling-search-input-hover.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
