### PR TITLE
build-tracker: fix go to build link

### DIFF
--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -239,7 +239,7 @@ func toBuildNotification(b *build.Build) *notify.BuildNotification {
 		Message:            b.GetMessage(),
 		Commit:             b.GetCommit(),
 		BuildStatus:        "",
-		BuildURL:           *b.URL,
+		BuildURL:           *b.WebURL,
 		Fixed:              []notify.JobLine{},
 		Failed:             []notify.JobLine{},
 	}


### PR DESCRIPTION
Go to build link was pointing to the API url ...
## Test plan
Did a curl request to the buildkite api and inspected the json - also looked at the docs.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
