### PR TITLE
fix: Use sparse protocol setting correctly

### DIFF
--- a/docker-images/syntax-highlighter/.cargo/config.toml
+++ b/docker-images/syntax-highlighter/.cargo/config.toml
@@ -6,6 +6,8 @@ rustflags = ["-Ctarget-feature=-crt-static"]
 
 [registry]
 default = "crates-io"
+
+[registries.crates-io]
 protocol = "sparse"
 # The sparse protocol cuts down on registry + crate fetching
 # time from about 1m30s to 21s.

--- a/docker-images/syntax-highlighter/.cargo/config.toml
+++ b/docker-images/syntax-highlighter/.cargo/config.toml
@@ -8,6 +8,7 @@ rustflags = ["-Ctarget-feature=-crt-static"]
 default = "crates-io"
 
 [registries.crates-io]
+index = "https://crates.io"
 protocol = "sparse"
 # The sparse protocol cuts down on registry + crate fetching
 # time from about 1m30s to 21s.

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "624e3eec03d147a53186fa80285e26b7e8b8d6ae59be22f791f34276e946ac82",
+  "checksum": "93e17d247f9cc3972348a03470b5fa0796e3959d22c27908feb32b930c91467a",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",


### PR DESCRIPTION
I benchmarked using the following `hyperfine` command.

```
hyperfine --runs 5 --prepare 'rm -rf /Users/varun/.asdf/installs/rust/1.68.0/registry' 'cargo fetch'
```

## Test plan

Build with Bazel.