### PR TITLE
App: Fix esbuild production build

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -17,11 +17,10 @@ import {
 } from '@sourcegraph/build-config'
 import { isDefined } from '@sourcegraph/common'
 
-import { ENVIRONMENT_CONFIG } from '../utils'
+import { ENVIRONMENT_CONFIG, IS_DEVELOPMENT, IS_PRODUCTION } from '../utils'
 
 import { manifestPlugin } from './manifestPlugin'
 
-const hashedEntrypoint = Boolean(process.env.ESBUILD_HASHED_ENTRYPOINT)
 const isEnterpriseBuild = ENVIRONMENT_CONFIG.ENTERPRISE
 const omitSlowDeps = ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
 
@@ -34,13 +33,14 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
             : path.join(ROOT_PATH, 'client/web/src/main.tsx'),
     },
     bundle: true,
+    minify: IS_PRODUCTION,
     format: 'esm',
     logLevel: 'error',
     jsx: 'automatic',
-    jsxDev: true, // we're only using esbuild for dev server right now
+    jsxDev: IS_DEVELOPMENT,
     splitting: true,
     chunkNames: 'chunks/chunk-[name]-[hash]',
-    entryNames: hashedEntrypoint ? 'scripts/[name]-[hash]' : undefined,
+    entryNames: IS_PRODUCTION ? 'scripts/[name]-[hash]' : undefined,
     outdir: STATIC_ASSETS_PATH,
     plugins: [
         stylePlugin,

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -20,7 +20,7 @@
     "task:gulp": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
     "dev": "pnpm task:gulp dev",
     "unsafeDev": "pnpm task:gulp unsafeDev",
-    "build": "ESBUILD_HASHED_ENTRYPOINT=1 pnpm task:gulp build",
+    "build": "NODE_ENV=production pnpm task:gulp build",
     "watch": "pnpm task:gulp watch",
     "watch-webpack": "pnpm task:gulp watchWebpack",
     "webpack": "pnpm task:gulp webpack",


### PR DESCRIPTION
Closes #49108
Follow up to #49029

This properly sets up esbuild to work for production build. The changes necessary were to:

- Disable jsxDev in production
- Enable minification in production

Additionally, this removes the workaround `ESBUILD_HASHED_ENTRYPOINT` flag added in #49029

We also now pass `NODE_ENV=production` directly to the build command in `client/web/package.json` (We do this for other client packages too)

## Test plan

1.  First of all we need to be able to run a dev server with the production build artifacts. To do this, I applied the following patch:
  ```diff
  diff --git a/gulpfile.js b/gulpfile.js
  index 36c27daa34..229ac4428b 100644
  --- a/gulpfile.js
  +++ b/gulpfile.js
  @@ -18,7 +18,7 @@ const build = gulp.series(generate, webWebpack)
  /**
    * Watches everything and rebuilds on file changes.
    */
  -const development = gulp.series(generate, gulp.parallel(watchGenerators, developmentServer))
  +const development = developmentServer //gulp.series(generate, gulp.parallel(watchGenerators, developmentServer))

  module.exports = {
    generate,
  (END)
```
1. Now we can create a build via `ENTERPRISE=1 DEV_WEB_BUILDER=esbuild pnpm run build-web`
1. Start the dev server via `sg start app`
1. See that the app is now running in production mode:
  <img width="475" alt="Screenshot 2023-03-14 at 19 26 00" src="https://user-images.githubusercontent.com/458591/225104083-dd6bfe84-b6c2-43b9-97c0-7d2f032be234.png">
1. Also verify that `DEV_WEB_BUILDER=esbuild sg start app` is still running in dev mode (I made a change to the GlobalNav to verify everything works as it did before)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
