### PR TITLE
Add back metadata comparison but remove json ommitempty

### DIFF
--- a/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_existing_changeset_and_existing_fork
+++ b/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_existing_changeset_and_existing_fork
@@ -32,6 +32,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  }

--- a/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_existing_changeset_and_new_fork
+++ b/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_existing_changeset_and_new_fork
@@ -32,6 +32,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  }

--- a/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_new_changeset_and_existing_fork
+++ b/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_new_changeset_and_existing_fork
@@ -32,6 +32,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  }

--- a/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_new_changeset_and_new_fork
+++ b/enterprise/internal/batches/sources/testdata/golden/GithubSource_GetFork_success_with_new_changeset_and_new_fork
@@ -32,6 +32,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  }

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1760,7 +1760,7 @@ type Repository struct {
 	ViewerPermission string // ADMIN, WRITE, READ, or empty if unknown. Only the graphql api populates this. https://developer.github.com/v4/enum/repositorypermission/
 
 	// a list of topics the repository is tagged with
-	RepositoryTopics RepositoryTopics `json:",omitempty"`
+	RepositoryTopics RepositoryTopics
 
 	// Metadata retained for ranking
 	StargazerCount int `json:",omitempty"`
@@ -1773,15 +1773,15 @@ type Repository struct {
 }
 
 type RepositoryTopics struct {
-	Nodes []RepositoryTopic `json:",omitempty"`
+	Nodes []RepositoryTopic
 }
 
 type RepositoryTopic struct {
-	Topic Topic `json:",omitempty"`
+	Topic Topic
 }
 
 type Topic struct {
-	Name string `json:",omitempty"`
+	Name string
 }
 
 type restRepositoryPermissions struct {

--- a/internal/extsvc/github/testdata/golden/ListOrgRepositories
+++ b/internal/extsvc/github/testdata/golden/ListOrgRepositories
@@ -11,7 +11,9 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   },
   {
    "ID": "MDEwOlJlcG9zaXRvcnkyNjMwMzM3NjE=",
@@ -25,6 +27,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "ADMIN",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  ]

--- a/internal/extsvc/github/testdata/golden/ListRepositoriesForSearch
+++ b/internal/extsvc/github/testdata/golden/ListRepositoriesForSearch
@@ -11,6 +11,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "READ",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  ]

--- a/internal/extsvc/github/testdata/golden/ListTeamRepositories
+++ b/internal/extsvc/github/testdata/golden/ListTeamRepositories
@@ -11,6 +11,8 @@
    "IsLocked": false,
    "IsDisabled": false,
    "ViewerPermission": "READ",
-   "RepositoryTopics": {}
+   "RepositoryTopics": {
+    "Nodes": []
+   }
   }
  ]

--- a/internal/extsvc/github/testdata/golden/SearchRepos-huge-query
+++ b/internal/extsvc/github/testdata/golden/SearchRepos-huge-query
@@ -111,7 +111,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": []
+    },
     "StargazerCount": 265043,
     "ForkCount": 21462
    },

--- a/internal/extsvc/github/testdata/golden/TestV3Client_Fork_success_sourcegraph-testing
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_Fork_success_sourcegraph-testing
@@ -10,5 +10,7 @@
   "IsLocked": false,
   "IsDisabled": false,
   "ViewerPermission": "ADMIN",
-  "RepositoryTopics": {}
+  "RepositoryTopics": {
+   "Nodes": []
+  }
  }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_Fork_success_user
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_Fork_success_user
@@ -10,5 +10,7 @@
   "IsLocked": false,
   "IsDisabled": false,
   "ViewerPermission": "ADMIN",
-  "RepositoryTopics": {}
+  "RepositoryTopics": {
+   "Nodes": []
+  }
  }

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_name-with-owner
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_name-with-owner
@@ -33,7 +33,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   },
   {
@@ -70,7 +72,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   }
  ]

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_path-pattern
@@ -33,7 +33,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   },
   {
@@ -70,7 +72,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   }
  ]

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_simple
@@ -33,7 +33,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   },
   {
@@ -70,7 +72,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   }
  ]

