### PR TITLE
local dev: enable gRPC zoekt client communication

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -496,6 +496,7 @@ commands:
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
       CTAGS_COMMAND: dev/universal-ctags-dev
+      GRPC_ENABLED: true
 
   zoekt-index-0:
     <<: *zoekt_indexserver_template


### PR DESCRIPTION
This enables gRPC client communication for zoekt-sourcegraph-indexserver, which communicatiates with sourcegraph's internal API for configuration purposes. See https://github.com/sourcegraph/zoekt/pull/551 for more information.

This is useful for QA testing for starship.



## Test plan

Manual testing. I ran `sg start` with the modified configuration and verified that I was seeing the communication I expected in Wireshark:

<img width="1653" alt="Screen Shot 2023-03-16 at 1 50 07 PM" src="https://user-images.githubusercontent.com/9022011/225749785-38c5ede5-d72c-4a90-9829-7cf0c8f3d016.png">
