### PR TITLE
ci: bazel build and test in a single job

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -20,3 +20,7 @@ test --action_env=PGDATABASE
 # Allow tests to understand they're running in CI, which forces dbtest to drop database even in case of failures.
 # TODO(JH) we should instead wipe all templates after a job finishes.
 test --action_env=CI
+
+# Ensure we're not exhausting database connections.
+test --action_env=GOMAXPROCS=10
+test --action_env=TESTDB_MAXOPENCONNS=15

--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -10,17 +10,17 @@ build --disk_cache=/home/buildkite/diskcache
 
 # We need /usr/local/bin
 # TODO(DevX) we should be narrower here.
-test --action_env=PATH
+build --test_env=PATH
 
 # Needed for DB in CI
-test --action_env=PGUSER
-test --action_env=PGSSLMODE
-test --action_env=PGDATABASE
+build --test_env=PGUSER
+build --test_env=PGSSLMODE
+build --test_env=PGDATABASE
 
 # Allow tests to understand they're running in CI, which forces dbtest to drop database even in case of failures.
 # TODO(JH) we should instead wipe all templates after a job finishes.
-test --action_env=CI
+build --test_env=CI
 
 # Ensure we're not exhausting database connections.
-test --action_env=GOMAXPROCS=10
-test --action_env=TESTDB_MAXOPENCONNS=15
+build --test_env=GOMAXPROCS=10
+build --test_env=TESTDB_MAXOPENCONNS=15

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -40,6 +40,7 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" ]]; then
         echo "running normal install"
         ./dev/ci/asdf-install.sh
     fi
-else
-    export BUILDKITE_ARTIFACT_PATHS="$(bazel info bazel-testlogs)/**/*.log"
+# else
+    # Only enable when you're debugging, this produces about 300 log files
+    # export BUILDKITE_ARTIFACT_PATHS="$(bazel info bazel-testlogs)/**/*.log"
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -40,4 +40,6 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" ]]; then
         echo "running normal install"
         ./dev/ci/asdf-install.sh
     fi
+else
+    export BUILDKITE_ARTIFACT_PATHS="$(bazel info bazel-testlogs)/**/*.log"
 fi

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -108,7 +108,7 @@ sg ci build bzl
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel**: Build ..., Tests
+- **Bazel**: Build && Test
 - Upload build trace
 
 ### Wolfi Exp Branch

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -22,7 +22,6 @@ func bazelBuildAndTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
-		bk.ArtifactPaths("$$(bazel info bazel-testlogs)/**/*.log"),
 	}
 
 	for _, target := range targets {
@@ -77,7 +76,6 @@ func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
-		bk.ArtifactPaths("$$(bazel info bazel-testlogs)/**/*.log"),
 	}
 
 	for _, target := range targets {

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -12,9 +12,65 @@ const bazelRemoteCacheURL = "https://storage.googleapis.com/sourcegraph_bazel_ca
 
 func BazelOperations(optional bool) *operations.Set {
 	ops := operations.NewNamedSet("Bazel")
-	ops.Append(bazelBuild(optional, "//..."))
-	ops.Append(bazelTest(optional, "//..."))
+	ops.Append(bazelBuildAndTest(optional, "//..."))
 	return ops
+}
+
+// bazelBuildAndTest will perform a build and test on the same agent, which is the preferred method
+// over running them in two separate jobs, so we don't build the same code twice.
+func bazelBuildAndTest(optional bool, targets ...string) func(*bk.Pipeline) {
+	cmds := []bk.StepOpt{
+		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
+		bk.Agent("queue", "bazel"),
+		bk.ArtifactPaths("$$(bazel info bazel-testlogs)/**/*.log"),
+	}
+
+	for _, target := range targets {
+		bazelBuildCmd := []string{
+			"bazel",
+			"--bazelrc=.bazelrc",
+			"--bazelrc=.aspect/bazelrc/ci.bazelrc",
+			"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
+			fmt.Sprintf("build %s", target),
+			"--remote_cache=$$CI_BAZEL_REMOTE_CACHE",
+			"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
+		}
+
+		bazelTestCmd := []string{
+			"bazel",
+			"--bazelrc=.bazelrc",
+			"--bazelrc=.aspect/bazelrc/ci.bazelrc",
+			"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
+			fmt.Sprintf("test %s", target),
+			"--remote_cache=$$CI_BAZEL_REMOTE_CACHE",
+			"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
+		}
+		cmds = append(
+			cmds,
+			bk.RawCmd(strings.Join(bazelBuildCmd, " ")),
+			bk.RawCmd(strings.Join(bazelTestCmd, " ")),
+		)
+	}
+
+	return func(pipeline *bk.Pipeline) {
+		if optional {
+			cmds = append(cmds, bk.SoftFail())
+		}
+
+		// TODO(JH) Broken we don't have go on the bazel agents
+		// cmds = append(cmds, bk.SlackStepNotify(&bk.SlackStepNotifyConfigPayload{
+		// 	Message:     ":alert: :bazel: test failed",
+		// 	ChannelName: "dev-experience-alerts",
+		// 	Conditions: bk.SlackStepNotifyPayloadConditions{
+		// 		Failed:   true,
+		// 		Branches: []string{"main"},
+		// 	},
+		// }))
+
+		pipeline.AddStep(":bazel: Build && Test",
+			cmds...,
+		)
+	}
 }
 
 func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {


### PR DESCRIPTION
This PR replaces the two separate jobs for building and testing with a single one, which should be faster most of the time and less resource hungry. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

green CI 