### PR TITLE
git-combine: do not create temp folder in repo

### DIFF
--- a/internal/cmd/git-combine/git-combine_test.go
+++ b/internal/cmd/git-combine/git-combine_test.go
@@ -23,6 +23,7 @@ func TestCombine(t *testing.T) {
 	if err := os.WriteFile(setupPath, []byte(`#!/usr/bin/env bash
 
 set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 mkdir origin
 cd origin


### PR DESCRIPTION
The test uses a temp directory, but actually doesn't create the repository in the temp directory. So if you run the test you end up with a dirty working directory.

## Test plan

- Run test, then `git status`