### PR TITLE
[docs] fix broken formatting and links

### DIFF
--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -3,8 +3,8 @@
 Sourcegraph can be configured to enforce the same access to repositories and underlying 
 source files as your code  host. If configured, Sourcegraph will allow the user to only 
 see the entities that they can see on the code host. These permissions are enforced 
-accross the product for all the use cases that need to read data from a repository, including
- the existence of such repository on the code host.
+accross the product for all the use cases that need to read data from a repository, 
+including the existence of such repository on the code host.
 
 > NOTE: Historically, we have referred to permissions-related features under different 
 names: "authorization", "repository permissions", "code host permissions". All of these 
@@ -14,7 +14,7 @@ can, for example, create a batch change or who is a site admin.
 
 ## Example
 
-Imagine a scenario, with 2 users, `alice` and `bob`. 
+Imagine a scenario, with 2 users, `alice` and `bob`: 
 
 - `alice` can access repositories `horsegraph/global` and `horsegraph/alice` on the code host
 - `bob` has access to repositories `horsegraph/global` and `horsegraph/docs` on the code host
@@ -22,7 +22,7 @@ Imagine a scenario, with 2 users, `alice` and `bob`.
 - all of the mentioned repositories are synced to Sourcegraph
 
 If `alice` tries to run a search on Sourcegraph, the results will only contain data from the public `horsegraph/global` repository 
-and the ones she has access to (`horsegraph/global` and `horsegraph/alice`). `alice` will not be able to see results
+and the ones she has access to (`horsegraph/global` and `horsegraph/alice`). `alice` will not be able to see results 
 from the `horsegraph/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
 
 Same for `bob`, the search results or any other feature will not show him the existence of `horsegraph/alice` repository on 
@@ -41,10 +41,10 @@ To know more about each method that we support, please follow the link above.
 ## Supported code hosts
 
 Support for repository permissions accross different code hosts is different. The following table captures current state of support (ordered alphabetically):
-| Code host | [Permission Syncing](syncing.md) | (Webhooks for Permissions](webhooks.md) | [Explicit API](api.md) | [Scale supported](#supported-scale) |
+| Code host | [Permission Syncing](syncing.md) | [Webhooks for Permissions](webhooks.md) | [Explicit API](api.md) | [Scale supported](#supported-scale) |
 | -------- | -------- | -------- | -------- | -------- |
-| Bitbucket Cloud <span class="badge badge-beta">Beta</span> | ✓ | ✗ | ✓ | 10k users, 100k repositories
-| Bitbucket Server | ✓ | ✗ | ✓ | 10k users, 100k repositories
+| Bitbucket Cloud <span class="badge badge-beta">Beta</span> | ✓ | ✗ | ✓ | 10k users, 100k repositories |
+| Bitbucket Server | ✓ | ✗ | ✓ | 10k users, 100k repositories |
 | Gerrit <span class="badge badge-beta">Beta</span> | ✓ | ✗ | ✓ | 10k users, 100k repositories |
 | GitHub   | ✓ | ✓ | ✓ | 40k users, 200k repositories |
 | GitHub Enterprise | ✓ | ✓ | ✓ | 40k users, 200k repositories |
@@ -70,7 +70,7 @@ Please contact support if you want to discuss bigger scale than specified.
 
 ## SLAs
 
-Each method of getting permissions to Sourcegraph has different SLA on how long it takes for permissions to appear
+Each method of getting permissions to Sourcegraph has different SLA on how long it takes for permissions to appear 
 in Sourcegraph.
 
 - [Permission syncing SLA](./syncing.md#sla)
@@ -80,8 +80,8 @@ in Sourcegraph.
 
 To have permission syncing available, the Sourcegraph instance needs to be configured with 
 a license that has `acls` feature enabled. If it is not present, Sourcegraph will not enforce 
-repository permissions and each repository will be treated as public - any user that has access
- to Sourcegraph will be able to access it.
+repository permissions and each repository will be treated as public - any user that has access 
+to Sourcegraph will be able to access it.
 
 ## Site administrators
 

--- a/doc/admin/permissions/syncing.md
+++ b/doc/admin/permissions/syncing.md
@@ -1,14 +1,15 @@
 # Permission syncing
 
-Permission syncing is a polling mechanism, that periodically checks via an API call to the code host to determine which permissions of a specific entity has.
-We have 2 ways to sync permissions. Both are on by default, resulting in double polling:
+Permission syncing is a polling mechanism, that periodically checks via an API call to the code 
+host to determine which permissions of a specific entity has. We have 2 ways to sync 
+permissions. Both are on by default, resulting in double polling:
 
 - **user-centric** permission syncing, where we ask the code host for a list of repositories that a specific user has read access to
 - **repo-centric** permission syncing, where we ask the code host for a list of users that can access a specific repository
 
 Sourcegraph collects this information and stores it in internal database. 
 
-To see which code hosts support permission syncing, please refer to [Supported code hosts table](../index.md#supported-code-hosts)
+To see which code hosts support permission syncing, please refer to [Supported code hosts table](../index.md#supported-code-hosts).
 ## How it works
 
 ### Periodic sync
@@ -22,8 +23,8 @@ There is a scheduler and job queue for both user-centric and repo-centric sync j
 
 ### On-demand sync
 
-Besides periodic schedule of jobs, we also have a way to request permission sync for a user or repository on-demand. 
-This is useful for example when a new user is added to Sourcegraph.
+Besides periodic schedule of jobs, we also have a way to request permission sync for a user 
+or repository on-demand. This is useful for example when a new user is added to Sourcegraph.
 
 To do that, the following GraphQL request needs to be made:
 ```graphql
