### PR TITLE
build-tracker: update bazel files

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -7,6 +7,7 @@ client/build-config/node_modules
 client/client-api/node_modules
 client/codeintellify/node_modules
 client/common/node_modules
+client/cody/node_modules
 client/eslint-plugin-wildcard/node_modules
 client/extension-api/node_modules
 client/extension-api-types/node_modules

--- a/dev/build-tracker/build/BUILD.bazel
+++ b/dev/build-tracker/build/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//dev/build-tracker/util",
+        "//lib/errors",
+        "//dev/build-tracker/notify",
         "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/dev/build-tracker/build/build.go
+++ b/dev/build-tracker/build/build.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/notify"
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/util"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Build keeps track of a buildkite.Build and it's associated jobs and pipeline.
@@ -61,7 +62,7 @@ const (
 func (b *Build) AddJob(j *Job) error {
 	stepName := j.GetName()
 	if stepName == "" {
-		return fmt.Errorf("job %q name is empty", j.GetID())
+		return errors.Newf("job %q name is empty", j.GetID())
 	}
 	step, ok := b.Steps[stepName]
 	// We don't know about this step, so it must be a new one

--- a/dev/build-tracker/notify/BUILD.bazel
+++ b/dev/build-tracker/notify/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//dev/team",
+        "//lib/errors",
         "@com_github_google_go_github_v41//github",
         "@com_github_slack_go_slack//:slack",
         "@com_github_sourcegraph_log//:log",
@@ -17,5 +18,5 @@ go_test(
     name = "notify_test",
     srcs = ["slack_test.go"],
     embed = [":notify"],
-    deps = ["@com_github_hexops_autogold//:autogold"],
+    deps = ["@com_github_hexops_autogold_v2//:autogold"],
 )


### PR DESCRIPTION
update build files to match new usage of libraries
## Test plan
`bazel build //dev/build-tracker/...`
`bazel test //dev/build-tracker/...`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
