### PR TITLE
Code monitors: fixes and cleanup

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -179,12 +179,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, triggerJob 
 		return errors.Wrap(err, "query settings")
 	}
 
-	query := q.QueryString
-	if !featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
-		// Only add an after filter when repo-aware monitors is disabled
-		query = newQueryWithAfterFilter(q)
-	}
-	results, searchErr := codemonitors.Search(ctx, logger, r.db, r.enterpriseJobs, query, m.ID, settings)
+	results, searchErr := codemonitors.Search(ctx, logger, r.db, r.enterpriseJobs, q.QueryString, m.ID, settings)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)
@@ -199,7 +194,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, triggerJob 
 	}
 
 	// Log the actual query we ran and whether we got any new results.
-	err = cm.UpdateTriggerJobWithResults(ctx, triggerJob.ID, query, results)
+	err = cm.UpdateTriggerJobWithResults(ctx, triggerJob.ID, q.QueryString, results)
 	if err != nil {
 		return errors.Wrap(err, "UpdateTriggerJobWithResults")
 	}

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -130,39 +129,12 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 		return nil, errcode.MakeNonRetryable(err)
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
-		hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, doSearch commit.DoSearchFunc) error {
-			return hookWithID(ctx, db, logger, gs, monitorID, repoID, args, doSearch)
-		}
-		{
-			// This block is a transitional block that can be removed in a
-			// future version. We need this block to exist when we transition
-			// from timestamp-based code monitors to commit-hash-based
-			// (repo-aware) code monitors.
-			//
-			// When we flip the switch to repo-aware, all existing code
-			// monitors will start executing as repo-aware code monitors.
-			// Without this block, this  would mean all repos would be detected
-			// as "unsearched" and we would start searching from the beginning
-			// of the repo's history, flooding every code monitor user with a
-			// notification with many results.
-			//
-			// Instead, this detects if this monitor has ever been run as a
-			// repo-aware monitor before and snapshots the current state of the
-			// searched repos rather than searching them.
-			hasAnyLastSearched, err := edb.NewEnterpriseDB(db).CodeMonitors().HasAnyLastSearched(ctx, monitorID)
-			if err != nil {
-				return nil, err
-			} else if !hasAnyLastSearched {
-				hook = func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, _ commit.DoSearchFunc) error {
-					return snapshotHook(ctx, db, gs, args, monitorID, repoID)
-				}
-			}
-		}
-		planJob, err = addCodeMonitorHook(planJob, hook)
-		if err != nil {
-			return nil, errcode.MakeNonRetryable(err)
-		}
+	hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, doSearch commit.DoSearchFunc) error {
+		return hookWithID(ctx, db, logger, gs, monitorID, repoID, args, doSearch)
+	}
+	planJob, err = addCodeMonitorHook(planJob, hook)
+	if err != nil {
+		return nil, errcode.MakeNonRetryable(err)
 	}
 
 	// Execute the search

--- a/enterprise/internal/database/code_monitor_trigger_jobs.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs.go
@@ -39,9 +39,12 @@ func (r *TriggerJob) RecordID() int {
 const enqueueTriggerQueryFmtStr = `
 WITH due AS (
     SELECT cm_queries.id as id
-    FROM cm_queries INNER JOIN cm_monitors ON cm_queries.monitor = cm_monitors.id
+    FROM cm_queries
+    JOIN cm_monitors ON cm_queries.monitor = cm_monitors.id
+    JOIN users ON cm_monitors.namespace_user_id = users.id
     WHERE (cm_queries.next_run <= clock_timestamp() OR cm_queries.next_run IS NULL)
-    AND cm_monitors.enabled = true
+        AND cm_monitors.enabled = true
+        AND users.deleted_at IS NULL
 ),
 busy AS (
     SELECT DISTINCT query as id FROM cm_trigger_jobs

--- a/enterprise/internal/database/code_monitor_trigger_jobs_test.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs_test.go
@@ -101,3 +101,19 @@ func TestListTriggerJobs(t *testing.T) {
 		require.Len(t, js, 1)
 	})
 }
+
+func TestEnqueueTriggerJobs(t *testing.T) {
+	logger := logtest.Scoped(t)
+	t.Run("does not enqueue jobs for deleted users", func(t *testing.T) {
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+		f := populateCodeMonitorFixtures(t, db)
+
+		err := db.Users().Delete(ctx, f.User.ID)
+		require.NoError(t, err)
+
+		jobs, err := db.CodeMonitors().EnqueueQueryTriggerJobs(ctx)
+		require.NoError(t, err)
+		require.Len(t, jobs, 0)
+	})
+}


### PR DESCRIPTION
This PR is composed of three commits: 
1) Skip running code monitors if the user is deleted. This will always fail, and will end up in a retry loop.
2) Stop running all code monitors in a transaction. In particular, when the transaction is rolled back, the "next run" time is unset, which puts us in another retry loop.
3) Remove transitional code. The feature flag has been enabled by default for quite a while now, and there are no plans to disable it.

Follow up from [this thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1678322373363769).

This does not fix the problem that invalid queries will always error, but it should ensure they don't run in a hot retry loop.

## Test plan

Added a test that we now skip monitors for deleted users.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
