### PR TITLE
Try to reduce memory footprint of ranking insertion

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/background/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/ranking.go
@@ -87,57 +87,85 @@ func setDefinitionsAndReferencesForUpload(
 	ctx context.Context,
 	store store.Store,
 	upload shared.ExportedUpload,
-	rankingBatchNumber int,
+	batchSize int,
 	rankingGraphKey, path string,
 	document *scip.Document,
 ) (int, int, error) {
+	seenDefinitions, err := setDefinitionsForUpload(ctx, store, upload, rankingGraphKey, path, document)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	references := make(chan string)
+	referencesCount := 0
+
+	go func() {
+		defer close(references)
+
+		for _, occ := range document.Occurrences {
+			if occ.Symbol == "" || scip.IsLocalSymbol(occ.Symbol) || strings.HasPrefix(occ.Symbol, skipPrefix) {
+				continue
+			}
+
+			if _, ok := seenDefinitions[occ.Symbol]; ok {
+				continue
+			}
+			if !scip.SymbolRole_Definition.Matches(occ) {
+				references <- occ.Symbol
+				referencesCount++
+			}
+		}
+	}()
+
+	if err := store.InsertReferencesForRanking(ctx, rankingGraphKey, batchSize, upload.ID, references); err != nil {
+		for range references {
+			// Drain channel to ensure it closes
+		}
+
+		return 0, 0, err
+	}
+
+	return len(seenDefinitions), referencesCount, nil
+}
+
+func setDefinitionsForUpload(
+	ctx context.Context,
+	store store.Store,
+	upload shared.ExportedUpload,
+	rankingGraphKey, path string,
+	document *scip.Document,
+) (map[string]struct{}, error) {
 	seenDefinitions := map[string]struct{}{}
-	definitions := []shared.RankingDefinitions{}
-	for _, occ := range document.Occurrences {
-		if occ.Symbol == "" || scip.IsLocalSymbol(occ.Symbol) || strings.HasPrefix(occ.Symbol, skipPrefix) {
-			continue
+	definitions := make(chan shared.RankingDefinitions)
+
+	go func() {
+		defer close(definitions)
+
+		for _, occ := range document.Occurrences {
+			if occ.Symbol == "" || scip.IsLocalSymbol(occ.Symbol) || strings.HasPrefix(occ.Symbol, skipPrefix) {
+				continue
+			}
+
+			if scip.SymbolRole_Definition.Matches(occ) {
+				definitions <- shared.RankingDefinitions{
+					UploadID:     upload.ID,
+					SymbolName:   occ.Symbol,
+					DocumentPath: filepath.Join(upload.Root, path),
+				}
+				seenDefinitions[occ.Symbol] = struct{}{}
+			}
+		}
+	}()
+
+	if err := store.InsertDefinitionsForRanking(ctx, rankingGraphKey, definitions); err != nil {
+		for range definitions {
+			// Drain channel to ensure it closes
 		}
 
-		if scip.SymbolRole_Definition.Matches(occ) {
-			definitions = append(definitions, shared.RankingDefinitions{
-				UploadID:     upload.ID,
-				SymbolName:   occ.Symbol,
-				DocumentPath: filepath.Join(upload.Root, path),
-			})
-			seenDefinitions[occ.Symbol] = struct{}{}
-		}
+		return nil, err
 	}
 
-	references := []string{}
-	for _, occ := range document.Occurrences {
-		if occ.Symbol == "" || scip.IsLocalSymbol(occ.Symbol) || strings.HasPrefix(occ.Symbol, skipPrefix) {
-			continue
-		}
-
-		if _, ok := seenDefinitions[occ.Symbol]; ok {
-			continue
-		}
-		if !scip.SymbolRole_Definition.Matches(occ) {
-			references = append(references, occ.Symbol)
-		}
-	}
-
-	if len(definitions) > 0 {
-		if err := store.InsertDefinitionsForRanking(ctx, rankingGraphKey, rankingBatchNumber, definitions); err != nil {
-			return 0, 0, err
-		}
-	}
-
-	if len(references) > 0 {
-		if err := store.InsertReferencesForRanking(ctx, rankingGraphKey, rankingBatchNumber, shared.RankingReferences{
-			UploadID:    upload.ID,
-			SymbolNames: references,
-		}); err != nil {
-			return 0, 0, err
-		}
-	}
-
-	return len(definitions), len(references), nil
+	return seenDefinitions, nil
 }
 
 func vacuumStaleDefinitions(ctx context.Context, store store.Store) (int, int, error) {

--- a/enterprise/internal/codeintel/ranking/internal/store/ranking_test.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking_test.go
@@ -33,8 +33,7 @@ func TestInsertDefinition(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	// Insert definitions
-	mockDefinitions := []shared.RankingDefinitions{
+	expectedDefinitions := []shared.RankingDefinitions{
 		{
 			UploadID:     1,
 			SymbolName:   "foo",
@@ -52,8 +51,13 @@ func TestInsertDefinition(t *testing.T) {
 		},
 	}
 
-	// Test InsertDefinitionsForRanking
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockDefinitions); err != nil {
+	// Insert definitions
+	mockDefinitions := make(chan shared.RankingDefinitions, len(expectedDefinitions))
+	for _, def := range expectedDefinitions {
+		mockDefinitions <- def
+	}
+	close(mockDefinitions)
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
@@ -63,7 +67,7 @@ func TestInsertDefinition(t *testing.T) {
 		t.Fatalf("unexpected error getting definitions: %s", err)
 	}
 
-	if diff := cmp.Diff(mockDefinitions, definitions); diff != "" {
+	if diff := cmp.Diff(expectedDefinitions, definitions); diff != "" {
 		t.Errorf("unexpected definitions (-want +got):\n%s", diff)
 	}
 }
@@ -75,15 +79,13 @@ func TestInsertReferences(t *testing.T) {
 	store := New(&observation.TestContext, db)
 
 	// Insert references
-	mockReferences := []shared.RankingReferences{
-		{UploadID: 1, SymbolNames: []string{"foo", "bar", "baz"}},
-	}
-
-	for _, reference := range mockReferences {
-		// Test InsertReferencesForRanking
-		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, reference); err != nil {
-			t.Fatalf("unexpected error inserting references: %s", err)
-		}
+	mockReferences := make(chan string, 3)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 1, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
 	// Test references were inserted
@@ -92,7 +94,13 @@ func TestInsertReferences(t *testing.T) {
 		t.Fatalf("unexpected error getting references: %s", err)
 	}
 
-	if diff := cmp.Diff(mockReferences, references); diff != "" {
+	expectedReferences := []shared.RankingReferences{
+		{
+			UploadID:    1,
+			SymbolNames: []string{"foo", "bar", "baz"},
+		},
+	}
+	if diff := cmp.Diff(expectedReferences, references); diff != "" {
 		t.Errorf("unexpected references (-want +got):\n%s", diff)
 	}
 }
@@ -110,37 +118,34 @@ func TestInsertPathRanks(t *testing.T) {
 	insertUploads(t, db, types.Upload{ID: 1})
 
 	// Insert definitions
-	mockDefinitions := []shared.RankingDefinitions{
-		{
-			UploadID:     1,
-			SymbolName:   "foo",
-			DocumentPath: "foo.go",
-		},
-		{
-			UploadID:     1,
-			SymbolName:   "bar",
-			DocumentPath: "bar.go",
-		},
-		{
-			UploadID:     1,
-			SymbolName:   "foo",
-			DocumentPath: "foo.go",
-		},
+	mockDefinitions := make(chan shared.RankingDefinitions, 3)
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     1,
+		SymbolName:   "foo",
+		DocumentPath: "foo.go",
 	}
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockDefinitions); err != nil {
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     1,
+		SymbolName:   "bar",
+		DocumentPath: "bar.go",
+	}
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     1,
+		SymbolName:   "foo",
+		DocumentPath: "foo.go",
+	}
+	close(mockDefinitions)
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
 	// Insert references
-	mockReferences := shared.RankingReferences{
-		UploadID: 1,
-		SymbolNames: []string{
-			mockDefinitions[0].SymbolName,
-			mockDefinitions[1].SymbolName,
-			mockDefinitions[2].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences := make(chan string, 3)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 1, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -161,11 +166,11 @@ func TestInsertPathRanks(t *testing.T) {
 	}
 
 	if numPathRanksInserted != 2 {
-		t.Fatalf("unexpected number of path ranks inserted. want=%d have=%d", 2, numPathRanksInserted)
+		t.Errorf("unexpected number of path ranks inserted. want=%d have=%d", 2, numPathRanksInserted)
 	}
 
 	if numInputsProcessed != 1 {
-		t.Fatalf("unexpected number of inputs processed. want=%d have=%d", 1, numInputsProcessed)
+		t.Errorf("unexpected number of inputs processed. want=%d have=%d", 1, numInputsProcessed)
 	}
 }
 
@@ -264,43 +269,40 @@ func TestInsertPathCountInputs(t *testing.T) {
 	)
 
 	// Insert definitions
-	mockDefinitions := []shared.RankingDefinitions{
-		{
-			UploadID:     42,
-			SymbolName:   "foo",
-			DocumentPath: "foo.go",
-		},
-		{
-			UploadID:     42,
-			SymbolName:   "bar",
-			DocumentPath: "bar.go",
-		},
-		{
-			UploadID:     43,
-			SymbolName:   "baz",
-			DocumentPath: "baz.go",
-		},
-		{
-			UploadID:     43,
-			SymbolName:   "bonk",
-			DocumentPath: "bonk.go",
-		},
+	mockDefinitions := make(chan shared.RankingDefinitions, 4)
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     42,
+		SymbolName:   "foo",
+		DocumentPath: "foo.go",
 	}
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockDefinitions); err != nil {
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     42,
+		SymbolName:   "bar",
+		DocumentPath: "bar.go",
+	}
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     43,
+		SymbolName:   "baz",
+		DocumentPath: "baz.go",
+	}
+	mockDefinitions <- shared.RankingDefinitions{
+		UploadID:     43,
+		SymbolName:   "bonk",
+		DocumentPath: "bonk.go",
+	}
+	close(mockDefinitions)
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
 	//
 	// Basic test case
 
-	mockReferences := shared.RankingReferences{
-		UploadID: 90,
-		SymbolNames: []string{
-			mockDefinitions[0].SymbolName,
-			mockDefinitions[1].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences := make(chan string, 2)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 90, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -309,36 +311,28 @@ func TestInsertPathCountInputs(t *testing.T) {
 	}
 
 	// Same ID split over two batches
-	mockReferences = shared.RankingReferences{
-		UploadID: 90,
-		SymbolNames: []string{
-			mockDefinitions[2].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences = make(chan string, 1)
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 90, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
-	mockReferences = shared.RankingReferences{
-		UploadID: 91,
-		SymbolNames: []string{
-			mockDefinitions[3].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+
+	mockReferences = make(chan string, 1)
+	mockReferences <- "bonk"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 91, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
 	// duplicate of 91 (should not be processed as it's older)
-	mockReferences = shared.RankingReferences{
-		UploadID: 92,
-		SymbolNames: []string{
-			mockDefinitions[0].SymbolName,
-			mockDefinitions[1].SymbolName,
-			mockDefinitions[2].SymbolName,
-			mockDefinitions[3].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences = make(chan string, 4)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	mockReferences <- "bonk"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 92, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -350,14 +344,11 @@ func TestInsertPathCountInputs(t *testing.T) {
 	//
 	// Incremental insertion test case
 
-	mockReferences = shared.RankingReferences{
-		UploadID: 93,
-		SymbolNames: []string{
-			mockDefinitions[0].SymbolName,
-			mockDefinitions[1].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences = make(chan string, 2)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 93, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -369,16 +360,13 @@ func TestInsertPathCountInputs(t *testing.T) {
 	//
 	// No-op test case
 
-	mockReferences = shared.RankingReferences{
-		UploadID: 94,
-		SymbolNames: []string{
-			mockDefinitions[0].SymbolName,
-			mockDefinitions[1].SymbolName,
-			mockDefinitions[2].SymbolName,
-			mockDefinitions[3].SymbolName,
-		},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockReferences); err != nil {
+	mockReferences = make(chan string, 4)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	mockReferences <- "bonk"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 94, mockReferences); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -419,47 +407,61 @@ func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
 		types.Upload{ID: 3},
 	)
 
-	mockDefinitions := []shared.RankingDefinitions{
-		{UploadID: 1, SymbolName: "foo", DocumentPath: "foo.go"},
-		{UploadID: 1, SymbolName: "bar", DocumentPath: "bar.go"},
-		{UploadID: 2, SymbolName: "foo", DocumentPath: "foo.go"},
-		{UploadID: 2, SymbolName: "bar", DocumentPath: "bar.go"},
-		{UploadID: 3, SymbolName: "baz", DocumentPath: "baz.go"},
-	}
-	mockReferences := []shared.RankingReferences{
-		{UploadID: 1, SymbolNames: []string{"foo"}},
-		{UploadID: 1, SymbolNames: []string{"bar"}},
-		{UploadID: 2, SymbolNames: []string{"foo"}},
-		{UploadID: 2, SymbolNames: []string{"bar"}},
-		{UploadID: 2, SymbolNames: []string{"baz"}},
-		{UploadID: 3, SymbolNames: []string{"bar"}},
-		{UploadID: 3, SymbolNames: []string{"baz"}},
-	}
-
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockDefinitions); err != nil {
+	mockDefinitions := make(chan shared.RankingDefinitions, 5)
+	mockDefinitions <- shared.RankingDefinitions{UploadID: 1, SymbolName: "foo", DocumentPath: "foo.go"}
+	mockDefinitions <- shared.RankingDefinitions{UploadID: 1, SymbolName: "bar", DocumentPath: "bar.go"}
+	mockDefinitions <- shared.RankingDefinitions{UploadID: 2, SymbolName: "foo", DocumentPath: "foo.go"}
+	mockDefinitions <- shared.RankingDefinitions{UploadID: 2, SymbolName: "bar", DocumentPath: "bar.go"}
+	mockDefinitions <- shared.RankingDefinitions{UploadID: 3, SymbolName: "baz", DocumentPath: "baz.go"}
+	close(mockDefinitions)
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockDefinitions); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
-	for _, reference := range mockReferences {
-		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, reference); err != nil {
-			t.Fatalf("unexpected error inserting references: %s", err)
-		}
+
+	mockReferences := make(chan string, 2)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 1, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
-	assertCounts := func(expectedNumDefinitions, expectedNumReferences int) {
+	mockReferences = make(chan string, 3)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 2, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
+	}
+
+	mockReferences = make(chan string, 2)
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 3, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
+	}
+
+	assertCounts := func(expectedNumDefinitions, expectedNumSymbolReferences int) {
 		definitions, err := getRankingDefinitions(ctx, t, db, mockRankingGraphKey)
 		if err != nil {
 			t.Fatalf("failed to get ranking definitions: %s", err)
 		}
 		if len(definitions) != expectedNumDefinitions {
-			t.Fatalf("unexpected number of definitions. want=%d have=%d", expectedNumDefinitions, len(definitions))
+			t.Errorf("unexpected number of definitions. want=%d have=%d", expectedNumDefinitions, len(definitions))
 		}
 
 		references, err := getRankingReferences(ctx, t, db, mockRankingGraphKey)
 		if err != nil {
 			t.Fatalf("failed to get ranking references: %s", err)
 		}
-		if len(references) != expectedNumReferences {
-			t.Fatalf("unexpected number of references. want=%d have=%d", expectedNumReferences, len(references))
+		numSymbolReferences := 0
+		for _, ref := range references {
+			numSymbolReferences += len(ref.SymbolNames)
+		}
+		if numSymbolReferences != expectedNumSymbolReferences {
+			t.Errorf("unexpected number of symbol references. want=%d have=%d", expectedNumSymbolReferences, len(references))
 		}
 	}
 
@@ -475,16 +477,12 @@ func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
 		t.Fatalf("unexpected error vacuuming stale definitions: %s", err)
 	}
 	if expected := 3; numStaleDefinitionRecordsDeleted != expected {
-		t.Fatalf("unexpected number of definition records deleted. want=%d have=%d", expected, numStaleDefinitionRecordsDeleted)
+		t.Errorf("unexpected number of definition records deleted. want=%d have=%d", expected, numStaleDefinitionRecordsDeleted)
 	}
 
 	// remove references for non-visible uploads
-	_, numStaleReferenceRecordsDeleted, err := store.VacuumStaleReferences(ctx, mockRankingGraphKey)
-	if err != nil {
+	if _, _, err := store.VacuumStaleReferences(ctx, mockRankingGraphKey); err != nil {
 		t.Fatalf("unexpected error vacuuming stale references: %s", err)
-	}
-	if expected := 4; numStaleReferenceRecordsDeleted != expected {
-		t.Fatalf("unexpected number of reference records deleted. want=%d have=%d", expected, numStaleReferenceRecordsDeleted)
 	}
 
 	// only upload 2's entries remain
@@ -511,7 +509,7 @@ func TestVacuumStaleInitialPaths(t *testing.T) {
 			t.Fatalf("failed to get initial ranks: %s", err)
 		}
 		if len(initialRanks) != expectedNumRecords {
-			t.Fatalf("unexpected number of initial ranks. want=%d have=%d", expectedNumRecords, len(initialRanks))
+			t.Errorf("unexpected number of initial ranks. want=%d have=%d", expectedNumRecords, len(initialRanks))
 		}
 	}
 
@@ -527,7 +525,7 @@ func TestVacuumStaleInitialPaths(t *testing.T) {
 		t.Fatalf("unexpected error vacuuming stale initial counts: %s", err)
 	}
 	if expected := 6; numRecordsDeleted != expected {
-		t.Fatalf("unexpected number of initial count records deleted. want=%d have=%d", expected, numRecordsDeleted)
+		t.Errorf("unexpected number of initial count records deleted. want=%d have=%d", expected, numRecordsDeleted)
 	}
 
 	// only upload 2's entries remain
@@ -545,22 +543,26 @@ func TestVacuumAbandonedDefinitions(t *testing.T) {
 		symbols = append(symbols, fmt.Sprintf("s%d", j+1))
 	}
 
-	// Insert definitions
-	mockDefinitions := []shared.RankingDefinitions{}
+	mockDefinitions1 := make(chan shared.RankingDefinitions, len(symbols))
+	mockDefinitions2 := make(chan shared.RankingDefinitions, len(symbols))
+	mockDefinitions3 := make(chan shared.RankingDefinitions, len(symbols))
 	for _, symbol := range symbols {
-		mockDefinitions = append(mockDefinitions, shared.RankingDefinitions{
-			UploadID:     1,
-			SymbolName:   symbol,
-			DocumentPath: "foo.go",
-		})
+		mockDefinitions1 <- shared.RankingDefinitions{UploadID: 1, SymbolName: symbol, DocumentPath: "foo.go"}
+		mockDefinitions2 <- shared.RankingDefinitions{UploadID: 1, SymbolName: symbol, DocumentPath: "foo.go"}
+		mockDefinitions3 <- shared.RankingDefinitions{UploadID: 1, SymbolName: symbol, DocumentPath: "foo.go"}
 	}
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey+"-abandoned", mockRankingBatchSize, mockDefinitions); err != nil {
+	close(mockDefinitions1)
+	close(mockDefinitions2)
+	close(mockDefinitions3)
+
+	// Insert definitions
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey+"-abandoned", mockDefinitions1); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, mockDefinitions); err != nil {
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey, mockDefinitions2); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
-	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey+"-abandoned", mockRankingBatchSize, mockDefinitions); err != nil {
+	if err := store.InsertDefinitionsForRanking(ctx, mockRankingGraphKey+"-abandoned", mockDefinitions3); err != nil {
 		t.Fatalf("unexpected error inserting definitions: %s", err)
 	}
 
@@ -594,23 +596,25 @@ func TestVacuumAbandonedReferences(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	symbols := []string{}
+	mockReferences1 := make(chan string, 30)
+	mockReferences2 := make(chan string, 30)
+	mockReferences3 := make(chan string, 30)
 	for j := 0; j < 30; j++ {
-		symbols = append(symbols, fmt.Sprintf("s%d", j+1))
+		mockReferences1 <- fmt.Sprintf("s%d", j+1)
+		mockReferences2 <- fmt.Sprintf("s%d", j+1)
+		mockReferences3 <- fmt.Sprintf("s%d", j+1)
 	}
+	close(mockReferences1)
+	close(mockReferences2)
+	close(mockReferences3)
 
-	mockReferences := []shared.RankingReferences{
-		{UploadID: 1, SymbolNames: symbols},
-		{UploadID: 2, SymbolNames: symbols},
-		{UploadID: 3, SymbolNames: symbols},
-	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey+"-abandoned", 1, mockReferences[0]); err != nil {
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey+"-abandoned", 1, 1, mockReferences1); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, 1, mockReferences[1]); err != nil {
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, 1, 1, mockReferences2); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
-	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey+"-abandoned", 1, mockReferences[2]); err != nil {
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey+"-abandoned", 1, 1, mockReferences3); err != nil {
 		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
@@ -693,19 +697,29 @@ func TestVacuumStaleGraphs(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	mockReferences := []shared.RankingReferences{
-		{UploadID: 1, SymbolNames: []string{"foo"}},
-		{UploadID: 1, SymbolNames: []string{"bar"}},
-		{UploadID: 2, SymbolNames: []string{"foo"}},
-		{UploadID: 2, SymbolNames: []string{"bar"}},
-		{UploadID: 2, SymbolNames: []string{"baz"}},
-		{UploadID: 3, SymbolNames: []string{"bar"}},
-		{UploadID: 3, SymbolNames: []string{"baz"}},
+	mockReferences := make(chan string, 2)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 1, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
 	}
-	for _, reference := range mockReferences {
-		if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, reference); err != nil {
-			t.Fatalf("unexpected error inserting references: %s", err)
-		}
+
+	mockReferences = make(chan string, 3)
+	mockReferences <- "foo"
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 2, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
+	}
+
+	mockReferences = make(chan string, 2)
+	mockReferences <- "bar"
+	mockReferences <- "baz"
+	close(mockReferences)
+	if err := store.InsertReferencesForRanking(ctx, mockRankingGraphKey, mockRankingBatchSize, 3, mockReferences); err != nil {
+		t.Fatalf("unexpected error inserting references: %s", err)
 	}
 
 	for _, graphKey := range []string{
@@ -735,7 +749,7 @@ func TestVacuumStaleGraphs(t *testing.T) {
 			t.Fatalf("failed to count input records: %s", err)
 		}
 		if expectedInputRecords != numInputRecords {
-			t.Fatalf("unexpected number of input records. want=%d have=%d", expectedInputRecords, numInputRecords)
+			t.Errorf("unexpected number of input records. want=%d have=%d", expectedInputRecords, numInputRecords)
 		}
 	}
 
@@ -804,7 +818,7 @@ func TestVacuumStaleRanks(t *testing.T) {
 		t.Fatalf("unexpected error vacuuming stale ranks: %s", err)
 	}
 	if expected := 6; rankRecordsDeleted != expected {
-		t.Fatalf("unexpected number of rank records deleted. want=%d have=%d", expected, rankRecordsDeleted)
+		t.Errorf("unexpected number of rank records deleted. want=%d have=%d", expected, rankRecordsDeleted)
 	}
 
 	// stale graph keys have been removed
@@ -1076,5 +1090,22 @@ func insertRepo(t testing.TB, db database.DB, id int, name string) {
 	)
 	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error while upserting repository: %s", err)
+	}
+}
+
+func TestBatchChannel(t *testing.T) {
+	ch := make(chan int, 10)
+	for i := 0; i < 10; i++ {
+		ch <- i
+	}
+	close(ch)
+
+	batches := [][]int{}
+	for batch := range batchChannel(ch, 3) {
+		batches = append(batches, batch)
+	}
+
+	if diff := cmp.Diff([][]int{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9}}, batches); diff != "" {
+		t.Errorf("unexpected batches (-want +got):\n%s", diff)
 	}
 }

--- a/enterprise/internal/codeintel/ranking/internal/store/store.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/store.go
@@ -29,8 +29,8 @@ type Store interface {
 	LastUpdatedAt(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID]time.Time, error)
 	UpdatedAfter(ctx context.Context, t time.Time) ([]api.RepoName, error)
 
-	InsertDefinitionsForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, definitions []shared.RankingDefinitions) (err error)
-	InsertReferencesForRanking(ctx context.Context, rankingGraphKey string, rankingBatchSize int, references shared.RankingReferences) (err error)
+	InsertDefinitionsForRanking(ctx context.Context, rankingGraphKey string, definitions chan shared.RankingDefinitions) error
+	InsertReferencesForRanking(ctx context.Context, rankingGraphKey string, batchSize int, uploadID int, references chan string) error
 	InsertInitialPathCounts(ctx context.Context, derivativeGraphKey string, batchSize int) (numInitialPathsProcessed int, numInitialPathRanksInserted int, err error)
 	InsertPathCountInputs(ctx context.Context, rankingGraphKey string, batchSize int) (numReferenceRecordsProcessed int, numInputsInserted int, err error)
 	InsertInitialPathRanks(ctx context.Context, uploadID int, documentPath []string, graphKey string) (err error)

--- a/enterprise/internal/codeintel/ranking/mocks_test.go
+++ b/enterprise/internal/codeintel/ranking/mocks_test.go
@@ -131,7 +131,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared.RankingDefinitions) (r0 error) {
+			defaultHook: func(context.Context, string, chan shared.RankingDefinitions) (r0 error) {
 				return
 			},
 		},
@@ -156,7 +156,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		InsertReferencesForRankingFunc: &StoreInsertReferencesForRankingFunc{
-			defaultHook: func(context.Context, string, int, shared.RankingReferences) (r0 error) {
+			defaultHook: func(context.Context, string, int, int, chan string) (r0 error) {
 				return
 			},
 		},
@@ -253,7 +253,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		InsertDefinitionsForRankingFunc: &StoreInsertDefinitionsForRankingFunc{
-			defaultHook: func(context.Context, string, int, []shared.RankingDefinitions) error {
+			defaultHook: func(context.Context, string, chan shared.RankingDefinitions) error {
 				panic("unexpected invocation of MockStore.InsertDefinitionsForRanking")
 			},
 		},
@@ -278,7 +278,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		InsertReferencesForRankingFunc: &StoreInsertReferencesForRankingFunc{
-			defaultHook: func(context.Context, string, int, shared.RankingReferences) error {
+			defaultHook: func(context.Context, string, int, int, chan string) error {
 				panic("unexpected invocation of MockStore.InsertReferencesForRanking")
 			},
 		},
@@ -966,24 +966,24 @@ func (c StoreGetUploadsForRankingFuncCall) Results() []interface{} {
 // InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked.
 type StoreInsertDefinitionsForRankingFunc struct {
-	defaultHook func(context.Context, string, int, []shared.RankingDefinitions) error
-	hooks       []func(context.Context, string, int, []shared.RankingDefinitions) error
+	defaultHook func(context.Context, string, chan shared.RankingDefinitions) error
+	hooks       []func(context.Context, string, chan shared.RankingDefinitions) error
 	history     []StoreInsertDefinitionsForRankingFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertDefinitionsForRanking delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertDefinitionsForRanking(v0 context.Context, v1 string, v2 int, v3 []shared.RankingDefinitions) error {
-	r0 := m.InsertDefinitionsForRankingFunc.nextHook()(v0, v1, v2, v3)
-	m.InsertDefinitionsForRankingFunc.appendCall(StoreInsertDefinitionsForRankingFuncCall{v0, v1, v2, v3, r0})
+func (m *MockStore) InsertDefinitionsForRanking(v0 context.Context, v1 string, v2 chan shared.RankingDefinitions) error {
+	r0 := m.InsertDefinitionsForRankingFunc.nextHook()(v0, v1, v2)
+	m.InsertDefinitionsForRankingFunc.appendCall(StoreInsertDefinitionsForRankingFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // InsertDefinitionsForRanking method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, []shared.RankingDefinitions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultHook(hook func(context.Context, string, chan shared.RankingDefinitions) error) {
 	f.defaultHook = hook
 }
 
@@ -992,7 +992,7 @@ func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreInsertDefinitionsForRankingFunc) PushHook(hook func(context.Context, string, int, []shared.RankingDefinitions) error) {
+func (f *StoreInsertDefinitionsForRankingFunc) PushHook(hook func(context.Context, string, chan shared.RankingDefinitions) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1001,19 +1001,19 @@ func (f *StoreInsertDefinitionsForRankingFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreInsertDefinitionsForRankingFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, []shared.RankingDefinitions) error {
+	f.SetDefaultHook(func(context.Context, string, chan shared.RankingDefinitions) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreInsertDefinitionsForRankingFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, []shared.RankingDefinitions) error {
+	f.PushHook(func(context.Context, string, chan shared.RankingDefinitions) error {
 		return r0
 	})
 }
 
-func (f *StoreInsertDefinitionsForRankingFunc) nextHook() func(context.Context, string, int, []shared.RankingDefinitions) error {
+func (f *StoreInsertDefinitionsForRankingFunc) nextHook() func(context.Context, string, chan shared.RankingDefinitions) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1055,10 +1055,7 @@ type StoreInsertDefinitionsForRankingFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []shared.RankingDefinitions
+	Arg2 chan shared.RankingDefinitions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -1067,7 +1064,7 @@ type StoreInsertDefinitionsForRankingFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreInsertDefinitionsForRankingFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
@@ -1535,24 +1532,24 @@ func (c StoreInsertPathRanksFuncCall) Results() []interface{} {
 // InsertReferencesForRanking method of the parent MockStore instance is
 // invoked.
 type StoreInsertReferencesForRankingFunc struct {
-	defaultHook func(context.Context, string, int, shared.RankingReferences) error
-	hooks       []func(context.Context, string, int, shared.RankingReferences) error
+	defaultHook func(context.Context, string, int, int, chan string) error
+	hooks       []func(context.Context, string, int, int, chan string) error
 	history     []StoreInsertReferencesForRankingFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertReferencesForRanking delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) InsertReferencesForRanking(v0 context.Context, v1 string, v2 int, v3 shared.RankingReferences) error {
-	r0 := m.InsertReferencesForRankingFunc.nextHook()(v0, v1, v2, v3)
-	m.InsertReferencesForRankingFunc.appendCall(StoreInsertReferencesForRankingFuncCall{v0, v1, v2, v3, r0})
+func (m *MockStore) InsertReferencesForRanking(v0 context.Context, v1 string, v2 int, v3 int, v4 chan string) error {
+	r0 := m.InsertReferencesForRankingFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertReferencesForRankingFunc.appendCall(StoreInsertReferencesForRankingFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // InsertReferencesForRanking method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreInsertReferencesForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, shared.RankingReferences) error) {
+func (f *StoreInsertReferencesForRankingFunc) SetDefaultHook(hook func(context.Context, string, int, int, chan string) error) {
 	f.defaultHook = hook
 }
 
@@ -1561,7 +1558,7 @@ func (f *StoreInsertReferencesForRankingFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreInsertReferencesForRankingFunc) PushHook(hook func(context.Context, string, int, shared.RankingReferences) error) {
+func (f *StoreInsertReferencesForRankingFunc) PushHook(hook func(context.Context, string, int, int, chan string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1570,19 +1567,19 @@ func (f *StoreInsertReferencesForRankingFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreInsertReferencesForRankingFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, int, shared.RankingReferences) error {
+	f.SetDefaultHook(func(context.Context, string, int, int, chan string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreInsertReferencesForRankingFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, int, shared.RankingReferences) error {
+	f.PushHook(func(context.Context, string, int, int, chan string) error {
 		return r0
 	})
 }
 
-func (f *StoreInsertReferencesForRankingFunc) nextHook() func(context.Context, string, int, shared.RankingReferences) error {
+func (f *StoreInsertReferencesForRankingFunc) nextHook() func(context.Context, string, int, int, chan string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1627,7 +1624,10 @@ type StoreInsertReferencesForRankingFuncCall struct {
 	Arg2 int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 shared.RankingReferences
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 chan string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -1636,7 +1636,7 @@ type StoreInsertReferencesForRankingFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreInsertReferencesForRankingFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
This does two things:

- Release memory for definitions kept in memory once we reach the references stage
- Don't accumulate all references in memory, instead pass them through a channel and only keep at most page_size in memory.

I've noticed that this is the the cause of the biggest allocated heap on dotcom, so maybe this helps? 

Just hacked together quickly, would need more work to land. Just trying to get some eyes on the solution to see if it would make sense at all.

<img width="1694" alt="Screenshot 2023-03-16 at 02 08 39@2x" src="https://user-images.githubusercontent.com/19534377/225483708-49b8b3a8-8787-4446-a2a6-da52af240c54.png">

## Test plan

Updated unit tests.