### PR TITLE
Highlighting: more C++ improvements

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-treesitter-languages/queries/cpp/highlights.scm
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-languages/queries/cpp/highlights.scm
@@ -1,7 +1,9 @@
 (string_literal) @string
 (system_lib_string) @string
+(raw_string_literal) @string
 
 (null) @constant.null
+(nullptr) @constant.null
 (number_literal) @number
 (char_literal) @character
 (true) @boolean

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/cpp_example3.cc
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/cpp_example3.cc
@@ -107,9 +107,23 @@ void literals() {
     char charLit = 'x';
     auto stringLit = "Hello";
     auto wideStringLit = L"World";
-    auto rawStringLit = R"(Hello
-    World)";
+    auto utf8StringLit = u8"World";
+    auto utf16StringLit = u"World";
+    auto utf32StringLit = U"World";
+    const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
+    auto rawStringLit = R"sequence(Hello
+    \n
+    \r
+    \t
+    World)sequence";
     auto nullptrLit = nullptr;
+    auto nullLit = NULL;
+    const wchar_t* s4 = L"ABC" L"DEF"; // ok, same as
+    const wchar_t* s5 = L"ABCDEF";
+    const char32_t* s6 = U"GHI" "JKL"; // ok, same as
+    const char32_t* s7 = U"GHIJKL";
+    const char16_t* s9 = "MN" u"OP" "QR"; // ok, same as
+    const char16_t* sA = u"MNOPQR";
 }
 
 
@@ -196,5 +210,4 @@ void attributes() {
     if (has_attribute<my_attribute>(myData)) {
         // data has the my_attribute attribute
     }
-}
 }

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/cpp_example3.cc
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/cpp_example3.cc
@@ -110,7 +110,6 @@ void literals() {
     auto utf8StringLit = u8"World";
     auto utf16StringLit = u"World";
     auto utf32StringLit = U"World";
-    const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
     auto rawStringLit = R"sequence(Hello
     \n
     \r
@@ -118,6 +117,9 @@ void literals() {
     World)sequence";
     auto nullptrLit = nullptr;
     auto nullLit = NULL;
+
+    // Examples from https://en.cppreference.com/w/cpp/language/string_literal
+    const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
     const wchar_t* s4 = L"ABC" L"DEF"; // ok, same as
     const wchar_t* s5 = L"ABCDEF";
     const char32_t* s6 = U"GHI" "JKL"; // ok, same as

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__cpp_example3.cc.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__cpp_example3.cc.snap
@@ -362,13 +362,77 @@ expression: "dump_document(&document, &contents)"
 //    ^^^^ Keyword 
 //         ^^^^^^^^^^^^^ Identifier 
 //                         ^^^^^^^^ StringLiteral 
-      auto rawStringLit = R"(Hello
+      auto utf8StringLit = u8"World";
+//    ^^^^ Keyword 
+//         ^^^^^^^^^^^^^ Identifier 
+//                         ^^^^^^^^^ StringLiteral 
+      auto utf16StringLit = u"World";
+//    ^^^^ Keyword 
+//         ^^^^^^^^^^^^^^ Identifier 
+//                          ^^^^^^^^ StringLiteral 
+      auto utf32StringLit = U"World";
+//    ^^^^ Keyword 
+//         ^^^^^^^^^^^^^^ Identifier 
+//                          ^^^^^^^^ StringLiteral 
+      const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
+//    ^^^^^ Keyword 
+//          ^^^^^^^ IdentifierType 
+//                   ^^ Identifier 
+//                        ^^^^^^^^^^^^^^ StringLiteral 
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
+      auto rawStringLit = R"sequence(Hello
 //    ^^^^ Keyword 
 //         ^^^^^^^^^^^^ Identifier 
-      World)";
+//                        ^^^^^^^^^^^^^^^^ StringLiteral 113:24..117:19 
+      \n
+      \r
+      \t
+      World)sequence";
       auto nullptrLit = nullptr;
 //    ^^^^ Keyword 
 //         ^^^^^^^^^^ Identifier 
