### PR TITLE
[fix] properly handle public repos with explicit perms and unified model

### DIFF
--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -162,7 +162,8 @@ func authzQuery(bypassAuthz, usePermissionsUserMapping bool, authenticatedUserID
 	conditions := []*sqlf.Query{unrestrictedReposQuery}
 
 	// Treat all external services as restricted when user mapping is enabled
-	if !usePermissionsUserMapping {
+	// but only if legacy permissions are used.
+	if !usePermissionsUserMapping || unifiedPermsEnabled {
 		conditions = append(conditions, ExternalServiceUnrestrictedCondition)
 	}
 

--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -161,9 +161,10 @@ func authzQuery(bypassAuthz, usePermissionsUserMapping bool, authenticatedUserID
 	unrestrictedReposQuery := GetUnrestrictedReposCond(unifiedPermsEnabled)
 	conditions := []*sqlf.Query{unrestrictedReposQuery}
 
-	// Treat all external services as restricted when user mapping is enabled
-	// but only if legacy permissions are used.
-	if !usePermissionsUserMapping || unifiedPermsEnabled {
+	// If unified permissions are enabled or explicit permissions API is disabled
+	// add a condition to check if repo is public or external service is unrestricted.
+	// Otherwise all repositories are considered as restricted, even public ones.
+	if unifiedPermsEnabled || !usePermissionsUserMapping {
 		conditions = append(conditions, ExternalServiceUnrestrictedCondition)
 	}
 


### PR DESCRIPTION
### Previous behavior

[As seen here](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@1fc50a2878c17dd0199a44acbe521726c425b449/-/blob/internal/database/repos_perm.go?L164-167) when explicit permissions are **ON**, we are turning **OFF** the condition that checks if the external service is restricted. In the same conditional logic, we are also turning **OFF** the check if the repo is public.
Which basically means, that if explicit permissions are ON, we are treating public repos as private.

That does not sound right to me 😞 

### With the fix

We use the condition for public repos and unrestricted external service even when explicit permissions are enabled. But _ONLY_ if also the new unified perms model is enabled.

This way we limit the exposure to instances that enabled the experimental feature `unifiedPermissions`.


## Test plan

Tested locally + unit tests
The feature is behind a feature flag, so expect no impact on customers.
