### PR TITLE
codeintel: Simplify connection resolver types

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4806,7 +4806,7 @@ type DiagnosticConnection {
     """
     The total count of diagnostics (which may be larger than nodes.length if the connection is paginated).
     """
-    totalCount: Int!
+    totalCount: Int
 
     """
     Pagination information.

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/precise_indexes.go
@@ -472,21 +472,21 @@ func NewPreciseIndexConnectionResolver(
 	}
 }
 
-func (r *preciseIndexConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.PreciseIndexResolver, error) {
-	return r.nodes, nil
+func (r *preciseIndexConnectionResolver) Nodes() []resolverstubs.PreciseIndexResolver {
+	return r.nodes
 }
 
-func (r *preciseIndexConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+func (r *preciseIndexConnectionResolver) TotalCount() *int32 {
 	count := int32(r.totalCount)
-	return &count, nil
+	return &count
 }
 
-func (r *preciseIndexConnectionResolver) PageInfo(ctx context.Context) (resolverstubs.PageInfo, error) {
+func (r *preciseIndexConnectionResolver) PageInfo() resolverstubs.PageInfo {
 	if r.cursor != "" {
-		return &pageInfo{hasNextPage: true, endCursor: &r.cursor}, nil
+		return &pageInfo{hasNextPage: true, endCursor: &r.cursor}
 	}
 
-	return &pageInfo{hasNextPage: false}, nil
+	return &pageInfo{hasNextPage: false}
 }
 
 func unmarshalPreciseIndexGQLID(id graphql.ID) (uploadID, indexID int, err error) {

--- a/enterprise/internal/codeintel/codenav/transport/graphql/diagnostic_resolver_connection.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/diagnostic_resolver_connection.go
@@ -1,8 +1,6 @@
 package graphql
 
 import (
-	"context"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/resolvers"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
@@ -22,18 +20,19 @@ func NewDiagnosticConnectionResolver(diagnostics []shared.DiagnosticAtUpload, to
 	}
 }
 
-func (r *diagnosticConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.DiagnosticResolver, error) {
+func (r *diagnosticConnectionResolver) Nodes() []resolverstubs.DiagnosticResolver {
 	resolvers := make([]resolverstubs.DiagnosticResolver, 0, len(r.diagnostics))
 	for i := range r.diagnostics {
 		resolvers = append(resolvers, NewDiagnosticResolver(r.diagnostics[i], r.locationResolver))
 	}
-	return resolvers, nil
+	return resolvers
 }
 
-func (r *diagnosticConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	return int32(r.totalCount), nil
+func (r *diagnosticConnectionResolver) TotalCount() *int32 {
+	v := int32(r.totalCount)
+	return &v
 }
 
-func (r *diagnosticConnectionResolver) PageInfo(ctx context.Context) (resolverstubs.PageInfo, error) {
-	return HasNextPage(len(r.diagnostics) < r.totalCount), nil
+func (r *diagnosticConnectionResolver) PageInfo() resolverstubs.PageInfo {
+	return HasNextPage(len(r.diagnostics) < r.totalCount)
 }

--- a/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver_connection.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver_connection.go
@@ -1,8 +1,6 @@
 package graphql
 
 import (
-	"context"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -30,20 +28,20 @@ func NewCodeIntelligenceConfigurationPolicyConnectionResolver(
 	}
 }
 
-func (r *codeIntelligenceConfigurationPolicyConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.CodeIntelligenceConfigurationPolicyResolver, error) {
+func (r *codeIntelligenceConfigurationPolicyConnectionResolver) Nodes() []resolverstubs.CodeIntelligenceConfigurationPolicyResolver {
 	resolvers := make([]resolverstubs.CodeIntelligenceConfigurationPolicyResolver, 0, len(r.policies))
 	for _, policy := range r.policies {
 		resolvers = append(resolvers, NewConfigurationPolicyResolver(r.repoStore, policy, r.errTracer))
 	}
 
-	return resolvers, nil
+	return resolvers
 }
 
-func (r *codeIntelligenceConfigurationPolicyConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+func (r *codeIntelligenceConfigurationPolicyConnectionResolver) TotalCount() *int32 {
 	v := int32(r.totalCount)
-	return &v, nil
+	return &v
 }
 
-func (r *codeIntelligenceConfigurationPolicyConnectionResolver) PageInfo(ctx context.Context) (resolverstubs.PageInfo, error) {
-	return HasNextPage(len(r.policies) < r.totalCount), nil
+func (r *codeIntelligenceConfigurationPolicyConnectionResolver) PageInfo() resolverstubs.PageInfo {
+	return HasNextPage(len(r.policies) < r.totalCount)
 }

--- a/enterprise/internal/codeintel/shared/resolvers/retention_policy_matcher_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/retention_policy_matcher_connection.go
@@ -1,8 +1,6 @@
 package sharedresolvers
 
 import (
-	"context"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -25,20 +23,20 @@ func NewCodeIntelligenceRetentionPolicyMatcherConnectionResolver(repoStore datab
 	}
 }
 
-func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.CodeIntelligenceRetentionPolicyMatchResolver, error) {
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) Nodes() []resolverstubs.CodeIntelligenceRetentionPolicyMatchResolver {
 	resolvers := make([]resolverstubs.CodeIntelligenceRetentionPolicyMatchResolver, 0, len(r.policies))
 	for _, policy := range r.policies {
 		resolvers = append(resolvers, NewRetentionPolicyMatcherResolver(r.repoStore, policy))
 	}
 
-	return resolvers, nil
+	return resolvers
 }
 
-func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) TotalCount() *int32 {
 	v := int32(r.totalCount)
-	return &v, nil
+	return &v
 }
 
-func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) PageInfo(ctx context.Context) (resolverstubs.PageInfo, error) {
-	return HasNextPage(len(r.policies) < r.totalCount), nil
+func (r *codeIntelligenceRetentionPolicyMatcherConnectionResolver) PageInfo() resolverstubs.PageInfo {
+	return HasNextPage(len(r.policies) < r.totalCount)
 }

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -41,17 +41,9 @@ type GetVulnerabilityMatchesArgs struct {
 	After *string
 }
 
-type VulnerabilityConnectionResolver interface {
-	Nodes() []VulnerabilityResolver
-	TotalCount() *int32
-	PageInfo() PageInfo
-}
+type VulnerabilityConnectionResolver = ConnectionResolver[VulnerabilityResolver]
 
-type VulnerabilityMatchConnectionResolver interface {
-	Nodes() []VulnerabilityMatchResolver
-	TotalCount() *int32
-	PageInfo() PageInfo
-}
+type VulnerabilityMatchConnectionResolver = ConnectionResolver[VulnerabilityMatchResolver]
 
 type VulnerabilityResolver interface {
 	ID() graphql.ID
@@ -150,17 +142,9 @@ type RepositoriesWithConfigurationArgs struct {
 	After *string
 }
 
-type CodeIntelRepositoryWithErrorConnectionResolver interface {
-	Nodes() []CodeIntelRepositoryWithErrorResolver
-	TotalCount() *int32
-	PageInfo() PageInfo
-}
+type CodeIntelRepositoryWithErrorConnectionResolver = ConnectionResolver[CodeIntelRepositoryWithErrorResolver]
 
-type CodeIntelRepositoryWithConfigurationConnectionResolver interface {
-	Nodes() []CodeIntelRepositoryWithConfigurationResolver
-	TotalCount() *int32
-	PageInfo() PageInfo
-}
+type CodeIntelRepositoryWithConfigurationConnectionResolver = ConnectionResolver[CodeIntelRepositoryWithConfigurationResolver]
 
 type CodeIntelRepositoryWithErrorResolver interface {
 	Repository() RepositoryResolver
@@ -201,11 +185,7 @@ type PreciseIndexesQueryArgs struct {
 	IncludeDeleted *bool
 }
 
-type PreciseIndexConnectionResolver interface {
-	Nodes(ctx context.Context) ([]PreciseIndexResolver, error)
-	TotalCount(ctx context.Context) (*int32, error)
-	PageInfo(ctx context.Context) (PageInfo, error)
-}
+type PreciseIndexConnectionResolver = ConnectionResolver[PreciseIndexResolver]
 
 type PreciseIndexResolver interface {
 	ID() graphql.ID
@@ -497,17 +477,9 @@ type HoverResolver interface {
 	Range() RangeResolver
 }
 
-type DiagnosticConnectionResolver interface {
-	Nodes(ctx context.Context) ([]DiagnosticResolver, error)
-	TotalCount(ctx context.Context) (int32, error)
-	PageInfo(ctx context.Context) (PageInfo, error)
-}
+type DiagnosticConnectionResolver = ConnectionResolver[DiagnosticResolver]
 
-type CodeIntelligenceConfigurationPolicyConnectionResolver interface {
-	Nodes(ctx context.Context) ([]CodeIntelligenceConfigurationPolicyResolver, error)
-	TotalCount(ctx context.Context) (*int32, error)
-	PageInfo(ctx context.Context) (PageInfo, error)
-}
+type CodeIntelligenceConfigurationPolicyConnectionResolver = ConnectionResolver[CodeIntelligenceConfigurationPolicyResolver]
 
 type RetentionPolicyMatcherResolver interface {
 	ConfigurationPolicy() CodeIntelligenceConfigurationPolicyResolver
@@ -603,11 +575,7 @@ type AuditLogColumnChangeResolver interface {
 	New() *string
 }
 
-type CodeIntelligenceRetentionPolicyMatchesConnectionResolver interface {
-	Nodes(ctx context.Context) ([]CodeIntelligenceRetentionPolicyMatchResolver, error)
-	TotalCount(ctx context.Context) (*int32, error)
-	PageInfo(ctx context.Context) (PageInfo, error)
-}
+type CodeIntelligenceRetentionPolicyMatchesConnectionResolver = ConnectionResolver[CodeIntelligenceRetentionPolicyMatchResolver]
 
 type CodeIntelligenceRetentionPolicyMatchResolver interface {
 	ConfigurationPolicy() CodeIntelligenceConfigurationPolicyResolver
@@ -791,4 +759,10 @@ func comparisonKey(root, indexer string) string {
 	hash := sha256.New()
 	_, _ = hash.Write([]byte(strings.Join([]string{root, indexer}, "\x00")))
 	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
+}
+
+type ConnectionResolver[T any] interface {
+	Nodes() []T
+	TotalCount() *int32
+	PageInfo() PageInfo
 }


### PR DESCRIPTION
Make a single definition for a common interface type.

## Test plan

Ran locally to ensure graphq types still line up 😵.