### PR TITLE
packages: set & insert pkgs block status at insert callsites

### DIFF
--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -207,6 +207,12 @@ type fakeDepsService struct {
 }
 
 func (s *fakeDepsService) InsertPackageRepoRefs(ctx context.Context, depsToAdd []dependencies.MinimalPackageRepoRef) (newRepos []dependencies.PackageRepoReference, newVersions []dependencies.PackageRepoRefVersion, _ error) {
+	for i := range depsToAdd {
+		depsToAdd[i].LastCheckedAt = nil
+		for j := range depsToAdd[i].Versions {
+			depsToAdd[i].Versions[j].LastCheckedAt = nil
+		}
+	}
 	s.upsertedDeps = append(s.upsertedDeps, depsToAdd...)
 	for _, depToAdd := range depsToAdd {
 		if existingDep, exists := s.deps[depToAdd.Name]; exists {

--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -163,7 +163,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 		require.Equal(t, s.svc.(*fakeDepsService).upsertedDeps, []dependencies.MinimalPackageRepoRef{{
 			Scheme:   fakeVersionedPackage{}.Scheme(),
 			Name:     "foo",
-			Versions: []string{"0.0.3"},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "0.0.3"}},
 		}})
 		s.assertRefs(t, dir, bothV2andV3Refs)
 		// We triggered a single download for v0.0.3 since it was lazily requested.
@@ -212,15 +212,17 @@ func (s *fakeDepsService) InsertPackageRepoRefs(ctx context.Context, depsToAdd [
 		if existingDep, exists := s.deps[depToAdd.Name]; exists {
 			for _, version := range depToAdd.Versions {
 				if !slices.ContainsFunc(existingDep.Versions, func(v dependencies.PackageRepoRefVersion) bool {
-					return v.Version == version
+					return v.Version == version.Version
 				}) {
 					existingDep.Versions = append(existingDep.Versions, dependencies.PackageRepoRefVersion{
 						PackageRefID: existingDep.ID,
-						Version:      version,
+						Version:      version.Version,
+						Blocked:      version.Blocked,
 					})
 					s.deps[depToAdd.Name] = existingDep
 					newVersions = append(newVersions, dependencies.PackageRepoRefVersion{
-						Version: version,
+						Version: version.Version,
+						Blocked: version.Blocked,
 					})
 				}
 			}
@@ -228,7 +230,8 @@ func (s *fakeDepsService) InsertPackageRepoRefs(ctx context.Context, depsToAdd [
 			versionsForDep := make([]dependencies.PackageRepoRefVersion, 0, len(depToAdd.Versions))
 			for _, version := range depToAdd.Versions {
 				versionsForDep = append(versionsForDep, dependencies.PackageRepoRefVersion{
-					Version: version,
+					Version: version.Version,
+					Blocked: version.Blocked,
 				})
 			}
 			s.deps[depToAdd.Name] = dependencies.PackageRepoReference{

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -164,7 +164,7 @@ func TestNpmCloneCommand(t *testing.T) {
 		{
 			Scheme:   dependencies.NpmPackagesScheme,
 			Name:     "example",
-			Versions: []string{exampleNpmVersion},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: exampleNpmVersion}},
 		},
 	}); err != nil {
 		t.Fatalf(err.Error())
@@ -176,7 +176,7 @@ func TestNpmCloneCommand(t *testing.T) {
 		{
 			Scheme:   dependencies.NpmPackagesScheme,
 			Name:     "example",
-			Versions: []string{exampleNpmVersion2},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: exampleNpmVersion2}},
 		},
 	}); err != nil {
 		t.Fatalf(err.Error())

--- a/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
@@ -10,10 +10,8 @@ import (
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	codeinteltypes "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
-	uploadshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -22,8 +20,6 @@ import (
 
 type DependenciesService interface {
 	InsertPackageRepoRefs(ctx context.Context, deps []dependencies.MinimalPackageRepoRef) ([]dependencies.PackageRepoReference, []dependencies.PackageRepoRefVersion, error)
-	IsPackageRepoAllowed(ctx context.Context, scheme string, pkg reposource.PackageName) (allowed bool, err error)
-	IsPackageRepoVersionAllowed(ctx context.Context, scheme string, pkg reposource.PackageName, version string) (allowed bool, err error)
 	ListPackageRepoFilters(ctx context.Context, opts dependencies.ListPackageRepoRefFiltersOpts) (_ []dependencies.PackageRepoFilter, hasMore bool, err error)
 }
 
@@ -76,5 +72,5 @@ type UploadService interface {
 	GetUploadByID(ctx context.Context, id int) (codeinteltypes.Upload, bool, error)
 	ReferencesForUpload(ctx context.Context, uploadID int) (shared.PackageReferenceScanner, error)
 	GetRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) (_ []int, err error)
-	GetRecentUploadsSummary(ctx context.Context, repositoryID int) (upload []uploadshared.UploadsWithRepositoryNamespace, err error)
+	GetRecentUploadsSummary(ctx context.Context, repositoryID int) (upload []shared.UploadsWithRepositoryNamespace, err error)
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
@@ -13,6 +13,7 @@ import (
 	uploadshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -21,6 +22,9 @@ import (
 
 type DependenciesService interface {
 	InsertPackageRepoRefs(ctx context.Context, deps []dependencies.MinimalPackageRepoRef) ([]dependencies.PackageRepoReference, []dependencies.PackageRepoRefVersion, error)
+	IsPackageRepoAllowed(ctx context.Context, scheme string, pkg reposource.PackageName) (allowed bool, err error)
+	IsPackageRepoVersionAllowed(ctx context.Context, scheme string, pkg reposource.PackageName, version string) (allowed bool, err error)
+	ListPackageRepoFilters(ctx context.Context, opts dependencies.ListPackageRepoRefFiltersOpts) (_ []dependencies.PackageRepoFilter, hasMore bool, err error)
 }
 
 type GitserverRepoStore interface {

--- a/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
@@ -19,7 +19,9 @@ import (
 	types1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	shared1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
+	dependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	shared "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+	reposource "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	database "github.com/sourcegraph/sourcegraph/internal/database"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	executor "github.com/sourcegraph/sourcegraph/internal/executor"
@@ -38,6 +40,16 @@ type MockDependenciesService struct {
 	// InsertPackageRepoRefsFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertPackageRepoRefs.
 	InsertPackageRepoRefsFunc *DependenciesServiceInsertPackageRepoRefsFunc
+	// IsPackageRepoAllowedFunc is an instance of a mock function object
+	// controlling the behavior of the method IsPackageRepoAllowed.
+	IsPackageRepoAllowedFunc *DependenciesServiceIsPackageRepoAllowedFunc
+	// IsPackageRepoVersionAllowedFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// IsPackageRepoVersionAllowed.
+	IsPackageRepoVersionAllowedFunc *DependenciesServiceIsPackageRepoVersionAllowedFunc
+	// ListPackageRepoFiltersFunc is an instance of a mock function object
+	// controlling the behavior of the method ListPackageRepoFilters.
+	ListPackageRepoFiltersFunc *DependenciesServiceListPackageRepoFiltersFunc
 }
 
 // NewMockDependenciesService creates a new mock of the DependenciesService
@@ -47,6 +59,21 @@ func NewMockDependenciesService() *MockDependenciesService {
 	return &MockDependenciesService{
 		InsertPackageRepoRefsFunc: &DependenciesServiceInsertPackageRepoRefsFunc{
 			defaultHook: func(context.Context, []shared.MinimalPackageRepoRef) (r0 []shared.PackageRepoReference, r1 []shared.PackageRepoRefVersion, r2 error) {
+				return
+			},
+		},
+		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
+			defaultHook: func(context.Context, string, reposource.PackageName) (r0 bool, r1 error) {
+				return
+			},
+		},
+		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
+			defaultHook: func(context.Context, string, reposource.PackageName, string) (r0 bool, r1 error) {
+				return
+			},
+		},
+		ListPackageRepoFiltersFunc: &DependenciesServiceListPackageRepoFiltersFunc{
+			defaultHook: func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) (r0 []shared.PackageRepoFilter, r1 bool, r2 error) {
 				return
 			},
 		},
@@ -63,6 +90,21 @@ func NewStrictMockDependenciesService() *MockDependenciesService {
 				panic("unexpected invocation of MockDependenciesService.InsertPackageRepoRefs")
 			},
 		},
+		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
+			defaultHook: func(context.Context, string, reposource.PackageName) (bool, error) {
+				panic("unexpected invocation of MockDependenciesService.IsPackageRepoAllowed")
+			},
+		},
+		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
+			defaultHook: func(context.Context, string, reposource.PackageName, string) (bool, error) {
+				panic("unexpected invocation of MockDependenciesService.IsPackageRepoVersionAllowed")
+			},
+		},
+		ListPackageRepoFiltersFunc: &DependenciesServiceListPackageRepoFiltersFunc{
+			defaultHook: func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
+				panic("unexpected invocation of MockDependenciesService.ListPackageRepoFilters")
+			},
+		},
 	}
 }
 
@@ -73,6 +115,15 @@ func NewMockDependenciesServiceFrom(i DependenciesService) *MockDependenciesServ
 	return &MockDependenciesService{
 		InsertPackageRepoRefsFunc: &DependenciesServiceInsertPackageRepoRefsFunc{
 			defaultHook: i.InsertPackageRepoRefs,
+		},
+		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
+			defaultHook: i.IsPackageRepoAllowed,
+		},
+		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
+			defaultHook: i.IsPackageRepoVersionAllowed,
+		},
+		ListPackageRepoFiltersFunc: &DependenciesServiceListPackageRepoFiltersFunc{
+			defaultHook: i.ListPackageRepoFilters,
 		},
 	}
 }
