### PR TITLE
Fix nil dereference on request body

### DIFF
--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -251,8 +251,8 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 		if err != nil {
 			return nil, 0, err
 		}
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}
-	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	req.URL = c.baseURL.ResolveReference(req.URL)
 	respHeader, respCode, err := c.doWithBaseURL(ctx, req, result)
 
@@ -260,7 +260,9 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 	numRetries := 0
 	for c.waitForRateLimit && numRetries < c.maxRateLimitRetries && respCode == http.StatusTooManyRequests {
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
-			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+			if req.Body != nil {
+				req.Body = io.NopCloser(bytes.NewReader(reqBody))
+			}
 			respHeader, respCode, err = c.doWithBaseURL(ctx, req, result)
 			numRetries += 1
 		} else {

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -51,8 +51,8 @@ func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *h
 		if err != nil {
 			return nil, err
 		}
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	if auther == nil {
 		return doer.Do(req.WithContext(ctx))
 	}
@@ -86,7 +86,9 @@ func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *h
 			return nil, errors.Wrap(err, "authenticating request after token refresh")
 		}
 		// We need to reset the body before retrying the request
-		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		if req.Body != nil {
+			req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		}
 		resp, err = doer.Do(req.WithContext(ctx))
 	}
 


### PR DESCRIPTION
Request body should be compared to nil before resetting the request body.

## Test plan

Passes again locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
