### PR TITLE
packages: faster should-filter query

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -13357,7 +13357,7 @@
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX lsif_dependency_repos_last_checked_at ON lsif_dependency_repos USING btree (last_checked_at)",
+          "IndexDefinition": "CREATE INDEX lsif_dependency_repos_last_checked_at ON lsif_dependency_repos USING btree (last_checked_at NULLS FIRST)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },
@@ -18365,7 +18365,7 @@
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX package_repo_versions_last_checked_at ON package_repo_versions USING btree (last_checked_at)",
+          "IndexDefinition": "CREATE INDEX package_repo_versions_last_checked_at ON package_repo_versions USING btree (last_checked_at NULLS FIRST)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1844,7 +1844,7 @@ Indexes:
     "lsif_dependency_repos_pkey" PRIMARY KEY, btree (id)
     "lsif_dependency_repos_unique_scheme_name" UNIQUE, btree (scheme, name)
     "lsif_dependency_repos_blocked" btree (blocked)
-    "lsif_dependency_repos_last_checked_at" btree (last_checked_at)
+    "lsif_dependency_repos_last_checked_at" btree (last_checked_at NULLS FIRST)
     "lsif_dependency_repos_name_id" btree (name, id)
     "lsif_dependency_repos_scheme_id" btree (scheme, id)
 Referenced by:
@@ -2774,7 +2774,7 @@ Indexes:
     "package_repo_versions_pkey" PRIMARY KEY, btree (id)
     "package_repo_versions_unique_version_per_package" UNIQUE, btree (package_id, version)
     "package_repo_versions_blocked" btree (blocked)
