### PR TITLE
rbac: protect batch changes bulk actions resolvers

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1090,7 +1090,7 @@ func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1342,7 +1342,7 @@ func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.De
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1381,7 +1381,7 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1429,7 +1429,7 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1468,7 +1468,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1510,7 +1510,7 @@ func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.Clo
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1551,7 +1551,7 @@ func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.P
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1823,7 +1823,7 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1962,7 +1962,7 @@ func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbac
 		return nil, err
 	}
 
-	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1090,6 +1090,10 @@ func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+		return nil, err
+	}
+
 	changesetID, err := unmarshalChangesetID(args.Changeset)
 	if err != nil {
 		return nil, err
@@ -1338,6 +1342,10 @@ func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.De
 		return nil, err
 	}
 
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+		return nil, err
+	}
+
 	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
 	if err != nil {
 		return nil, err
@@ -1370,6 +1378,10 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 		tr.Finish()
 	}()
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1417,6 +1429,10 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 		return nil, err
 	}
 
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+		return nil, err
+	}
+
 	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
 	if err != nil {
 		return nil, err
@@ -1449,6 +1465,10 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 		tr.Finish()
 	}()
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1490,6 +1510,10 @@ func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.Clo
 		return nil, err
 	}
 
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+		return nil, err
+	}
+
 	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
 	if err != nil {
 		return nil, err
@@ -1524,6 +1548,10 @@ func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.P
 		tr.Finish()
 	}()
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 
@@ -1795,6 +1823,10 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 		return nil, err
 	}
 
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
+		return nil, err
+	}
+
 	var workspaceIDs []int64
 	for _, raw := range args.BatchSpecWorkspaces {
 		id, err := unmarshalBatchSpecWorkspaceID(raw)
@@ -1927,6 +1959,10 @@ func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbac
 	}()
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
+		return nil, err
+	}
+
+	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), br.BatchChangesWritePermission); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -189,7 +189,7 @@ func TestCreateBatchSpec(t *testing.T) {
 		userID         int32
 		unauthorized   bool
 	}{
-		"unauthorized user": {
+		"unauthorized access": {
 			changesetSpecs: []*btypes.ChangesetSpec{},
 			licenseInfo:    licensingInfo("starter"),
 			wantErr:        true,
@@ -398,7 +398,7 @@ func TestCreateBatchSpecFromRaw(t *testing.T) {
 		"batchChange": batchChangeID,
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ CreateBatchSpecFromRaw apitest.BatchSpec }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 
@@ -506,7 +506,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 		"changesetSpec": bt.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID), "d34db33f"),
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ CreateChangesetSpec apitest.ChangesetSpec }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateChangesetSpec)
@@ -604,7 +604,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 		},
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ CreateChangesetSpecs []apitest.ChangesetSpec }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateChangesetSpecs)
@@ -747,7 +747,7 @@ func TestApplyBatchChange(t *testing.T) {
 		"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ ApplyBatchChange apitest.BatchChange }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationApplyBatchChange)
@@ -886,7 +886,7 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 		"name":      "my-batch-change",
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ CreateEmptyBatchChange apitest.BatchChange }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateEmptyBatchChange)
@@ -994,7 +994,7 @@ func TestUpsertEmptyBatchChange(t *testing.T) {
 		"name":      "my-batch-change",
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ UpsertEmptyBatchChange apitest.BatchChange }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationUpsertEmptyBatchChange)
@@ -1094,7 +1094,7 @@ func TestCreateBatchChange(t *testing.T) {
 		"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ CreateBatchChange apitest.BatchChange }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateBatchChange)
@@ -1255,7 +1255,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 			Published: true,
 		})
 
