### PR TITLE
[Backport 5.0] ci: run Chromatic on release branches

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -312,7 +312,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Core tests
 		ops.Merge(CoreTestOperations(changed.All, CoreTestOperationsOptions{
-			ChromaticShouldAutoAccept: c.RunType.Is(runtype.MainBranch),
+			ChromaticShouldAutoAccept: c.RunType.Is(runtype.MainBranch, runtype.ReleaseBranch, runtype.TaggedRelease),
 			MinimumUpgradeableVersion: minimumUpgradeableVersion,
 			ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
 			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun),


### PR DESCRIPTION
## Context

Currently, Chromatic is not executed on release branches. This PR changes it. We auto-accept changes to make them available as the baseline for PRs to the release branch. Based on [the Slack thread](https://sourcegraph.slack.com/archives/C032Z79NZQC/p1678994188865799).

## Test plan

CI
