### PR TITLE
svcmain: introduce urfave/cli

### DIFF
--- a/cmd/sourcegraph-oss/main.go
+++ b/cmd/sourcegraph-oss/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"os"
+
 	blobstore_shared "github.com/sourcegraph/sourcegraph/cmd/blobstore/shared"
 	frontend_shared "github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	githubproxy_shared "github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared"
@@ -29,5 +31,5 @@ var services = []service.Service{
 }
 
 func main() {
-	osscmd.MainOSS(services)
+	osscmd.MainOSS(services, os.Args)
 }

--- a/cmd/sourcegraph-oss/osscmd/osscmd.go
+++ b/cmd/sourcegraph-oss/osscmd/osscmd.go
@@ -17,8 +17,8 @@ var config = svcmain.Config{
 }
 
 // Main is called from the `main` function of the `sourcegraph-oss` command.
-func MainOSS(services []service.Service) {
-	svcmain.Main(services, config)
+func MainOSS(services []service.Service, args []string) {
+	svcmain.Main(services, config, args)
 }
 
 // DeprecatedSingleServiceMainOSS is called from the `main` function of a command in the OSS build

--- a/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
+++ b/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
@@ -12,8 +12,8 @@ import (
 var config = svcmain.Config{}
 
 // MainEnterprise is called from the `main` function of the `sourcegraph` command.
-func MainEnterprise(services []service.Service) {
-	svcmain.Main(services, config)
+func MainEnterprise(services []service.Service, args []string) {
+	svcmain.Main(services, config, args)
 }
 
 // DeprecatedSingleServiceMainEnterprise is called from the `main` function of a command in the

--- a/enterprise/cmd/sourcegraph/main.go
+++ b/enterprise/cmd/sourcegraph/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/servegit"
@@ -33,5 +35,5 @@ var services = []service.Service{
 }
 
 func main() {
-	enterprisecmd.MainEnterprise(services)
+	enterprisecmd.MainEnterprise(services, os.Args)
 }

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -29,8 +29,11 @@ type Config struct {
 	AfterConfigure func() // run after all services' Configure hooks are called
 }
 
-// Main is called from the `main` function of the `sourcegraph-oss` and `sourcegraph` commands.
-func Main(services []sgservice.Service, config Config) {
+// Main is called from the `main` function of the `sourcegraph-oss` and
+// `sourcegraph` commands.
+//
+// args is the commandline arguments (usually os.Args).
+func Main(services []sgservice.Service, config Config, args []string) {
 	// Unlike other sourcegraph binaries we expect Sourcegraph App to be run
 	// by a user instead of deployed to a cloud. So adjust the default output
 	// format before initializing log.


### PR DESCRIPTION
This is a minimal usage. The only thing we get in this commit is the possibility to extend this in the future. Additionally we get output when you run --help.

Test Plan: .bin/sourcegraph --help and sg start app continue to work
