### PR TITLE
Code Intel: Add tooltip to brain icon

### DIFF
--- a/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 import { mdiBrain } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Button, Icon, Link } from '@sourcegraph/wildcard'
+import { Button, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { INDEX_COMPLETED_STATES, INDEX_FAILURE_STATES } from '../constants'
 import { useRepoCodeIntelStatus } from '../hooks/useRepoCodeIntelStatus'
@@ -61,7 +61,7 @@ export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName }) =
     }, [indexes, suggestedIndexers])
 
     return (
-        <>
+        <Tooltip content="View code intelligence summary">
             <Link to={`/${repoName}/-/code-graph/dashboard`}>
                 <Button
                     className={classNames('text-decoration-none', styles.braindot, dotStyle)}
@@ -70,6 +70,6 @@ export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName }) =
                     <Icon aria-hidden={true} svgPath={mdiBrain} />
                 </Button>
             </Link>
-        </>
+        </Tooltip>
     )
 }


### PR DESCRIPTION
## Description

Adds tooltip to explain what this link actually directs towards.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/9516420/225296603-fe5a57e9-b6e8-4361-9f3d-7a6f7a6fb908.png">



## Test plan

Tested locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-add-intel-tooltip.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
