### PR TITLE
own: chore: reformat pings list on site admin page

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -417,10 +417,10 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                         </ul>
                     </li>
                     <li>
-                        Sourcegraph Own usage data.
+                        Sourcegraph Own usage data
                         <ul>
                             <li>
-                                Whether the <pre>search-ownership</pre> feature flag is turned on.
+                                Whether the search-ownership feature flag is turned on.
                             </li>
                             <li>
                                 Number and ratio of repositories for which ownership data is available via CODEOWNERS
@@ -429,10 +429,10 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                             <li>Aggregate monthly weekly and daily active users for the following activities:</li>
                             <ul>
                                 <li>
-                                    Narrowing search results by owner using <pre>file:has.owners</pre> predicate.
+                                    Narrowing search results by owner using file:has.owner() predicate.
                                 </li>
                                 <li>
-                                    Selecting owner search result through <pre>select:file.owners</pre>.
+                                    Selecting owner search result through select:file.owners.
                                 </li>
                                 <li>Displaying ownership panel in file view.</li>
                             </ul>

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -419,21 +419,15 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                     <li>
                         Sourcegraph Own usage data
                         <ul>
-                            <li>
-                                Whether the search-ownership feature flag is turned on.
-                            </li>
+                            <li>Whether the search-ownership feature flag is turned on.</li>
                             <li>
                                 Number and ratio of repositories for which ownership data is available via CODEOWNERS
                                 file or the API.
                             </li>
                             <li>Aggregate monthly weekly and daily active users for the following activities:</li>
                             <ul>
-                                <li>
-                                    Narrowing search results by owner using file:has.owner() predicate.
-                                </li>
-                                <li>
-                                    Selecting owner search result through select:file.owners.
-                                </li>
+                                <li>Narrowing search results by owner using file:has.owner() predicate.</li>
+                                <li>Selecting owner search result through select:file.owners.</li>
                                 <li>Displaying ownership panel in file view.</li>
                             </ul>
                         </ul>

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -202,11 +202,11 @@ This telemetry can be disabled using the `disableNonCriticalTelemetry` option in
     - Count interactions with the go imports search query transformation feature
     - Count of unique users who interacted with the go imports search query transformation feature
 - Sourcegraph Own usage data
-  - Whether the search-ownership feature flag is turned on.
+  - Whether the `search-ownership` feature flag is turned on.
   - Number and ratio of repositories for which ownership data is available via CODEOWNERS file or the API.
   - Aggregate monthly weekly and daily active users for the following activities:
-    - Narrowing search results by owner using file:has.owner() predicate.
-    - Selecting owner search result through select:file.owners.
+    - Narrowing search results by owner using `file:has.owners` predicate.
+    - Selecting owner search result through `select:file.owners`.
     - Displaying ownership panel in file view.
 - Histogram of cloned repository sizes
 </details>

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -202,11 +202,11 @@ This telemetry can be disabled using the `disableNonCriticalTelemetry` option in
     - Count interactions with the go imports search query transformation feature
     - Count of unique users who interacted with the go imports search query transformation feature
 - Sourcegraph Own usage data
-  - Whether the `search-ownership` feature flag is turned on.
+  - Whether the search-ownership feature flag is turned on.
   - Number and ratio of repositories for which ownership data is available via CODEOWNERS file or the API.
   - Aggregate monthly weekly and daily active users for the following activities:
-    - Narrowing search results by owner using `file:has.owners` predicate.
-    - Selecting owner search result through `select:file.owners`.
+    - Narrowing search results by owner using file:has.owner() predicate.
+    - Selecting owner search result through select:file.owners.
     - Displaying ownership panel in file view.
 - Histogram of cloned repository sizes
 </details>


### PR DESCRIPTION
beautify

## Test plan

| before | after |
| -- | -- |
| <img width="765" alt="Screenshot 2023-03-16 at 15 50 17" src="https://user-images.githubusercontent.com/29406849/225678673-e0f2c099-78ab-4c6c-b0c5-225786f8647c.png"> | <img width="770" alt="Screenshot 2023-03-16 at 15 50 01" src="https://user-images.githubusercontent.com/29406849/225678683-57ecffba-8ba6-476b-b74a-bf2b294ee9da.png">  |

## App preview:

- [Web](https://sg-web-leo-nit-doc-pings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
