### PR TITLE
experimental search input: Enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [Sourcegraph Own](https://docs.sourcegraph.com/own) is now available as an experimental enterprise feature. Enable the `search-ownership` feature flag to use it.
 - Gitserver supports a new `COURSIER_CACHE_DIR` env var to configure the cache location for coursier JVM package repos.
 - Pings now emit a histogram of repository sizes cloned by Sourcegraph [48211](https://github.com/sourcegraph/sourcegraph/pull/48211).
+- The search input has been redesigned to greatly improve usability. New contextual suggestions help users learn the Sourcegraph query language as they search. Suggestions have been unified across contexts and filters, and the history mode has been integrated into the input. Improved and expanded keyboard shortcuts also make navigation much easier. This functionality is in beta, and can be disabled in the user menu.
 
 ### Changed
 

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -447,6 +447,7 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                     <div
                         ref={editorContainerRef}
                         className={classNames(styles.input, 'test-query-input', 'test-editor')}
+                        data-editor="codemirror6"
                     />
                     {!mode && children}
                 </div>

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -384,7 +384,6 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                         // comboboxes are not allowed to be multiline
                         'aria-multiline': 'false',
                         'aria-controls': popoverID,
-                        'aria-owns': popoverID,
                         'aria-haspopup': 'grid',
                         'aria-label': 'Search query',
                     }),
