### PR TITLE
app: skip one-minor-version upgrade check

### DIFF
--- a/internal/version/upgradestore/upgrade.go
+++ b/internal/version/upgradestore/upgrade.go
@@ -1,12 +1,23 @@
 package upgradestore
 
-import "github.com/Masterminds/semver"
+import (
+	"github.com/Masterminds/semver"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
+)
 
 // IsValidUpgrade returns true if the given previous and latest versions comply with our
 // documented upgrade policy. All roll-backs or downgrades are supported.
 //
 // See https://docs.sourcegraph.com/#upgrading-sourcegraph.
 func IsValidUpgrade(previous, latest *semver.Version) bool {
+	// NOTE: Sourcegraph App does not need downgrade support and can't have the
+	// guarantee of one minor version upgrade at a time. The duration between `brew
+	// install sourcegraph` and `brew upgrade sourcegraph` could be months apart.
+	if deploy.IsApp() {
+		return true
+	}
+
 	switch {
 	case previous == nil || latest == nil:
 		return true


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/48940

@efritz - what's the worst thing that can happen if we merge this PR? 😂 

## Test plan

App can start from `0.0.0+dev` to any other version (`2023.03.21`).
