### PR TITLE
add --clean and --if-exists flags to all dump commands in use in docs

### DIFF
--- a/doc/admin/deploy/docker-compose/migrate.md
+++ b/doc/admin/deploy/docker-compose/migrate.md
@@ -58,9 +58,9 @@ CONTAINER ID        IMAGE
 
 ```bash
 # Use the CONTAINER_ID found in the previous step
-docker exec -it "$CONTAINER_ID" sh -c 'pg_dump -C --username=postgres sourcegraph' > /tmp/sourcegraph_db.out
+docker exec -it "$CONTAINER_ID" sh -c 'pg_dump -C --clean --if-exists --username=postgres sourcegraph' > /tmp/sourcegraph_db.out
 
-docker exec -it "$CONTAINER_ID" sh -c 'pg_dump -C --username=postgres sourcegraph-codeintel' > /tmp/codeintel_db.out
+docker exec -it "$CONTAINER_ID" sh -c 'pg_dump -C --clean --if-exists --username=postgres sourcegraph-codeintel' > /tmp/codeintel_db.out
 ```
 
 * Copy Postgres dump from the `sourcegraph/server` container to the host machine

--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -89,8 +89,8 @@ docker-compose -f db-only-migrate.docker-compose.yaml up -d
 5\. Generate the database dumps
 
 ```bash
-docker exec pgsql sh -c 'pg_dump -C --username sg sg' > sourcegraph_db.out
-docker exec codeintel-db -c 'pg_dump -C --username sg sg' > codeintel_db.out
+docker exec pgsql sh -c 'pg_dump -C --clean --if-exists --username sg sg' > sourcegraph_db.out
+docker exec codeintel-db -c 'pg_dump -C --clean --if-exists --username sg sg' > codeintel_db.out
 ```
 
 6\. Ensure the `sourcegraph_db.out` and `codeintel_db.out` files are moved to a safe and secure location. 

--- a/doc/admin/deploy/kubernetes/operations.md
+++ b/doc/admin/deploy/kubernetes/operations.md
@@ -290,9 +290,9 @@ and i.indisready AND i.indisvalid;
 D. Generate the database dumps
 
 ```bash
-$ kubectl exec -it $pgsql_POD_NAME -- bash -c 'pg_dump -C --username sg sg' > sourcegraph_db.out
-$ kubectl exec -it $codeintel-db_POD_NAME -- bash -c 'pg_dump -C --username sg sg' > codeintel_db.out
-$ kubectl exec -it $codeinsights-db_POD_NAME -- bash -c 'pg_dump -C --username postgres postgres' > codeinsights_db.out
+$ kubectl exec -it $pgsql_POD_NAME -- bash -c 'pg_dump -C --clean --if-exists --username sg sg' > sourcegraph_db.out
+$ kubectl exec -it $codeintel-db_POD_NAME -- bash -c 'pg_dump -C --clean --if-exists --username sg sg' > codeintel_db.out
+$ kubectl exec -it $codeinsights-db_POD_NAME -- bash -c 'pg_dump -C --clean --if-exists --username postgres postgres' > codeinsights_db.out
 ```
 
 Ensure the `sourcegraph_db.out`, `codeintel_db.out` and `codeinsights_db.out` files are moved to a safe and secure location.


### PR DESCRIPTION
This normalizes our suggested dump procedures in docs with what can be found in the `src-cli` tooling soon to be released for users in the snapshot
https://github.com/sourcegraph/src-cli/blob/0ce1ae4772737264b3fa826e6c6b114754c87009/internal/pgdump/pgdump.go#L44-L51

## Test plan
doc update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
