### PR TITLE
Smartsearch: recognize alternates in capture groups as regex

### DIFF
--- a/internal/search/smartsearch/rules.go
+++ b/internal/search/smartsearch/rules.go
@@ -139,7 +139,6 @@ func regexpPatterns(b query.Basic) *query.Basic {
 				syntax.OpNoMatch,
 				syntax.OpEmptyMatch,
 				syntax.OpLiteral,
-				syntax.OpCapture,
 				syntax.OpConcat:
 				count += countMetaSyntax(r.Sub)
 			case
@@ -171,6 +170,18 @@ func regexpPatterns(b query.Basic) *query.Basic {
 					count += countMetaSyntax(r.Sub) + 2
 				default:
 					count += countMetaSyntax(r.Sub) + 1
+				}
+			case
+				// capture groups over an alternate like (a|b)
+				// are weighted one. All other capture groups
+				// are weighted zero on their own because parens
+				// are very common in code.
+				syntax.OpCapture:
+				switch r.Sub[0].Op {
+				case syntax.OpAlternate:
+					count += countMetaSyntax(r.Sub) + 1
+				default:
+					count += countMetaSyntax(r.Sub)
 				}
 			}
 		}

--- a/internal/search/smartsearch/rules_test.go
+++ b/internal/search/smartsearch/rules_test.go
@@ -134,6 +134,8 @@ func Test_regexpPatterns(t *testing.T) {
 		`(ab)*`,
 		`c++`,
 		`my.yaml.conf`,
+		`(using|struct)`,
+		`test.get(id)`,
 	}
 
 	for _, c := range cases {

--- a/internal/search/smartsearch/testdata/Test_regexpPatterns/regexp_patterns#04.golden
+++ b/internal/search/smartsearch/testdata/Test_regexpPatterns/regexp_patterns#04.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "(using|struct)",
+  "Query": "/(using|struct)/"
+}

--- a/internal/search/smartsearch/testdata/Test_regexpPatterns/regexp_patterns#05.golden
+++ b/internal/search/smartsearch/testdata/Test_regexpPatterns/regexp_patterns#05.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "test.get(id)",
+  "Query": "DOES NOT APPLY"
+}


### PR DESCRIPTION
With the current smartsearch rules, we don't optimistically execute patterns like `(a|b)` because our heuristic doesn't recognize it as regexy enough to be confident it's a regex pattern. However, an alternation inside a capture group would be a pretty rare pattern to see outside an attempted regex search, so let's add slightly special case to treat that pattern as regex.

Inspired by [this thread](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1678935888415839)

## Test plan

Add a couple of test cases to cover the new condition.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