@@ -45,14 +46,15 @@ mutation {
 
 **Example**:
 - User `bob` is added to Sourcegraph.
-- `bob` has access to repositories `horsegraph/global` and `horsegraph/bob` on the code host.
+- `bob` has access to repositories `horsegraph/global` and `horsegraph/bob` on the code host
 - an on-demand request is made to sync repository permissions of `bob`, this job is added to the queue with high priority, so it will be processed
   quicker than jobs with lower priority
 - by the time `bob` actually logs into Sourcegraph, the permissions should already be synced with this on-demand job.
 
 ### Scheduling
 
-A variety of heuristics are used to determine when a user or a repository should be scheduled for a permissions sync to ensure the permissions data Sourcegraph has is up to date.
+A variety of heuristics are used to determine when a user or a repository should be 
+scheduled for a permissions sync to ensure the permissions data Sourcegraph has is up to date.
 
 Permissions syncs are regularly scheduled in these scenarios
 
@@ -62,8 +64,9 @@ Permissions syncs are regularly scheduled in these scenarios
 - When a user or repository permissions are stale (i.e. some amount of time has passed since the last sync for a user or repository)
   - in this case, Sourcegraph schedules a certain amount of users/repositories with oldest permissions on each scheduling interval.
 
-When a sync job is scheduled, it is added to a priority queue that is steadily processed.
-To avoid overloading the code host a sync job [might not be processed immediately](#sync-duration) and depending on the code host, might be heavily rate limited. 
+When a sync job is scheduled, it is added to a priority queue that is steadily 
+processed. To avoid overloading the code host a sync job [might not be processed immediately](#sync-duration) 
+and depending on the code host, might be heavily rate limited. 
 
 Priority queue is needed to process the sync jobs in the order of most important first. E.g.:
 - on-demand sync is high priority
@@ -72,11 +75,16 @@ Priority queue is needed to process the sync jobs in the order of most important
 
 ### Mapping code host identifiers
 
-To identify which Sourcegraph users or repositories the permissions relate to, we need to map the users identifiers from code host with userIDs on Sourcegraph and similarly for repository identifiers from code host to repoIDs on Sourcegraph side. 
+To identify which Sourcegraph users or repositories the permissions relate to, we need to map the 
+users identifiers from code host with userIDs on Sourcegraph and similarly for repository 
+identifiers from code host to repoIDs on Sourcegraph side. 
 
-> WARNING: For this process to work correctly, the user needs to have an external account from code host mapped to the user account on Sourcegraph, otherwise the code host identifier cannot be matched and repository permissions cannot be enforced. 
+> WARNING: For this process to work correctly, the user needs to have an external account 
+from code host mapped to the user account on Sourcegraph, otherwise the code host 
+identifier cannot be matched and repository permissions cannot be enforced. 
 
-This is the main reason to require users to connect to their code host. This can be done on the Account security settings page: `/users/$USER/settings/security`.
+This is the main reason to require users to connect to their code host. This 
+can be done on the Account security settings page: `/users/$USER/settings/security`.
 
 ### Entities that do not exist on Sourcegraph
 
@@ -84,16 +92,17 @@ There might be cases, when the identifiers on the code host do not match any use
 In that case, Sourcegraph still stores the permission information in the internal database as **pending permissions**
 In case that an entity with the same code host identifier is added later, Sourcegraph applies these pending permissions.
 
-** Sourcegraph only keeps pending permissions for repositories that were added to Sourcegraph.**
+**Sourcegraph only keeps pending permissions for repositories that were added to Sourcegraph.**
 We will never store information about repositories that are not shared with us.
 
-If everything works correctly in such a case, [on-demand sync request](#on-demand-sync) is not strictly needed. 
-But the permissions of the entity might have changed in the time since the last sync of these pending permissions, 
-so it is safer to make the request anyway to keep the permissions as fresh as possible
+If everything works correctly in such a case, [on-demand sync request](#on-demand-sync) 
+is not strictly needed. But the permissions of the entity might have changed in the time 
+since the last sync of these pending permissions, so it is safer to make the request 
+anyway to keep the permissions as fresh as possible.
 
 ## SLA
 
-Sourcegraph SLA is, that the time it takes for permissions from code host to be synced via permission syncing
+Sourcegraph SLA is, that the time it takes for permissions from code host to be synced via permission syncing 
 to Sourcegraph is the same as the [lag-time](#lag-time) defined below. So as long as a full cycle of permission syncing takes.
 
 ## Checking permissions sync state
@@ -128,15 +137,31 @@ query {
 }
 ```
 
-In the GraphQL API, `syncedAt` indicates the last complete sync and `updatedAt` indicates the last incremental sync. If `syncedAt` is more recent than `updatedAt`, the user or repository is in a state of complete sync - [learn more](#complete-sync-vs-incremental-sync).
+### Difference between `syncedAt` and `updatedAt`
+
+Because we do double polling with user-centric permission sync running alongside repo-centric permission sync, the `syncedAt` 
+and `updatedAt` times might be different.
+
+For *user permission sync*, the GraphQL API `syncedAt` indicates the time of last user-centric permission sync for the user 
+and `updatedAt` indicates the last repo-centric permission sync for any of the repositories the user has access to. 
+If `syncedAt` is more recent than `updatedAt`, it means the last user-centric permission sync for the user is more recent 
+than any of the repo-centric permission syncs for the repositories the user has access to.
+
+For *repository permission sync*, the case is orthogonal to the above. The GraphQL API `syncedAt` indicates the time of last 
+repo-centric permission sync for the repository and `updatedAt` indicates the last user-centric permission sync for any of 
+the users that can access the repository. 
+If `syncedAt` is more recent than `updatedAt`, it means the last repo-centric permission sync for the repository is more recent 
+than any of the user-centric permission syncs for the users that can access the repository.
 
 ## Sync duration
 
-When syncing permissions from code hosts with large numbers of users and repositories, it can take a lot of time to complete syncing all permissions from a code host for every user and every repository. 
-Typically due to internal rate limits imposed by Sourcegraph and external rate limits imposed by the code host, it can take hours for customers with large amounts of users or repositories.
-Please contact the support team for further assistance. 
+When syncing permissions from code hosts with large numbers of users and repositories, it can take a lot of time 
+to complete syncing all permissions from a code host for every user and every repository. Typically due to internal 
+rate limits imposed by Sourcegraph and external rate limits imposed by the code host, it can take hours for customers 
+with large amounts of users or repositories. Please contact the support team for further assistance. 
 
-For initial setup of instance, when the initial sync for all repositories and users is running, users will gradually see more and more search results from repositories they have access to.
+For initial setup of instance, when the initial sync for all repositories and users is running, users will 
+gradually see more and more search results from repositories they have access to.
 
 ### Lag-time
 
@@ -164,7 +189,10 @@ So the answer to the question of how long the *lag-time* is, in the worst case 1
 
 ### Request count
 
-To calculate how long a full sync takes, it is important to take into consideration many factors - how quickly we fill the sync job queue, how is internal rate limiter and external rate limiter configured, etc. But in general, we need to make the following amount of requests to fully sync all the user-centric permissions (and we double poll, so double the number for repo-centric sync jobs):
+To calculate how long a full sync takes, it is important to take into consideration many factors - how quickly we 
+fill the sync job queue, how is internal rate limiter and external rate limiter configured, etc. But in general, we 
+need to make the following amount of requests to fully sync all the user-centric permissions 
+(and we double poll, so double the number for repo-centric sync jobs):
 
 ```
 request_count = ((users * avg_repository_access) / per_page_items) + 
@@ -173,15 +201,17 @@ request_count = ((users * avg_repository_access) / per_page_items) +
 
 **Example:**
 
-There are `10 000` users, `40 000` repositories and the github.com API is paginated on `100` items per page. 
-On average, every user has read access to `300` repositories and on average a repository is accessible by `75` users.
+There are `10 000` users, `40 000` repositories and the github.com API is paginated on `100` items per page. On 
+average, every user has read access to `300` repositories and on average a repository is accessible by `75` users.
 
-We need to make `3M` requests. To cover both user-centric and repo-centric case, it means `6M` requests.
-Github.com has an API rate limit of `5000` requests per hour. In that case, complete permission sync of all users takes `3M requests / 5000  = 600` hours, which is `25` days approximately. 
+We need to make `3M` requests. To cover both user-centric and repo-centric case, it means `6M` requests. 
+[github.com](https://github.com) has an API rate limit of `5000` requests per hour. In that case, complete 
+permission sync of all users takes `3M requests / 5000  = 600` hours, which is `25` days approximately. 
 
-`25` days to complete a full cycle of permission sync is not great, it can potentially mean `25` days of lag time mentioned above. 
-Even if we let permission sync consume all the rate limit and we stagger our requests perfectly, which is rarely the case. 
-Depending on the code host, the rate limit might be much higher, but then we might be firing huge amounts of requests to the code host.
+`25` days to complete a full cycle of permission sync is not great, it can potentially mean `25` days of lag time 
+mentioned above. Even if we let permission sync consume all the rate limit and we stagger our requests perfectly, which 
+is rarely the case. Depending on the code host, the rate limit might be much higher, but then we might be 
+firing huge amounts of requests to the code host.
 
 > IMPORTANT: For permission syncing to be quicker, the code host needs to be able to handle big amounts of requests per hour.
 
@@ -190,8 +220,8 @@ Depending on the code host, the rate limit might be much higher, but then we mig
 > IMPORTANT: We recommend **configuring webhooks for permissions on GitHub** which makes lag time much smaller.
 
 ## Configuration
-There are variety of options in the site configuration to tune how the permissions sync requests are scheduled. 
-Default values are shown below:
+There are variety of options in the site configuration to tune how the permissions sync requests are 
+scheduled. Default values are shown below:
 
 ```json
 {
@@ -224,18 +254,21 @@ If there are a lot less users, than repositories, it is better to rely on user-c
   "permissions.syncOldestRepos": 1,
 ```
 
-This configuration change will schedule `20` users on each scheduler iteration and just `1` repository. That way, we use the API requests better and user sync will be prefered.
-This is just an example, please change the `syncOldestUsers` value to what is desired in your organization. 
+This configuration change will schedule `20` users on each scheduler iteration and just `1` repository. That 
+way, we use the API requests better and user sync will be prefered. This is just an example, please change 
+the `syncOldestUsers` value to what is desired in your organization. 
 
 **Example**:
-There are `10 000` users, `40 000` repositories and the desired time to do a full cycle of permission sync is `2 hours`.
-That means we need to sync 5000 users an hour. If we keep the `syncScheduleInterval` to `15s` (the default), we schedule 4-times a minute. `5000/(4 * 60) = 20.8`, so the scheduler needs to schedule 21 users on each iteration to get under the 2 hour mark.
+There are `10 000` users, `40 000` repositories and the desired time to do a full cycle of permission sync is `2 hours`. That 
+means we need to sync 5000 users an hour. If we keep the `syncScheduleInterval` to `15s` (the default), we schedule 4-times 
+a minute. `5000/(4 * 60) = 20.8`, so the scheduler needs to schedule 21 users on each iteration to get under the 2 hour mark.
 
-The rate limit for the code host would need to be changed to support the load. In that case the recommendation is to set it to 2x of the amount of [requests expected from permission syncing](#request-count).
+The rate limit for the code host would need to be changed to support the load. In that case the recommendation 
+is to set it to 2x of the amount of [requests expected from permission syncing](#request-count).
 #### More users than repositories
 
-If the situation is reversed, it is recommended to do the opposite than above. 
-Prefer repo-centric permission sync in these situations:
+If the situation is reversed, it is recommended to do the opposite than above. Prefer repo-centric 
+permission sync in these situations:
 
 ```json
   "permissions.syncOldestUsers": 1,
@@ -243,8 +276,9 @@ Prefer repo-centric permission sync in these situations:
 ```
 
 **Example**
-There are `10 000` users, `5000` repositories and the desired time for a full permission sync cycle is `2 hours`.
-That means we need to sync 2500 repositories an hour. If we keep the `syncScheduleInterval` to `15s`(the default), we schedule 4-times a minute. `2500/(4 * 60) = 10.4`, so the scheduler needs to schedule 11 repositories on each iteration to get under the 2 hour mark.
+There are `10 000` users, `5000` repositories and the desired time for a full permission sync cycle is `2 hours`. That means we 
+need to sync 2500 repositories an hour. If we keep the `syncScheduleInterval` to `15s`(the default), we schedule 4-times 
+a minute. `2500/(4 * 60) = 10.4`, so the scheduler needs to schedule 11 repositories on each iteration to get under the 2 hour mark.
 
-The rate limit for the code host needs to be changed to support the load. 
-In that case the recommendation is to set it to 2x of the amount of [requests expected from permission syncing](#request-count).
+The rate limit for the code host needs to be changed to support the load. In that case the recommendation 
+is to set it to 2x of the amount of [requests expected from permission syncing](#request-count).

--- a/doc/admin/permissions/webhooks.md
+++ b/doc/admin/permissions/webhooks.md
@@ -1,7 +1,8 @@
 # Webhooks for repository permissions
 
-Sourcegraph allows customers to use webhooks to react to events that modify user permissions on the code host.
-Currently the only supported code host for webhooks is [Github](../external_service/github.md)
+Sourcegraph allows customers to use webhooks to react to events that modify user permissions 
+on the code host. Currently the only supported code host for webhooks 
+is [Github](../external_service/github.md).
 
 > NOTE: Using webhooks is the *recommended* way to get code host permissions to Sourcegraph
 
@@ -15,7 +16,7 @@ Sourcegraph exposes endpoints to receive webhooks. These endpoints are authentic
 
 ## SLA
 
-Sourcegraph SLA is, that **p95 of webhook requests will be processed within 5 minutes**. This means, that
+Sourcegraph SLA is, that **p95 of webhook requests will be processed within 5 minutes**. This means, that 
 when the permissions are changed on the code host, it takes at most 5 minutes for the same permissions to be reflected on the Sourcegraph side.
 
 ## Advantages
@@ -24,11 +25,13 @@ when the permissions are changed on the code host, it takes at most 5 minutes fo
 - least amount of resource usage (bandwidth, code host rate limit), as we only ask code host for permission data when there is an actual change
 ## Disadvantages
 
-Webhooks are best effort and there is no 100% guarantee that a webhook will be fired from the code host side when the data change.
-Especially with permissions, this is something to be aware of, as important permission related webhooks might not be sent to Sourcegraph.
+Webhooks are best effort and there is no 100% guarantee that a webhook will be 
+fired from the code host side when the data change. Especially with permissions, this 
+is something to be aware of, as important permission related webhooks might 
+not be sent to Sourcegraph.
 
 > NOTE: That's why we recommend to use webhooks alongside the permission syncing mechanism.
 
 ## Configuring webhooks
 
-Please follow the link for [configuring permission syncing webhooks for Github](../config/webhooks.md#user-permissions)
+Please follow the link for [configuring permission syncing webhooks for Github](../config/webhooks.md#user-permissions).


### PR DESCRIPTION
## Description

Fixing broken formatting, when the paragraph in markdown did not have spaces at the end of lines.
Fixed some broken links, fixed broken **bold section**.
Fixed the section for updatedAt and syncedAt times by adding a different explanation.

## Test plan

tested locally by running docsite