+//                      ^^^^^^^ IdentifierNull 
+      auto nullLit = NULL;
+//    ^^^^ Keyword 
+//         ^^^^^^^ Identifier 
+//                   ^^^^ IdentifierNull 
+      const wchar_t* s4 = L"ABC" L"DEF"; // ok, same as
+//    ^^^^^ Keyword 
+//          ^^^^^^^ IdentifierType 
+//                   ^^ Identifier 
+//                        ^^^^^^ StringLiteral 
+//                               ^^^^^^ StringLiteral 
+//                                       ^^^^^^^^^^^^^^ Comment 
+      const wchar_t* s5 = L"ABCDEF";
+//    ^^^^^ Keyword 
+//          ^^^^^^^ IdentifierType 
+//                   ^^ Identifier 
+//                        ^^^^^^^^^ StringLiteral 
+      const char32_t* s6 = U"GHI" "JKL"; // ok, same as
+//    ^^^^^ Keyword 
+//          ^^^^^^^^ IdentifierBuiltinType 
+//                    ^^ Identifier 
+//                         ^^^^^^ StringLiteral 
+//                                ^^^^^ StringLiteral 
+//                                       ^^^^^^^^^^^^^^ Comment 
+      const char32_t* s7 = U"GHIJKL";
+//    ^^^^^ Keyword 
+//          ^^^^^^^^ IdentifierBuiltinType 
+//                    ^^ Identifier 
+//                         ^^^^^^^^^ StringLiteral 
+      const char16_t* s9 = "MN" u"OP" "QR"; // ok, same as
+//    ^^^^^ Keyword 
+//          ^^^^^^^^ IdentifierBuiltinType 
+//                    ^^ Identifier 
+//                         ^^^^ StringLiteral 
+//                              ^^^^^ StringLiteral 
+//                                    ^^^^ StringLiteral 
+//                                          ^^^^^^^^^^^^^^ Comment 
+      const char16_t* sA = u"MNOPQR";
+//    ^^^^^ Keyword 
+//          ^^^^^^^^ IdentifierBuiltinType 
+//                    ^^ Identifier 
+//                         ^^^^^^^^^ StringLiteral 
   }
   
   
@@ -646,6 +710,5 @@ expression: "dump_document(&document, &contents)"
           // data has the my_attribute attribute
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
       }
-  }
   }
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__cpp_example3.cc.snap
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/sg_syntax__sg_treesitter__test__cpp_example3.cc.snap
@@ -374,16 +374,10 @@ expression: "dump_document(&document, &contents)"
 //    ^^^^ Keyword 
 //         ^^^^^^^^^^^^^^ Identifier 
 //                          ^^^^^^^^ StringLiteral 
-      const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
-//    ^^^^^ Keyword 
-//          ^^^^^^^ IdentifierType 
-//                   ^^ Identifier 
-//                        ^^^^^^^^^^^^^^ StringLiteral 
-//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
       auto rawStringLit = R"sequence(Hello
 //    ^^^^ Keyword 
 //         ^^^^^^^^^^^^ Identifier 
-//                        ^^^^^^^^^^^^^^^^ StringLiteral 113:24..117:19 
+//                        ^^^^^^^^^^^^^^^^ StringLiteral 112:24..116:19 
       \n
       \r
       \t
@@ -396,6 +390,15 @@ expression: "dump_document(&document, &contents)"
 //    ^^^^ Keyword 
 //         ^^^^^^^ Identifier 
 //                   ^^^^ IdentifierNull 
+  
+      // Examples from https://en.cppreference.com/w/cpp/language/string_literal
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
+      const wchar_t* sC = LR"--(STUV)--"; // ok, raw string literal
+//    ^^^^^ Keyword 
+//          ^^^^^^^ IdentifierType 
+//                   ^^ Identifier 
+//                        ^^^^^^^^^^^^^^ StringLiteral 
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ Comment 
       const wchar_t* s4 = L"ABC" L"DEF"; // ok, same as
 //    ^^^^^ Keyword 
 //          ^^^^^^^ IdentifierType 


### PR DESCRIPTION
* Treat raw string literals as strings
* Treat nullptr as a null literal

I was hoping to be able to use `@string.escape` for the character sequence before in raw string literals but the grammar we're using (official C++ grammar) doesn't provide AST nodes for them. We should consider moving to a non-official grammar that supports these, see https://sourcegraph.slack.com/archives/C03C5EFRMR8/p1678881469547489

## Test plan

See updated snapshots.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
