### PR TITLE
batches: disable "Create batch change" search action item if user has insufficient permissions

### DIFF
--- a/client/web/src/batches/utils.ts
+++ b/client/web/src/batches/utils.ts
@@ -1,0 +1,13 @@
+import { findIndex } from 'lodash'
+
+import { AuthenticatedUser } from '../auth'
+import { BatchChangesWritePermission } from '../rbac/constants'
+
+export const canWriteBatchChanges = (user: Pick<AuthenticatedUser, 'permissions'> | null): boolean =>
+    !!user &&
+    findIndex(user.permissions.nodes, permission => permission.displayName === BatchChangesWritePermission) !== -1
+
+export const NO_ACCESS_SOURCEGRAPH_COM = 'Batch changes are not available on Sourcegraph.com.'
+export const NO_ACCESS_BATCH_CHANGES_WRITE =
+    'Your user does not have sufficient permissions to create batch changes. Contact your site admin to request access.'
+export const NO_ACCESS_NAMESPACE = 'Your user is not able to create batch changes in this namespace.'

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -9,6 +9,7 @@ import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
+import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../../batches/utils'
 import { NotFoundPage } from '../../../components/HeroPage'
 import type { BatchChangeClosePageProps } from '../close/BatchChangeClosePage'
 import type { CreateBatchChangePageProps } from '../create/CreateBatchChangePage'
@@ -16,7 +17,6 @@ import type { BatchChangeDetailsPageProps } from '../detail/BatchChangeDetailsPa
 import { TabName } from '../detail/BatchChangeDetailsTabs'
 import type { BatchChangeListPageProps, NamespaceBatchChangeListPageProps } from '../list/BatchChangeListPage'
 import type { BatchChangePreviewPageProps } from '../preview/BatchChangePreviewPage'
