### PR TITLE
own: add more test CODEOWNERS entries for the team

### DIFF
--- a/.github/test.CODEOWNERS
+++ b/.github/test.CODEOWNERS
@@ -245,5 +245,3 @@
 /client/web/src/**/own/ @sourcegraph/own
 /cmd/frontend/graphqlbackend/own* @sourcegraph/own
 /internal/usagestats/own* @sourcegraph/own
-
-

--- a/.github/test.CODEOWNERS
+++ b/.github/test.CODEOWNERS
@@ -240,6 +240,10 @@
 /monitoring/precise_code_intel_* @efritz @sourcegraph/code-intelligence
 
 /enterprise/internal/own/ @sourcegraph/own
-/client/web/src/repo/blob/own/ @sourcegraph/own
+/enterprise/internal/database/codeowners* @sourcegraph/own
+/enterprise/cmd/frontend/internal/own/ @sourcegraph/own
+/client/web/src/**/own/ @sourcegraph/own
 /cmd/frontend/graphqlbackend/own* @sourcegraph/own
-/internal/usagestats/own.go @sourcegraph/own 
+/internal/usagestats/own* @sourcegraph/own
+
+


### PR DESCRIPTION
was QAing `file:has.owner` and thought it'd be fun to find some other unowned paths using `repo:^github\.com/sourcegraph/sourcegraph$ file:own -file:has.owner()`, this adds some other ones that seem relevant

## Test plan

codeowners change only- checked syntax.