### PR TITLE
rbac: disable batch_changes#read permission

### DIFF
--- a/client/web/src/enterprise/rbac/components/Permissions.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.tsx
@@ -1,7 +1,10 @@
 import React, { ChangeEvent, FocusEventHandler } from 'react'
 
-import { Text, Checkbox, Grid } from '@sourcegraph/wildcard'
+import { mdiInformationOutline } from '@mdi/js'
 
+import { Text, Checkbox, Grid, Tooltip, Icon } from '@sourcegraph/wildcard'
+
+import { BatchChangesReadPermission } from '../../../rbac/constants'
 import { prettifyAction, prettifyNamespace } from '../../../util/settings'
 import { PermissionsMap, allNamespaces } from '../backend'
 
@@ -27,18 +30,45 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                 <div key={namespace}>
                     <Text className="font-weight-bold">{prettifyNamespace(namespace)}</Text>
                     <Grid columnCount={4}>
-                        {namespacePermissions.map(permission => (
-                            <Checkbox
-                                key={permission.id}
-                                label={prettifyAction(permission.action)}
-                                id={permission.displayName}
-                                checked={isChecked(permission.id)}
-                                value={permission.id}
-                                onChange={onChange}
-                                onBlur={onBlur}
-                                disabled={disabled}
-                            />
-                        ))}
+                        {namespacePermissions.map(permission => {
+                            // This is a hack to disable the BatchChangesReadPermission
+                            // from the UI for now until it's fully implemented.
+                            if (permission.displayName === BatchChangesReadPermission) {
+                                return (
+                                    <Checkbox
+                                        key={permission.id}
+                                        label={
+                                            <>
+                                                {prettifyAction(permission.action)}
+                                                <Tooltip content="Coming soon">
+                                                    <Icon
+                                                        aria-label="Batch changes read access restrictions coming soon"
+                                                        className="ml-2"
+                                                        svgPath={mdiInformationOutline}
+                                                    />
+                                                </Tooltip>
+                                            </>
+                                        }
+                                        id={permission.displayName}
+                                        checked={isChecked(permission.id)}
+                                        value={permission.id}
+                                        disabled={true}
+                                    />
+                                )
+                            }
+                            return (
+                                <Checkbox
+                                    key={permission.id}
+                                    label={prettifyAction(permission.action)}
+                                    id={permission.displayName}
+                                    checked={isChecked(permission.id)}
+                                    value={permission.id}
+                                    onChange={onChange}
+                                    onBlur={onBlur}
+                                    disabled={disabled}
+                                />
+                            )
+                        })}
                     </Grid>
                 </div>
             )


### PR DESCRIPTION
Since we've not yet implemented anything to actually enforce this permission, we've agreed to temporarily just disable it in the UI and add the "Coming soon" icon next to it. There's technically nothing stopping someone from unassigning it via the GraphQL API directly, but since it makes no difference having it assigned vs unassigned and this is only temporary until we build https://github.com/sourcegraph/sourcegraph/issues/36021, it didn't feel necessary to guard this at any deeper level.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/8942601/225987497-04d0af5e-234b-4ca2-a2ab-61d0aeae7a67.png">

I've preemptively re-assigned the batch_changes#read permission to all roles on S2 and rctest for now.

## Test plan

Storybook coverage. Tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-disable-bc-read-checkbox.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
