### PR TITLE
chore: remove `text-secondary` example from story.

### DIFF
--- a/client/wildcard/src/components/Typography/Typography.story.tsx
+++ b/client/wildcard/src/components/Typography/Typography.story.tsx
@@ -1,6 +1,6 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
-import { BrandedStory } from '../../stories/BrandedStory'
+import { BrandedStory } from '../../stories'
 import { Link } from '../Link'
 
 import { Code, Label, H1, H2, H3, H4, H5, H6, Text } from '.'
@@ -299,7 +299,7 @@ export const CrossingStyles: Story = () => (
     </>
 )
 
-const SEMANTIC_COLORS = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'merged'] as const
+const SEMANTIC_COLORS = ['primary', 'success', 'danger', 'warning', 'info', 'merged'] as const
 export const Prose: Story = () => (
     <>
         <H2>Prose</H2>


### PR DESCRIPTION
This text color has bad contrast in dark theme, therefore should not be used in code and as an example in Storybook.

Test plan:
Storybook.

Closes https://github.com/sourcegraph/sourcegraph/issues/49410

## App preview:

- [Web](https://sg-web-ao-ui-remove-text-secondary.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
