### PR TITLE
Background jobs: fix Invalid time format issue

### DIFF
--- a/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
@@ -416,7 +416,8 @@ const StartedStoppedIndicator: React.FunctionComponent<{ routine: BackgroundRout
     const mostRecentRunDate = routine.recentRuns.length ? new Date(routine.recentRuns[0].at) : null
 
     // See if this routine is stopped or not seen recently
-    const isStopped = earliestStopDateString ? earliestStopDateString >= latestStartDateString : false
+    const isStopped =
+        latestStartDateString && earliestStopDateString ? earliestStopDateString >= latestStartDateString : false
     const isUnseenInAWhile = !!(
         routine.intervalMs &&
         routine.type !== BackgroundRoutineType.DB_BACKED &&


### PR DESCRIPTION
Handling edge case when we got an "Invalid time format" error message when `lastStartedAt` is `null` but `lastStoppedAt` isn't.]

## Test plan

If CI passes I'm happy

## App preview:

- [Web](https://sg-web-dv-fix-background-jobs-invalid.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

