### PR TITLE
Fix Organization page having massive user icons

### DIFF
--- a/client/shared/src/components/UserAvatar.tsx
+++ b/client/shared/src/components/UserAvatar.tsx
@@ -61,6 +61,7 @@ export const UserAvatar = React.forwardRef(function UserAvatar(
             src: url,
             id: targetID,
             role: 'presentation',
+            width: size,
             ...otherProps,
         }
 


### PR DESCRIPTION
Adds a `width` property to the user image so that it is sized properly even when the image returned from the URL is not properly sized.

**Before**

![image](https://user-images.githubusercontent.com/6427795/225258442-23db367c-9917-4872-8c31-2f7b6b7c8754.png)

**After**

<img width="686" alt="image" src="https://user-images.githubusercontent.com/6427795/225258546-7bfb28f3-fec7-4f7a-96b7-100970320cae.png">

## Test plan

Visual change. Verified myself by running sourcegraph locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-org-page-user-icon-size-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
