### PR TITLE
dev/pr-auditor: use labels to exempt from review

### DIFF
--- a/dev/pr-auditor/check.go
+++ b/dev/pr-auditor/check.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-github/v41/github"
 	"github.com/grafana/regexp"
+	"golang.org/x/exp/slices"
 )
 
 type checkResult struct {
@@ -30,6 +31,8 @@ var (
 	noReviewNeededDividerRegexp = regexp.MustCompile("(?m)([nN]o [rR]eview [rR]equired:)")
 
 	markdownCommentRegexp = regexp.MustCompile("<!--((.|\n)*?)-->(\n)*")
+
+	noReviewNeedLabels = []string{"no-review-required", "automerge"}
 )
 
 type checkOpts struct {
@@ -72,6 +75,15 @@ func checkPR(ctx context.Context, ghc *github.Client, payload *EventPayload, opt
 		noReviewRequiredExplanation := cleanMarkdown(sections[1])
 		if len(noReviewRequiredExplanation) > 0 {
 			reviewed = true
+		}
+	}
+
+	if testPlan != "" {
+		for _, label := range pr.Labels {
+			if slices.Contains(noReviewNeedLabels, label.Name) {
+				reviewed = true
+				break
+			}
 		}
 	}
 

--- a/dev/pr-auditor/webhook.go
+++ b/dev/pr-auditor/webhook.go
@@ -24,6 +24,8 @@ type PullRequestPayload struct {
 	Body   string `json:"body"`
 	Draft  bool   `json:"draft"`
 
+	Labels []Label `json:"labels"`
+
 	ReviewComments int `json:"review_comments"`
 
 	Merged   bool        `json:"merged"`
@@ -33,6 +35,10 @@ type PullRequestPayload struct {
 
 	Base RefPayload `json:"base"`
 	Head RefPayload `json:"head"`
+}
+
+type Label struct {
+	Name string `json:"name"`
 }
 
 type UserPayload struct {

--- a/doc/dev/background-information/testing_principles.md
+++ b/doc/dev/background-information/testing_principles.md
@@ -146,6 +146,9 @@ For these PRs a review may not be required. This can be indicated by creating a 
 No review required: deploys tested changes.
 ```
 
+Or, you may also attach `automerge` or `no-review-required` label to the PR to indicate the status of the PR and include a normal test plan without the `No review required:` prefix.
+
+
 ## Test health
 
 ### Failures on the `main` branch


### PR DESCRIPTION
This PR added a new way to indicate a PR is exempt from review by attaching a `no-review-required` or `automerge` label. Test plan is still needed, just you don't have to include the magic prefix `No review required:` anymore

![CleanShot 2023-03-17 at 17 35 35](https://user-images.githubusercontent.com/8373004/226073737-78f3b230-3c69-424c-910e-7f32dcb82931.png)

I made too many typo and it isn't very pleasant.

using labels also makes it easier to filter PR

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Added unit test

it works https://github.com/sourcegraph/sourcegraph/pull/49657