### PR TITLE
Bug fix: Setup Wizard > Re route non-admin users

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -132,7 +132,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
         return <Navigate replace={true} to={{ ...location, pathname: location.pathname.slice(0, -1) }} />
     }
 
-    if (isSetupWizardPage) {
+    if (isSetupWizardPage && !!props.authenticatedUser?.siteAdmin) {
         return (
             <Suspense
                 fallback={

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -151,7 +151,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     // setup wizard state, since we don't have a good solution for this at the
     // moment, we use mutable window.context object here.
     // TODO remove window.context and use injected context store/props
-    if (window.context.needsRepositoryConfiguration && !wasSetupWizardSkipped) {
+    if (window.context.needsRepositoryConfiguration && !wasSetupWizardSkipped && props.authenticatedUser?.siteAdmin) {
         return <Navigate to={PageRoutes.SetupWizard} replace={true} />
     }
 

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -137,7 +137,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
         return <Navigate replace={true} to={{ ...location, pathname: location.pathname.slice(0, -1) }} />
     }
 
-    if (isSetupWizardPage) {
+    if (isSetupWizardPage && !!props.authenticatedUser?.siteAdmin) {
         return (
             <Suspense
                 fallback={
@@ -156,7 +156,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
     // setup wizard state, since we don't have a good solution for this at the
     // moment, we use mutable window.context object here.
     // TODO remove window.context and use injected context store/props
-    if (window.context.needsRepositoryConfiguration && !wasSetupWizardSkipped) {
+    if (window.context.needsRepositoryConfiguration && !wasSetupWizardSkipped && props.authenticatedUser?.siteAdmin) {
         return <Navigate to={PageRoutes.SetupWizard} replace={true} />
     }
 


### PR DESCRIPTION
Closes #49267. Only makes Setup Wizard route available for non admin users.

### BEFORE
![image](https://user-images.githubusercontent.com/59381432/225156223-74629b46-7016-4449-8bb3-1a016b5a872b.png)

### AFTER
![image](https://user-images.githubusercontent.com/59381432/225156283-f526755c-ec63-4dcd-b6df-a2fdf9628ec9.png)

## Test plan
- Login with a non site admin user
- Ensure navigating to `/setup` redirects

## App preview:

- [Web](https://sg-web-becca-bug-fix-reroute-nonadmin-on.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
