### PR TITLE
[fix] set permissions return proper statistics

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -131,7 +131,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		AccountIDs:  pendingBindIDs,
 	}
 
-	if err = txs.SetRepoPerms(ctx, p.RepoID, perms, authz.SourceAPI); err != nil {
+	if _, err = txs.SetRepoPerms(ctx, p.RepoID, perms, authz.SourceAPI); err != nil {
 		return nil, errors.Wrap(err, "set user repo permissions")
 	} else if _, err = txs.SetRepoPermissions(ctx, p); err != nil {
 		return nil, errors.Wrap(err, "set repository permissions")

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -188,20 +188,20 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 			perms := edb.NewStrictMockPermsStore()
 			perms.TransactFunc.SetDefaultReturn(perms, nil)
 			perms.DoneFunc.SetDefaultReturn(nil)
-			perms.SetRepoPermsFunc.SetDefaultHook(func(_ context.Context, repoID int32, ids []authz.UserIDWithExternalAccountID, source authz.PermsSource) error {
+			perms.SetRepoPermsFunc.SetDefaultHook(func(_ context.Context, repoID int32, ids []authz.UserIDWithExternalAccountID, source authz.PermsSource) (*database.SetPermissionsResult, error) {
 				expUserIDs := maps.Keys(test.expUserIDs)
 				userIDs := make([]int32, len(ids))
 				for i, u := range ids {
 					userIDs[i] = u.UserID
 				}
 				if diff := cmp.Diff(expUserIDs, userIDs); diff != "" {
-					return errors.Errorf("userIDs expected: %v, got: %v", expUserIDs, userIDs)
+					return nil, errors.Errorf("userIDs expected: %v, got: %v", expUserIDs, userIDs)
 				}
 				if source != authz.SourceAPI {
-					return errors.Errorf("source expected: %s, got: %s", authz.SourceAPI, source)
+					return nil, errors.Errorf("source expected: %s, got: %s", authz.SourceAPI, source)
 				}
 
-				return nil
+				return nil, nil
 			})
 			perms.SetRepoPermissionsFunc.SetDefaultHook(func(_ context.Context, p *authz.RepoPermissions) (*database.SetPermissionsResult, error) {
 				ids := p.UserIDs

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler_test.go
@@ -29,7 +29,7 @@ func addPerms(t *testing.T, s edb.PermsStore, userID, repoID int32) {
 	ctx := context.Background()
 
 	if conf.ExperimentalFeatures().UnifiedPermissions {
-		err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{repoID}, authz.SourceUserSync)
+		_, err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: userID - 1}, []int32{repoID}, authz.SourceUserSync)
 		require.NoError(t, err)
 	} else {
 		_, err := s.SetUserPermissions(ctx, &authz.UserPermissions{

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -628,11 +628,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		IDs:    map[int32]struct{}{},
 	}
 
-	unifiedResult := &database.SetPermissionsResult{
-		Added:   0,
-		Found:   0,
-		Removed: 0,
-	}
+	unifiedResult := &database.SetPermissionsResult{}
 	for acctID, repoIDs := range results.repoPerms {
 		// write to new user_repo_permissions table by default
 		stats, err := s.saveUserPermsForAccount(ctx, userID, acctID, repoIDs)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -574,7 +574,7 @@ func (s *PermsSyncer) saveUserPermsForAccount(ctx context.Context, userID int32,
 	// Save new permissions to database
 	defer s.permsUpdateLock.Unlock()
 
-	err := s.permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
+	_, err := s.permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
 		UserID:            userID,
 		ExternalAccountID: acctID,
 	}, repoIDs, authz.SourceUserSync)
@@ -824,7 +824,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	defer func() { err = txs.Done(err) }()
 
 	// write to new user_repo_permissions table by default
-	if err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
+	if _, err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
 		return result, providerStates, errors.Wrapf(err, "set user repo permissions for repository %q (id: %d)", repo.Name, repo.ID)
 	}
 	result, err = txs.SetRepoPermissions(ctx, p)

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -330,7 +330,7 @@ func (h *bitbucketProjectPermissionsHandler) setRepoPermissions(ctx context.Cont
 	}
 
 	// set repo permissions (and user permissions)
-	if err = txs.SetRepoPerms(ctx, int32(repoID), perms, authz.SourceAPI); err != nil {
+	if _, err = txs.SetRepoPerms(ctx, int32(repoID), perms, authz.SourceAPI); err != nil {
 		return errors.Wrapf(err, "failed to set user repo permissions for repo %d and users %v", repoID, perms)
 	} else if _, err = txs.SetRepoPermissions(ctx, &p); err != nil {
 		return errors.Wrapf(err, "failed to set repo permissions for repo %d", repoID)

--- a/enterprise/internal/batches/testing/mock_repo_perms.go
+++ b/enterprise/internal/batches/testing/mock_repo_perms.go
@@ -29,7 +29,7 @@ func MockRepoPermissions(t *testing.T, db database.DB, userID int32, repoIDs ...
 		repoIDMap[int32(id)] = struct{}{}
 	}
 
-	err := permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
+	_, err := permsStore.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{
 		UserID: userID,
 	}, maps.Keys(repoIDMap), authz.SourceUserSync)
 	require.NoError(t, err)

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -332,7 +332,7 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 						UserID: userID,
 					}
 				}
-				if err := s.store.SetRepoPerms(ctx, update.repoID, userIDs, authz.SourceAPI); err != nil {
+				if _, err := s.store.SetRepoPerms(ctx, update.repoID, userIDs, authz.SourceAPI); err != nil {
 					t.Fatal(err)
 				}
 				_, err := s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{
@@ -373,7 +373,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	}
 
 	// Set both effective and pending permissions for a user
-	if err = s.store.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: user.ID}, []int32{int32(repo.ID)}, authz.SourceAPI); err != nil {
+	if _, err = s.store.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: user.ID}, []int32{int32(repo.ID)}, authz.SourceAPI); err != nil {
 		t.Fatal(err)
 	}
 	if _, err = s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -39,8 +39,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		name string
 		test func(*testing.T)
 	}{
-		{"FetchReposByUserAndExternalService", testPermsStore_FetchReposByUserAndExternalService(db)},
-		{"FetchReposByExternalAccount", testPermsStore_FetchReposByExternalAccount(db)},
 		{"LoadUserPendingPermissions", testPermsStore_LoadUserPendingPermissions(db)},
 		{"SetRepoPendingPermissions", testPermsStore_SetRepoPendingPermissions(db)},
 		{"ListPendingUsers", testPermsStore_ListPendingUsers(db)},

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -14396,12 +14396,12 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		SetRepoPermsFunc: &PermsStoreSetRepoPermsFunc{
-			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (r0 error) {
+			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (r0 *database.SetPermissionsResult, r1 error) {
 				return
 			},
 		},
 		SetUserExternalAccountPermsFunc: &PermsStoreSetUserExternalAccountPermsFunc{
-			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (r0 error) {
+			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (r0 *database.SetPermissionsResult, r1 error) {
 				return
 			},
 		},
@@ -14548,12 +14548,12 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		SetRepoPermsFunc: &PermsStoreSetRepoPermsFunc{
-			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
+			defaultHook: func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error) {
 				panic("unexpected invocation of MockPermsStore.SetRepoPerms")
 			},
 		},
 		SetUserExternalAccountPermsFunc: &PermsStoreSetUserExternalAccountPermsFunc{
-			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
+			defaultHook: func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error) {
 				panic("unexpected invocation of MockPermsStore.SetUserExternalAccountPerms")
 			},
 		},
@@ -17094,24 +17094,24 @@ func (c PermsStoreSetRepoPermissionsUnrestrictedFuncCall) Results() []interface{
 // PermsStoreSetRepoPermsFunc describes the behavior when the SetRepoPerms
 // method of the parent MockPermsStore instance is invoked.
 type PermsStoreSetRepoPermsFunc struct {
-	defaultHook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error
-	hooks       []func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error
+	defaultHook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error)
+	hooks       []func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error)
 	history     []PermsStoreSetRepoPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // SetRepoPerms delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockPermsStore) SetRepoPerms(v0 context.Context, v1 int32, v2 []authz.UserIDWithExternalAccountID, v3 authz.PermsSource) error {
-	r0 := m.SetRepoPermsFunc.nextHook()(v0, v1, v2, v3)
-	m.SetRepoPermsFunc.appendCall(PermsStoreSetRepoPermsFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockPermsStore) SetRepoPerms(v0 context.Context, v1 int32, v2 []authz.UserIDWithExternalAccountID, v3 authz.PermsSource) (*database.SetPermissionsResult, error) {
+	r0, r1 := m.SetRepoPermsFunc.nextHook()(v0, v1, v2, v3)
+	m.SetRepoPermsFunc.appendCall(PermsStoreSetRepoPermsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the SetRepoPerms method
 // of the parent MockPermsStore instance is invoked and the hook queue is
 // empty.
-func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error) {
+func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error)) {
 	f.defaultHook = hook
 }
 
@@ -17119,7 +17119,7 @@ func (f *PermsStoreSetRepoPermsFunc) SetDefaultHook(hook func(context.Context, i
 // SetRepoPerms method of the parent MockPermsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error) {
+func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17127,20 +17127,20 @@ func (f *PermsStoreSetRepoPermsFunc) PushHook(hook func(context.Context, int32, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreSetRepoPermsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
-		return r0
+func (f *PermsStoreSetRepoPermsFunc) SetDefaultReturn(r0 *database.SetPermissionsResult, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreSetRepoPermsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
-		return r0
+func (f *PermsStoreSetRepoPermsFunc) PushReturn(r0 *database.SetPermissionsResult, r1 error) {
+	f.PushHook(func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error) {
+		return r0, r1
 	})
 }
 
-func (f *PermsStoreSetRepoPermsFunc) nextHook() func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) error {
+func (f *PermsStoreSetRepoPermsFunc) nextHook() func(context.Context, int32, []authz.UserIDWithExternalAccountID, authz.PermsSource) (*database.SetPermissionsResult, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17187,7 +17187,10 @@ type PermsStoreSetRepoPermsFuncCall struct {
 	Arg3 authz.PermsSource
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *database.SetPermissionsResult
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17199,31 +17202,31 @@ func (c PermsStoreSetRepoPermsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c PermsStoreSetRepoPermsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // PermsStoreSetUserExternalAccountPermsFunc describes the behavior when the
 // SetUserExternalAccountPerms method of the parent MockPermsStore instance
 // is invoked.
 type PermsStoreSetUserExternalAccountPermsFunc struct {
-	defaultHook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error
-	hooks       []func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error
+	defaultHook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error)
+	hooks       []func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error)
 	history     []PermsStoreSetUserExternalAccountPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // SetUserExternalAccountPerms delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) SetUserExternalAccountPerms(v0 context.Context, v1 authz.UserIDWithExternalAccountID, v2 []int32, v3 authz.PermsSource) error {
-	r0 := m.SetUserExternalAccountPermsFunc.nextHook()(v0, v1, v2, v3)
-	m.SetUserExternalAccountPermsFunc.appendCall(PermsStoreSetUserExternalAccountPermsFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockPermsStore) SetUserExternalAccountPerms(v0 context.Context, v1 authz.UserIDWithExternalAccountID, v2 []int32, v3 authz.PermsSource) (*database.SetPermissionsResult, error) {
+	r0, r1 := m.SetUserExternalAccountPermsFunc.nextHook()(v0, v1, v2, v3)
+	m.SetUserExternalAccountPermsFunc.appendCall(PermsStoreSetUserExternalAccountPermsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // SetUserExternalAccountPerms method of the parent MockPermsStore instance
 // is invoked and the hook queue is empty.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error) {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error)) {
 	f.defaultHook = hook
 }
 
@@ -17232,7 +17235,7 @@ func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultHook(hook func(con
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error) {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17240,20 +17243,20 @@ func (f *PermsStoreSetUserExternalAccountPermsFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
-		return r0
+func (f *PermsStoreSetUserExternalAccountPermsFunc) SetDefaultReturn(r0 *database.SetPermissionsResult, r1 error) {
+	f.SetDefaultHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreSetUserExternalAccountPermsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
-		return r0
+func (f *PermsStoreSetUserExternalAccountPermsFunc) PushReturn(r0 *database.SetPermissionsResult, r1 error) {
+	f.PushHook(func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error) {
+		return r0, r1
 	})
 }
 
-func (f *PermsStoreSetUserExternalAccountPermsFunc) nextHook() func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) error {
+func (f *PermsStoreSetUserExternalAccountPermsFunc) nextHook() func(context.Context, authz.UserIDWithExternalAccountID, []int32, authz.PermsSource) (*database.SetPermissionsResult, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17302,7 +17305,10 @@ type PermsStoreSetUserExternalAccountPermsFuncCall struct {
 	Arg3 authz.PermsSource
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *database.SetPermissionsResult
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17314,7 +17320,7 @@ func (c PermsStoreSetUserExternalAccountPermsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c PermsStoreSetUserExternalAccountPermsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // PermsStoreSetUserPermissionsFunc describes the behavior when the

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"sort"
 	"strings"
 	"time"
 
@@ -664,10 +663,12 @@ func (s *permsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermis
 	}
 
 	added, removed := computeDiff(oldIDs, p.IDs)
+	addedIDs := len(added)
+	removedIDs := len(removed)
 
 	// Iterating over maps doesn't guarantee order so we sort the slices to avoid doing unnecessary DB updates.
-	sort.Slice(added, func(i, j int) bool { return added[i] < added[j] })
-	sort.Slice(removed, func(i, j int) bool { return removed[i] < removed[j] })
+	slices.Sort(added)
+	slices.Sort(removed)
 
 	updatedAt := txs.clock()
 	if len(added) != 0 || len(removed) != 0 {
@@ -703,8 +704,8 @@ func (s *permsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermis
 	}
 
 	return &database.SetPermissionsResult{
-		Added:   len(added),
-		Removed: len(removed),
+		Added:   addedIDs,
+		Removed: removedIDs,
 		Found:   len(p.IDs),
 	}, nil
 }
@@ -778,10 +779,12 @@ func (s *permsStore) SetRepoPermissions(ctx context.Context, p *authz.RepoPermis
 	}
 
 	added, removed := computeDiff(oldIDs, p.UserIDs)
+	addedIDs := len(added)
+	removedIDs := len(removed)
 
 	// Iterating over maps doesn't guarantee order, so we sort the slices to avoid doing unnecessary DB updates.
-	sort.Slice(added, func(i, j int) bool { return added[i] < added[j] })
-	sort.Slice(removed, func(i, j int) bool { return removed[i] < removed[j] })
+	slices.Sort(added)
+	slices.Sort(removed)
 
 	updatedAt := txs.clock()
 	if len(added) != 0 || len(removed) != 0 {
@@ -804,8 +807,8 @@ func (s *permsStore) SetRepoPermissions(ctx context.Context, p *authz.RepoPermis
 	}
 
 	return &database.SetPermissionsResult{
-		Added:   len(added),
-		Removed: len(removed),
+		Added:   addedIDs,
+		Removed: removedIDs,
 		Found:   len(p.UserIDs),
 	}, nil
 }

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -97,7 +97,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 2, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -124,7 +124,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 2, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -156,7 +156,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 			}
 			setupPermsRelatedEntities(t, s, []authz.Permission{{UserID: 1, RepoID: 1}, {UserID: 2, RepoID: 1}, {UserID: 3, RepoID: 1}})
 
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 1}, {UserID: 2}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 1}, {UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -167,7 +167,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 				Perm:    authz.Read,
 				UserIDs: toMapset(2, 3),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}, {UserID: 3}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}, {UserID: 3}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 				t.Fatal(err)
@@ -247,7 +247,7 @@ func TestPermsStore_LoadRepoPermissions(t *testing.T) {
 				Type:   authz.PermRepos,
 				IDs:    toMapset(1),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetUserPermissions(context.Background(), up); err != nil {
 				t.Fatal(err)
@@ -274,7 +274,7 @@ func TestPermsStore_LoadRepoPermissions(t *testing.T) {
 				Type:   authz.PermRepos,
 				IDs:    toMapset(1),
 			}
-			if err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
+			if _, err := s.SetRepoPerms(ctx, 1, []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 				t.Fatal(err)
 			} else if _, err := s.SetUserPermissions(context.Background(), up); err != nil {
 				t.Fatal(err)
@@ -1211,7 +1211,7 @@ func TestPermsStore_SetRepoPermissionsUnrestricted(t *testing.T) {
 		if _, err := s.SetRepoPermissions(context.Background(), rp); err != nil {
 			t.Fatal(err)
 		}
-		if err := s.SetRepoPerms(context.Background(), int32(i+1), []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
+		if _, err := s.SetRepoPerms(context.Background(), int32(i+1), []authz.UserIDWithExternalAccountID{{UserID: 2}}, authz.SourceRepoSync); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2760,7 +2760,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 						})
 					}
 
-					if err := s.SetRepoPerms(ctx, repoID, users, authz.SourceRepoSync); err != nil {
+					if _, err := s.SetRepoPerms(ctx, repoID, users, authz.SourceRepoSync); err != nil {
 						t.Fatal(err)
 					}
 
@@ -2936,7 +2936,7 @@ func TestPermsStore_DeleteAllUserPermissions(t *testing.T) {
 	// Set unified permissions for user 1 and 2
 	for _, userID := range []int32{1, 2} {
 		for _, repoID := range []int32{1, 2} {
-			if err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: repoID}, []int32{repoID}, authz.SourceUserSync); err != nil {
+			if _, err := s.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: userID, ExternalAccountID: repoID}, []int32{repoID}, authz.SourceUserSync); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -3406,7 +3406,7 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 		q := sqlf.Sprintf(`INSERT INTO permission_sync_jobs(repository_id, finished_at, reason) VALUES(%d, NOW(), %s)`, 1, database.ReasonRepoNoPermissions)
 		execQuery(t, ctx, s, q)
 
-		err := s.SetRepoPerms(ctx, 3, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}}, authz.SourceRepoSync)
+		_, err := s.SetRepoPerms(ctx, 3, []authz.UserIDWithExternalAccountID{{UserID: 1, ExternalAccountID: 1}}, authz.SourceRepoSync)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description

Fixes the calculation of added/removed permissions for both unified and legacy permissions tables.

The problem with legacy path - [we define added and removed as variables here](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@1fc50a2878c17dd0199a44acbe521726c425b449/-/blob/enterprise/internal/database/perms_store.go?L652-666), but then those slices are modified in the upsert method

The problem with unified path - no calculation made at all :)

## Related issue
fixes #49327
- https://github.com/sourcegraph/sourcegraph/issues/49327

## Test plan

Tested locally + unit tests
