### PR TITLE
Remove globbing from all frontend code

### DIFF
--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -84,7 +84,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
     onFocus,
     onBlur,
     isSourcegraphDotCom,
-    globbing,
     onEditorCreated,
     interpretComments,
     className,
@@ -128,19 +127,11 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
             createDefaultSuggestions({
                 fetchSuggestions: query =>
                     fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)),
-                globbing,
                 isSourcegraphDotCom,
                 navigate,
                 applyOnEnter: applySuggestionsOnEnter,
             }),
-        [
-            globbing,
-            isSourcegraphDotCom,
-            navigate,
-            applySuggestionsOnEnter,
-            fetchStreamSuggestions,
-            selectedSearchContextSpec,
-        ]
+        [isSourcegraphDotCom, navigate, applySuggestionsOnEnter, fetchStreamSuggestions, selectedSearchContextSpec]
     )
 
     const extensions = useMemo(() => {

--- a/client/branded/src/search-ui/input/QueryInput.ts
+++ b/client/branded/src/search-ui/input/QueryInput.ts
@@ -25,8 +25,6 @@ export interface QueryInputProps
     onEditorCreated?: (editor: IEditor) => void
     fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     autoFocus?: boolean
-    // Whether globbing is enabled for filters.
-    globbing: boolean
 
     // Whether comments are parsed and highlighted
     interpretComments?: boolean

--- a/client/branded/src/search-ui/input/SearchBox.story.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.story.tsx
@@ -28,7 +28,6 @@ const defaultProps: SearchBoxProps = {
         final: null,
         subjects: null,
     },
-    globbing: false,
     queryState: { query: 'hello repo:test' },
     isSourcegraphDotCom: false,
     patternType: SearchPatternType.standard,

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -31,7 +31,6 @@ export interface SearchBoxProps
             | 'autoFocus'
             | 'onFocus'
             | 'onSubmit'
-            | 'globbing'
             | 'interpretComments'
             | 'onChange'
             | 'onCompletionItemSelected'
@@ -181,7 +180,6 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                         autoFocus={props.autoFocus}
                         caseSensitive={props.caseSensitive}
                         fetchStreamSuggestions={props.fetchStreamSuggestions}
-                        globbing={props.globbing}
                         interpretComments={props.interpretComments}
                         isSourcegraphDotCom={props.isSourcegraphDotCom}
                         onChange={props.onChange}

--- a/client/branded/src/search-ui/input/codemirror/completion.test.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.test.ts
@@ -20,10 +20,9 @@ async function getCompletionItems(
     token: Token,
     position: number,
     fetchSuggestions: () => Promise<SearchMatch[]>,
-    options?: { globbing?: boolean; isSourcegraphDotCom?: boolean; tokens?: Token[] }
+    options?: { isSourcegraphDotCom?: boolean; tokens?: Token[] }
 ) {
     const sources = createDefaultSuggestionSources({
-        globbing: false,
         isSourcegraphDotCom: false,
         fetchSuggestions,
         ...options,

--- a/client/branded/src/search-ui/input/codemirror/completion.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.ts
@@ -316,7 +316,6 @@ export function searchQueryAutocompletion(
 export interface DefaultSuggestionSourcesOptions {
     fetchSuggestions: (query: string, onAbort: (listener: () => void) => void) => Promise<SearchMatch[]>
     isSourcegraphDotCom: boolean
-    globbing: boolean
     applyOnEnter?: boolean
     disableFilterCompletion?: true
     disableSymbolCompletion?: true
@@ -462,7 +461,7 @@ export function createDefaultSuggestionSources(
                     to: token.value?.range.end,
                     filter: false,
                     options: filteredResults,
-                    getMatch: insidePredicate || options.globbing ? undefined : createMatchFunction(token),
+                    getMatch: insidePredicate ? undefined : createMatchFunction(token),
                 }
             })
         )

--- a/client/branded/src/search-ui/input/codemirror/completion.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.ts
@@ -575,7 +575,7 @@ function completionFromSearchMatch(
                               revision: match.commit,
                               repoName: match.repository,
                           }),
-                    apply: (params?.isDefaultSource ? 'file:' : '') + regexInsertText(match.path, options) + ' ',
+                    apply: (params?.isDefaultSource ? 'file:' : '') + regexInsertText(match.path) + ' ',
                     info: match.repository,
                 },
             ]
@@ -586,10 +586,7 @@ function completionFromSearchMatch(
                     type: 'repository',
                     url: hasNonActivePatternTokens ? undefined : `/${match.repository}`,
                     detail: formatRepositoryStars(match.repoStars),
-                    apply:
-                        (params?.isDefaultSource ? 'repo:' : '') +
-                        repositoryInsertText(match, { ...options, filterValue: params?.filterValue }) +
-                        ' ',
+                    apply: (params?.isDefaultSource ? 'repo:' : '') + repositoryInsertText(match) + ' ',
                 },
             ]
         case 'symbol':

