### PR TITLE
buf: pin buf.build/protocolbuffers/go to v1.29.1, buf.build/grpc/go to v1.3.0

### DIFF
--- a/internal/gitserver/v1/buf.gen.yaml
+++ b/internal/gitserver/v1/buf.gen.yaml
@@ -1,11 +1,11 @@
 # Configuration file for https://buf.build/, which we use for Protobuf code generation.
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.29.1
     out: .
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: .
     opt:
       - paths=source_relative

--- a/internal/repoupdater/v1/buf.gen.yaml
+++ b/internal/repoupdater/v1/buf.gen.yaml
@@ -1,11 +1,11 @@
 # Configuration file for https://buf.build/, which we use for Protobuf code generation.
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.29.1
     out: .
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: .
     opt:
       - paths=source_relative

--- a/internal/searcher/v1/buf.gen.yaml
+++ b/internal/searcher/v1/buf.gen.yaml
@@ -1,11 +1,11 @@
 # Configuration file for https://buf.build/, which we use for Protobuf code generation.
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.29.1
     out: .
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: .
     opt:
       - paths=source_relative

--- a/internal/symbols/v1/buf.gen.yaml
+++ b/internal/symbols/v1/buf.gen.yaml
@@ -1,11 +1,11 @@
 # Configuration file for https://buf.build/, which we use for Protobuf code generation.
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.29.1
     out: .
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: .
     opt:
       - paths=source_relative


### PR DESCRIPTION
This PR pins the following buf plugins to ensure that they aren't silently upgraded whenever new versions are published:

- [buf.build/protocolbuffers/go](https://buf.build/protocolbuffers/go): `v1.29.1`
- [buf.build/grpc/go](https://buf.build/grpc/go): `v1.3.0`


## Test plan

CI pipeline