### PR TITLE
rbac: prevent modifying site admin role permissions

### DIFF
--- a/client/web/src/enterprise/rbac/components/Permissions.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.tsx
@@ -8,8 +8,9 @@ import { PermissionsMap, allNamespaces } from '../backend'
 interface PermissionListProps {
     allPermissions: PermissionsMap
     isChecked: (value: string) => boolean
-    onChange: (event: ChangeEvent<HTMLInputElement>) => void
-    onBlur: FocusEventHandler<HTMLInputElement>
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void
+    onBlur?: FocusEventHandler<HTMLInputElement>
+    disabled?: boolean
 }
 
 export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<PermissionListProps>> = ({
@@ -17,6 +18,7 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
     isChecked,
     onChange,
     onBlur,
+    disabled,
 }) => (
     <>
         {allNamespaces.map(namespace => {
@@ -34,6 +36,7 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                                 value={permission.id}
                                 onChange={onChange}
                                 onBlur={onBlur}
+                                disabled={disabled}
                             />
                         ))}
                     </Grid>

--- a/client/web/src/enterprise/rbac/components/RoleNode.module.scss
+++ b/client/web/src/enterprise/rbac/components/RoleNode.module.scss
@@ -37,7 +37,9 @@
         align-self: center;
     }
 
-    &__delete-btn-icon {
+    &__delete-btn-icon,
+    &__locked-icon {
+        flex-shrink: 0;
         fill: currentColor !important;
     }
 }

--- a/client/web/src/enterprise/rbac/components/RoleNode.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.tsx
@@ -247,7 +247,7 @@ const LockedRoleNode: React.FunctionComponent<Pick<RoleNodeProps, 'node' | 'allP
                                 <SystemLabel />
                                 <Tooltip content="This role is locked. Its permissions are managed by Sourcegraph and cannot be modified.">
                                     <Icon
-                                        className="flex-shrink-0 text-muted"
+                                        className={styles.roleNodeLockedIcon}
                                         aria-label="Locked role"
                                         svgPath={mdiLock}
                                     />

--- a/client/web/src/enterprise/rbac/mock.ts
+++ b/client/web/src/enterprise/rbac/mock.ts
@@ -58,7 +58,7 @@ export const mockRoles: AllRolesResult = {
             {
                 __typename: 'Role',
                 id: 'role-1',
-                name: 'Site Administrator',
+                name: 'SITE_ADMINISTRATOR',
                 system: true,
                 permissions: {
                     nodes: mockPermissions.permissions.nodes,

--- a/internal/database/role_permissions.go
+++ b/internal/database/role_permissions.go
@@ -426,9 +426,9 @@ func (rp *rolePermissionStore) AssignToSystemRole(ctx context.Context, opts Assi
 	return nil
 }
 
-// BulkAssignPermissionsToRole assigns multiple permissions to a system role. Note that it
-// is the only method allowed to modify the permissions of the site admin role, which it
-// does from the `UpdatePermissions` startup process.
+// BulkAssignPermissionsToSystemRoles assigns a permissions to multiple system roles. Note
+// that it is the only method allowed to modify the permissions of the
+// `SITE_ADMINISTRATOR` role, which it does from the `UpdatePermissions` startup process.
 func (rp *rolePermissionStore) BulkAssignPermissionsToSystemRoles(ctx context.Context, opts BulkAssignPermissionsToSystemRolesOpts) error {
 	if opts.PermissionID == 0 {
 		return errors.New("permission id is required")

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -854,6 +854,14 @@ type Role struct {
 	CreatedAt time.Time
 }
 
+func (r Role) IsSiteAdmin() bool {
+	return r.Name == string(SiteAdministratorSystemRole)
+}
+
+func (r Role) IsUser() bool {
+	return r.Name == string(UserSystemRole)
+}
+
 // A PermissionNamespace represents a distinct context within which permission policies
 // are defined and enforced.
 type PermissionNamespace string


### PR DESCRIPTION
We realized the `SITE_ADMINISTRATOR` role probably should not allow its permissions to be manually modified.

This PR adds a guard to `RolePermission` store methods that the role being modified is not the `SITE_ADMINISTRATOR` one, with the exception of `BulkAssignPermissionsToSystemRoles`, which is used in the startup process to sync permissions from the RBAC schema file.

It also updates the UI to disable the form and display a lock icon for the role, to indicate it cannot be modified:

<img width="979" alt="image" src="https://user-images.githubusercontent.com/8942601/225476805-003d952e-12e0-4ff1-8c88-d65133b8780e.png">

<img width="976" alt="image" src="https://user-images.githubusercontent.com/8942601/225476828-0c54b66b-1bdb-4022-9df9-aff1c02ee8c7.png">


## Test plan

Added additional unit test coverage, Storybook story coverage.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
