### PR TITLE
bazel: add missing devserver dep

### DIFF
--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -53,6 +53,7 @@ ts_project(
         "//:node_modules/lodash",
         "//:node_modules/signale",
         "//:node_modules/webpack",  #keep
+        "//:node_modules/webpack-dev-server",  #keep
         "//client/web:node_modules/@sourcegraph/build-config",
         "//client/web:web_lib",  #keep
     ],


### PR DESCRIPTION
## Test plan

`bazel test //client/...`

## App preview:

- [Web](https://sg-web-bazel-devserver-err.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
