### PR TITLE
bext: include code-intel extensions to native integration bundle

### DIFF
--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -125,6 +125,7 @@ export function copyIntegrationAssets(): void {
     shelljs.cp('build/dist/css/style.bundle.css', 'build/integration/css')
     shelljs.cp('build/dist/css/inject.bundle.css', 'build/integration/css')
     shelljs.cp('src/native-integration/extensionHostFrame.html', 'build/integration')
+    copyInlineExtensions('build/integration/extensions')
     // Copy to the ui/assets directory so that these files can be served by
     // the webapp.
     shelljs.mkdir('-p', '../../ui/assets/extension')

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -125,7 +125,7 @@ export function copyIntegrationAssets(): void {
     shelljs.cp('build/dist/css/style.bundle.css', 'build/integration/css')
     shelljs.cp('build/dist/css/inject.bundle.css', 'build/integration/css')
     shelljs.cp('src/native-integration/extensionHostFrame.html', 'build/integration')
-    copyInlineExtensions('build/integration/extensions')
+    copyInlineExtensions('build/integration')
     // Copy to the ui/assets directory so that these files can be served by
     // the webapp.
     shelljs.mkdir('-p', '../../ui/assets/extension')

--- a/client/browser/src/shared/platform/context.ts
+++ b/client/browser/src/shared/platform/context.ts
@@ -127,7 +127,7 @@ export function createPlatformContext(
         },
         sourcegraphURL,
         clientApplication: 'other',
-        getStaticExtensions: () => getInlineExtensions(),
+        getStaticExtensions: () => getInlineExtensions(sourcegraphURL),
     }
     return context
 }

--- a/client/browser/src/shared/platform/context.ts
+++ b/client/browser/src/shared/platform/context.ts
@@ -127,7 +127,7 @@ export function createPlatformContext(
         },
         sourcegraphURL,
         clientApplication: 'other',
-        getStaticExtensions: () => getInlineExtensions(sourcegraphURL),
+        getStaticExtensions: () => getInlineExtensions(assetsURL),
     }
     return context
 }

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -9,10 +9,7 @@ import extensions from '../../../code-intel-extensions.json'
 /**
  * Get the manifest URL and script URL for a Sourcegraph extension which is inline (bundled with the browser add-on).
  */
