### PR TITLE
experimental search input: Scroll selection into view after completion

### DIFF
--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -570,6 +570,7 @@ function applyAction(view: EditorView, action: Action, option: Option, source: S
                     view.dispatch({
                         ...changeSet,
                         effects: changeSet.effects.concat(setModeEffect.of(null)),
+                        scrollIntoView: true,
                     })
                 }
                 notifySelectionListeners(view.state, option, action, source)


### PR DESCRIPTION
Originally I wanted to do properly pass in the `globbing` parameter but then I noticed that this feature had been removed for quite a while (#27886, #46045).
But while working on this I noticed that the cursor is not properly scrolled into view when completing a long value. Adding `scrollIntoView` fixes that.


## Test plan

Enter a long query into the input, type `file:` and select a long file suggestion. The input should scroll the cursor into view.

## App preview:

- [Web](https://sg-web-fkling-search-input-globbing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
