### PR TITLE
Highlighting: use same color for built-in identifiers and keywords

### DIFF
--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -505,7 +505,7 @@
         color: var(--hl-blue);
     }
     .hl-typed-IdentifierBuiltin {
-        color: var(--hl-pink);
+        color: var(--hl-green);
         // filter: brightness(105%);
     }
     .hl-typed-IdentifierBuiltinType {
@@ -933,8 +933,11 @@
         color: var(--hl-gray-1);
     }
     .hl-typed-IdentifierBuiltin {
-        color: var(--hl-purple);
+        color: var(--hl-dark-blue-2);
         // filter: brightness(105%);
+    }
+    .hl-typed-IdentifierBuiltinType {
+        color: var(--hl-dark-blue-2);
     }
     .hl-typed-IdentifierNull {
         color: var(--hl-orange);
@@ -970,9 +973,6 @@
     }
     .hl-typed-IdentifierMacroDefinition {
         color: var(--hl-yellow);
-    }
-    .hl-typed-IdentifierBuiltinType {
-        color: var(--hl-orange);
     }
     .hl-typed-IdentifierAttribute {
         color: var(--hl-purple);


### PR DESCRIPTION
Previously, we used different colors for built-in identifiers and for keywords. On top of that, we didn't consistently use different kinds of colors between dark and light themes.

In this PR, we change the colors for all built-in identifiers to have the same color as keywords. This color choice is consistent with how JetBrains IDEs color tokens.

![CleanShot 2023-03-20 at 11 33 10@2x](https://user-images.githubusercontent.com/1408093/226315685-f7c77951-cee1-4665-8dcf-41d80060a994.png)
![CleanShot 2023-03-20 at 11 33 26@2x](https://user-images.githubusercontent.com/1408093/226315691-6c51cb66-0659-45da-8b95-dc8bd8eee335.png)


GoLand and Rider highlighting to demonstrate how JetBrains IDEs color built-in types like keywords
<img width="394" alt="CleanShot 2023-03-20 at 11 37 02@2x" src="https://user-images.githubusercontent.com/1408093/226315647-d93c588a-c5a1-4972-a38b-9374c16eba0f.png">
<img width="454" alt="CleanShot 2023-03-20 at 11 36 56@2x" src="https://user-images.githubusercontent.com/1408093/226315659-34e1dd8a-5c5a-45f2-9c17-1e461200985b.png">

## Test plan

The best way to review this diff is to look at client/wildcard/src/global-styles/highlight.scss and verify that the kinds `Keyword`, `IdentifierBuiltin` and `IdentifierBuiltinType` have the same colors.

Start locally and visit file https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@7ddfb94479a539e711eedbb3f1c38116ee4dcdb0/-/blob/docker-images/syntax-highlighter/crates/sg-syntax/src/snapshots/files/csharp_timed_out_syntect.cs

Observe that `public` and `void` have the same colors.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-cs-hl.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
