### PR TITLE
Close telemetry client when finished

### DIFF
--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -321,6 +321,7 @@ func sendEvents(ctx context.Context, events []*database.Event, config topicConfi
 	if err != nil {
 		return errors.Wrap(err, "pubsub.NewClient")
 	}
+	defer client.Close()
 
 	var toSend []*bigQueryEvent
 	for _, event := range events {


### PR DESCRIPTION
This seems to be the primary cause of goroutine leaks we're seeing on s2. 

## Test plan

It builds. Will follow the metrics on s2 to ensure this actually fixes the goroutine leaks.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
