### PR TITLE
Code Insights: Fix insight clear filters button

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -149,7 +149,14 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         contexts.input.onChange('')
         includeRegex.input.onChange('')
         excludeRegex.input.onChange('')
-        seriesDisplayOptionsField.input.onChange(originalValues.seriesDisplayOptions)
+        seriesDisplayOptionsField.input.onChange({
+            limit: null,
+            numSamples: null,
+            sortOptions: {
+                mode: SeriesSortMode.RESULT_COUNT,
+                direction: SeriesSortDirection.DESC,
+            },
+        })
     }
 
     const isHorizontalMode = visualMode === FilterSectionVisualMode.HorizontalSections


### PR DESCRIPTION
Reported in [slack](https://sourcegraph.slack.com/archives/C01RVEVPWLC/p1679055905424439)

Prior to this PR clear filters button didn't work as it should (it sets previous values for the series display option, for some reason), and as a result, it didn't clear the series display options section in case you had a series display option filter before. 


## Test plan
- Clear filters button should clear all filters (series display options as well as all other filters)
- After you cleared the filters you should see no purple dot next to filter button (because you don't have any filters applied anymore)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
