### PR TITLE
rbac: add text on role assignment to roles page

### DIFF
--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -56,7 +56,11 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
             <PageHeader
                 className={styles.rolesPageHeader}
                 description={
-                    <>Roles represent a set of permissions that are granted to a user. Roles are currently only available for Batch Changes functionality. Use the <Link to="/site-admin/users">user administration page</Link> to assign roles.</>
+                    <>
+                        Roles represent a set of permissions that are granted to a user. Roles are currently only
+                        available for Batch Changes functionality. Use the{' '}
+                        <Link to="/site-admin/users">user administration page</Link> to assign roles.
+                    </>
                 }
                 actions={
                     <Button variant="primary" onClick={openModal}>

--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -4,7 +4,7 @@ import { mdiPlus } from '@mdi/js'
 import { groupBy, noop } from 'lodash'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { PageHeader, Button, Icon, ProductStatusBadge, ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
+import { PageHeader, Button, Icon, ProductStatusBadge, ErrorAlert, LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 
@@ -55,7 +55,9 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
             <PageTitle title="Roles - Admin" />
             <PageHeader
                 className={styles.rolesPageHeader}
-                description="Roles represent a set of permissions that are granted to a user. Roles are currently only available for Batch Changes functionality."
+                description={
+                    <>Roles represent a set of permissions that are granted to a user. Roles are currently only available for Batch Changes functionality. Use the <Link to="/site-admin/users">user administration page</Link> to assign roles.</>
+                }
                 actions={
                     <Button variant="primary" onClick={openModal}>
                         <Icon aria-hidden={true} svgPath={mdiPlus} /> Create Role


### PR DESCRIPTION
This PR adds a link to the user management page so site administrators can assign roles to users.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Manual testing.

<img width="1482" alt="CleanShot 2023-03-17 at 16 50 43@2x" src="https://user-images.githubusercontent.com/25608335/225956037-b7356d20-bcd0-4d9d-a4d9-c5e82a580381.png">

## App preview:

- [Web](https://sg-web-bo-add-instructions-for-assigning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