--- a/internal/repos/testdata/golden/GithubSource_makeRepo_ssh
+++ b/internal/repos/testdata/golden/GithubSource_makeRepo_ssh
@@ -33,7 +33,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   },
   {
@@ -70,7 +72,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "",
-    "RepositoryTopics": {}
+    "RepositoryTopics": {
+     "Nodes": null
+    }
    }
   }
  ]

--- a/internal/repos/testdata/golden/TestRepositoryQuery_DoSingleRequest/exceeds-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_DoSingleRequest/exceeds-limit
@@ -134,7 +134,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": []
+    },
     "StargazerCount": 10098,
     "ForkCount": 1316
    },
@@ -153,7 +155,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": []
+    },
     "StargazerCount": 10094,
     "ForkCount": 2261
    },
@@ -276,7 +280,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": []
+    },
     "StargazerCount": 10087,
     "ForkCount": 1307
    },
@@ -295,7 +301,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": []
+    },
     "StargazerCount": 10085,
     "ForkCount": 531
    },

--- a/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
@@ -278,7 +278,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10059,
     "ForkCount": 1309
@@ -299,7 +299,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10054,
     "ForkCount": 1304
@@ -471,7 +471,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10029,
     "ForkCount": 874
@@ -594,7 +594,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10021,
     "ForkCount": 719
@@ -615,7 +615,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10017,
     "ForkCount": 1180
@@ -688,7 +688,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10008,
     "ForkCount": 1120
@@ -1103,7 +1103,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10019,
     "ForkCount": 2243
@@ -1181,7 +1181,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10013,
     "ForkCount": 2331
@@ -1487,7 +1487,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10086,
     "ForkCount": 529
@@ -1508,7 +1508,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10057,
     "ForkCount": 661
@@ -1633,7 +1633,7 @@
     "IsDisabled": false,
     "ViewerPermission": "READ",
     "RepositoryTopics": {
-     "Nodes": null
+     "Nodes": []
     },
     "StargazerCount": 10036,
     "ForkCount": 531

--- a/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
@@ -277,7 +277,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10059,
     "ForkCount": 1309
    },
@@ -296,7 +298,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10054,
     "ForkCount": 1304
    },
@@ -466,7 +470,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10029,
     "ForkCount": 874
    },
@@ -587,7 +593,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10021,
     "ForkCount": 719
    },
@@ -606,7 +614,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10017,
     "ForkCount": 1180
    },
@@ -677,7 +687,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10008,
     "ForkCount": 1120
    },
@@ -1090,7 +1102,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10019,
     "ForkCount": 2243
    },
@@ -1166,7 +1180,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10013,
     "ForkCount": 2331
    },
@@ -1470,7 +1486,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10086,
     "ForkCount": 529
    },
@@ -1489,7 +1507,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10057,
     "ForkCount": 661
    },
@@ -1612,7 +1632,9 @@
     "IsLocked": false,
     "IsDisabled": false,
     "ViewerPermission": "READ",
-    "RepositoryTopics": {},
+    "RepositoryTopics": {
+     "Nodes": null
+    },
     "StargazerCount": 10036,
     "ForkCount": 531
    },

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -271,9 +271,10 @@ func (r *Repo) Update(n *Repo) (modified RepoModified) {
 		modified |= RepoModifiedStars
 	}
 
-	// We don't compare the Metadata fields to determine whether or not a repo
-	// has been modified. The reflect.DeepEqual always returns false for
-	// some code hosts (i.e. GitHub).
+	if !reflect.DeepEqual(r.Metadata, n.Metadata) {
+		r.Metadata = n.Metadata
+		modified |= RepoModifiedMetadata
+	}
 
 	for urn, info := range n.Sources {
 		if old, ok := r.Sources[urn]; !ok || !reflect.DeepEqual(info, old) {


### PR DESCRIPTION
Adds back the metadata comparison when updating repo, since otherwise metadata will never be updated. However, for repository topics, remove the `ommitempty` tag in the json string, otherwise `reflect.DeepEqual` always returns false.

## Test plan

Verified locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
