### PR TITLE
prevent auto focusing of input element in FilteredConnection if autoF…

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -452,7 +452,11 @@ class InnerFilteredConnection<N, NP = {}, HP = {}, C extends Connection<N> = Con
                     map(({ queryConnection }) => queryConnection),
                     distinctUntilChanged(),
                     skip(1), // prevent from triggering on initial mount
-                    tap(() => this.focusFilter())
+                    tap(() => {
+                        if (this.props.autoFocus) {
+                            this.focusFilter()
+                        }
+                    })
                 )
                 .subscribe(() =>
                     this.setState({ loading: true, connectionOrError: undefined }, () =>

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
@@ -162,6 +162,7 @@ export const SiteAdminMigrationsPage: React.FunctionComponent<
                             nodeComponent={MigrationNode}
                             nodeComponentProps={{ now }}
                             filters={filters}
+                            autoFocus={false}
                         />
                     </Container>
                 </>


### PR DESCRIPTION
closes #49273

Prevent auto focusing of input element in `FilteredConnection` if `autoFocus=false`



## Test plan

I tested this on the migrations page locally with `sg start` -- this change may affect other uses of `FilteredConnection`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
