### PR TITLE
gitserver: pass coursier cache dir down to jvmpackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added feature to disable some fields on user profiles for SCIM-controlled users. [#48816](https://github.com/sourcegraph/sourcegraph/pull/48816)
 - Native support for ingesting and searching GitHub topics with `repo:has.topic()` [#48875](https://github.com/sourcegraph/sourcegraph/pull/48875)
 - [Sourcegraph Own](https://docs.sourcegraph.com/own) is now available as an experimental enterprise feature. Enable the `search-ownership` feature flag to use it.
+- Gitserver supports a new `COURSIER_CACHE_DIR` env var to configure the cache location for coursier JVM package repos.
 
 ### Changed
 

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -36,7 +36,7 @@ const (
 	jvmMajorVersion0 = 44
 )
 
-func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *dependencies.Service) VCSSyncer {
+func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *dependencies.Service, cacheDir string) VCSSyncer {
 	placeholder, err := reposource.ParseMavenVersionedPackage("com.sourcegraph:sourcegraph:1.0.0")
 	if err != nil {
 		panic(fmt.Sprintf("expected placeholder package to parse but got %v", err))
@@ -47,7 +47,7 @@ func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *depende
 		configDeps = connection.Maven.Dependencies
 	}
 
-	chandle := coursier.NewCoursierHandle(observation.NewContext(log.Scoped("gitserver.jvmsyncer", "")))
+	chandle := coursier.NewCoursierHandle(observation.NewContext(log.Scoped("gitserver.jvmsyncer", "")), cacheDir)
 
 	return &vcsPackagesSyncer{
 		logger:      log.Scoped("JVMPackagesSyncer", "sync JVM packages"),

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -129,8 +129,9 @@ func TestNoMaliciousFiles(t *testing.T) {
 	extractPath := path.Join(dir, "extracted")
 	assert.Nil(t, os.Mkdir(extractPath, os.ModePerm))
 
+	cacheDir := filepath.Join(dir, "cache")
 	s := jvmPackagesSyncer{
-		coursier: coursier.NewCoursierHandle(&observation.TestContext),
+		coursier: coursier.NewCoursierHandle(&observation.TestContext, cacheDir),
 		config:   &schema.JVMPackagesConnection{Maven: &schema.Maven{Dependencies: []string{}}},
 		fetch: func(ctx context.Context, config *schema.JVMPackagesConnection, dependency *reposource.MavenVersionedPackage) (sourceCodeJarPath string, err error) {
 			jarPath := path.Join(dir, "sampletext.zip")

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -200,7 +200,8 @@ func TestJVMCloneCommand(t *testing.T) {
 	coursier.CoursierBinary = coursierScript(t, dir)
 
 	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(logger, t)))
-	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: &schema.Maven{Dependencies: []string{}}}, depsSvc).(*vcsPackagesSyncer)
+	cacheDir := filepath.Join(dir, "cache")
+	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: &schema.Maven{Dependencies: []string{}}}, depsSvc, cacheDir).(*vcsPackagesSyncer)
 	bareGitDirectory := path.Join(dir, "git")
 
 	s.runCloneCommand(t, examplePackageUrl, bareGitDirectory, []string{exampleVersionedPackage})

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -77,7 +77,7 @@ type EnterpriseInit func(db database.DB)
 type Config struct {
 	env.BaseConfig
 
-	ReposDir string
+	ReposDir         string
 	CoursierCacheDir string
 }
 

--- a/cmd/gitserver/shared/shared_test.go
+++ b/cmd/gitserver/shared/shared_test.go
@@ -152,6 +152,7 @@ func TestGetVCSSyncer(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+	tempCoursierCacheDir := filepath.Join(tempReposDir, "coursier")
 
 	repo := api.RepoName("foo/bar")
 	extsvcStore := database.NewMockExternalServiceStore()
@@ -181,7 +182,7 @@ func TestGetVCSSyncer(t *testing.T) {
 		}, nil
 	})
 
-	s, err := getVCSSyncer(context.Background(), extsvcStore, repoStore, depsSvc, repo, tempReposDir)
+	s, err := getVCSSyncer(context.Background(), extsvcStore, repoStore, depsSvc, repo, tempReposDir, tempCoursierCacheDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/shared/shared_test.go
+++ b/cmd/gitserver/shared/shared_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -1567,6 +1567,35 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1678898749,
+				"Name": "make unreferenced documents index usable",
+				"UpQuery": "-- Perform migration here.\n--\n-- See /migrations/README.md. Highlights:\n--  * Make migrations idempotent (use IF EXISTS)\n--  * Make migrations backwards-compatible (old readers/writers must continue to work)\n--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement\n--    is defined per file, and that each such statement is NOT wrapped in a transaction.\n--    Each such migration must also declare \"createIndexConcurrently: true\" in their\n--    associated metadata.yaml file.\n--  * If you are modifying Postgres extensions, you must also declare \"privileged: true\"\n--    in the associated metadata.yaml file.\n\nCREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_scip_documents_dereference_logs_last_removal_time_desc_doc\nON codeintel_scip_documents_dereference_logs (last_removal_time DESC, document_id);",
+				"DownQuery": "-- Undo the changes made in the up migration\n\nDROP INDEX IF EXISTS codeintel_scip_documents_dereference_logs_last_removal_time_desc_doc;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678041507
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "codeintel_scip_documents_dereference_logs",
+					"IndexName": "codeintel_scip_documents_dereference_logs_last_removal_time_desc_doc"
+				}
+			},
+			{
+				"ID": 1678899132,
+				"Name": "remove unused unreferenced documents index",
+				"UpQuery": "-- Perform migration here.\n--\n-- See /migrations/README.md. Highlights:\n--  * Make migrations idempotent (use IF EXISTS)\n--  * Make migrations backwards-compatible (old readers/writers must continue to work)\n--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement\n--    is defined per file, and that each such statement is NOT wrapped in a transaction.\n--    Each such migration must also declare \"createIndexConcurrently: true\" in their\n--    associated metadata.yaml file.\n--  * If you are modifying Postgres extensions, you must also declare \"privileged: true\"\n--    in the associated metadata.yaml file.\n\nDROP INDEX IF EXISTS codeintel_scip_documents_dereference_logs_last_removal_time_doc;",
+				"DownQuery": "-- Undo the changes made in the up migration\n\nCREATE INDEX IF NOT EXISTS codeintel_scip_documents_dereference_logs_last_removal_time_doc\nON codeintel_scip_documents_dereference_logs (last_removal_time, document_id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678898749
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -1779,7 +1808,7 @@
 			"v5.0.0": {
 				"RootID": 1000000033,
 				"LeafIDs": [
-					1678041507
+					1678899132
 				],
 				"PreCreation": false
 			}

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -25,12 +25,12 @@ var CoursierBinary = "coursier"
 
 var (
 	invocTimeout, _ = time.ParseDuration(env.Get("SRC_COURSIER_TIMEOUT", "2m", "Time limit per Coursier invocation, which is used to resolve JVM/Java dependencies."))
-	mkdirOnce        sync.Once
+	mkdirOnce       sync.Once
 )
 
 type CoursierHandle struct {
 	operations *operations
-	cacheDir string
+	cacheDir   string
 }
 
 func NewCoursierHandle(obsctx *observation.Context, cacheDir string) *CoursierHandle {
@@ -44,7 +44,7 @@ func NewCoursierHandle(obsctx *observation.Context, cacheDir string) *CoursierHa
 	})
 	return &CoursierHandle{
 		operations: newOperations(obsctx),
-		cacheDir: cacheDir,
+		cacheDir:   cacheDir,
 	}
 }
 

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -26,31 +25,26 @@ var CoursierBinary = "coursier"
 
 var (
 	invocTimeout, _ = time.ParseDuration(env.Get("SRC_COURSIER_TIMEOUT", "2m", "Time limit per Coursier invocation, which is used to resolve JVM/Java dependencies."))
-	// if COURSIER_CACHE_DIR is set, try create that dir and use it. If not set, use the SRC_REPOS_DIR value (or default).
-	// This is expected to only be used in gitserver, if this assumption changes, please revisit this due to the failability
-	// of this on read-only filesystems.
-	coursierCacheDir = env.Get("COURSIER_CACHE_DIR", "", "Directory in which coursier data is cached for JVM package repos.")
-	srcReposDir      = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
 	mkdirOnce        sync.Once
 )
 
 type CoursierHandle struct {
 	operations *operations
+	cacheDir string
 }
 
