### PR TITLE
SCIM: add constant time comparison

### DIFF
--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -72,8 +72,7 @@ func newHandler(ctx context.Context, db database.DB, observationCtx *observation
 	// wrap server into logger handler
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// 🚨 SECURITY: Use constant-time comparisons to avoid leaking the verification
-		// code via timing attack. It is not important to avoid leaking the *length* of
-		// the code, because the length of verification codes is constant.
+		// code via timing attack.
 		if subtle.ConstantTimeCompare([]byte(conf.Get().ScimAuthToken),
 			[]byte(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))) != 1 {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/enterprise/internal/scim/init.go
+++ b/enterprise/internal/scim/init.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -70,7 +71,11 @@ func newHandler(ctx context.Context, db database.DB, observationCtx *observation
 
 	// wrap server into logger handler
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if conf.Get().ScimAuthToken != strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ") {
+		// 🚨 SECURITY: Use constant-time comparisons to avoid leaking the verification
+		// code via timing attack. It is not important to avoid leaking the *length* of
+		// the code, because the length of verification codes is constant.
+		if subtle.ConstantTimeCompare([]byte(conf.Get().ScimAuthToken),
+			[]byte(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))) != 1 {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Adding a constant time comparison for the auth token. This makes sure no timing attacks are possible to get the token.

## Test plan
- [x] ci test
- [x] review

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
