### PR TITLE
[feat] disable adding private repos on dotcom

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/singleflight"
 	"golang.org/x/time/rate"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -609,6 +610,14 @@ func (s *Syncer) SyncExternalService(
 		}
 
 		sourced := res.Repo
+
+		if envvar.SourcegraphDotComMode() && sourced.Private {
+			err := errors.Newf("%s is private, but dotcom does not support private repositories.", sourced.Name)
+			syncProgress.Errors++
+			logger.Error("failed to sync private repo", log.String("repo", string(sourced.Name)), log.Error(err))
+			errs = errors.Append(errs, err)
+			continue
+		}
 
 		var diff Diff
 		if diff, err = s.sync(ctx, svc, sourced); err != nil {

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1349,17 +1349,17 @@ func TestCloudDefaultExternalServicesDontSync(t *testing.T) {
 }
 
 func TestDotComPrivateReposDontSync(t *testing.T) {
-	t.Parallel()
-	store := getTestRepoStore(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
 	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	t.Cleanup(func() {
 		envvar.MockSourcegraphDotComMode(orig)
 		cancel()
 	})
+
+	store := getTestRepoStore(t)
 
 	now := time.Now()
 
@@ -1400,6 +1400,7 @@ func TestDotComPrivateReposDontSync(t *testing.T) {
 var basicGitHubConfig = `{"url": "https://github.com", "token": "beef", "repos": ["owner/name"]}`
 
 func TestConflictingSyncers(t *testing.T) {
+	t.Parallel()
 	store := getTestRepoStore(t)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -1344,6 +1346,55 @@ func TestCloudDefaultExternalServicesDontSync(t *testing.T) {
 	if !errors.Is(have, want) {
 		t.Fatalf("have err: %v, want %v", have, want)
 	}
+}
+
+func TestDotComPrivateReposDontSync(t *testing.T) {
+	t.Parallel()
+	store := getTestRepoStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+
+	t.Cleanup(func() {
+		envvar.MockSourcegraphDotComMode(orig)
+		cancel()
+	})
+
+	now := time.Now()
+
+	svc1 := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "Github - Test1",
+		Config:      extsvc.NewUnencryptedConfig(basicGitHubConfig),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	// setup services
+	if err := store.ExternalServiceStore().Upsert(ctx, svc1); err != nil {
+		t.Fatal(err)
+	}
+
+	privateRepo := &types.Repo{
+		Name:    "github.com/org/foo",
+		Private: true,
+	}
+
+	syncer := &repos.Syncer{
+		ObsvCtx: observation.TestContextTB(t),
+		Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
+			s := repos.NewFakeSource(svc1, nil, privateRepo)
+			return s, nil
+		},
+		Store: store,
+		Now:   time.Now,
+	}
+
+	have := syncer.SyncExternalService(ctx, svc1.ID, 10*time.Second, noopProgressRecorder)
+	errorMsg := fmt.Sprintf("%s is private, but dotcom does not support private repositories.", string(privateRepo.Name))
+
+	require.EqualError(t, have, errorMsg)
 }
 
 var basicGitHubConfig = `{"url": "https://github.com", "token": "beef", "repos": ["owner/name"]}`

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1400,7 +1400,6 @@ func TestDotComPrivateReposDontSync(t *testing.T) {
 var basicGitHubConfig = `{"url": "https://github.com", "token": "beef", "repos": ["owner/name"]}`
 
 func TestConflictingSyncers(t *testing.T) {
-	t.Parallel()
 	store := getTestRepoStore(t)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Description

We do not have any private repositories on dotcom right now.

But we do have a few code host connections, that enforce authorization and cause permission syncing to happen for all users that are connected to it.

We should not allow private repositories to be added on dotcom anymore:

1. Security reasons - we do not want to leak private code on dotcom
2. We want to turn the permission syncing off, this will free up CPU and other resources for dotcom, which should make it cheaper to run

## Screenshot

This is how it looks if we get errors when adding private repos to dotcom:
<img width="877" alt="Screenshot 2023-03-14 at 12 46 51" src="https://user-images.githubusercontent.com/9974711/224991630-2f564534-e40d-4eb6-8b94-d4d164897825.png">



## Test plan

tested locally + unit tests