-    "package_repo_versions_last_checked_at" btree (last_checked_at)
+    "package_repo_versions_last_checked_at" btree (last_checked_at NULLS FIRST)
 Foreign-key constraints:
     "package_id_fk" FOREIGN KEY (package_id) REFERENCES lsif_dependency_repos(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1678994673_package_repos_last_checked_at_index/down.sql
+++ b/migrations/frontend/1678994673_package_repos_last_checked_at_index/down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;
+DROP INDEX IF EXISTS package_repo_versions_last_checked_at;
+
+CREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at
+ON lsif_dependency_repos
+USING btree (last_checked_at);
+
+CREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at
+ON package_repo_versions
+USING btree (last_checked_at);

--- a/migrations/frontend/1678994673_package_repos_last_checked_at_index/metadata.yaml
+++ b/migrations/frontend/1678994673_package_repos_last_checked_at_index/metadata.yaml
@@ -1,0 +1,2 @@
+name: package_repos_last_checked_at_index
+parents: [1678899992, 1678832491]

--- a/migrations/frontend/1678994673_package_repos_last_checked_at_index/up.sql
+++ b/migrations/frontend/1678994673_package_repos_last_checked_at_index/up.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;
+DROP INDEX IF EXISTS package_repo_versions_last_checked_at;
+
+CREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at
+ON lsif_dependency_repos
+USING btree (last_checked_at ASC NULLS FIRST);
+
+CREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at
+ON package_repo_versions
+USING btree (last_checked_at ASC NULLS FIRST);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5265,7 +5265,7 @@ CREATE INDEX lsif_dependency_indexing_jobs_upload_id ON lsif_dependency_syncing_
 
 CREATE INDEX lsif_dependency_repos_blocked ON lsif_dependency_repos USING btree (blocked);
 
-CREATE INDEX lsif_dependency_repos_last_checked_at ON lsif_dependency_repos USING btree (last_checked_at);
+CREATE INDEX lsif_dependency_repos_last_checked_at ON lsif_dependency_repos USING btree (last_checked_at NULLS FIRST);
 
 CREATE INDEX lsif_dependency_repos_name_id ON lsif_dependency_repos USING btree (name, id);
 
@@ -5355,7 +5355,7 @@ CREATE UNIQUE INDEX package_repo_filters_unique_matcher_per_scheme ON package_re
 
 CREATE INDEX package_repo_versions_blocked ON package_repo_versions USING btree (blocked);
 
-CREATE INDEX package_repo_versions_last_checked_at ON package_repo_versions USING btree (last_checked_at);
+CREATE INDEX package_repo_versions_last_checked_at ON package_repo_versions USING btree (last_checked_at NULLS FIRST);
 
 CREATE UNIQUE INDEX package_repo_versions_unique_version_per_package ON package_repo_versions USING btree (package_id, version);
 


### PR DESCRIPTION
Make fast, zoom zoom :sanic:

Due to some weird query optimization barrier (or something no one seems to be able to explain), the old query degenerates to a seq scan with hundreds of thousands of rows filtered out in both `lsif_dependency_repos` and `package_repo_versions`. When hard-coding the value the CTE returns, we get an expected sub 1ms query (using bitmap heap scan + bitmap OR). Instead of doing that by splitting into two queries (fetch oldest date or null, then old query without CTE), we just reformulate the query so that theres never a possibility to have to scan over every single row in both tables (additionally thanks to two updated indices for `NULLS FIRST`) by selecting 1 row from both `lsif_dependency_repos` and `package_repo_versions` for the oldest `last_checked_at` or NULL, and then comparing that against all the rows from `package_repo_filters`, which is going to be hugely smaller

<details>
<summary>Old query</summary>

[https://explain.dalibo.com/plan/g72113d9e585827h](https://explain.dalibo.com/plan/g72113d9e585827h)

```sql
EXPLAIN (ANALYZE, BUFFERS , VERBOSE )
WITH most_recent_filters_change AS (
	SELECT COALESCE(deleted_at, updated_at)
	FROM package_repo_filters
	ORDER BY COALESCE(deleted_at, updated_at) DESC
	LIMIT 1
)
SELECT EXISTS (
	SELECT 1
	FROM lsif_dependency_repos
	WHERE
	    last_checked_at < (SELECT * FROM most_recent_filters_change)
		OR last_checked_at IS NULL
    LIMIT 1
) OR EXISTS (
	SELECT 1
	FROM package_repo_versions
	WHERE
		last_checked_at IS NULL
		OR last_checked_at < (SELECT * FROM most_recent_filters_change)
    LIMIT 1
);
```

```
Result  (cost=18.74..18.75 rows=1 width=1) (actual time=215.815..215.821 rows=1 loops=1)
  Output: ($2 OR $4)
  Buffers: shared hit=50361 read=1
  I/O Timings: read=0.421
  CTE most_recent_filters_change
    ->  Limit  (cost=18.40..18.40 rows=1 width=8) (actual time=0.458..0.460 rows=1 loops=1)
"          Output: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at))"
          Buffers: shared hit=3 read=1
          I/O Timings: read=0.421
          ->  Sort  (cost=18.40..19.80 rows=560 width=8) (actual time=0.454..0.454 rows=1 loops=1)
"                Output: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at))"
"                Sort Key: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at)) DESC"
                Sort Method: quicksort  Memory: 25kB
                Buffers: shared hit=3 read=1
                I/O Timings: read=0.421
                ->  Seq Scan on public.package_repo_filters  (cost=0.00..15.60 rows=560 width=8) (actual time=0.430..0.431 rows=1 loops=1)
"                      Output: COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at)"
                      Buffers: shared read=1
                      I/O Timings: read=0.421
  InitPlan 3 (returns $2)
    ->  Seq Scan on public.lsif_dependency_repos  (cost=0.02..30251.85 rows=184955 width=0) (actual time=71.360..71.362 rows=0 loops=1)
          Filter: ((lsif_dependency_repos.last_checked_at < $1) OR (lsif_dependency_repos.last_checked_at IS NULL))
          Rows Removed by Filter: 267000
          Buffers: shared hit=23319 read=1
          I/O Timings: read=0.421
          InitPlan 2 (returns $1)
            ->  CTE Scan on most_recent_filters_change  (cost=0.00..0.02 rows=1 width=8) (actual time=0.459..0.469 rows=1 loops=1)
"                  Output: most_recent_filters_change.""coalesce"""
                  Buffers: shared hit=3 read=1
                  I/O Timings: read=0.421
  InitPlan 5 (returns $4)
    ->  Seq Scan on public.package_repo_versions  (cost=0.02..139518.88 rows=1059196 width=0) (actual time=144.450..144.451 rows=1 loops=1)
          Filter: ((package_repo_versions.last_checked_at IS NULL) OR (package_repo_versions.last_checked_at < $3))
          Rows Removed by Filter: 782538
          Buffers: shared hit=27042
          InitPlan 4 (returns $3)
            ->  CTE Scan on most_recent_filters_change most_recent_filters_change_1  (cost=0.00..0.02 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=1)
"                  Output: most_recent_filters_change_1.""coalesce"""
Planning Time: 2.777 ms
Execution Time: 215.885 ms
```

</details>

<details>
<summary>New query</summary>

[https://explain.dalibo.com/plan/7e72d5ce0gdaa943](https://explain.dalibo.com/plan/7e72d5ce0gdaa943)

```sql
WITH least_recently_checked AS (
	-- select oldest last_checked_at from either package_repo_versions
	-- or lsif_dependency_repos, prioritising NULL
    SELECT * FROM (
        (
			SELECT last_checked_at FROM lsif_dependency_repos
			ORDER BY last_checked_at ASC NULLS FIRST
			LIMIT 1
		)
        UNION ALL
        (
			SELECT last_checked_at FROM package_repo_versions
			ORDER BY last_checked_at ASC NULLS FIRST
			LIMIT 1
		)
    ) p
    ORDER BY last_checked_at ASC NULLS FIRST
    LIMIT 1
),
most_recently_updated_filter AS (
    SELECT COALESCE(deleted_at, updated_at)
	FROM package_repo_filters
	ORDER BY COALESCE(deleted_at, updated_at) DESC
	LIMIT 1
)
SELECT 1
WHERE
	-- comparisons on empty table from either least_recently_checked or most_recently_updated_filter
	-- will yield NULL, making the query return 1 if either CTE returns nothing
    (SELECT COUNT(*) FROM most_recently_updated_filter) <> 0 AND
    (SELECT COUNT(*) FROM least_recently_checked) <> 0 AND
    (
        (SELECT * FROM least_recently_checked) IS NULL OR
        (SELECT * FROM least_recently_checked) < (SELECT * FROM most_recently_updated_filter)
    );
```

```
Result  (cost=2.04..2.05 rows=1 width=4) (actual time=0.074..0.076 rows=0 loops=1)
  Output: 1
  One-Time Filter: (($2 <> 0) AND ($3 <> 0) AND ($4 < $5))
  Buffers: shared hit=10
  CTE oldest
    ->  Limit  (cost=0.86..0.90 rows=1 width=8) (actual time=0.053..0.054 rows=1 loops=1)
          Output: lsif_dependency_repos.last_checked_at
          Buffers: shared hit=9
          ->  Merge Append  (cost=0.86..0.94 rows=2 width=8) (actual time=0.053..0.054 rows=1 loops=1)
                Sort Key: lsif_dependency_repos.last_checked_at NULLS FIRST
                Buffers: shared hit=9
                ->  Limit  (cost=0.42..0.44 rows=1 width=8) (actual time=0.027..0.027 rows=1 loops=1)
                      Output: lsif_dependency_repos.last_checked_at
                      Buffers: shared hit=4
                      ->  Index Only Scan using noah_test_lsif_dependency_repos_checked_at on public.lsif_dependency_repos  (cost=0.42..4845.76 rows=267302 width=8) (actual time=0.027..0.027 rows=1 loops=1)
                            Output: lsif_dependency_repos.last_checked_at
                            Heap Fetches: 0
                            Buffers: shared hit=4
                ->  Limit  (cost=0.43..0.45 rows=1 width=8) (actual time=0.025..0.025 rows=1 loops=1)
                      Output: package_repo_versions.last_checked_at
                      Buffers: shared hit=5
                      ->  Index Only Scan using noah_test_package_repo_versions_checked_at on public.package_repo_versions  (cost=0.43..25090.50 rows=1336747 width=8) (actual time=0.025..0.025 rows=1 loops=1)
                            Output: package_repo_versions.last_checked_at
                            Heap Fetches: 1
                            Buffers: shared hit=5
  CTE most_recently_updated_filter
    ->  Limit  (cost=1.02..1.02 rows=1 width=8) (actual time=0.012..0.012 rows=1 loops=1)
"          Output: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at))"
          Buffers: shared hit=1
          ->  Sort  (cost=1.02..1.02 rows=1 width=8) (actual time=0.011..0.011 rows=1 loops=1)
"                Output: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at))"
"                Sort Key: (COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at)) DESC"
                Sort Method: quicksort  Memory: 25kB
                Buffers: shared hit=1
                ->  Seq Scan on public.package_repo_filters  (cost=0.00..1.01 rows=1 width=8) (actual time=0.005..0.006 rows=1 loops=1)
"                      Output: COALESCE(package_repo_filters.deleted_at, package_repo_filters.updated_at)"
                      Buffers: shared hit=1
  InitPlan 3 (returns $2)
    ->  Aggregate  (cost=0.02..0.03 rows=1 width=8) (actual time=0.015..0.016 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=1
          ->  CTE Scan on most_recently_updated_filter  (cost=0.00..0.02 rows=1 width=0) (actual time=0.013..0.013 rows=1 loops=1)
"                Output: most_recently_updated_filter.""coalesce"""
                Buffers: shared hit=1
  InitPlan 4 (returns $3)
    ->  Aggregate  (cost=0.02..0.03 rows=1 width=8) (actual time=0.055..0.055 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=9
          ->  CTE Scan on oldest  (cost=0.00..0.02 rows=1 width=0) (actual time=0.054..0.054 rows=1 loops=1)
                Output: oldest.last_checked_at
                Buffers: shared hit=9
  InitPlan 5 (returns $4)
    ->  CTE Scan on oldest oldest_1  (cost=0.00..0.02 rows=1 width=8) (actual time=0.000..0.001 rows=1 loops=1)
          Output: oldest_1.last_checked_at
  InitPlan 6 (returns $5)
    ->  CTE Scan on most_recently_updated_filter most_recently_updated_filter_1  (cost=0.00..0.02 rows=1 width=8) (actual time=0.000..0.000 rows=1 loops=1)
"          Output: most_recently_updated_filter_1.""coalesce"""
Planning Time: 0.488 ms
Execution Time: 0.131 ms
```

</details>

## Test plan

Fairly comprehensive local testing for different value scenarios
