### PR TITLE
SCIM: add docs

### DIFF
--- a/doc/admin/auth/saml/azure_ad.md
+++ b/doc/admin/auth/saml/azure_ad.md
@@ -32,3 +32,5 @@
  ]
 }
 ```
+
+Optional: if you also need automatic provisioning, continue to our [SCIM docs](../../scim). 

--- a/doc/admin/auth/saml/azure_ad.md
+++ b/doc/admin/auth/saml/azure_ad.md
@@ -33,4 +33,4 @@
 }
 ```
 
-Optional: if you also need automatic provisioning, continue to our [SCIM docs](../../scim). 
+> NOTE: Optional, but recommended: [add automatic provisioning of users with SCIM](../../scim). 

--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -3,10 +3,10 @@
 ## 1. Add a SAML application in Okta
 
 1. Login to your Okta account.
-1. On the left hand side, click on the “Applications” menu, and then select the “Applications” item.
-1. Click on “Create App Integration”. Another screen should pop-up, listing sign-in methods. Choose “SAML 2.0”. Click "Next".
-1. You should now see “Create SAML Integration” on this page, and you will be on “General Settings”. Specify a name for “App name” (Ex: “Sourcegraph”). Click “Next”.
-1. Now you should be on “Configure SAML”. On this page, you will need your Sourcegraph URL (Ex: `https://sourcegraph.example.com`). Follow along with the following instructions, replacing `<URL>` with your Sourcegraph URL:
+2. On the left hand side, click on the “Applications” menu, and then select the “Applications” item.
+3. Click on “Create App Integration”. Another screen should pop-up, listing sign-in methods. Choose “SAML 2.0”. Click "Next".
+4. You should now see “Create SAML Integration” on this page, and you will be on “General Settings”. Specify a name for “App name” (Ex: “Sourcegraph”). Click “Next”.
+5. Now you should be on “Configure SAML”. On this page, you will need your Sourcegraph URL (Ex: `https://sourcegraph.example.com`). Follow along with the following instructions, replacing `<URL>` with your Sourcegraph URL:
     - In section A ("SAML Settings"), under "General":
       - For “Single sign on URL”, set the value to `<URL>`/.auth/saml/acs
         - Under this box, there should be a checkbox labeled “Use this for Recipient URL and Destination URL”. Check the box if it is not already selected.
@@ -17,13 +17,13 @@
       - Email: user.email (This one is required)
       - Login: user.login (This one is optional)
       - displayName: user.firstName (This one is optional)
-1. Click Next.
-1. Now you should be on the “Feedback” step. Select the radio button for “I’m an Okta customer adding an internal app”, and provide feedback if you wish. Click "Finish".
-1. You should now be on the Application page for Sourcegraph, where you can view the settings and configurations you have just set. You will want to grant users or groups sign-in access before moving on.
+6. Click Next.
+7. Now you should be on the “Feedback” step. Select the radio button for “I’m an Okta customer adding an internal app”, and provide feedback if you wish. Click "Finish".
+8. You should now be on the Application page for Sourcegraph, where you can view the settings and configurations you have just set. You will want to grant users or groups sign-in access before moving on.
     - To grant access to your own user:
       - Go to the “Assignments” tab, where you should see a table of People and Groups. Click the “Assign” dropdown, and then “Assign to People”.
       - A new window should pop-up. Find your account, and click “Assign”, “Save and Go Back”, and then “Done”.
-2. You have now finished configuring the settings in Okta. Before moving to step #2, make sure you have granted access to users/groups and copy the metadata URL to your clipboard:
+9. You have now finished configuring the settings in Okta. Before moving to step #2, make sure you have granted access to users/groups and copy the metadata URL to your clipboard:
    - Go into the “Sign On” tab
    - Scroll down to the section "SAML Signing Certificates"
    - Click the "Actions" dropdown in the active certificate and then "View IdP Metadata"
@@ -51,3 +51,5 @@
  ]
 }
 ```
+
+Optional: if you also need automatic provisioning, continue to our [SCIM docs](../../scim). 

--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -52,4 +52,4 @@
 }
 ```
 
