### PR TITLE
Sourcegraph App: Fix small UI paper cuts

### DIFF
--- a/client/web/src/components/LimitedAccessBanner.tsx
+++ b/client/web/src/components/LimitedAccessBanner.tsx
@@ -9,6 +9,7 @@ import styles from './LimitedAccessBanner.module.scss'
 interface LimitedAccessBannerProps {
     badgeText?: string
     storageKey: string
+    className?: string
 }
 
 export const LimitedAccessBanner: React.FunctionComponent<
@@ -22,7 +23,7 @@ export const LimitedAccessBanner: React.FunctionComponent<
     }
 
     return (
-        <div className={classNames('my-4 p-1', styles.banner)}>
+        <div className={classNames('p-1', styles.banner, props.className)}>
             <div className={classNames('py-2 px-3', styles.content)}>
                 <div>
                     <Badge className={classNames('mb-2', styles.badge)}>{badgeText}</Badge>

--- a/client/web/src/enterprise/app/AppComingSoonPage.module.scss
+++ b/client/web/src/enterprise/app/AppComingSoonPage.module.scss
@@ -1,5 +1,9 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
+.root {
+    height: min-content;
+}
+
 .link {
     font-size: 1rem;
     font-weight: 600;

--- a/client/web/src/enterprise/app/AppComingSoonPage.tsx
+++ b/client/web/src/enterprise/app/AppComingSoonPage.tsx
@@ -17,7 +17,7 @@ export const AppComingSoonPage: React.FC = () => {
     useEffect(() => eventLogger.logPageView('AppComingSoonPage'), [])
 
     return (
-        <Page>
+        <Page className={styles.root}>
             <PageTitle title="Coming soon" />
             <PageHeader
                 description="Exciting things are coming to Sourcegraph. Stay tuned for upcoming features."

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -180,7 +180,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 </PageHeader.Heading>
             </PageHeader>
             {isSourcegraphApp && (
-                <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.batchChanges">
+                <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.batchChanges" className="my-4">
                     Batch Changes is currently available to try for free, up to 10 changesets, while Sourcegraph App is
                     in beta. Pricing and availability for Batch Changes is subject to change in future releases.{' '}
                     <strong>

--- a/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/CodeInsightsPage.tsx
@@ -19,7 +19,7 @@ export const CodeInsightsPage: React.FunctionComponent<React.PropsWithChildren<C
 
     return (
         <Page {...props}>
-            {props.isSourcegraphApp && <CodeInsightsLimitedAccessAppBanner authenticatedUser={null} />}
+            {props.isSourcegraphApp && <CodeInsightsLimitedAccessAppBanner authenticatedUser={null} className="mb-4" />}
             {!licensed && !props.isSourcegraphApp && <CodeInsightsLimitAccessBanner className="mb-4" />}
             {props.children}
         </Page>

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -6,9 +6,10 @@ import { LimitedAccessBanner } from '../../../../../components/LimitedAccessBann
 
 interface Props {
     authenticatedUser: Pick<AuthenticatedUser, 'displayName' | 'emails'> | null | undefined
+    className?: string
 }
 export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
-    <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.codeInsights">
+    <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.codeInsights" className={props.className}>
         Code Insights is currently available to try for free, up to 2 insights, while Sourcegraph App is in beta.
         Pricing and availability for Code Insights is subject to change in future releases.{' '}
         <strong>

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -262,7 +262,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                 </PageHeader>
 
                 {isSourcegraphApp && (
-                    <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.notebooks">
+                    <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.notebooks" className="my-4">
                         Notebooks is currently available to try for free while Sourcegraph App is in beta. Pricing and
                         availability for Notebooks is subject to change in future releases.
                     </LimitedAccessBanner>


### PR DESCRIPTION
Fix small UI paper cuts for Sourcegraph App 
- Coming soon page padding (in the main version there is no padding, infamous problem with our main container `display:flex` styles)
- Adjust padding for the limited banner in code insights UI (i think because it's positioned a bit differently, we should use different spacing for different consumers of this banner)

## Test plan
- Check the coming soon page
- Check limited banner in Batch Changes, Code Insights, Code Monitoring

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
