### PR TITLE
Highlighting: tweak color choices

### DIFF
--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -94,6 +94,28 @@
     --hl-purple: #6c71c4;
     --hl-pink: #d33682;
 
+    // Tailwind 800
+    // --scip-keyword: #c2410c;
+    // --scip-identifier: #1e40af;
+    // --scip-identifier-type: #3730a3;
+    // --scip-identifier-attribute: #86198f;
+    // --scip-identifier-function: #854d0e;
+    // --scip-string-literal: #115e59;
+    // --scip-escape: #991b1b;
+    // --scip-numeric-literal: #155e75;
+    // --scip-comment: #3f6212;
+
+    // Tailwind 700
+    --scip-keyword: #c2410c; // Orange
+    --scip-identifier: #1d4ed8; // Blue
+    --scip-identifier-type: #4338ca; // Indigo
+    --scip-identifier-attribute: #a21caf; // Fuchsia
+    --scip-identifier-function: #a16207; // Yello
+    --scip-string-literal: #0f766e; // Teal
+    --scip-escape: #b91c1c; // Red
+    --scip-numeric-literal: #0e7490; // Cyan
+    --scip-comment: #4d7c0f; // Lime
+
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // Define these in a way that are good. These are just the same values as before.
     --hl-dark-green: #859900;
@@ -486,74 +508,72 @@
     // .hl-typed-$SYNTAX_KIND
 
     .hl-typed-Comment {
-        color: var(--hl-gray-0);
+        color: var(--scip-comment);
     }
-    .hl-typed-PunctuationDelimiter {
-        color: var(--hl-gray-0);
-    }
-    .hl-typed-PunctuationBracket {
-        color: var(--hl-gray-0);
-    }
+    // .hl-typed-PunctuationDelimiter {
+    //     color: var(--hl-gray-0);
+    // }
+    // .hl-typed-PunctuationBracket {
+    //     color: var(--hl-gray-0);
+    // }
     .hl-typed-IdentifierKeyword,
     .hl-typed-Keyword {
-        color: var(--hl-green);
+        color: var(--scip-keyword);
     }
