### PR TITLE
executors: add aws and google executors to release tool

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -19,6 +19,22 @@
       "current": "5.1.0",
       "captainGitHubUsername": "coury-clark",
       "captainSlackUsername": "coury"
+    },
+    "5.1.0": {
+      "codeFreezeDate": "2023-03-15T10:34:35.948-07:00",
+      "securityApprovalDate": "2023-03-15T10:34:35.948-07:00",
+      "releaseDate": "2023-03-22T10:34:35.948-07:00",
+      "patches": [
+        "2023-04-05T10:34:35.948-07:00",
+        "2023-04-19T10:34:35.948-07:00",
+        "2023-05-03T10:34:35.948-07:00",
+        "2023-05-17T10:34:35.948-07:00",
+        "2023-05-31T10:34:35.948-07:00",
+        "2023-06-14T10:34:35.948-07:00"
+      ],
+      "current": "5.1.0",
+      "captainGitHubUsername": "coury-clark",
+      "captainSlackUsername": "coury"
     }
   },
   "dryRun": {
@@ -27,5 +43,18 @@
     "trackingIssues": false,
     "calendar": false,
     "slack": false
+  },
+  "in_progress": {
+    "captainGitHubUsername": "coury-clark",
+    "captainSlackUsername": "coury",
+    "releases": [
+      {
+        "version": "5.1.0",
+        "previous": "5.0.0"
+      }
+    ],
+    "srcCliVersion": "5.1.0",
+    "googleExecutorVersion": "5.1.0",
+    "awsExecutorVersion": "5.1.0"
   }
 }

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -1,60 +1,31 @@
 {
-  "metadata": {
-    "teamEmail": "team@sourcegraph.com",
-    "slackAnnounceChannel": "announce-engineering"
-  },
-  "scheduledReleases": {
-    "5.1.0": {
-      "codeFreezeDate": "2023-06-14T10:00:00.000-07:00",
-      "securityApprovalDate": "2023-06-21T10:00:00.000-07:00",
-      "releaseDate": "2023-06-28T10:00:00.000-07:00",
-      "patches": [
-        "2023-07-12T10:00:00.000-07:00",
-        "2023-07-26T10:00:00.000-07:00",
-        "2023-08-09T10:00:00.000-07:00",
-        "2023-08-23T10:00:00.000-07:00",
-        "2023-09-06T10:00:00.000-07:00",
-        "2023-09-20T10:00:00.000-07:00"
-      ],
-      "current": "5.1.0",
-      "captainGitHubUsername": "coury-clark",
-      "captainSlackUsername": "coury"
+    "metadata": {
+      "teamEmail": "team@sourcegraph.com",
+      "slackAnnounceChannel": "announce-engineering"
     },
-    "5.1.0": {
-      "codeFreezeDate": "2023-03-15T10:34:35.948-07:00",
-      "securityApprovalDate": "2023-03-15T10:34:35.948-07:00",
-      "releaseDate": "2023-03-22T10:34:35.948-07:00",
-      "patches": [
-        "2023-04-05T10:34:35.948-07:00",
-        "2023-04-19T10:34:35.948-07:00",
-        "2023-05-03T10:34:35.948-07:00",
-        "2023-05-17T10:34:35.948-07:00",
-        "2023-05-31T10:34:35.948-07:00",
-        "2023-06-14T10:34:35.948-07:00"
-      ],
-      "current": "5.1.0",
-      "captainGitHubUsername": "coury-clark",
-      "captainSlackUsername": "coury"
-    }
-  },
-  "dryRun": {
-    "tags": false,
-    "changesets": false,
-    "trackingIssues": false,
-    "calendar": false,
-    "slack": false
-  },
-  "in_progress": {
-    "captainGitHubUsername": "coury-clark",
-    "captainSlackUsername": "coury",
-    "releases": [
-      {
-        "version": "5.1.0",
-        "previous": "5.0.0"
+    "scheduledReleases": {
+      "5.1.0": {
+        "codeFreezeDate": "2023-06-14T10:00:00.000-07:00",
+        "securityApprovalDate": "2023-06-21T10:00:00.000-07:00",
+        "releaseDate": "2023-06-28T10:00:00.000-07:00",
+        "patches": [
+          "2023-07-12T10:00:00.000-07:00",
+          "2023-07-26T10:00:00.000-07:00",
+          "2023-08-09T10:00:00.000-07:00",
+          "2023-08-23T10:00:00.000-07:00",
+          "2023-09-06T10:00:00.000-07:00",
+          "2023-09-20T10:00:00.000-07:00"
+        ],
+        "current": "5.1.0",
+        "captainGitHubUsername": "coury-clark",
+        "captainSlackUsername": "coury"
       }
-    ],
-    "srcCliVersion": "5.1.0",
-    "googleExecutorVersion": "5.1.0",
-    "awsExecutorVersion": "5.1.0"
+    },
+    "dryRun": {
+      "tags": false,
+      "changesets": false,
+      "trackingIssues": false,
+      "calendar": false,
+      "slack": false
+    }
   }
-}

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -183,6 +183,8 @@ export interface ReleaseCaptainInformation {
 export interface InProgress extends ReleaseCaptainInformation {
     releases: ActiveReleaseDefinition[]
     srcCliVersion?: string
+    googleExecutorVersion?: string
+    awsExecutorVersion?: string
 }
 
 export interface ReleaseConfig {
@@ -272,6 +274,20 @@ async function getScheduledReleaseWithInput(
 export function setSrcCliVersion(config: ReleaseConfig, version: string): void {
     if (config.in_progress) {
         config.in_progress.srcCliVersion = version
+    }
+    saveReleaseConfig(config)
+}
+
+export function setGoogleExecutorVersion(config: ReleaseConfig, version: string): void {
+    if (config.in_progress) {
+        config.in_progress.googleExecutorVersion = version
+    }
+    saveReleaseConfig(config)
+}
+
+export function setAWSExecutorVersion(config: ReleaseConfig, version: string): void {
+    if (config.in_progress) {
+        config.in_progress.awsExecutorVersion = version
     }
     saveReleaseConfig(config)
 }

--- a/dev/release/src/git.ts
+++ b/dev/release/src/git.ts
@@ -23,6 +23,7 @@ export function getReleaseTags(workdir: string, prefix: string): string[] {
 
 const mainRepoTagPrefix = 'v[0-9]*.[0-9]*.[0-9]*'
 export const srcCliTagPrefix = '[0-9]*.[0-9]*.[0-9]*'
+export const executorTagPrefix = 'v[0-9]*.[0-9]*.[0-9]*'
 
 // Returns the version tagged in the repository previous to a provided input version. If no input version it will
 // simply return the highest version found in the repository.
@@ -56,4 +57,8 @@ export function getPreviousVersion(
 
 export function getPreviousVersionSrcCli(path: string): SemVer {
     return getPreviousVersion(undefined, srcCliTagPrefix, path)
+}
+
+export function getPreviousVersionExecutor(path: string): SemVer {
+    return getPreviousVersion(undefined, executorTagPrefix, path)
 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -1230,26 +1230,25 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             }
             const sets = await createChangesets({
                 requiredCommands: [],
-                    changes: [
-                        {
-                            ...prDetails,
-                                repo: 'terraform-google-executors',
-                                owner: 'sourcegraph',
-                                base: 'master',
-                                head: `release/prepare-${next.version}`,
-                                edits: [`./prepare-release.sh ${next.version}`],
-                                labels: [releaseBlockerLabel],
-                                draft: true,
-                            },
-                        ],
-                        dryRun: config.dryRun.changesets,
+                changes: [
+                    {
+                        ...prDetails,
+                        repo: 'terraform-google-executors',
+                        owner: 'sourcegraph',
+                        base: 'master',
+                        head: `release/prepare-${next.version}`,
+                        edits: [`./prepare-release.sh ${next.version}`],
+                        labels: [releaseBlockerLabel],
+                        draft: true,
+                    },
+                ],
+                dryRun: config.dryRun.changesets,
             })
             console.log('Merge the following pull requests:\n')
-                    for (const set of sets) {
-                        console.log(set.pullRequestURL)
-                    }
-        }
-
+            for (const set of sets) {
+                console.log(set.pullRequestURL)
+            }
+        },
     },
     {
         id: 'release:prepare-aws-executors',
@@ -1276,33 +1275,31 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 commitMessage: `executor: v${next.version}`,
             }
             const sets = await createChangesets({
-                        requiredCommands: [],
-                        changes: [
-                            {
-                                ...prDetails,
-                                repo: 'sourcegraph',
-                                owner: 'terraform-aws-executors',
-                                base: 'master',
-                                head: `release/prepare-${next.version}`,
-                                edits: [`./prepare-release.sh ${next.version}`],
-                                labels: [releaseBlockerLabel],
-                                draft: true,
-                            },
-                        ],
-                        dryRun: config.dryRun.changesets,
-                    })
-                    console.log('Merge the following pull requests:\n')
-                    for (const set of sets) {
-
-                        console.log(set.pullRequestURL)
-                    }
-        }
+                requiredCommands: [],
+                changes: [
+                    {
+                        ...prDetails,
+                        repo: 'sourcegraph',
+                        owner: 'terraform-aws-executors',
+                        base: 'master',
+                        head: `release/prepare-${next.version}`,
+                        edits: [`./prepare-release.sh ${next.version}`],
+                        labels: [releaseBlockerLabel],
+                        draft: true,
+                    },
+                ],
+                dryRun: config.dryRun.changesets,
+            })
+            console.log('Merge the following pull requests:\n')
+            for (const set of sets) {
+                console.log(set.pullRequestURL)
+            }
+        },
     },
     {
         id: 'release:google-executors-tags',
         description: 'Release a new version of google executors. Only required for minor and major versions',
         run: async config => {
-
             const release = await getActiveRelease(config)
             if (release.version.patch !== 0) {
                 console.log('executor releases are only supported in this tool for major / minor releases')
@@ -1333,7 +1330,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             } else {
                 console.log(chalk.blue('Skipping sourcegraph/terraform-google-executors release for dry run'))
             }
-        }
+        },
     },
     {
         id: 'release:aws-executors-tags',
@@ -1371,7 +1368,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             } else {
                 console.log(chalk.blue('Skipping sourcegraph/terraform-aws-executors release for dry run'))
             }
