### PR TITLE
codeintel: Fix missing index

### DIFF
--- a/internal/database/schema.codeintel.json
+++ b/internal/database/schema.codeintel.json
@@ -650,6 +650,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_scip_metadata_pkey ON codeintel_scip_metadata USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "codeintel_scip_metadata_upload_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_scip_metadata_upload_id ON codeintel_scip_metadata USING btree (upload_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": null,

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -142,6 +142,7 @@ Tracks the range of `schema_versions` values associated with each document refer
  protocol_version       | integer |           | not null | 
 Indexes:
     "codeintel_scip_metadata_pkey" PRIMARY KEY, btree (id)
+    "codeintel_scip_metadata_upload_id" btree (upload_id)
 
 ```
 

--- a/migrations/codeintel/1679010276_add_missing_index/down.sql
+++ b/migrations/codeintel/1679010276_add_missing_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_scip_metadata_upload_id;

--- a/migrations/codeintel/1679010276_add_missing_index/metadata.yaml
+++ b/migrations/codeintel/1679010276_add_missing_index/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing index
+parents: [1678899132]
+createIndexConcurrently: true

--- a/migrations/codeintel/1679010276_add_missing_index/up.sql
+++ b/migrations/codeintel/1679010276_add_missing_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_scip_metadata_upload_id ON codeintel_scip_metadata(upload_id);

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -409,6 +409,8 @@ CREATE INDEX codeintel_scip_document_lookup_document_id ON codeintel_scip_docume
 
 CREATE INDEX codeintel_scip_documents_dereference_logs_last_removal_time_des ON codeintel_scip_documents_dereference_logs USING btree (last_removal_time DESC, document_id);
 
+CREATE INDEX codeintel_scip_metadata_upload_id ON codeintel_scip_metadata USING btree (upload_id);
+
 CREATE INDEX codeintel_scip_symbol_names_upload_id_roots ON codeintel_scip_symbol_names USING btree (upload_id) WHERE (prefix_id IS NULL);
 
 CREATE INDEX codeintel_scip_symbols_document_lookup_id ON codeintel_scip_symbols USING btree (document_lookup_id);


### PR DESCRIPTION
There was a seq scan dominating the dotcom codeintel-db looking for an `upload_id = ANY(%s)`. Not sure why this index was missing. Should probably be upgraded to a unique index in the future.

## Test plan

CI pipelines.