### PR TITLE
internal/conf: Redact Azure DevOps client secret

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -226,7 +226,7 @@ var siteConfigSecrets = []struct {
 // UnredactSecrets unredacts unchanged secrets back to their original value for
 // the given configuration.
 //
-// Updates to this function should also being reflected in the RedactSecrets.
+// Updates to this function should also be reflected in the RedactSecrets.
 func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 	oldCfg, err := ParseConfig(raw)
 	if err != nil {
@@ -246,6 +246,9 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 		}
 		if ap.Bitbucketcloud != nil {
 			oldSecrets[ap.Bitbucketcloud.ClientKey] = ap.Bitbucketcloud.ClientSecret
+		}
+		if ap.AzureDevOps != nil {
+			oldSecrets[ap.AzureDevOps.ClientID] = ap.AzureDevOps.ClientSecret
 		}
 	}
 
@@ -267,6 +270,9 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 		}
 		if ap.Bitbucketcloud != nil && ap.Bitbucketcloud.ClientSecret == redactedSecret {
 			ap.Bitbucketcloud.ClientSecret = oldSecrets[ap.Bitbucketcloud.ClientKey]
+		}
+		if ap.AzureDevOps != nil && ap.AzureDevOps.ClientSecret == redactedSecret {
+			ap.AzureDevOps.ClientSecret = oldSecrets[ap.AzureDevOps.ClientID]
 		}
 	}
 	unredactedSite, err := jsonc.Edit(input, newCfg.AuthProviders, "auth.providers")