-        }
+        },
     },
     {
         id: 'util:clear-cache',

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -28,7 +28,7 @@ import {
     setGoogleExecutorVersion,
     setAWSExecutorVersion,
 } from './config'
-import { getCandidateTags, getPreviousVersion, getTags } from './git'
+import { getCandidateTags, getPreviousVersion } from './git'
 import {
     cloneRepo,
     closeTrackingIssue,

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -1314,12 +1314,12 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             const next = await nextAWSExecutorVersionInputWithAutodetect(config, workdir)
             setAWSExecutorVersion(config, next.version)
 
-            const pr = await client.search.issuesAndPullRequests({
+            const mergedPR = await client.search.issuesAndPullRequests({
                 q: `repo:sourcegraph/terraform-google-executors is:pr is:closed is:merged in:title Update files for ${next.version} release `,
             })
             if (!config.dryRun.changesets) {
                 // actually execute the release
-                if (pr.data.total_count > 0) {
+                if (mergedPR.data.total_count > 0) {
                     await execa('bash', ['-c', `yes | ./release.sh ${next.version}`], {
                         stdio: 'inherit',
                         cwd: workdir,
@@ -1351,13 +1351,13 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             setAWSExecutorVersion(config, next.version)
 
             // check if the release PR is already merged
-            const pr = await client.search.issuesAndPullRequests({
+            const mergedPR = await client.search.issuesAndPullRequests({
                 q: `repo:sourcegraph/terraform-aws-executors is:pr is:closed is:merged in:title Update files for ${next.version} release `,
             })
 
             if (!config.dryRun.changesets) {
                 // actually execute the release
-                if (pr.data.total_count > 0) {
+                if (mergedPR.data.total_count > 0) {
                     await execa('bash', ['-c', `yes | ./release.sh ${next.version}`], {
                         stdio: 'inherit',
                         cwd: workdir,

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -1150,7 +1150,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             }
 
             const repos = ['src-cli', 'terraform-google-executors', 'terraform-aws-executors']
-            let tags: ReleaseTag[] = []
+            const tags: ReleaseTag[] = []
 
             const client = await getAuthenticatedGitHubClient()
 
@@ -1161,7 +1161,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 })
 
                 switch (repo) {
-                    case 'src-cli':
+                    case 'src-cli': {
                         const next = await nextSrcCliVersionInputWithAutodetect(config, workdir)
                         setSrcCliVersion(config, next.version)
                         tags.push({
@@ -1170,7 +1170,8 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                             workDir: workdir,
                         })
                         break
-                    case 'terraform-google-executors':
+                    }
+                    case 'terraform-google-executors': {
                         const nextGoogle = await nextGoogleExecutorVersionInputWithAutodetect(config, workdir)
                         setGoogleExecutorVersion(config, nextGoogle.version)
                         tags.push({
@@ -1179,7 +1180,8 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                             workDir: workdir,
                         })
                         break
-                    case 'terraform-aws-executors':
+                    }
+                    case 'terraform-aws-executors': {
                         const nextAWS = await nextAWSExecutorVersionInputWithAutodetect(config, workdir)
                         setAWSExecutorVersion(config, nextAWS.version)
                         tags.push({
@@ -1188,6 +1190,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                             workDir: workdir,
                         })
                         break
+                    }
                 }
             }
 
@@ -1195,7 +1198,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 const { repo, nextTag, workDir } = tag
                 if (!config.dryRun.changesets) {
                     // actually execute the release
-                    if (repo === `src-cli`) {
+                    if (repo === 'src-cli') {
                         await execa('bash', ['-c', 'yes | ./release.sh'], {
                             stdio: 'inherit',
                             cwd: workDir,

--- a/dev/release/src/static-updates.ts
+++ b/dev/release/src/static-updates.ts
@@ -2,7 +2,12 @@ import { SemVer } from 'semver'
 
 import { ReleaseConfig, setAWSExecutorVersion, setGoogleExecutorVersion, setSrcCliVersion } from './config'
 import { cloneRepo, createChangesets, Edit, getAuthenticatedGitHubClient, releaseBlockerLabel } from './github'
-import { nextAWSExecutorVersionInputWithAutodetect, nextGoogleExecutorVersionInputWithAutodetect, nextSrcCliVersionInputWithAutodetect, pullRequestBody } from './util'
+import {
+    nextAWSExecutorVersionInputWithAutodetect,
+    nextGoogleExecutorVersionInputWithAutodetect,
+    nextSrcCliVersionInputWithAutodetect,
+    pullRequestBody,
+} from './util'
 
 export async function bakeSrcCliSteps(config: ReleaseConfig): Promise<Edit[]> {
     const client = await getAuthenticatedGitHubClient()
@@ -65,7 +70,6 @@ export async function bakeAWSExecutorsSteps(config: ReleaseConfig): Promise<void
         console.log(set.pullRequestURL)
     }
 }
-
 
 export async function bakeGoogleExecutorsSteps(config: ReleaseConfig): Promise<void> {
     const client = await getAuthenticatedGitHubClient()

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -412,7 +412,7 @@ export async function nextGoogleExecutorVersionInputWithAutodetect(
         next = new SemVer(config.in_progress.googleExecutorVersion)
     }
 
-    if (!(await softVerifyWithInput(`Confirm next version of executor should be: ${next.version}`))) {
+    if (!(await softVerifyWithInput(`Confirm next version of sourcegraph/terraform-google-executors should be: ${next.version}`))) {
         return new SemVer(
             await retryInput(
                 'Enter the next version of executor: ',
@@ -440,7 +440,7 @@ export async function nextAWSExecutorVersionInputWithAutodetect(
         }
         console.log('Attempting to detect previous executor version...')
         const previous = getPreviousVersionExecutor(repoPath)
-        console.log(chalk.blue(`Detected previous executor version: ${previous.version}`))
+        console.log(chalk.blue(`Detected previous sourcegraph/terraform-aws-executors version: ${previous.version}`))
         next = previous.inc('minor')
     } else {
         next = new SemVer(config.in_progress.awsExecutorVersion)

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -17,6 +17,12 @@ import * as update from './update'
 
 const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
 
+export interface ReleaseTag {
+    repo: string
+    nextTag: string
+    workDir: string
+}
+
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 export function formatDate(date: Date): string {
     return `${date.toLocaleString('en-US', {
@@ -412,7 +418,11 @@ export async function nextGoogleExecutorVersionInputWithAutodetect(
         next = new SemVer(config.in_progress.googleExecutorVersion)
     }
 
-    if (!(await softVerifyWithInput(`Confirm next version of sourcegraph/terraform-google-executors should be: ${next.version}`))) {
+    if (
+        !(await softVerifyWithInput(
+            `Confirm next version of sourcegraph/terraform-google-executors should be: ${next.version}`
+        ))
+    ) {
         return new SemVer(
             await retryInput(
                 'Enter the next version of executor: ',

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -390,7 +390,10 @@ export async function nextSrcCliVersionInputWithAutodetect(config: ReleaseConfig
     return next
 }
 
-export async function nextGoogleExecutorVersionInputWithAutodetect(config: ReleaseConfig, repoPath?: string): Promise<SemVer> {
+export async function nextGoogleExecutorVersionInputWithAutodetect(
+    config: ReleaseConfig,
+    repoPath?: string
+): Promise<SemVer> {
     let next: SemVer
     if (!config.in_progress?.googleExecutorVersion) {
         if (!repoPath) {
@@ -421,7 +424,10 @@ export async function nextGoogleExecutorVersionInputWithAutodetect(config: Relea
     return next
 }
 
-export async function nextAWSExecutorVersionInputWithAutodetect(config: ReleaseConfig, repoPath?: string): Promise<SemVer> {
+export async function nextAWSExecutorVersionInputWithAutodetect(
+    config: ReleaseConfig,
+    repoPath?: string
+): Promise<SemVer> {
     let next: SemVer
     if (!config.in_progress?.awsExecutorVersion) {
         if (!repoPath) {


### PR DESCRIPTION
Added the following commands to the release tool in order to add the executor release to the release tool process.
```
'release:prepare-google-executors'
 'release:prepare-aws-executors'
 'release:google-executors-tags'
 'release:aws-executors-tags'
```
 The prepare functions create the PR for the changes to update the version within the files of the repos
 the tag functions publish the tags for the release
 
 Still need to implement a verification function to confirm tags have been published
 

## Test plan
ran command for `prepare-google-executors` in dry run mode. It pushed I branch looked at the preview of what diff of the PR are would be and all the changes manually.

`google-executors-tags` command simply runs the ./release.sh command, which I have run manually before and does publish the tags

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mucles-release-add-executors.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
