### PR TITLE
experimental search input: Better context: filter handling on paste

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -37,7 +37,7 @@ import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
 import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
-import { overrideContextOnPaste, shiftPasteOverwrite } from './codemirror/searchcontext'
+import { overrideContextOnPaste } from './codemirror/searchcontext'
 import { filterDecoration } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
 import { Source, suggestions, startCompletion } from './suggestionsExtension'
@@ -207,7 +207,6 @@ const staticExtensions: Extension = [
     keymap.of(defaultKeymap),
     codemirrorHistory(),
     filterPlaceholder,
-    shiftPasteOverwrite(),
     modeScope([queryDiagnostic(), overrideContextOnPaste], [null]),
     Prec.low([querySyntaxHighlighting, modeScope([tokenInfo(), filterDecoration], [null])]),
     EditorView.theme({

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -37,7 +37,7 @@ import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
 import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
-import { overrideContextOnPaste } from './codemirror/searchcontext'
+import { overrideContextOnPaste, shiftPasteOverwrite } from './codemirror/searchcontext'
 import { filterDecoration } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
 import { Source, suggestions, startCompletion } from './suggestionsExtension'
@@ -207,6 +207,7 @@ const staticExtensions: Extension = [
     keymap.of(defaultKeymap),
     codemirrorHistory(),
     filterPlaceholder,
+    shiftPasteOverwrite(),
     modeScope([queryDiagnostic(), overrideContextOnPaste], [null]),
     Prec.low([querySyntaxHighlighting, modeScope([tokenInfo(), filterDecoration], [null])]),
     EditorView.theme({

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -37,6 +37,7 @@ import { querySyntaxHighlighting } from '../codemirror/syntax-highlighting'
 import { tokenInfo } from '../codemirror/token-info'
 import { useUpdateEditorFromQueryState } from '../CodeMirrorQueryInput'
 
+import { overrideContextOnPaste } from './codemirror/searchcontext'
 import { filterDecoration } from './codemirror/syntax-highlighting'
 import { modeScope, useInputMode } from './modes'
 import { Source, suggestions, startCompletion } from './suggestionsExtension'
@@ -206,7 +207,7 @@ const staticExtensions: Extension = [
     keymap.of(defaultKeymap),
     codemirrorHistory(),
     filterPlaceholder,
-    queryDiagnostic(),
+    modeScope([queryDiagnostic(), overrideContextOnPaste], [null]),
     Prec.low([querySyntaxHighlighting, modeScope([tokenInfo(), filterDecoration], [null])]),
     EditorView.theme({
         '&': {

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
@@ -35,19 +35,24 @@ describe('overrideContextOnPaste', () => {
         return state.update({ ...state.replaceSelection(insert), userEvent: 'input.paste' }).state.sliceDoc()
     }
 
-    it('removes the existing global context: filter if the new input would have multiple global context: filters', () => {
-        expect(test('context:global one |two| three', 'context:foo bar')).toStrictEqual('one context:foo bar three')
-        expect(test('context:global one |two three', 'context:foo bar')).toStrictEqual('one context:foo bartwo three')
+    it('removes the existing global context: filter if it is considered "empty"', () => {
         expect(test('context:global |', 'context:foo bar')).toStrictEqual('context:foo bar')
         expect(test('context:global|', 'bar context:foo')).toStrictEqual('bar context:foo')
     })
 
-    it('keeps the filter if the new value contains subexpressions', () => {
-        expect(test('context:global foo ', 'OR context:foo bar')).toStrictEqual('context:global foo OR context:foo bar')
+    it('removes the new context: filter if the existing query is not "empty"', () => {
+        expect(test('context:global one |two| three', 'context:foo bar')).toStrictEqual('context:global one bar three')
+
+    })
+
+    it('keeps the filter the query contains kewords', () => {
+        expect(test('context:global foo |', 'OR context:foo bar')).toStrictEqual('context:global foo OR context:foo bar')
+        expect(test('context:global |foo OR bar ', 'context:foo bar')).toStrictEqual('context:global context:foo barfoo OR bar ')
     })
 
     it('keeps the filter if the new value does not contain a context filter', () => {
         expect(test('context:global ', 'foo')).toStrictEqual('context:global foo')
+        expect(test('context:global | bar', 'foo')).toStrictEqual('context:global foo bar')
     })
 
     it('keeps the filter if the current value contains the word "context"', () => {
@@ -56,6 +61,7 @@ describe('overrideContextOnPaste', () => {
 
     it('keeps the filter if the new value contains the word "context"', () => {
         expect(test('context:global ', 'context bar')).toStrictEqual('context:global context bar')
+        expect(test('context:global ', 'content:"context:foo" bar')).toStrictEqual('context:global content:"context:foo" bar')
     })
 
     it('does not remove the filter if the new value somehow "breaks" the context filters', () => {

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
@@ -40,10 +40,6 @@ describe('overrideContextOnPaste', () => {
         expect(test('context:global|', 'bar context:foo')).toStrictEqual('bar context:foo')
     })
 
-    it('removes the new context: filter if the existing query is not "empty"', () => {
-        expect(test('context:global one |two| three', 'context:foo bar')).toStrictEqual('context:global one bar three')
-    })
-
     it('keeps the filter the query contains kewords', () => {
         expect(test('context:global foo |', 'OR context:foo bar')).toStrictEqual(
             'context:global foo OR context:foo bar'
@@ -72,8 +68,5 @@ describe('overrideContextOnPaste', () => {
     it('does not remove the filter if the new value somehow "breaks" the context filters', () => {
         expect(test('context:global|', 'context:foo bar')).toStrictEqual('context:globalcontext:foo bar')
         expect(test('|context:global ', 'context:foo bar')).toStrictEqual('context:foo barcontext:global ')
-        expect(test('context:global one| two', 'context:foo bar')).toStrictEqual(
-            'context:global onecontext:foo bar two'
-        )
     })
 })

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
@@ -12,7 +12,7 @@ describe('overrideContextOnPaste', () => {
      */
     function test(doc: string, insert: string): string {
         let from = doc.indexOf('|')
-        let to: number | undefined = undefined
+        let to: number | undefined
 
         if (from > -1) {
             doc = doc.replace(/\|/, '')
@@ -42,12 +42,15 @@ describe('overrideContextOnPaste', () => {
 
     it('removes the new context: filter if the existing query is not "empty"', () => {
         expect(test('context:global one |two| three', 'context:foo bar')).toStrictEqual('context:global one bar three')
-
     })
 
     it('keeps the filter the query contains kewords', () => {
-        expect(test('context:global foo |', 'OR context:foo bar')).toStrictEqual('context:global foo OR context:foo bar')
-        expect(test('context:global |foo OR bar ', 'context:foo bar')).toStrictEqual('context:global context:foo barfoo OR bar ')
+        expect(test('context:global foo |', 'OR context:foo bar')).toStrictEqual(
+            'context:global foo OR context:foo bar'
+        )
+        expect(test('context:global |foo OR bar ', 'context:foo bar')).toStrictEqual(
+            'context:global context:foo barfoo OR bar '
+        )
     })
 
     it('keeps the filter if the new value does not contain a context filter', () => {
@@ -61,7 +64,9 @@ describe('overrideContextOnPaste', () => {
 
     it('keeps the filter if the new value contains the word "context"', () => {
         expect(test('context:global ', 'context bar')).toStrictEqual('context:global context bar')
-        expect(test('context:global ', 'content:"context:foo" bar')).toStrictEqual('context:global content:"context:foo" bar')
+        expect(test('context:global ', 'content:"context:foo" bar')).toStrictEqual(
+            'context:global content:"context:foo" bar'
+        )
     })
 
     it('does not remove the filter if the new value somehow "breaks" the context filters', () => {

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.test.ts
@@ -1,0 +1,68 @@
+import { EditorState } from '@codemirror/state'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import { parseInputAsQuery } from '../../codemirror/parsedQuery'
+
+import { overrideContextOnPaste } from './searchcontext'
+
+describe('overrideContextOnPaste', () => {
+    /**
+     * `doc` can contain one or two | to denote the current selection.
+     */
+    function test(doc: string, insert: string): string {
+        let from = doc.indexOf('|')
+        let to: number | undefined = undefined
+
+        if (from > -1) {
+            doc = doc.replace(/\|/, '')
+
+            to = doc.indexOf('|')
+            if (to > -1) {
+                doc = doc.replace(/\|/, '')
+            } else {
+                to = undefined
+            }
+        } else {
+            from = doc.length
+        }
+
+        const state = EditorState.create({
+            doc,
+            extensions: [overrideContextOnPaste, parseInputAsQuery({ patternType: SearchPatternType.standard })],
+            selection: { anchor: from, head: to },
+        })
+        return state.update({ ...state.replaceSelection(insert), userEvent: 'input.paste' }).state.sliceDoc()
+    }
+
+    it('removes the existing global context: filter if the new input would have multiple global context: filters', () => {
+        expect(test('context:global one |two| three', 'context:foo bar')).toStrictEqual('one context:foo bar three')
+        expect(test('context:global one |two three', 'context:foo bar')).toStrictEqual('one context:foo bartwo three')
+        expect(test('context:global |', 'context:foo bar')).toStrictEqual('context:foo bar')
+        expect(test('context:global|', 'bar context:foo')).toStrictEqual('bar context:foo')
+    })
+
+    it('keeps the filter if the new value contains subexpressions', () => {
+        expect(test('context:global foo ', 'OR context:foo bar')).toStrictEqual('context:global foo OR context:foo bar')
+    })
+
+    it('keeps the filter if the new value does not contain a context filter', () => {
+        expect(test('context:global ', 'foo')).toStrictEqual('context:global foo')
+    })
+
+    it('keeps the filter if the current value contains the word "context"', () => {
+        expect(test('context ', 'context:foo bar')).toStrictEqual('context context:foo bar')
+    })
+
+    it('keeps the filter if the new value contains the word "context"', () => {
+        expect(test('context:global ', 'context bar')).toStrictEqual('context:global context bar')
+    })
+
+    it('does not remove the filter if the new value somehow "breaks" the context filters', () => {
+        expect(test('context:global|', 'context:foo bar')).toStrictEqual('context:globalcontext:foo bar')
+        expect(test('|context:global ', 'context:foo bar')).toStrictEqual('context:foo barcontext:global ')
+        expect(test('context:global one| two', 'context:foo bar')).toStrictEqual(
+            'context:global onecontext:foo bar two'
+        )
+    })
+})

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
@@ -1,11 +1,10 @@
-import { ChangeSpec, EditorSelection, EditorState, Extension, StateField } from '@codemirror/state'
+import { EditorSelection, EditorState, Extension, StateField } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { mdiFilterOutline } from '@mdi/js'
 import { inRange } from 'lodash'
 
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { FilterKind, findFilter, getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
-import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter } from '@sourcegraph/shared/src/search/query/token'
 import { isFilterType } from '@sourcegraph/shared/src/search/query/validate'
 

--- a/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/searchcontext.ts
@@ -1,5 +1,4 @@
-import { EditorSelection, EditorState, Extension, StateField } from '@codemirror/state'
-import { EditorView } from '@codemirror/view'
+import { EditorState, Extension, StateField } from '@codemirror/state'
 import { mdiFilterOutline } from '@mdi/js'
 import { inRange } from 'lodash'
 
@@ -91,29 +90,6 @@ const lastContextField = StateField.define<string | undefined>({
         return value
     },
 })
-
-/**
- * Allows the user to overwrite the existing input value when pasting by pressing "Shift"
- */
-export function shiftPasteOverwrite(): Extension {
-    let shiftPressed = false
-    return EditorView.domEventHandlers({
-        keydown(event) {
-            shiftPressed = event.shiftKey
-        },
-        keyup() {
-            shiftPressed = false
-        },
-        paste(_event, view) {
-            if (shiftPressed) {
-                // Select the existing value to let the paste event overwrite it
-                view.dispatch({
-                    selection: EditorSelection.range(0, view.state.doc.length),
-                })
-            }
-        },
-    })
-}
 
 /**
  * When the user pastes a new value into the input, this extension tries to be smart about


### PR DESCRIPTION
In the common case of pasting a new query with context: filter into the input containing only a context: filter, the existing filter is removed.

## Test plan

Manual testing, unit test.

## App preview:

- [Web](https://sg-web-fkling-search-input-context-paste.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
