### PR TITLE
embeddings: store ranks with embeddings

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/document_ranks.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/document_ranks.go
@@ -1,0 +1,61 @@
+package repo
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func getDocumentRanks(ctx context.Context, repoName string) (types.RepoPathRanks, error) {
+	root, err := url.Parse(internalapi.Client.URL)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+	u := root.ResolveReference(&url.URL{
+		Path: "/.internal/ranks/" + strings.Trim(repoName, "/") + "/documents",
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	resp, err := httpcli.InternalDoer.Do(req)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return types.RepoPathRanks{}, err
+		}
+		return types.RepoPathRanks{}, &url.Error{
+			Op:  "Get",
+			URL: u.String(),
+			Err: errors.Errorf("%s: %s", resp.Status, string(b)),
+		}
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	ranks := types.RepoPathRanks{}
+	err = json.Unmarshal(b, &ranks)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	return ranks, nil
+}

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -2,18 +2,9 @@ package repo
 
 import (
 	"context"
-	"encoding/json"
-	"io"
-	"math"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/grafana/regexp"
@@ -33,7 +24,6 @@ type handler struct {
 	db              edb.EnterpriseDB
 	uploadStore     uploadstore.Store
 	gitserverClient gitserver.Client
-	sourcegraphURL  *url.URL
 }
 
 var _ workerutil.Handler[*repoembeddingsbg.RepoEmbeddingJob] = &handler{}
@@ -93,73 +83,12 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 		func(fileName string) ([]byte, error) {
 			return h.gitserverClient.ReadFile(ctx, nil, repo.Name, record.Revision, fileName)
 		},
-		func(ctx context.Context, repoName string) (types.RepoPathRanks, error) {
-			return getDocumentRanksWithRetries(ctx, repoName, h.sourcegraphURL, 2)
-		})
+		getDocumentRanks,
+	)
 
 	if err != nil {
 		return err
 	}
 
 	return embeddings.UploadIndex(ctx, h.uploadStore, string(embeddings.GetRepoEmbeddingIndexName(repo.Name)), repoEmbeddingIndex)
-}
-func getDocumentRanksWithRetries(ctx context.Context, repoName string, sourcegraphRoot *url.URL, retries int) (types.RepoPathRanks, error) {
-
-	ranks, err := getDocumentRanks(ctx, repoName, sourcegraphRoot)
-	if err == nil {
-		return ranks, nil
-	}
-
-	for i := 0; i < retries; i++ {
-		ranks, err := getDocumentRanks(ctx, repoName, sourcegraphRoot)
-		if err == nil {
-			return ranks, nil
-		}
-		delay := time.Duration(int(math.Pow(float64(2), float64(i))))
-		time.Sleep(delay * time.Second)
-	}
-
-	return types.RepoPathRanks{}, err
-}
-
-func getDocumentRanks(ctx context.Context, repoName string, sourcegraphRoot *url.URL) (types.RepoPathRanks, error) {
-	u := sourcegraphRoot.ResolveReference(&url.URL{
-		Path: "/.internal/ranks/" + strings.Trim(repoName, "/") + "/documents",
-	})
-
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return types.RepoPathRanks{}, err
-	}
-
-	resp, err := httpcli.InternalDoer.Do(req)
-	if err != nil {
-		return types.RepoPathRanks{}, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		_ = resp.Body.Close()
-		if err != nil {
-			return types.RepoPathRanks{}, err
-		}
-		return types.RepoPathRanks{}, &url.Error{
-			Op:  "Get",
-			URL: u.String(),
-			Err: errors.Errorf("%s: %s", resp.Status, string(b)),
-		}
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return types.RepoPathRanks{}, err
-	}
-
-	ranks := types.RepoPathRanks{}
-	err = json.Unmarshal(b, &ranks)
-	if err != nil {
-		return types.RepoPathRanks{}, err
-	}
-
-	return ranks, nil
 }

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -147,7 +147,7 @@ func getDocumentRanks(ctx context.Context, repoName string, sourcegraphRoot *url
 		return types.RepoPathRanks{}, &url.Error{
 			Op:  "Get",
 			URL: u.String(),
-			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
+			Err: errors.Errorf("%s: %s", resp.Status, string(b)),
 		}
 	}
 

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -3,7 +3,6 @@ package repo
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math"
 	"net/http"

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -2,9 +2,19 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/grafana/regexp"
@@ -24,6 +34,7 @@ type handler struct {
 	db              edb.EnterpriseDB
 	uploadStore     uploadstore.Store
 	gitserverClient gitserver.Client
+	sourcegraphURL  *url.URL
 }
 
 var _ workerutil.Handler[*repoembeddingsbg.RepoEmbeddingJob] = &handler{}
