### PR TITLE
Don't access process.env in browser build

### DIFF
--- a/client/wildcard/src/components/Link/Link/Link.tsx
+++ b/client/wildcard/src/components/Link/Link/Link.tsx
@@ -45,7 +45,7 @@ if (process.env.NODE_ENV !== 'production') {
 /**
  * Set link component for jest tests.
  */
-if (process.env.JEST_WORKER_ID !== undefined) {
+if (typeof globalThis.process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined) {
     setLinkComponent(AnchorLink)
 }
 


### PR DESCRIPTION
Different from webpack, esbuild does not patch the global object and create a `process` object with all environment flags. Instead, they will be replaced at compile time (which I think is actually more sane because we are not in a node process environment anyways).

Because of this though, we can't simply access `process.env` because it might be undefined. Instead of changing the esbuild output, this PR adds a guard to check of `process` is defined on the global object. This is always the case in a Node env.

## Test plan

- Locally run the dev server with esbuild `DEV_WEB_BUILDER=esbuild sg start`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-global-processes-access.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
