### PR TITLE
[chore] hide cursor and bracket match in read-only code host config

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.module.scss
+++ b/client/web/src/components/externalServices/ExternalServicePage.module.scss
@@ -1,0 +1,8 @@
+.external-service-page {
+    // hide cursor and bracket match in monaco editor
+    div[data-editor="monaco"] {
+        textarea, canvas, :global(.cdr.bracket-match) { //, :global(.contentWidgets), :global(.cursors-layer), :global(.overlayWidgets), :global(.view-overlays) {
+            display: none;
+        }
+    }
+}

--- a/client/web/src/components/externalServices/ExternalServicePage.module.scss
+++ b/client/web/src/components/externalServices/ExternalServicePage.module.scss
@@ -1,7 +1,9 @@
 .external-service-page {
     // hide cursor and bracket match in monaco editor
-    div[data-editor="monaco"] {
-        textarea, canvas, :global(.cdr.bracket-match) {
+    div[data-editor='monaco'] {
+        textarea,
+        canvas,
+        :global(.cdr.bracket-match) {
             display: none;
         }
     }

--- a/client/web/src/components/externalServices/ExternalServicePage.module.scss
+++ b/client/web/src/components/externalServices/ExternalServicePage.module.scss
@@ -1,7 +1,7 @@
 .external-service-page {
     // hide cursor and bracket match in monaco editor
     div[data-editor="monaco"] {
-        textarea, canvas, :global(.cdr.bracket-match) { //, :global(.contentWidgets), :global(.cursors-layer), :global(.overlayWidgets), :global(.view-overlays) {
+        textarea, canvas, :global(.cdr.bracket-match) {
             display: none;
         }
     }

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -34,6 +34,8 @@ import { ExternalServiceSyncJobsList } from './ExternalServiceSyncJobsList'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 import { isAppLocalFileService } from './isAppLocalFileService'
 
+import styles from './ExternalServicePage.module.scss'
+
 interface Props extends TelemetryProps {
     afterDeleteRoute: string
 
@@ -172,7 +174,7 @@ export const ExternalServicePage: FC<Props> = props => {
     }
 
     return (
-        <div>
+        <div className={styles.externalServicePage}>
             {externalService ? (
                 <PageTitle title={`Code host - ${externalService.displayName}`} />
             ) : (


### PR DESCRIPTION
## Video

https://www.loom.com/share/65d920b3a1c54ae8b17d5eb8bc38a9c9


## Test plan

CSS change only. Tested locally, works as shown on the video above.

## App preview:

- [Web](https://sg-web-milan-ronly-code-host-config.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
