### PR TITLE
insights: during backfill skip not found repos

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -213,6 +213,11 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 					p.Go(func(ctx context.Context) error {
 						repo, repoErr := h.repoStore.Get(ctx, repoId)
 						if repoErr != nil {
+							// If the repo is not found it was deleted and will return no results
+							// no need to error here which will add an alert to the insight
+							if errors.Is(repoErr, &database.RepoNotFoundErr{ID: repoId}) {
+								return nil
+							}
 							mu.Lock()
 							repoErrors[int32(repoId)] = errors.Wrap(repoErr, "InProgressHandler.repoStore.Get")
 							mu.Unlock()

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -419,6 +419,11 @@ func Test_BackfillWithRepoNotFound(t *testing.T) {
 
 	completedBackfill, err := bfs.LoadBackfill(ctx, backfill.Id)
 	require.NoError(t, err)
+
+	it, err := completedBackfill.repoIterator(ctx, bfs)
+	require.NoError(t, err)
+	require.Equal(t, 0, it.ErroredRepos())
+
 	if completedBackfill.State != BackfillStateCompleted {
 		t.Fatal(errors.New("backfill should be state completed"))
 	}


### PR DESCRIPTION
During the time between the repos being selected for an insight series and attempting to run the backfill queries, it is possible that repos are marked as deleted.  Currently when this happens the error is captured are recorded against the insight.  This causes a UI element to appear on the insight warning the user that the insight does not have all the data.

When the insight is not found we can continue processing without recording an error because a search against this repo would return no results, so there is not any missing data.
## Test plan
Unit tests added

Created an insight and deleted a repo after the repo query was run but before processing.  Verified that no errors were recorded.
<img width="791" alt="image" src="https://user-images.githubusercontent.com/6098507/225726904-dc68b475-2707-45fc-84dd-9a391ed474e9.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
