### PR TITLE
fixing stitch migration drift from backport-49550-to-5.0

### DIFF
--- a/migrations/frontend/1678994673_package_repos_last_checked_at_index/metadata.yaml
+++ b/migrations/frontend/1678994673_package_repos_last_checked_at_index/metadata.yaml
@@ -1,2 +1,2 @@
 name: package_repos_last_checked_at_index
-parents: [1678899992, 1678832491]
+parents: [1678601228, 1678832491]


### PR DESCRIPTION
fixing stitch migration drift from backport-49550-to-5.0
relates to CI blocking backport https://github.com/sourcegraph/sourcegraph/pull/49555
## Test plan
n/a
following these instructions
https://handbook.sourcegraph.com/departments/engineering/dev/tools/backport/#how-to-update-the-stitched-migration-files
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
