### PR TITLE
Code Insights: Fix code insight polling mechanism

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
@@ -1,7 +1,7 @@
 import { BackendInsight, isComputeInsight } from '../../..'
 
 const ALL_REPOS_POLL_INTERVAL = 30000
-const SOME_REPOS_POLL_INTERVAL = 2000
+const SOME_REPOS_POLL_INTERVAL = 7000
 
 export function insightPollingInterval(insight: BackendInsight): number {
     if (isComputeInsight(insight)) {

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/utils/insight-polling.ts
@@ -1,8 +1,16 @@
-import { BackendInsight } from '../../..'
+import { BackendInsight, isComputeInsight } from '../../..'
 
 const ALL_REPOS_POLL_INTERVAL = 30000
 const SOME_REPOS_POLL_INTERVAL = 2000
 
 export function insightPollingInterval(insight: BackendInsight): number {
-    return insight.repositories.length > 0 ? SOME_REPOS_POLL_INTERVAL : ALL_REPOS_POLL_INTERVAL
+    if (isComputeInsight(insight)) {
+        return SOME_REPOS_POLL_INTERVAL
+    }
+
+    if (insight.repoQuery.trim() === 'repo:.*') {
+        return ALL_REPOS_POLL_INTERVAL
+    }
+
+    return SOME_REPOS_POLL_INTERVAL
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/49517

It seems like with the Apollo version upgrading, we broke code insight polling logic, onCompleted doesn't run on every fetch call in the new version, and we rely on this in the code insight logic. 

This PR fixes this problem and also tunes the polling interval taking into account repositories query API 

## Test plan
- Check that polling works properly right after you're created an insight you can see how it updates insight on the dashboard
- Check that insight polling is disabled if insight isn't in the visible viewport area
- Check that polling enables when insight comes into the visible area
- Check that polling works on the standalone insight page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-polling.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
