### PR TITLE
insights: return a list of zeroes even if we have no data at all?

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -745,11 +745,10 @@ func (s *Store) augmentSeriesPoints(ctx context.Context, opts SeriesPointsOpts, 
 	if err != nil {
 		return nil, errors.Wrap(err, "GetInsightSeriesRecordingTimes")
 	}
-	var augmentedPoints []SeriesPoint
-	if len(recordingsData.RecordingTimes) > 0 {
-		augmentedPoints = coalesceZeroValues(*opts.SeriesID, pointsMap, captureValues, recordingsData.RecordingTimes)
+	if len(captureValues) == 0 {
+		captureValues[""] = struct{}{}
 	}
-	return augmentedPoints, nil
+	return coalesceZeroValues(*opts.SeriesID, pointsMap, captureValues, recordingsData.RecordingTimes), nil
 }
 
 func coalesceZeroValues(seriesID string, pointsMap map[string]*SeriesPoint, captureValues map[string]struct{}, recordingTimes []types.RecordingTime) []SeriesPoint {


### PR DESCRIPTION
follow up on #feedback-dogfood convo: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1679064801534999

<img width="473" alt="image" src="https://user-images.githubusercontent.com/29406849/225963731-7c5ad654-e5fd-4b5f-bc5f-8ffa9bfbe6e9.png">

before:
<img width="767" alt="Screenshot 2023-03-17 at 16 28 51" src="https://user-images.githubusercontent.com/29406849/225963892-9f252901-2db0-4cfe-8995-dc2dfa279d74.png">

after:
<img width="760" alt="Screenshot 2023-03-17 at 16 28 09" src="https://user-images.githubusercontent.com/29406849/225963918-3ad875b7-cdcf-4308-b5b1-e8230817f3e6.png">


Maybe we could have a client check such that if there are no results at all we still return the no data to display card. what is preferred?

## Test plan

manual tests, would have to do more testing
