### PR TITLE
Bump embeddings base image to resolve vulnerabilities

### DIFF
--- a/enterprise/cmd/embeddings/Dockerfile
+++ b/enterprise/cmd/embeddings/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcegraph/alpine-3.14:196830_2023-02-01_af83eee939ca@sha256:b4d7040d41fcf37fbf96fe5a14c39ae15580a3a6c76355cc7ea04a74b6c3b9fa
+FROM sourcegraph/alpine-3.14:201280_2023-02-23_4.5-1071f8b97a60@sha256:c4970b21169db155c1b497740e622adb23007ac11a87ec571d9ecef8aba0adc5
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
Not sure why this image was out of date, but I saw critical vulns in this image that should be resolved by this bump.

## Test plan

CI should find build issues.