@@ -73,12 +84,83 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 
 	embeddingsClient := embed.NewEmbeddingsClient()
 
-	repoEmbeddingIndex, err := embed.EmbedRepo(ctx, repo.Name, record.Revision, validFiles, embeddingsClient, splitOptions, func(fileName string) ([]byte, error) {
-		return h.gitserverClient.ReadFile(ctx, nil, repo.Name, record.Revision, fileName)
-	})
+	repoEmbeddingIndex, err := embed.EmbedRepo(
+		ctx,
+		repo.Name,
+		record.Revision,
+		validFiles,
+		embeddingsClient,
+		splitOptions,
+		func(fileName string) ([]byte, error) {
+			return h.gitserverClient.ReadFile(ctx, nil, repo.Name, record.Revision, fileName)
+		},
+		func(ctx context.Context, repoName string) (types.RepoPathRanks, error) {
+			return getDocumentRanksWithRetries(ctx, repoName, h.sourcegraphURL, 2)
+		})
+
 	if err != nil {
 		return err
 	}
 
 	return embeddings.UploadIndex(ctx, h.uploadStore, string(embeddings.GetRepoEmbeddingIndexName(repo.Name)), repoEmbeddingIndex)
+}
+func getDocumentRanksWithRetries(ctx context.Context, repoName string, sourcegraphRoot *url.URL, retries int) (types.RepoPathRanks, error) {
+
+	ranks, err := getDocumentRanks(ctx, repoName, sourcegraphRoot)
+	if err == nil {
+		return ranks, nil
+	}
+
+	for i := 0; i < retries; i++ {
+		ranks, err := getDocumentRanks(ctx, repoName, sourcegraphRoot)
+		if err == nil {
+			return ranks, nil
+		}
+		delay := time.Duration(int(math.Pow(float64(2), float64(i))))
+		time.Sleep(delay * time.Second)
+	}
+
+	return types.RepoPathRanks{}, err
+}
+
+func getDocumentRanks(ctx context.Context, repoName string, sourcegraphRoot *url.URL) (types.RepoPathRanks, error) {
+	u := sourcegraphRoot.ResolveReference(&url.URL{
+		Path: "/.internal/ranks/" + strings.Trim(repoName, "/") + "/documents",
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	resp, err := httpcli.InternalDoer.Do(req)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return types.RepoPathRanks{}, err
+		}
+		return types.RepoPathRanks{}, &url.Error{
+			Op:  "Get",
+			URL: u.String(),
+			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
+		}
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	ranks := types.RepoPathRanks{}
+	err = json.Unmarshal(b, &ranks)
+	if err != nil {
+		return types.RepoPathRanks{}, err
+	}
+
+	return ranks, nil
 }

--- a/enterprise/cmd/worker/internal/embeddings/repo/worker.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/worker.go
@@ -2,8 +2,6 @@ package repo
 
 import (
 	"context"
-	"net/url"
-	"os"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
@@ -74,7 +72,6 @@ func newRepoEmbeddingJobWorker(
 		db:              db,
 		uploadStore:     uploadStore,
 		gitserverClient: gitserverClient,
-		sourcegraphURL:  sourcegraphURL(),
 	}
 	return dbworker.NewWorker[*repoembeddingsbg.RepoEmbeddingJob](ctx, workerStore, handler, workerutil.WorkerOptions{
 		Name:              "repo_embedding_job_worker",
@@ -83,20 +80,4 @@ func newRepoEmbeddingJobWorker(
 		HeartbeatInterval: 10 * time.Second,
 		Metrics:           workerutil.NewMetrics(observationCtx, "repo_embedding_job_worker"),
 	})
-}
-
-func sourcegraphURL() *url.URL {
-	rawURL := os.Getenv("SRC_FRONTEND_INTERNAL")
-	if rawURL == "" {
-		rawURL = "sourcegraph-frontend-internal"
-	}
-
-	// api/internalapi/client.go relies on SRC_FRONTEND_INTERNAL being passed
-	// without a scheme. Here we adhere to the same convention.
-	u, err := url.Parse("http://" + rawURL)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
 }

--- a/enterprise/cmd/worker/internal/embeddings/repo/worker.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/worker.go
@@ -47,7 +47,6 @@ func (s *repoEmbeddingJob) Routines(_ context.Context, observationCtx *observati
 
 	workCtx := actor.WithInternalActor(context.Background())
 	return []goroutine.BackgroundRoutine{
-
 		newRepoEmbeddingJobWorker(
 			workCtx,
 			observationCtx,
@@ -67,7 +66,6 @@ func newRepoEmbeddingJobWorker(
 	uploadStore uploadstore.Store,
 	gitserverClient gitserver.Client,
 ) *workerutil.Worker[*repoembeddingsbg.RepoEmbeddingJob] {
-
 	handler := &handler{
 		db:              db,
 		uploadStore:     uploadStore,

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
@@ -19,6 +20,7 @@ const EMBEDDING_BATCHES = 5
 const EMBEDDING_BATCH_SIZE = 512
 
 type readFile func(fileName string) ([]byte, error)
+type ranksGetter func(ctx context.Context, repoName string) (types.RepoPathRanks, error)
 
 // EmbedRepo embeds file contents from the given file names for a repository.
 // It separates the file names into code files and text files and embeds them separately.
@@ -31,6 +33,7 @@ func EmbedRepo(
 	client EmbeddingsClient,
 	splitOptions split.SplitOptions,
 	readFile readFile,
+	getDocumentRanks ranksGetter,
 ) (*embeddings.RepoEmbeddingIndex, error) {
 	codeFileNames, textFileNames := []string{}, []string{}
 	for _, fileName := range fileNames {
@@ -41,12 +44,17 @@ func EmbedRepo(
 		}
 	}
 
-	codeIndex, err := embedFiles(codeFileNames, client, splitOptions, readFile, MAX_CODE_EMBEDDING_VECTORS)
+	ranks, err := getDocumentRanks(ctx, string(repoName))
 	if err != nil {
 		return nil, err
 	}
 
-	textIndex, err := embedFiles(textFileNames, client, splitOptions, readFile, MAX_TEXT_EMBEDDING_VECTORS)
+	codeIndex, err := embedFiles(codeFileNames, client, splitOptions, readFile, MAX_CODE_EMBEDDING_VECTORS, ranks)
+	if err != nil {
+		return nil, err
+	}
+
+	textIndex, err := embedFiles(textFileNames, client, splitOptions, readFile, MAX_TEXT_EMBEDDING_VECTORS, ranks)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +79,7 @@ func embedFiles(
 	splitOptions split.SplitOptions,
 	readFile readFile,
 	maxEmbeddingVectors int,
+	repoPathRanks types.RepoPathRanks,
 ) (embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata], error) {
 	dimensions, err := client.GetDimensions()
 	if err != nil {
@@ -85,6 +94,7 @@ func embedFiles(
 		Embeddings:      make([]float32, 0, len(fileNames)*dimensions),
 		RowMetadata:     make([]embeddings.RepoEmbeddingRowMetadata, 0, len(fileNames)),
 		ColumnDimension: dimensions,
+		Ranks:           make([]float64, 0, len(fileNames)),
 	}
 
 	// addEmbeddableChunks batches embeddable chunks, gets embeddings for the batches, and appends them to the index above.
@@ -98,6 +108,11 @@ func embedFiles(
 			for idx, chunk := range batch {
 				batchChunks[idx] = chunk.Content
 				index.RowMetadata = append(index.RowMetadata, embeddings.RepoEmbeddingRowMetadata{FileName: chunk.FileName, StartLine: chunk.StartLine, EndLine: chunk.EndLine})
+
+				// Unknown documents have rank 0. Zoekt is a bit smarter about this, assigning 0
+				// to "unimportant" files and the average for unknown files. We should probably
+				// add this here, too.
+				index.Ranks = append(index.Ranks, repoPathRanks.Paths[chunk.FileName])
 			}
 
 			batchEmbeddings, err := client.GetEmbeddingsWithRetries(batchChunks, GET_EMBEDDINGS_MAX_RETRIES)

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -94,7 +94,7 @@ func embedFiles(
 		Embeddings:      make([]float32, 0, len(fileNames)*dimensions),
 		RowMetadata:     make([]embeddings.RepoEmbeddingRowMetadata, 0, len(fileNames)),
 		ColumnDimension: dimensions,
-		Ranks:           make([]float64, 0, len(fileNames)),
+		Ranks:           make([]float32, 0, len(fileNames)),
 	}
 
 	// addEmbeddableChunks batches embeddable chunks, gets embeddings for the batches, and appends them to the index above.
@@ -112,7 +112,7 @@ func embedFiles(
 				// Unknown documents have rank 0. Zoekt is a bit smarter about this, assigning 0
 				// to "unimportant" files and the average for unknown files. We should probably
 				// add this here, too.
-				index.Ranks = append(index.Ranks, repoPathRanks.Paths[chunk.FileName])
+				index.Ranks = append(index.Ranks, float32(repoPathRanks.Paths[chunk.FileName]))
 			}
 
 			batchEmbeddings, err := client.GetEmbeddingsWithRetries(batchChunks, GET_EMBEDDINGS_MAX_RETRIES)

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -6,6 +6,7 @@ type EmbeddingIndex[T any] struct {
 	Embeddings      []float32
 	ColumnDimension int
 	RowMetadata     []T
+	Ranks           []float64
 }
 
 type RepoEmbeddingRowMetadata struct {

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -6,7 +6,7 @@ type EmbeddingIndex[T any] struct {
 	Embeddings      []float32
 	ColumnDimension int
 	RowMetadata     []T
-	Ranks           []float64
+	Ranks           []float32
 }
 
 type RepoEmbeddingRowMetadata struct {


### PR DESCRIPTION
With this change we save the documents ranks together with the embeddings. We don't use the ranks yet, but the plan is to implement a linear scoring function which combines cosine similarity and document ranks.

Based on the [gob docs](https://pkg.go.dev/encoding/gob#hdr-Types_and_Values), old indexes should continue to work.

>  For structs, fields (identified by name) that are in the source but absent from the receiving variable will be ignored. Fields that are in the receiving variable but missing from the transmitted type or value will be ignored in the destination.



## Test plan
- updated unit tests
- manual testing
  - compute document ranks
    - `sg start embeddings`
    - site-config:
      - “codeIntelRanking.documentReferenceCountsEnabled”: true
    - sg.config.yaml:
      - start codeintel-worker and codeintel-executor
      - set EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:9000/ for `worker` and `embeddings`
    - create global code intel policy
    - confirm that document ranks have been computed
  - trigger embeddings job and confirm that ranks are saved with embeddings.

UPDATE:

I confirmed by manual testing that existing indexes continue to work.
  - checked out main
  - triggered embedding jobs for several repos
  - checked out this branch and called the embeddings service directly

```
curl --request POST \
  --url http://localhost:9991/search \
  --header 'Content-Type: application/json' \
  --data '{	
	"repoName": "github.com/sourcegraph-testing/etcd",
	"query": "func error",
	"codeResultsCount": 1,
	"textResultsCount": 1
}'
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
