### PR TITLE
App: Various header menu tweaks

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, ChangeEventHandler, FC } from 'react'
 
-import { mdiChevronDown, mdiChevronUp, mdiAccountWrenchOutline, mdiOpenInNew } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiCogOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
@@ -117,7 +117,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             <div className="position-relative">
                                 <div className="align-items-center d-flex">
                                     {isSourcegraphApp ? (
-                                        <Icon svgPath={mdiAccountWrenchOutline} aria-hidden={true} />
+                                        <Icon svgPath={mdiCogOutline} aria-hidden={true} />
                                     ) : (
                                         <UserAvatar user={authenticatedUser} className={styles.avatar} />
                                     )}

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, ChangeEventHandler, FC } from 'react'
 
-import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiAccountOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
@@ -116,7 +116,11 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                         >
                             <div className="position-relative">
                                 <div className="align-items-center d-flex">
-                                    <UserAvatar user={authenticatedUser} className={styles.avatar} />
+                                    {isSourcegraphApp ? (
+                                        <Icon svgPath={mdiAccountOutline} aria-hidden={true} />
+                                    ) : (
+                                        <UserAvatar user={authenticatedUser} className={styles.avatar} />
+                                    )}
                                     <Icon svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} aria-hidden={true} />
                                 </div>
                             </div>
@@ -127,10 +131,14 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             className={styles.dropdownMenu}
                             aria-label="User. Open menu"
                         >
-                            <MenuHeader className={styles.dropdownHeader}>
-                                Signed in as <strong>@{authenticatedUser.username}</strong>
-                            </MenuHeader>
-                            <MenuDivider className={styles.dropdownDivider} />
+                            {!isSourcegraphApp ? (
+                                <>
+                                    <MenuHeader className={styles.dropdownHeader}>
+                                        Signed in as <strong>@{authenticatedUser.username}</strong>
+                                    </MenuHeader>
+                                    <MenuDivider className={styles.dropdownDivider} />
+                                </>
+                            ) : null}
                             <MenuLink as={Link} to={authenticatedUser.settingsURL!}>
                                 Settings
                             </MenuLink>
@@ -140,6 +148,11 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             {isSourcegraphApp && (
                                 <MenuLink as={Link} to="/setup">
                                     Setup wizard
+                                </MenuLink>
+                            )}
+                            {isSourcegraphApp && (
+                                <MenuLink as={Link} to="/site-admin/repositories">
+                                    Repositories
                                 </MenuLink>
                             )}
                             {enableTeams && !isSourcegraphDotCom && (

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, ChangeEventHandler, FC } from 'react'
 
-import { mdiChevronDown, mdiChevronUp, mdiAccountOutline, mdiOpenInNew } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiCogOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
@@ -117,7 +117,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             <div className="position-relative">
                                 <div className="align-items-center d-flex">
                                     {isSourcegraphApp ? (
-                                        <Icon svgPath={mdiAccountOutline} aria-hidden={true} />
+                                        <Icon svgPath={mdiCogOutline} aria-hidden={true} />
                                     ) : (
                                         <UserAvatar user={authenticatedUser} className={styles.avatar} />
                                     )}

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, ChangeEventHandler, FC } from 'react'
 
-import { mdiChevronDown, mdiChevronUp, mdiCogOutline, mdiOpenInNew } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiAccountWrenchOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
@@ -117,7 +117,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             <div className="position-relative">
                                 <div className="align-items-center d-flex">
                                     {isSourcegraphApp ? (
-                                        <Icon svgPath={mdiCogOutline} aria-hidden={true} />
+                                        <Icon svgPath={mdiAccountWrenchOutline} aria-hidden={true} />
                                     ) : (
                                         <UserAvatar user={authenticatedUser} className={styles.avatar} />
                                     )}


### PR DESCRIPTION
After #49476, a user no longer needs to think about the concept of accounts. To make the experience smoother, this PR removes a few account-isms from the app header menu:

- Removes the avatar from the header in favor of a more generic icon
- Removes the "Logged in as" text
- Adds a quick link to "Repositories" to the dropdown menu

## Icon instead of avatar?

I’m not sure which one works best here so I prepared a few options for y'all to decide on 🙂 

<table>
<tr>
	<td><code>mdiCogOutline</code>
	<td><img width="517" alt="Screenshot 2023-03-17 at 11 03 01" src="https://user-images.githubusercontent.com/458591/225877012-1bc2ec57-9b80-4b68-aeee-775d4245bc39.png">
<tr>
	<td><code>mdiDotsHorizontal</code>
	<td><img width="587" alt="Screenshot 2023-03-17 at 11 03 49" src="https://user-images.githubusercontent.com/458591/225877125-e75fef18-a09f-4ade-978e-6091e417e902.png">
<tr>
	<td><code>mdiDotsVertical</code>
	<td><img width="729" alt="Screenshot 2023-03-17 at 11 04 24" src="https://user-images.githubusercontent.com/458591/225877211-deb7c492-23f1-4a56-b26a-c223b4311788.png">
<tr>
	<td><code>mdiAccountWrenchOutline</code>
	<td><img width="463" alt="Screenshot 2023-03-17 at 11 05 10" src="https://user-images.githubusercontent.com/458591/225877252-c5b40d76-42d0-4677-b8d9-83b1c0fc8e6a.png">
<tr>
	<td><code>mdiAccountOutline</code>
	<td><img width="391" alt="Screenshot 2023-03-17 at 11 12 23" src="https://user-images.githubusercontent.com/458591/225877309-6c43aefb-42a9-479a-8172-7c161ea37473.png">
</table>

My favorite is the generic `mdiCogOutline`.

## Test plan

See screenshots above.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-header-tweaks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
