### PR TITLE
docs: fix references to 4.6 -> 5.0

### DIFF
--- a/doc/admin/updates/index.md
+++ b/doc/admin/updates/index.md
@@ -8,7 +8,7 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 
 ## Check the upgrade readiness
 
-Starting 4.6.0, you are able to check the instance upgrade readiness by navigating to **Site admin > Updates** page, readiness information includes:
+Starting 5.0.0, you are able to check the instance upgrade readiness by navigating to **Site admin > Updates** page, readiness information includes:
 
 - Whether there are [schema drifts](../how-to/schema-drift.md)
 - Whether there are pending [out-of-band migrations](../../dev/background-information/oobmigrations.md) but need to complete

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -371,7 +371,7 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
 
 - Aggregation: weekly
 - Event Code: [WeeklyDataExportClicks](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+WeeklyDataExportClicks&patternType=standard), `InsightsDataExportRequest` in `event_logs`
-- **Version added:** 4.6
+- **Version added:** 5.0
 
 ## Search results aggregations metrics
 


### PR DESCRIPTION
Updates two references to 4.6 to 5.0.

## Test plan

N/A just docs changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