-func NewCoursierHandle(obsctx *observation.Context) *CoursierHandle {
+func NewCoursierHandle(obsctx *observation.Context, cacheDir string) *CoursierHandle {
 	mkdirOnce.Do(func() {
-		if coursierCacheDir == "" && srcReposDir != "" {
-			coursierCacheDir = filepath.Join(srcReposDir, "coursier")
+		if cacheDir == "" {
+			return
 		}
-		if coursierCacheDir != "" {
-			if err := os.MkdirAll(coursierCacheDir, os.ModePerm); err != nil {
-				panic(fmt.Sprintf("failed to create coursier cache dir in %q: %s\n", coursierCacheDir, err))
-			}
+		if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+			panic(fmt.Sprintf("failed to create coursier cache dir in %q: %s\n", cacheDir, err))
 		}
 	})
 	return &CoursierHandle{
 		operations: newOperations(obsctx),
+		cacheDir: cacheDir,
 	}
 }
 
@@ -183,8 +177,8 @@ func (c *CoursierHandle) runCoursierCommand(ctx context.Context, config *schema.
 			fmt.Sprintf("COURSIER_REPOSITORIES=%v", strings.Join(config.Maven.Repositories, "|")),
 		)
 	}
-	if coursierCacheDir != "" {
-		cmd.Env = append(cmd.Env, "COURSIER_CACHE="+coursierCacheDir)
+	if c.cacheDir != "" {
+		cmd.Env = append(cmd.Env, "COURSIER_CACHE="+c.cacheDir)
 	}
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
Before this change we would `env.Get` register the same `SRC_REPOS_DIR` in two locations (and have to keep the descriptions and default values in sync), which is a bit nasty. For App, it also caused two problems:

1. Init order issue - one location was done as part of the service config loading, while the other was in a global `var()` block. The latter doesn't give App a chance to set the default value.
2. `panic: env var "SRC_REPOS_DIR" already registered with a different description or value` (due to the default values differing due to point 2 above)

This change makes us pass the coursier cache dir down to jvmpackages from the gitserver svc config, which I think is nicer code quality & fixes the app issues above.

## Test plan

existing tests + careful review