### PR TITLE
blob: fix text selection UI

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/decorations.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/decorations.ts
@@ -57,8 +57,7 @@ export function interactiveOccurrencesExtension(): Extension {
                         decoration: Decoration.mark({
                             class: classNames(
                                 'interactive-occurrence', // used as interactive occurrence selector
-                                'focus-visible', // prevents code editor from blur when focused element inside it changes
-                                'selection-highlight' // highlights the selected (focused) occurrence
+                                'focus-visible' // prevents code editor from blur when focused element inside it changes
                             ),
                             attributes: {
                                 // Selected (focused) occurrence is the only focusable element in the editor.

--- a/client/web/src/repo/blob/codemirror/token-selection/definition.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/definition.ts
@@ -71,7 +71,7 @@ export function goToDefinitionOnMouseEvent(
         return
     }
     if (isInteractiveOccurrence(atEvent.occurrence)) {
-        selectOccurrence(view, atEvent.occurrence)
+        selectOccurrence(view, atEvent.occurrence, true)
 
         // Ensure editor remains focused for the keyboard navigation to work
         view.contentDOM.focus()


### PR DESCRIPTION
This PR:
1. Fixes focused token background overlapping with the text selection layer issue. We remove `selection-highlight` highlight class from the focused token, and the focus ring remains the only indicator of the currently focused occurrence. This makes the selection of the focused occurrence parts visible. 
2. Fixes double and triple clicks to select word and line. Previously double click on the occurrence had no visual feedback (despite the word being actually selected), and triple click caused weird text selection layer flickering.
Not to break the default double and triple mouse click logic we:
- set the editor selection to the focused occurrence start (instead of a range)   
- do not explicitly set selection if the occurrence was focused in response to the mouse click.

Before/after video 👇🏻 

https://user-images.githubusercontent.com/25318659/225686072-209abcd4-6bb8-4279-b3c0-4a9990545d6b.mov



## Test plan
- Try different text selection scenarios:
  - select occurrence with a mouse and expand selection using the keyboard shortcuts
  - select text with mouse only
  - navigate the blob view using the arrow keys and select text using the shortcuts.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-blob-fix-text.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
