### PR TITLE
App: Remove empty webhooks section from site admin sidebar

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -127,16 +127,15 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
 
 const webhooksGroup: SiteAdminSideBarGroup = {
     header: { label: 'Webhooks', icon: WebhookIcon },
+    condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
     items: [
         {
             label: 'Incoming webhooks',
             to: '/site-admin/webhooks/incoming',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Outgoing webhooks',
             to: '/site-admin/webhooks/outgoing',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],
 }


### PR DESCRIPTION
Must have been an oversight (or we removed an option that we used to show there?) 🤷

## Before

<img width="295" alt="Screenshot 2023-03-20 at 14 37 29" src="https://user-images.githubusercontent.com/458591/226357405-d49550c1-3a71-445c-83db-fa7f2eeba4a9.png">

## Test plan

<img width="475" alt="Screenshot 2023-03-20 at 14 38 17" src="https://user-images.githubusercontent.com/458591/226357428-d0828352-decd-46a9-8786-cf0881c8e848.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-app-admin-sidebar-rm-empty.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
