### PR TITLE
codeintel: Refactor cached location resolver

### DIFF
--- a/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver.go
@@ -2,12 +2,8 @@ package sharedresolvers
 
 import (
 	"context"
-	"sync"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -17,246 +13,142 @@ import (
 
 // CachedLocationResolver resolves repositories, commits, and git tree entries and caches the resulting
 // resolvers so that the same request does not re-resolve the same repository, commit, or path multiple
-// times during execution. This cache reduces the number duplicate of database and gitserver queries for
-// definition, reference, and diagnostic queries, which return collections of results that often refer
-// to a small set of repositories, commits, and paths with a large multiplicity.
+// times during execution.
 //
-// This resolver maintains a hierarchy of caches as a way to decrease lock contention. Resolution of a
-// repository holds the top-level lock. Resolution of a commit holds a lock associated with the parent
-// repository. Similarly, resolution of a path holds a lock associated with the parent commit.
+// This cache reduces duplicate database and gitserver calls when resolving repositories, commits, or
+// locations (but does not batch or pre-fetch). Location resolvers generally have a small set of paths
+// with large multiplicity, so the savings here can be significant.
 type CachedLocationResolver struct {
-	sync.RWMutex
-	repositoryResolvers map[api.RepoID]*cachedRepositoryResolver
-	cloneURLToRepoName  CloneURLToRepoNameFunc
-	repoStore           database.RepoStore
-	gitserverClient     gitserver.Client
-	logger              log.Logger
+	repositoryCache *DoubleLockedCache[api.RepoID, cachedRepositoryResolver]
 }
 
 type cachedRepositoryResolver struct {
-	sync.RWMutex
 	repositoryResolver *RepositoryResolver
-	commitResolvers    map[string]*cachedCommitResolver
+	commitCache        *DoubleLockedCache[string, cachedCommitResolver]
 }
 
 type cachedCommitResolver struct {
-	sync.RWMutex
 	commitResolver *GitCommitResolver
-	pathResolvers  map[string]*GitTreeEntryResolver
+	dirCache       *DoubleLockedCache[string, *GitTreeEntryResolver]
+	pathCache      *DoubleLockedCache[string, *GitTreeEntryResolver]
 }
 
-type CachedLocationResolverFactory struct {
-	cloneURLToRepoName CloneURLToRepoNameFunc
-	repoStore          database.RepoStore
-	gitserverClient    gitserver.Client
-}
+func (r *GitTreeEntryResolver) RecordID() string        { return r.stat.Name() }
+func (r cachedRepositoryResolver) RecordID() api.RepoID { return r.repositoryResolver.repo.ID }
+func (r cachedCommitResolver) RecordID() string         { return string(r.commitResolver.oid) }
 
-func NewCachedLocationResolverFactory(cloneURLToRepoName CloneURLToRepoNameFunc, repoStore database.RepoStore, gitserverClient gitserver.Client) *CachedLocationResolverFactory {
-	return &CachedLocationResolverFactory{
-		cloneURLToRepoName: cloneURLToRepoName,
-		repoStore:          repoStore,
-		gitserverClient:    gitserverClient,
-	}
-}
+func NewCachedLocationResolver(
+	cloneURLToRepoName CloneURLToRepoNameFunc,
+	repoStore database.RepoStore,
+	gitserverClient gitserver.Client,
+) *CachedLocationResolver {
+	resolveRepo := func(ctx context.Context, repoID api.RepoID) (*RepositoryResolver, error) {
+		repo, err := repoStore.Get(ctx, repoID)
+		if err != nil {
+			if errcode.IsNotFound(err) {
+				return nil, nil
+			}
 
-func (f *CachedLocationResolverFactory) Create() *CachedLocationResolver {
-	return NewCachedLocationResolver(f.cloneURLToRepoName, f.repoStore, f.gitserverClient)
-}
+			return nil, err
+		}
 
-// NewCachedLocationResolver creates a location resolver with an empty cache.
-func NewCachedLocationResolver(cloneURLToRepoName CloneURLToRepoNameFunc, repoStore database.RepoStore, gitserverClient gitserver.Client) *CachedLocationResolver {
-	return &CachedLocationResolver{
-		logger:              log.Scoped("CachedLocationResolver", ""),
-		cloneURLToRepoName:  cloneURLToRepoName,
-		repoStore:           repoStore,
-		gitserverClient:     gitserverClient,
-		repositoryResolvers: map[api.RepoID]*cachedRepositoryResolver{},
-	}
-}
-
-// Repository resolves the repository with the given identifier. This method may return a nil resolver
-// if the repository is not known by gitserver - this happens if there is exists still a bundle for a
-// repo that has since been deleted.
-func (r *CachedLocationResolver) Repository(ctx context.Context, id api.RepoID) (*RepositoryResolver, error) {
-	resolver, err := r.cachedRepository(ctx, id)
-	if err != nil || resolver == nil {
-		return nil, err
-	}
-	return resolver.repositoryResolver, nil
-}
-
-// Commit resolves the git commit with the given repository identifier and commit hash. This method may
-// return a nil resolver if the commit is not known by gitserver.
-func (r *CachedLocationResolver) Commit(ctx context.Context, id api.RepoID, commit string) (*GitCommitResolver, error) {
-	resolver, err := r.cachedCommit(ctx, id, commit)
-	if err != nil || resolver == nil {
-		return nil, err
-	}
-	return resolver.commitResolver, nil
-}
-
-// Path resolves the git tree entry with the given repository identifier, commit hash, and relative path.
-// This method may return a nil resolver if the commit is not known by gitserver.
-func (r *CachedLocationResolver) Path(ctx context.Context, id api.RepoID, commit, path string, isDir bool) (*GitTreeEntryResolver, error) {
-	return r.cachedPath(ctx, id, commit, path, isDir)
-}
-
-// cachedRepository resolves the repository with the given identifier if the resulting resolver does not
-// already exist in the cache. The cache is tested/populated with double-checked locking, which ensures
-// that the resolver is created exactly once per GraphQL request.
-//
-// See https://en.wikipedia.org/wiki/Double-checked_locking.
-func (r *CachedLocationResolver) cachedRepository(ctx context.Context, id api.RepoID) (*cachedRepositoryResolver, error) {
-	// Fast-path cache check
-	r.RLock()
-	cachedResolver, ok := r.repositoryResolvers[id]
-	r.RUnlock()
-	if ok {
-		return cachedResolver, nil
+		return NewRepositoryResolver(repo), nil
 	}
 
-	r.Lock()
-	defer r.Unlock()
+	resolveCommit := func(ctx context.Context, repositoryResolver *RepositoryResolver, commit string) (*GitCommitResolver, error) {
+		commitID, err := gitserverClient.ResolveRevision(ctx, repositoryResolver.repo.Name, commit, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+		if err != nil {
+			if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+				return nil, nil
+			}
+			return nil, err
+		}
 
-	// Check again once locked to avoid race
-	if cachedResolver, ok := r.repositoryResolvers[id]; ok {
-		return cachedResolver, nil
+		commitResolver := NewGitCommitResolver(repositoryResolver, commitID)
+		commitResolver.inputRev = &commit
+		return commitResolver, nil
 	}
 
-	// Resolve new value and store in cache
-	repositoryResolver, err := r.resolveRepository(ctx, id)
-	if err != nil {
-		return nil, err
+	resolvePath := func(commitResolver *GitCommitResolver, path string, isDir bool) *GitTreeEntryResolver {
+		return NewGitTreeEntryResolver(cloneURLToRepoName, commitResolver, CreateFileInfo(path, isDir))
 	}
 
-	// Ensure value written to the cache is nil and not a nil resolver wrapped in a non-nil cached
-	// commit resolver. Otherwise, a subsequent resolution of a path may result in a nil dereference.
-	if repositoryResolver != nil {
-		cachedResolver = &cachedRepositoryResolver{
+	resolveRepositoryCached := func(ctx context.Context, repoID api.RepoID) (*cachedRepositoryResolver, error) {
+		repositoryResolver, err := resolveRepo(ctx, repoID)
+		if err != nil || repositoryResolver == nil {
+			return nil, err
+		}
+
+		resolveCommitCached := func(ctx context.Context, commit string) (*cachedCommitResolver, error) {
+			commitResolver, err := resolveCommit(ctx, repositoryResolver, commit)
+			if err != nil || commitResolver == nil {
+				return nil, err
+			}
+
+			return &cachedCommitResolver{
+				commitResolver: commitResolver,
+				dirCache: NewDoubleLockedCache(MultiFactoryFromFactoryFunc(func(ctx context.Context, path string) (*GitTreeEntryResolver, error) {
+					return resolvePath(commitResolver, path, true), nil
+				})),
+				pathCache: NewDoubleLockedCache(MultiFactoryFromFactoryFunc(func(ctx context.Context, path string) (*GitTreeEntryResolver, error) {
+					return resolvePath(commitResolver, path, false), nil
+				})),
+			}, nil
+		}
+
+		return &cachedRepositoryResolver{
 			repositoryResolver: repositoryResolver,
-			commitResolvers:    map[string]*cachedCommitResolver{},
-		}
+			commitCache:        NewDoubleLockedCache(MultiFactoryFromFallibleFactoryFunc(resolveCommitCached)),
+		}, nil
 	}
-	r.repositoryResolvers[id] = cachedResolver
-	return cachedResolver, nil
+
+	return &CachedLocationResolver{
+		repositoryCache: NewDoubleLockedCache(MultiFactoryFromFallibleFactoryFunc(resolveRepositoryCached)),
+	}
 }
 
-// cachedCommit resolves the commit with the given repository identifier and commit hash if the resulting
-// resolver does not already exist in the cache. The cache is tested/populated with double-checked locking,
-// which ensures that the resolver is created exactly once per GraphQL request.
-//
-// See https://en.wikipedia.org/wiki/Double-checked_locking.
-func (r *CachedLocationResolver) cachedCommit(ctx context.Context, id api.RepoID, commit string) (*cachedCommitResolver, error) {
-	repositoryResolver, err := r.cachedRepository(ctx, id)
-	if err != nil || repositoryResolver == nil {
+// Repository resolves (once) the given repository. May return nil if the repository is not available.
+func (r *CachedLocationResolver) Repository(ctx context.Context, id api.RepoID) (*RepositoryResolver, error) {
+	repositoryWrapper, ok, err := r.repositoryCache.GetOrLoad(ctx, id)
+	if err != nil || !ok {
 		return nil, err
 	}
 
-	// Fast-path cache check
-	repositoryResolver.RLock()
-	cachedResolver, ok := repositoryResolver.commitResolvers[commit]
-	repositoryResolver.RUnlock()
-	if ok {
-		return cachedResolver, nil
-	}
-
-	repositoryResolver.Lock()
-	defer repositoryResolver.Unlock()
-
-	// Check again once locked to avoid race
-	if cachedResolver, ok := repositoryResolver.commitResolvers[commit]; ok {
-		return cachedResolver, nil
-	}
-
-	// Resolve new value and store in cache
-	commitResolver, err := r.resolveCommit(ctx, repositoryResolver.repositoryResolver, commit)
-	if err != nil {
-		return nil, err
-	}
-
-	// Ensure value written to the cache is nil and not a nil resolver wrapped in a non-nil cached
-	// commit resolver. Otherwise, a subsequent resolution of a path may result in a nil dereference.
-	if commitResolver != nil {
-		cachedResolver = &cachedCommitResolver{
-			commitResolver: commitResolver,
-			pathResolvers:  map[string]*GitTreeEntryResolver{},
-		}
-	}
-	repositoryResolver.commitResolvers[commit] = cachedResolver
-	return cachedResolver, nil
+	return repositoryWrapper.repositoryResolver, nil
 }
 
-// cachedPath resolves the commit with the given repository identifier, commit hash, and relative path
-// if the resulting resolver does not already exist in the cache. The cache is tested/populated with
-// double-checked locking, which ensures that the resolver is created exactly once per GraphQL request.
-//
-// See https://en.wikipedia.org/wiki/Double-checked_locking.
-func (r *CachedLocationResolver) cachedPath(ctx context.Context, id api.RepoID, commit, path string, isDir bool) (*GitTreeEntryResolver, error) {
-	commitResolver, err := r.cachedCommit(ctx, id, commit)
-	if err != nil || commitResolver == nil {
+// Commit resolves (once) the given repository and commit. May return nil if the repository or commit is unknown.
+func (r *CachedLocationResolver) Commit(ctx context.Context, id api.RepoID, commit string) (*GitCommitResolver, error) {
+	repositoryWrapper, ok, err := r.repositoryCache.GetOrLoad(ctx, id)
+	if err != nil || !ok {
 		return nil, err
 	}
 
-	// Fast-path cache check
-	commitResolver.Lock()
-	cachedResolver, ok := commitResolver.pathResolvers[path]
-	commitResolver.Unlock()
-	if ok {
-		return cachedResolver, nil
+	commitWrapper, ok, err := repositoryWrapper.commitCache.GetOrLoad(ctx, commit)
+	if err != nil || !ok {
+		return nil, err
 	}
 
-	commitResolver.Lock()
-	defer commitResolver.Unlock()
-
-	// Check again once locked to avoid race
-	if cachedResolver, ok := commitResolver.pathResolvers[path]; ok {
-		return cachedResolver, nil
-	}
-
-	// Resolve new value and store in cache
-	pathResolver := r.resolvePath(commitResolver.commitResolver, path, isDir)
-	commitResolver.pathResolvers[path] = pathResolver
-	return pathResolver, nil
+	return commitWrapper.commitResolver, nil
 }
 
-// Repository resolves the repository with the given identifier. This method may return a nil resolver
-// if the repository is not known by gitserver - this happens if there is exists still a bundle for a
-// repo that has since been deleted. This method must be called only when constructing a resolver to
-// populate the cache.
-func (r *CachedLocationResolver) resolveRepository(ctx context.Context, id api.RepoID) (*RepositoryResolver, error) {
-	repo, err := r.repoStore.Get(ctx, id)
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil, nil
-		}
+// Path resolves (once) the given repository, commit, and path. May return nil if the repository, commit, or path is unknown.
+func (r *CachedLocationResolver) Path(ctx context.Context, id api.RepoID, commit, path string, isDir bool) (*GitTreeEntryResolver, error) {
+	repositoryWrapper, ok, err := r.repositoryCache.GetOrLoad(ctx, id)
+	if err != nil || !ok {
 		return nil, err
 	}
 
-	return NewRepositoryResolver(repo), nil
-}
-
-// Commit resolves the git commit with the given repository resolver and commit hash. This method may
-// return a nil resolver if the commit is not known by gitserver. This method must be called only when
-// constructing a resolver to populate the cache.
-func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryResolver *RepositoryResolver, commit string) (*GitCommitResolver, error) {
-	repo, err := repositoryResolver.Type(ctx)
-	if err != nil {
+	commitWrapper, ok, err := repositoryWrapper.commitCache.GetOrLoad(ctx, commit)
+	if err != nil || !ok {
 		return nil, err
 	}
 
-	commitID, err := r.gitserverClient.ResolveRevision(ctx, repo.Name, commit, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
-	if err != nil {
-		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-			return nil, nil
-		}
-		return nil, err
+	cache := commitWrapper.pathCache
+	if isDir {
+		cache = commitWrapper.dirCache
 	}
 
-	return repositoryResolver.commitFromID(&resolverstubs.RepositoryCommitArgs{Rev: commit}, commitID)
-}
-
-// Path resolves the git tree entry with the given commit resolver and relative path. This method must be
-// called only when constructing a resolver to populate the cache.
-func (r *CachedLocationResolver) resolvePath(commitResolver *GitCommitResolver, path string, isDir bool) *GitTreeEntryResolver {
-	return NewGitTreeEntryResolver(r.cloneURLToRepoName, commitResolver, CreateFileInfo(path, isDir))
+	resolver, _, err := cache.GetOrLoad(ctx, path)
+	return resolver, err
 }

--- a/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver_factory.go
+++ b/enterprise/internal/codeintel/shared/resolvers/cached_location_resolver_factory.go
@@ -1,0 +1,24 @@
+package sharedresolvers
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+type CachedLocationResolverFactory struct {
+	cloneURLToRepoName CloneURLToRepoNameFunc
+	repoStore          database.RepoStore
+	gitserverClient    gitserver.Client
+}
+
+func NewCachedLocationResolverFactory(cloneURLToRepoName CloneURLToRepoNameFunc, repoStore database.RepoStore, gitserverClient gitserver.Client) *CachedLocationResolverFactory {
+	return &CachedLocationResolverFactory{
+		cloneURLToRepoName: cloneURLToRepoName,
+		repoStore:          repoStore,
+		gitserverClient:    gitserverClient,
+	}
+}
+
+func (f *CachedLocationResolverFactory) Create() *CachedLocationResolver {
+	return NewCachedLocationResolver(f.cloneURLToRepoName, f.repoStore, f.gitserverClient)
+}

--- a/enterprise/internal/codeintel/shared/resolvers/repository_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/repository_resolver.go
@@ -43,10 +43,6 @@ func (r *RepositoryResolver) Type(ctx context.Context) (*types.Repo, error) {
 }
 
 func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *resolverstubs.RepositoryCommitArgs, commitID api.CommitID) (resolverstubs.GitCommitResolver, error) {
-	return r.commitFromID(args, commitID)
-}
-
-func (r *RepositoryResolver) commitFromID(args *resolverstubs.RepositoryCommitArgs, commitID api.CommitID) (*GitCommitResolver, error) {
 	resolver := NewGitCommitResolver(r, commitID)
 	if args.InputRevspec != nil {
 		resolver.inputRev = args.InputRevspec


### PR DESCRIPTION
Rewrite the shared cached location resolver to use the recently added double-locked cache utils.

## Test plan

Unit tests.