### PR TITLE
bazel: enable `web` and `observability-server` jest tests

### DIFF
--- a/client/observability-server/BUILD.bazel
+++ b/client/observability-server/BUILD.bazel
@@ -56,16 +56,16 @@ ts_project(
 jest_test(
     name = "test",
     data = [
-        ":observability-server_tests",
-        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css",
-        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.gz",
-        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.br",
         "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js",
-        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js",
         "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js.br",
-        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js.br",
         "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js.gz",
+        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js",
+        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js.br",
         "src/webBundleSize/__mocks__/assets/scripts/sg_home.js.gz",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.br",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.gz",
+        ":observability-server_tests",
     ],
     # TODO(bazel): requires webpack setup for testing
     tags = ["manual"],

--- a/client/observability-server/BUILD.bazel
+++ b/client/observability-server/BUILD.bazel
@@ -57,6 +57,15 @@ jest_test(
     name = "test",
     data = [
         ":observability-server_tests",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.gz",
+        "src/webBundleSize/__mocks__/assets/styles/app.123.bundle.css.br",
+        "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js",
+        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js",
+        "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js.br",
+        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js.br",
+        "src/webBundleSize/__mocks__/assets/scripts/app.bundle.js.gz",
+        "src/webBundleSize/__mocks__/assets/scripts/sg_home.js.gz",
     ],
     # TODO(bazel): requires webpack setup for testing
     tags = ["manual"],

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1846,8 +1846,6 @@ jest_test(
     data = [
         ":web_tests",
     ],
-    # TODO(bazel): enable when snapshots updated to support pre-compiled .js files
-    tags = ["manual"],
 )
 
 # webpack dev environment -------------------

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1843,6 +1843,7 @@ npm_package(
 
 jest_test(
     name = "test",
+    size = "large",
     data = [
         ":web_tests",
     ],

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -17,16 +17,16 @@ import { GET_INSIGHT_DASHBOARDS_GQL } from '../core/hooks/use-insight-dashboards
 
 import { CodeInsightsRootPage, CodeInsightsRootPageTab } from './CodeInsightsRootPage'
 
-interface ReactRouterMock {
-    useNavigate: () => unknown
+function mockRouterDom() {
+    return {
+        ...jest.requireActual('react-router-dom'),
+        useNavigate: () => ({
+            push: jest.fn(),
+        }),
+    }
 }
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual<ReactRouterMock>('react-router-dom'),
-    useNavigate: () => ({
-        push: jest.fn(),
-    }),
-}))
+jest.mock('react-router-dom', () => mockRouterDom())
 
 const mockTelemetryService = {
     log: sinon.spy(),

--- a/dev/linters/forbidigo/BUILD.bazel
+++ b/dev/linters/forbidigo/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/forbidigo",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_ashanbrown_forbidigo//forbidigo:go_default_library", #keep
-        "@com_github_ashanbrown_forbidigo//pkg/analyzer:go_default_library", #keep
+        "@com_github_ashanbrown_forbidigo//forbidigo:go_default_library",  #keep
+        "@com_github_ashanbrown_forbidigo//pkg/analyzer:go_default_library",  #keep
         "@org_golang_x_tools//go/analysis",
     ],
 )

--- a/dev/linters/gocritic/BUILD.bazel
+++ b/dev/linters/gocritic/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/gocritic",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_go_critic_go_critic//framework/linter:go_default_library", #keep
+        "@com_github_go_critic_go_critic//framework/linter:go_default_library",  #keep
         "@org_golang_x_tools//go/analysis",
     ],
 )

--- a/internal/service/svcmain/BUILD.bazel
+++ b/internal/service/svcmain/BUILD.bazel
@@ -22,5 +22,6 @@ go_library(
         "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//output",
+        "@com_github_urfave_cli_v2//:cli",
     ],
 )


### PR DESCRIPTION
## Contet

Enable all remaining jest test targets: `web` and `observability-server`.

## Test plan

CI with Bazel

## App preview:

- [Web](https://sg-web-vb-bazel-jest-tests.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
