### PR TITLE
insights: Update fetch policy for all insights view so it picks up new insights

### DIFF
--- a/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
+++ b/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
@@ -35,7 +35,7 @@ export const AllInsightsView: FC<AllInsightsViewProps> = props => {
 
             return insightViews
         },
-        options: { fetchPolicy: 'cache-first' },
+        options: { fetchPolicy: 'cache-and-network' },
     })
 
     if (connection === undefined) {


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/44960

When creating a new insight they are not visible on the All Insights page until the user refreshes the page, because the page is relying on the cache. This change instructs the page to return with the cache but also run a new network request to update data.
## Test plan
Create a new insight 
return to all insights page ensure the new insight is visible.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
