### PR TITLE
Code navigation: impose minimum latency on goto definition

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/definition.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/definition.ts
@@ -232,7 +232,7 @@ async function goToDefinition(
             return {
                 locations: definition,
                 url: hrefTo,
-                handler: (_, startTime) => {
+                handler: (_position, startTime) => {
                     const elapsed = Date.now() - startTime
                     if (elapsed < MINIMUM_LATENCY_MILLIS) {
                         setTimeout(handler, MINIMUM_LATENCY_MILLIS - elapsed)

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -93,13 +93,14 @@ const keybindings: KeyBinding[] = [
             // show loading tooltip
             view.dispatch({ effects: setFocusedOccurrenceTooltip.of(new LoadingTooltip(offset)) })
 
+            const startTime = Date.now()
             goToDefinitionAtOccurrence(view, selected.occurrence)
                 .then(
                     ({ handler, url }) => {
                         if (view.state.field(isModifierKeyHeld) && url) {
                             window.open(url, '_blank')
                         } else {
-                            handler(selected.occurrence.range.start)
+                            handler(selected.occurrence.range.start, startTime)
                         }
                     },
                     () => {}

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -56,11 +56,13 @@ export class CodeIntelTooltip implements Tooltip {
             const instantDefinitionResult: AsyncDefinitionResult = {
                 locations: [{ uri: '' }],
                 handler: () => {},
-                asyncHandler: () =>
-                    goToDefinitionAtOccurrence(view, occurrence).then(
-                        ({ handler }) => handler(occurrence.range.start),
+                asyncHandler: () => {
+                    const startTime = Date.now()
+                    return goToDefinitionAtOccurrence(view, occurrence).then(
+                        ({ handler }) => handler(occurrence.range.start, startTime),
                         () => {}
-                    ),
+                    )
+                },
             }
             const definitionResults: Observable<AsyncDefinitionResult> = concat(
                 // Show active "Go to definition" button until we have resolved


### PR DESCRIPTION
Previously, there was no visual hint in the UI when the user cmd-clicked multiple times from the same location. This behavior felt buggy because it looks like the app is unresponsive (nothing happens) when in reality the action happened too fast and nothing changed because you already triggered the action. This situation happens frequently when the definition is already visible in the viewport and the user may not have noticed where the focus moved.

In this PR, we delay "Go to definition" for maximum 20 milliseconds when there is only a single definition. There is no delay if the request takes more than 20 milliseconds to resolve.  This 20 millisecond delay makes the focus on the definition token disappear briefly before it re-appears again making it easier to notice that something happened on cmd-click.

I recommend reviewing the diff without whitespace.

## Test plan

Start local server and cmd-click from the same local reference multiple times in a row. Notice that the definition token gets briefly unfocused on every request. Link to reproduce https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@7ddfb94479a539e711eedbb3f1c38116ee4dcdb0/-/blob/client/web/src/components/fuzzyFinder/FuzzyModal.tsx?L252

On sourcegraph.com, notice that the definition token doesn't get unfocused making it difficult to notice that something happened.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-double-definition.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
