### PR TITLE
Fix commits link for subdirectories

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -453,6 +453,15 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
     const node = data?.node && data?.node.__typename === 'Repository' ? data.node : null
     const connection = node?.commit?.ancestors
 
+    // In the case of a user-generated `/-/tree` folder, this will also match but we only replace
+    // the first occurrence so it's fine.
+    let commitsUrl = tree.url
+    if (tree.url.includes('/-/tree')) {
+        commitsUrl = commitsUrl.replace('/-/tree', '/-/commits')
+    } else {
+        commitsUrl = commitsUrl + '/-/commits'
+    }
+
     return (
         <ConnectionContainer>
             {error && <ConnectionError errors={[error.message]} />}
@@ -496,9 +505,7 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
                             </span>
                         </small>
                         <small>
-                            <Link to={`${tree.url}/-/commits`}>
-                                Show {connection.pageInfo.hasNextPage ? 'more' : 'all'}
-                            </Link>
+                            <Link to={commitsUrl}>Show {connection.pageInfo.hasNextPage ? 'more' : 'all'}</Link>
                         </small>
                     </>
                 )}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -453,8 +453,6 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
     const node = data?.node && data?.node.__typename === 'Repository' ? data.node : null
     const connection = node?.commit?.ancestors
 
-    // In the case of a user-generated `/-/tree` folder, this will also match but we only replace
-    // the first occurrence so it's fine.
     let commitsUrl = tree.url
     if (tree.url.includes('/-/tree')) {
         commitsUrl = commitsUrl.replace('/-/tree', '/-/commits')

--- a/client/web/src/util/url.ts
+++ b/client/web/src/util/url.ts
@@ -91,6 +91,7 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI & Pick<ParsedRe
     const treeSeparator = pathname.indexOf('/-/tree/')
     const blobSeparator = pathname.indexOf('/-/blob/')
     const comparisonSeparator = pathname.indexOf('/-/compare/')
+    const commitsSeparator = pathname.indexOf('/-/commits/')
     if (treeSeparator !== -1) {
         filePath = decodeURIComponent(pathname.slice(treeSeparator + '/-/tree/'.length))
     }
@@ -99,6 +100,9 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI & Pick<ParsedRe
     }
     if (comparisonSeparator !== -1) {
         commitRange = pathname.slice(comparisonSeparator + '/-/compare/'.length)
+    }
+    if (commitsSeparator !== -1) {
+        filePath = decodeURIComponent(pathname.slice(commitsSeparator + '/-/commits/'.length))
     }
     let position: Position | undefined
     let range: Range | undefined


### PR DESCRIPTION
Follow up to #47375

This is awkward, but it seems like I never actually tested the commit page for subdirectories after seeing that it supports subdirectories in the source code. 😐 

This PR updates the URL parsing logic to allow for subtrees to be specified after a `/-/commits` link and generates the proper link.

## Test plan

- Verified locally
<img width="1613" alt="Screenshot 2023-03-20 at 16 35 28" src="https://user-images.githubusercontent.com/458591/226391572-7b1f0156-4486-4fd9-9e66-3a1fb5f5da05.png">
<img width="1145" alt="Screenshot 2023-03-20 at 16 33 44" src="https://user-images.githubusercontent.com/458591/226391584-eef099a7-0fe1-42a6-ae93-d6d514fbd49d.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-commits-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
