### PR TITLE
Revert unnecessary nil request body checks

### DIFF
--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -108,12 +108,14 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 	queryParams.Set("api-version", apiVersion)
 	req.URL.RawQuery = queryParams.Encode()
 	req.URL = u.ResolveReference(req.URL)
+
+	var reqBody []byte
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
-	}
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return "", err
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return "", err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -108,15 +108,14 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 	queryParams.Set("api-version", apiVersion)
 	req.URL.RawQuery = queryParams.Encode()
 	req.URL = u.ResolveReference(req.URL)
-	var reqBody []byte
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
-		reqBody, err = io.ReadAll(req.Body)
-		if err != nil {
-			return "", err
-		}
-		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	// Add authentication headers for authenticated requests.
 	if err := c.auth.Authenticate(req); err != nil {
@@ -143,9 +142,7 @@ func (c *client) do(ctx context.Context, req *http.Request, urlOverride string, 
 	for c.waitForRateLimit && resp.StatusCode == http.StatusTooManyRequests &&
 		numRetries < c.maxRateLimitRetries {
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
-			if req.Body != nil {
-				req.Body = io.NopCloser(bytes.NewReader(reqBody))
-			}
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
 			resp, err = oauthutil.DoRequest(ctx, logger, c.httpClient, req, c.auth)
 			numRetries++
 		} else {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -217,15 +217,8 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 	// If the request doesn't expect a body, then including a content-type can
 	// actually cause errors on the Bitbucket side. So we need to pick apart the
 	// request just a touch to figure out if we should add the header.
-	var reqBody []byte
-	var err error
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
-		reqBody, err = io.ReadAll(req.Body)
-		if err != nil {
-			return err
-		}
-		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}
 
 	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
@@ -237,6 +230,12 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 	if err := c.rateLimit.Wait(ctx); err != nil {
 		return err
 	}
+
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	// Because we have no external rate limiting data for Bitbucket Cloud, we do an exponential
 	// back-off and retry for requests where we recieve a 429 Too Many Requests.
@@ -258,9 +257,7 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		if sleepTime.Seconds() > 160 {
 			break
 		}
-		if req.Body != nil {
-			req.Body = io.NopCloser(bytes.NewReader(reqBody))
-		}
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	}
 
 	defer resp.Body.Close()

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -217,9 +217,16 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 	// If the request doesn't expect a body, then including a content-type can
 	// actually cause errors on the Bitbucket side. So we need to pick apart the
 	// request just a touch to figure out if we should add the header.
+	var reqBody []byte
+	var err error
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
 	}
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
 		req.WithContext(ctx),
@@ -227,15 +234,9 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		nethttp.ClientTrace(false))
 	defer ht.Finish()
 
-	if err := c.rateLimit.Wait(ctx); err != nil {
+	if err = c.rateLimit.Wait(ctx); err != nil {
 		return err
 	}
-
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return err
-	}
-	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	// Because we have no external rate limiting data for Bitbucket Cloud, we do an exponential
 	// back-off and retry for requests where we recieve a 429 Too Many Requests.

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -222,9 +222,12 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		c.externalRateLimiter.WaitForRateLimit(ctx, 1) // We don't care whether we waited or not, this is a preventative measure.
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	var resp *httpResponseState

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -222,14 +222,11 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		c.externalRateLimiter.WaitForRateLimit(ctx, 1) // We don't care whether we waited or not, this is a preventative measure.
 	}
 
-	var reqBody []byte
-	if req.Body != nil {
-		reqBody, err = io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
 	}
+	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	var resp *httpResponseState
 	resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 
@@ -243,9 +240,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		errors.As(err, &apiError) && apiError.Code == http.StatusForbidden {
 		// If we end up waiting because of an external rate limit, we need to retry the request.
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
-			if req.Body != nil {
-				req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-			}
+			req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 			numRetries++
 		} else {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -245,9 +245,12 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 		_ = c.externalRateLimiter.WaitForRateLimit(ctx, 1)
 	}
 
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, 0, err
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 	req.URL = c.baseURL.ResolveReference(req.URL)

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -55,14 +55,18 @@ func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *h
 		}
 	}
 
-	if err := auther.Authenticate(req); err != nil {
+	var err error
+	if err = auther.Authenticate(req); err != nil {
 		return nil, errors.Wrap(err, "authenticating request")
 	}
 
 	// Store the body first in case we need to retry the request
-	reqBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var reqBody []byte
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	// Do first request

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -43,16 +43,6 @@ type TokenRefresher func(ctx context.Context, doer httpcli.Doer, oauthCtx OAuthC
 // it will also attempt to refresh the token in case of a 401 response.
 // If the token is updated successfully, the same request will be retried exactly once.
 func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *http.Request, auther auth.Authenticator) (*http.Response, error) {
-	// Store the body first in case we need to retry the request
-	var err error
-	var reqBody []byte
-	if req.Body != nil {
-		reqBody, err = io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-	}
 	if auther == nil {
 		return doer.Do(req.WithContext(ctx))
 	}
@@ -69,6 +59,12 @@ func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *h
 		return nil, errors.Wrap(err, "authenticating request")
 	}
 
+	// Store the body first in case we need to retry the request
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	// Do first request
 	resp, err := doer.Do(req.WithContext(ctx))
 	if err != nil {
@@ -86,9 +82,7 @@ func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *h
 			return nil, errors.Wrap(err, "authenticating request after token refresh")
 		}
 		// We need to reset the body before retrying the request
-		if req.Body != nil {
-			req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-		}
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 		resp, err = doer.Do(req.WithContext(ctx))
 	}
 


### PR DESCRIPTION
This PR reverts the checks added in https://github.com/sourcegraph/sourcegraph/pull/49542

With the proper fix merged (here: https://github.com/sourcegraph/sourcegraph/pull/49571 ), we no longer need these checks, and they only add confusion.

## Test plan

All unit tests added by the proper fix should still pass. I also verified that it still works locally with Outgoing Request Logs enabled.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
