### PR TITLE
bext: fix styles issues on Bitbucket

### DIFF
--- a/client/browser/src/shared/code-hosts/bitbucket/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/codeHost.module.scss
@@ -80,6 +80,18 @@
     }
 }
 
+.hover-overlay {
+    // HoverOverlay max-width is defined in rem (https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0a7bfc6c389b71484615e788a62b9ef262823726/-/blob/client/shared/src/hover/HoverOverlay.module.scss?L15).
+    // Rem on Bitbucket equals to 14px vs 16px on Sourcegraph.
+    // Set value in pixels to ensure content fits container.
+    max-width: 544px !important; // 34rem * 16px in Sourcegraph web app
+}
+
+.hover-actions {
+    display: flex;
+    gap: 5px;
+}
+
 /* Hover overlay buttons */
 .hover-action-item {
     margin: 0 !important;
@@ -90,11 +102,6 @@
 
     &:first-child {
         border-left: none !important;
-    }
-
-    /* Add margin between buttons. Important is required to override the rule above. */
-    & + & {
-        margin-left: 0.25rem !important;
     }
 }
 

--- a/client/browser/src/shared/code-hosts/bitbucket/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/codeHost.module.scss
@@ -88,8 +88,10 @@
 }
 
 .hover-actions {
-    display: flex;
-    gap: 5px;
+    > span:not(:first-child) {
+        /* Add margin between buttons. */
+        margin-left: 0.25rem !important;
+    }
 }
 
 /* Hover overlay buttons */
@@ -102,6 +104,11 @@
 
     &:first-child {
         border-left: none !important;
+    }
+
+    /* Add margin between buttons. Important is required to override the rule above. */
+    & + & {
+        margin-left: 0.25rem !important;
     }
 }
 

--- a/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/bitbucket/codeHost.tsx
@@ -236,7 +236,8 @@ export const bitbucketServerCodeHost: CodeHost = {
         listItemClass: styles.actionNavItem,
     },
     hoverOverlayClassProps: {
-        className: 'aui-dialog',
+        className: classNames('aui-dialog', styles.hoverOverlay),
+        actionsClassName: styles.hoverActions,
         actionItemClassName: classNames('aui-button', styles.hoverActionItem),
         iconClassName,
     },

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -39,6 +39,7 @@ export interface HoverOverlayClassProps {
     actionItemPressedClassName?: string
 
     contentClassName?: string
+    actionsClassName?: string
 }
 
 export interface HoverOverlayProps
@@ -105,6 +106,7 @@ export const HoverOverlay: React.FunctionComponent<React.PropsWithChildren<Hover
         actionItemClassName,
         actionItemPressedClassName,
         contentClassName,
+        actionsClassName,
 
         actionItemStyleProps,
 
@@ -172,7 +174,7 @@ export const HoverOverlay: React.FunctionComponent<React.PropsWithChildren<Hover
                     !isErrorLike(actionsOrError) &&
                     actionsOrError.length > 0 && (
                         <div className={hoverOverlayStyle.actions}>
-                            <div className={hoverOverlayStyle.actionsInner}>
+                            <div className={classNames(hoverOverlayStyle.actionsInner, actionsClassName)}>
                                 {actionsOrError.map((action, index) => (
                                     <ActionItem
                                         key={index}


### PR DESCRIPTION
Fixes browser extension style regressions on Bitbucket Server.

1. Adjsuts code-intel popover max-width (see comment in code).
2. Adds spacing between the code-intel actions. 
This is reached by adding an extra className prop to the `HoverOverlay` component. The [existing approach to styling buttons](https://github.com/sourcegraph/sourcegraph/pull/49424/files#diff-51b5265e8486cfdbbb933a15b0cc8f99cd65e019b7e792bd488ff0a184348073R109-R112) likely stopped working with https://github.com/sourcegraph/sourcegraph/pull/41898 when code-intel actions were wrapped with an extra `span` element. Still, we don't remove these styles as `ActionItem` (rendered by `HoverOverlay`) [conditionally wraps actions with `span`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@135064fb4f98218d3290dae6fdc36cbc2504c886/-/blob/client/shared/src/actions/ActionItem.tsx?L267-338).

| Before | After |
|--|--|
|<img width="742" alt="Screenshot 2023-03-15 at 17 33 46" src="https://user-images.githubusercontent.com/25318659/225362316-642c75b1-9345-4eca-937b-97a39a5a93bf.png">|<img width="742" alt="Screenshot 2023-03-15 at 18 01 18" src="https://user-images.githubusercontent.com/25318659/225370805-f85dbe52-2c65-47fb-9cf9-04d23e331ae6.png">|

## Test plan
- check hover tooltip styles on Bitbucket server using the browser extension or the native integration (see https://github.com/sourcegraph/sourcegraph/pull/49396#issue-1625341479 test plan for setup instructions)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-styles-on.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
