### PR TITLE
codeintel: Return PreciseIndexes over LSIFIndexes in GraphQL API

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/hooks/useEnqueueIndexJob.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/hooks/useEnqueueIndexJob.tsx
@@ -9,96 +9,16 @@ import {
     QueueAutoIndexJobsForRepoResult,
 } from '../../../../graphql-operations'
 
-export const lsifIndexFieldsFragment = gql`
-    fragment LsifIndexFields on LSIFIndex {
-        __typename
-        id
-        inputCommit
-        tags
-        inputRoot
-        inputIndexer
-        indexer {
-            name
-            url
-        }
-        projectRoot {
-            url
-            path
-            repository {
-                url
-                name
-            }
-            commit {
-                url
-                oid
-                abbreviatedOID
-            }
-        }
-        steps {
-            ...LsifIndexStepsFields
-        }
-        state
-        failure
-        queuedAt
-        startedAt
-        finishedAt
-        placeInQueue
-        associatedUpload {
-            id
-            state
-            uploadedAt
-            startedAt
-            finishedAt
-            placeInQueue
-        }
-        shouldReindex
-    }
-
-    fragment LsifIndexStepsFields on IndexSteps {
-        setup {
-            ...ExecutionLogEntryFields
-        }
-        preIndex {
-            root
-            image
-            commands
-            logEntry {
-                ...ExecutionLogEntryFields
-            }
-        }
-        index {
-            indexerArgs
-            outfile
-            logEntry {
-                ...ExecutionLogEntryFields
-            }
-        }
-        upload {
-            ...ExecutionLogEntryFields
-        }
-        teardown {
-            ...ExecutionLogEntryFields
-        }
-    }
-
-    fragment ExecutionLogEntryFields on ExecutionLogEntry {
-        key
-        command
-        startTime
-        exitCode
-        out
-        durationMilliseconds
-    }
-`
+import { preciseIndexFieldsFragment } from './types'
 
 const QUEUE_AUTO_INDEX_JOBS = gql`
     mutation QueueAutoIndexJobsForRepo($id: ID!, $rev: String) {
         queueAutoIndexJobsForRepo(repository: $id, rev: $rev) {
-            ...LsifIndexFields
+            ...PreciseIndexFields
         }
     }
 
-    ${lsifIndexFieldsFragment}
+    ${preciseIndexFieldsFragment}
 `
 
 type EnqueueIndexJobResults = Promise<

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -64,7 +64,7 @@ extend type Mutation {
     existing in-database configuration, finally falling back to the automatically inferred
     configuration based on the repo contents at the target commit.
     """
-    queueAutoIndexJobsForRepo(repository: ID!, rev: String, configuration: String): [LSIFIndex!]!
+    queueAutoIndexJobsForRepo(repository: ID!, rev: String, configuration: String): [PreciseIndex!]!
 
     """
     Deletes an LSIF upload.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers.go
@@ -152,7 +152,7 @@ func (r *Resolver) CommitGraph(ctx context.Context, id graphql.ID) (_ resolverst
 	return r.uploadsRootResolver.CommitGraph(ctx, id)
 }
 
-func (r *Resolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *resolverstubs.QueueAutoIndexJobsForRepoArgs) (_ []resolverstubs.LSIFIndexResolver, err error) {
+func (r *Resolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *resolverstubs.QueueAutoIndexJobsForRepoArgs) (_ []resolverstubs.PreciseIndexResolver, err error) {
 	return r.autoIndexingRootResolver.QueueAutoIndexJobsForRepo(ctx, args)
 }
 

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -113,7 +113,7 @@ type AutoindexingServiceResolver interface {
 	LSIFIndexes(ctx context.Context, args *LSIFIndexesQueryArgs) (LSIFIndexConnectionResolver, error)
 	LSIFIndexesByRepo(ctx context.Context, args *LSIFRepositoryIndexesQueryArgs) (LSIFIndexConnectionResolver, error)
 	InferAutoIndexJobsForRepo(ctx context.Context, args *InferAutoIndexJobsForRepoArgs) ([]AutoIndexJobDescriptionResolver, error)
-	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]LSIFIndexResolver, error)
+	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]PreciseIndexResolver, error)
 	UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error)
 	CodeIntelSummary(ctx context.Context) (CodeIntelSummaryResolver, error)
 	RepositorySummary(ctx context.Context, id graphql.ID) (CodeIntelRepositorySummaryResolver, error)


### PR DESCRIPTION
We're removing lsifUploads/lsifIndexes from the GraphQL layer.

## Test plan

CI.