@@ -189,6 +240,354 @@ func (c DependenciesServiceInsertPackageRepoRefsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DependenciesServiceInsertPackageRepoRefsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// DependenciesServiceIsPackageRepoAllowedFunc describes the behavior when
+// the IsPackageRepoAllowed method of the parent MockDependenciesService
+// instance is invoked.
+type DependenciesServiceIsPackageRepoAllowedFunc struct {
+	defaultHook func(context.Context, string, reposource.PackageName) (bool, error)
+	hooks       []func(context.Context, string, reposource.PackageName) (bool, error)
+	history     []DependenciesServiceIsPackageRepoAllowedFuncCall
+	mutex       sync.Mutex
+}
+
+// IsPackageRepoAllowed delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDependenciesService) IsPackageRepoAllowed(v0 context.Context, v1 string, v2 reposource.PackageName) (bool, error) {
+	r0, r1 := m.IsPackageRepoAllowedFunc.nextHook()(v0, v1, v2)
+	m.IsPackageRepoAllowedFunc.appendCall(DependenciesServiceIsPackageRepoAllowedFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the IsPackageRepoAllowed
+// method of the parent MockDependenciesService instance is invoked and the
+// hook queue is empty.
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) SetDefaultHook(hook func(context.Context, string, reposource.PackageName) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// IsPackageRepoAllowed method of the parent MockDependenciesService
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) PushHook(hook func(context.Context, string, reposource.PackageName) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, reposource.PackageName) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, string, reposource.PackageName) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) nextHook() func(context.Context, string, reposource.PackageName) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) appendCall(r0 DependenciesServiceIsPackageRepoAllowedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// DependenciesServiceIsPackageRepoAllowedFuncCall objects describing the
+// invocations of this function.
+func (f *DependenciesServiceIsPackageRepoAllowedFunc) History() []DependenciesServiceIsPackageRepoAllowedFuncCall {
+	f.mutex.Lock()
+	history := make([]DependenciesServiceIsPackageRepoAllowedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DependenciesServiceIsPackageRepoAllowedFuncCall is an object that
+// describes an invocation of method IsPackageRepoAllowed on an instance of
+// MockDependenciesService.
+type DependenciesServiceIsPackageRepoAllowedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 reposource.PackageName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DependenciesServiceIsPackageRepoAllowedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DependenciesServiceIsPackageRepoAllowedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// DependenciesServiceIsPackageRepoVersionAllowedFunc describes the behavior
+// when the IsPackageRepoVersionAllowed method of the parent
+// MockDependenciesService instance is invoked.
+type DependenciesServiceIsPackageRepoVersionAllowedFunc struct {
+	defaultHook func(context.Context, string, reposource.PackageName, string) (bool, error)
+	hooks       []func(context.Context, string, reposource.PackageName, string) (bool, error)
+	history     []DependenciesServiceIsPackageRepoVersionAllowedFuncCall
+	mutex       sync.Mutex
+}
+
+// IsPackageRepoVersionAllowed delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockDependenciesService) IsPackageRepoVersionAllowed(v0 context.Context, v1 string, v2 reposource.PackageName, v3 string) (bool, error) {
+	r0, r1 := m.IsPackageRepoVersionAllowedFunc.nextHook()(v0, v1, v2, v3)
+	m.IsPackageRepoVersionAllowedFunc.appendCall(DependenciesServiceIsPackageRepoVersionAllowedFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// IsPackageRepoVersionAllowed method of the parent MockDependenciesService
+// instance is invoked and the hook queue is empty.
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) SetDefaultHook(hook func(context.Context, string, reposource.PackageName, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// IsPackageRepoVersionAllowed method of the parent MockDependenciesService
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) PushHook(hook func(context.Context, string, reposource.PackageName, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, reposource.PackageName, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, string, reposource.PackageName, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) nextHook() func(context.Context, string, reposource.PackageName, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) appendCall(r0 DependenciesServiceIsPackageRepoVersionAllowedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// DependenciesServiceIsPackageRepoVersionAllowedFuncCall objects describing
+// the invocations of this function.
+func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) History() []DependenciesServiceIsPackageRepoVersionAllowedFuncCall {
+	f.mutex.Lock()
+	history := make([]DependenciesServiceIsPackageRepoVersionAllowedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DependenciesServiceIsPackageRepoVersionAllowedFuncCall is an object that
+// describes an invocation of method IsPackageRepoVersionAllowed on an
+// instance of MockDependenciesService.
+type DependenciesServiceIsPackageRepoVersionAllowedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 reposource.PackageName
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DependenciesServiceIsPackageRepoVersionAllowedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DependenciesServiceIsPackageRepoVersionAllowedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// DependenciesServiceListPackageRepoFiltersFunc describes the behavior when
+// the ListPackageRepoFilters method of the parent MockDependenciesService
+// instance is invoked.
+type DependenciesServiceListPackageRepoFiltersFunc struct {
+	defaultHook func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error)
+	hooks       []func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error)
+	history     []DependenciesServiceListPackageRepoFiltersFuncCall
+	mutex       sync.Mutex
+}
+
+// ListPackageRepoFilters delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockDependenciesService) ListPackageRepoFilters(v0 context.Context, v1 dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
+	r0, r1, r2 := m.ListPackageRepoFiltersFunc.nextHook()(v0, v1)
+	m.ListPackageRepoFiltersFunc.appendCall(DependenciesServiceListPackageRepoFiltersFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// ListPackageRepoFilters method of the parent MockDependenciesService
+// instance is invoked and the hook queue is empty.
+func (f *DependenciesServiceListPackageRepoFiltersFunc) SetDefaultHook(hook func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListPackageRepoFilters method of the parent MockDependenciesService
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *DependenciesServiceListPackageRepoFiltersFunc) PushHook(hook func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DependenciesServiceListPackageRepoFiltersFunc) SetDefaultReturn(r0 []shared.PackageRepoFilter, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DependenciesServiceListPackageRepoFiltersFunc) PushReturn(r0 []shared.PackageRepoFilter, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *DependenciesServiceListPackageRepoFiltersFunc) nextHook() func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DependenciesServiceListPackageRepoFiltersFunc) appendCall(r0 DependenciesServiceListPackageRepoFiltersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// DependenciesServiceListPackageRepoFiltersFuncCall objects describing the
+// invocations of this function.
+func (f *DependenciesServiceListPackageRepoFiltersFunc) History() []DependenciesServiceListPackageRepoFiltersFuncCall {
+	f.mutex.Lock()
+	history := make([]DependenciesServiceListPackageRepoFiltersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DependenciesServiceListPackageRepoFiltersFuncCall is an object that
+// describes an invocation of method ListPackageRepoFilters on an instance
+// of MockDependenciesService.
+type DependenciesServiceListPackageRepoFiltersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 dependencies.ListPackageRepoRefFiltersOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.PackageRepoFilter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DependenciesServiceListPackageRepoFiltersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DependenciesServiceListPackageRepoFiltersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 

--- a/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
@@ -21,7 +21,6 @@ import (
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	dependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	shared "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
-	reposource "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	database "github.com/sourcegraph/sourcegraph/internal/database"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	executor "github.com/sourcegraph/sourcegraph/internal/executor"
@@ -40,13 +39,6 @@ type MockDependenciesService struct {
 	// InsertPackageRepoRefsFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertPackageRepoRefs.
 	InsertPackageRepoRefsFunc *DependenciesServiceInsertPackageRepoRefsFunc
-	// IsPackageRepoAllowedFunc is an instance of a mock function object
-	// controlling the behavior of the method IsPackageRepoAllowed.
-	IsPackageRepoAllowedFunc *DependenciesServiceIsPackageRepoAllowedFunc
-	// IsPackageRepoVersionAllowedFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// IsPackageRepoVersionAllowed.
-	IsPackageRepoVersionAllowedFunc *DependenciesServiceIsPackageRepoVersionAllowedFunc
 	// ListPackageRepoFiltersFunc is an instance of a mock function object
 	// controlling the behavior of the method ListPackageRepoFilters.
 	ListPackageRepoFiltersFunc *DependenciesServiceListPackageRepoFiltersFunc
@@ -59,16 +51,6 @@ func NewMockDependenciesService() *MockDependenciesService {
 	return &MockDependenciesService{
 		InsertPackageRepoRefsFunc: &DependenciesServiceInsertPackageRepoRefsFunc{
 			defaultHook: func(context.Context, []shared.MinimalPackageRepoRef) (r0 []shared.PackageRepoReference, r1 []shared.PackageRepoRefVersion, r2 error) {
-				return
-			},
-		},
-		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
-			defaultHook: func(context.Context, string, reposource.PackageName) (r0 bool, r1 error) {
-				return
-			},
-		},
-		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
-			defaultHook: func(context.Context, string, reposource.PackageName, string) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -90,16 +72,6 @@ func NewStrictMockDependenciesService() *MockDependenciesService {
 				panic("unexpected invocation of MockDependenciesService.InsertPackageRepoRefs")
 			},
 		},
-		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
-			defaultHook: func(context.Context, string, reposource.PackageName) (bool, error) {
-				panic("unexpected invocation of MockDependenciesService.IsPackageRepoAllowed")
-			},
-		},
-		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
-			defaultHook: func(context.Context, string, reposource.PackageName, string) (bool, error) {
-				panic("unexpected invocation of MockDependenciesService.IsPackageRepoVersionAllowed")
-			},
-		},
 		ListPackageRepoFiltersFunc: &DependenciesServiceListPackageRepoFiltersFunc{
 			defaultHook: func(context.Context, dependencies.ListPackageRepoRefFiltersOpts) ([]shared.PackageRepoFilter, bool, error) {
 				panic("unexpected invocation of MockDependenciesService.ListPackageRepoFilters")
@@ -115,12 +87,6 @@ func NewMockDependenciesServiceFrom(i DependenciesService) *MockDependenciesServ
 	return &MockDependenciesService{
 		InsertPackageRepoRefsFunc: &DependenciesServiceInsertPackageRepoRefsFunc{
 			defaultHook: i.InsertPackageRepoRefs,
-		},
-		IsPackageRepoAllowedFunc: &DependenciesServiceIsPackageRepoAllowedFunc{
-			defaultHook: i.IsPackageRepoAllowed,
-		},
-		IsPackageRepoVersionAllowedFunc: &DependenciesServiceIsPackageRepoVersionAllowedFunc{
-			defaultHook: i.IsPackageRepoVersionAllowed,
 		},
 		ListPackageRepoFiltersFunc: &DependenciesServiceListPackageRepoFiltersFunc{
 			defaultHook: i.ListPackageRepoFilters,
@@ -241,239 +207,6 @@ func (c DependenciesServiceInsertPackageRepoRefsFuncCall) Args() []interface{} {
 // invocation.
 func (c DependenciesServiceInsertPackageRepoRefsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// DependenciesServiceIsPackageRepoAllowedFunc describes the behavior when
-// the IsPackageRepoAllowed method of the parent MockDependenciesService
-// instance is invoked.
-type DependenciesServiceIsPackageRepoAllowedFunc struct {
-	defaultHook func(context.Context, string, reposource.PackageName) (bool, error)
-	hooks       []func(context.Context, string, reposource.PackageName) (bool, error)
-	history     []DependenciesServiceIsPackageRepoAllowedFuncCall
-	mutex       sync.Mutex
-}
-
-// IsPackageRepoAllowed delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockDependenciesService) IsPackageRepoAllowed(v0 context.Context, v1 string, v2 reposource.PackageName) (bool, error) {
-	r0, r1 := m.IsPackageRepoAllowedFunc.nextHook()(v0, v1, v2)
-	m.IsPackageRepoAllowedFunc.appendCall(DependenciesServiceIsPackageRepoAllowedFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the IsPackageRepoAllowed
-// method of the parent MockDependenciesService instance is invoked and the
-// hook queue is empty.
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) SetDefaultHook(hook func(context.Context, string, reposource.PackageName) (bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// IsPackageRepoAllowed method of the parent MockDependenciesService
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) PushHook(hook func(context.Context, string, reposource.PackageName) (bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, reposource.PackageName) (bool, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, string, reposource.PackageName) (bool, error) {
-		return r0, r1
-	})
-}
-
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) nextHook() func(context.Context, string, reposource.PackageName) (bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) appendCall(r0 DependenciesServiceIsPackageRepoAllowedFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// DependenciesServiceIsPackageRepoAllowedFuncCall objects describing the
-// invocations of this function.
-func (f *DependenciesServiceIsPackageRepoAllowedFunc) History() []DependenciesServiceIsPackageRepoAllowedFuncCall {
-	f.mutex.Lock()
-	history := make([]DependenciesServiceIsPackageRepoAllowedFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// DependenciesServiceIsPackageRepoAllowedFuncCall is an object that
-// describes an invocation of method IsPackageRepoAllowed on an instance of
-// MockDependenciesService.
-type DependenciesServiceIsPackageRepoAllowedFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 reposource.PackageName
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c DependenciesServiceIsPackageRepoAllowedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c DependenciesServiceIsPackageRepoAllowedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// DependenciesServiceIsPackageRepoVersionAllowedFunc describes the behavior
-// when the IsPackageRepoVersionAllowed method of the parent
-// MockDependenciesService instance is invoked.
-type DependenciesServiceIsPackageRepoVersionAllowedFunc struct {
-	defaultHook func(context.Context, string, reposource.PackageName, string) (bool, error)
-	hooks       []func(context.Context, string, reposource.PackageName, string) (bool, error)
-	history     []DependenciesServiceIsPackageRepoVersionAllowedFuncCall
-	mutex       sync.Mutex
-}
-
-// IsPackageRepoVersionAllowed delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockDependenciesService) IsPackageRepoVersionAllowed(v0 context.Context, v1 string, v2 reposource.PackageName, v3 string) (bool, error) {
-	r0, r1 := m.IsPackageRepoVersionAllowedFunc.nextHook()(v0, v1, v2, v3)
-	m.IsPackageRepoVersionAllowedFunc.appendCall(DependenciesServiceIsPackageRepoVersionAllowedFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// IsPackageRepoVersionAllowed method of the parent MockDependenciesService
-// instance is invoked and the hook queue is empty.
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) SetDefaultHook(hook func(context.Context, string, reposource.PackageName, string) (bool, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// IsPackageRepoVersionAllowed method of the parent MockDependenciesService
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) PushHook(hook func(context.Context, string, reposource.PackageName, string) (bool, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, reposource.PackageName, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, string, reposource.PackageName, string) (bool, error) {
-		return r0, r1
-	})
-}
-
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) nextHook() func(context.Context, string, reposource.PackageName, string) (bool, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) appendCall(r0 DependenciesServiceIsPackageRepoVersionAllowedFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// DependenciesServiceIsPackageRepoVersionAllowedFuncCall objects describing
-// the invocations of this function.
-func (f *DependenciesServiceIsPackageRepoVersionAllowedFunc) History() []DependenciesServiceIsPackageRepoVersionAllowedFuncCall {
-	f.mutex.Lock()
-	history := make([]DependenciesServiceIsPackageRepoVersionAllowedFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// DependenciesServiceIsPackageRepoVersionAllowedFuncCall is an object that
-// describes an invocation of method IsPackageRepoVersionAllowed on an
-// instance of MockDependenciesService.
-type DependenciesServiceIsPackageRepoVersionAllowedFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 string
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 reposource.PackageName
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 string
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 bool
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c DependenciesServiceIsPackageRepoVersionAllowedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c DependenciesServiceIsPackageRepoVersionAllowedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // DependenciesServiceListPackageRepoFiltersFunc describes the behavior when

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -224,7 +224,7 @@ func (j *crateSyncerJob) handleCrateSyncer(ctx context.Context, interval time.Du
 				if err := j.autoindexingSvc.QueueIndexesForPackage(clientCtx, shared.MinimialVersionedPackageRepo{
 					Scheme:  pkg.Scheme,
 					Name:    pkg.Name,
-					Version: version,
+					Version: version.Version,
 				}, true); err != nil {
 					queueErrs = errors.Append(queueErrs, err)
 				}
@@ -314,6 +314,8 @@ func singleRustExternalService(ctx context.Context, store ExternalServiceStore) 
 func parseCrateInformation(contents []byte) ([]shared.MinimalPackageRepoRef, error) {
 	result := make([]shared.MinimalPackageRepoRef, 0, 1)
 
+	instant := time.Now()
+
 	for _, line := range bytes.Split(contents, []byte("\n")) {
 		if len(line) == 0 {
 			continue
@@ -331,9 +333,12 @@ func parseCrateInformation(contents []byte) ([]shared.MinimalPackageRepoRef, err
 
 		name := reposource.PackageName(info.Name)
 		result = append(result, shared.MinimalPackageRepoRef{
-			Scheme:   shared.RustPackagesScheme,
-			Name:     name,
-			Versions: []string{info.Version},
+			Scheme: shared.RustPackagesScheme,
+			Name:   name,
+			// doing a bit of a dot-com specific assumption here, that all these packages are resolvable
+			// and not covered by a filter.
+			Versions:      []shared.MinimalPackageRepoRefVersion{{Version: info.Version, LastCheckedAt: &instant}},
+			LastCheckedAt: &instant,
 		})
 	}
 

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer_test.go
@@ -44,7 +44,9 @@ func TestCrateSyncer(t *testing.T) {
 			if versions, ok := refs[r.Name]; ok {
 				refs[r.Name] = append(versions, r.Versions...)
 				for _, v := range r.Versions {
-					if slices.Contains(versions, v) {
+					if slices.ContainsFunc(versions, func(v2 shared.MinimalPackageRepoRefVersion) bool {
+						return v.Version == v2.Version && v.Blocked == v2.Blocked
+					}) {
 						newV = append(newV, shared.PackageRepoRefVersion{Version: v.Version})
 					}
 				}
@@ -169,7 +171,7 @@ func TestCrateSyncer(t *testing.T) {
 		}
 
 		if len(extsvcStore.GetByIDFunc.History()) != 1 {
-			t.Errorf("unexpected number of calls to GetByID (want=%d, got=%d)", 0, len(extsvcStore.GetByIDFunc.History()))
+			t.Errorf("unexpected number of calls to GetByID (want=%d, got=%d)", 1, len(extsvcStore.GetByIDFunc.History()))
 		}
 
 		if len(autoindexSvc.QueueIndexesForPackageFunc.History()) != 2 {
@@ -184,13 +186,7 @@ func createArchive(t *testing.T, info fileInfo) io.ReadCloser {
 	var buf bytes.Buffer
 	tarWriter := tar.NewWriter(&buf)
 
-	// switch path {
-	// case "petgraph":
-	// 	addFileToTarball(t, tarWriter, fileInfo{"petgraph", []byte(petgraphJSON)})
-	// case "percent":
-	//  addFileToTarball(t, tarWriter, fileInfo{"percent", []byte(percentEncJSON)})
 	addFileToTarball(t, tarWriter, info)
-	// }
 
 	return io.NopCloser(&buf)
 }

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer_test.go
@@ -37,7 +37,7 @@ func TestCrateSyncer(t *testing.T) {
 	// dont need any functionality for this
 	autoindexSvc := NewMockAutoIndexingService()
 
-	refs := make(map[reposource.PackageName][]string)
+	refs := make(map[reposource.PackageName][]shared.MinimalPackageRepoRefVersion)
 	dependenciesSvc := NewMockDependenciesService()
 	dependenciesSvc.InsertPackageRepoRefsFunc.SetDefaultHook(func(ctx context.Context, refList []shared.MinimalPackageRepoRef) (newRef []shared.PackageRepoReference, newV []shared.PackageRepoRefVersion, err error) {
 		for _, r := range refList {
@@ -45,13 +45,13 @@ func TestCrateSyncer(t *testing.T) {
 				refs[r.Name] = append(versions, r.Versions...)
 				for _, v := range r.Versions {
 					if slices.Contains(versions, v) {
-						newV = append(newV, shared.PackageRepoRefVersion{Version: v})
+						newV = append(newV, shared.PackageRepoRefVersion{Version: v.Version})
 					}
 				}
 			} else {
 				newRef = append(newRef, shared.PackageRepoReference{Name: r.Name})
 				for _, v := range r.Versions {
-					newV = append(newV, shared.PackageRepoRefVersion{Version: v})
+					newV = append(newV, shared.PackageRepoRefVersion{Version: v.Version})
 				}
 				refs[r.Name] = r.Versions
 			}

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -25,12 +25,12 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 	s := store.New(&observation.TestContext, db)
 
 	deps := []shared.MinimalPackageRepoRef{
-		{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0", "2.0.1", "3.0.0"}},
-		{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
-		{Scheme: "npm", Name: "banana", Versions: []string{"2.0.0"}},
-		{Scheme: "rust-analyzer", Name: "burger", Versions: []string{"1.0.0", "1.0.1", "1.0.2"}},
+		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}, {Version: "2.0.1"}, {Version: "3.0.0"}}},
+		{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}},
+		{Scheme: "npm", Name: "banana", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+		{Scheme: "rust-analyzer", Name: "burger", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}, {Version: "1.0.1"}, {Version: "1.0.2"}}},
 		// make sure filters only apply to their respective scheme
-		{Scheme: "semanticdb", Name: "burger", Versions: []string{"1.0.3"}},
+		{Scheme: "semanticdb", Name: "burger", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.3"}}},
 	}
 
 	if _, _, err := s.InsertPackageRepoRefs(ctx, deps); err != nil {
@@ -117,12 +117,12 @@ func TestPackageRepoFiltersBlockAllow(t *testing.T) {
 	s := store.New(&observation.TestContext, db)
 
 	deps := []shared.MinimalPackageRepoRef{
-		{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0", "2.0.1", "3.0.0"}},
-		{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
-		{Scheme: "npm", Name: "banana", Versions: []string{"2.0.0"}},
-		{Scheme: "rust-analyzer", Name: "burger", Versions: []string{"1.0.0", "1.0.1", "1.0.2"}},
-		{Scheme: "rust-analyzer", Name: "frogger", Versions: []string{"4.1.2", "3.0.0"}},
-		{Scheme: "semanticdb", Name: "burger", Versions: []string{"1.0.3"}},
+		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}, {Version: "2.0.1"}, {Version: "3.0.0"}}},
+		{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}},
+		{Scheme: "npm", Name: "banana", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+		{Scheme: "rust-analyzer", Name: "burger", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}, {Version: "1.0.1"}, {Version: "1.0.2"}}},
+		{Scheme: "rust-analyzer", Name: "frogger", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "4.1.2"}, {Version: "3.0.0"}}},
+		{Scheme: "semanticdb", Name: "burger", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.3"}}},
 	}
 
 	if _, _, err := s.InsertPackageRepoRefs(ctx, deps); err != nil {

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -253,10 +253,10 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 		tx.Handle(),
 		"t_package_repo_refs",
 		batch.MaxNumPostgresParameters,
-		[]string{"scheme", "name"},
+		[]string{"scheme", "name", "blocked", "last_checked_at"},
 		func(inserter *batch.Inserter) error {
 			for _, pkg := range deps {
-				if err := inserter.Insert(ctx, pkg.Scheme, pkg.Name); err != nil {
+				if err := inserter.Insert(ctx, pkg.Scheme, pkg.Name, pkg.Blocked, pkg.LastCheckedAt); err != nil {
 					return err
 				}
 			}
@@ -268,7 +268,7 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 	}
 
 	newDeps, err = basestore.NewSliceScanner(func(rows dbutil.Scanner) (dep shared.PackageRepoReference, err error) {
-		err = rows.Scan(&dep.ID, &dep.Scheme, &dep.Name)
+		err = rows.Scan(&dep.ID, &dep.Scheme, &dep.Name, &dep.Blocked, &dep.LastCheckedAt)
 		return
 	})(tx.Query(ctx, sqlf.Sprintf(transferPackageRepoRefsQuery)))
 	if err != nil {
@@ -324,11 +324,11 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 		tx.Handle(),
 		"t_package_repo_versions",
 		batch.MaxNumPostgresParameters,
-		[]string{"package_id", "version"},
+		[]string{"package_id", "version", "blocked", "last_checked_at"},
 		func(inserter *batch.Inserter) error {
 			for i, dep := range deps {
 				for _, version := range dep.Versions {
-					if err := inserter.Insert(ctx, allIDs[i], version); err != nil {
+					if err := inserter.Insert(ctx, allIDs[i], version.Version, version.Blocked, version.LastCheckedAt); err != nil {
 						return err
 					}
 				}
@@ -340,7 +340,7 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 	}
 
 	newVersions, err = basestore.NewSliceScanner(func(rows dbutil.Scanner) (version shared.PackageRepoRefVersion, err error) {
-		err = rows.Scan(&version.ID, &version.PackageRefID, &version.Version)
+		err = rows.Scan(&version.ID, &version.PackageRefID, &version.Version, &version.Blocked, &version.LastCheckedAt)
 		return
 	})(tx.Query(ctx, sqlf.Sprintf(transferPackageRepoRefVersionsQuery)))
 	if err != nil {
@@ -353,20 +353,24 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 const temporaryPackageRepoRefsTableQuery = `
 CREATE TEMPORARY TABLE t_package_repo_refs (
 	scheme TEXT NOT NULL,
-	name TEXT NOT NULL
+	name TEXT NOT NULL,
+	blocked BOOLEAN NOT NULL,
+	last_checked_at TIMESTAMPTZ
 ) ON COMMIT DROP
 `
 
 const temporaryPackageRepoRefVersionsTableQuery = `
 CREATE TEMPORARY TABLE t_package_repo_versions (
 	package_id BIGINT NOT NULL,
-	version TEXT NOT NULL
+	version TEXT NOT NULL,
+	blocked BOOLEAN NOT NULL,
+	last_checked_at TIMESTAMPTZ
 ) ON COMMIT DROP
 `
 
 const transferPackageRepoRefsQuery = `
-INSERT INTO lsif_dependency_repos (scheme, name)
-SELECT scheme, name
+INSERT INTO lsif_dependency_repos (scheme, name, blocked, last_checked_at)
+SELECT scheme, name, blocked, last_checked_at
 FROM t_package_repo_refs t
 WHERE NOT EXISTS (
 	SELECT scheme, name
@@ -375,14 +379,14 @@ WHERE NOT EXISTS (
 	name = t.name
 )
 ORDER BY name
-RETURNING id, scheme, name
+RETURNING id, scheme, name, blocked, last_checked_at
 `
 
 const transferPackageRepoRefVersionsQuery = `
-INSERT INTO package_repo_versions (package_id, version)
+INSERT INTO package_repo_versions (package_id, version, blocked, last_checked_at)
 -- we dont reduce package repo versions,
 -- so DISTINCT here to avoid conflict
-SELECT DISTINCT package_id, version
+SELECT DISTINCT ON (package_id, version) package_id, version, blocked, last_checked_at
 FROM t_package_repo_versions t
 WHERE NOT EXISTS (
 	SELECT package_id, version
@@ -392,7 +396,7 @@ WHERE NOT EXISTS (
 )
 -- unit tests rely on a certain order
 ORDER BY package_id, version
-RETURNING id, package_id, version
+RETURNING id, package_id, version, blocked, last_checked_at
 `
 
 const getAttemptedInsertDependencyReposQuery = `

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
-func TestUpsertDependencyRepo(t *testing.T) {
+func TestInsertDependencyRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-
+	instant := timeutil.Now()
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
@@ -26,16 +27,19 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	batches := [][]shared.MinimalPackageRepoRef{
 		{
 			// Test same-set flushes
-			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0"}},
-			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0"}},
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
 		},
 		{
-			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []string{"3.0.0"}}, // id=3
-			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}}, // id=4
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "3.0.0"}}}, // id=3
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}}, // id=4
 		},
 		{
 			// Test different-set flushes
-			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0", "2.0.0"}},
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}, {Version: "2.0.0"}}},
+		},
+		{
+			shared.MinimalPackageRepoRef{Scheme: "npm", Name: "zasdf", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "0.0.0"}}, Blocked: true, LastCheckedAt: &instant},
 		},
 	}
 
@@ -54,6 +58,7 @@ func TestUpsertDependencyRepo(t *testing.T) {
 	want := []shared.PackageRepoReference{
 		{ID: 1, Scheme: "npm", Name: "bar"},
 		{ID: 2, Scheme: "npm", Name: "foo"},
+		{ID: 3, Scheme: "npm", Name: "zasdf", Blocked: true, LastCheckedAt: &instant},
 	}
 	if diff := cmp.Diff(want, allNewDeps); diff != "" {
 		t.Fatalf("mismatch (-want, +got): %s", diff)
@@ -64,13 +69,15 @@ func TestUpsertDependencyRepo(t *testing.T) {
 		{ID: 2, PackageRefID: 1, Version: "3.0.0"},
 		{ID: 3, PackageRefID: 2, Version: "1.0.0"},
 		{ID: 4, PackageRefID: 2, Version: "2.0.0"},
+		{ID: 5, PackageRefID: 3, Version: "0.0.0"},
 	}
 	if diff := cmp.Diff(wantV, allNewVersions); diff != "" {
 		t.Fatalf("mismatch (-want, +got): %s", diff)
 	}
 
 	have, _, hasMore, err := store.ListPackageRepoRefs(ctx, ListDependencyReposOpts{
-		Scheme: shared.NpmPackagesScheme,
+		Scheme:         shared.NpmPackagesScheme,
+		IncludeBlocked: true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -82,6 +89,7 @@ func TestUpsertDependencyRepo(t *testing.T) {
 
 	want[0].Versions = []shared.PackageRepoRefVersion{{ID: 1, PackageRefID: 1, Version: "2.0.0"}, {ID: 2, PackageRefID: 1, Version: "3.0.0"}}
 	want[1].Versions = []shared.PackageRepoRefVersion{{ID: 3, PackageRefID: 2, Version: "1.0.0"}, {ID: 4, PackageRefID: 2, Version: "2.0.0"}}
+	want[2].Versions = []shared.PackageRepoRefVersion{{ID: 5, PackageRefID: 3, Version: "0.0.0"}}
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatalf("mismatch (-want, +got): %s", diff)
 	}
@@ -99,24 +107,24 @@ func TestListPackageRepoRefs(t *testing.T) {
 
 	batches := [][]shared.MinimalPackageRepoRef{
 		{
-			{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0"}},
-			{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
-			{Scheme: "npm", Name: "bar", Versions: []string{"2.0.1"}},
-			{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}},
+			{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+			{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}},
+			{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.1"}}},
+			{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}},
 		},
 		{
-			{Scheme: "npm", Name: "bar", Versions: []string{"3.0.0"}},
-			{Scheme: "npm", Name: "banana", Versions: []string{"2.0.0"}},
-			{Scheme: "npm", Name: "turtle", Versions: []string{"4.2.0"}},
+			{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "3.0.0"}}},
+			{Scheme: "npm", Name: "banana", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+			{Scheme: "npm", Name: "turtle", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "4.2.0"}}},
 		},
 		// catch lack of ordering by ID at the right place
 		{
-			{Scheme: "npm", Name: "applesauce", Versions: []string{"1.2.3"}},
-			{Scheme: "somethingelse", Name: "banana", Versions: []string{"0.1.2"}},
+			{Scheme: "npm", Name: "applesauce", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.2.3"}}},
+			{Scheme: "somethingelse", Name: "banana", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "0.1.2"}}},
 		},
 		// should not be listed due to no versions
 		{
-			{Scheme: "npm", Name: "burger", Versions: []string{}},
+			{Scheme: "npm", Name: "burger", Versions: []shared.MinimalPackageRepoRefVersion{}},
 		},
 	}
 
@@ -189,16 +197,26 @@ func TestDeletePackageRepoRefsByID(t *testing.T) {
 
 	repos := []shared.MinimalPackageRepoRef{
 		// Test same-set flushes
-		{Scheme: "npm", Name: "bar", Versions: []string{"2.0.0"}},
-		{Scheme: "npm", Name: "bar", Versions: []string{"3.0.0"}}, // deleted
-		{Scheme: "npm", Name: "foo", Versions: []string{"1.0.0"}}, // deleted
-		{Scheme: "npm", Name: "foo", Versions: []string{"2.0.0"}},
-		{Scheme: "npm", Name: "banan", Versions: []string{"4.2.0"}}, // deleted
+		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+		{Scheme: "npm", Name: "bar", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "3.0.0"}}}, // version deleted
+		{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "1.0.0"}}}, // version deleted
+		{Scheme: "npm", Name: "foo", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "2.0.0"}}},
+		{Scheme: "npm", Name: "banan", Versions: []shared.MinimalPackageRepoRefVersion{{Version: "4.2.0"}}}, // package deleted
 	}
 
-	if _, _, err := store.InsertPackageRepoRefs(ctx, repos); err != nil {
+	newDeps, newVersions, err := store.InsertPackageRepoRefs(ctx, repos)
+	if err != nil {
 		t.Fatal(err)
 	}
+
+	if len(newDeps) != 3 {
+		t.Fatalf("unexpected number of inserted package repos: (want=%d,got=%d)", 3, len(newDeps))
+	}
+
+	if len(newVersions) != 5 {
+		t.Fatalf("unexpected number of inserted package repo versions: (want=%d,got=%d)", 5, len(newVersions))
+	}
+
 	if err := store.DeletePackageRepoRefsByID(ctx, 1); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -32,6 +32,7 @@ type (
 	PackageRepoRefVersion        = shared.PackageRepoRefVersion
 	MinimalPackageRepoRef        = shared.MinimalPackageRepoRef
 	MinimialVersionedPackageRepo = shared.MinimialVersionedPackageRepo
+	MinimalPackageRepoRefVersion = shared.MinimalPackageRepoRefVersion
 	PackageRepoFilter            = shared.PackageRepoFilter
 )
 

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -24,9 +24,17 @@ type PackageRepoRefVersion struct {
 }
 
 type MinimalPackageRepoRef struct {
-	Scheme   string
-	Name     reposource.PackageName
-	Versions []string
+	Scheme        string
+	Name          reposource.PackageName
+	Versions      []MinimalPackageRepoRefVersion
+	Blocked       bool
+	LastCheckedAt *time.Time
+}
+
+type MinimalPackageRepoRefVersion struct {
+	Version       string
+	Blocked       bool
+	LastCheckedAt *time.Time
 }
 
 type MinimialVersionedPackageRepo struct {

--- a/internal/repos/go_packages_test.go
+++ b/internal/repos/go_packages_test.go
@@ -18,22 +18,22 @@ func TestGoPackagesSource_ListRepos(t *testing.T) {
 		{
 			Scheme: dependencies.GoPackagesScheme,
 			Name:   "github.com/foo/barbaz",
-			Versions: []string{
-				"v0.0.1",
+			Versions: []dependencies.MinimalPackageRepoRefVersion{
+				{Version: "v0.0.1"},
 			}, // test that we create a repo for this module even if it's missing.
 		},
 		{
 			Scheme: dependencies.GoPackagesScheme,
 			Name:   "github.com/gorilla/mux",
-			Versions: []string{
-				"v1.8.0", // test deduplication with version from config
-				"v1.7.4", // test multiple versions of the same module
+			Versions: []dependencies.MinimalPackageRepoRefVersion{
+				{Version: "v1.8.0"}, // test deduplication with version from config
+				{Version: "v1.7.4"}, // test multiple versions of the same module
 			},
 		},
 		{
 			Scheme:   dependencies.GoPackagesScheme,
 			Name:     "github.com/goware/urlx",
-			Versions: []string{"v0.3.1"},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "v0.3.1"}},
 		},
 	})
 

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -132,7 +132,7 @@ var testDependencyRepos = func() []dependencies.MinimalPackageRepoRef {
 		dependencyRepos = append(dependencyRepos, dependencies.MinimalPackageRepoRef{
 			Scheme:   dependencies.NpmPackagesScheme,
 			Name:     dep.PackageSyntax(),
-			Versions: []string{dep.Version},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: dep.Version}},
 		})
 	}
 
@@ -145,20 +145,20 @@ func TestNPMPackagesSource_ListRepos(t *testing.T) {
 		{
 			Scheme: dependencies.NpmPackagesScheme,
 			Name:   "@sourcegraph/sourcegraph.proposed",
-			Versions: []string{
-				"12.0.0", // test deduplication with version from config
-				"12.0.1", // test deduplication with version from config
+			Versions: []dependencies.MinimalPackageRepoRefVersion{
+				{Version: "12.0.0"}, // test deduplication with version from config
+				{Version: "12.0.1"}, // test deduplication with version from config
 			},
 		},
 		{
 			Scheme:   dependencies.NpmPackagesScheme,
 			Name:     "@sourcegraph/web-ext",
-			Versions: []string{"3.0.0-fork.1"},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "3.0.0-fork.1"}},
 		},
 		{
 			Scheme:   dependencies.NpmPackagesScheme,
 			Name:     "fastq",
-			Versions: []string{"0.9.9"}, // test missing modules still create a repo.
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "0.9.9"}}, // test missing modules still create a repo.
 		},
 	})
 

--- a/internal/repos/packages_test.go
+++ b/internal/repos/packages_test.go
@@ -17,7 +17,7 @@ func TestPackagesSource_GetRepo(t *testing.T) {
 		{
 			Scheme:   "go",
 			Name:     "github.com/sourcegraph-testing/go-repo-a",
-			Versions: []string{"1.0.0"},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "1.0.0"}},
 		},
 	})
 

--- a/internal/repos/python_packages_test.go
+++ b/internal/repos/python_packages_test.go
@@ -18,20 +18,20 @@ func TestPythonPackagesSource_ListRepos(t *testing.T) {
 		{
 			Scheme: dependencies.PythonPackagesScheme,
 			Name:   "requests",
-			Versions: []string{
-				"2.27.1", // test deduplication with version from config
-				"2.27.2", // test multiple versions of the same module
+			Versions: []dependencies.MinimalPackageRepoRefVersion{
+				{Version: "2.27.1"}, // test deduplication with version from config
+				{Version: "2.27.2"}, // test multiple versions of the same module
 			},
 		},
 		{
 			Scheme:   dependencies.PythonPackagesScheme,
 			Name:     "numpy",
-			Versions: []string{"1.22.3"},
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "1.22.3"}},
 		},
 		{
 			Scheme:   dependencies.PythonPackagesScheme,
 			Name:     "lofi",
-			Versions: []string{"foobar"}, // test that we create a repo for this package even if it's missing.
+			Versions: []dependencies.MinimalPackageRepoRefVersion{{Version: "foobar"}}, // test that we create a repo for this package even if it's missing.
 		},
 	})
 


### PR DESCRIPTION
We observed on dotcom that the package filtering background job would be running almost constantly due to two reasons: 1) the job is sorta slow (12+min) and 2) it was being triggered constantly by null `last_checked_at` fields.
This PR addresses this unnecessary work by allowing the block status to be set by callers of the Insert methods, and implements this where relevant (one place in gitserver, when we do a lazy-sync, and two places in worker for crate syncing and upload referenced package syncing)

## Test plan

Added additional unit testing to test the inserts and row scanning
