### PR TITLE
Fix requests with long retry times failing

### DIFF
--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -113,7 +113,7 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 		req.Header.Set("Content-Type", "application/json")
 		reqBody, err = io.ReadAll(req.Body)
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 	}
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -2,6 +2,7 @@
 package azuredevops
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -107,9 +108,15 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 	queryParams.Set("api-version", apiVersion)
 	req.URL.RawQuery = queryParams.Encode()
 	req.URL = u.ResolveReference(req.URL)
+	var reqBody []byte
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return "", nil
+		}
 	}
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	// Add authentication headers for authenticated requests.
 	if err := c.auth.Authenticate(req); err != nil {
@@ -136,6 +143,7 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 	for c.waitForRateLimit && resp.StatusCode == http.StatusTooManyRequests &&
 		numRetries < c.maxRateLimitRetries {
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
 			resp, err = oauthutil.DoRequest(ctx, logger, c.httpClient, req, c.auth)
 			numRetries++
 		} else {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -231,9 +231,13 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		return err
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return err
+	var err error
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -222,9 +222,12 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		c.externalRateLimiter.WaitForRateLimit(ctx, 1) // We don't care whether we waited or not, this is a preventative measure.
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	var resp *httpResponseState

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -173,6 +174,7 @@ func (c *V4Client) requestGraphQL(ctx context.Context, query string, vars map[st
 
 	for c.waitForRateLimit && err != nil && numRetries < c.maxRateLimitRetries &&
 		errors.As(err, &apiError) && apiError.Code == http.StatusForbidden {
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 		if c.externalRateLimiter.WaitForRateLimit(ctx, cost) {
 			_, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, &respBody)
 			numRetries++

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -120,53 +120,61 @@ func TestV4Client_RateLimitRetry(t *testing.T) {
 		},
 	}
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			numRequests := 0
-			succeeded := false
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				numRequests++
-				if tt.secondaryLimitWasHit {
-					w.Header().Add("retry-after", "1")
-					w.WriteHeader(http.StatusForbidden)
-					w.Write([]byte(`{"message": "Secondary rate limit hit"}`))
+	// Test both a GET and POST request to make sure retrying is working correctly
+	methodTests := []string{"GET", "POST"}
+	for _, methodTest := range methodTests {
+		for name, tt := range tests {
+			t.Run(methodTest+"_"+name, func(t *testing.T) {
+				numRequests := 0
+				succeeded := false
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					numRequests++
+					if tt.secondaryLimitWasHit {
+						w.Header().Add("retry-after", "1")
+						w.WriteHeader(http.StatusForbidden)
+						w.Write([]byte(`{"message": "Secondary rate limit hit"}`))
 
-					tt.secondaryLimitWasHit = false
-					return
-				}
+						tt.secondaryLimitWasHit = false
+						return
+					}
 
-				if tt.primaryLimitWasHit {
-					w.Header().Add("x-ratelimit-remaining", "0")
-					w.Header().Add("x-ratelimit-limit", "5000")
-					resetTime := time.Now().Add(time.Second)
-					w.Header().Add("x-ratelimit-reset", strconv.Itoa(int(resetTime.Unix())))
-					w.WriteHeader(http.StatusForbidden)
-					w.Write([]byte(`{"message": "Primary rate limit hit"}`))
+					if tt.primaryLimitWasHit {
+						w.Header().Add("x-ratelimit-remaining", "0")
+						w.Header().Add("x-ratelimit-limit", "5000")
+						resetTime := time.Now().Add(time.Second)
+						w.Header().Add("x-ratelimit-reset", strconv.Itoa(int(resetTime.Unix())))
+						w.WriteHeader(http.StatusForbidden)
+						w.Write([]byte(`{"message": "Primary rate limit hit"}`))
 
-					tt.primaryLimitWasHit = false
-					return
-				}
+						tt.primaryLimitWasHit = false
+						return
+					}
 
-				succeeded = true
-				w.Write([]byte(`{"message": "Very nice"}`))
-			}))
+					succeeded = true
+					w.Write([]byte(`{"message": "Very nice"}`))
+				}))
 
-			t.Cleanup(srv.Close)
+				t.Cleanup(srv.Close)
 
-			srvURL, err := url.Parse(srv.URL)
-			require.NoError(t, err)
-
-			client := NewV4Client("test", srvURL, nil, nil)
-			_, err = client.GetAuthenticatedUser(ctx)
-			if tt.succeeded {
+				srvURL, err := url.Parse(srv.URL)
 				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-			}
 
-			assert.Equal(t, tt.numRequests, numRequests)
-			assert.Equal(t, tt.succeeded, succeeded)
-		})
+				transport := http.DefaultTransport.(*http.Transport).Clone()
+				transport.DisableKeepAlives = true // Disable keep-alives otherwise the read of the request body is cached
+				cli := &http.Client{Transport: transport}
+				client := NewV4Client("test", srvURL, nil, cli)
+				client.githubDotCom = true // Otherwise it will make an extra request to determine GH version
+				if methodTest == "POST" {
+					_, err = client.SearchRepos(ctx, SearchReposParams{Query: "test"})
+				} else {
+					_, err = client.GetAuthenticatedUser(ctx)
+				}
+				require.NoError(t, err)
+
+				assert.Equal(t, tt.numRequests, numRequests)
+				assert.Equal(t, tt.succeeded, succeeded)
+			})
+		}
 	}
 }
 

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -245,9 +245,12 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 		_ = c.externalRateLimiter.WaitForRateLimit(ctx, 1)
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, 0, err
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	req.URL = c.baseURL.ResolveReference(req.URL)

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -44,11 +44,14 @@ type TokenRefresher func(ctx context.Context, doer httpcli.Doer, oauthCtx OAuthC
 // If the token is updated successfully, the same request will be retried exactly once.
 func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *http.Request, auther auth.Authenticator) (*http.Response, error) {
 	// Store the body first in case we need to retry the request
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var err error
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
-	req.Body.Close()
 	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	if auther == nil {
 		return doer.Do(req.WithContext(ctx))


### PR DESCRIPTION
Closes #49300 

Go's `http.Client` keeps connections alive by default. This caches the body of the request.
However, when retrying a request after a long time (~90 seconds), reading the body again will fail as the body is no longer cached once the connection is no longer alive.

This PR changes or clients so that the body is stored before requests are done that can be retried. This way we can reset the body before retrying a request.

## Test plan

Some unit tests added, current ones still passing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
