### PR TITLE
RFC: Use native links in references panel

### DIFF
--- a/client/branded/src/search-ui/components/codeLinkNavigation.ts
+++ b/client/branded/src/search-ui/components/codeLinkNavigation.ts
@@ -120,7 +120,7 @@ function isTextSelectionEvent(event: MouseEvent<HTMLElement>): boolean {
  * - Firefox will insert \t\n in between table rows, causing the copied
  * text to be different from what is in the file/search result.
  */
-export function onClickCodeExcerptHref(
+function onClickCodeExcerptHref(
     event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>,
     onClickHref: (href: string) => void
 ): void {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -169,6 +169,10 @@
         background-color: var(--color-bg-3);
     }
 
+    &--link:focus-visible {
+        box-shadow: var(--focus-box-shadow);
+    }
+
     code {
         font-family: var(--code-font-family);
         overflow: hidden;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -120,9 +120,18 @@
         background-color: var(--color-bg-3);
         padding-left: 0.25rem;
         padding-right: 0.1rem;
-        display: flex;
+        display: none;
         justify-content: center;
         align-items: center;
+
+        &.isFirstInActive {
+            display: flex;
+        }
+
+        .location:hover &.isMetaPressed {
+            display: flex;
+            background-color: transparent;
+        }
     }
 
     &--link:hover {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -106,45 +106,9 @@
         border-bottom: 1px solid var(--body-bg);
     }
 
-    &--active {
-        background-color: var(--color-bg-3);
-    }
-
-    &--active-icon {
-        width: 1.35rem;
-        // stylelint-disable-next-line declaration-property-unit-allowed-list
-        height: calc(100% - 1px);
-        position: absolute;
-        right: 0;
-        top: 0;
-        background-color: var(--color-bg-3);
-        padding-left: 0.25rem;
-        padding-right: 0.1rem;
-        display: none;
-        justify-content: center;
-        align-items: center;
-
-        &.isFirstInActive {
-            display: flex;
-        }
-
-        .location:hover &.isMetaPressed {
-            display: flex;
-            background-color: transparent;
-        }
-    }
-
-    &--link:hover {
-        background-color: var(--color-bg-2);
-        cursor: pointer;
-    }
-
-    &--active:hover {
-        // Needed to override `&--link:hover`
-        background-color: var(--color-bg-3);
-    }
-
     &--link {
+        all: unset;
+
         display: flex;
         flex-direction: column;
         flex: 1;
@@ -160,7 +124,7 @@
         // Avoid line number and filename getting put on different lines
         white-space: nowrap;
         padding-left: 0;
-        font-family: 'SF Mono', monospace;
+        font-family: var(--code-font-family);
 
         border: none;
 
@@ -174,8 +138,39 @@
         }
     }
 
+    &--active {
+        background-color: var(--color-bg-3);
+    }
+
+    &--active-icon {
+        width: 1.35rem;
+        // stylelint-disable-next-line declaration-property-unit-allowed-list
+        height: calc(100% - 1px);
+        position: absolute;
+        right: 0;
+        top: 0;
+        background-color: var(--color-bg-3);
+        padding-left: 0.25rem;
+        padding-right: 0.1rem;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    &--link:hover {
+        all: unset;
+
+        background-color: var(--color-bg-2);
+        cursor: pointer;
+    }
+
+    &--active:hover {
+        // Needed to override `&--link:hover`
+        background-color: var(--color-bg-3);
+    }
+
     code {
-        font-family: 'SF Mono', monospace;
+        font-family: var(--code-font-family);
         overflow: hidden;
         color: var(--body-color);
         font-weight: 400;
@@ -183,7 +178,7 @@
     }
 
     mark {
-        font-family: 'SF Mono', monospace;
+        font-family: var(--code-font-family);
         font-weight: 400;
         font-size: 0.75rem;
     }

--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -72,7 +72,7 @@ describe('ReferencesPanel', () => {
         const referenceButton = within(referencesList).getByTestId('reference-item-diff/diff.go-0')
         const fullReferenceURL =
             '/github.com/sourcegraph/go-diff@9d1f353a285b3094bc33bdae277a19aedabe8b71/-/blob/diff/diff.go?L16:2-16:10'
-        expect(referenceButton).toHaveAttribute('data-href', fullReferenceURL)
+        expect(referenceButton).toHaveAttribute('href', fullReferenceURL)
         expect(referenceButton).not.toHaveClass('locationActive')
 
         // Click on reference

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -1,12 +1,4 @@
-import React, {
-    KeyboardEvent as ReactKeyboardEvent,
-    MouseEvent,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useMemo,
-    useState,
-} from 'react'
+import React, { MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronUp, mdiFilterOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
@@ -16,7 +8,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 
-import { CodeExcerpt, onClickCodeExcerptHref } from '@sourcegraph/branded'
+import { CodeExcerpt } from '@sourcegraph/branded'
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import { ErrorLike, logger, pluralize } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-classes'

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -944,8 +944,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
 
     const open = isOpen(group.path) ?? true
 
-    const isMetaPressed = useIsMetaPressed()
-
     return (
         <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
             <div className={styles.locationGroup}>
@@ -998,16 +996,17 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 const isFirstInActive =
                                     isActive && !(index > 0 && isActiveLocation(group.locations[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
-                                const selectReference = (
-                                    event: ReactKeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>
-                                ): void => {
-                                    onClickCodeExcerptHref(event, () => {
-                                        if (isActive || event.metaKey) {
-                                            navigateToUrl(locationToUrl(reference))
-                                        } else {
-                                            setActiveLocation(reference)
-                                        }
-                                    })
+                                const clickReference = (event: MouseEvent<HTMLElement>): void => {
+                                    event.preventDefault()
+                                    if (isActive) {
+                                        navigateToUrl(locationToUrl(reference))
+                                    } else {
+                                        setActiveLocation(reference)
+                                    }
+                                }
+                                const doubleClickReference = (event: MouseEvent<HTMLElement>): void => {
+                                    event.preventDefault()
+                                    navigateToUrl(locationToUrl(reference))
                                 }
 
                                 return (
@@ -1015,13 +1014,13 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                         key={reference.url}
                                         className={classNames('border-0 rounded-0 mb-0', styles.location)}
                                     >
-                                        <div
-                                            role="link"
+                                        {/* eslint-disable-next-line react/forbid-elements */}
+                                        <a
                                             data-testid={`reference-item-${group.path}-${index}`}
                                             tabIndex={0}
-                                            onClick={selectReference}
-                                            onKeyDown={selectReference}
-                                            data-href={reference.url}
+                                            onClick={clickReference}
+                                            onDoubleClick={doubleClickReference}
+                                            href={reference.url}
                                             className={classNames(styles.locationLink, locationActive)}
                                         >
                                             <CodeExcerpt
@@ -1045,24 +1044,21 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                                     fetchPlainTextFileRangeLines(reference)
                                                 }
                                             />
-                                            <span
-                                                className={classNames('ml-2', styles.locationActiveIcon, {
-                                                    [styles.isFirstInActive]: isFirstInActive,
-                                                    [styles.isMetaPressed]: isMetaPressed,
-                                                })}
-                                            >
-                                                <Tooltip
-                                                    content="Click again to open line in full view"
-                                                    placement="left"
-                                                >
-                                                    <Icon
-                                                        aria-label="Open line in full view"
-                                                        size="sm"
-                                                        svgPath={mdiOpenInNew}
-                                                    />
-                                                </Tooltip>
-                                            </span>
-                                        </div>
+                                            {isFirstInActive ? (
+                                                <span className={classNames('ml-2', styles.locationActiveIcon)}>
+                                                    <Tooltip
+                                                        content="Click again to open line in full view"
+                                                        placement="left"
+                                                    >
+                                                        <Icon
+                                                            aria-label="Open line in full view"
+                                                            size="sm"
+                                                            svgPath={mdiOpenInNew}
+                                                        />
+                                                    </Tooltip>
+                                                </span>
+                                            ) : null}
+                                        </a>
                                     </li>
                                 )
                             })}
@@ -1118,27 +1114,4 @@ function locationToUrl(location: Location): string {
               }
             : undefined,
     })
-}
-
-function useIsMetaPressed(): boolean {
-    const [isMetaPressed, setIsMetaPressed] = useState(false)
-    useEffect(() => {
-        function onKeyDown(event: KeyboardEvent): void {
-            if (event.metaKey) {
-                setIsMetaPressed(true)
-            }
-        }
-        function onKeyUp(event: KeyboardEvent): void {
-            if (!event.metaKey) {
-                setIsMetaPressed(false)
-            }
-        }
-        window.addEventListener('keydown', onKeyDown)
-        window.addEventListener('keyup', onKeyUp)
-        return () => {
-            window.removeEventListener('keydown', onKeyDown)
-            window.removeEventListener('keyup', onKeyUp)
-        }
-    }, [])
-    return isMetaPressed
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -989,6 +989,19 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                     isActive && !(index > 0 && isActiveLocation(group.locations[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
                                 const clickReference = (event: MouseEvent<HTMLElement>): void => {
+                                    // If anything other than a normal primary click is detected,
+                                    // treat this as a normal link click and let the browser handle
+                                    // it.
+                                    if (
+                                        event.button !== 0 ||
+                                        event.altKey ||
+                                        event.ctrlKey ||
+                                        event.metaKey ||
+                                        event.shiftKey
+                                    ) {
+                                        return
+                                    }
+
                                     event.preventDefault()
                                     if (isActive) {
                                         navigateToUrl(locationToUrl(reference))


### PR DESCRIPTION
This was motivated by [feedback from this conversation](https://sourcegraph.slack.com/archives/C04931KQVRC/p1679323575904199)

This changes the implementation of the references panel to use a native `<a>` tag instead of the current `<div role="link>`, removing the previous need to [custom handled click event](https://github.com/sourcegraph/sourcegraph/blob/d646d9b71f3b91f3e7b79e70386bbd437e99de5f/client/branded/src/search-ui/components/codeLinkNavigation.ts#L123:17) to make it easier to select text on the link but giving us the following benifits:

- We can now add a native onDoubleClick handler (not possible with the previous selection logic as double click was used to select the word). This way, we can use a normal double click to open a reference directly in the blob view instead of having this awkward "click twice with a delay" pattern.
- We can now right click => Open link in new tab 🤯 
- cmd+click also now opens the symbol in a new tab which is super handy.

While doing this, I also fixed another issue: We used a different font to render the references than we used in the blob view. This changes the fonts to use `var(--code-font-family);` instead.

## Test plan

https://user-images.githubusercontent.com/458591/226999869-1b8806ed-7188-4656-ae0b-226936c650a1.mov

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-ref-panel-cmd-click.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
