### PR TITLE
experimental search input: Move `History:` mode indicator into button

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -118,6 +118,11 @@
         &:hover {
             background-color: var(--color-bg-2);
         }
+
+        span {
+            font-family: var(--code-font-family);
+            font-size: var(--code-font-size);
+        }
     }
 
     &--active {

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -468,9 +468,9 @@ const SearchModeSwitcher: FC<SearchModeSwitcherProps> = props => {
             <Tooltip content="Recent searches">
                 <Button variant="icon" aria-label="Open search history" onClick={onModeChange}>
                     <Icon svgPath={mdiClockOutline} aria-hidden="true" />
+                    {mode && <span className="ml-1">{mode}:</span>}
                 </Button>
             </Tooltip>
-            {mode && <span className="ml-1">{mode}:</span>}
         </div>
     )
 }


### PR DESCRIPTION
This allows the user to disable history mode by clicking on the text as well.

Question: Should the text be hidden from screen readers?

## Test plan

👀 

## App preview:

- [Web](https://sg-web-fkling-search-input-history-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
