### PR TITLE
bazel: build searcher for docker

### DIFF
--- a/cmd/searcher/BUILD.bazel
+++ b/cmd/searcher/BUILD.bazel
@@ -15,4 +15,8 @@ go_binary(
     name = "searcher",
     embed = [":searcher_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )

--- a/cmd/searcher/build.sh
+++ b/cmd/searcher/build.sh
@@ -10,6 +10,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [[ "$DOCKER_BAZEL" == "true" ]]; then
+   bazel build //cmd/searcher \
+     --stamp \
+     --workspace_status_command=./dev/bazel_stamp_vars.sh \
+     --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+
+   out=$(bazel cquery //cmd/searcher --output=files)
+   cp "$out" "$OUTPUT"
+
+   docker build -f cmd/searcher/Dockerfile -t "$IMAGE" "$OUTPUT" \
+     --progress=plain \
+     --build-arg COMMIT_SHA \
+     --build-arg DATE \
+     --build-arg VERSION
+   exit $?
+fi
+
 # Environment for building linux binaries
 export GO111MODULE=on
 export GOARCH=amd64


### PR DESCRIPTION
Build the searcher binary with bazel and copy it into docker

depends on:
- https://github.com/sourcegraph/sourcegraph/pull/49228

## Test plan
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
