### PR TITLE
ranking: Improve system throughput

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -236,7 +236,6 @@ Generated query for warning alert: `max((histogram_quantile(0.9, sum by (le) (ra
 **Descriptions**
 
 - <span class="badge badge-critical">critical</span> frontend: 5s+ 90th percentile blob load latency over 10m
-- The 90th percentile of API calls to the blob route in the frontend API is at 5 seconds or more, meaning calls to the blob route, are slow to return a response. The blob API route provides the files and code snippets that the UI displays. When this alert fires, the UI will likely experience delays loading files and code snippets. It is likely that the gitserver and/or frontend services are experiencing issues, leading to slower responses.
 
 **Next steps**
 
@@ -8403,3 +8402,4 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*embeddings"})
 </details>
 
 <br />
+

--- a/enterprise/internal/codeintel/ranking/config.go
+++ b/enterprise/internal/codeintel/ranking/config.go
@@ -22,6 +22,6 @@ func (c *rankingConfig) Load() {
 	c.SymbolExporterInterval = c.GetInterval("CODEINTEL_RANKING_SYMBOL_EXPORTER_INTERVAL", "1s", "How frequently to serialize a batch of the code intel graph for ranking.")
 	c.SymbolExporterReadBatchSize = c.GetInt("CODEINTEL_RANKING_SYMBOL_EXPORTER_READ_BATCH_SIZE", "16", "How many uploads to process at once.")
 	c.SymbolExporterWriteBatchSize = c.GetInt("CODEINTEL_RANKING_SYMBOL_EXPORTER_WRITE_BATCH_SIZE", "10000", "The number of definitions and references to populate the ranking graph per batch.")
-	c.MapperBatchSize = c.GetInt("CODEINTEL_RANKING_MAPPER_BATCH_SIZE", "1000", "How many definitions and references to map at once.")
-	c.ReducerBatchSize = c.GetInt("CODEINTEL_RANKING_REDUCER_BATCH_SIZE", "1000", "How many path counts to reduce at once.")
+	c.MapperBatchSize = c.GetInt("CODEINTEL_RANKING_MAPPER_BATCH_SIZE", "100", "How many definitions and references to map at once.")
+	c.ReducerBatchSize = c.GetInt("CODEINTEL_RANKING_REDUCER_BATCH_SIZE", "100", "How many path counts to reduce at once.")
 }

--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -339,12 +339,16 @@ input_ranks AS (
 		pci.document_path AS path,
 		pci.count
 	FROM codeintel_ranking_path_counts_inputs pci
-	JOIN repo r ON r.id = pci.repository_id
 	WHERE
 		pci.graph_key = %s AND
 		NOT pci.processed AND
-		r.deleted_at IS NULL AND
-		r.blocked IS NULL
+		EXISTS (
+			SELECT 1 FROM repo r
+			WHERE
+				r.id = pci.repository_id AND
+				r.deleted_at IS NULL AND
+				r.blocked IS NULL
+		)
 	ORDER BY pci.graph_key, pci.repository_id, pci.id
 	LIMIT %s
 	FOR UPDATE SKIP LOCKED
@@ -396,7 +400,7 @@ SELECT
 `
 
 // TODO - configure via envvar
-const vacuumBatchSize = 1000
+const vacuumBatchSize = 100
 
 // TODO - configure via envvar
 var threshold = time.Duration(1) * time.Hour

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -290,7 +290,7 @@ func CodeIntelRankingStaleResultAge() time.Duration {
 	if val := Get().CodeIntelRankingStaleResultsAge; val > 0 {
 		return time.Duration(val) * time.Hour
 	}
-	return 72 * time.Hour
+	return 24 * time.Hour
 }
 
 func EmbeddingsEnabled() bool {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2378,7 +2378,7 @@ type SiteConfiguration struct {
 	CodeIntelRankingDocumentReferenceCountsEnabled *bool `json:"codeIntelRanking.documentReferenceCountsEnabled,omitempty"`
 	// CodeIntelRankingDocumentReferenceCountsGraphKey description: An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).
 	CodeIntelRankingDocumentReferenceCountsGraphKey string `json:"codeIntelRanking.documentReferenceCountsGraphKey,omitempty"`
-	// CodeIntelRankingStaleResultsAge description: The interval at which to run the reduce job that computes document reference counts. Default is 72hrs.
+	// CodeIntelRankingStaleResultsAge description: The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.
 	CodeIntelRankingStaleResultsAge int `json:"codeIntelRanking.staleResultsAge,omitempty"`
 	// Completions description: Configuration for the completions service.
 	Completions *Completions `json:"completions,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -687,9 +687,9 @@
       "examples": [""]
     },
     "codeIntelRanking.staleResultsAge": {
-      "description": "The interval at which to run the reduce job that computes document reference counts. Default is 72hrs.",
+      "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
       "type": "integer",
-      "default": 72,
+      "default": 24,
       "group": "Code intelligence"
     },
     "corsOrigin": {


### PR DESCRIPTION
The queries are FINE the batch sizes are just TOO BIG. I lowered them from 1000 to 100 and things started flowing nicely. Right now it takes 30-90s for each of the queries at a batch size of 1000 on sourcegraph.com. They're now running ~100-200ms a batch size of 100, which is much higher throughput.

I also rewrote a join into a correlated subquery because it helped use some part of the reducer index. Query plans looked identical though, so I'm a bit perplexed. Would love to see this get in and just *fix* the stalls in the backend though.

(Timings largely unscientific but still convincing how little variance there was while testing both).

## Test plan

Fiddled with the production database to confirm my hypothesis like a real cowboy developer. 🤠 