### PR TITLE
migrator: errors.As requires pointer as input

### DIFF
--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -498,7 +498,7 @@ pollIndexStatusLoop:
 				if err == nil {
 					return err
 				}
-				if !errors.As(err, pgErr) || pgErr.Code != "42P07" {
+				if !errors.As(err, &pgErr) || pgErr.Code != "42P07" {
 					return err
 				}
 


### PR DESCRIPTION
I ran into a panic locally which pointed at this line:

```
panic: errors.As: target must be a non-nil pointer, found pgconn.PgError
...snip
github.com/sourcegraph/sourcegraph/internal/database/migration/runner.(*Runner).createIndexConcurrently.func3({0x63afbe0, 0xc002cda2d0})
/home/keegan/src/github.com/sourcegraph/sourcegraph/internal/database/migration/runner/run.go:501 +0x79
```

Test Plan: I'm unsure how to get that code path executing again, so just assuming this is correct by inspection.
