### PR TITLE
return 1 when src-cli fails to validate to allow scripting

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -1152,6 +1152,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 console.log(chalk.green('All versions matched expected version!'))
             } else {
                 console.log(chalk.red('Failed to verify src-cli versions'))
+                exit(1)
             }
         },
     },


### PR DESCRIPTION
To facilitate some automation, return 1 when the validation fails.
## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-exit-1-when-verifying-src.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
