### PR TITLE
Bug fix: Setup Wizard > Determine no repos exist status in nav

### DIFF
--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -83,10 +83,6 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
         productVersion: '0.0.0+dev',
     }),
 
-    StatusMessages: () => ({
-        statusMessages: [],
-    }),
-
     EventLogsData: () => ({
         node: {
             __typename: 'User',

--- a/client/web/src/nav/StatusMessagesNavItem.mocks.ts
+++ b/client/web/src/nav/StatusMessagesNavItem.mocks.ts
@@ -2,11 +2,11 @@ import { MockedResponse } from '@apollo/client/testing'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 
-import { StatusMessagesResult } from '../graphql-operations'
+import { StatusAndRepoStatsResult } from '../graphql-operations'
 
-import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
+import { STATUS_AND_REPO_STATS } from './StatusMessagesNavItemQueries'
 
-export const allStatusMessages: StatusMessagesResult['statusMessages'] = [
+export const allStatusMessages: StatusAndRepoStatsResult['statusMessages'] = [
     {
         __typename: 'ExternalServiceSyncError',
         externalService: {
@@ -31,10 +31,10 @@ export const allStatusMessages: StatusMessagesResult['statusMessages'] = [
 ]
 
 export const newStatusMessageMock = (
-    messages: StatusMessagesResult['statusMessages']
-): MockedResponse<StatusMessagesResult> => ({
+    messages: StatusAndRepoStatsResult['statusMessages']
+): MockedResponse<StatusAndRepoStatsResult> => ({
     request: {
-        query: getDocumentNode(STATUS_MESSAGES),
+        query: getDocumentNode(STATUS_AND_REPO_STATS),
     },
     result: {
         data: {

--- a/client/web/src/nav/StatusMessagesNavItem.mocks.ts
+++ b/client/web/src/nav/StatusMessagesNavItem.mocks.ts
@@ -39,6 +39,16 @@ export const newStatusMessageMock = (
     result: {
         data: {
             statusMessages: messages,
+            repositoryStats: {
+                __typename: 'RepositoryStats',
+                cloned: 7,
+                cloning: 0,
+                corrupted: 0,
+                failedFetch: 0,
+                indexed: 7,
+                notCloned: 0,
+                total: 7,
+            },
         },
     },
 })

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -24,10 +24,9 @@ import {
     ErrorAlert,
 } from '@sourcegraph/wildcard'
 
-import { StatusMessagesResult, RepositoryStatsResult, RepositoryStatsVariables } from '../graphql-operations'
-import { REPOSITORY_STATS } from '../site-admin/backend'
+import { StatusAndRepoStatsResult } from '../graphql-operations'
 
-import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
+import { STATUS_AND_REPO_STATS } from './StatusMessagesNavItemQueries'
 
 import styles from './StatusMessagesNavItem.module.scss'
 
@@ -164,12 +163,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
     const [isOpen, setIsOpen] = useState(false)
     const toggleIsOpen = (): void => setIsOpen(old => !old)
 
-    const { data, error } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
-        fetchPolicy: 'no-cache',
-        pollInterval: props.disablePolling !== true ? STATUS_MESSAGES_POLL_INTERVAL : undefined,
-    })
-
-    const { data: repoData } = useQuery<RepositoryStatsResult, RepositoryStatsVariables>(REPOSITORY_STATS, {
+    const { data, error } = useQuery<StatusAndRepoStatsResult>(STATUS_AND_REPO_STATS, {
         fetchPolicy: 'no-cache',
         pollInterval: props.disablePolling !== true ? STATUS_MESSAGES_POLL_INTERVAL : undefined,
     })
@@ -197,7 +191,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
             codeHostMessage = 'Indexing repositories...'
             iconProps = { as: CloudSyncIconRefresh }
-        } else if (data.statusMessages.length === 0 && repoData?.repositoryStats.total === 0) {
+        } else if (data.statusMessages.length === 0 && data.repositoryStats.total === 0) {
             codeHostMessage = 'No repositories detected'
             iconProps = { as: CloudAlertIconRefresh }
         } else {
@@ -223,7 +217,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
 
         // no status messages
         if (data.statusMessages.length === 0) {
-            if (repoData?.repositoryStats.total === 0) {
+            if (data.repositoryStats.total === 0) {
                 return (
                     <StatusMessagesNavItemEntry
                         key="no-repositories"

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -1,7 +1,17 @@
 import { gql } from '@sourcegraph/http-client'
 
-export const STATUS_MESSAGES = gql`
-    query StatusMessages {
+export const STATUS_AND_REPO_STATS = gql`
+    query StatusAndRepoStats {
+        repositoryStats {
+            __typename
+            total
+            notCloned
+            cloned
+            cloning
+            failedFetch
+            corrupted
+            indexed
+        }
         statusMessages {
             ... on GitUpdatesDisabled {
                 __typename

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -10,16 +10,13 @@ import {
 } from '@sourcegraph/shared/src/components/icons'
 import { Icon, Text } from '@sourcegraph/wildcard'
 
-import { RepositoryStatsResult, RepositoryStatsVariables, StatusMessagesResult } from '../../graphql-operations'
-import { STATUS_MESSAGES } from '../../nav/StatusMessagesNavItemQueries'
-import { REPOSITORY_STATS } from '../../site-admin/backend'
+import { StatusAndRepoStatsResult } from '../../graphql-operations'
+import { STATUS_AND_REPO_STATS } from '../../site-admin/backend'
 
 import styles from './ProgressBar.module.scss'
 
 export const ProgressBar: FC<{}> = () => {
-    const { data } = useQuery<RepositoryStatsResult, RepositoryStatsVariables>(REPOSITORY_STATS, { pollInterval: 2000 })
-
-    const { data: statusData } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
+    const { data } = useQuery<StatusAndRepoStatsResult>(STATUS_AND_REPO_STATS, {
         fetchPolicy: 'cache-and-network',
         pollInterval: 2000,
     })
@@ -63,14 +60,14 @@ export const ProgressBar: FC<{}> = () => {
         let codeHostMessage
         let iconProps
 
-        if (!statusData || statusData.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
+        if (!data || data.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Syncing'
             iconProps = { as: CloudSyncIconRefresh }
-        } else if (statusData.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
+        } else if (data.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
             codeHostMessage = 'Indexing'
             iconProps = { as: CloudSyncIconRefresh }
         } else if (
-            statusData.statusMessages?.some(
+            data.statusMessages?.some(
                 ({ __typename: type }) =>
                     type === 'GitUpdatesDisabled' || type === 'ExternalServiceSyncError' || type === 'SyncError'
             )
@@ -97,7 +94,7 @@ export const ProgressBar: FC<{}> = () => {
                 </Text>
             </div>
         )
-    }, [statusData])
+    }, [data])
 
     if (data?.repositoryStats.total === 0) {
         return null

--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -19,16 +19,15 @@ import {
     RepositoriesResult,
     RepositoriesVariables,
     RepositoryOrderBy,
-    RepositoryStatsResult,
     ExternalServiceIDsAndNamesVariables,
     ExternalServiceIDsAndNamesResult,
-    RepositoryStatsVariables,
     SiteAdminRepositoryFields,
+    StatusAndRepoStatsResult,
 } from '../graphql-operations'
 import { PageRoutes } from '../routes.constants'
 
 import { ValueLegendList, ValueLegendListProps } from './analytics/components/ValueLegendList'
-import { REPOSITORY_STATS, REPO_PAGE_POLL_INTERVAL, REPOSITORIES_QUERY } from './backend'
+import { STATUS_AND_REPO_STATS, REPO_PAGE_POLL_INTERVAL, REPOSITORIES_QUERY } from './backend'
 import { RepositoryNode } from './RepositoryNode'
 
 const STATUS_FILTERS: { [label: string]: FilteredConnectionFilterValue } = {
@@ -141,7 +140,7 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent = () => {
         error: repoStatsError,
         startPolling,
         stopPolling,
-    } = useQuery<RepositoryStatsResult, RepositoryStatsVariables>(REPOSITORY_STATS, {})
+    } = useQuery<StatusAndRepoStatsResult>(STATUS_AND_REPO_STATS, {})
     const location = useLocation()
     const navigate = useNavigate()
 

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -713,8 +713,8 @@ export function fetchFeatureFlags(): Observable<FeatureFlagFields[]> {
     )
 }
 
-export const REPOSITORY_STATS = gql`
-    query RepositoryStats {
+export const STATUS_AND_REPO_STATS = gql`
+    query StatusAndRepoStats {
         repositoryStats {
             __typename
             total
@@ -724,6 +724,41 @@ export const REPOSITORY_STATS = gql`
             failedFetch
             corrupted
             indexed
+        }
+        statusMessages {
+            ... on GitUpdatesDisabled {
+                __typename
+
+                message
+            }
+
+            ... on CloningProgress {
+                __typename
+
+                message
+            }
+
+            ... on IndexingProgress {
+                __typename
+
+                notIndexed
+                indexed
+            }
+
+            ... on SyncError {
+                __typename
+
+                message
+            }
+
+            ... on ExternalServiceSyncError {
+                __typename
+
+                externalService {
+                    id
+                    displayName
+                }
+            }
         }
     }
 `


### PR DESCRIPTION
Closes #46539. Determines if no repos exist and display more accurate repo status.

### BEFORE
![image](https://user-images.githubusercontent.com/59381432/225146496-3280f719-033c-4437-a59c-712bb3395aeb.png)

### AFTER
![Screenshot 2023-03-14 at 3 34 51 PM](https://user-images.githubusercontent.com/59381432/225146526-b1284d5a-5228-480b-a2d8-5088580e91ee.png)

## Test plan
- Run `EXTSVC_CONFIG_ALLOW_EDITS=1 sg start`
- Delete all connected code hosts
- Ensure nav item updates correctly
- Ensure nav item updates correctly after repos are added

## App preview:

- [Web](https://sg-web-becca-bug-fix-false-repos-up-to.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
