### PR TITLE
[doc] make paths formatted the same as everywhere else

### DIFF
--- a/doc/admin/executors/deploy_executors.md
+++ b/doc/admin/executors/deploy_executors.md
@@ -122,7 +122,7 @@ Once the shared secret is set in Sourcegraph, you can start setting up executors
 
 ## Confirm executors are working
 
-If executor instances boot correctly and can authenticate with the Sourcegraph frontend, they will show up in the _Executors_ page under _Site Admin_ > _Maintenance_.
+If executor instances boot correctly and can authenticate with the Sourcegraph frontend, they will show up in the **Executors** page under **Site admin > Maintenance**.
 
 ![Executor list in UI](https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.34/executor-ui-test.png)
 

--- a/doc/admin/executors/deploy_executors_kubernetes.md
+++ b/doc/admin/executors/deploy_executors_kubernetes.md
@@ -27,7 +27,7 @@ Ensure you have the following tools installed:
 2. Run `cd deploy-sourcegraph/configure/executors`.
 3. Configure the [Executor environment variables](https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables) in the `executor/executor.deployment.yaml` file.
 4. Run  `kubectl apply -f . --recursive` to deploy all components.
-5. Confirm executors are working are working by checking the _Executors_ page under _Site Admin_ > _Executors_ > _Instances_ .
+5. Confirm executors are working are working by checking the _Executors_ page under **Site admin > Executors > Instances** .
 
 #### Deployment via Helm
 
@@ -36,7 +36,7 @@ Ensure you have the following tools installed:
 3. Edit the `values.yaml` with any other customizations you may require.
 4. Run the following command:
    1. `helm upgrade --install -f values.yaml --version 4.5.1 sg-executor sourcegraph/sourcegraph-executor`
-5. Confirm executors are working are working by checking the _Executors_ page under _Site Admin_ > _Executors_ > _Instances_ .
+5. Confirm executors are working are working by checking the _Executors_ page under **Site admin > Executors > Instances** .
 
 
 For more information on the components being deployed see the [Executors readme](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/configure/executors/README.md).


### PR DESCRIPTION
[There's 50 results for using paths with bold](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+lang:Markdown+**Site+admin+%3E&patternType=standard&sm=1&groupBy=path) vs [5 results for using _Site admin_](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+lang:Markdown+%22_Site+Admin_%22&patternType=standard&case=yes&sm=1&groupBy=path) way. I think we should try to be consistent with the majority.

## Test plan

just docs changes