-		t.Run("unauthorized user", func(t *testing.T) {
+		t.Run("unauthorized access", func(t *testing.T) {
 			input := map[string]any{
 				"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
 				"publicationStates": map[string]any{
@@ -1452,7 +1452,7 @@ func TestApplyBatchChangeWithLicenseFail(t *testing.T) {
 			numChangesets: 11,
 		},
 		{
-			name:           "Unauthorized user",
+			name:           "unauthorized access",
 			numChangesets:  1,
 			isunauthorized: true,
 		},
@@ -1567,7 +1567,7 @@ func TestMoveBatchChange(t *testing.T) {
 		"newName":     newBatchChagneName,
 	}
 
-	t.Run("unauthorized user", func(t *testing.T) {
+	t.Run("unauthorized access", func(t *testing.T) {
 		var response struct{ MoveBatchChange apitest.BatchChange }
 		actorCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
 		errs := apitest.Exec(actorCtx, t, s, input, &response, mutationMoveBatchChange)
@@ -2052,6 +2052,12 @@ func TestCreateChangesetComments(t *testing.T) {
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
+	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
+	// to create Batch Changes.
+	assignBatchChangesWritePermissionToUser(ctx, t, db, userID)
+
+	unauthorizedUser := bt.CreateTestUser(t, db, false)
+
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-comments", userID, 0)
 	otherBatchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-comments-other", userID, 0)
 	batchChange := bt.CreateBatchChange(t, ctx, bstore, "test-comments", userID, batchSpec.ID)
@@ -2086,6 +2092,19 @@ func TestCreateChangesetComments(t *testing.T) {
 		CreateChangesetComments apitest.BulkOperation
 	}
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+	t.Run("unauthorized access", func(t *testing.T) {
+		input := generateInput()
+		unauthorizedCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
+		errs := apitest.Exec(unauthorizedCtx, t, s, input, &response, mutationCreateChangesetComments)
+		if errs == nil {
+			t.Fatal("expected error")
+		}
+		firstErr := errs[0]
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+			t.Fatalf("expected unauthorized error, got %+v", err)
+		}
+	})
 
 	t.Run("empty body fails", func(t *testing.T) {
 		input := generateInput()
@@ -2153,6 +2172,12 @@ func TestReenqueueChangesets(t *testing.T) {
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
+	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
+	// to create Batch Changes.
+	assignBatchChangesWritePermissionToUser(ctx, t, db, userID)
+
+	unauthorizedUser := bt.CreateTestUser(t, db, false)
+
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-reenqueue", userID, 0)
 	otherBatchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-reenqueue-other", userID, 0)
 	batchChange := bt.CreateBatchChange(t, ctx, bstore, "test-reenqueue", userID, batchSpec.ID)
@@ -2195,6 +2220,20 @@ func TestReenqueueChangesets(t *testing.T) {
 		ReenqueueChangesets apitest.BulkOperation
 	}
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+	t.Run("unauthorized access", func(t *testing.T) {
+		unauthorizedCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
+		input := generateInput()
+		input["changesets"] = []string{string(bgql.MarshalChangesetID(successfulChangeset.ID))}
+		errs := apitest.Exec(unauthorizedCtx, t, s, input, &response, mutationReenqueueChangesets)
+		if errs == nil {
+			t.Fatal("expected error")
+		}
+		firstErr := errs[0]
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+			t.Fatalf("expected unauthorized error, got %+v", err)
+		}
+	})
 
 	t.Run("0 changesets fails", func(t *testing.T) {
 		input := generateInput()
@@ -2484,6 +2523,12 @@ func TestPublishChangesets(t *testing.T) {
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
+	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
+	// to create Batch Changes.
+	assignBatchChangesWritePermissionToUser(ctx, t, db, userID)
+
+	unauthorizedUser := bt.CreateTestUser(t, db, false)
+
 	batchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-close", userID, 0)
 	otherBatchSpec := bt.CreateBatchSpec(t, ctx, bstore, "test-close-other", userID, 0)
 	batchChange := bt.CreateBatchChange(t, ctx, bstore, "test-close", userID, batchSpec.ID)
@@ -2554,6 +2599,19 @@ func TestPublishChangesets(t *testing.T) {
 		PublishChangesets apitest.BulkOperation
 	}
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
+
+	t.Run("unauthorized access", func(t *testing.T) {
+		unauthorizedCtx := actor.WithActor(ctx, actor.FromUser(unauthorizedUser.ID))
+		input := generateInput()
+		errs := apitest.Exec(unauthorizedCtx, t, s, input, &response, mutationPublishChangesets)
+		if errs == nil {
+			t.Fatal("expected error")
+		}
+		firstErr := errs[0]
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+			t.Fatalf("expected unauthorized error, got %+v", err)
+		}
+	})
 
 	t.Run("0 changesets fails", func(t *testing.T) {
 		input := generateInput()

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -2101,7 +2101,7 @@ func TestCreateChangesetComments(t *testing.T) {
 			t.Fatal("expected error")
 		}
 		firstErr := errs[0]
-		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", rbac.BatchChangesWritePermission)) {
 			t.Fatalf("expected unauthorized error, got %+v", err)
 		}
 	})
@@ -2230,7 +2230,7 @@ func TestReenqueueChangesets(t *testing.T) {
 			t.Fatal("expected error")
 		}
 		firstErr := errs[0]
-		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", rbac.BatchChangesWritePermission)) {
 			t.Fatalf("expected unauthorized error, got %+v", err)
 		}
 	})
@@ -2360,7 +2360,7 @@ func TestMergeChangesets(t *testing.T) {
 			t.Fatal("expected error")
 		}
 		firstErr := errs[0]
-		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", rbac.BatchChangesWritePermission)) {
 			t.Fatalf("expected unauthorized error, got %+v", err)
 		}
 	})
@@ -2490,7 +2490,7 @@ func TestCloseChangesets(t *testing.T) {
 			t.Fatal("expected error")
 		}
 		firstErr := errs[0]
-		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", rbac.BatchChangesWritePermission)) {
 			t.Fatalf("expected unauthorized error, got %+v", err)
 		}
 	})
@@ -2646,7 +2646,7 @@ func TestPublishChangesets(t *testing.T) {
 			t.Fatal("expected error")
 		}
 		firstErr := errs[0]
-		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", br.BatchChangesWritePermission)) {
+		if !strings.Contains(firstErr.Error(), fmt.Sprintf("user is missing permission %s", rbac.BatchChangesWritePermission)) {
 			t.Fatalf("expected unauthorized error, got %+v", err)
 		}
 	})


### PR DESCRIPTION
This PR adds an extra layer of RBAC protection to Bulk Operations. While testing, we noticed that users without the required permission could perform bulk operations.

Examples of bulk operation errors from an authenticated context.

* Close Changesets
<img width="584" alt="CleanShot 2023-03-17 at 17 48 21@2x" src="https://user-images.githubusercontent.com/25608335/225967900-b5c2f365-63f0-417c-9df9-cf633b00c326.png">

* Publish Changesets
<img width="631" alt="CleanShot 2023-03-17 at 17 48 31@2x" src="https://user-images.githubusercontent.com/25608335/225967869-ccff6850-7545-4f39-a741-cbbc3d43d33c.png">

* Create Comment
<img width="549" alt="CleanShot 2023-03-17 at 17 48 12@2x" src="https://user-images.githubusercontent.com/25608335/225967913-daa6e0f7-9a8e-4342-bdac-51e6bcbabb61.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manual test
* Add unit tests