### PR TITLE
permissions-center: UX improvements.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -98,11 +98,20 @@ export const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStat
     },
 }
 
-export const PermissionsSyncJobStatusBadge: React.FunctionComponent<{ state: PermissionsSyncJobState }> = ({
+interface PermissionsSyncJobStatusBadgeProps {
+    state: PermissionsSyncJobState
+    cancellationReason: string | null
+    failureMessage: string | null
+}
+
+export const PermissionsSyncJobStatusBadge: React.FunctionComponent<PermissionsSyncJobStatusBadgeProps> = ({
     state,
+    cancellationReason,
+    failureMessage,
 }) => (
     <Badge
         className={classNames(styles.statusContainer, 'mr-1')}
+        tooltip={cancellationReason ?? failureMessage ?? undefined}
         variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}
     >
         {state}

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -344,7 +344,13 @@ const TableColumns: IColumn<PermissionsSyncJob>[] = [
     {
         key: 'Status',
         header: 'Status',
-        render: ({ state }: PermissionsSyncJob) => <PermissionsSyncJobStatusBadge state={state} />,
+        render: ({ state, cancellationReason, failureMessage }: PermissionsSyncJob) => (
+            <PermissionsSyncJobStatusBadge
+                state={state}
+                cancellationReason={cancellationReason}
+                failureMessage={failureMessage}
+            />
+        ),
     },
     {
         key: 'Name',
@@ -375,7 +381,7 @@ const TableColumns: IColumn<PermissionsSyncJob>[] = [
         header: 'Total',
         align: 'right',
         render: ({ permissionsFound }: PermissionsSyncJob) => (
-            <div className="text-secondary text-right mr-2">
+            <div className="text-muted text-right mr-2">
                 <b>{permissionsFound}</b>
             </div>
         ),
@@ -539,6 +545,7 @@ const CodeHostStatesTableColumns: IColumn<CodeHostState>[] = [
 
 const renderModal = (job: PermissionsSyncJob, hideModal: () => void): React.ReactNode => (
     <Modal onDismiss={hideModal} aria-labelledby="permissions-sync-job-modal">
+        {job.cancellationReason && <Alert variant="info">Cancellation reason: {job.cancellationReason}</Alert>}
         {job.failureMessage && <Alert variant="danger">{job.failureMessage}</Alert>}
         <div className={classNames(styles.modalGrid, 'mb-2')}>
             <Text className="mb-0" weight="bold">


### PR DESCRIPTION
Including:
- Added a badge tooltip for `canceled` and `failed` jobs;
- Added an alert with cancellation reason to the top of the details modal;
- Fixed contrast of total number of permissions found.

Test plan:
Local sg run and manual test.

### Demo

https://user-images.githubusercontent.com/94846361/225313030-4b15ca33-0cb9-429b-95da-23e66ce8895f.mp4