### PR TITLE
Setup Wizard: Fix UI paper cuts for local repositories picker

### DIFF
--- a/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.module.scss
+++ b/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.module.scss
@@ -17,8 +17,22 @@
 .input {
     // Reserve place for input loader
     padding-right: 2rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:disabled {
+        color: inherit;
+        background-color: inherit;
+    }
+
+    &-loader {
+        flex-grow: 1;
+    }
 
     &--with-action {
+        // In case if input is in file picker mode the whole input is clickable
+        // enforce cursor point to make it more explicit for user
+        cursor: pointer;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }

--- a/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.tsx
@@ -18,6 +18,7 @@ import {
     LoaderInput,
     Text,
     useDebounce,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import {
@@ -206,7 +207,7 @@ const LocalRepositoriesForm: FC<LocalRepositoriesFormProps> = props => {
                     as={InputWitActions}
                     value={path}
                     label="Directory path"
-                    disabled={isFilePickerAvailable}
+                    isFilePickerMode={isFilePickerAvailable}
                     placeholder="/Users/user-name/Projects/"
                     message="Pick a git directory or folder that contains multiple git folders"
                     isProcessing={loading}
@@ -262,27 +263,38 @@ const LocalRepositoriesForm: FC<LocalRepositoriesFormProps> = props => {
 }
 
 interface InputWithActionsProps extends InputHTMLAttributes<HTMLInputElement> {
+    isFilePickerMode: boolean
     isProcessing: boolean
     onPickPath: () => void
     onPathReset: () => void
 }
 
+/**
+ * Renders either file picker input (non-editable but clickable and with "pick a path" action button or
+ * simple input where user can input path manually.
+ */
 const InputWitActions = forwardRef<HTMLInputElement, InputWithActionsProps>((props, ref) => {
-    const { isProcessing, onPickPath, onPathReset, className, disabled, ...attributes } = props
+    const { isFilePickerMode, isProcessing, onPickPath, onPathReset, className, value, ...attributes } = props
 
     return (
         <div className={styles.inputRoot}>
-            <LoaderInput loading={isProcessing} className="flex-grow-1">
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <input
-                    {...attributes}
-                    ref={ref}
-                    disabled={disabled}
-                    className={classNames(className, styles.input, { [styles.inputWithAction]: disabled })}
-                />
-            </LoaderInput>
-
-            {disabled && (
+            <Tooltip content={isFilePickerMode ? value : undefined}>
+                <LoaderInput
+                    loading={isProcessing}
+                    className={styles.inputLoader}
+                    onClick={isFilePickerMode ? onPickPath : undefined}
+                >
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <input
+                        {...attributes}
+                        ref={ref}
+                        value={value}
+                        disabled={isFilePickerMode}
+                        className={classNames(className, styles.input, { [styles.inputWithAction]: isFilePickerMode })}
+                    />
+                </LoaderInput>
+            </Tooltip>
+            {isFilePickerMode && (
                 <Button size="sm" type="button" variant="primary" className={styles.pickPath} onClick={onPickPath}>
                     Pick a path
                 </Button>

--- a/client/wildcard/src/components/Form/LoaderInput/LoaderInput.tsx
+++ b/client/wildcard/src/components/Form/LoaderInput/LoaderInput.tsx
@@ -1,25 +1,23 @@
-import React from 'react'
+import { HTMLAttributes, forwardRef } from 'react'
 
 import classNames from 'classnames'
 
-import { LoadingSpinner } from '../../LoadingSpinner/LoadingSpinner'
+import { LoadingSpinner } from '../../LoadingSpinner'
 
 import styles from './LoaderInput.module.scss'
 
-/** Takes loading prop, input component as child */
-interface LoaderInputProps {
+interface LoaderInputProps extends HTMLAttributes<HTMLDivElement> {
     loading: boolean
     children: React.ReactNode
-    className?: string
 }
 
-export const LoaderInput: React.FunctionComponent<React.PropsWithChildren<LoaderInputProps>> = ({
-    loading,
-    children,
-    className,
-}) => (
-    <div className={classNames(styles.container, className)}>
-        {children}
-        {loading && <LoadingSpinner inline={false} className={styles.spinner} />}
-    </div>
-)
+export const LoaderInput = forwardRef<HTMLDivElement, LoaderInputProps>((props, ref) => {
+    const { loading, children, className, ...attributes } = props
+
+    return (
+        <div ref={ref} className={classNames(styles.container, className)} {...attributes}>
+            {children}
+            {loading && <LoadingSpinner inline={false} className={styles.spinner} />}
+        </div>
+    )
+})


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/49151

I also fixed visual disabled input state in order to make text more contrast. 

## Test plan
- Check the local repositories picker 
- It should has truncated text in case if path doesn't fully fit in input
- In file picker mode it should has Tooltip with path value within 
- Check that input itself is clickable when it's in file picker mode (you can click input itself not just pick a path button)
- Check that in common text input mode, there is no Tooltip and it's not clickable 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-local-repositories-picker.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
