### PR TITLE
Use repo_statistics correctly in own pings

### DIFF
--- a/internal/usagestats/own.go
+++ b/internal/usagestats/own.go
@@ -17,10 +17,11 @@ const (
 
 func GetOwnershipUsageStats(ctx context.Context, db database.DB) (*types.OwnershipUsageStatistics, error) {
 	var stats types.OwnershipUsageStatistics
-	var totalReposCount int32
-	if err := db.QueryRowContext(ctx, `SELECT total FROM repo_statistics`).Scan(&totalReposCount); err != nil {
+	rs, err := db.RepoStatistics().GetRepoStatistics(ctx)
+	if err != nil {
 		return nil, err
 	}
+	totalReposCount := int32(rs.Total)
 	var ingestedOwnershipReposCount int32
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT repo_id) FROM codeowners`).Scan(&ingestedOwnershipReposCount); err != nil {
 		return nil, err

--- a/internal/usagestats/own_test.go
+++ b/internal/usagestats/own_test.go
@@ -101,7 +101,7 @@ func TestGetOwnershipUsageStatsReposCountNoRepos(t *testing.T) {
 	}
 }
 
-func TestGetOwnershipUsageStatsReposCountNoStats(t *testing.T) {
+func TestGetOwnershipUsageStatsReposCountStatsNotCompacted(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
@@ -130,11 +130,11 @@ func TestGetOwnershipUsageStatsReposCountNoStats(t *testing.T) {
 	iptr := func(i int32) *int32 { return &i }
 	want := &types.OwnershipUsageReposCounts{
 		// Can have zero repos and one ingested ownership then.
-		Total:                 iptr(0),
+		Total:                 iptr(2),
 		WithIngestedOwnership: iptr(1),
 	}
 	if diff := cmp.Diff(want, stats.ReposCount); diff != "" {
-		t.Errorf("GetOwnershipUsageStates.ReposCount, +want,-got:\n%s", diff)
+		t.Errorf("GetOwnershipUsageStates.ReposCount, -want,+got:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
`repo_statistics` has to be queried with `SUM`s to aggregate rows.

## Test plan

Amend existing unit tests to reflect correct behavior.
