### PR TITLE
gRPC: log on dial

### DIFF
--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -6,6 +6,7 @@ package defaults
 
 import (
 	"context"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -30,6 +31,7 @@ func Dial(addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, err
 
 // DialContext creates a client connection to the given target with the default options.
 func DialContext(ctx context.Context, addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	log.Scoped("grpc", "").Info("dialing gRPC", log.String("stack", string(debug.Stack())))
 	return grpc.DialContext(ctx, addr, append(DialOptions(), additionalOpts...)...)
 }
 

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -72,7 +71,7 @@ func NewClient(serverURL string) *Client {
 			if err != nil {
 				return nil, err
 			}
-			conn, err := grpc.Dial(u.Host, defaults.DialOptions()...)
+			conn, err := defaults.Dial(u.Host)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
We're having trouble tracking down where repeated dials are coming from, so this logs every time we dial a new connection. This should not be a high volume log since we try to dial once per service. 

## Test plan

Checked that the log shows up on startup locally. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