@@ -334,6 +340,9 @@ func redactConfSecrets(raw conftypes.RawUnified, hashSecrets bool) (empty confty
 		}
 		if ap.Bitbucketcloud != nil {
 			ap.Bitbucketcloud.ClientSecret = getRedactedSecret(ap.Bitbucketcloud.ClientSecret)
+		}
+		if ap.AzureDevOps != nil {
+			ap.AzureDevOps.ClientSecret = getRedactedSecret(ap.AzureDevOps.ClientSecret)
 		}
 	}
 	redactedSite := raw.Site

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -18,6 +18,7 @@ const (
 	authOpenIDClientSecret                      = "authOpenIDClientSecret"
 	authGitHubClientSecret                      = "authGitHubClientSecret"
 	authGitLabClientSecret                      = "authGitLabClientSecret"
+	authAzureDevOpsClientSecret                 = "authAzureDevOpsClientSecret"
 	emailSMTPPassword                           = "emailSMTPPassword"
 	organizationInvitationsSigningKey           = "organizationInvitationsSigningKey"
 	githubClientSecret                          = "githubClientSecret"
@@ -216,16 +217,21 @@ func TestRedactSecrets(t *testing.T) {
 	redacted, err := RedactSecrets(
 		conftypes.RawUnified{
 			Site: getTestSiteWithSecrets(
-				executorsAccessToken,
-				authOpenIDClientSecret, authGitLabClientSecret, authGitHubClientSecret,
-				emailSMTPPassword,
-				organizationInvitationsSigningKey,
-				githubClientSecret,
-				dotcomGitHubAppCloudClientSecret,
-				dotcomGitHubAppCloudPrivateKey,
-				dotcomSrcCliVersionCacheGitHubToken,
-				dotcomSrcCliVersionCacheGitHubWebhookSecret,
-				authUnlockAccountLinkSigningKey,
+				testSecrets{
+					executorsAccessToken:                        executorsAccessToken,
+					authOpenIDClientSecret:                      authOpenIDClientSecret,
+					authGitLabClientSecret:                      authGitLabClientSecret,
+					authGitHubClientSecret:                      authGitHubClientSecret,
+					authAzureDevOpsClientSecret:                 authAzureDevOpsClientSecret,
+					emailSMTPPassword:                           emailSMTPPassword,
+					organizationInvitationsSigningKey:           organizationInvitationsSigningKey,
+					githubClientSecret:                          githubClientSecret,
+					dotcomGitHubAppCloudClientSecret:            dotcomGitHubAppCloudClientSecret,
+					dotcomGitHubAppCloudPrivateKey:              dotcomGitHubAppCloudPrivateKey,
+					dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
+					dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
+					authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+				},
 			),
 		},
 	)
@@ -262,26 +268,26 @@ func TestRedactConfSecrets(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		hasSecrets     bool
+		hashSecrets    bool
 		redactedFmtStr string
 	}{
 		{
-			name:       "hasSecrets true",
-			hasSecrets: true,
+			name:        "hashSecrets true",
+			hashSecrets: true,
 			// This is the first 10 chars of the SHA256 of "strongsecret". See this go playground to
 			// verify: https://go.dev/play/p/N-4R4_fO9XI.
 			redactedFmtStr: "REDACTED-DATA-CHUNK-f434ecc765",
 		},
 		{
-			name:           "hasSecrets false",
-			hasSecrets:     false,
+			name:           "hashSecrets false",
+			hashSecrets:    false,
 			redactedFmtStr: "REDACTED",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			redacted, err := redactConfSecrets(conftypes.RawUnified{Site: conf}, tc.hasSecrets)
+			redacted, err := redactConfSecrets(conftypes.RawUnified{Site: conf}, tc.hashSecrets)
 			require.NoError(t, err)
 
 			want := fmt.Sprintf(want, tc.redactedFmtStr)
@@ -307,16 +313,21 @@ func TestRedactSecrets_AuthProvidersSectionNotAdded(t *testing.T) {
 
 func TestUnredactSecrets(t *testing.T) {
 	previousSite := getTestSiteWithSecrets(
-		executorsAccessToken,
-		authOpenIDClientSecret, authGitLabClientSecret, authGitHubClientSecret,
-		emailSMTPPassword,
-		organizationInvitationsSigningKey,
-		githubClientSecret,
-		dotcomGitHubAppCloudClientSecret,
-		dotcomGitHubAppCloudPrivateKey,
-		dotcomSrcCliVersionCacheGitHubToken,
-		dotcomSrcCliVersionCacheGitHubWebhookSecret,
-		authUnlockAccountLinkSigningKey,
+		testSecrets{
+			executorsAccessToken:                        executorsAccessToken,
+			authOpenIDClientSecret:                      authOpenIDClientSecret,
+			authGitLabClientSecret:                      authGitLabClientSecret,
+			authGitHubClientSecret:                      authGitHubClientSecret,
+			authAzureDevOpsClientSecret:                 authAzureDevOpsClientSecret,
+			emailSMTPPassword:                           emailSMTPPassword,
+			organizationInvitationsSigningKey:           organizationInvitationsSigningKey,
+			githubClientSecret:                          githubClientSecret,
+			dotcomGitHubAppCloudClientSecret:            dotcomGitHubAppCloudClientSecret,
+			dotcomGitHubAppCloudPrivateKey:              dotcomGitHubAppCloudPrivateKey,
+			dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
+			dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
+			authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+		},
 	)
 
 	t.Run("replaces REDACTED with corresponding secret", func(t *testing.T) {
@@ -329,32 +340,42 @@ func TestUnredactSecrets(t *testing.T) {
 
 	t.Run("unredacts secrets AND respects specified edits to secret", func(t *testing.T) {
 		input := getTestSiteWithSecrets(
-			"new"+executorsAccessToken,
-			redactedSecret, "new"+authGitLabClientSecret, redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
+			testSecrets{
+				executorsAccessToken:                        "new" + executorsAccessToken,
+				authOpenIDClientSecret:                      redactedSecret,
+				authGitLabClientSecret:                      "new" + authGitLabClientSecret,
+				authGitHubClientSecret:                      redactedSecret,
+				authAzureDevOpsClientSecret:                 redactedSecret,
+				emailSMTPPassword:                           redactedSecret,
+				organizationInvitationsSigningKey:           redactedSecret,
+				githubClientSecret:                          redactedSecret,
+				dotcomGitHubAppCloudClientSecret:            redactedSecret,
+				dotcomGitHubAppCloudPrivateKey:              redactedSecret,
+				dotcomSrcCliVersionCacheGitHubToken:         redactedSecret,
+				dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
+				authUnlockAccountLinkSigningKey:             redactedSecret,
+			},
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
 		require.NoError(t, err)
 
 		// Expect to have newly-specified secrets and to fill in "REDACTED" secrets with secrets from previous site
 		want := getTestSiteWithSecrets(
-			"new"+executorsAccessToken,
-			authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
-			emailSMTPPassword,
-			organizationInvitationsSigningKey,
-			githubClientSecret,
-			dotcomGitHubAppCloudClientSecret,
-			dotcomGitHubAppCloudPrivateKey,
-			dotcomSrcCliVersionCacheGitHubToken,
-			dotcomSrcCliVersionCacheGitHubWebhookSecret,
-			authUnlockAccountLinkSigningKey,
+			testSecrets{
+				executorsAccessToken:                        "new" + executorsAccessToken,
+				authOpenIDClientSecret:                      authOpenIDClientSecret,
+				authGitLabClientSecret:                      "new" + authGitLabClientSecret,
+				authGitHubClientSecret:                      authGitHubClientSecret,
+				authAzureDevOpsClientSecret:                 authAzureDevOpsClientSecret,
+				emailSMTPPassword:                           emailSMTPPassword,
+				organizationInvitationsSigningKey:           organizationInvitationsSigningKey,
+				githubClientSecret:                          githubClientSecret,
+				dotcomGitHubAppCloudClientSecret:            dotcomGitHubAppCloudClientSecret,
+				dotcomGitHubAppCloudPrivateKey:              dotcomGitHubAppCloudPrivateKey,
+				dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
+				dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
+				authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+			},
 		)
 		assert.Equal(t, want, unredactedSite)
 	})
@@ -362,16 +383,21 @@ func TestUnredactSecrets(t *testing.T) {
 	t.Run("unredacts secrets and respects edits to config", func(t *testing.T) {
 		const newEmail = "new_email@example.com"
 		input := getTestSiteWithSecrets(
-			"new"+executorsAccessToken,
-			redactedSecret, "new"+authGitLabClientSecret, redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
-			redactedSecret,
+			testSecrets{
+				executorsAccessToken:                        "new" + executorsAccessToken,
+				authOpenIDClientSecret:                      redactedSecret,
+				authGitLabClientSecret:                      "new" + authGitLabClientSecret,
+				authGitHubClientSecret:                      redactedSecret,
+				authAzureDevOpsClientSecret:                 redactedSecret,
+				emailSMTPPassword:                           redactedSecret,
+				organizationInvitationsSigningKey:           redactedSecret,
+				githubClientSecret:                          redactedSecret,
+				dotcomGitHubAppCloudClientSecret:            redactedSecret,
+				dotcomGitHubAppCloudPrivateKey:              redactedSecret,
+				dotcomSrcCliVersionCacheGitHubToken:         redactedSecret,
+				dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
+				authUnlockAccountLinkSigningKey:             redactedSecret,
+			},
 			newEmail,
 		)
 		unredactedSite, err := UnredactSecrets(input, conftypes.RawUnified{Site: previousSite})
@@ -379,16 +405,21 @@ func TestUnredactSecrets(t *testing.T) {
 
 		// Expect new secrets and new email to show up in the unredacted version
 		want := getTestSiteWithSecrets(
-			"new"+executorsAccessToken,
-			authOpenIDClientSecret, "new"+authGitLabClientSecret, authGitHubClientSecret,
-			emailSMTPPassword,
-			organizationInvitationsSigningKey,
-			githubClientSecret,
-			dotcomGitHubAppCloudClientSecret,
-			dotcomGitHubAppCloudPrivateKey,
-			dotcomSrcCliVersionCacheGitHubToken,
-			dotcomSrcCliVersionCacheGitHubWebhookSecret,
-			authUnlockAccountLinkSigningKey,
+			testSecrets{
+				executorsAccessToken:                        "new" + executorsAccessToken,
+				authOpenIDClientSecret:                      authOpenIDClientSecret,
+				authGitLabClientSecret:                      "new" + authGitLabClientSecret,
+				authGitHubClientSecret:                      authGitHubClientSecret,
+				authAzureDevOpsClientSecret:                 authAzureDevOpsClientSecret,
+				emailSMTPPassword:                           emailSMTPPassword,
+				organizationInvitationsSigningKey:           organizationInvitationsSigningKey,
+				githubClientSecret:                          githubClientSecret,
+				dotcomGitHubAppCloudClientSecret:            dotcomGitHubAppCloudClientSecret,
+				dotcomGitHubAppCloudPrivateKey:              dotcomGitHubAppCloudPrivateKey,
+				dotcomSrcCliVersionCacheGitHubToken:         dotcomSrcCliVersionCacheGitHubToken,
+				dotcomSrcCliVersionCacheGitHubWebhookSecret: dotcomSrcCliVersionCacheGitHubWebhookSecret,
+				authUnlockAccountLinkSigningKey:             authUnlockAccountLinkSigningKey,
+			},
 			newEmail,
 		)
 		assert.Equal(t, want, unredactedSite)
@@ -396,20 +427,42 @@ func TestUnredactSecrets(t *testing.T) {
 }
 
 func getTestSiteWithRedactedSecrets() string {
-	return getTestSiteWithSecrets(redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret, redactedSecret)
+	return getTestSiteWithSecrets(
+		testSecrets{
+			executorsAccessToken:                        redactedSecret,
+			authOpenIDClientSecret:                      redactedSecret,
+			authGitLabClientSecret:                      redactedSecret,
+			authGitHubClientSecret:                      redactedSecret,
+			authAzureDevOpsClientSecret:                 redactedSecret,
+			emailSMTPPassword:                           redactedSecret,
+			organizationInvitationsSigningKey:           redactedSecret,
+			githubClientSecret:                          redactedSecret,
+			dotcomGitHubAppCloudClientSecret:            redactedSecret,
+			dotcomGitHubAppCloudPrivateKey:              redactedSecret,
+			dotcomSrcCliVersionCacheGitHubToken:         redactedSecret,
+			dotcomSrcCliVersionCacheGitHubWebhookSecret: redactedSecret,
+			authUnlockAccountLinkSigningKey:             redactedSecret,
+		},
+	)
 }
 
-func getTestSiteWithSecrets(
-	executorsAccessToken,
-	authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,
-	emailSMTPPassword,
-	organizationInvitationsSigningKey,
-	githubClientSecret,
-	dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey,
-	dotcomSrcCliVersionCacheGitHubToken, dotcomSrcCliVersionCacheGitHubWebhookSecret,
-	authUnlockAccountLinkSigningKey string,
-	optionalEdit ...string,
-) string {
+type testSecrets struct {
+	executorsAccessToken                        string
+	authOpenIDClientSecret                      string
+	authGitHubClientSecret                      string
+	authGitLabClientSecret                      string
+	authAzureDevOpsClientSecret                 string
+	emailSMTPPassword                           string
+	organizationInvitationsSigningKey           string
+	githubClientSecret                          string
+	dotcomGitHubAppCloudClientSecret            string
+	dotcomGitHubAppCloudPrivateKey              string
+	dotcomSrcCliVersionCacheGitHubToken         string
+	dotcomSrcCliVersionCacheGitHubWebhookSecret string
+	authUnlockAccountLinkSigningKey             string
+}
+
+func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) string {
 	email := "noreply+dev@sourcegraph.com"
 	if len(optionalEdit) > 0 {
 		email = optionalEdit[0]
@@ -445,6 +498,13 @@ func getTestSiteWithSecrets(
       "displayName": "GitLab.com",
       "type": "gitlab",
       "url": "https://gitlab.com"
+    },
+    {
+      "apiScope": "vso.code,vso.identity,vso.project,vso.work",
+      "clientID": "sourcegraph-client-azuredevops",
+      "clientSecret": "%s",
+      "displayName": "Azure DevOps",
+      "type": "azureDevOps"
     }
   ],
   "observability.tracing": {
@@ -474,15 +534,20 @@ func getTestSiteWithSecrets(
   "auth.unlockAccountLinkSigningKey": "%s",
 }`,
 		email,
-		executorsAccessToken,
-		authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,
-		emailSMTPPassword, // used again as username
-		emailSMTPPassword,
-		organizationInvitationsSigningKey,
-		githubClientSecret,
-		dotcomGitHubAppCloudClientSecret, dotcomGitHubAppCloudPrivateKey,
-		dotcomSrcCliVersionCacheGitHubToken, dotcomSrcCliVersionCacheGitHubWebhookSecret,
-		authUnlockAccountLinkSigningKey,
+		testSecrets.executorsAccessToken,
+		testSecrets.authOpenIDClientSecret,
+		testSecrets.authGitHubClientSecret,
+		testSecrets.authGitLabClientSecret,
+		testSecrets.authAzureDevOpsClientSecret,
+		testSecrets.emailSMTPPassword, // used again as username
+		testSecrets.emailSMTPPassword,
+		testSecrets.organizationInvitationsSigningKey,
+		testSecrets.githubClientSecret,
+		testSecrets.dotcomGitHubAppCloudClientSecret,
+		testSecrets.dotcomGitHubAppCloudPrivateKey,
+		testSecrets.dotcomSrcCliVersionCacheGitHubToken,
+		testSecrets.dotcomSrcCliVersionCacheGitHubWebhookSecret,
+		testSecrets.authUnlockAccountLinkSigningKey,
 	)
 
 }


### PR DESCRIPTION
There is not risk as this feature is not released yet and I have only tested in dogfood environments with test accounts.

## Note to reviewers

The change itself is small, and most of the change in this PR is fixing the monstrosity that was `getTestSiteWithSecrets`. Somebody had to do it. 

## Test plan

1. Tested locally
1. Added tests
1. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
