### PR TITLE
Ranking: replace custom aggregate with jsonb_object_agg

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -360,11 +360,12 @@ inserted AS (
 	SELECT
 		temp.repository_id,
 		%s,
-		sg_jsonb_concat_agg(temp.row)
+		jsonb_object_agg(temp.path, temp.count)
 	FROM (
 		SELECT
 			cr.repository_id,
-			jsonb_build_object(cr.path, SUM(count)) AS row
+			cr.path,
+			SUM(count) AS count
 		FROM input_ranks cr
 		GROUP BY cr.repository_id, cr.path
 	) temp

--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -377,8 +377,8 @@ inserted AS (
 				THEN EXCLUDED.payload
 			ELSE
 				(
-					SELECT sg_jsonb_concat_agg(row) FROM (
-						SELECT jsonb_build_object(key, SUM(value::int)) AS row
+					SELECT jsonb_object_agg(key, sum) FROM (
+						SELECT key, SUM(value::int) AS sum
 						FROM
 							(
 								SELECT * FROM jsonb_each(pr.payload)

--- a/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/down.sql
+++ b/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/down.sql
@@ -1,0 +1,8 @@
+-- Undo the changes made in the up migration
+
+CREATE AGGREGATE IF NOT EXISTS sg_jsonb_concat_agg(jsonb) (
+    SFUNC = jsonb_concat,
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+

--- a/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/down.sql
+++ b/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/down.sql
@@ -1,6 +1,6 @@
 -- Undo the changes made in the up migration
 
-CREATE AGGREGATE IF NOT EXISTS sg_jsonb_concat_agg(jsonb) (
+CREATE OR REPLACE AGGREGATE sg_jsonb_concat_agg(jsonb) (
     SFUNC = jsonb_concat,
     STYPE = jsonb,
     INITCOND = '{}'

--- a/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/metadata.yaml
+++ b/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/metadata.yaml
@@ -1,0 +1,2 @@
+name: remove sg_jsonb_concat_agg
+parents: [1676420496, 1678409821, 1678456448]

--- a/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/up.sql
+++ b/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/up.sql
@@ -10,4 +10,4 @@
 --  * If you are modifying Postgres extensions, you must also declare "privileged: true"
 --    in the associated metadata.yaml file.
 
-DROP AGGREGATE IF EXISTS sg_jsonb_concat_agg;
+DROP AGGREGATE IF EXISTS sg_jsonb_concat_agg(jsonb);

--- a/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/up.sql
+++ b/migrations/frontend/1678832491_remove_sg_jsonb_concat_agg/up.sql
@@ -1,0 +1,13 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+DROP AGGREGATE IF EXISTS sg_jsonb_concat_agg;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -823,12 +823,6 @@ BEGIN
     RETURN NEW;
 END $$;
 
-CREATE AGGREGATE sg_jsonb_concat_agg(jsonb) (
-    SFUNC = jsonb_concat,
-    STYPE = jsonb,
-    INITCOND = '{}'
-);
-
 CREATE AGGREGATE snapshot_transition_columns(hstore[]) (
     SFUNC = merge_audit_log_transitions,
     STYPE = hstore,


### PR DESCRIPTION
This replaces our custom aggregation based on `jsonb_object()` with the builtin `jsonb_object_agg()`, which is much more efficient. I think this is because it does not merge each new row into a new JSONB object (`jsonb_object` takes exactly two arguments). 

Current pattern, takes 783ms locally:
```sql
with objects as ( 
  select jsonb_build_object(key, value) as object 
  from (select generate_series(1,6000)::text as key, generate_series(1,6000)::text as value) t1
) 
select sg_jsonb_concat_agg(object) from objects;
```

New pattern, takes 10ms locally:
```sql
with objects as (
  select key, value 
  from (select generate_series(1,6000)::text as key, generate_series(1,6000)::text as value) t1
) 
select jsonb_object_agg(key, value) from objects;
```

## Test plan

Running unit tests and integration tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
