### PR TITLE
Setup Wizard: Fix progress bar appearance 

### DIFF
--- a/client/web/src/setup-wizard/components/ProgressBar.module.scss
+++ b/client/web/src/setup-wizard/components/ProgressBar.module.scss
@@ -1,3 +1,14 @@
+.root {
+    // This is important because progress bar is rendered within
+    // dynamic Setup wizard footer widget portal which sets background
+    // with positioned absolute pseudo after element, z-index here
+    // pull this on top of pseudo element (otherwise pseudo overlaps with
+    // progress bar and user sees nothing but white background)
+    z-index: 1;
+    display: flex;
+    align-items: center;
+}
+
 .loading {
     min-width: 4rem;
 

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -99,7 +99,10 @@ export const ProgressBar: FC<{}> = () => {
         )
     }, [statusData])
 
-    if (data?.repositoryStats.total === 0) {
+    const totalRepositories = data?.repositoryStats.total ?? 0
+
+    // If there is no repositories do not render progress bar UI
+    if (totalRepositories === 0) {
         return null
     }
 

--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -107,7 +107,7 @@ export const ProgressBar: FC<{}> = () => {
     }
 
     return (
-        <section className="d-flex align-items-center">
+        <section className={styles.root}>
             {statusMessage}
 
             {items.map(item => (

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
@@ -138,7 +138,7 @@
         //
         // Note: dynamic :has(element:empty) { display: none } doesn't work
         // properly in Safari
-        &:after {
+        &::after {
             background-color: var(--color-bg-1);
             border-top: 1px solid var(--border-color);
 
@@ -148,6 +148,7 @@
             bottom: 0;
             left: 0;
             right: 0;
+            // stylelint-disable-next-line declaration-property-unit-allowed-list
             margin: 0 calc(50% - 50vw);
             height: 100%;
             z-index: 0;

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.module.scss
@@ -96,11 +96,7 @@
 .footer {
     display: flex;
     flex-direction: column;
-    position: sticky;
-    bottom: 0;
     background-color: var(--gray-02);
-
-    $self: &;
 
     :global(.theme-dark) & {
         background-color: var(--color-bg-2);
@@ -123,20 +119,39 @@
 
     &-widget {
         display: flex;
+        flex-grow: 1;
         width: 100%;
-        background-color: var(--color-bg-1);
-        border-top: 1px solid var(--border-color);
-
-        &:has(> #{$self}-inner-widget:empty) {
-            display: none;
-        }
-    }
-
-    &-inner-widget {
         max-width: 55rem;
         margin: auto;
-        flex-grow: 1;
+        position: relative;
         padding: 0.25rem 0.5rem;
+
+        // Hide when we have no custom widget within
+        &:empty {
+            display: none;
+        }
+
+        // Since empty selector above implies that widget should have
+        // only custom widget and no wrappers (otherwise :empty will
+        // be never triggered) we set border and background with pseudo after
+        // element stretched to the full width of the screen
+        //
+        // Note: dynamic :has(element:empty) { display: none } doesn't work
+        // properly in Safari
+        &:after {
+            background-color: var(--color-bg-1);
+            border-top: 1px solid var(--border-color);
+
+            display: block;
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            margin: 0 calc(50% - 50vw);
+            height: 100%;
+            z-index: 0;
+        }
     }
 
     // Hide default next button if the custom button is rendered

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -221,9 +221,7 @@ export const SetupStepsFooter: FC<HTMLAttributes<HTMLElement>> = props => {
 
     return (
         <footer {...attributes} className={classNames(styles.footer, className)}>
-            <div className={styles.footerWidget}>
-                <div ref={setFooterPortal} className={styles.footerInnerWidget} />
-            </div>
+            <div ref={setFooterPortal} className={styles.footerWidget} />
             <div className={styles.footerNavigation}>
                 <div className={styles.footerInnerNavigation}>
                     <Button variant="link" className={styles.footerSkip} onClick={onSkip}>


### PR DESCRIPTION

It looks like that right now we alway render something even if we have no connected code host 

https://user-images.githubusercontent.com/18492575/225138606-82929cc4-5e9e-4d38-b7f0-14b4ef6a23e3.mov

In Safari we have empty state for footer when we render nothing in progress bar slot 
<img width="1127" alt="Screenshot 2023-03-14 at 18 19 27" src="https://user-images.githubusercontent.com/18492575/225138767-6347c8ae-19db-4125-8b66-d0d2f028e380.png">


## Test plan
- Open wizard 
- If you have no connected code host you should see no progress bar
- Only after you connected at least one code host you should see progress bar with stats
- Check that there is no flashes 
- Check Safari that there is no empty footer blocks 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-progress-bar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
