### PR TITLE
Docs: fix newlines in doc

### DIFF
--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -183,16 +183,16 @@ We recognize there are other code hosts including CVS, SVN, and many more. Today
 
 ## Rate limits
 
-Sourcegraph makes our best effort to use the least amount of calls to your code host. However, it is possible for Sourcegraph
-to encounter rate limits in some scenarios. Please see the specific code host documentation for more information and how to
+Sourcegraph makes our best effort to use the least amount of calls to your code host. However, it is possible for Sourcegraph 
+to encounter rate limits in some scenarios. Please see the specific code host documentation for more information and how to 
 mitigate these issues.
 
 ### Rate limit syncing
 
-Sourcegraph has a mechanism of syncing code host rate limits. When Sourcegraph is started, code host configurations of all
+Sourcegraph has a mechanism of syncing code host rate limits. When Sourcegraph is started, code host configurations of all 
 external services are checked for rate limits and these rate limits are stored and used.
 
-When any of code host configurations is edited, rate limits are synchronized and updated if needed, this way Sourcegraph always
+When any of code host configurations is edited, rate limits are synchronized and updated if needed, this way Sourcegraph always 
 knows how many requests to which code host can be sent at a given point of time.
 
 ### Current rate limit settings
@@ -200,7 +200,7 @@ knows how many requests to which code host can be sent at a given point of time.
 Current rate limit settings can be viewed by site admins on the following page: `Site Admin -> Instrumentation -> Repo Updater -> Rate Limiter State`.
 This page includes rate limit settings for all external services configured in Sourcegraph.
 
-Here is an example of one external service, including information about external service name, maximum allowed burst of requests,
+Here is an example of one external service, including information about external service name, maximum allowed burst of requests, 
 maximum allowed requests per second and whether the limiter is infinite (there is no rate limiting):
 
 ```json


### PR DESCRIPTION
Thanks @Strum355 for bringing this up.
Text on newlines were rendering without spaces between them and the previous lines:

Now:
![image](https://user-images.githubusercontent.com/20795805/225412009-3eab8399-b462-4dfd-9845-74129a555b6e.png)

Before:
![image](https://user-images.githubusercontent.com/20795805/225411612-a1bcbf68-af35-465f-9d19-f610ec555f65.png)

## Test plan
docs