-function getURLsForInlineExtension(
-    extensionID: string,
-    sourcegraphURL: string
-): { manifestURL: string; scriptURL: string } {
+function getURLsForInlineExtension(extensionID: string, assetsURL: string): { manifestURL: string; scriptURL: string } {
     const kebabCaseExtensionID = extensionID.replace(/^sourcegraph\//, 'sourcegraph-')
     const manifestPath = `extensions/${kebabCaseExtensionID}/package.json`
     const scriptPath = `extensions/${kebabCaseExtensionID}/extension.js`
@@ -29,32 +26,28 @@ function getURLsForInlineExtension(
     }
 
     /**
-     * In a native integration environment if SOURCEGRAPH_ASSETS_URL is defined (e.g. GitLab, see [sourcegraph/index.js](https://sourcegraph.com/gitlab.com/gitlab-org/gitlab@a99a4b33543b01d05abd5fcd76b05298ae614fe4/-/blob/app/assets/javascripts/sourcegraph/index.js)),
-     * we can use this URL as the root for bundled assets.
+     * In a native integration environment we can use this URL as the root for bundled assets.
+     * We assume that bundled extensions are available by that URL. For example,
+     *
+     * • GitLab native integration and its assets are hosted on a corresponding GitLab instance (see {@link https://sourcegraph.com/gitlab.com/gitlab-org/gitlab@a99a4b33543b01d05abd5fcd76b05298ae614fe4/-/blob/app/assets/javascripts/sourcegraph/index.js|sourcegraph/index.js} and {@link https://github.com/sourcegraph/sourcegraph/pull/42106|pull/42106})
+     *
+     * • Bitbucket Server integration and its assets are hosted on a connected Sourcegraph instance (see {@link https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/src/main/resources/js/sourcegraph-bitbucket.js|sourcegraph-bitbucket.js} and {@link copyIntegrationAssets})
      */
-    if (window.SOURCEGRAPH_ASSETS_URL) {
+    if (assetsURL) {
         return {
-            manifestURL: new URL(manifestPath, window.SOURCEGRAPH_ASSETS_URL).toString(),
-            scriptURL: new URL(scriptPath, window.SOURCEGRAPH_ASSETS_URL).toString(),
+            manifestURL: new URL(manifestPath, assetsURL).toString(),
+            scriptURL: new URL(scriptPath, assetsURL).toString(),
         }
     }
 
-    /**
-     * In a native integration environment if SOURCEGRAPH_ASSETS_URL is not defined,
-     * we assume that native integration has code-intel extensions bundled during the {@link copyIntegrationAssets} step.
-     * (e.g. BitBucket, see [sourcegraph-bitbucket.js](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/src/main/resources/js/sourcegraph-bitbucket.js)).
-     */
-    return {
-        manifestURL: new URL(`.assets/extension/${manifestPath}`, sourcegraphURL).toString(),
-        scriptURL: new URL(`.assets/extension/${scriptPath}`, sourcegraphURL).toString(),
-    }
+    throw new Error('Can not construct extension URLs')
 }
 
-export function getInlineExtensions(sourcegraphURL: string): Observable<ExecutableExtension[]> {
+export function getInlineExtensions(assetsURL: string): Observable<ExecutableExtension[]> {
     const promises: Promise<ExecutableExtension>[] = []
 
     for (const extensionID of extensions) {
-        const { manifestURL, scriptURL } = getURLsForInlineExtension(extensionID, sourcegraphURL)
+        const { manifestURL, scriptURL } = getURLsForInlineExtension(extensionID, assetsURL)
         promises.push(
             fetch(manifestURL)
                 .then(response => checkOk(response).json())

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -15,7 +15,7 @@ function getURLsForInlineExtension(extensionID: string, assetsURL: string): { ma
     const scriptPath = `extensions/${kebabCaseExtensionID}/extension.js`
 
     /**
-     * In a browser extension environment, we need to find the absolute ULR in the browser extension assets directory.
+     * In a browser extension environment, we need to find the absolute URL in the browser extension assets directory.
      * We assume extension bundles exist (e.g. were built using [build-inline-extensions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a2190db3ee4b7e61f02f821cd2e5b58fa9814540/-/blob/client/browser/scripts/build-inline-extensions.js) script).
      */
     if (typeof window.browser !== 'undefined') {

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -40,9 +40,9 @@ function getURLsForInlineExtension(
     }
 
     /**
-     *  In a native integration environment if SOURCEGRAPH_ASSETS_URL is not defined,
-     *  we assume that native integration has code-intel extensions bundled during the {@link copyIntegrationAssets} step.
-     *  (e.g. BitBucket, see [sourcegraph-bitbucket.js](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/src/main/resources/js/sourcegraph-bitbucket.js)).
+     * In a native integration environment if SOURCEGRAPH_ASSETS_URL is not defined,
+     * we assume that native integration has code-intel extensions bundled during the {@link copyIntegrationAssets} step.
+     * (e.g. BitBucket, see [sourcegraph-bitbucket.js](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/src/main/resources/js/sourcegraph-bitbucket.js)).
      */
     return {
         manifestURL: new URL(`.assets/extension/${manifestPath}`, sourcegraphURL).toString(),

--- a/client/browser/src/shared/platform/inlineExtensionsService.ts
+++ b/client/browser/src/shared/platform/inlineExtensionsService.ts
@@ -9,22 +9,29 @@ import extensions from '../../../code-intel-extensions.json'
 /**
  * Get the manifest URL and script URL for a Sourcegraph extension which is inline (bundled with the browser add-on).
  */
-function getURLsForInlineExtension(extensionID: string): { manifestURL: string; scriptURL: string } {
+function getURLsForInlineExtension(
+    extensionID: string,
+    sourcegraphURL: string
+): { manifestURL: string; scriptURL: string } {
     const kebabCaseExtensionID = extensionID.replace(/^sourcegraph\//, 'sourcegraph-')
-
     const manifestPath = `extensions/${kebabCaseExtensionID}/package.json`
     const scriptPath = `extensions/${kebabCaseExtensionID}/extension.js`
 
-    // In a browser extension environment, we need to find the absolute ULR in the browser extension
-    // asssets directory.
+    /**
+     * In a browser extension environment, we need to find the absolute ULR in the browser extension assets directory.
+     * We assume extension bundles exist (e.g. were built using [build-inline-extensions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a2190db3ee4b7e61f02f821cd2e5b58fa9814540/-/blob/client/browser/scripts/build-inline-extensions.js) script).
+     */
     if (typeof window.browser !== 'undefined') {
         return {
-            manifestURL: browser.extension.getURL(manifestPath),
-            scriptURL: browser.extension.getURL(scriptPath),
+            manifestURL: browser.runtime.getURL(manifestPath),
+            scriptURL: browser.runtime.getURL(scriptPath),
         }
     }
-    // If SOURCEGRAPH_ASSETS_URL is defined (happening for e.g. GitLab native extenisons), we can
-    // use this URL as the root for bundled assets.
+
+    /**
+     * In a native integration environment if SOURCEGRAPH_ASSETS_URL is defined (e.g. GitLab, see [sourcegraph/index.js](https://sourcegraph.com/gitlab.com/gitlab-org/gitlab@a99a4b33543b01d05abd5fcd76b05298ae614fe4/-/blob/app/assets/javascripts/sourcegraph/index.js)),
+     * we can use this URL as the root for bundled assets.
+     */
     if (window.SOURCEGRAPH_ASSETS_URL) {
         return {
             manifestURL: new URL(manifestPath, window.SOURCEGRAPH_ASSETS_URL).toString(),
@@ -32,14 +39,22 @@ function getURLsForInlineExtension(extensionID: string): { manifestURL: string; 
         }
     }
 
-    throw new Error('Can not construct extension URLs')
+    /**
+     *  In a native integration environment if SOURCEGRAPH_ASSETS_URL is not defined,
+     *  we assume that native integration has code-intel extensions bundled during the {@link copyIntegrationAssets} step.
+     *  (e.g. BitBucket, see [sourcegraph-bitbucket.js](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/src/main/resources/js/sourcegraph-bitbucket.js)).
+     */
+    return {
+        manifestURL: new URL(`.assets/extension/${manifestPath}`, sourcegraphURL).toString(),
+        scriptURL: new URL(`.assets/extension/${scriptPath}`, sourcegraphURL).toString(),
+    }
 }
 
-export function getInlineExtensions(): Observable<ExecutableExtension[]> {
+export function getInlineExtensions(sourcegraphURL: string): Observable<ExecutableExtension[]> {
     const promises: Promise<ExecutableExtension>[] = []
 
     for (const extensionID of extensions) {
-        const { manifestURL, scriptURL } = getURLsForInlineExtension(extensionID)
+        const { manifestURL, scriptURL } = getURLsForInlineExtension(extensionID, sourcegraphURL)
         promises.push(
             fetch(manifestURL)
                 .then(response => checkOk(response).json())


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/49380

Bundles code-intel extensions with the native integrations code.

## Test plan
- Ensure browser extension is working ([README](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d1bb51b94cd90f960691fd5fde7cf4cb20fe5522/-/blob/client/browser/README.md?L70))
- Ensure Bitbucket integration is working:
  - `sg start` (ensure Bitbucket code host is configured)
  - `sg run bext`
  - log in to our Bitbucket instance https://bitbucket.sgdev.org
    - ensure Sourcegraph integration is enabled and it points to your local Sourcegraph instance ([README](https://sourcegraph.com/github.com/sourcegraph/bitbucket-server-plugin@97fc6d39f406b100359ee5e22cc3bee9d1453df8/-/blob/README.md?L33-38&view=code))
  - open repo on the Bitbucket instance and ensure that view repo/file on Sourcegraph and code-intel tooltips work as expected

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-bitbucket.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

