### PR TITLE
Setup Wizard: Fix global alerts reloading

### DIFF
--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -45,7 +45,7 @@ const QUERY = gql`
 export const GlobalAlerts: React.FunctionComponent<Props> = ({ authenticatedUser, isSourcegraphDotCom }) => {
     const settings = useSettings()
     const { data } = useQuery<GlobalAlertsSiteFlagsResult, GlobalAlertsSiteFlagsVariables>(QUERY, {
-        fetchPolicy: 'cache-first',
+        fetchPolicy: 'cache-and-network',
     })
     const siteFlagsValue = data?.site
 


### PR DESCRIPTION
Prior to this PR right after you finish setup flow you still can see global alert about intense setup. In setup wizard we have a logic about siteFlags reloading but it didn't work properly because site flags query had cache-first policy 

We simply change it and with cache-and-network policy refreshSiteFlags query works as expected 

@philipp-spiess any changes you remember why cache-first was needed there?

## Test plan
- Open setup wizard when you have 0 connected code hosts
- Finish setup wizard
- You should see no global alerts about setup experience 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-global-alerts-reload.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
