### PR TITLE
bazel: remove timeout from jest test

### DIFF
--- a/client/observability-client/BUILD.bazel
+++ b/client/observability-client/BUILD.bazel
@@ -87,7 +87,6 @@ ts_project(
 
 jest_test(
     name = "test",
-    timeout = "short",
     data = [
         ":observability-client_tests",
     ],


### PR DESCRIPTION
timeoutes are not valid in jest_test


## Test plan

tested locally