### PR TITLE
bazel: add bazel configure step

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -108,7 +108,7 @@ sg ci build bzl
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel**: Build && Test
+- **Bazel**: Configure, Build && Test
 - Upload build trace
 
 ### Wolfi Exp Branch

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -24,13 +24,12 @@ func bazelConfigure() func(*bk.Pipeline) {
 		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
 		"configure",
-		"--remote_cache=$$CI_BAZEL_REMOTE_CACHE",
-		"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
 	}
 
 	// if there are changes diff will exit with 1, and 0 otherwise
 	gitDiff := "git diff --quiet --exit-code"
 	cmds := []bk.StepOpt{
+		bk.Key("bazel-configure"),
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 		bk.RawCmd(strings.Join(configureCmd, " ")),
@@ -48,7 +47,7 @@ func bazelConfigure() func(*bk.Pipeline) {
 // over running them in two separate jobs, so we don't build the same code twice.
 func bazelBuildAndTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.DependsOn(":bazel: Configure"),
+		bk.DependsOn("bazel-configure"),
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 	}

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -27,7 +27,7 @@ func bazelConfigure() func(*bk.Pipeline) {
 	}
 
 	// if there are changes diff will exit with 1, and 0 otherwise
-	gitDiff := "git diff --quiet --exit-code"
+	gitDiff := "git diff --exit-code"
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-configure"),
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -18,12 +18,13 @@ func BazelOperations(optional bool) *operations.Set {
 }
 
 func bazelConfigure() func(*bk.Pipeline) {
+	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	configureCmd := []string{
 		"bazel",
 		"--bazelrc=.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
-		"configure",
+		"run :gazelle",
 	}
 
 	// if there are changes diff will exit with 1, and 0 otherwise


### PR DESCRIPTION
Run `bazel run :gazelle` before even trying to `bazel build && test`. This will enable us to avoid running jobs the PR itself is outdated from a buildfile perspective. 

- Requires `bazelisk` which is added here https://github.com/sourcegraph/infrastructure/pull/4714

## Test plan

* This PR should initially fail, since there are BUILD files that need to be updated. The failure should be on the `bazel configure` step
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
