### PR TITLE
insights: Only send repo criteria at the insight level

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
@@ -50,7 +50,7 @@ export function getCaptureGroupInsightCreateInput(
         dataSeries: [
             {
                 query: insight.query,
-                options: {},                
+                options: {},
                 timeScope: { stepInterval: { unit, value } },
                 generatedFromCaptureGroups: true,
             },

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/create-insight/serializators.ts
@@ -39,7 +39,7 @@ export function getCaptureGroupInsightCreateInput(
     insight: MinimalCaptureGroupInsightData,
     dashboardId: string | null
 ): LineChartSearchInsightInput {
-    const { step, repositories, repoQuery, filters, title } = insight
+    const { step, repoQuery, filters, title } = insight
     const [unit, value] = getStepInterval(step)
 
     const input: LineChartSearchInsightInput = {
@@ -50,8 +50,7 @@ export function getCaptureGroupInsightCreateInput(
         dataSeries: [
             {
                 query: insight.query,
-                options: {},
-                repositoryScope: { repositories },
+                options: {},                
                 timeScope: { stepInterval: { unit, value } },
                 generatedFromCaptureGroups: true,
             },


### PR DESCRIPTION
Detect & Track insights were sending conflicting insight and series level repo information.  This caused the series level data to override the insight level.  The series level was not including the repo search and it was being mistaken for an "all repos" insight.

resolves https://github.com/sourcegraph/sourcegraph/issues/49631

## Test plan
Create a detect & track insight with repos specified as a repo search.
After creation go to edit to view insight ensure the repo search is still specified.
Verify insight only contains data from expected repos.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-detect-track-repocriteria.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
