### PR TITLE
bazel: add integration test target

### DIFF
--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("//dev:defs.bzl", "ts_project")
+load("//dev:mocha.bzl", "mocha_test")
 
 # integration/ does not contain a src/
 # gazelle:js_files **/*.{ts,tsx}
@@ -96,4 +97,10 @@ ts_project(
         "//client/web:node_modules/@sourcegraph/common",
         "//client/web:node_modules/@sourcegraph/shared",
     ],
+)
+
+mocha_test(
+    name = "integration-tests",
+    tests = [test.replace(".ts", ".js") for test in glob(["**/*.test.ts"])],
+    deps = [":integration_tests"],
 )


### PR DESCRIPTION
## Context

Adds client integration tests target. Currently, it fails with [the output](https://gist.github.com/valerybugakov/df2881d48119442360c97071ae7054d4).

## Test plan

`bazel test //client/web/src/integration:integration-tests`
