### PR TITLE
test: move react-visibilty-sense mock to named function

### DIFF
--- a/client/shared/src/testing/mockReactVisibilitySensor.tsx
+++ b/client/shared/src/testing/mockReactVisibilitySensor.tsx
@@ -17,13 +17,12 @@ export class MockVisibilitySensor extends React.Component<VisibilitySensorPropsT
     }
 }
 
-jest.mock(
-    'react-visibility-sensor',
-    (): typeof _VisibilitySensor =>
-        ({ children, onChange }: VisibilitySensorPropsType) =>
-            (
-                <>
-                    <MockVisibilitySensor onChange={onChange}>{children}</MockVisibilitySensor>
-                </>
-            )
-)
+function mockVisibilitySensor({ children, onChange }: VisibilitySensorPropsType): typeof _VisibilitySensor {
+    return (
+        <>
+            <MockVisibilitySensor onChange={onChange}>{children}</MockVisibilitySensor>
+        </>
+    )
+}
+
+jest.mock('react-visibility-sensor', (): typeof _VisibilitySensor => mockVisibilitySensor)


### PR DESCRIPTION
React forbids access to non-mock logic within mock implementations. When compiled to jsx the mock react-visibility-sensor invokes jsx() method which must be done within a mock*() method

When compiling with bazel the .js is pre-compiled and enforces this restriction.


## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-react-vis.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