-    .hl-typed-IdentifierOperator {
-        color: var(--hl-gray-3);
-    }
+    // .hl-typed-IdentifierOperator {
+    //     color: var(--hl-gray-3);
+    // }
     .hl-typed-Identifier {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierBuiltin {
-        color: var(--hl-green);
-        // filter: brightness(105%);
+        color: var(--scip-keyword);
     }
     .hl-typed-IdentifierBuiltinType {
-        color: var(--hl-green);
+        color: var(--scip-keyword);
     }
     .hl-typed-IdentifierNull {
-        color: var(--hl-orange);
-        // filter: brightness(130%);
+        color: var(--scip-keyword);
     }
     .hl-typed-BooleanLiteral {
-        color: var(--hl-orange);
+        color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMutableGlobal {
-        color: var(--hl-dark-blue-1);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierParameter {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierLocal {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierShadowed {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierModule,
     .hl-typed-IdentifierNamespace {
-        color: var(--hl-orange); // Same as IdentifierType
+        color: var(--scip-identifier-type);
     }
     .hl-typed-IdentifierFunction {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier-function);
     }
     .hl-typed-IdentifierFunctionDefinition {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier-function);
     }
     .hl-typed-IdentifierMacro {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMacroDefinition {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierType {
-        color: var(--hl-orange);
+        color: var(--scip-identifier-type);
     }
     .hl-typed-IdentifierAttribute {
-        color: var(--hl-pink);
+        color: var(--scip-identifier-attribute);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
@@ -569,28 +589,27 @@
     // }
 
     .hl-typed-StringLiteral {
-        color: var(--hl-cyan);
+        color: var(--scip-string-literal);
     }
     .hl-typed-StringLiteralEscape {
-        color: var(--hl-red);
+        color: var(--scip-escape);
     }
     .hl-typed-StringLiteralSpecial {
-        color: var(--hl-red);
+        color: var(--scip-escape);
     }
     .hl-typed-StringLiteralKey {
-        color: var(--hl-red);
+        color: var(--scip-identifier-attribute);
     }
     .hl-typed-CharacterLiteral {
-        color: var(--hl-red);
+        color: var(--scip-string-literal);
     }
     .hl-typed-NumericLiteral {
-        color: var(--hl-purple);
+        color: var(--scip-numeric-literal);
     }
     .hl-typed-TagAttribute {
-        color: var(--hl-gray-2);
+        color: var(--scip-identifier-attribute);
     }
 
-    // color: var(--hl-gray-3);
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // .hl-typed-Tag {
     // }
@@ -905,77 +924,101 @@
     //
     // Each group should exactly match the name of the spec.
     // .hl-typed-$SYNTAX_KIND
-    --hl-scip-identifier: #859900;
+    --scip-identifier: #859900;
+    --scip-keyword: #429feb;
+    --scip-identifier: #c0c5ce;
+    --scip-identifier-constant: #96b5b4;
+    --scip-identifier-type: #96b5b4;
+    --scip-identifier-attribute: #eb519c; // Properties/fields
+    --scip-identifier-function: #fbd460;
+    --scip-string-literal: #fb90c4;
+    --scip-escape: #d70505;
+    --scip-numeric-literal: #c0c0c9;
+    --scip-comment: #3fad55;
+
+    // Tailwind 300
+    --scip-keyword: #fdba74; // Orange
+    --scip-identifier: #93c5fd; // Blue
+    --scip-identifier-type: #a5b4fc; // Indigo
+    --scip-identifier-attribute: #f0abfc; // Fuchsia
+    --scip-identifier-function: #fde047; // Yellow
+    --scip-string-literal: #5eead4; // Teal
+    --scip-escape: #fca5a5; // Red
+    --scip-numeric-literal: #67e8f9; // Cyan
+    --scip-comment: #bef264; // Lime
 
     .hl-typed-Comment {
-        color: var(--hl-dark-green);
+        color: var(--scip-comment);
     }
-    .hl-typed-PunctuationDelimiter {
-        color: var(--hl-gray-2);
-    }
-    .hl-typed-PunctuationBracket {
-        color: var(--hl-gray-2);
-    }
+    // .hl-typed-PunctuationDelimiter {
+    //     color: var(--hl-gray-2);
+    // }
+    // .hl-typed-PunctuationBracket {
+    //     color: var(--hl-gray-2);
+    // }
     .hl-typed-IdentifierKeyword,
     .hl-typed-Keyword {
-        color: var(--hl-dark-blue-2);
+        color: var(--scip-keyword);
     }
-    .hl-typed-IdentifierOperator {
-        color: var(--hl-gray-0);
-    }
+    // .hl-typed-IdentifierOperator {
+    //     color: var(--hl-gray-0);
+    // }
     .hl-typed-Identifier {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierFunction {
-        color: var(--hl-dark-yellow);
+        color: var(--scip-identifier-function);
     }
     .hl-typed-IdentifierType {
-        color: var(--hl-gray-1);
+        color: var(--scip-identifier-type);
     }
     .hl-typed-IdentifierBuiltin {
-        color: var(--hl-dark-blue-2);
+        color: var(--scip-keyword);
         // filter: brightness(105%);
     }
     .hl-typed-IdentifierBuiltinType {
         color: var(--hl-dark-blue-2);
     }
     .hl-typed-IdentifierNull {
-        color: var(--hl-orange);
+        color: var(--scip-keyword);
         // filter: brightness(130%);
     }
     .hl-typed-BooleanLiteral {
-        color: var(--hl-orange);
+        color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--hl-orange);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMutableGlobal {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierParameter {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierLocal {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierShadowed {
-        color: var(--hl-blue);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierModule,
     .hl-typed-IdentifierNamespace {
-        color: var(--hl-gray-1); // Same as IdentifierType
+        color: var(--scip-identifier-type);
     }
     .hl-typed-IdentifierFunctionDefinition {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier-function);
     }
     .hl-typed-IdentifierMacro {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMacroDefinition {
-        color: var(--hl-yellow);
+        color: var(--scip-identifier);
+    }
+    .hl-typed-IdentifierBuiltinType {
+        color: var(--scip-keyword);
     }
     .hl-typed-IdentifierAttribute {
-        color: var(--hl-purple);
+        color: var(--scip-identifier-attribute);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
@@ -991,25 +1034,25 @@
     // }
 
     .hl-typed-StringLiteral {
-        color: var(--hl-red);
+        color: var(--scip-string-literal);
     }
     .hl-typed-StringLiteralEscape {
-        color: var(--hl-red);
+        color: var(--scip-escape);
     }
     .hl-typed-StringLiteralSpecial {
-        color: var(--hl-red);
+        color: var(--scip-escape);
     }
     .hl-typed-StringLiteralKey {
-        color: var(--hl-red);
+        color: var(--scip-identifier-attribute);
     }
     .hl-typed-CharacterLiteral {
-        color: var(--hl-red);
+        color: var(--scip-string-literal);
     }
     .hl-typed-NumericLiteral {
-        color: var(--hl-green-1);
+        color: var(--scip-numeric-literal);
     }
     .hl-typed-TagAttribute {
-        color: var(--hl-gray-3);
+        color: var(--scip-identifier-attribute);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995

--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -108,6 +108,7 @@
     // Tailwind 700
     --scip-keyword: #c2410c; // Orange
     --scip-identifier: #1d4ed8; // Blue
+    --scip-identifier-constant: #0369a1; // Sky
     --scip-identifier-type: #4338ca; // Indigo
     --scip-identifier-attribute: #a21caf; // Fuchsia
     --scip-identifier-function: #a16207; // Yello
@@ -539,7 +540,7 @@
         color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--scip-identifier);
+        color: var(--scip-identifier-constant);
     }
     .hl-typed-IdentifierMutableGlobal {
         color: var(--scip-identifier);
@@ -924,21 +925,22 @@
     //
     // Each group should exactly match the name of the spec.
     // .hl-typed-$SYNTAX_KIND
-    --scip-identifier: #859900;
-    --scip-keyword: #429feb;
-    --scip-identifier: #c0c5ce;
-    --scip-identifier-constant: #96b5b4;
-    --scip-identifier-type: #96b5b4;
-    --scip-identifier-attribute: #eb519c; // Properties/fields
-    --scip-identifier-function: #fbd460;
-    --scip-string-literal: #fb90c4;
-    --scip-escape: #d70505;
-    --scip-numeric-literal: #c0c0c9;
-    --scip-comment: #3fad55;
+    // --scip-identifier: #859900;
+    // --scip-keyword: #429feb;
+    // --scip-identifier: #c0c5ce;
+    // --scip-identifier-constant: #96b5b4;
+    // --scip-identifier-type: #96b5b4;
+    // --scip-identifier-attribute: #eb519c; // Properties/fields
+    // --scip-identifier-function: #fbd460;
+    // --scip-string-literal: #fb90c4;
+    // --scip-escape: #d70505;
+    // --scip-numeric-literal: #c0c0c9;
+    // --scip-comment: #3fad55;
 
     // Tailwind 300
     --scip-keyword: #fdba74; // Orange
     --scip-identifier: #93c5fd; // Blue
+    --scip-identifier-constant: #7dd3fc; // Sky
     --scip-identifier-type: #a5b4fc; // Indigo
     --scip-identifier-attribute: #f0abfc; // Fuchsia
     --scip-identifier-function: #fde047; // Yellow
@@ -987,7 +989,7 @@
         color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--scip-identifier);
+        color: var(--scip-identifier-constant);
     }
     .hl-typed-IdentifierMutableGlobal {
         color: var(--scip-identifier);

--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -9,6 +9,14 @@
     color: inherit;
 }
 
+:global(.cm-line) {
+    background-color: #282a36 !important;
+}
+
+:global(.selected-line) {
+    background-color: #44475a !important;
+}
+
 .theme-light {
     // Adapted from https://github.com/highlightjs/highlight.js/blob/1b10552510a1ec13a3d30d46281dc268553ad157/src/styles/vs.css
 
@@ -925,16 +933,39 @@
     // Each group should exactly match the name of the spec.
     // .hl-typed-$SYNTAX_KIND
 
+    // Darcula
+    --darcula-background: #282a36;
+    --darcula-current-line: #44475a;
+    --darcula-foreground: #f8f8f2;
+    --darcula-comment: #6272a4;
+    --darcula-cyan: #8be9fd;
+    --darcula-green: #50fa7b;
+    --darcula-orange: #ffb86c;
+    --darcula-pink: #ff79c6;
+    --darcula-purple: #bd93f9;
+    --darcula-red: #ff5555;
+    --darcula-yellow: #f1fa8c;
+
+    --scip-keyword: var(--darcula-orange);
+    --scip-identifier: var(--darcula-foreground);
+    --scip-identifier-type: var(--darcula-foreground);
+    --scip-identifier-attribute: var(--darcula-green);
+    --scip-identifier-function: var(--darcula-yellow);
+    --scip-string-literal: var(--darcula-cyan);
+    --scip-escape: var(--darcula-red);
+    --scip-numeric-literal: var(--darcula-purple);
+    --scip-comment: var(--darcula-comment);
+
     // Tailwind 300
-    --scip-keyword: var(--oc-orange-4);
-    --scip-identifier: var(--oc-blue-3);
-    --scip-identifier-type: var(--oc-indigo-3);
-    --scip-identifier-attribute: var(--oc-grape-3);
-    --scip-identifier-function: var(--oc-yellow-3);
-    --scip-string-literal: var(--oc-teal-3);
-    --scip-escape: var(--oc-red-3);
-    --scip-numeric-literal: var(--oc-cyan-3);
-    --scip-comment: var(--oc-green-5);
+    // --scip-keyword: var(--oc-orange-4);
+    // --scip-identifier: var(--oc-blue-3);
+    // --scip-identifier-type: var(--oc-indigo-3);
+    // --scip-identifier-attribute: var(--oc-grape-3);
+    // --scip-identifier-function: var(--oc-yellow-3);
+    // --scip-string-literal: var(--oc-teal-3);
+    // --scip-escape: var(--oc-red-3);
+    // --scip-numeric-literal: var(--oc-cyan-3);
+    // --scip-comment: var(--oc-green-5);
 
     .hl-typed-Comment {
         color: var(--scip-comment);

--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -106,16 +106,15 @@
     // --scip-comment: #3f6212;
 
     // Tailwind 700
-    --scip-keyword: #c2410c; // Orange
-    --scip-identifier: #1d4ed8; // Blue
-    --scip-identifier-constant: #0369a1; // Sky
-    --scip-identifier-type: #4338ca; // Indigo
-    --scip-identifier-attribute: #a21caf; // Fuchsia
-    --scip-identifier-function: #a16207; // Yello
-    --scip-string-literal: #0f766e; // Teal
-    --scip-escape: #b91c1c; // Red
-    --scip-numeric-literal: #0e7490; // Cyan
-    --scip-comment: #4d7c0f; // Lime
+    --scip-keyword: var(--oc-orange-7);
+    --scip-identifier: var(--oc-blue-7);
+    --scip-identifier-type: var(--oc-indigo-7);
+    --scip-identifier-attribute: var(--oc-grape-7);
+    --scip-identifier-function: var(--oc-yellow-7);
+    --scip-string-literal: var(--oc-teal-7);
+    --scip-escape: var(--oc-red-7);
+    --scip-numeric-literal: var(--oc-cyan-7);
+    --scip-comment: var(--oc-green-7);
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // Define these in a way that are good. These are just the same values as before.
@@ -540,7 +539,7 @@
         color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--scip-identifier-constant);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMutableGlobal {
         color: var(--scip-identifier);
@@ -925,29 +924,17 @@
     //
     // Each group should exactly match the name of the spec.
     // .hl-typed-$SYNTAX_KIND
-    // --scip-identifier: #859900;
-    // --scip-keyword: #429feb;
-    // --scip-identifier: #c0c5ce;
-    // --scip-identifier-constant: #96b5b4;
-    // --scip-identifier-type: #96b5b4;
-    // --scip-identifier-attribute: #eb519c; // Properties/fields
-    // --scip-identifier-function: #fbd460;
-    // --scip-string-literal: #fb90c4;
-    // --scip-escape: #d70505;
-    // --scip-numeric-literal: #c0c0c9;
-    // --scip-comment: #3fad55;
 
     // Tailwind 300
-    --scip-keyword: #fdba74; // Orange
-    --scip-identifier: #93c5fd; // Blue
-    --scip-identifier-constant: #7dd3fc; // Sky
-    --scip-identifier-type: #a5b4fc; // Indigo
-    --scip-identifier-attribute: #f0abfc; // Fuchsia
-    --scip-identifier-function: #fde047; // Yellow
-    --scip-string-literal: #5eead4; // Teal
-    --scip-escape: #fca5a5; // Red
-    --scip-numeric-literal: #67e8f9; // Cyan
-    --scip-comment: #bef264; // Lime
+    --scip-keyword: var(--oc-orange-4);
+    --scip-identifier: var(--oc-blue-3);
+    --scip-identifier-type: var(--oc-indigo-3);
+    --scip-identifier-attribute: var(--oc-grape-3);
+    --scip-identifier-function: var(--oc-yellow-3);
+    --scip-string-literal: var(--oc-teal-3);
+    --scip-escape: var(--oc-red-3);
+    --scip-numeric-literal: var(--oc-cyan-3);
+    --scip-comment: var(--oc-green-5);
 
     .hl-typed-Comment {
         color: var(--scip-comment);
@@ -989,7 +976,7 @@
         color: var(--scip-keyword);
     }
     .hl-typed-IdentifierConstant {
-        color: var(--scip-identifier-constant);
+        color: var(--scip-identifier);
     }
     .hl-typed-IdentifierMutableGlobal {
         color: var(--scip-identifier);


### PR DESCRIPTION
The old color choices for tree-sitter highlighting were mostly random. The choices had a few problems including using low-contrast colors making it difficult to distinguish between colors, and using too many colors where the code is actually easier to read if we use fewer colors.

This PR cleans up the CSS around how we decide colors for SCIP highlighting. There are new `--scip-*` variables that are exclusively used for SCIP syntax kinds. The general strategy to pick colors is:

* Use Tailwind colors from https://tailwindcss.com/docs/customizing-colors
* Aim for high contrast
* Be conservative with number of different colors, meaning we should use fewer colors even if that means different syntax kinds reuse a color.


Early results

<img width="828" alt="CleanShot 2023-03-14 at 14 45 29@2x" src="https://user-images.githubusercontent.com/1408093/225022876-a649e656-3eb0-4284-a2e0-77ac3824e453.png">
<img width="823" alt="CleanShot 2023-03-14 at 14 46 07@2x" src="https://user-images.githubusercontent.com/1408093/225022889-56e4ccfc-6ccd-4e05-8028-17481426de61.png">
<img width="693" alt="CleanShot 2023-03-14 at 14 47 35@2x" src="https://user-images.githubusercontent.com/1408093/225022897-aa9ddb7a-37db-4c6a-bf5a-2b232e560d5d.png">
<img width="760" alt="CleanShot 2023-03-14 at 14 47 32@2x" src="https://user-images.githubusercontent.com/1408093/225022908-056bd452-fc2b-4757-bafb-06e902a49b25.png">

## Test plan

Manually reviewed with standalone web server

```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

The snapshot testing directory is a good place to open different kinds of files

https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@olafurpg/cpp-tweaks/-/tree/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-hl-color.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

