### PR TITLE
Highlighting: use same color for IdentifierNamespace and IdentifierType

### DIFF
--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -535,7 +535,7 @@
     }
     .hl-typed-IdentifierModule,
     .hl-typed-IdentifierNamespace {
-        color: var(--hl-blue);
+        color: var(--hl-orange); // Same as IdentifierType
     }
     .hl-typed-IdentifierFunction {
         color: var(--hl-yellow);
@@ -960,7 +960,7 @@
     }
     .hl-typed-IdentifierModule,
     .hl-typed-IdentifierNamespace {
-        color: var(--hl-blue);
+        color: var(--hl-gray-1); // Same as IdentifierType
     }
     .hl-typed-IdentifierFunctionDefinition {
         color: var(--hl-yellow);


### PR DESCRIPTION
This makes code like `std::vector` in C++ have the the same color for `std` and `vector`. The IdentifierNamespace kind is only used by C++ for now so this is a low-risk change to merge and backport into 5.0.

Note: there are still cases where we have `NAMESPACE::IDENTIFIER` where each have different colors.

Examples
<img width="614" alt="CleanShot 2023-03-14 at 20 37 57@2x" src="https://user-images.githubusercontent.com/1408093/225118402-c2cf4b27-a18c-411b-9b5c-e8a482a45958.png">
<img width="339" alt="CleanShot 2023-03-14 at 20 37 47@2x" src="https://user-images.githubusercontent.com/1408093/225118405-42bc2a7c-b851-41ef-ac75-4758c68c3704.png">

<img width="543" alt="CleanShot 2023-03-14 at 20 40 40@2x" src="https://user-images.githubusercontent.com/1408093/225118393-9e7e9df9-2bbd-4565-8f94-4f0706ece5e7.png">


## Test plan


Manually tested with `sg start` and opening files here https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@olafurpg/cpp-tweaks/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/cpp_example2.cc
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-scip-namespace.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
