### PR TITLE
codeintel: Update codeintel-qa test to target new (preferred) resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -242,6 +242,13 @@ extend type Query {
         dependentOf: ID
 
         """
+        When specified, merges the list of existing uploads with data from
+        uploads that have been deleted but for which audit logs still exist.
+        Only makes sense when state filter is unset or equal to 'DELETED'.
+        """
+        includeDeleted: Boolean
+
+        """
         If specified, this limits the number of results per request.
         """
         first: Int

--- a/dev/codeintel-qa/cmd/clear/main.go
+++ b/dev/codeintel-qa/cmd/clear/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/codeintel-qa/internal"
@@ -54,15 +53,7 @@ func mainErr(ctx context.Context) error {
 		return err
 	}
 
-	if err := clearAllIndexes(ctx); err != nil {
-		if !strings.Contains(err.Error(), "not enabled") {
-			return err
-		}
-
-		fmt.Printf("[%5s] %s Auto-indexing is not enabled on this instance\n", internal.TimeSince(start), internal.EmojiProblem)
-	}
-
-	if err := clearAllUploads(ctx); err != nil {
+	if err := clearAllPreciseIndexes(ctx); err != nil {
 		return err
 	}
 

--- a/dev/codeintel-qa/cmd/query/query.go
+++ b/dev/codeintel-qa/cmd/query/query.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-const uploadsQuery = `
-	query Uploads {
-		lsifUploads(state: COMPLETED) {
+const preciseIndexesQuery = `
+	query PreciseIndexes {
+		preciseIndexes(states: [COMPLETED]) {
 			nodes {
 				projectRoot {
 					repository {
@@ -23,10 +23,10 @@ const uploadsQuery = `
 	}
 `
 
-func queryUploads(ctx context.Context) (_ map[string][]string, err error) {
+func queryPreciseIndexes(ctx context.Context) (_ map[string][]string, err error) {
 	var payload struct {
 		Data struct {
-			LSIFUploads struct {
+			PreciseIndexes struct {
 				Nodes []struct {
 					ProjectRoot struct {
 						Repository struct {
@@ -37,15 +37,15 @@ func queryUploads(ctx context.Context) (_ map[string][]string, err error) {
 						} `json:"commit"`
 					} `json:"projectRoot"`
 				} `json:"nodes"`
-			} `json:"lsifUploads"`
+			} `json:"preciseIndexes"`
 		} `json:"data"`
 	}
-	if err := queryGraphQL(ctx, "CodeIntelQA_Query_Uploads", uploadsQuery, map[string]any{}, &payload); err != nil {
+	if err := queryGraphQL(ctx, "CodeIntelQA_Query_PreciseIndexes", preciseIndexesQuery, map[string]any{}, &payload); err != nil {
 		return nil, err
 	}
 
 	commitsByRepo := map[string][]string{}
-	for _, node := range payload.Data.LSIFUploads.Nodes {
+	for _, node := range payload.Data.PreciseIndexes.Nodes {
 		projectRoot := node.ProjectRoot
 		name := projectRoot.Repository.Name
 		commit := projectRoot.Commit.OID

--- a/dev/codeintel-qa/cmd/query/state.go
+++ b/dev/codeintel-qa/cmd/query/state.go
@@ -36,7 +36,7 @@ func instanceStateDiff(ctx context.Context) (string, error) {
 		expectedCommitsByRepo[internal.MakeTestRepoName(repoName)] = commits
 	}
 
-	uploadedCommitsByRepo, err := queryUploads(ctx)
+	uploadedCommitsByRepo, err := queryPreciseIndexes(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
@@ -150,14 +150,15 @@ func (r *rootResolver) PreciseIndexes(ctx context.Context, args *resolverstubs.P
 	totalUploadCount := 0
 	if !skipUploads {
 		if uploads, totalUploadCount, err = r.uploadSvc.GetUploads(ctx, uploadsshared.GetUploadsOptions{
-			RepositoryID: repositoryID,
-			States:       uploadStates,
-			Term:         term,
-			DependencyOf: dependencyOf,
-			DependentOf:  dependentOf,
-			IndexerNames: indexerNames,
-			Limit:        pageSize,
-			Offset:       uploadOffset,
+			RepositoryID:       repositoryID,
+			States:             uploadStates,
+			Term:               term,
+			DependencyOf:       dependencyOf,
+			DependentOf:        dependentOf,
+			AllowDeletedUpload: args.IncludeDeleted != nil && *args.IncludeDeleted,
+			IndexerNames:       indexerNames,
+			Limit:              pageSize,
+			Offset:             uploadOffset,
 		}); err != nil {
 			return nil, err
 		}

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -191,13 +191,14 @@ type IndexerKeyQueryArgs struct {
 
 type PreciseIndexesQueryArgs struct {
 	ConnectionArgs
-	After        *string
-	Repo         *graphql.ID
-	Query        *string
-	States       *[]string
-	IndexerKey   *string
-	DependencyOf *string
-	DependentOf  *string
+	After          *string
+	Repo           *graphql.ID
+	Query          *string
+	States         *[]string
+	IndexerKey     *string
+	DependencyOf   *string
+	DependentOf    *string
+	IncludeDeleted *bool
 }
 
 type PreciseIndexConnectionResolver interface {


### PR DESCRIPTION
We're removing lsifUploads/lsifIndexes from the GraphQL layer.

**Note**: Currently failing without treating LSIFUpload IDs as PreciseIndex ids; must be merged in conjunction with #49481.

## Test plan

Ran test pipeline locally.