### PR TITLE
Revert "gRPC: log on dial"

### DIFF
--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -6,7 +6,6 @@ package defaults
 
 import (
 	"context"
-	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -31,7 +30,6 @@ func Dial(addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, err
 
 // DialContext creates a client connection to the given target with the default options.
 func DialContext(ctx context.Context, addr string, additionalOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	log.Scoped("grpc", "").Info("dialing gRPC", log.String("stack", string(debug.Stack())))
 	return grpc.DialContext(ctx, addr, append(DialOptions(), additionalOpts...)...)
 }
 

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -71,7 +72,7 @@ func NewClient(serverURL string) *Client {
 			if err != nil {
 				return nil, err
 			}
-			conn, err := defaults.Dial(u.Host)
+			conn, err := grpc.Dial(u.Host, defaults.DialOptions()...)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#49624. We were able to debug and fix the goroutine leak with the `tracebackancestors` debug flag. This is a noisy log, so let's not keep it around.