### PR TITLE
jscontext: Use faster, non-blocking method to determine initialized state

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -226,8 +226,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	siteID := siteid.Get()
 
 	// Show the site init screen?
-	globalState, err := db.GlobalState().Get(ctx)
-	needsSiteInit := err == nil && !globalState.Initialized
+	siteInitialized, err := db.GlobalState().SiteInitialized(ctx)
+	needsSiteInit := err == nil && !siteInitialized
 
 	// Auth providers
 	var authProviders []authProviderInfo

--- a/internal/database/global_state.go
+++ b/internal/database/global_state.go
@@ -94,11 +94,7 @@ func (g *globalStateStore) SiteInitialized(ctx context.Context) (bool, error) {
 	return alreadyInitialized, err
 }
 
-var globalStateSiteInitializedQuery = fmt.Sprintf(`
-%s
-`,
-	globalStateInitializedFragment,
-)
+var globalStateSiteInitializedQuery = globalStateInitializedFragment
 
 func (g *globalStateStore) EnsureInitialized(ctx context.Context) (_ bool, err error) {
 	if err := g.initializeDBState(ctx); err != nil {
@@ -133,7 +129,6 @@ func (g *globalStateStore) initializeDBState(ctx context.Context) (err error) {
 		return err
 	}
 	defer func() { err = tx.Done(err) }()
-
 	if err := tx.Exec(ctx, sqlf.Sprintf(globalStateInitializeDBStateUpdateQuery)); err != nil {
 		return err
 	}


### PR DESCRIPTION
The Get method ensures the site id has been generated already, which requires a transaction and effectively sequentializes page loads across frontend instances. This is a simple read and will not block. I've seen 120k of these queries in 1h on dotcom, and they had pretty bad lock contention, effectively on average making page loads 17ms slower in that window, according to query insights. This doesn't happen often, but still a small improvement maybe?

## Test plan

CI test suite.