### PR TITLE
Fix error handling in native-SSBC execution mode

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -266,6 +266,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 				Commands: []string{
 					// Hide commands from stderr.
 					"{ set +x; } 2>/dev/null",
+					"{ set -eo pipefail; } 2>/dev/null",
 					fmt.Sprintf(`(exec "%s/step%d.sh" | tee %s/stdout%d.log) 3>&1 1>&2 2>&3 | tee %s/stderr%d.log`, runDirToScriptDir, i, runDirToScriptDir, i, runDirToScriptDir, i),
 				},
 			})


### PR DESCRIPTION
If the actual command script fails, the error would not propagate because the pipe into tee would swallow the error. This fixes it.

## Test plan

Verified errors are now reported properly.