### PR TITLE
internal/repos: Log repo name in error

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -9310,6 +9310,20 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1678994673,
+				"Name": "package_repos_last_checked_at_index",
+				"UpQuery": "DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;\nDROP INDEX IF EXISTS package_repo_versions_last_checked_at;\n\nCREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at\nON lsif_dependency_repos\nUSING btree (last_checked_at ASC NULLS FIRST);\n\nCREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at\nON package_repo_versions\nUSING btree (last_checked_at ASC NULLS FIRST);",
+				"DownQuery": "DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;\nDROP INDEX IF EXISTS package_repo_versions_last_checked_at;\n\nCREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at\nON lsif_dependency_repos\nUSING btree (last_checked_at);\n\nCREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at\nON package_repo_versions\nUSING btree (last_checked_at);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678601228,
+					1678832491
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -9540,7 +9554,7 @@
 				"RootID": 1648051770,
 				"LeafIDs": [
 					1678899992,
-					1678832491
+					1678994673
 				],
 				"PreCreation": false
 			}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -814,7 +814,7 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		}
 
 		if err = tx.CreateExternalServiceRepo(ctx, svc, sourced); err != nil {
-			return Diff{}, errors.Wrap(err, "syncer: failed to create external service repo")
+			return Diff{}, errors.Wrapf(err, "syncer: failed to create external service repo: %s", sourced.Name)
 		}
 
 		d.Added = append(d.Added, sourced)


### PR DESCRIPTION
The current error message does not contain the name which makes it hard to debug.

![image](https://user-images.githubusercontent.com/2682729/226364386-72ac9c01-c6df-4cf4-971d-c2cd9136b7c9.png)


## Test plan

Log additional string only.

Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
