### PR TITLE
[Backport 5.0] webhooks: add user-facing docs for outgoing webhooks (#49670)

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -2,7 +2,6 @@ import BrainIcon from 'mdi-react/BrainIcon'
 import BriefcaseIcon from 'mdi-react/BriefcaseIcon'
 import PackageVariantIcon from 'mdi-react/PackageVariantIcon'
 import RobotOutlineIcon from 'mdi-react/RobotOutlineIcon'
-import WebhookIcon from 'mdi-react/WebhookIcon'
 
 import { BatchChangesIcon } from '../../batches/icons'
 import {
@@ -24,6 +23,16 @@ const configurationGroup: SiteAdminSideBarGroup = {
             label: 'License',
             to: '/site-admin/license',
 
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
+        },
+        {
+            label: 'Incoming webhooks',
+            to: '/site-admin/webhooks/incoming',
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
+        },
+        {
+            label: 'Outgoing webhooks',
+            to: '/site-admin/webhooks/outgoing',
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],
@@ -124,22 +133,6 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
     ],
 }
 
-const webhooksGroup: SiteAdminSideBarGroup = {
-    header: { label: 'Webhooks', icon: WebhookIcon },
-    items: [
-        {
-            label: 'Incoming webhooks',
-            to: '/site-admin/webhooks/incoming',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
-        },
-        {
-            label: 'Outgoing webhooks',
-            to: '/site-admin/webhooks/outgoing',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
-        },
-    ],
-}
-
 export const codyGroup: SiteAdminSideBarGroup = {
     header: { label: 'Cody', icon: RobotOutlineIcon },
     items: [
@@ -170,7 +163,6 @@ export const enterpriseSiteAdminSidebarGroups: SiteAdminSideBarGroups = [
     analyticsGroup,
     configurationGroup,
     repositoriesGroup,
-    webhooksGroup,
     codeIntelGroup,
     usersGroup,
     executorsGroup,

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -24,7 +24,7 @@ This page documents how to configure a Sourcegraph instance. For deployment conf
 - [Using external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md)
 - [PostgreSQL Config](./postgres-conf.md)
 - [Disabling user invitations](./user_invitations.md)
-- [Configuring incoming webhooks](./webhooks/incoming.md)
+- [Configuring webhooks](./webhooks/index.md)
 
 ## Advanced tasks
 

--- a/doc/admin/config/webhooks/incoming.md
+++ b/doc/admin/config/webhooks/incoming.md
@@ -9,7 +9,7 @@ Webhooks are currently implemented to speed up two types of external events:
 
 See the table below for code host compatibility:
 
-Code host | [Batch changes](../../batch_changes/index.md) | Code push | User permissions
+Code host | [Batch changes](../../../batch_changes/index.md) | Code push | User permissions
 --------- | :-: | :-: | :-:
 GitHub | 🟢 | 🟢 | 🟢
 GitLab | 🟢 | 🟢 | 🔴
@@ -21,11 +21,11 @@ To receive webhooks both Sourcegraph and the code host need to be configured. To
 
 ## Adding an incoming webhook
 
-Before adding an incoming webhook you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
+Before adding an incoming webhook you should ensure that you have at least one [code host connection](../../external_services/index.md) configured.
 
 The incoming webhook will be configured to accept events from a specific code host connection based on its type and URN.
 
-1. Navigate to _Site Admin_ > _Webhooks_ > _Incoming webhooks_
+1. Navigate to **Site Admin > Configuration > Incoming webhooks**
    ![Incoming webhooks page](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/incoming-webhooks-page.png)
 2. Click **+ Create webhook**
    ![Adding an incoming webhook](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/adding-webhook.png)
@@ -68,7 +68,7 @@ The instructions for setting up webhooks on the code host are specific to each c
 1. Click **Add webhook**.
 1. Confirm that the new webhook is listed.
 
-Done! Sourcegraph will now receive webhook events from GitHub and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Done! Sourcegraph will now receive webhook events from GitHub and use them to sync pull request events, used by [batch changes](../../../batch_changes/index.md), faster and more efficiently.
 
 #### Code push
 
@@ -101,7 +101,7 @@ When one of these events occur, a permissions sync will trigger for the relevant
 1. Click **Add webhook**.
 1. Confirm that the new webhook is listed below **Project Hooks**.
 
-Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [batch changes](../../../batch_changes/index.md), faster and more efficiently.
 
 **NOTE:** We currently do not support [system webhooks](https://docs.gitlab.com/ee/administration/system_hooks.html) as these provide a different set of payloads.
 
@@ -113,9 +113,9 @@ Follow the same steps as above, but ensure you include the `Push events` trigger
 
 #### Batch changes
 
-The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server / Bitbucket Data Center instance to send webhooks to Sourcegraph.
+The [Sourcegraph Bitbucket Server plugin](../../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server / Bitbucket Data Center instance to send webhooks to Sourcegraph.
 
-1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server / Bitbucket Data Center instance.
+1. Install the [Sourcegraph Bitbucket Server plugin](../../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server / Bitbucket Data Center instance.
 1. On your Bitbucket Server / Bitbucket Data Center instance, go to **Administration > Add-ons > Sourcegraph**
 1. Fill in the **Add a webhook** form
    * **Name**: A unique name representing your Sourcegraph instance.
@@ -125,7 +125,7 @@ The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#
    * **Secret**: The secret you configured when creating the incoming webhook.
 1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
-Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../../batch_changes/index.md), faster and more efficiently.
 
 #### Code push
 
@@ -146,7 +146,7 @@ Follow the same steps as above, but ensure you tick the `Push` option. If asked 
 1. Click **Save**.
 1. Confirm that the new webhook is listed below **Repository hooks**.
 
-Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../../batch_changes/index.md), faster and more efficiently.
 
 #### Code push
 
@@ -168,19 +168,19 @@ Follow the same steps as above, but ensure you tick the `Push` option.
 6. Click **Test** to verify the webhook works. Then click **Finish**.
 7. Repeat the steps above, this time choosing **Pull request merged** as your event type.
 
-Done! Sourcegraph will now receive webhook events from Azure DevOps and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Done! Sourcegraph will now receive webhook events from Azure DevOps and use them to sync pull request events, used by [batch changes](../../../batch_changes/index.md), faster and more efficiently.
 
 
 ## Webhook logging
 
 Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
 
-1. Via _Site Admin_ > _Webhooks_ > _Incoming webhooks_
+1. Via **Site Admin > Configuration > Incoming webhooks**
    ![Webhook logs](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/webhook-logs.png)
-2. **Deprecated** Via code host connection: _Site Admin_ > _Batch Changes_ > _Incoming webhooks_
+2. **Deprecated** Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**
    ![Legacy webhook logs](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/webhook-logs-legacy.png)
 
-By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
+By default, sites without [database encryption](../encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
 
 ### Enabling webhook logging
 
@@ -215,7 +215,7 @@ To retain webhook logs for one day:
 
 ### Encrypting webhook logs
 
-Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](../encryption.md).
 
 ## Deprecation notice
 

--- a/doc/admin/config/webhooks/index.md
+++ b/doc/admin/config/webhooks/index.md
@@ -1,3 +1,4 @@
 # Webhooks
 
 - [Incoming webhooks](incoming.md)
+- <span class="badge badge-beta">Beta</span> [Outgoing webhooks](outgoing.md)

--- a/doc/admin/config/webhooks/outgoing.md
+++ b/doc/admin/config/webhooks/outgoing.md
@@ -1,0 +1,123 @@
+# Outgoing webhooks
+
+<aside class="beta">
+<p>
+<span class="badge badge-beta">Beta</span> <strong>This feature is currently in beta.</strong>
+</p>
+</aside>
+
+Outgoing webhooks can be configured on a Sourcegraph instance in order to send Sourcegraph events to external tools and services. This allows for deeper integrations between Sourcegraph and other applications.
+
+Currently, webhooks are only implemented for events related to [Batch Changes](../../batch_changes/index.md). They also cannot yet be scoped to specific entities, meaning that they will be triggered for all events of the specified type across Sourcegraph. Expanded support for more event types and scoped events is planned for the future. Please [let us know](mailto:feedback@sourcegraph.com) what types of events you would like to see implemented next, or if you have any other feedback!
+
+> WARNING: Outgoing webhooks have the potential to send sensitive information about your repositories and code to other untrusted services. When configuring outgoing webhooks, be sure to only send events to trusted service URLs and to use the shared secret to verify any requests received.
+
+## Adding an outgoing webhook
+
+1. Navigate to **Site Admin > Configuration > Ougoing webhooks**
+   ![Outgoing webhooks page](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/outgoing-webhooks-page.png)
+1. Click **+ Create webhook**
+   ![Adding an outgoing webhook](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/adding-outgoing-webhook.png)
+1. Fill out the form:
+   1. **URL**: URL endpoint of the external service that Sourcegraph should send webhook events to.
+   1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided, but you are free to change it.
+   1. **Event types**: The types of [events](#supported-event-types) that will trigger a webhook event. Currently, only events related to Batch Changes are supported.
+1. Click **Create**
+
+The outgoing webhook will now be created and active. To view or edit its details, or to see the log of event requests that have been sent for it, click the **Edit** button on the outgoing webhook's row.
+![Created webhook](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/outgoing-webhook-details.png)
+
+## Supported event types
+
+### Batch change
+
+- **batch_change:apply** - Triggered when a batch spec is applied to a batch change.
+- **batch_change:close** - Triggered when a batch change is closed.
+- **batch_change:delete** - Triggered when a batch change is deleted.
+
+#### Example payload
+
+The batch change webhook event payload mirrors the [GraphQL API](../../../api/graphql/index.md) `BatchChange` type and contains the following fields:
+
+```json
+{
+  // The unique ID for the batch change.
+  "id": "QmF0Y2hDaGFuZ2U6MTcz",
+  // The ID of the namespace where this batch change is defined.
+  "namespace_id": "VXNlcjox",
+  // The name of the batch change.
+  "name": "hello-world",
+  // The description of the batch change (as Markdown).
+  "description": "Add Hello World to READMEs",
+  // The state of the batch change on Sourcegraph.
+  "state": "OPEN",
+  // The ID of the user who created this batch change.
+  "creator_user_id": "VXNlcjox",
+  // The ID of the user who last applied a spec to this batch change.
+  "last_applier_user_id": "VXNlcjox",
+  // The URL path on Sourcegraph for this batch change.
+  "url": "/users/my-username/batch-changes/hello-world",
+  // The date and time when the batch change was created.
+  "created_at": "2023-03-19T05:41:24Z",
+  // The date and time when the batch change was last updated.
+  "updated_at": "2023-03-19T05:43:04Z",
+  // The date and time when the batch change was last updated with a new spec.
+  "last_applied_at": "2023-03-19T05:43:04Z",
+  // The date and time when the batch change was closed, or null if it's still open.
+  "closed_at": null
+}
+```
+
+### Changeset
+
+- **changeset:close** - Triggered when a changeset is closed by Sourcegraph.
+- **changeset:publish** - Triggered when a changeset is successfully published to the code host.
+- **changeset:publish_error** - Triggered when an attempt to publish a changeset to the code host fails.
+- **changeset:update** - Triggered when a changeset is updated on the code host by Sourcegraph.
+- **changeset:update_error** - Triggered when an attempt to update a changeset on the code host fails.
+
+#### Example payload
+
+The changeset webhook event payload mirrors the [GraphQL API](../../../api/graphql/index.md) `ExternalChangeset` type and contains the following fields:
+
+```json
+{
+  // The unique ID for the changeset.
+  "id": "Q2hhbmdlc2V0OjI4MA==",
+  // The external ID that uniquely identifies this ExternalChangeset on the code host (e.g. the pull request number). Note that this is only available after the changeset has been published.
+  "external_id": "204",
+  // The IDs of the batch changes that this changeset is associated with.
+  "batch_change_ids": [
+    "QmF0Y2hDaGFuZ2U6MTcz"
+  ],
+  // The ID (on Sourcegraph) of the repository that this changeset is associated with.
+  "repository_id": "UmVwb3NpdG9yeToxNQ==",
+  // The date and time when the batch change was created.
+  "created_at": "2023-03-19T05:41:24Z",
+  // The date and time when the batch change was last updated.
+  "title": "Hello World",
+  // The body of the changese (as Markdown).
+  "body": "My first batch change!",
+  // The author of the changeset. Note that this is only available after the changeset has been published.
+  "author_name": "my-username",
+  // The state of the changeset on Sourcegraph.
+  "state": "OPEN",
+  // Any labels attached to the changeset on the code host.
+  "labels": ["bug"],
+  // The external URL of the changeset on the code host. Note that this is only available after the changeset has been published.
+  "external_url": "https://github.com/my-org/my-repo/pull/204",
+  // If the changeset was opened from a fork, this is the namespace of the fork on the code host.
+  "fork_namespace": "fork-username",
+  // If the changeset was opened from a fork, this is the name of the fork repository. Note that this is only available after the changeset has been published.
+  "fork_name": "my-repo-fork",
+  // The review state of this changeset on the code host. Note that this is only available after the changeset has been published.
+  "review_state": "CHANGES_REQUESTED",
+  // The check state of this changeset on the code host. Note that this is only available after the changeset has been published.
+  "check_state": "PASSED",
+  // Any error that occurred when publishing or updating the changeset.
+  "error": null,
+  // Any error that occured during the last sync of the changeset by Sourcegraph.
+  "syncer_error": null,
+  // The ID of the batch change that produced this changeset.
+  "owning_batch_change_id": "QmF0Y2hDaGFuZ2U6MTcz"
+}

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -42,7 +42,7 @@ Administration is usually handled by site administrators are the admins responsi
 - [Repository permissions](permissions/index.md)
   - [Row-level security](repo/row_level_security.md)
 - [Batch Changes](../batch_changes/how-tos/site_admin_configuration.md)
-- [Configure incoming webhooks](config/webhooks/incoming.md)
+- [Configure webhooks](config/webhooks/index.md)
 
 For deployment configuration, please refer to the relevant [installation guide](deploy/index.md).
 

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -8,11 +8,12 @@
 
 1. [Configure credentials](configuring_credentials.md).
 
-1. [Setup webhooks](../../admin/config/webhooks/incoming.md) to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
+1. [Setup incoming webhooks](../../admin/config/webhooks/incoming.md) to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
 
 1. Configure any desired optional features, such as:
-    * [Rollout windows](../../../admin/config/batch_changes.md#rollout-windows), which control the rate at which Batch Changes will publish changesets on code hosts.
-    * [Forks](../../../admin/config/batch_changes.md#forks), which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
+    * [Rollout windows](../../admin/config/batch_changes.md#rollout-windows), which control the rate at which Batch Changes will publish changesets on code hosts.
+    * [Forks](../../admin/config/batch_changes.md#forks), which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
+    * [Outgoing webhooks](../../admin/config/webhooks/outgoing.md), which publish events related to batch changes and changesets to enable deeper integrations with your other tools and systems.
 
 #### Disable Batch Changes
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).


### PR DESCRIPTION
Backport from https://github.com/sourcegraph/sourcegraph/pull/49670.

Adds user-facing docs for the new outgoing webhooks feature, including instructions for configuring them, descriptions for support event types, and example webhook payloads.

This PR also moves the webhooks site admin pages to be nested under "Configuration", per Daniel and Rob's [feedback](https://sourcegraph.slack.com/archives/C0HMGV90V/p1679004219020309).

## Test plan

Primarily docs changes. Verified the moved site admin links appear and work as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->