### PR TITLE
app: always print version first-thing on startup

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -15,10 +15,16 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 func Init(logger log.Logger) {
+	if deploy.IsApp() {
+		fmt.Fprintln(os.Stderr, "✱ Sourcegraph App version:", version.Version())
+	}
+
 	// TODO(sqs) TODO(single-binary): see the env.HackClearEnvironCache docstring, we should be able to remove this
 	// eventually.
 	env.HackClearEnvironCache()


### PR DESCRIPTION
It's really useful to know when debugging customer issues what version they are running, and in the macOS app bundle we'll only have access to logs (can't ask them to run `sourcegraph version` command once it exists) so with this change we always print the version on startup:

```
[    sourcegraph] ✱ Sourcegraph App version: 0.0.0+dev
```

This is the first thing printed, to ensure it goes out before the binary crashes (if such an issue is occurring.)

## Test plan

`sg start app` & confirm output manually
