### PR TITLE
Search: allow `repo:has.topic()` and `repo:has.description()` in contexts

### DIFF
--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -200,10 +200,11 @@ func validateSearchContextQuery(contextQuery string) error {
 		case query.FieldRepo:
 			if a.Labels.IsSet(query.IsPredicate) {
 				predName, _ := query.ParseAsPredicate(value)
-				if predName != "has" && predName != "has.tag" && predName != "has.key" {
+				switch predName {
+				case "has", "has.tag", "has.key", "has.topic", "has.description":
+				default:
 					errs = errors.Append(errs,
 						errors.Errorf("unsupported repo field predicate in search context query: %q", value))
-					return
 				}
 				return
 			}

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -721,3 +721,66 @@ func TestParseRepoOpts(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateSearchContextQuery(t *testing.T) {
+	cases := []struct {
+		query   string
+		wantErr bool
+	}{{
+		query:   "repo:has(key:value)",
+		wantErr: false,
+	}, {
+		query:   "repo:has.tag(mytag)",
+		wantErr: false,
+	}, {
+		query:   "repo:has.key(mykey)",
+		wantErr: false,
+	}, {
+		query:   "repo:has.topic(mytopic)",
+		wantErr: false,
+	}, {
+		query:   "repo:has.path(mytopic)",
+		wantErr: true,
+	}, {
+		query:   "repo:has.description(mytopic)",
+		wantErr: false,
+	}, {
+		query:   "lang:go",
+		wantErr: false,
+	}, {
+		query:   "fork:yes",
+		wantErr: false,
+	}, {
+		query:   "archived:yes",
+		wantErr: false,
+	}, {
+		query:   "case:yes",
+		wantErr: false,
+	}, {
+		query:   "file:test",
+		wantErr: false,
+	}, {
+		query:   "visibility:public",
+		wantErr: false,
+	}, {
+		query:   "type:commit author:camden",
+		wantErr: true,
+	}, {
+		query:   "type:diff author:camden",
+		wantErr: true,
+	}, {
+		query:   "testpattern",
+		wantErr: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			err := validateSearchContextQuery(tc.query)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a minimal change that adds `repo:has.topic()` and `repo:has.description()` to the allowed list of predicates in search contexts.

We should follow up with an audit of what exactly we can allow in query-based search contexts. They are currently unnecessarily restrictive. We should also probably do some work to figure out what's needed to move query-based search predicates out of beta. 

I would like to backport this to the 5.0 release branch because the change is very small, well-tested, makes the new features much more valuable, and contributes to the general feel of polish of this release. 

## Test plan

I added a test for the `validateSearchContextQuery` function (this previously had very poor coverage). I manually tested that creating a search context using these predicates works as expected now.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
