### PR TITLE
pings: only compute repo buckets out of cloned repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Native support for ingesting and searching GitHub topics with `repo:has.topic()` [#48875](https://github.com/sourcegraph/sourcegraph/pull/48875)
 - [Sourcegraph Own](https://docs.sourcegraph.com/own) is now available as an experimental enterprise feature. Enable the `search-ownership` feature flag to use it.
 - Gitserver supports a new `COURSIER_CACHE_DIR` env var to configure the cache location for coursier JVM package repos.
+- Pings now emit a histogram of repository sizes cloned by Sourcegraph [48211](https://github.com/sourcegraph/sourcegraph/pull/48211).
 
 ### Changed
 

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -438,6 +438,9 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                             </ul>
                         </ul>
                     </li>
+                    <li>
+                        Histogram of cloned repository sizes
+                    </li>
                 </ul>
                 {updatesDisabled ? (
                     <Text>All telemetry is disabled.</Text>

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -438,9 +438,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                             </ul>
                         </ul>
                     </li>
-                    <li>
-                        Histogram of cloned repository sizes
-                    </li>
+                    <li>Histogram of cloned repository sizes</li>
                 </ul>
                 {updatesDisabled ? (
                     <Text>All telemetry is disabled.</Text>

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -208,6 +208,7 @@ This telemetry can be disabled using the `disableNonCriticalTelemetry` option in
     - Narrowing search results by owner using `file:has.owners` predicate.
     - Selecting owner search result through `select:file.owners`.
     - Displaying ownership panel in file view.
+- Histogram of cloned repository sizes
 </details>
 
 ## CIDR Range for Sourcegraph

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -82,15 +82,15 @@ func GetRepositorySizeHistorgram(ctx context.Context, db database.DB) ([]RepoSiz
 
 	var results []RepoSizeBucket
 
-	baseQuery := "select coalesce(count(repo_size_bytes), 0) from gitserver_repos"
 	baseStore := basestore.NewWithHandle(db.Handle())
 
 	getCount := func(start int64, end *int64) (int64, bool, error) {
+		baseQuery := "select coalesce(count(repo_size_bytes), 0) from gitserver_repos where clone_status = 'cloned' "
 		upperBound := sqlf.Sprintf("and true")
 		if end != nil {
 			upperBound = sqlf.Sprintf("and repo_size_bytes < %s", *end)
 		}
-		return basestore.ScanFirstInt64(baseStore.Query(ctx, sqlf.Sprintf("%s where repo_size_bytes >= %s %s", sqlf.Sprintf(baseQuery), start, upperBound)))
+		return basestore.ScanFirstInt64(baseStore.Query(ctx, sqlf.Sprintf("%s and repo_size_bytes >= %s %s", sqlf.Sprintf(baseQuery), start, upperBound)))
 	}
 
 	for i := 1; i < len(sizes); i++ {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/49464

Changes the repo size bucket ping to only count cloned repos.

## Test plan

I forced a repo to reclone and checked pings during and after

During reclone
<img width="356" alt="CleanShot 2023-03-15 at 16 19 48@2x" src="https://user-images.githubusercontent.com/5090588/225465683-a48899a1-cf77-4b76-b71f-58c66af5c82e.png">

After
<img width="419" alt="CleanShot 2023-03-15 at 16 21 31@2x" src="https://user-images.githubusercontent.com/5090588/225465686-507ae00e-aad0-49a9-84d4-1a8ef23c16fd.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
