### PR TITLE
doc: update broken executor links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
 - [Webhooks](https://docs.sourcegraph.com/admin/config/webhooks) have been overhauled completely and can now be found under **Site admin > Repositories > Incoming webhooks**. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
 - Added support for receiving webhook `push` events from GitHub which will trigger Sourcegraph to fetch the latest commit rather than relying on polling.
-- Added support for private container registries in Sourcegraph executors. [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries)
+- Added support for private container registries in Sourcegraph executors. [Using private registries](https://docs.sourcegraph.com/admin/executors/deploy_executors#using-private-registries)
 
 ### Changed
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -657,7 +657,7 @@ cc @${release.captainGitHubUsername}
                             // Update Sourcegraph versions in installation guides
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E 's/SOURCEGRAPH_VERSION="v${versionRegex}"/SOURCEGRAPH_VERSION="v${release.version.version}"/g' {} +`,
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E 's/--version ${versionRegex}/--version ${release.version.version}/g' {} +`,
-                            `${sed} -i -E 's/${versionRegex}/${release.version.version}/g' ./doc/admin/deploy_executors_kubernetes.md`,
+                            `${sed} -i -E 's/${versionRegex}/${release.version.version}/g' ./doc/admin/executors/deploy_executors_kubernetes.md`,
                             // Update fork variables in installation guides
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E "s/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${versionRegex}'/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${release.version.version}'/g" {} +`,
 

--- a/doc/admin/deploy_executors_kubernetes.md
+++ b/doc/admin/deploy_executors_kubernetes.md
@@ -25,7 +25,7 @@ Ensure you have the following tools installed:
 
 1. Clone the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository to your local machine.
 2. Run `cd deploy-sourcegraph/configure/executors`.
-3. Configure the [Executor environment variables](https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables) in the `executor/executor.deployment.yaml` file.
+3. Configure the [Executor environment variables](https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables) in the `executor/executor.deployment.yaml` file.
 4. Run  `kubectl apply -f . --recursive` to deploy all components.
 5. Confirm executors are working are working by checking the _Executors_ page under _Site Admin_ > _Executors_ > _Instances_ .
 

--- a/doc/admin/executors/deploy_executors.md
+++ b/doc/admin/executors/deploy_executors.md
@@ -95,24 +95,24 @@ Once the shared secret is set in Sourcegraph, you can start setting up executors
 ### Supported installation types
 
 <div class="grid">
-  <a class="btn-app btn" href="/admin/deploy_executors_terraform">
+  <a class="btn-app btn" href="/admin/executors/deploy_executors_terraform">
     <h3>Terraform</h3>
     <p>Simply launch executors on AWS or GCP using Sourcegraph-maintained modules and machine images.</p>
     <p>Supports auto scaling.</p>
   </a>
-  <a class="btn-app btn" href="/admin/deploy_executors_binary">
+  <a class="btn-app btn" href="/admin/executors/deploy_executors_binary">
     <h3>Install executor on your machine</h3>
     <p>Run executors on any linux amd64 machine.</p>
   </a>
 </div>
 
 <div class="grid">
-  <a class="btn-app btn" href="/admin/deploy_executors_kubernetes">
+  <a class="btn-app btn" href="/admin/executors/deploy_executors_kubernetes">
     <h3>Kubernetes</h3>
     <p>Run executors on kubernetes</p>
     <p>Requires privileged access to a container runtime.</p>
   </a>
-  <a class="btn-app btn" href="/admin/deploy_executors_docker">
+  <a class="btn-app btn" href="/admin/executors/deploy_executors_docker">
     <h3>Docker Compose</h3>
     <p>Run executors on any linux amd64 machine with docker-compose</p>
     <p>Requires privileged access to a container runtime.</p>

--- a/doc/admin/executors/executors_troubleshooting.md
+++ b/doc/admin/executors/executors_troubleshooting.md
@@ -3,7 +3,7 @@ This page compiles a list of common troubleshooting steps found during developme
 
 
 ## Disabling the auto-deletion of Executor VMs
-> NOTE: These instructions are for users using the VMs deployed via the [Terraform Modules](https://docs.sourcegraph.com/admin/deploy_executors_terraform)
+> NOTE: These instructions are for users using the VMs deployed via the [Terraform Modules](https://docs.sourcegraph.com/admin/executors/deploy_executors_terraform)
 
 The Executor host VMs are configured to automatically tear themselves down once all jobs in the queue are completed. While this is desired behaviour under regular circumstances, it complicates debugging issues in the executor configuration or connections. To prevent the VMs from automatically stopping:
 1. `ssh` into the VM
@@ -15,7 +15,7 @@ The VM should now persist after all jobs are satisfied.
 ## Creating a Debug Firecracker VM
 To create a temporary Firecracker VM for debugging purposes:
 
-> NOTE: if the host VM is provisioned with the [Sourcegraph terraform modules](https://docs.sourcegraph.com/admin/deploy_executors_terraform), the VMs may be configured to stop automatically. Refer to [Disabling the auto-deletion of Executor VMs](#disabling-the-auto-deletion-of-executor-vms) for information to prevent this.
+> NOTE: if the host VM is provisioned with the [Sourcegraph terraform modules](https://docs.sourcegraph.com/admin/executors/deploy_executors_terraform), the VMs may be configured to stop automatically. Refer to [Disabling the auto-deletion of Executor VMs](#disabling-the-auto-deletion-of-executor-vms) for information to prevent this.
 
 1. `ssh` into the host VM
 1. `sudo su` to become the `root` user
@@ -31,7 +31,7 @@ To create a temporary Firecracker VM for debugging purposes:
 ## Recreating a Firecracker VM 
 If a server-side batch change fails unexpectedly, it's possible to recreate the generated Firecracker VM from the batch change execution.
 
-> NOTE: if the host VM is provisioned with the [Sourcegraph terraform modules](https://docs.sourcegraph.com/admin/deploy_executors_terraform), the VMs may be configured to stop automatically. Refer to [Disabling the auto-deletion of Executor VMs](#disabling-the-auto-deletion-of-executor-vms) for information to prevent this.
+> NOTE: if the host VM is provisioned with the [Sourcegraph terraform modules](https://docs.sourcegraph.com/admin/executors/deploy_executors_terraform), the VMs may be configured to stop automatically. Refer to [Disabling the auto-deletion of Executor VMs](#disabling-the-auto-deletion-of-executor-vms) for information to prevent this.
 
 1. Navigate to the failed execution page of the Batch Change
 1. Select a failed Workspace on the left and click the `Diagnostics` link on the right pane


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/49155 moved the paths for these and these links were not correctly updated.

## Test plan
Manual review. Docs change.

## App preview:

- [Web](https://sg-web-dd-fix-executors-links.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
