### PR TITLE
svcmain: use hexops/cmder for CLI arg parsing

### DIFF
--- a/cmd/sourcegraph-oss/main.go
+++ b/cmd/sourcegraph-oss/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"os"
+
 	blobstore_shared "github.com/sourcegraph/sourcegraph/cmd/blobstore/shared"
 	frontend_shared "github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	githubproxy_shared "github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared"
@@ -29,5 +31,5 @@ var services = []service.Service{
 }
 
 func main() {
-	osscmd.MainOSS(services)
+	osscmd.MainOSS(services, os.Args)
 }

--- a/cmd/sourcegraph-oss/osscmd/osscmd.go
+++ b/cmd/sourcegraph-oss/osscmd/osscmd.go
@@ -17,8 +17,8 @@ var config = svcmain.Config{
 }
 
 // Main is called from the `main` function of the `sourcegraph-oss` command.
-func MainOSS(services []service.Service) {
-	svcmain.Main(services, config)
+func MainOSS(services []service.Service, args []string) {
+	svcmain.Main(services, config, args)
 }
 
 // DeprecatedSingleServiceMainOSS is called from the `main` function of a command in the OSS build

--- a/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
+++ b/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
@@ -12,8 +12,8 @@ import (
 var config = svcmain.Config{}
 
 // MainEnterprise is called from the `main` function of the `sourcegraph` command.
-func MainEnterprise(services []service.Service) {
-	svcmain.Main(services, config)
+func MainEnterprise(services []service.Service, args []string) {
+	svcmain.Main(services, config, args)
 }
 
 // DeprecatedSingleServiceMainEnterprise is called from the `main` function of a command in the

--- a/enterprise/cmd/sourcegraph/main.go
+++ b/enterprise/cmd/sourcegraph/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/servegit"
@@ -33,5 +35,5 @@ var services = []service.Service{
 }
 
 func main() {
-	enterprisecmd.MainEnterprise(services)
+	enterprisecmd.MainEnterprise(services, os.Args)
 }

--- a/go.mod
+++ b/go.mod
@@ -220,6 +220,7 @@ require (
 	github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20210128111500-3ff779b52992 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hexops/cmder v1.0.2 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -967,6 +967,8 @@ github.com/hexops/autogold v0.8.1/go.mod h1:97HLDXyG23akzAoRYJh/2OBs3kd80eHyKPvZ
 github.com/hexops/autogold v1.3.1 h1:YgxF9OHWbEIUjhDbpnLhgVsjUDsiHDTyDfy2lrfdlzo=
 github.com/hexops/autogold/v2 v2.1.0 h1:5s9J6CROngFPkgowSkV20bIflBrImSdDqIpoXJeZSkU=
 github.com/hexops/autogold/v2 v2.1.0/go.mod h1:cYVc0tJn6v9Uf9xMOHvmH6scuTxsVJSxGcKR/yOVPzY=
+github.com/hexops/cmder v1.0.2 h1:lNANYaWASSFP9jpq1lBqIfNoWBXvUMWXCp9v0GZhyf0=
+github.com/hexops/cmder v1.0.2/go.mod h1:7vsl5I9EK1NGtWYgBzQtOM4e13WReMsXpogtGhZWzAg=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hexops/valast v1.4.3 h1:oBoGERMJh6UZdRc6cduE1CTPK+VAdXA59Y1HFgu3sm0=

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -46,7 +46,7 @@ func init() {
 			return nil
 		},
 		UsageFunc: func() {
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'sourcegraph %s':\n", runFlagSet.Name())
+			fmt.Fprintf(flag.CommandLine.Output(), "Usage of 'sourcegraph %s':\n", flagSet.Name())
 			flagSet.PrintDefaults()
 		},
 	})

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -29,8 +29,11 @@ type Config struct {
 	AfterConfigure func() // run after all services' Configure hooks are called
 }
 
-// Main is called from the `main` function of the `sourcegraph-oss` and `sourcegraph` commands.
-func Main(services []sgservice.Service, config Config) {
+// Main is called from the `main` function of the `sourcegraph-oss` and
+// `sourcegraph` commands.
+//
+// args is the commandline arguments (usually os.Args).
+func Main(services []sgservice.Service, config Config, args []string) {
 	// Unlike other sourcegraph binaries we expect Sourcegraph App to be run
 	// by a user instead of deployed to a cloud. So adjust the default output
 	// format before initializing log.


### PR DESCRIPTION
@keegancsmith this is an alternative to your PR https://github.com/sourcegraph/sourcegraph/pull/49518 which uses urfave/cli.

I thought I'd whip this up real quick, in case folks like this approach better. [hexops/cmder](https://github.com/hexops/cmder) (by yours truly) I think is a bit nicer than urface/cli because:

1. It's lighter weight; compare https://github.com/urfave/cli with the ~100 LOC file that is cmder: https://github.com/hexops/cmder/blob/main/cmder.go - just less magical overall.
2. It is directly modeled after what the `go` tool does internally; uses the Go `flag` package, etc. **it is literally just the Go flag package + the ability to have subcommands nicely.
3. It's the same pattern we use in https://github.com/sourcegraph/src-cli (but, well, as a library you can't easily mess up.)

I just figured as long as we're picking a CLI parser I'd throw this one into the hat. I recognize I wrote the library and so am super biased; I don't mind if we go with urfave/cli at all (and, if that's what Keegan or others prefer, we definitely should.)

Feel free to close if you prefer urfave/cli instead! I don't mind :)

## Test plan

* `.bin/sourcegraph --help` works
* `.bin/sourcegraph version` reports the version
* `.bin/sourcegraph` and `.bin/sourcegraph run` start running Sourcegraph
* `sg start app` works
