### PR TITLE
cody: scroll to view on new chat messages

### DIFF
--- a/client/cody/vscode-codegen/webviews/Chat.css
+++ b/client/cody/vscode-codegen/webviews/Chat.css
@@ -185,11 +185,11 @@
 
 .context-files-toggle-icon {
     cursor: pointer;
-    margin-right: 1em;
+    margin-right: 0.5em;
 }
 
 .context-files-toggle-icon > i {
-    font-size: var(--vscode-editor-font-size) !important;
+    font-size: cal(var(--vscode-editor-font-size) * 0.5) !important;
 }
 
 .context-files-list-title {
@@ -203,15 +203,16 @@
 
 .context-files-collapsed .context-files-toggle-icon {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    padding-top: 0.2rem;
 }
 
 .context-files-collapsed-text {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     font-style: italic;
 }
 
 .context-file {
-    padding: 4px;
+    padding: 0.1rem;
 }

--- a/client/cody/vscode-codegen/webviews/Chat.css
+++ b/client/cody/vscode-codegen/webviews/Chat.css
@@ -63,7 +63,7 @@
 
 .bubble-content pre,
 .bubble-content code {
-    color: white;
+    color: var(--vscode-input-foreground);
 }
 
 .human-bubble-content {

--- a/client/cody/vscode-codegen/webviews/Chat.tsx
+++ b/client/cody/vscode-codegen/webviews/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { VSCodeButton, VSCodeTextArea } from '@vscode/webview-ui-toolkit/react'
 
@@ -25,6 +25,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 }) => {
     const [inputRows, setInputRows] = useState(5)
     const [formInput, setFormInput] = useState('')
+    const chatboxRef = useRef<HTMLInputElement>(null)
 
     const inputHandler = useCallback(
         (inputValue: string) => {
@@ -62,6 +63,14 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     }, [formInput, setTranscript, setMessageInProgress, transcript])
 
     const bubbleClassName = (speaker: string): string => (speaker === 'you' ? 'human' : 'bot')
+
+    const scrollToBottom = () => {
+        chatboxRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+
+    useEffect(() => {
+        scrollToBottom()
+    }, [transcript, chatboxRef])
 
     return (
         <div className="inner-container">
@@ -119,6 +128,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                                 </div>
                             </div>
                         )}
+                        <div ref={chatboxRef} />
                     </div>
                 )}
             </div>

--- a/client/cody/vscode-codegen/webviews/Chat.tsx
+++ b/client/cody/vscode-codegen/webviews/Chat.tsx
@@ -170,7 +170,7 @@ const ContextFiles: React.FunctionComponent<{ contextFiles: string[] }> = ({ con
         return (
             <p className="context-files-expanded">
                 <span className="context-files-toggle-icon" onClick={() => setIsExpanded(false)}>
-                    <i className="codicon codicon-triangle-up" slot="start" />
+                    <i className="codicon codicon-triangle-down" slot="start" />
                 </span>
                 <div>
                     <div className="context-files-list-title" onClick={() => setIsExpanded(false)}>

--- a/client/cody/vscode-codegen/webviews/Chat.tsx
+++ b/client/cody/vscode-codegen/webviews/Chat.tsx
@@ -65,7 +65,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     const bubbleClassName = (speaker: string): string => (speaker === 'you' ? 'human' : 'bot')
 
     const scrollToBottom = () => {
-        chatboxRef.current?.scrollIntoView({ behavior: 'smooth' })
+        chatboxRef.current?.scrollIntoView?.({ behavior: 'smooth' })
     }
 
     useEffect(() => {

--- a/client/cody/vscode-codegen/webviews/index.css
+++ b/client/cody/vscode-codegen/webviews/index.css
@@ -3,9 +3,9 @@
 
 :root {
     --human-bubble-color: #565eb9;
+    --human-text-color: var(--vscode-dropdown-foreground);
     --bot-bubble-color: var(--vscode-input-background);
-    --human-text-color: var(--vscode-input-foreground);
-    --bubble-text-color: var(--vscode-input-foreground);
+    --bubble-text-color: var(--vscode-inputOption-activeForeground);
     --code-background: var(--vscode-textCodeBlock-background);
 }
 
@@ -18,9 +18,10 @@
 
 body[data-vscode-theme-kind='vscode-light'],
 body[data-vscode-theme-kind='vscode-high-contrast-light'] {
-    --human-bubble-color: var(--vscode-editor-wordHighlightBackground);
+    --human-bubble-color: var(--vscode-dropdown-background);
+    --human-text-color: var(--vscode-dropdown-foreground);
     --bot-bubble-color: var(--vscode-input-background);
-    --bubble-text-color: var(--vscode-input-foreground);
+    --bubble-text-color: var(--vscode-inputOption-activeForeground);
     --code-background: var(--vscode-textCodeBlock-background);
 }
 


### PR DESCRIPTION
RE [slack thread
](https://sourcegraph.slack.com/archives/C04NPH6SZMW/p1678900652268589)

1. Add: auto scroll to the bottom of the screen on new chat messages ([Loom](https://www.loom.com/share/5bf6b5d9bef6446291d5a8ef480f7776))

![cody](https://user-images.githubusercontent.com/68532117/225409267-c67b0485-b5b2-4e0a-b979-ef9f4994da29.gif)

2. Replace `arrow-up` icon with `arrow-down`  on expanded context messages.

Also updated the default font color for bot messages

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="487" alt="image" src="https://user-images.githubusercontent.com/68532117/225406411-f3d2ddaa-aa1c-4627-9d25-13f04d64cf06.png">
</td>
<td>
<img width="489" alt="image" src="https://user-images.githubusercontent.com/68532117/225405891-ef303973-4140-4b4a-a429-92b7a4f5aa7a.png">
</td>
</tr>
</table>


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

launch Cody in VS Code Debug mode:
- Run `pnpm i` at the root of this repository
- Select `Launch Cody Extension` from the dropdown menu in the `RUN AND DEBUG` sidebar in VS Code

## App preview:

- [Web](https://sg-web-bee-cody-chat-scroll.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

