### PR TITLE
doc: typo fix on migrate-backup

### DIFF
--- a/doc/admin/deploy/migrate-backup.md
+++ b/doc/admin/deploy/migrate-backup.md
@@ -76,7 +76,7 @@ The easiest option is to simply back up or migrate [configuration JSON data](#co
 
 ### Option 2: All Postgres data
 
-This option provides a more complete backup, and ensures that almost all state will be restored. Repositories will have to be recloned and reindexed, so some downtime will be required while these oprations complete.
+This option provides a more complete backup, and ensures that almost all state will be restored. Repositories will have to be recloned and reindexed, so some downtime will be required while these operations complete.
 
 Follow the instructions in our [Docker to Docker Compose migration guide](../deploy/docker-compose/migrate.md#backup-single-docker-image-database) to generate a dump of Sourcegraph's Postgres database. [Contact us](https://about.sourcegraph.com/contact/sales) for specific recommendations for your deployment type.
 
@@ -91,7 +91,7 @@ Please use the below table for reference when migrating your data from a Kuberne
 
 |Name|Recreatable|Notes|
 |---|---|---|
-|codeinsight-db|Yes|
+|codeinsights-db|Yes|
 |codeintel-db|Yes|While the data is recreateable, we suggest including the disk during your migration as it often contains a lot of data that would take awhile to regenerate|
 |indexed-search|Yes||
 |gitserver|Yes||


### PR DESCRIPTION
Minor typo fixes on this doc



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
No test plan required. Typo fix on doc