### PR TITLE
bazel: fix checks in sg.config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1009,7 +1009,7 @@ commandsets:
       - redis
       - postgres
       - git
-      - bazel
+      - bazelisk
       - ibazel
     bazelCommands:
       - oss-frontend
@@ -1062,7 +1062,7 @@ commandsets:
       - redis
       - postgres
       - git
-      - bazel
+      - bazelisk
       - ibazel
     bazelCommands:
       - frontend
@@ -1128,7 +1128,7 @@ commandsets:
       - redis
       - postgres
       - git
-      - bazel
+      - bazelisk
       - ibazel
     bazelCommands:
       - frontend


### PR DESCRIPTION
`sg.config.yaml` was referring to a check that doesn't exist anymore - it should use the `bazelisk` check instead


## Test plan
`sg start oss-bazel` started without the error `check 'bazel' not found`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
