### PR TITLE
Fix bug where a nil reader could crash the redis middleware logger

### DIFF
--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -53,7 +53,7 @@ func redisLoggerMiddleware() Middleware {
 
 			// Read body
 			var requestBody []byte
-			if req != nil && req.Body != nil {
+			if req != nil && req.GetBody != nil {
 				body, _ := req.GetBody()
 				if body != nil {
 					var readErr error

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -26,7 +26,7 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 	normalReq, _ := http.NewRequest("GET", "http://dev/null", strings.NewReader("horse"))
 	complexReq, _ := http.NewRequest("PATCH", "http://test.aa?a=2", strings.NewReader("graph"))
 	complexReq.Header.Set("Cache-Control", "no-cache")
-	postReqNoBody, _ := http.NewRequest("POST", "http://dev/null", io.NopCloser(bytes.NewBuffer(nil)))
+	postReqEmptyBody, _ := http.NewRequest("POST", "http://dev/null", io.NopCloser(bytes.NewBuffer([]byte{})))
 
 	testCases := []struct {
 		req  *http.Request
@@ -72,13 +72,13 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 			err: "oh no",
 		},
 		{
-			req:  postReqNoBody,
-			name: "post request with nil body",
+			req:  postReqEmptyBody,
+			name: "post request with empty body",
 			cli:  newFakeClientWithHeaders(map[string][]string{"X-Test-Header": {"value1", "value2"}}, http.StatusOK, []byte(`{"permission":false}`), nil),
 			err:  "<nil>",
 			want: &types.OutboundRequestLogItem{
-				Method:          postReqNoBody.Method,
-				URL:             postReqNoBody.URL.String(),
+				Method:          postReqEmptyBody.Method,
+				URL:             postReqEmptyBody.URL.String(),
 				RequestHeaders:  map[string][]string{},
 				RequestBody:     "",
 				StatusCode:      http.StatusOK,

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -1,8 +1,10 @@
 package httpcli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -24,6 +26,7 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 	normalReq, _ := http.NewRequest("GET", "http://dev/null", strings.NewReader("horse"))
 	complexReq, _ := http.NewRequest("PATCH", "http://test.aa?a=2", strings.NewReader("graph"))
 	complexReq.Header.Set("Cache-Control", "no-cache")
+	postReqNoBody, _ := http.NewRequest("POST", "http://dev/null", io.NopCloser(bytes.NewBuffer(nil)))
 
 	testCases := []struct {
 		req  *http.Request
@@ -67,6 +70,20 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 				return nil, errors.New("oh no")
 			}),
 			err: "oh no",
+		},
+		{
+			req:  postReqNoBody,
+			name: "post request with nil body",
+			cli:  newFakeClientWithHeaders(map[string][]string{"X-Test-Header": {"value1", "value2"}}, http.StatusOK, []byte(`{"permission":false}`), nil),
+			err:  "<nil>",
+			want: &types.OutboundRequestLogItem{
+				Method:          postReqNoBody.Method,
+				URL:             postReqNoBody.URL.String(),
+				RequestHeaders:  map[string][]string{},
+				RequestBody:     "",
+				StatusCode:      http.StatusOK,
+				ResponseHeaders: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}, "X-Test-Header": {"value1", "value2"}},
+			},
 		},
 	}
 


### PR DESCRIPTION
Check for GetBody != nil instead to make middleware layer more robust.

Just because a request has a `Body` does not mean that `GetBody` will be set, because the io.Reader of the body can still produce a nil value.

Here's an example in the `net/http` library where a nil check is done on `GetBody` instead: https://sourcegraph.com/github.com/golang/go/-/blob/src/net/http/client.go?L662-669

## Test plan

Added test case

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