-Optional: if you also need automatic provisioning, continue to our [SCIM docs](../../scim). 
+> NOTE: Optional, but recommended: [add automatic provisioning of users with SCIM](../../scim). 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -16,7 +16,7 @@ Sourcegraph supports SCIM 2.0 for provisioning and de-provisioning _users_.
 
 ## How to use
 
-To use SCIM, you must have an existing IdP configured to connect to and authenticate with your Sourcegraph instance. For auth, we currently support Bearer token authentication.
+To use SCIM, you must have an existing IdP configured to connect to and authenticate with your Sourcegraph instance. For auth, we currently support Bearer token authentication. We have a guide for Okta setup [below](#setting-up-okta-as-the-idp).
 
 To configure:
 
@@ -42,6 +42,24 @@ To configure:
    ```
    https://sourcegraph.company.com/.api/scim/v2/Users
    ```
+
+## Setting up Okta as the IdP
+
+To set up user provisioning in Okta, you must first set up a new app integration of the "SAML 2.0" type, then configure it to use SCIM. Here are the steps to do this:
+
+1. Follow our [SAML guide](auth/saml/okta) to set up a new app integration with SAML, then open the integration you just created.
+    - If you already have the integration, just open your existing app integration.
+2. Go to the "General" tab and click "Edit" in the "App Settings" section.
+3. Set "Provisioning" to "SCIM". This makes a new tab called "Provisioning" appear.
+4. Go to the new tab, and click "Edit"
+   - Set "SCIM connector base URL" to `{yourSourcegraphUrl}/.api/scim/v2`
+   - Set "Unique identifier field for users" to `userName`
+   - Check the first three items in `Supported provisioning actions`
+   - Set "Authentication mode" to "HTTP Header"
+   - Under "HTTP Header", paste the same alphanumeric bearer token you used in your site config.
+   - Click "Save".
+
+Note that you can also use our [SAML](auth/saml/okta) and [OpenID Connect](auth#openid-connect) integrations with Okta.
 
 ## Features and limitations
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -16,7 +16,7 @@ Sourcegraph supports SCIM 2.0 for provisioning and de-provisioning _users_.
 
 ## How to use
 
-To use SCIM, you must have an existing IdP configured to connect to and authenticate with your Sourcegraph instance. For auth, we currently support Bearer token authentication. We have a guide for Okta setup [below](#setting-up-okta-as-the-idp).
+To use SCIM, you must have an existing IdP configured as an auth provider on your Sourcegraph instance. For authenticating SCIM requests, we currently support Bearer token authentication. We have a guide for Okta setup [below](#setting-up-okta-as-the-idp).
 
 To configure:
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -49,9 +49,9 @@ To set up user provisioning in Okta, you must first set up a new app integration
 
 1. Follow our [SAML guide](auth/saml/okta) to set up a new app integration with SAML, then open the integration you just created.
     - If you already have the integration, just open your existing app integration.
-2. Go to the "General" tab and click "Edit" in the "App Settings" section.
-3. Set "Provisioning" to "SCIM". This makes a new tab called "Provisioning" appear.
-4. Go to the new tab, and click "Edit"
+1. Go to the "General" tab and click "Edit" in the "App Settings" section.
+1. Set "Provisioning" to "SCIM". This creates a new tab called "Provisioning".
+1. Go to the "Provisioning" tab, and click "Edit"
    - Set "SCIM connector base URL" to `{yourSourcegraphUrl}/.api/scim/v2`
    - Set "Unique identifier field for users" to `userName`
    - Check the first three items in `Supported provisioning actions`

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -45,7 +45,7 @@ To configure:
 
 ## Configuring SCIM for Okta
 
-To set up user provisioning in Okta, you must first set up a new app integration of the "SAML 2.0" type, then configure it to use SCIM. Here are the steps to do this:
+To set up user provisioning in [Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SCIM.htm), you must first set up a new app integration of the "SAML 2.0" type, then configure it to use SCIM. Here are the steps to do this:
 
 1. Follow our [SAML guide](auth/saml/okta) to set up a new app integration with SAML, then open the integration you just created.
     - If you already have the integration, just open your existing app integration.
@@ -54,12 +54,12 @@ To set up user provisioning in Okta, you must first set up a new app integration
 1. Go to the "Provisioning" tab, and click "Edit"
    - Set "SCIM connector base URL" to `{yourSourcegraphUrl}/.api/scim/v2`
    - Set "Unique identifier field for users" to `userName`
-   - Check the first three items in `Supported provisioning actions`
+   - Check the first three items in `Supported provisioning actions`: "Import New Users and Profile Updates", "Push New Users", and "Push Profile Updates".
    - Set "Authentication mode" to "HTTP Header"
    - Under "HTTP Header", paste the same alphanumeric bearer token you used in your site config.
    - Click "Save".
 
-Note that you can also use our [SAML](auth/saml/okta) and [OpenID Connect](auth#openid-connect) integrations with Okta.
+> NOTE: You can also use our [SAML](auth/saml/okta) and [OpenID Connect](auth#openid-connect) integrations with Okta.
 
 ## Features and limitations
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -43,7 +43,7 @@ To configure:
    https://sourcegraph.company.com/.api/scim/v2/Users
    ```
 
-## Setting up Okta as the IdP
+## Configuring SCIM for Okta
 
 To set up user provisioning in Okta, you must first set up a new app integration of the "SAML 2.0" type, then configure it to use SCIM. Here are the steps to do this:
 

--- a/doc/admin/scim.md
+++ b/doc/admin/scim.md
@@ -52,12 +52,12 @@ To set up user provisioning in [Okta](https://help.okta.com/en-us/Content/Topics
 1. Go to the "General" tab and click "Edit" in the "App Settings" section.
 1. Set "Provisioning" to "SCIM". This creates a new tab called "Provisioning".
 1. Go to the "Provisioning" tab, and click "Edit"
-   - Set "SCIM connector base URL" to `{yourSourcegraphUrl}/.api/scim/v2`
-   - Set "Unique identifier field for users" to `userName`
-   - Check the first three items in `Supported provisioning actions`: "Import New Users and Profile Updates", "Push New Users", and "Push Profile Updates".
-   - Set "Authentication mode" to "HTTP Header"
-   - Under "HTTP Header", paste the same alphanumeric bearer token you used in your site config.
-   - Click "Save".
+1. Set "SCIM connector base URL" to `{yourSourcegraphUrl}/.api/scim/v2`
+1. Set "Unique identifier field for users" to `userName`
+1. Check the first three items in `Supported provisioning actions`: "Import New Users and Profile Updates", "Push New Users", and "Push Profile Updates".
+1. Set "Authentication mode" to "HTTP Header"
+1. Under "HTTP Header", paste the same alphanumeric bearer token you used in your site config.
+1. Click "Save".
 
 > NOTE: You can also use our [SAML](auth/saml/okta) and [OpenID Connect](auth#openid-connect) integrations with Okta.
 

--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -28,6 +28,7 @@
   - [Temporary settings](web/temporary_settings.md)
   - [Build process](web/build.md)
 - [Developing the GraphQL API](graphql_api.md)
+- [Developing the SCIM API](scim_api.md)
 - [Developing batch changes](batch_changes/index.md)
 - [Developing code intelligence](codeintel/index.md)
 - [Developing code insights](insights/index.md)

--- a/doc/dev/background-information/scim_api.md
+++ b/doc/dev/background-information/scim_api.md
@@ -10,23 +10,27 @@ Our implementation is in [this folder](https://sourcegraph.com/github.com/source
 
 To try it, follow the [How to use section of our SCIM admin guide](doc/admin/scim.md#how-to-use), then see the [manual-testing-with-postman](#manual-testing-with-postman) section below to see it in action. It should take you 10–20 minutes to set up everything and see the full CRUD magic happen.
 
-Using ngrok is a good idea because it lets you inspect the requests and responses at http://127.0.0.1:4040/inspect/http.
+To inspect the requests and responses, you can use [ngrok](https://ngrok.com/). You can then open your browser at http://127.0.0.1:4040/inspect/http to dive deep into the details.
 
 > WARNING: Running the tests and validators referenced on this page will trigger sending live emails. Be sure to set the environment variables `DISABLE_EMAIL_INVITES=true` or `DEBUG_EMAIL_INVITES_MOCK=true` when running live SCIM API calls if you don't want emails to go out.
 
 ## Manual testing with Postman
 
 Postman collection for testing SCIM API locally or through ngrok: [scim_postman_collection.json](scim_postman_collection.json). Steps to use it:
-- Download and run Postman
+- [Download](https://www.postman.com/) and run Postman
 - Go to `File | Import...` and import the JSON.
 - You can import it into Postman and run the requests from top to bottom.
 - Go to `SCIM | Variables` and set your token and optionally your SCIM base URL, in the format of `https://{sourcegraph URL}/.api/scim/v2`.
 - For a quick test, run "User create" and "User delete".
 - For a complete test, run all requests from top to bottom. They should all pass.
 
+You can also just use [cURL](https://curl.se/) if you prefer a CLI tool.
+
 ## Validators
 
-We use three validators: two for Okta and one for Azure AD.
+The creators of major IdPs supply validators that one can use to test their SCIM implementation.
+
+We used three validators when testing our implementation: two for Okta and one for Azure AD.
 
 1. Okta SPEC test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api) to set it up in five minutes. Tests should be green.
 2. Okta CRUD test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-test/main/) to set up these tests in your Runscope. This also needs access to an Okta application, which you can find [here](https://dev-433675-admin.oktapreview.com/admin/app/dev-433675_k8ssgdevorgsamlscim_1/instance/0oa1l85zn9a0tgzKP0h8/). Log in with shared credentials in 1Password. Tests should be green, except for the last ones that rely on soft deletion which we don't support yet.

--- a/doc/dev/background-information/scim_api.md
+++ b/doc/dev/background-information/scim_api.md
@@ -17,6 +17,7 @@ To inspect the requests and responses, you can use [ngrok](https://ngrok.com/). 
 ## Manual testing with Postman
 
 Postman collection for testing SCIM API locally or through ngrok: [scim_postman_collection.json](scim_postman_collection.json). Steps to use it:
+
 - [Download](https://www.postman.com/) and run Postman
 - Go to `File | Import...` and import the JSON.
 - You can import it into Postman and run the requests from top to bottom.
@@ -35,7 +36,6 @@ We used three validators when testing our implementation: two for Okta and one f
 1. Okta SPEC test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api) to set it up in five minutes. Tests should be green.
 2. Okta CRUD test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-test/main/) to set up these tests in your Runscope. This also needs access to an Okta application, which you can find [here](https://dev-433675-admin.oktapreview.com/admin/app/dev-433675_k8ssgdevorgsamlscim_1/instance/0oa1l85zn9a0tgzKP0h8/). Log in with shared credentials in 1Password. Tests should be green, except for the last ones that rely on soft deletion which we don't support yet.
 3. Azure AD validator – It's [here](https://scimvalidator.microsoft.com). It doesn't have a lot of docs. Just use "Discover my schema", then enter the endpoint (for example, https://sourcegraph.test:3443/search/.api/scim/v2) and the token you have in your settings. It should work right away, and all tests should pass.
-
 
 ## Publishing on Okta
 

--- a/doc/dev/background-information/scim_api.md
+++ b/doc/dev/background-information/scim_api.md
@@ -1,0 +1,46 @@
+# Developing the SCIM API
+
+SCIM is a REST API specification standard for provisioning and deprovisioning users. It can also handle group (de)provisioning, but we don't support that yet.
+
+If you're just getting started with SCIM, watch [this](https://www.youtube.com/watch?v=LBZPPBOdImU) (1.5min) and [this](https://www.youtube.com/watch?v=ID-ApdGu2Hc) (2.5 min) video.
+
+IETF RFCs [7642](https://www.rfc-editor.org/rfc/rfc7642), [7643](https://www.rfc-editor.org/rfc/rfc7643), and [7644](https://www.rfc-editor.org/rfc/rfc7644) are pretty dry, but very useful reference materials.
+
+Our implementation is in [this folder](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/enterprise/internal/scim).
+
+To try it, follow the "How to use" section of our [SCIM admin guide](doc/admin/scim.md), then see the [manual-testing-with-postman](#manual-testing-with-postman) section below to see it in action. It should take you 10–20 minutes to set up everything and see the full CRUD magic happen.
+
+Using ngrok is a good idea because it lets you inspect the requests and responses at http://127.0.0.1:4040/inspect/http.
+
+> WARNING: Running the tests and validators referenced on this page will trigger sending live emails. Be sure to set the environment variables `DISABLE_EMAIL_INVITES=true` or `DEBUG_EMAIL_INVITES_MOCK=true` when running live SCIM API calls if you don't want emails to go out.
+
+## Manual testing with Postman
+
+Postman collection for testing SCIM API locally or through ngrok: [scim_postman_collection.json](scim_postman_collection.json). Steps to use it:
+- Download and run Postman
+- Go to `File | Import...` and import the JSON.
+- You can import it into Postman and run the requests from top to bottom.
+- Go to `SCIM | Variables` and set your token and optionally your SCIM base URL, in the format of `https://{sourcegraph URL}/.api/scim/v2`.
+- For a quick test, run "User create" and "User delete".
+- For a complete test, run all requests from top to bottom. They should all pass.
+
+## Validators
+
+We use three validators: two for Okta and one for Azure AD.
+
+1. Okta SPEC test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api) to set it up in five minutes. Tests should be green.
+2. Okta CRUD test – Follow [this guide](https://developer.okta.com/docs/guides/scim-provisioning-integration-test/main/) to set up these tests in your Runscope. This also needs access to an Okta application, which you can find [here](https://dev-433675-admin.oktapreview.com/admin/app/dev-433675_k8ssgdevorgsamlscim_1/instance/0oa1l85zn9a0tgzKP0h8/). Log in with shared credentials in 1Password. Tests should be green, except for the last ones that rely on soft deletion which we don't support yet.
+3. Azure AD validator – It's [here](https://scimvalidator.microsoft.com). It doesn't have a lot of docs. Just use "Discover my schema", then enter the endpoint (for example, https://sourcegraph.test:3443/search/.api/scim/v2) and the token you have in your settings. It should work right away, and all tests should pass.
+
+
+## Publishing on Okta
+
+Our integration is [here](https://oinmanager.okta.com/app-integration/1731). To access this page, you will need a bit of a hackery:
+
+1. Log in to the Okta test instance [here](https://dev-433675-admin.oktapreview.com/) with the l/p you find in LastPass
+2. Go to Directory → [People](https://dev-433675-admin.oktapreview.com/admin/users), and click on the "Add Person" button
+3. Add your own name and email, and click "Save"
+4. Still with the admin account, open your new user by clicking on it, go to the "Admin roles" tab, and make your user an "Application Administrator".
+5. Save, log out, confirm your email, and log in with your new user. Now you should be able to access the [app integration](https://oinmanager.okta.com/app-integration/1731).
+
+Make changes to it as needed, and submit your changes for review. We haven't tested this process, so this territory is uncharted.

--- a/doc/dev/background-information/scim_api.md
+++ b/doc/dev/background-information/scim_api.md
@@ -8,7 +8,7 @@ IETF RFCs [7642](https://www.rfc-editor.org/rfc/rfc7642), [7643](https://www.rfc
 
 Our implementation is in [this folder](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/enterprise/internal/scim).
 
-To try it, follow the "How to use" section of our [SCIM admin guide](doc/admin/scim.md), then see the [manual-testing-with-postman](#manual-testing-with-postman) section below to see it in action. It should take you 10–20 minutes to set up everything and see the full CRUD magic happen.
+To try it, follow the [How to use section of our SCIM admin guide](doc/admin/scim.md#how-to-use), then see the [manual-testing-with-postman](#manual-testing-with-postman) section below to see it in action. It should take you 10–20 minutes to set up everything and see the full CRUD magic happen.
 
 Using ngrok is a good idea because it lets you inspect the requests and responses at http://127.0.0.1:4040/inspect/http.
 

--- a/doc/dev/background-information/scim_postman_collection.json
+++ b/doc/dev/background-information/scim_postman_collection.json
@@ -1,0 +1,464 @@
+{
+	"info": {
+		"_postman_id": "e328dec5-cc3c-43f5-b51c-4f6943cb05d6",
+		"name": "SCIM",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "8185968"
+	},
+	"item": [
+		{
+			"name": "ServiceProviderConfig",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{scim_base_url}}/Schemas",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Schemas"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User get all",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{scim_base_url}}/Users",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User get filter",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "scim_base_url}}/Users?filter=name.formatted co \"test\"",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users"
+					],
+					"query": [
+						{
+							"key": "filter",
+							"value": "name.formatted co \"test\""
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User create",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var jsonData = JSON.parse(responseBody);",
+							"pm.collectionVariables.set(\"user_id\", jsonData.id);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"active\": true,\n  \"userName\": \"test+user@company.com\",\n  \"displayName\": \"User Test\",\n  \"name\": {\n    \"givenName\": \"User\",\n    \"familyName\": \"Test\"\n  },\n  \"nickName\": \"Testy\",\n  \"emails\": [\n    {\n      \"value\": \"test2@company.com\",\n      \"primary\": true\n    }\n  ],\n  \"addresses\": [\n    {\n      \"type\": \"work\",\n      \"streetAddress\": \"11336 Crona Trail\",\n      \"locality\": \"Turmoil\",\n      \"region\": \"Winston\",\n      \"postalCode\": \"dn1 6nt\",\n      \"country\": \"Norfolk Island\"\n    }\n  ],\n  \"schemas\": [\n    \"urn:ietf:params:scim:schemas:core:2.0:User\",\n    \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\"\n  ]\n}"
+				},
+				"url": {
+					"raw": "{{scim_base_url}}/Users",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User get",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{scim_base_url}}/Users/{{user_id}}",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users",
+						"{{user_id}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User patch",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"Operations\": [\n    {\n      \"op\": \"replace\",\n      \"value\": {\n        \"userName\": \"euna@borer.ca\",\n        \"displayName\": \"Y9SN5MS0O5FV\",\n        \"name.givenName\": \"Leilani\",\n        \"name.familyName\": \"Salvador\",\n        \"name.formatted\": \"Chyna\",\n        \"name.middleName\": \"Ibrahim\",\n        \"nickName\": \"L3TA6I9XJ7W5\"\n      }\n    }\n  ],\n  \"schemas\": [\n    \"urn:ietf:params:scim:api:messages:2.0:PatchOp\"\n  ]\n}"
+				},
+				"url": {
+					"raw": "{{scim_base_url}}/Users/{{user_id}}",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users",
+						"{{user_id}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User replace",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"active\": true,\n  \"userName\": \"test+user@company.com\",\n  \"displayName\": \"User Test\",\n  \"name\": {\n    \"givenName\": \"User\",\n    \"familyName\": \"Test\"\n  },\n  \"nickName\": \"Testy2\",\n  \"emails\": [\n    {\n      \"value\": \"test+user@company.com\",\n      \"primary\": true\n    }\n  ],\n  \"schemas\": [\n    \"urn:ietf:params:scim:schemas:core:2.0:User\",\n    \"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\"\n  ]\n}"
+				},
+				"url": {
+					"raw": "{{scim_base_url}}/Users/{{user_id}}",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users",
+						"{{user_id}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "User delete (ngrok)",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Accept-Charset",
+						"value": "utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/scim+json; charset=utf-8",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/scim+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{scim_base_url}}/Users/{{user_id}}",
+					"host": [
+						"{{scim_base_url}}"
+					],
+					"path": [
+						"Users",
+						"{{user_id}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "scim_base_url",
+			"value": "https://sourcegraph.test:3443/.api/scim/v2",
+			"type": "string"
+		},
+		{
+			"key": "token",
+			"value": "TODO paste random token here",
+		},
+		{
+			"key": "user_id",
+			"value": "{CREATE will write this}",
+			"type": "string"
+		}
+	]
+}

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -87,6 +87,7 @@ Clarification and discussion about key concepts, architecture, and development s
   - [Temporary settings](background-information/web/temporary_settings.md)
   - [Build process](background-information/web/build.md)
 - [Developing the GraphQL API](background-information/graphql_api.md)
+- [Developing the SCIM API](background-information/scim_api.md)
 - [Developing batch changes](background-information/batch_changes/index.md)
 - [Developing code navigation](background-information/codeintel/index.md)
 - [Developing code insights](background-information/insights/index.md)


### PR DESCRIPTION
- Completes https://github.com/sourcegraph/sourcegraph/issues/49216
- Completes https://github.com/sourcegraph/sourcegraph/issues/49020

Three changes:

- Added Okta-specific setup info for admins
- Added dev docs to capture the most crucial info that we only had in the SCIM Google Doc
- Linked SCIM from SAML pages for Okta and Azure AD to improve discoverability at the points where it's the most relevant

## Test plan

Only docs changes.
I've clicked through the links.