### PR TITLE
[chore] disable permission sync scheduling on dotcom

### DIFF
--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
@@ -315,7 +316,8 @@ func syncRepoBackoff() time.Duration {
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
 func permissionSyncingDisabled() bool {
-	return (globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
+	return envvar.SourcegraphDotComMode() ||
+		(globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
 		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -41,7 +41,8 @@ import (
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
 func PermissionSyncingDisabled() bool {
-	return (globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
+	return envvar.SourcegraphDotComMode() ||
+		(globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
 		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -16,9 +16,8 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
@@ -34,18 +33,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
-// It is not enabled if:
-//   - Permissions user mapping (aka explicit permissions API) is enabled and unified permissions model is not enabled
-//   - Not purchased with the current license
-//   - `disableAutoCodeHostSyncs` site setting is set to true
-func PermissionSyncingDisabled() bool {
-	return envvar.SourcegraphDotComMode() ||
-		(globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
-		licensing.Check(licensing.FeatureACLs) != nil ||
-		conf.Get().DisableAutoCodeHostSyncs
-}
 
 var scheduleReposCounter = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_repoupdater_perms_syncer_schedule_repos_total",
@@ -1164,7 +1151,7 @@ func (s *PermsSyncer) schedule(ctx context.Context) (*schedule, error) {
 	return schedule, nil
 }
 
-func (s *PermsSyncer) isDisabled() bool { return PermissionSyncingDisabled() }
+func (s *PermsSyncer) isDisabled() bool { return eiauthz.PermissionSyncingDisabled() }
 
 // runSchedule periodically looks for least updated records and schedule syncs
 // for them.

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -59,7 +59,7 @@ func EnterpriseInit(
 
 	permsJobStore := db.PermissionSyncJobs()
 	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason ossDB.PermissionsSyncJobReason) error {
-		if authz.PermissionSyncingDisabled() {
+		if frontendAuthz.PermissionSyncingDisabled() {
 			return nil
 		}
 

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/azuredevops"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/bitbucketserver"
@@ -16,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/github"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/gitlab"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/perforce"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -199,4 +201,18 @@ func RefreshInterval() time.Duration {
 		return 5 * time.Second
 	}
 	return time.Duration(interval) * time.Second
+}
+
+// PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
+// It is not enabled if:
+//   - There are no code host connections with authorization or enforcePermissions enabled
+//   - Permissions user mapping (aka explicit permissions API) is enabled and unified permissions model is not enabled
+//   - Not purchased with the current license
+//   - `disableAutoCodeHostSyncs` site setting is set to true
+func PermissionSyncingDisabled() bool {
+	_, p := authz.GetProviders()
+	return len(p) == 0 ||
+		(globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
+		licensing.Check(licensing.FeatureACLs) != nil ||
+		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/internal/authz/register.go
+++ b/internal/authz/register.go
@@ -14,10 +14,7 @@ var (
 	// not matched by any authz provider. The default value is true. It is only set to false in
 	// error modes (when the configuration is in a state where interpreting it literally could lead
 	// to leakage of private repositories).
-	//
-	// 🚨 SECURITY: We do not want to allow access by default by any means on
-	// dotcom.
-	allowAccessByDefault = !envvar.SourcegraphDotComMode()
+	allowAccessByDefault = true
 
 	// authzProvidersReady and authzProvidersReadyOnce together indicate when
 	// GetProviders should no longer block. It should block until SetProviders


### PR DESCRIPTION

## Test plan

Tested locally, if I run in dotcom mode, permission syncs are not scheduled, if I run in enterprise mode, they are.
