### PR TITLE
SCIM: Fix some random issues

### DIFF
--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -26,10 +26,10 @@ To configure:
    ```
    "scim.authToken": "{your token}"
    ```
-3. Add the following setting to your site config and select the Identity Provider you intend to use. If your specific provider is not listed, select the default value `STANDARD` which matches the SCIM specification.
+3. If you use Microsoft Azure AD: Add the following setting to your site config:
 
    ```
-   "scim.identityProvider": 
+   "scim.identityProvider": "Azure AD"
    ```
 4. Set up your IdP to use our SCIM API. The API is at
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -26,7 +26,7 @@ To configure:
    ```
    "scim.authToken": "{your token}"
    ```
-3. If you use Microsoft Azure AD: Add the following setting to your site config:
+3. If you use Microsoft Azure AD, add the following setting to your site config:
 
    ```
    "scim.identityProvider": "Azure AD"

--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -19,17 +19,17 @@ import (
 type IdentityProvider string
 
 const (
-	SCIM_AZURE_AD IdentityProvider = "Azure AD"
-	SCIM_STANDARD IdentityProvider = "STANDARD"
+	IDPAzureAd  IdentityProvider = "Azure AD"
+	IDPStandard IdentityProvider = "standards-compatible"
 )
 
 func getConfiguredIdentityProvider() IdentityProvider {
 	value := conf.Get().ScimIdentityProvider
 	switch value {
-	case string(SCIM_AZURE_AD):
-		return SCIM_AZURE_AD
+	case string(IDPAzureAd):
+		return IDPAzureAd
 	default:
-		return SCIM_STANDARD
+		return IDPStandard
 	}
 }
 

--- a/enterprise/internal/scim/user.go
+++ b/enterprise/internal/scim/user.go
@@ -68,7 +68,7 @@ func NewUserResourceHandler(ctx context.Context, observationCtx *observation.Con
 func getUserFromDB(ctx context.Context, store database.UserStore, idStr string) (*types.UserForSCIM, error) {
 	id, err := strconv.ParseInt(idStr, 10, 32)
 	if err != nil {
-		return nil, scimerrors.ScimError{Status: http.StatusBadRequest, Detail: "invalid user id"}
+		return nil, scimerrors.ScimErrorResourceNotFound(idStr)
 	}
 
 	users, err := store.ListForSCIM(ctx, &database.UsersListOptions{

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -366,8 +366,8 @@ func azureMultiValueReplaceNotFoundStrategy(multiValueAttribute []interface{},
 	switch v := filterExpression.(type) {
 	case *filter.AttributeExpression:
 		if v.Operator != filter.EQ {
-			// There is nothing we can do in this case because the expected behavior is that an object will be created using the
-			// the left and right side of the operator as a property and value
+			// There is nothing we can do in this case because the expected behavior is to create
+			// an object using the left and right side of the operator as a property and value.
 			return nil, scimerrors.ScimErrorNoTarget
 		}
 		newItem := map[string]interface{}{v.AttributePath.AttributeName: v.CompareValue, propertyToSet: value}

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -379,7 +379,7 @@ func azureMultiValueReplaceNotFoundStrategy(multiValueAttribute []interface{},
 
 func getMultiValueReplaceNotFoundStrategy(provider IdentityProvider) multiValueReplaceNotFoundStrategy {
 	switch provider {
-	case SCIM_AZURE_AD:
+	case IDPAzureAd:
 		return azureMultiValueReplaceNotFoundStrategy
 	default:
 		return standardMultiValueReplaceNotFoundStrategy

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -353,14 +353,14 @@ func standardMultiValueReplaceNotFoundStrategy(
 	_ string,
 	_ interface{},
 	_ string,
-	filterExpression filter.Expression) ([]interface{}, error) {
+	_ filter.Expression) ([]interface{}, error) {
 	return nil, scimerrors.ScimErrorNoTarget
 }
 
 func azureMultiValueReplaceNotFoundStrategy(multiValueAttribute []interface{},
 	propertyToSet string,
 	value interface{},
-	operation string,
+	_ string,
 	filterExpression filter.Expression,
 ) ([]interface{}, error) {
 	switch v := filterExpression.(type) {

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -195,7 +195,7 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 			}
 			validator, _ := sgfilter.NewValidator(buildFilterString(valueExpr, attrName), h.coreSchema, getExtensionSchemas(h.schemaExtensions)...)
 			filterMatched := false
-			// Capture the proper name of the attribute to set so we don't have to do it each iteration
+			// Capture the proper name of the attribute to set, so we don't have to do it each iteration
 			attributeToSet := attrName
 			if subAttrName != "" {
 				attributeToSet = subAttrName
@@ -206,7 +206,7 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 					continue // if this isn't a map of properties it can't match or be replaced
 				}
 				if arrayItemMatchesFilter(attrName, item, validator) {
-					// Note that we found a matching item so we dont' need to take additional actions
+					// Note that we found a matching item, so we don't need to take additional actions
 					filterMatched = true
 					newlyChanged := applyAttributeChange(item, attributeToSet, v, op.Op)
 					if newlyChanged {
@@ -271,13 +271,13 @@ func applyChangeToAttributes(attributes scim.ResourceAttributes, rawPath string,
 
 // applyAttributeChange applies a change to an _existing_ resource attribute (for example, userName).
 func applyAttributeChange(attributes scim.ResourceAttributes, attrName string, value interface{}, op string) (changed bool) {
-	// apply remove operation
+	// Apply remove operation
 	if op == "remove" {
 		delete(attributes, attrName)
 		return true
 	}
 
-	// add only works for arrays and maps, otherwise it's the same as replace
+	// Add only works for arrays and maps, otherwise it's the same as replace
 	if op == "add" {
 		switch value := value.(type) {
 		case []interface{}:
@@ -288,7 +288,7 @@ func applyAttributeChange(attributes scim.ResourceAttributes, attrName string, v
 		}
 	}
 
-	// apply replace operation (or add operation for non-array and non-map values)
+	// Apply "replace" operation (or "add" operation for non-array and non-map values)
 	attributes[attrName] = value
 	return true
 }

--- a/enterprise/internal/scim/user_patch_test.go
+++ b/enterprise/internal/scim/user_patch_test.go
@@ -315,7 +315,7 @@ func Test_UserResourceHandler_Patch_ReplaceStrategies(t *testing.T) {
 		config     *conf.Unified
 	}{
 		{
-			config: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ScimIdentityProvider: string(SCIM_AZURE_AD)}},
+			config: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ScimIdentityProvider: string(IDPAzureAd)}},
 			name:   "Add email with replace Azure",
 			userId: "1",
 			operations: []scim.PatchOperation{


### PR DESCRIPTION
Contains these changes:
- **Giving 404 response for invalid IDs**: Okta validator sends stuff like `010101001010101011001010101011` to check nonexistent users. We returned `400` to these, which made the tests fail. We now return `404`.
- **Simplified docs**: The `scim.identityProvider` setting was mentioned as required, and its description wasn't that specific and led me to believe that this setting was more than just "standard/Azure AD". I've marked it as optional, and cleared up its description.
- **Renamed two constants** to match Go standards. (My IDE gave a warning on these.)
- **Deleted unused arguments** to get rid of code warnings.
- I also **fixed some typos** in comments.

## Test plan

- Tested with Azure AD validator and Okta's SPEC validator.