@@ -437,17 +436,17 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
         return (
             <div
                 ref={inputContainerRef}
-                className={classNames(styles.container, className, {
+                className={classNames(styles.container, className, 'test-experimental-search-input', 'test-editor', {
                     [styles.containerCompact]: visualMode === QueryInputVisualMode.Compact,
                 })}
                 role="search"
+                data-editor="experimental-search-input"
             >
                 <div className={styles.focusContainer}>
                     <SearchModeSwitcher mode={mode} onModeChange={toggleHistoryMode} />
                     <div
                         ref={editorContainerRef}
                         className={classNames(styles.input, 'test-query-input', 'test-editor')}
-                        data-editor="codemirror6"
                     />
                     {!mode && children}
                 </div>

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -380,9 +380,13 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                 () => [
                     EditorView.contentAttributes.of({
                         role: 'combobox',
+                        // CodeMirror sets aria-multiline: true by default but it seems
+                        // comboboxes are not allowed to be multiline
+                        'aria-multiline': 'false',
                         'aria-controls': popoverID,
                         'aria-owns': popoverID,
                         'aria-haspopup': 'grid',
+                        'aria-label': 'Search query',
                     }),
                     staticExtensions,
                     extensionsCompartment.of(dynamicExtensions),
@@ -436,10 +440,15 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                 className={classNames(styles.container, className, {
                     [styles.containerCompact]: visualMode === QueryInputVisualMode.Compact,
                 })}
+                role="search"
             >
                 <div className={styles.focusContainer}>
                     <SearchModeSwitcher mode={mode} onModeChange={toggleHistoryMode} />
-                    <div ref={editorContainerRef} className={styles.input} />
+                    <div
+                        ref={editorContainerRef}
+                        className={classNames(styles.input, 'test-query-input', 'test-editor')}
+                        data-editor="codemirror6"
+                    />
                     {!mode && children}
                 </div>
                 <div

--- a/client/branded/src/search-ui/input/experimental/Suggestions.tsx
+++ b/client/branded/src/search-ui/input/experimental/Suggestions.tsx
@@ -1,7 +1,7 @@
 import React, { MouseEvent, useMemo, useState, useCallback, useLayoutEffect } from 'react'
 
 import { mdiInformationOutline } from '@mdi/js'
-import classnames from 'classnames'
+import classNames from 'classnames'
 
 import { isSafari } from '@sourcegraph/common'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
@@ -118,7 +118,10 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
                                     )}
                                     <div className={styles.innerRow}>
                                         <div className="d-flex flex-wrap">
-                                            <div role="gridcell" className={styles.label}>
+                                            <div
+                                                role="gridcell"
+                                                className={classNames(styles.label, 'test-option-label')}
+                                            >
                                                 {option.render ? (
                                                     renderStringOrRenderer(option.render, option)
                                                 ) : option.matches ? (
@@ -156,7 +159,7 @@ export const Suggestions: React.FunctionComponent<SuggesionsProps> = ({
 }
 
 const Footer: React.FunctionComponent<{ option: Option }> = ({ option }) => (
-    <div className={classnames(styles.footer, 'd-flex align-items-center justify-content-between')}>
+    <div className={classNames(styles.footer, 'd-flex align-items-center justify-content-between')}>
         <span>
             {option.info && renderStringOrRenderer(option.info, option)}
             {!option.info && (

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -516,7 +516,8 @@ const suggestionsStateField = StateField.define<SuggestionsState>({
             const suggestionState = state.field(field)
             const groupRowIndex = suggestionState.result.groupRowIndex(suggestionState.selectedOption)
             return {
-                'aria-expanded': suggestionState.result.empty() ? 'false' : 'true',
+                'aria-expanded':
+                    suggestionState.query.isInactive() || suggestionState.result.empty() ? 'false' : 'true',
                 'aria-activedescendant': groupRowIndex ? `${id}-${groupRowIndex[0]}x${groupRowIndex[1]}` : '',
             }
         })

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -516,8 +516,7 @@ const suggestionsStateField = StateField.define<SuggestionsState>({
             const suggestionState = state.field(field)
             const groupRowIndex = suggestionState.result.groupRowIndex(suggestionState.selectedOption)
             return {
-                'aria-expanded':
-                    suggestionState.query.isInactive() || suggestionState.result.empty() ? 'false' : 'true',
+                'aria-expanded': suggestionState.open && !suggestionState.result.empty() ? 'true' : 'false',
                 'aria-activedescendant': groupRowIndex ? `${id}-${groupRowIndex[0]}x${groupRowIndex[1]}` : '',
             }
         })

--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -308,6 +308,7 @@ const defaultFeatures: SettingsExperimentalFeatures = {
     codeInsightsRepoUI: 'search-query-or-strict-list',
     applySearchQuerySuggestionOnEnter: false,
     isInitialized: true,
+    searchQueryInput: 'experimental',
 }
 
 /**

--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -57,8 +57,10 @@ export async function accessibilityAudit(page: Page, config: AccessibilityAuditC
          * TODO: Design review on some CodeMirror query input features to choose
          * a color that fulfill contrast requirements:
          * https://github.com/sourcegraph/sourcegraph/issues/36534
+         * Additionally role="combobox" cannot be used together with aria-multiline, which
+         * CodeMirror sets by default.
          */
-        .exclude('.cm-content .cm-line')
+        .exclude('.cm-content')
 
     if (options) {
         axe.options(options)

--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -19,7 +19,7 @@ import {
     createFileNamesResult,
 } from './graphQlResponseHelpers'
 import { commonWebGraphQlResults } from './graphQlResults'
-import { createEditorAPI } from './utils'
+import { createEditorAPI, removeContextFromQuery } from './utils'
 
 const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
     ...commonWebGraphQlResults,
@@ -103,7 +103,7 @@ describe('GlobalNavbar', () => {
             await (await driver.page.waitForSelector('.test-breadcrumb-part-last'))?.click()
 
             const input = await createEditorAPI(driver, '.test-query-input')
-            expect(await input.getValue()).toContain('repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md')
+            expect(removeContextFromQuery(await input.getValue() ?? '')).toStrictEqual('repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md')
         })
     })
 

--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -103,7 +103,7 @@ describe('GlobalNavbar', () => {
             await (await driver.page.waitForSelector('.test-breadcrumb-part-last'))?.click()
 
             const input = await createEditorAPI(driver, '.test-query-input')
-            expect(await input.getValue()).toEqual('repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md')
+            expect(await input.getValue()).toContain('repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md')
         })
     })
 

--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -103,7 +103,9 @@ describe('GlobalNavbar', () => {
             await (await driver.page.waitForSelector('.test-breadcrumb-part-last'))?.click()
 
             const input = await createEditorAPI(driver, '.test-query-input')
-            expect(removeContextFromQuery(await input.getValue() ?? '')).toStrictEqual('repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md')
+            expect(removeContextFromQuery((await input.getValue()) ?? '')).toStrictEqual(
+                'repo:^github\\.com/sourcegraph/sourcegraph$ file:^README\\.md'
+            )
         })
     })
 

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -578,7 +578,7 @@ describe('Repository', () => {
             await assertSelectorHasText('.test-tree-entry-file', 'readme.md')
 
             {
-                const queryInput = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
+                const queryInput = await createEditorAPI(driver, '.test-query-input')
                 assert.strictEqual(
                     removeContextFromQuery((await queryInput.getValue()) ?? ''),
                     'repo:^ubuntu/\\+source/quemu$ '

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -28,7 +28,7 @@ import {
     createFileTreeEntriesResult,
 } from './graphQlResponseHelpers'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
-import { createEditorAPI, percySnapshotWithVariants } from './utils'
+import { createEditorAPI, percySnapshotWithVariants, removeContextFromQuery } from './utils'
 
 export const getCommonRepositoryGraphQlResults = (
     repositoryName: string,
@@ -540,9 +540,9 @@ describe('Repository', () => {
             ])
 
             {
-                const queryInput = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
+                const queryInput = await createEditorAPI(driver, '.test-query-input')
                 assert.strictEqual(
-                    await queryInput.getValue(),
+                    removeContextFromQuery((await queryInput.getValue()) ?? ''),
                     "repo:^github\\.com/ggilmore/q-test$ file:^Geoffrey's\\ random\\ queries\\.32r242442bf/%\\ token\\.4288249258\\.sql"
                 )
             }
@@ -579,7 +579,10 @@ describe('Repository', () => {
 
             {
                 const queryInput = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
-                assert.strictEqual(await queryInput.getValue(), 'repo:^ubuntu/\\+source/quemu$ ') // + should be escaped in regular expression
+                assert.strictEqual(
+                    removeContextFromQuery((await queryInput.getValue()) ?? ''),
+                    'repo:^ubuntu/\\+source/quemu$ '
+                ) // + should be escaped in regular expression
             }
 
             // page.click() fails for some reason with Error: Node is either not visible or not an HTMLElement

--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -11,7 +11,7 @@ import { GetSearchAggregationResult, WebGraphQlOperations, SearchAggregationMode
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
-import { createEditorAPI } from './utils'
+import { createEditorAPI, removeContextFromQuery } from './utils'
 
 const aggregationDefaultMock = (mode: SearchAggregationMode): GetSearchAggregationResult => ({
     searchQueryAggregate: {
@@ -131,7 +131,7 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     }),
 }
 
-const QUERY_INPUT_SELECTOR = '[data-testid="searchbox"] .test-query-input'
+const QUERY_INPUT_SELECTOR = '.test-query-input'
 
 describe('Search aggregation', () => {
     let driver: Driver
@@ -320,7 +320,9 @@ describe('Search aggregation', () => {
             await delay(200)
             await driver.page.click('[aria-label="Sidebar search aggregation chart"] a')
 
-            expect(await editor.getValue()).toStrictEqual('insights repo:sourcegraph/sourcegraph')
+            expect(removeContextFromQuery((await editor.getValue()) ?? '')).toStrictEqual(
+                'insights repo:sourcegraph/sourcegraph'
+            )
 
             await driver.page.waitForSelector('[data-testid="expand-aggregation-ui"]')
             await driver.page.click('[data-testid="expand-aggregation-ui"]')
@@ -337,7 +339,9 @@ describe('Search aggregation', () => {
                 '[aria-label="Expanded search aggregation chart"] [aria-label="Bar chart content"] g:nth-child(2) a'
             )
 
-            expect(await editor.getValue()).toStrictEqual('insights repo:sourecegraph/about')
+            expect(removeContextFromQuery((await editor.getValue()) ?? '')).toStrictEqual(
+                'insights repo:sourecegraph/about'
+            )
         })
 
         test('should preserve case sensitive filter in a query', async () => {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -13,7 +13,7 @@ import { WebGraphQlOperations } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
-import { createEditorAPI, percySnapshotWithVariants, withSearchQueryInput } from './utils'
+import { createEditorAPI, getSearchQueryInputConfig, percySnapshotWithVariants } from './utils'
 
 const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
     ...commonWebGraphQlResults,
@@ -91,35 +91,35 @@ describe('Search contexts', () => {
         expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')
     })
 
-    withSearchQueryInput(editorName => {
-        test(`Unavailable search context should remain in the query and disable the search context dropdown with default context (${editorName})`, async () => {
-            testContext.overrideGraphQL({
-                ...testContextForSearchContexts,
-                ...createViewerSettingsGraphQLOverride({
-                    user: {
-                        experimentalFeatures: {
-                            showSearchContext: true,
-                        },
-                    },
-                }),
-                DefaultSearchContextSpec: () => ({
-                    defaultSearchContext: {
-                        __typename: 'SearchContext',
-                        spec: 'ctx-1',
-                    },
-                }),
-            })
+    test('Unavailable search context should remain in the query and disable the search context dropdown with default context', async () => {
+        const { waitForInput, applySettings } = getSearchQueryInputConfig('codemirror6')
 
-            await driver.page.goto(
-                driver.sourcegraphBaseUrl + '/search?q=context:%40unavailableCtx+test&patternType=regexp',
-                { waitUntil: 'networkidle0' }
-            )
-            await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            const editor = await createEditorAPI(driver, '[data-testid="searchbox"] .test-query-input')
-            expect(await editor.getValue()).toStrictEqual('context:@unavailableCtx test')
-            expect(await isSearchContextDropdownDisabled()).toBeTruthy()
-            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:ctx-1')
+        testContext.overrideGraphQL({
+            ...testContextForSearchContexts,
+            ...createViewerSettingsGraphQLOverride({
+                user: applySettings({
+                    experimentalFeatures: {
+                        showSearchContext: true,
+                    },
+                }),
+            }),
+            DefaultSearchContextSpec: () => ({
+                defaultSearchContext: {
+                    __typename: 'SearchContext',
+                    spec: 'ctx-1',
+                },
+            }),
         })
+
+        await driver.page.goto(
+            driver.sourcegraphBaseUrl + '/search?q=context:%40unavailableCtx+test&patternType=regexp',
+            { waitUntil: 'networkidle0' }
+        )
+        await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
+        const editor = await waitForInput(driver, '[data-testid="searchbox"] .test-query-input')
+        expect(await editor.getValue()).toStrictEqual('context:@unavailableCtx test')
+        expect(await isSearchContextDropdownDisabled()).toBeTruthy()
+        expect(await getSelectedSearchContextSpec()).toStrictEqual('context:ctx-1')
     })
 
     test('Reset unavailable search context from default if query is not present', async () => {

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -267,9 +267,7 @@ describe('Search', () => {
                     const editor = await waitForInput(driver, queryInputSelector)
                     await editor.waitForIt()
                     await driver.page.waitForSelector('[data-testid="results-info-bar"]')
-                    expect(await editor.getValue()).toStrictEqual(
-                        name === 'experimental-search-input' ? 'context:global foo' : 'foo'
-                    )
+                    expect(await editor.getValue()).toStrictEqual('foo')
                     // Field value is cleared when navigating to a non search-related page
                     await driver.page.waitForSelector('a[href="/notebooks"]')
                     await driver.page.click('a[href="/notebooks"]')

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -279,9 +279,7 @@ describe('Search', () => {
                     await driver.page.goBack()
                     await editor.waitForIt()
                     await driver.page.waitForSelector('[data-testid="results-info-bar"]')
-                    expect(await editor.getValue()).toStrictEqual(
-                        name === 'experimental-search-input' ? 'context:global foo' : 'foo'
-                    )
+                    expect(await editor.getValue()).toStrictEqual('foo')
                 })
 
                 test('Normalizes input with line breaks', async () => {

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -2,12 +2,7 @@ import expect from 'expect'
 import { test } from 'mocha'
 import { Key } from 'ts-key-enum'
 
-import {
-    NotAvailableReasonType,
-    SearchAggregationMode,
-    SharedGraphQlOperations,
-    SymbolKind,
-} from '@sourcegraph/shared/src/graphql-operations'
+import { SharedGraphQlOperations, SymbolKind } from '@sourcegraph/shared/src/graphql-operations'
 import {
     commitHighlightResult,
     commitSearchStreamEvents,
@@ -64,19 +59,6 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     ...commonWebGraphQlResults,
     IsSearchContextAvailable: () => ({
         isSearchContextAvailable: true,
-    }),
-    GetSearchAggregation: () => ({
-        __typename: 'Query',
-        searchQueryAggregate: {
-            __typename: 'SearchQueryAggregate',
-            aggregations: {
-                __typename: 'SearchAggregationNotAvailable',
-                mode: SearchAggregationMode.REPO,
-                reason: '...',
-                reasonType: NotAvailableReasonType.OTHER_ERROR,
-            },
-            modeAvailability: [],
-        },
     }),
     SuggestionsRepo: () => ({
         __typename: 'Query',
@@ -285,7 +267,9 @@ describe('Search', () => {
                     const editor = await waitForInput(driver, queryInputSelector)
                     await editor.waitForIt()
                     await driver.page.waitForSelector('[data-testid="results-info-bar"]')
-                    expect(await editor.getValue()).toStrictEqual('foo')
+                    expect(await editor.getValue()).toStrictEqual(
+                        name === 'experimental-search-input' ? 'context:global foo' : 'foo'
+                    )
                     // Field value is cleared when navigating to a non search-related page
                     await driver.page.waitForSelector('a[href="/notebooks"]')
                     await driver.page.click('a[href="/notebooks"]')
@@ -295,7 +279,9 @@ describe('Search', () => {
                     await driver.page.goBack()
                     await editor.waitForIt()
                     await driver.page.waitForSelector('[data-testid="results-info-bar"]')
-                    expect(await editor.getValue()).toStrictEqual('foo')
+                    expect(await editor.getValue()).toStrictEqual(
+                        name === 'experimental-search-input' ? 'context:global foo' : 'foo'
+                    )
                 })
 
                 test('Normalizes input with line breaks', async () => {
@@ -303,7 +289,9 @@ describe('Search', () => {
                     const editor = await waitForInput(driver, queryInputSelector)
                     await editor.focus()
                     await driver.paste('foo\n\n\n\n\nbar')
-                    expect(await editor.getValue()).toBe('foo bar')
+                    expect(await editor.getValue()).toBe(
+                        name === 'experimental-search-input' ? 'context:global foo bar' : 'foo bar'
+                    )
                 })
             })
         })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -2,7 +2,12 @@ import expect from 'expect'
 import { test } from 'mocha'
 import { Key } from 'ts-key-enum'
 
-import { SharedGraphQlOperations, SymbolKind } from '@sourcegraph/shared/src/graphql-operations'
+import {
+    NotAvailableReasonType,
+    SearchAggregationMode,
+    SharedGraphQlOperations,
+    SymbolKind,
+} from '@sourcegraph/shared/src/graphql-operations'
 import {
     commitHighlightResult,
     commitSearchStreamEvents,
@@ -22,7 +27,7 @@ import { WebGraphQlOperations } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
-import { createEditorAPI, percySnapshotWithVariants, withSearchQueryInput } from './utils'
+import { getSearchQueryInputConfig, percySnapshotWithVariants, SearchQueryInput, withSearchQueryInput } from './utils'
 
 const mockDefaultStreamEvents: SearchEvent[] = [
     {
@@ -60,6 +65,45 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     IsSearchContextAvailable: () => ({
         isSearchContextAvailable: true,
     }),
+    GetSearchAggregation: () => ({
+        __typename: 'Query',
+        searchQueryAggregate: {
+            __typename: 'SearchQueryAggregate',
+            aggregations: {
+                __typename: 'SearchAggregationNotAvailable',
+                mode: SearchAggregationMode.REPO,
+                reason: '...',
+                reasonType: NotAvailableReasonType.OTHER_ERROR,
+            },
+            modeAvailability: [],
+        },
+    }),
+    SuggestionsRepo: () => ({
+        __typename: 'Query',
+        search: {
+            __typename: 'Search',
+            results: {
+                __typename: 'SearchResults',
+                repositories: [
+                    {
+                        __typename: 'Repository',
+                        name: 'github.com/Algorilla/manta-ray',
+                        stars: 1,
+                    },
+                    {
+                        __typename: 'Repository',
+                        name: 'github.com/Algorilla/manta-ray-2',
+                        stars: 2,
+                    },
+                    {
+                        __typename: 'Repository',
+                        name: 'github.com/Algorilla/manta-ray-3',
+                        stars: 3,
+                    },
+                ],
+            },
+        },
+    }),
 }
 
 const commonSearchGraphQLResultsWithUser: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
@@ -85,7 +129,10 @@ const commonSearchGraphQLResultsWithUser: Partial<WebGraphQlOperations & SharedG
     }),
 }
 
-const queryInputSelector = '[data-testid="searchbox"] .test-query-input'
+const queryInputSelectors: Record<SearchQueryInput, string> = {
+    codemirror6: '[data-testid="searchbox"] .test-query-input',
+    'experimental-search-input': '.test-experimental-search-input',
+}
 
 describe('Search', () => {
     let driver: Driver
@@ -130,30 +177,34 @@ describe('Search', () => {
     })
 
     describe('Filter completion', () => {
-        withSearchQueryInput(editorName => {
-            test.skip(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
+        withSearchQueryInput(({ name, waitForInput, applySettings }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            test.skip(`Completing a negated filter should insert the filter with - prefix (${name})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
-                    ...createViewerSettingsGraphQLOverride(),
+                    ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
                 })
 
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                const editor = await createEditorAPI(driver, queryInputSelector)
+                const editor = await waitForInput(driver, queryInputSelector)
                 await editor.replace('-file')
                 await editor.selectSuggestion('-file')
                 expect(await editor.getValue()).toStrictEqual('-file:')
-                await percySnapshotWithVariants(driver.page, `Search home page (${editorName})`)
+                await percySnapshotWithVariants(driver.page, `Search home page (${name})`)
                 await accessibilityAudit(driver.page)
             })
         })
     })
 
     describe('Suggestions', () => {
-        withSearchQueryInput(editorName => {
-            test.skip(`Typing in the search field shows relevant suggestions (${editorName})`, async () => {
+        withSearchQueryInput(({ name, waitForInput, applySettings }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            test.skip(`Typing in the search field shows relevant suggestions (${name})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
-                    ...createViewerSettingsGraphQLOverride(),
+                    ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
                 })
                 testContext.overrideSearchStreamEvents([
                     {
@@ -187,7 +238,7 @@ describe('Search', () => {
 
                 // Repo autocomplete from homepage
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                const editor = await createEditorAPI(driver, queryInputSelector)
+                const editor = await waitForInput(driver, queryInputSelector)
                 await editor.focus()
                 await editor.replace('repo:go-jwt-middlew')
                 await editor.selectSuggestion('github.com/auth0/go-jwt-middleware')
@@ -218,18 +269,20 @@ describe('Search', () => {
     })
 
     describe('Search field value', () => {
-        withSearchQueryInput(editorName => {
-            describe(editorName, () => {
+        withSearchQueryInput(({ name, waitForInput, applySettings }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            describe(name, () => {
                 beforeEach(() => {
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
-                        ...createViewerSettingsGraphQLOverride(),
+                        ...createViewerSettingsGraphQLOverride({ user: applySettings({}) }),
                     })
                 })
 
                 test('Is set from the URL query parameter when loading a search-related page', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=foo')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await editor.waitForIt()
                     await driver.page.waitForSelector('[data-testid="results-info-bar"]')
                     expect(await editor.getValue()).toStrictEqual('foo')
@@ -247,7 +300,7 @@ describe('Search', () => {
 
                 test('Normalizes input with line breaks', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await editor.focus()
                     await driver.paste('foo\n\n\n\n\nbar')
                     expect(await editor.getValue()).toBe('foo bar')
@@ -257,23 +310,26 @@ describe('Search', () => {
     })
 
     describe('Case sensitivity toggle', () => {
-        withSearchQueryInput(editorName => {
-            describe(editorName, () => {
+        withSearchQueryInput(({ name, applySettings, waitForInput }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            describe(name, () => {
                 beforeEach(() => {
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
-                        ...createViewerSettingsGraphQLOverride(),
+                        ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
                     })
                 })
 
                 test('Clicking toggle turns on case sensitivity', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await editor.focus()
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-case-sensitivity-toggle')
-                    await driver.page.click('aria/Search[role="button"]')
+                    await editor.focus()
+                    await driver.page.keyboard.press(Key.Enter)
                     await driver.assertWindowLocation(
                         '/search?q=context:global+test&patternType=standard&case=yes&sm=1'
                     )
@@ -281,11 +337,16 @@ describe('Search', () => {
 
                 test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
                     await driver.page.goto(
-                        driver.sourcegraphBaseUrl + '/search?q=test&patternType=standard&case=yes&sm=1'
+                        driver.sourcegraphBaseUrl + '/search?q=context:global+test&patternType=standard&case=yes&sm=1'
                     )
-                    await createEditorAPI(driver, queryInputSelector)
+                    const input = await waitForInput(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await driver.page.click('.test-case-sensitivity-toggle')
+                    if (name === 'experimental-search-input') {
+                        // The the toggle buttons do not submit automatically in the new search input
+                        await input.focus()
+                        await driver.page.keyboard.press(Key.Enter)
+                    }
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=1')
                 })
             })
@@ -293,40 +354,53 @@ describe('Search', () => {
     })
 
     describe('Structural search toggle', () => {
-        withSearchQueryInput(editorName => {
-            describe(editorName, () => {
+        withSearchQueryInput(({ name, applySettings, waitForInput }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            describe(name, () => {
                 beforeEach(() => {
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
-                        ...createViewerSettingsGraphQLOverride(),
+                        ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
                     })
                 })
 
                 test('Clicking toggle turns on structural search', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await editor.focus()
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.page.click('aria/Search[role="button"]')
+                    await editor.focus()
+                    await driver.page.keyboard.press(Key.Enter)
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=1')
                 })
 
                 test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await editor.focus()
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
+                    if (name === 'experimental-search-input') {
+                        // The the toggle buttons do not submit automatically in the new search input
+                        await editor.focus()
+                        await driver.page.keyboard.press(Key.Enter)
+                    }
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=0')
                 })
 
                 test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=structural')
-                    await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
+                    if (name === 'experimental-search-input') {
+                        // The the toggle buttons do not submit automatically in the new search input
+                        await editor.focus()
+                        await driver.page.keyboard.press(Key.Enter)
+                    }
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=0')
                 })
             })
@@ -334,9 +408,18 @@ describe('Search', () => {
     })
 
     describe('Search button', () => {
+        const { waitForInput, applySettings } = getSearchQueryInputConfig('codemirror6')
+
+        beforeEach(() => {
+            testContext.overrideGraphQL({
+                ...commonSearchGraphQLResults,
+                ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
+            })
+        })
+
         test('Clicking search button executes search', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
-            const editor = await createEditorAPI(driver, queryInputSelector)
+            const editor = await waitForInput(driver, queryInputSelectors.codemirror6)
             await editor.focus()
             await driver.page.keyboard.type(' hello')
 
@@ -559,12 +642,14 @@ describe('Search', () => {
     })
 
     describe('Search sidebar', () => {
-        withSearchQueryInput(editorName => {
-            describe(editorName, () => {
+        withSearchQueryInput(({ name, waitForInput, applySettings }) => {
+            const queryInputSelector = queryInputSelectors[name]
+
+            describe(name, () => {
                 beforeEach(() => {
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
-                        ...createViewerSettingsGraphQLOverride(),
+                        ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
                     })
                 })
 
@@ -572,7 +657,7 @@ describe('Search', () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test')
                     await driver.page.waitForSelector('[data-testid="search-type-suggest"]')
                     await driver.page.click('[data-testid="search-type-suggest"]')
-                    const editor = await createEditorAPI(driver, queryInputSelector)
+                    const editor = await waitForInput(driver, queryInputSelector)
                     await editor.waitForSuggestion()
                     expect(await editor.getValue()).toEqual('test repo:')
                 })

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -395,6 +395,12 @@ export const withSearchQueryInput = (callback: (config: SearchQueryInputAPI) => 
     }
 }
 
+/**
+ * This helper function removes any context:... filter in the query (via regular expression)
+ * to make it easier to compare query inputs when the context doesn't amtter.
+ */
+export const removeContextFromQuery = (input: string): string => input.replace(/\s*context:\S*\s*/, '')
+
 export const isElementDisabled = (driver: Driver, query: string): Promise<boolean> =>
     driver.page.evaluate((query: string) => {
         const element = document.querySelector<HTMLButtonElement>(query)


### PR DESCRIPTION
**NOTE:** Hide whitespace differences for review.

This enables the new search input by default. It can still be disabled in the user menu.

This PR also updates the existing integration tests to work with the new and the old input. I'm not super happy about mixing configurations for "higher level" inputs (the search input) and lower level components (Monaco, CodeMirror), but this was the less intrusive way to get this working.
Note that I've updated the skipped tests as well but haven't actually run them.
I'd love to clean up the helper API and tests eventually.

## Test plan

Go to https://sourcegraph.test:3443 and see that the new search input is enabled even when not logged in.
CI

## App preview:

- [Web](https://sg-web-fkling-search-input-enable.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