--- a/client/branded/src/search-ui/input/codemirror/index.ts
+++ b/client/branded/src/search-ui/input/codemirror/index.ts
@@ -76,7 +76,6 @@ interface CreateDefaultSuggestionsOptions extends Omit<DefaultSuggestionSourcesO
  */
 export const createDefaultSuggestions = ({
     isSourcegraphDotCom,
-    globbing,
     fetchSuggestions,
     disableFilterCompletion,
     disableSymbolCompletion,
@@ -87,7 +86,6 @@ export const createDefaultSuggestions = ({
     searchQueryAutocompletion(
         createDefaultSuggestionSources({
             fetchSuggestions: createCancelableFetchSuggestions(fetchSuggestions),
-            globbing,
             isSourcegraphDotCom,
             disableSymbolCompletion,
             disableFilterCompletion,

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -21,7 +21,6 @@ public class ConfigUtil {
         configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(project));
         configAsJson.addProperty("accessToken", ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null);
         configAsJson.addProperty("customRequestHeadersAsString", ConfigUtil.getCustomRequestHeaders(project));
-        configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(project));
         configAsJson.addProperty("pluginVersion", ConfigUtil.getPluginVersion());
         configAsJson.addProperty("anonymousUserId", ConfigUtil.getAnonymousUserId());
         return configAsJson;
@@ -140,12 +139,6 @@ public class ConfigUtil {
         // User level or default
         String userLevelRemoteUrlReplacements = UserLevelConfig.getRemoteUrlReplacements();
         return userLevelRemoteUrlReplacements != null ? userLevelRemoteUrlReplacements : "";
-    }
-
-    public static boolean isGlobbingEnabled(@NotNull Project project) {
-        // Project level → application level
-        Boolean projectLevelIsGlobbingEnabled = getProjectLevelConfig(project).isGlobbingEnabled();
-        return projectLevelIsGlobbingEnabled != null ? projectLevelIsGlobbingEnabled : getApplicationLevelConfig().isGlobbingEnabled();
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -38,7 +38,6 @@ public class SettingsComponent {
     private JBTextField customRequestHeadersTextField;
     private JBTextField defaultBranchNameTextField;
     private JBTextField remoteUrlReplacementsTextField;
-    private JBCheckBox globbingCheckBox;
     private JBCheckBox isUrlNotificationDismissedCheckBox;
 
     public JComponent getPreferredFocusedComponent() {
@@ -221,14 +220,6 @@ public class SettingsComponent {
         remoteUrlReplacementsTextField.setText(value);
     }
 
-    public boolean isGlobbingEnabled() {
-        return globbingCheckBox.isSelected();
-    }
-
-    public void setGlobbingEnabled(boolean value) {
-        globbingCheckBox.setSelected(value);
-    }
-
     public boolean isUrlNotificationDismissed() {
         return isUrlNotificationDismissedCheckBox.isSelected();
     }
@@ -304,7 +295,6 @@ public class SettingsComponent {
                 ? new ValidationInfo("Must be a comma-separated list of pairs", remoteUrlReplacementsTextField)
                 : null);
 
-        globbingCheckBox = new JBCheckBox("Enable globbing");
         isUrlNotificationDismissedCheckBox = new JBCheckBox("Do not show the \"No Sourcegraph URL set\" notification for this project");
 
         JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
@@ -314,7 +304,6 @@ public class SettingsComponent {
             .addTooltip("You can replace specified strings in your repo's remote URL.")
             .addTooltip("Use any number of pairs: \"search1, replacement1, search2, replacement2, ...\".")
             .addTooltip("Pairs are replaced from left to right. Whitespace around commas doesn't matter.")
-            .addComponent(globbingCheckBox)
             .addComponent(isUrlNotificationDismissedCheckBox, 10)
             .getPanel();
         navigationSettingsPanel.setBorder(IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -45,7 +45,6 @@ public class SettingsConfigurable implements Configurable {
             || !mySettingsComponent.getCustomRequestHeaders().equals(ConfigUtil.getCustomRequestHeaders(project))
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
-            || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project)
             || mySettingsComponent.isUrlNotificationDismissed() != ConfigUtil.isUrlNotificationDismissed();
     }
 
@@ -96,12 +95,6 @@ public class SettingsConfigurable implements Configurable {
         } else {
             aSettings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
         }
-        //noinspection ReplaceNullCheck
-        if (pSettings.isGlobbingEnabled != null) {
-            pSettings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
-        } else {
-            aSettings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
-        }
         aSettings.isUrlNotificationDismissed = mySettingsComponent.isUrlNotificationDismissed();
 
         publisher.afterAction(context);
@@ -118,7 +111,6 @@ public class SettingsConfigurable implements Configurable {
         mySettingsComponent.setDefaultBranchName(defaultBranchName);
         String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);
         mySettingsComponent.setRemoteUrlReplacements(remoteUrlReplacements);
-        mySettingsComponent.setGlobbingEnabled(ConfigUtil.isGlobbingEnabled(project));
         mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -23,7 +23,6 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     public String defaultBranch;
     @Nullable
     public String remoteUrlReplacements;
-    public boolean isGlobbingEnabled; // This can be a primitive boolean, we need no "null" state
     @Nullable
     public String anonymousUserId;
     public boolean isInstallEventLogged;
@@ -69,9 +68,6 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         return remoteUrlReplacements;
     }
 
-    public boolean isGlobbingEnabled() {
-        return this.isGlobbingEnabled;
-    }
 
     @Nullable
     public String getAnonymousUserId() {
@@ -110,7 +106,6 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         this.customRequestHeaders = settings.customRequestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
-        this.isGlobbingEnabled = settings.isGlobbingEnabled;
         this.anonymousUserId = settings.anonymousUserId;
         this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
         this.authenticationFailedLastTime = settings.authenticationFailedLastTime;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -25,8 +25,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Nullable
     public String remoteUrlReplacements;
     @Nullable
-    public Boolean isGlobbingEnabled; // This needs to be a Boolean rather than a primitive: we need the "null" state
-    @Nullable
     public String lastSearchQuery;
     public boolean lastSearchCaseSensitive;
     @Nullable
@@ -70,11 +68,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     }
 
     @Nullable
-    public Boolean isGlobbingEnabled() {
-        return this.isGlobbingEnabled;
-    }
-
-    @Nullable
     public Search getLastSearch() {
         if (lastSearchQuery == null) {
             return null;
@@ -97,7 +90,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         this.customRequestHeaders = settings.customRequestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
-        this.isGlobbingEnabled = settings.isGlobbingEnabled;
         this.lastSearchQuery = settings.lastSearchQuery != null ? settings.lastSearchQuery : "";
         this.lastSearchCaseSensitive = settings.lastSearchCaseSensitive;
         this.lastSearchPatternType = settings.lastSearchPatternType != null ? settings.lastSearchPatternType : "literal";

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -55,7 +55,6 @@ function handleRequest(
                     instanceURL,
                     accessToken,
                     customRequestHeadersAsString: 'Client-ID,99999,X-Test-Header,Some value',
-                    isGlobbingEnabled: true,
                     pluginVersion: '1.2.3',
                     anonymousUserId: 'test',
                 })

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -36,7 +36,6 @@ import styles from './App.module.scss'
 interface Props {
     isDarkTheme: boolean
     instanceURL: string
-    isGlobbingEnabled: boolean
     accessToken: string | null
     customRequestHeaders: Record<string, string> | null
     onPreviewChange: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
@@ -69,7 +68,6 @@ function fallbackToLiteralSearchIfNeeded(
 export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     isDarkTheme,
     instanceURL,
-    isGlobbingEnabled,
     accessToken,
     customRequestHeaders,
     onPreviewChange,
@@ -276,7 +274,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                                 getUserSearchContextNamespaces={getUserSearchContextNamespaces}
                                 fetchStreamSuggestions={fetchStreamSuggestionsWithStaticUrl}
                                 settingsCascade={settingsCascade}
-                                globbing={isGlobbingEnabled}
                                 telemetryService={telemetryService}
                                 platformContext={platformContext}
                                 className=""

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -25,7 +25,6 @@ setLinkComponent(AnchorLink)
 
 let isDarkTheme = false
 let instanceURL = 'https://sourcegraph.com/'
-let isGlobbingEnabled = false
 let accessToken: string | null = null
 let customRequestHeaders: Record<string, string> | null = {}
 let anonymousUserId: string
@@ -72,7 +71,6 @@ export function renderReactApp(): void {
             key={`${instanceURL}-${accessToken}-${errorRetryIndex}`}
             isDarkTheme={isDarkTheme}
             instanceURL={instanceURL}
-            isGlobbingEnabled={isGlobbingEnabled}
             accessToken={accessToken}
             customRequestHeaders={customRequestHeaders}
             initialSearch={initialSearch}
@@ -90,7 +88,6 @@ export function renderReactApp(): void {
 
 export function applyConfig(config: PluginConfig): void {
     instanceURL = config.instanceURL
-    isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
     customRequestHeaders = parseCustomRequestHeadersString(config.customRequestHeadersAsString)
     anonymousUserId = config.anonymousUserId || 'no-user-id'

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
@@ -71,7 +71,6 @@ export const JetBrainsSearchBoxStory: Story = () => {
                                     getUserSearchContextNamespaces={() => []}
                                     fetchStreamSuggestions={() => NEVER}
                                     settingsCascade={EMPTY_SETTINGS_CASCADE}
-                                    globbing={false}
                                     telemetryService={NOOP_TELEMETRY_SERVICE}
                                     platformContext={{ requestGraphQL: () => EMPTY }}
                                     className=""

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.tsx
@@ -41,9 +41,6 @@ export interface JetBrainsSearchBoxProps
     className?: string
     containerClassName?: string
 
-    /** Whether globbing is enabled for filters. */
-    globbing: boolean
-
     /** Whether comments are parsed and highlighted */
     interpretComments?: boolean
 
@@ -120,7 +117,6 @@ export const JetBrainsSearchBox: React.FunctionComponent<React.PropsWithChildren
                         autoFocus={props.autoFocus}
                         caseSensitive={props.caseSensitive}
                         fetchStreamSuggestions={props.fetchStreamSuggestions}
-                        globbing={props.globbing}
                         isSourcegraphDotCom={props.isSourcegraphDotCom}
                         onChange={props.onChange}
                         onSubmit={props.onSubmit}

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -111,7 +111,6 @@ export async function getConfigAlwaysFulfill(): Promise<PluginConfig> {
             instanceURL: 'https://sourcegraph.com/',
             accessToken: null,
             customRequestHeadersAsString: null,
-            isGlobbingEnabled: false,
             pluginVersion: '0.0.0',
             anonymousUserId: 'no-user-id',
         }

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -21,7 +21,6 @@ export interface PluginConfig {
     instanceURL: string
     accessToken: string | null
     customRequestHeadersAsString: string | null
-    isGlobbingEnabled: boolean
     pluginVersion: string
     anonymousUserId: string
 }

--- a/client/shared/src/search/query/completion-utils.ts
+++ b/client/shared/src/search/query/completion-utils.ts
@@ -14,8 +14,8 @@ export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
  * regexInsertText escapes the provided value so that it can be used as value
  * for a filter which expects a regular expression.
  */
-export const regexInsertText = (value: string, options: { globbing: boolean }): string => {
-    const insertText = options.globbing ? value : `^${escapeRegExp(value)}$`
+export const regexInsertText = (value: string, _options: {}): string => {
+    const insertText = `^${escapeRegExp(value)}$`
     return escapeSpaces(insertText)
 }
 
@@ -23,10 +23,8 @@ export const regexInsertText = (value: string, options: { globbing: boolean }): 
  * repositoryInsertText escapes the provides value so that it can be used as a
  * value for the `repo:` filter.
  */
-export const repositoryInsertText = (
-    { repository }: RepositoryMatch,
-    options: { globbing: boolean; filterValue?: string }
-): string => regexInsertText(repository, options)
+export const repositoryInsertText = ({ repository }: RepositoryMatch, options: { filterValue?: string }): string =>
+    regexInsertText(repository, options)
 
 /**
  * Given a list of filter types, this function returns a list of objects which

--- a/client/shared/src/search/query/completion-utils.ts
+++ b/client/shared/src/search/query/completion-utils.ts
@@ -14,7 +14,7 @@ export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
  * regexInsertText escapes the provided value so that it can be used as value
  * for a filter which expects a regular expression.
  */
-export const regexInsertText = (value: string, _options: {}): string => {
+export const regexInsertText = (value: string): string => {
     const insertText = `^${escapeRegExp(value)}$`
     return escapeSpaces(insertText)
 }
@@ -23,8 +23,7 @@ export const regexInsertText = (value: string, _options: {}): string => {
  * repositoryInsertText escapes the provides value so that it can be used as a
  * value for the `repo:` filter.
  */
-export const repositoryInsertText = ({ repository }: RepositoryMatch, options: { filterValue?: string }): string =>
-    regexInsertText(repository, options)
+export const repositoryInsertText = ({ repository }: RepositoryMatch): string => regexInsertText(repository)
 
 /**
  * Given a list of filter types, this function returns a list of objects which

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -265,7 +265,7 @@ export async function getCompletionItems(
             tokenAtPosition,
             async (token, type) =>
                 (await fetchDynamicSuggestions(token, type)).flatMap(suggestion =>
-                    suggestionToCompletionItems(suggestion, {})
+                    suggestionToCompletionItems(suggestion)
                 ),
             disablePatternSuggestions
         )
@@ -289,9 +289,7 @@ export async function getCompletionItems(
                 async (token, type) =>
                     (
                         await fetchDynamicSuggestions(token, type)
-                    ).flatMap(suggestion =>
-                        suggestionToCompletionItems(suggestion, { filterValue: token.value?.value })
-                    ),
+                    ).flatMap(suggestion => suggestionToCompletionItems(suggestion)),
                 column,
                 isSourcegraphDotCom
             )

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -77,7 +77,7 @@ const symbolKindToCompletionItemKind: Record<SymbolKind, Monaco.languages.Comple
  */
 const suggestionToCompletionItems = (
     suggestion: SearchMatch,
-    options: { globbing: boolean; filterValue?: string }
+    options: { filterValue?: string }
 ): PartialCompletionItem[] | PartialCompletionItem => {
     switch (suggestion.type) {
         case 'path':
@@ -253,10 +253,9 @@ export async function getCompletionItems(
     { column }: Pick<Monaco.Position, 'column'>,
     fetchDynamicSuggestions: FetchSuggestions,
     {
-        globbing = false,
         isSourcegraphDotCom = false,
         disablePatternSuggestions = false,
-    }: { globbing?: boolean; isSourcegraphDotCom?: boolean; disablePatternSuggestions?: boolean }
+    }: { isSourcegraphDotCom?: boolean; disablePatternSuggestions?: boolean }
 ): Promise<Monaco.languages.CompletionList | null> {
     let suggestions: Monaco.languages.CompletionItem[] = []
 
@@ -269,7 +268,7 @@ export async function getCompletionItems(
             tokenAtPosition,
             async (token, type) =>
                 (await fetchDynamicSuggestions(token, type)).flatMap(suggestion =>
-                    suggestionToCompletionItems(suggestion, { globbing })
+                    suggestionToCompletionItems(suggestion, {})
                 ),
             disablePatternSuggestions
         )
@@ -294,7 +293,7 @@ export async function getCompletionItems(
                     (
                         await fetchDynamicSuggestions(token, type)
                     ).flatMap(suggestion =>
-                        suggestionToCompletionItems(suggestion, { globbing, filterValue: token.value?.value })
+                        suggestionToCompletionItems(suggestion, { filterValue: token.value?.value })
                     ),
                 column,
                 isSourcegraphDotCom

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -75,16 +75,13 @@ const symbolKindToCompletionItemKind: Record<SymbolKind, Monaco.languages.Comple
  * Maps a SearchMatch result from the server to a partial competion item for
  * Monaco.
  */
-const suggestionToCompletionItems = (
-    suggestion: SearchMatch,
-    options: { filterValue?: string }
-): PartialCompletionItem[] | PartialCompletionItem => {
+const suggestionToCompletionItems = (suggestion: SearchMatch): PartialCompletionItem[] | PartialCompletionItem => {
     switch (suggestion.type) {
         case 'path':
             return {
                 label: suggestion.path,
                 kind: Monaco.languages.CompletionItemKind.File,
-                insertText: regexInsertText(suggestion.path, options) + ' ',
+                insertText: regexInsertText(suggestion.path) + ' ',
                 filterText: suggestion.path,
                 detail: `${suggestion.path} - ${suggestion.repository}`,
             }
@@ -92,7 +89,7 @@ const suggestionToCompletionItems = (
             return {
                 label: suggestion.repository,
                 kind: repositoryCompletionItemKind,
-                insertText: repositoryInsertText(suggestion, options) + ' ',
+                insertText: repositoryInsertText(suggestion) + ' ',
                 filterText: suggestion.repository,
             }
         case 'symbol':

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -41,7 +41,6 @@ export function getProviders(
     fetchSuggestions: (input: string) => Observable<SearchMatch[]>,
     options: {
         patternType: SearchPatternType
-        globbing: boolean
         disablePatternSuggestions?: boolean
         interpretComments?: boolean
         isSourcegraphDotCom?: boolean

--- a/client/shared/src/util/globbing.ts
+++ b/client/shared/src/util/globbing.ts
@@ -1,9 +1,0 @@
-import { isErrorLike } from '@sourcegraph/common'
-
-import { SettingsCascadeOrError } from '../settings/settings'
-
-/**
- * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise
- */
-export const globbingEnabledFromSettings = (settings: SettingsCascadeOrError): boolean =>
-    !!(settings.final && !isErrorLike(settings.final) && settings.final['search.globbing'])

--- a/client/vscode/src/webview/search-panel/SearchHomeView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchHomeView.tsx
@@ -11,7 +11,6 @@ import { collectMetrics } from '@sourcegraph/shared/src/search/query/metrics'
 import { appendContextFilter, sanitizeQueryForTelemetry } from '@sourcegraph/shared/src/search/query/transformer'
 import { LATEST_VERSION, SearchMatch } from '@sourcegraph/shared/src/search/stream'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
 
 import { SearchPatternType } from '../../graphql-operations'
 import { SearchHomeState } from '../../state'
@@ -136,8 +135,6 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
         }
     }, [context.searchSidebarQueryState.proposedQueryState?.queryState])
 
-    const globbing = useMemo(() => globbingEnabledFromSettings(settingsCascade), [settingsCascade])
-
     const setSelectedSearchContextSpec = useCallback(
         (spec: string) => {
             extensionCoreAPI.setSelectedSearchContextSpec(spec).catch(error => {
@@ -188,7 +185,6 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
                         getUserSearchContextNamespaces={getUserSearchContextNamespaces}
                         fetchStreamSuggestions={fetchStreamSuggestions}
                         settingsCascade={settingsCascade}
-                        globbing={globbing}
                         telemetryService={platformContext.telemetryService}
                         platformContext={platformContext}
                         className={classNames('flex-grow-1 flex-shrink-past-contents', styles.searchBox)}

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -15,7 +15,6 @@ import {
     updateFilters,
 } from '@sourcegraph/shared/src/search/query/transformer'
 import { LATEST_VERSION, RepositoryMatch, SearchMatch } from '@sourcegraph/shared/src/search/stream'
-import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { SearchPatternType } from '../../graphql-operations'
@@ -252,8 +251,6 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
         [extensionCoreAPI, instanceURL]
     )
 
-    const globbing = useMemo(() => globbingEnabledFromSettings(settingsCascade), [settingsCascade])
-
     const setSelectedSearchContextSpec = useCallback(
         (spec: string) => {
             extensionCoreAPI
@@ -343,7 +340,6 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                     getUserSearchContextNamespaces={getUserSearchContextNamespaces}
                     fetchStreamSuggestions={fetchStreamSuggestions}
                     settingsCascade={settingsCascade}
-                    globbing={globbing}
                     telemetryService={platformContext.telemetryService}
                     platformContext={platformContext}
                     className={classNames('flex-grow-1 flex-shrink-past-contents', styles.searchBox)}

--- a/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
@@ -44,7 +44,6 @@
             parseInputAsQuery({ patternType: config.patternType, interpretComments: config.interpretComments }),
             createDefaultSuggestions({
                 fetchSuggestions: query => fetchStreamSuggestions(query),
-                globbing: false,
                 isSourcegraphDotCom: false,
                 navigate: url => goto(url.toString()),
                 applyOnEnter: true,

--- a/client/web-sveltekit/src/routes/(enterprise)/notebooks/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/(enterprise)/notebooks/[...path]/+page.svelte
@@ -1,7 +1,7 @@
 <!--
     This page is rendered by using the corresponding React component.
 
-    CAVEAT: Using back/forward buttons to navigate between headings inside a 
+    CAVEAT: Using back/forward buttons to navigate between headings inside a
     Notebook (has navigation) doesn't scroll the target into view.
     We need to investigate if that's a fundamental problem with
     SvelteKit<->ReactRouter of if Notebooks are doing something that prevents
@@ -36,7 +36,6 @@
         platformContext: data.platformContext as any,
         authenticatedUser: data.user,
         notebooksEnabled: true,
-        globbing: false,
         settingsCascade: data.settings,
         searchContextsEnabled: false,
         streamSearch: aggregateStreamingSearch,

--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -18,7 +18,6 @@ import {
 } from '@sourcegraph/shared/src/search'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
 
 import { isBatchChangesExecutionEnabled } from './batches'
 import { useBreadcrumbs, BreadcrumbSetters, BreadcrumbsProps } from './components/Breadcrumbs'
@@ -39,7 +38,6 @@ export interface LegacyRouteComputedContext {
     /**
      * TODO: expose these fields in the new `useSettings()` hook, calculate next to source.
      */
-    globbing: boolean
     batchChangesExecutionEnabled: boolean
 
     /**
@@ -153,7 +151,6 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
     } satisfies LegacyRouteStaticInjections
 
     const computedContextFields = {
-        globbing: globbingEnabledFromSettings(settingsCascade),
         batchChangesExecutionEnabled: isBatchChangesExecutionEnabled(settingsCascade),
         isMacPlatform: isMacPlatform(),
     } satisfies LegacyRouteComputedContext

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -37,7 +37,6 @@ import {
 } from '@sourcegraph/shared/src/settings/settings'
 import { TemporarySettingsProvider } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsProvider'
 import { TemporarySettingsStorage } from '@sourcegraph/shared/src/settings/temporary/TemporarySettingsStorage'
-import { globbingEnabledFromSettings } from '@sourcegraph/shared/src/util/globbing'
 import { setLinkComponent, RouterLink, WildcardThemeContext, WildcardTheme } from '@sourcegraph/wildcard'
 
 import { authenticatedUser as authenticatedUserSubject, AuthenticatedUser, authenticatedUserValue } from './auth'
@@ -77,11 +76,6 @@ interface LegacySourcegraphWebAppState extends SettingsCascadeProps {
     viewerSubject: LegacyLayoutProps['viewerSubject']
 
     selectedSearchContextSpec?: string
-
-    /**
-     * Whether globbing is enabled for filters.
-     */
-    globbing: boolean
 }
 
 const WILDCARD_THEME: WildcardTheme = {
@@ -109,7 +103,6 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
             authenticatedUser: authenticatedUserValue,
             settingsCascade: EMPTY_SETTINGS_CASCADE,
             viewerSubject: siteSubjectNoAdmin(),
-            globbing: false,
         }
     }
 
@@ -143,7 +136,6 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                 this.setState({
                     settingsCascade,
                     authenticatedUser,
-                    globbing: globbingEnabledFromSettings(settingsCascade),
                     viewerSubject: viewerSubjectFromSettings(settingsCascade, authenticatedUser),
                 })
             })
@@ -236,7 +228,6 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                             updateSearchContext={updateSearchContext}
                             deleteSearchContext={deleteSearchContext}
                             isSearchContextSpecAvailable={isSearchContextSpecAvailable}
-                            globbing={this.state.globbing}
                             streamSearch={aggregateStreamingSearch}
                         />
                     }

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -126,7 +126,6 @@ const commonProps = () =>
         batchChangesEnabled: false,
         authenticatedUser: authUser,
         communitySearchContextMetadata: temporal,
-        globbing: false,
         fetchSearchContexts: mockFetchSearchContexts,
         getUserSearchContextNamespaces: mockGetUserSearchContextNamespaces,
         fetchSearchContextBySpec: fetchCommunitySearchContext,

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -39,9 +39,6 @@ export interface CommunitySearchContextPageProps
 
     // CommunitySearchContext page metadata
     communitySearchContextMetadata: CommunitySearchContextMetadata
-
-    /** Whether globbing is enabled for filters. */
-    globbing: boolean
 }
 
 export const CommunitySearchContextPage: React.FunctionComponent<

--- a/client/web/src/components/legacyLayoutRouteContext.ts
+++ b/client/web/src/components/legacyLayoutRouteContext.ts
@@ -56,7 +56,6 @@ export const dynamicWebAppConfig = {
 } satisfies DynamicSourcegraphWebAppContext
 
 export const legacyRouteComputedContext = {
-    globbing: false,
     batchChangesExecutionEnabled: true,
     isMacPlatform: true,
 } satisfies LegacyRouteComputedContext

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -240,7 +240,6 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     caseSensitive={false}
                                     queryState={queryState}
                                     onChange={setQueryState}
-                                    globbing={false}
                                     preventNewLine={true}
                                     autoFocus={true}
                                     applySuggestionsOnEnter={applySuggestionsOnEnter}

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -85,7 +85,6 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
             onChange={onChange}
             patternType={patternType}
             caseSensitive={false}
-            globbing={false}
             placeholder={placeholder}
             className={classNames(className, styles.monacoField, 'form-control', 'with-invalid-icon', {
                 [styles.focusContainer]: !renderedWithinFocusContainer,

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -449,7 +449,6 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                                 caseSensitive={true}
                                 queryState={queryState}
                                 onChange={setQueryState}
-                                globbing={false}
                                 preventNewLine={false}
                                 applySuggestionsOnEnter={applySuggestionsOnEnter}
                             />

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -20,7 +20,6 @@ const defaultProps: GlobalNavbarProps = {
         subjects: null,
     },
     telemetryService: NOOP_TELEMETRY_SERVICE,
-    globbing: false,
     platformContext: {} as any,
     selectedSearchContextSpec: '',
     setSelectedSearchContextSpec: () => undefined,

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -26,7 +26,6 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     showSearchBox: true,
     selectedSearchContextSpec: '',
     setSelectedSearchContextSpec: () => undefined,
-    globbing: false,
     branding: undefined,
     routes: [],
     searchContextsEnabled: true,

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -61,8 +61,6 @@ export interface GlobalNavbarProps
     showSearchBox: boolean
     routes: RouteObject[]
 
-    // Whether globbing is enabled for filters.
-    globbing: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
     branding?: typeof window.context.branding

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -33,7 +33,6 @@ export interface GlobalNotebooksAreaProps
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
-    globbing: boolean
 }
 /**
  * The global code monitoring area.

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
@@ -49,7 +49,6 @@ export const Default: Story = () => (
                 isReadOnly={false}
                 showMenu={false}
                 isSourcegraphDotCom={false}
-                globbing={false}
             />
         )}
     </WebStory>
@@ -68,7 +67,6 @@ export const EditMode: Story = () => (
                 isReadOnly={false}
                 showMenu={false}
                 isSourcegraphDotCom={false}
-                globbing={false}
             />
         )}
     </WebStory>
@@ -89,7 +87,6 @@ export const ErrorFetchingFile: Story = () => (
                 isReadOnly={false}
                 showMenu={false}
                 isSourcegraphDotCom={false}
-                globbing={false}
             />
         )}
     </WebStory>

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -30,7 +30,6 @@ import styles from './NotebookFileBlock.module.scss'
 
 interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps {
     isSourcegraphDotCom: boolean
-    globbing: boolean
 }
 
 const LOADING = 'loading' as const

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
@@ -30,7 +30,6 @@ const defaultProps = {
     editor: undefined,
     onEditorCreated: noop,
     isSourcegraphDotCom: false,
-    globbing: false,
 }
 
 export const Default: Story = () => (

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
@@ -28,7 +28,6 @@ interface NotebookFileBlockInputsProps extends Pick<BlockProps, 'onRunBlock'> {
     onLineRangeChange: (lineRange: HighlightLineRange | null) => void
     onFileSelected: (file: FileBlockInput) => void
     isSourcegraphDotCom: boolean
-    globbing: boolean
 }
 
 function getFileSuggestionsQuery(queryInput: string): string {
@@ -46,7 +45,7 @@ const editorAttributes = [
 
 export const NotebookFileBlockInputs: React.FunctionComponent<
     React.PropsWithChildren<NotebookFileBlockInputsProps>
-> = ({ id, lineRange, onFileSelected, onLineRangeChange, globbing, isSourcegraphDotCom, ...inputProps }) => {
+> = ({ id, lineRange, onFileSelected, onLineRangeChange, isSourcegraphDotCom, ...inputProps }) => {
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
@@ -99,11 +98,10 @@ export const NotebookFileBlockInputs: React.FunctionComponent<
         () =>
             createDefaultSuggestions({
                 isSourcegraphDotCom,
-                globbing,
                 fetchSuggestions: fetchStreamSuggestions,
                 applyOnEnter: applySuggestionsOnEnter,
             }),
-        [isSourcegraphDotCom, globbing, applySuggestionsOnEnter]
+        [isSourcegraphDotCom, applySuggestionsOnEnter]
     )
 
     return (

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
@@ -62,7 +62,6 @@ export const Default: Story = () => (
                 isSourcegraphDotCom={true}
                 searchContextsEnabled={true}
                 ownEnabled={true}
-                globbing={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
@@ -87,7 +86,6 @@ export const Selected: Story = () => (
                 isSourcegraphDotCom={true}
                 searchContextsEnabled={true}
                 ownEnabled={true}
-                globbing={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
@@ -113,7 +111,6 @@ export const ReadOnlySelected: Story = () => (
                 isSourcegraphDotCom={true}
                 searchContextsEnabled={true}
                 ownEnabled={true}
-                globbing={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -41,7 +41,6 @@ interface NotebookQueryBlockProps
         TelemetryProps,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
-    globbing: boolean
     isSourcegraphDotCom: boolean
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
     authenticatedUser: AuthenticatedUser | null
@@ -69,7 +68,6 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         onBlockInputChange,
         fetchHighlightedFileLineRanges,
         onRunBlock,
-        globbing,
         isSourcegraphDotCom,
         searchContextsEnabled,
         ownEnabled,
@@ -134,11 +132,10 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
             () =>
                 createDefaultSuggestions({
                     isSourcegraphDotCom,
-                    globbing,
                     fetchSuggestions: fetchStreamSuggestions,
                     applyOnEnter: applySuggestionsOnEnter,
                 }),
-            [isSourcegraphDotCom, globbing, applySuggestionsOnEnter]
+            [isSourcegraphDotCom, applySuggestionsOnEnter]
         )
 
         // Focus editor on component creation if necessary

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -34,7 +34,6 @@ interface NotebookSymbolBlockProps
         TelemetryProps,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'> {
     isSourcegraphDotCom: boolean
-    globbing: boolean
 }
 
 const LOADING = 'LOADING' as const

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
@@ -21,7 +21,6 @@ interface NotebookSymbolBlockInputProps extends Pick<BlockProps, 'onRunBlock'> {
     onEditorCreated: (editor: EditorView) => void
     setQueryInput: (value: string) => void
     onSymbolSelected: (symbol: SymbolBlockInput) => void
-    globbing: boolean
     isSourcegraphDotCom: boolean
 }
 
@@ -40,7 +39,7 @@ const editorAttributes = [
 
 export const NotebookSymbolBlockInput: React.FunctionComponent<
     React.PropsWithChildren<NotebookSymbolBlockInputProps>
-> = ({ onSymbolSelected, isSourcegraphDotCom, globbing, ...inputProps }) => {
+> = ({ onSymbolSelected, isSourcegraphDotCom, ...inputProps }) => {
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
@@ -70,12 +69,11 @@ export const NotebookSymbolBlockInput: React.FunctionComponent<
         () =>
             createDefaultSuggestions({
                 isSourcegraphDotCom,
-                globbing,
                 fetchSuggestions: fetchStreamSuggestions,
                 applyOnEnter: applySuggestionsOnEnter,
                 disableSymbolCompletion: true,
             }),
-        [isSourcegraphDotCom, globbing, applySuggestionsOnEnter]
+        [isSourcegraphDotCom, applySuggestionsOnEnter]
     )
 
     return (

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -46,7 +46,6 @@ export const Default: Story = () => (
                 isSourcegraphDotCom={true}
                 searchContextsEnabled={true}
                 ownEnabled={true}
-                globbing={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 streamSearch={() => NEVER}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
@@ -71,7 +70,6 @@ export const DefaultReadOnly: Story = () => (
                 isSourcegraphDotCom={true}
                 searchContextsEnabled={true}
                 ownEnabled={true}
-                globbing={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 streamSearch={() => NEVER}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -36,7 +36,6 @@ export interface NotebookComponentProps
         TelemetryProps,
         Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded' | 'executedQuery' | 'enableOwnershipSearch'>,
         OwnConfigProps {
-    globbing: boolean
     isReadOnly?: boolean
     blocks: BlockInit[]
     authenticatedUser: AuthenticatedUser | null
@@ -88,7 +87,6 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
         platformContext,
         blocks: initialBlocks,
         fetchHighlightedFileLineRanges,
-        globbing,
         searchContextsEnabled,
         ownEnabled,
         settingsCascade,
@@ -392,7 +390,6 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...blockProps}
                                 telemetryService={telemetryService}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
-                                globbing={globbing}
                             />
                         )
                     case 'query':
@@ -401,7 +398,6 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...block}
                                 {...blockProps}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
-                                globbing={globbing}
                                 fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 searchContextsEnabled={searchContextsEnabled}
                                 ownEnabled={ownEnabled}
@@ -417,7 +413,6 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...block}
                                 {...blockProps}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
-                                globbing={globbing}
                                 telemetryService={telemetryService}
                                 platformContext={platformContext}
                             />
@@ -438,7 +433,6 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 isEmbedded,
                 telemetryService,
                 isSourcegraphDotCom,
-                globbing,
                 fetchHighlightedFileLineRanges,
                 searchContextsEnabled,
                 ownEnabled,

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -75,7 +75,6 @@ export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformCo
                     blocks={notebookOrError.blocks}
                     onUpdateBlocks={noop}
                     viewerCanManage={false}
-                    globbing={true}
                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     streamSearch={aggregateStreamingSearch}
                     telemetryService={eventLogger}

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -25,7 +25,6 @@ export interface NotebookContentProps
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
     authenticatedUser: AuthenticatedUser | null
-    globbing: boolean
     viewerCanManage: boolean
     blocks: NotebookFields['blocks']
     exportedFileName: string
@@ -42,7 +41,6 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
         exportedFileName,
         onCopyNotebook,
         onUpdateBlocks,
-        globbing,
         streamSearch,
         telemetryService,
         searchContextsEnabled,
@@ -82,7 +80,6 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
 
         return (
             <NotebookComponent
-                globbing={globbing}
                 streamSearch={streamSearch}
                 telemetryService={telemetryService}
                 searchContextsEnabled={searchContextsEnabled}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -62,7 +62,6 @@ interface NotebookPageProps
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
     authenticatedUser: AuthenticatedUser | null
-    globbing: boolean
     fetchNotebook?: typeof _fetchNotebook
     updateNotebook?: typeof _updateNotebook
     deleteNotebook?: typeof _deleteNotebook
@@ -84,7 +83,6 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     createNotebookStar = _createNotebookStar,
     deleteNotebookStar = _deleteNotebookStar,
     copyNotebook = _copyNotebook,
-    globbing,
     streamSearch,
     telemetryService,
     searchContextsEnabled,
@@ -312,7 +310,6 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                 onUpdateBlocks={onUpdateBlocks}
                                 onCopyNotebook={onCopyNotebook}
                                 exportedFileName={exportedFileName}
-                                globbing={globbing}
                                 streamSearch={streamSearch}
                                 telemetryService={telemetryService}
                                 searchContextsEnabled={searchContextsEnabled}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -88,8 +88,6 @@ export interface RepoContainerContext
 
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 
-    globbing: boolean
-
     isMacPlatform: boolean
 
     isSourcegraphDotCom: boolean
@@ -124,7 +122,6 @@ interface RepoContainerProps
     repoSettingsAreaRoutes: readonly RepoSettingsAreaRoute[]
     repoSettingsSidebarGroups: readonly RepoSettingsSideBarGroup[]
     authenticatedUser: AuthenticatedUser | null
-    globbing: boolean
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
 }
@@ -140,7 +137,7 @@ export interface HoverThresholdProps {
  * Renders a horizontal bar and content for a repository page.
  */
 export const RepoContainer: FC<RepoContainerProps> = props => {
-    const { extensionsController, globbing, repoContainerRoutes, authenticatedUser, selectedSearchContextSpec } = props
+    const { extensionsController, repoContainerRoutes, authenticatedUser, selectedSearchContextSpec } = props
 
     const location = useLocation()
 
@@ -270,15 +267,15 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     )
     const onNavbarQueryChange = useNavbarQueryState(state => state.setQueryState)
     useEffect(() => {
-        let query = queryPrefix + searchQueryForRepoRevision(repoName, globbing, revision)
+        let query = queryPrefix + searchQueryForRepoRevision(repoName, revision)
         if (filePath) {
-            query = `${query.trimEnd()} file:${escapeSpaces(globbing ? filePath : '^' + escapeRegExp(filePath))}`
+            query = `${query.trimEnd()} file:${escapeSpaces('^' + escapeRegExp(filePath))}`
         }
         onNavbarQueryChange({
             query,
             hint: EditorHint.Blur,
         })
-    }, [revision, filePath, repoName, onNavbarQueryChange, globbing, queryPrefix])
+    }, [revision, filePath, repoName, onNavbarQueryChange, queryPrefix])
 
     const isError = isErrorLike(repoOrError) || isErrorLike(resolvedRevisionOrError)
 

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -62,8 +62,6 @@ export interface RepoRevisionContainerContext
 
     repoName: string
 
-    globbing: boolean
-
     isMacPlatform: boolean
 
     isSourcegraphDotCom: boolean
@@ -102,8 +100,6 @@ interface RepoRevisionContainerProps
 
     /** The repoName from the URL */
     repoName: string
-
-    globbing: boolean
 
     isMacPlatform: boolean
 

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -31,7 +31,7 @@ const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
 /** A page that shows a file or a directory (tree view) in a repository at the
  * current revision. */
 export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => {
-    const { repo, resolvedRevision, repoName, globbing, objectType: maybeObjectType, ...context } = props
+    const { repo, resolvedRevision, repoName, objectType: maybeObjectType, ...context } = props
 
     const location = useLocation()
     const { filePath = '' } = parseBrowserRepoURL(location.pathname) // empty string is root
@@ -95,7 +95,6 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                     {...context}
                                     commitID={resolvedRevision?.commitID}
                                     filePath={filePath}
-                                    globbing={globbing}
                                     repoID={repo?.id}
                                     repoName={repoName}
                                     repoUrl={repo?.url}
@@ -114,7 +113,6 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                 {...props}
                                 commitID={resolvedRevision?.commitID}
                                 filePath={filePath}
-                                globbing={globbing}
                                 repo={repo}
                                 repoName={repoName}
                                 isSourcegraphDotCom={context.isSourcegraphDotCom}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -102,7 +102,6 @@ interface BlobPageProps
         NotebookProps,
         OwnConfigProps {
     authenticatedUser: AuthenticatedUser | null
-    globbing: boolean
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
     repoID?: Scalars['ID']

--- a/client/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -9,7 +9,6 @@ import { RepositoryStatsContributorsPage } from './RepositoryStatsContributorsPa
 
 interface Props extends BreadcrumbSetters {
     repo: RepositoryFields | undefined
-    globbing: boolean
 }
 
 /**
@@ -28,12 +27,12 @@ const BREADCRUMB = { key: 'contributors', element: 'Contributors' }
  * Renders pages related to repository stats.
  */
 export const RepositoryStatsArea: FC<Props> = props => {
-    const { useBreadcrumb, repo, globbing } = props
+    const { useBreadcrumb, repo } = props
     useBreadcrumb(BREADCRUMB)
 
     return (
         <div className="repository-stats-area container mt-3">
-            {repo ? <RepositoryStatsContributorsPage repo={repo} globbing={globbing} /> : <LoadingSpinner />}
+            {repo ? <RepositoryStatsContributorsPage repo={repo} /> : <LoadingSpinner />}
         </div>
     )
 }

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -56,7 +56,6 @@ interface QuerySpec {
 interface RepositoryContributorNodeProps extends QuerySpec {
     node: RepositoryContributorNodeFields
     repoName: string
-    globbing: boolean
 }
 
 const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren<RepositoryContributorNodeProps>> = ({
@@ -65,12 +64,11 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
     revisionRange,
     after,
     path,
-    globbing,
 }) => {
     const commit = node.commits.nodes[0] as RepositoryContributorNodeFields['commits']['nodes'][number] | undefined
 
     const query: string = [
-        searchQueryForRepoRevision(repoName, globbing),
+        searchQueryForRepoRevision(repoName),
         'type:diff',
         `author:${quoteIfNeeded(node.person.email)}`,
         after ? `after:${quoteIfNeeded(after)}` : '',
@@ -193,9 +191,7 @@ const BATCH_COUNT = 20
 
 const equalOrEmpty = (a: string | undefined, b: string | undefined): boolean => a === b || (!a && !b)
 
-interface Props extends RepositoryStatsAreaPageProps {
-    globbing: boolean
-}
+interface Props extends RepositoryStatsAreaPageProps {}
 
 const contributorsPageInputIds: Record<string, string> = {
     REVISION_RANGE: 'repository-stats-contributors-page__revision-range',
@@ -215,7 +211,7 @@ const getUrlQuery = (spec: Partial<QuerySpec>): string => {
 }
 
 /** A page that shows a repository's contributors. */
-export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = ({ repo, globbing }) => {
+export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = ({ repo }) => {
     const location = useLocation()
     const navigate = useNavigate()
     const queryParameters = new URLSearchParams(location.search)
@@ -325,7 +321,6 @@ export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = (
                             key={`${node.person.displayName}:${node.count}`}
                             node={node}
                             repoName={repo.name}
-                            globbing={globbing}
                             {...spec}
                         />
                     ))}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -72,7 +72,6 @@ interface Props
     filePath: string
     commitID: string
     revision: string
-    globbing: boolean
     isSourcegraphDotCom: boolean
     className?: string
 }

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -379,7 +379,7 @@ const RepositoryContributorNode: React.FC<RepositoryContributorNodeProps> = ({
     path,
 }) => {
     const query: string = [
-        searchQueryForRepoRevision(repoName, false),
+        searchQueryForRepoRevision(repoName),
         'type:diff',
         `author:${quoteIfNeeded(node.person.email)}`,
         after ? `after:${quoteIfNeeded(after)}` : '',

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -132,7 +132,7 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
                             caseSensitive={false}
                             queryState={queryState}
                             onChange={setQueryState}
-                            globbing={false}
+                            ={false}
                             preventNewLine={true}
                             applySuggestionsOnEnter={applySuggestionsOnEnter}
                         />

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -132,7 +132,6 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
                             caseSensitive={false}
                             queryState={queryState}
                             onChange={setQueryState}
-                            ={false}
                             preventNewLine={true}
                             applySuggestionsOnEnter={applySuggestionsOnEnter}
                         />

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -35,14 +35,13 @@ interface SearchConsolePageProps
             'allExpanded' | 'executedQuery' | 'showSearchContext' | 'enableOwnershipSearch'
         >,
         OwnConfigProps {
-    globbing: boolean
     isMacPlatform: boolean
 }
 
 export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<SearchConsolePageProps>> = props => {
     const location = useLocation()
     const navigate = useNavigate()
-    const { globbing, streamSearch, isSourcegraphDotCom, ownEnabled } = props
+    const { streamSearch, isSourcegraphDotCom, ownEnabled } = props
     const { applySuggestionsOnEnter } = useExperimentalFeatures(features => ({
         applySuggestionsOnEnter: features.applySearchQuerySuggestionOnEnter ?? true,
     }))
@@ -74,11 +73,10 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
         () =>
             createDefaultSuggestions({
                 fetchSuggestions: query => fetchStreamSuggestions(query),
-                globbing,
                 isSourcegraphDotCom,
                 applyOnEnter: applySuggestionsOnEnter,
             }),
-        [globbing, isSourcegraphDotCom, applySuggestionsOnEnter]
+        [isSourcegraphDotCom, applySuggestionsOnEnter]
     )
 
     const extensions = useMemo(

--- a/client/web/src/search/index.test.ts
+++ b/client/web/src/search/index.test.ts
@@ -163,7 +163,7 @@ describe('search/index', () => {
 
 describe('repoFilterForRepoRevision escapes values with spaces', () => {
     test('escapes spaces in value', () => {
-        expect(repoFilterForRepoRevision('7 is my final answer', false)).toMatchInlineSnapshot(
+        expect(repoFilterForRepoRevision('7 is my final answer')).toMatchInlineSnapshot(
             '"^7\\\\ is\\\\ my\\\\ final\\\\ answer$"'
         )
     })

--- a/client/web/src/search/index.ts
+++ b/client/web/src/search/index.ts
@@ -141,15 +141,12 @@ export function parseSearchURL(
     }
 }
 
-export function repoFilterForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {
-    if (globbing) {
-        return `${escapeSpaces(`${repoName}${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
-    }
+export function repoFilterForRepoRevision(repoName: string, revision?: string): string {
     return `${escapeSpaces(`^${escapeRegExp(repoName)}$${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
 }
 
-export function searchQueryForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {
-    return `repo:${repoFilterForRepoRevision(repoName, globbing, revision)} `
+export function searchQueryForRepoRevision(repoName: string, revision?: string): string {
+    return `repo:${repoFilterForRepoRevision(repoName, revision)} `
 }
 
 function abbreviateOID(oid: string): string {

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -25,7 +25,6 @@ interface Props
         PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
-    globbing: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
     isLightTheme: boolean

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -186,7 +186,7 @@ function toRepoCompletion(
         kind: 'repo',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.name, { globbing: false }) + ' ',
+            insertValue: valuePrefix + regexInsertText(item.name, {}) + ' ',
             from,
             to,
         },
@@ -260,7 +260,7 @@ function toFileCompletion(
         kind: 'file',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.path, { globbing: false }) + ' ',
+            insertValue: valuePrefix + regexInsertText(item.path, {}) + ' ',
             from,
             to,
         },

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -186,7 +186,7 @@ function toRepoCompletion(
         kind: 'repo',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.name, {}) + ' ',
+            insertValue: valuePrefix + regexInsertText(item.name) + ' ',
             from,
             to,
         },
@@ -260,7 +260,7 @@ function toFileCompletion(
         kind: 'file',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.path, {}) + ' ',
+            insertValue: valuePrefix + regexInsertText(item.path) + ' ',
             from,
             to,
         },

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -55,7 +55,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
 
     const {
         authenticatedUser,
-        globbing,
         isSourcegraphDotCom,
         telemetryService,
         platformContext,
@@ -158,7 +157,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
     ) : (
         <SearchBox
             platformContext={platformContext}
-            globbing={globbing}
             getUserSearchContextNamespaces={getUserSearchContextNamespaces}
             fetchSearchContexts={fetchSearchContexts}
             selectedSearchContextSpec={selectedSearchContextSpec}


### PR DESCRIPTION
As @fkling noticed in #49684, these option is no longer supported:

- https://github.com/sourcegraph/sourcegraph/pull/27886
- https://github.com/sourcegraph/sourcegraph/pull/46045

Time to do some cleanup in the front end code!

Process:

- Grep for `globbing`
- Delete everything that is related to front end code

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-rm-globbing-from-frontend.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
