### PR TITLE
API allows making a team root

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9721,12 +9721,19 @@ extend type Mutation {
 
     To unset the display name, pass an empty string. Null will make it ignore updates.
 
-    Either parentTeam XOR parentTeamName can be specified to make the team a child
-    team of the given parent.
+    Either parentTeam XOR parentTeamName XOR makeRoot can be specified to make the team a child
+    team of the given parent or conversely to make a team a root team (with no parent team).
     The user has to be a team-member of both the child and parent team for that, and
     neither can be read-only. Site-admin can modify all teams without constraints.
     """
-    updateTeam(id: ID, name: String, displayName: String, parentTeam: ID, parentTeamName: String): Team!
+    updateTeam(
+        id: ID
+        name: String
+        displayName: String
+        parentTeam: ID
+        parentTeamName: String
+        makeRoot: Boolean
+    ): Team!
 
     """
     Delete team deletes a team. ID or Name must be specified, but not both.

--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -413,6 +413,7 @@ type UpdateTeamArgs struct {
 	DisplayName    *string
 	ParentTeam     *graphql.ID
 	ParentTeamName *string
+	MakeRoot       *bool
 }
 
 func (r *schemaResolver) UpdateTeam(ctx context.Context, args *UpdateTeamArgs) (*TeamResolver, error) {
@@ -426,8 +427,14 @@ func (r *schemaResolver) UpdateTeam(ctx context.Context, args *UpdateTeamArgs) (
 	if args.ID != nil && args.Name != nil {
 		return nil, errors.New("team to update is identified by either id or name, but both were specified")
 	}
+	if (args.ParentTeam != nil || args.ParentTeamName != nil) && args.MakeRoot != nil {
+		return nil, errors.New("specifying a parent team contradicts making a team root (no parent team)")
+	}
 	if args.ParentTeam != nil && args.ParentTeamName != nil {
 		return nil, errors.New("parent team is identified by either id or name, but both were specified")
+	}
+	if args.MakeRoot != nil && !*args.MakeRoot {
+		return nil, errors.New("the only possible value for makeRoot is true (if set); to assign a parent team please use parentTeam or parentTeamName parameters")
 	}
 	var t *types.Team
 	err := r.db.WithTransact(ctx, func(tx database.DB) (err error) {
@@ -465,6 +472,10 @@ func (r *schemaResolver) UpdateTeam(ctx context.Context, args *UpdateTeamArgs) (
 				needsUpdate = true
 				t.ParentTeamID = parentTeam.ID
 			}
+		}
+		if args.MakeRoot != nil && *args.MakeRoot && t.ParentTeamID != 0 {
+			needsUpdate = true
+			t.ParentTeamID = 0
 		}
 		if needsUpdate {
 			return tx.Teams().UpdateTeam(ctx, t)


### PR DESCRIPTION
This change introduces `makeRoot: Boolean` parameter into `updateTeam` mutation. This allows making a team root (or top-level, no-parent-team). Previously there was no way to do this through the API.

## Test plan

GraphQL API test.

👐  https://www.loom.com/share/5d6b044772874bdaa695b9a825ce0827