-import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../utils'
 
 const BatchChangeListPage = lazyComponent<BatchChangeListPageProps, 'BatchChangeListPage'>(
     () => import('../list/BatchChangeListPage'),

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -14,6 +14,7 @@ import { Button, PageHeader, Link, Container, H3, Text, screenReaderAnnounce } f
 import { AuthenticatedUser } from '../../../auth'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { BatchChangesIcon } from '../../../batches/icons'
+import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_NAMESPACE } from '../../../batches/utils'
 import { useShowMorePagination } from '../../../components/FilteredConnection/hooks/useShowMorePagination'
 import {
     ConnectionContainer,
@@ -37,7 +38,6 @@ import {
     GetLicenseAndUsageInfoVariables,
 } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
-import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_NAMESPACE } from '../utils'
 
 import { BATCH_CHANGES, BATCH_CHANGES_BY_NAMESPACE, GET_LICENSE_AND_USAGE_INFO } from './backend'
 import { BatchChangeListFilters } from './BatchChangeListFilters'

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -8,6 +8,7 @@ import { PageHeader, H2, useObservable, Text, H4 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { BatchChangesIcon } from '../../../batches/icons'
+import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../../batches/utils'
 import { DiffStat } from '../../../components/diff/DiffStat'
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
@@ -21,7 +22,6 @@ import {
     ChangesetStatusMerged,
 } from '../detail/changesets/ChangesetStatusCell'
 import { NewBatchChangeButton } from '../list/NewBatchChangeButton'
-import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../utils'
 
 import {
     queryRepoBatchChanges as _queryRepoBatchChanges,

--- a/client/web/src/enterprise/batches/utils.ts
+++ b/client/web/src/enterprise/batches/utils.ts
@@ -1,13 +1,9 @@
-import { findIndex } from 'lodash'
-
-import { AuthenticatedUser } from '../../auth'
 import {
     ChangesetCheckState,
     ChangesetReviewState,
     ChangesetSpecOperation,
     ChangesetState,
 } from '../../graphql-operations'
-import { BatchChangesWritePermission } from '../../rbac/constants'
 
 export function isValidChangesetReviewState(input: string): input is ChangesetReviewState {
     return Object.values<string>(ChangesetReviewState).includes(input)
@@ -24,12 +20,3 @@ export function isValidChangesetSpecOperation(input: string): input is Changeset
 export function isValidChangesetState(input: string): input is ChangesetState {
     return Object.values<string>(ChangesetState).includes(input)
 }
-
-export const canWriteBatchChanges = (user: Pick<AuthenticatedUser, 'permissions'> | null): boolean =>
-    !!user &&
-    findIndex(user.permissions.nodes, permission => permission.displayName === BatchChangesWritePermission) !== -1
-
-export const NO_ACCESS_SOURCEGRAPH_COM = 'Batch changes are not available on Sourcegraph.com.'
-export const NO_ACCESS_BATCH_CHANGES_WRITE =
-    'Your user does not have sufficient permissions to create batch changes. Contact your site admin to request access.'
-export const NO_ACCESS_NAMESPACE = 'Your user is not able to create batch changes in this namespace.'

--- a/client/web/src/enterprise/organizations/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/organizations/settings/sidebaritems.ts
@@ -1,6 +1,6 @@
+import { canWriteBatchChanges } from '../../../batches/utils'
 import { OrgSettingsSidebarItems } from '../../../org/settings/OrgSettingsSidebar'
 import { orgSettingsSideBarItems } from '../../../org/settings/sidebaritems'
-import { canWriteBatchChanges } from '../../batches/utils'
 
 export const enterpriseOrgSettingsSideBarItems: OrgSettingsSidebarItems = [
     ...orgSettingsSideBarItems,

--- a/client/web/src/enterprise/user/settings/routes.tsx
+++ b/client/web/src/enterprise/user/settings/routes.tsx
@@ -1,8 +1,8 @@
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
+import { canWriteBatchChanges } from '../../../batches/utils'
 import { userSettingsAreaRoutes } from '../../../user/settings/routes'
 import { UserSettingsAreaRoute } from '../../../user/settings/UserSettingsArea'
-import { canWriteBatchChanges } from '../../batches/utils'
 import { SHOW_BUSINESS_FEATURES } from '../../dotcom/productSubscriptions/features'
 import type { ExecutorsUserAreaProps } from '../../executors/ExecutorsUserArea'
 

--- a/client/web/src/enterprise/user/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/user/settings/sidebaritems.ts
@@ -1,6 +1,6 @@
+import { canWriteBatchChanges } from '../../../batches/utils'
 import { userSettingsSideBarItems } from '../../../user/settings/sidebaritems'
 import { UserSettingsSidebarItems } from '../../../user/settings/UserSettingsSidebar'
-import { canWriteBatchChanges } from '../../batches/utils'
 import { SHOW_BUSINESS_FEATURES } from '../../dotcom/productSubscriptions/features'
 
 export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = [

--- a/client/web/src/search/results/SearchActionsMenu.tsx
+++ b/client/web/src/search/results/SearchActionsMenu.tsx
@@ -97,16 +97,18 @@ export const SearchActionsMenu: React.FunctionComponent<SearchActionsMenuProps> 
                         )}
                         <MenuHeader>Search query</MenuHeader>
                         {createActions.map(createAction => (
-                            <MenuLink key={createAction.label} as={Link} to={createAction.url}>
-                                <Icon
-                                    aria-hidden="true"
-                                    className="mr-1"
-                                    {...(typeof createAction.icon === 'string'
-                                        ? { svgPath: createAction.icon }
-                                        : { as: createAction.icon })}
-                                />
-                                {createAction.label}
-                            </MenuLink>
+                            <Tooltip content={createAction.tooltip} key={createAction.label} placement="left">
+                                <MenuLink as={Link} to={createAction.url} disabled={createAction.disabled}>
+                                    <Icon
+                                        aria-hidden="true"
+                                        className="mr-1"
+                                        {...(typeof createAction.icon === 'string'
+                                            ? { svgPath: createAction.icon }
+                                            : { as: createAction.icon })}
+                                    />
+                                    {createAction.label}
+                                </MenuLink>
+                            </Tooltip>
                         ))}
                         {createCodeMonitorAction && (
                             <Tooltip
@@ -115,6 +117,7 @@ export const SearchActionsMenu: React.FunctionComponent<SearchActionsMenuProps> 
                                         ? 'Code monitors only support type:diff or type:commit searches.'
                                         : undefined
                                 }
+                                placement="left"
                             >
                                 <MenuLink
                                     as={Link}

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -15,6 +15,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
         id: 'userID',
         displayName: 'Chuck Cheese',
         emails: [{ email: 'chuck@chuckeecheese.com', isPrimary: true, verified: true }],
+        permissions: { nodes: [] },
     },
     allExpanded: true,
     onExpandAllResultsToggle: noop,

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -84,12 +84,10 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         [globalTypeFilter]
     )
 
-    const canCreateBatchChangeFromQuery = useMemo(
-        () => globalTypeFilter !== 'diff' && globalTypeFilter !== 'commit',
-        [globalTypeFilter]
-    )
-
     const canCreateBatchChanges: boolean | string = useMemo(() => {
+        if (globalTypeFilter === 'diff' || globalTypeFilter === 'commit') {
+            return 'Batch changes cannot be created from searches with type:diff or type:commit'
+        }
         if (props.isSourcegraphDotCom) {
             return NO_ACCESS_SOURCEGRAPH_COM
         }
@@ -101,6 +99,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         }
         return true
     }, [
+        globalTypeFilter,
         props.isSourcegraphDotCom,
         props.batchChangesEnabled,
         props.batchChangesExecutionEnabled,
@@ -112,15 +111,11 @@ export const SearchResultsInfoBar: React.FunctionComponent<
     const createActions = useMemo(
         () =>
             [
-                getBatchChangeCreateAction(
-                    props.query,
-                    props.patternType,
-                    canCreateBatchChangeFromQuery && canCreateBatchChanges
-                ),
+                getBatchChangeCreateAction(props.query, props.patternType, canCreateBatchChanges),
                 getSearchContextCreateAction(props.query, props.authenticatedUser),
                 getInsightsCreateAction(props.query, props.patternType, window.context?.codeInsightsEnabled),
             ].filter((button): button is CreateAction => button !== null),
-        [props.authenticatedUser, props.patternType, props.query, canCreateBatchChangeFromQuery, canCreateBatchChanges]
+        [props.authenticatedUser, props.patternType, props.query, canCreateBatchChanges]
     )
 
     // The create code monitor action is separated from the rest of the actions, because we use the

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -12,6 +12,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { Button, Icon, Label } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
+import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../batches/utils'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 
 import {
@@ -31,7 +32,7 @@ export interface SearchResultsInfoBarProps
         SearchPatternTypeProps,
         Pick<CaseSensitivityProps, 'caseSensitive'> {
     /** The currently authenticated user or null */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'displayName' | 'emails'> | null
+    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'displayName' | 'emails' | 'permissions'> | null
 
     enableCodeInsights?: boolean
     enableCodeMonitoring: boolean
@@ -88,6 +89,24 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         [globalTypeFilter]
     )
 
+    const canCreateBatchChanges: boolean | string = useMemo(() => {
+        if (props.isSourcegraphDotCom) {
+            return NO_ACCESS_SOURCEGRAPH_COM
+        }
+        if (!props.batchChangesEnabled || !props.batchChangesExecutionEnabled) {
+            return false
+        }
+        if (!canWriteBatchChanges(props.authenticatedUser)) {
+            return NO_ACCESS_BATCH_CHANGES_WRITE
+        }
+        return true
+    }, [
+        props.isSourcegraphDotCom,
+        props.batchChangesEnabled,
+        props.batchChangesExecutionEnabled,
+        props.authenticatedUser,
+    ])
+
     // When adding a new create action check and update the $collapse-breakpoint in CreateActions.module.scss.
     // The collapse breakpoint indicates at which window size we hide the buttons and show the collapsed menu instead.
     const createActions = useMemo(
@@ -96,24 +115,12 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                 getBatchChangeCreateAction(
                     props.query,
                     props.patternType,
-                    Boolean(
-                        props.batchChangesEnabled &&
-                            props.batchChangesExecutionEnabled &&
-                            props.authenticatedUser &&
-                            canCreateBatchChangeFromQuery
-                    )
+                    canCreateBatchChangeFromQuery && canCreateBatchChanges
                 ),
                 getSearchContextCreateAction(props.query, props.authenticatedUser),
                 getInsightsCreateAction(props.query, props.patternType, window.context?.codeInsightsEnabled),
             ].filter((button): button is CreateAction => button !== null),
-        [
-            props.authenticatedUser,
-            props.patternType,
-            props.query,
-            props.batchChangesEnabled,
-            props.batchChangesExecutionEnabled,
-            canCreateBatchChangeFromQuery,
-        ]
+        [props.authenticatedUser, props.patternType, props.query, canCreateBatchChangeFromQuery, canCreateBatchChanges]
     )
 
     // The create code monitor action is separated from the rest of the actions, because we use the

--- a/client/web/src/search/results/createActions.ts
+++ b/client/web/src/search/results/createActions.ts
@@ -84,7 +84,7 @@ export function getCodeMonitoringCreateAction(
 export function getBatchChangeCreateAction(
     query: string | undefined,
     patternType: SearchPatternType,
-    canCreateBatchChange: boolean
+    canCreateBatchChange: boolean | string
 ): CreateAction | null {
     if (!canCreateBatchChange) {
         return null

--- a/client/web/src/search/results/createActions.ts
+++ b/client/web/src/search/results/createActions.ts
@@ -16,6 +16,7 @@ export interface CreateAction {
     icon: IconType
     label: string
     tooltip: string
+    disabled?: boolean
     eventToLog?: string
 }
 
@@ -37,7 +38,7 @@ export function getSearchContextCreateAction(
     searchParameters.set('q', sanitizedQuery)
     const url = `/contexts/new?${searchParameters.toString()}`
 
-    return { url, icon: mdiMagnify, label: 'Create context', tooltip: 'Create a search context based on this query' }
+    return { url, icon: mdiMagnify, label: 'Create context', tooltip: 'Create a search context based on this query.' }
 }
 
 export function getInsightsCreateAction(
@@ -57,7 +58,7 @@ export function getInsightsCreateAction(
         url,
         icon: CodeInsightsIcon,
         label: 'Create insight',
-        tooltip: 'Create Insight based on this search query',
+        tooltip: 'Create Insight based on this search query.',
     }
 }
 
@@ -77,7 +78,7 @@ export function getCodeMonitoringCreateAction(
         url,
         icon: CodeMonitoringLogo,
         label: 'monitor',
-        tooltip: 'Create a code monitor based on this query',
+        tooltip: 'Create a code monitor based on this query.',
     }
 }
 
@@ -86,9 +87,17 @@ export function getBatchChangeCreateAction(
     patternType: SearchPatternType,
     canCreateBatchChange: boolean | string
 ): CreateAction | null {
-    if (!canCreateBatchChange) {
+    if (canCreateBatchChange === false) {
         return null
     }
+
+    let disabled = false
+    let tooltip: string | undefined
+    if (typeof canCreateBatchChange === 'string') {
+        disabled = true
+        tooltip = canCreateBatchChange
+    }
+
     const searchParameters = new URLSearchParams(location.search)
     searchParameters.set('trigger-query', `${query} patterntype:${patternType}`)
     const url = `/batch-changes/create?${searchParameters.toString()}`
@@ -97,7 +106,8 @@ export function getBatchChangeCreateAction(
         url,
         icon: BatchChangesIcon,
         label: 'Create batch change',
-        tooltip: 'Create a batch change based on this query',
+        tooltip: tooltip || 'Create a batch change based on this query.',
         eventToLog: 'search_result_page:create_batch_change:clicked',
+        disabled,
     }
 }


### PR DESCRIPTION
Updates the conditions for the "Create batch change" button in the search actions context menu to check that the user has the `BATCH_CHANGES#WRITE` permission and disables the button with a tooltip if not.

<img width="571" alt="image" src="https://user-images.githubusercontent.com/8942601/226021473-801691b8-6eb0-4c44-b1ae-81655a088398.png">

It seems that the tooltips for these `MenuLink`s weren't actually being rendered. This PR restores them, and updates their placement to be off to the side, for easier menu browsing:

https://user-images.githubusercontent.com/8942601/226024575-82755372-e2d2-4672-9c9d-ad7fe400ab52.mov

## Test plan

Manual testing with a user with and without the appropriate permission granted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-fixup-search-action-bc-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
