### PR TITLE
[Backport 5.0] rbac: add user-facing docs (#49472)

### DIFF
--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -57,20 +57,22 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
                 className={styles.rolesPageHeader}
                 description={
                     <>
-                        Roles represent a set of permissions that are granted to a user. Roles are currently only
-                        available for Batch Changes functionality. Use the{' '}
-                        <Link to="/site-admin/users">user administration page</Link> to assign roles.
+                        Roles are a part of the{' '}
+                        <Link to="/help/admin/access_control">Role-Based Access Control system</Link> for Sourcegraph
+                        and represent a set of in-product permissions. Roles are currently only available for Batch
+                        Changes functionality. Use the <Link to="/site-admin/users">user administration page</Link> to
+                        assign roles.
                     </>
                 }
                 actions={
                     <Button variant="primary" onClick={openModal}>
-                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Create Role
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Create role
                     </Button>
                 }
             >
                 <PageHeader.Heading as="h2">
                     <PageHeader.Breadcrumb>
-                        Roles <ProductStatusBadge status="experimental" />
+                        Roles <ProductStatusBadge status="beta" />
                     </PageHeader.Breadcrumb>
                 </PageHeader.Heading>
             </PageHeader>

--- a/doc/admin/access_control/batch_changes.md
+++ b/doc/admin/access_control/batch_changes.md
@@ -1,0 +1,8 @@
+# Access control for Batch Changes
+
+Granular controls for who can access [Batch Changes](../../batch_changes/index.md) can be configured by site admins by tuning the roles assigned to users and the permissions granted to those roles. This page describes the permission types available for Batch Changes, and whether they are granted by default to the **User** [system role](./index.md#system-roles). All permissions are granted to the **Site Administrator** system role by default.
+
+Name      | Description | Granted to **User** by default?
+--------- | ----------- | :-:
+`batch_changes:read` | **_Coming soon!_**<!--<ul><li>User can view batch changes in the open or closed state, belonging to themselves or other users or orgs.</li><li>User can view most details about a batch change, including its latest batch spec, the changesets for repositories they have access to, the burndown chart, and bulk action logs.</li></ul>--> | ✓
+`batch_changes:write` | <ul><li>User can create, update, close, or delete batch changes.</li><li>User can create, execute, and apply batch specs.</li><li>User can perform bulk operations on changesets such as publishing, commenting on, closing, or merging them.</ul> | ✓

--- a/doc/admin/access_control/index.md
+++ b/doc/admin/access_control/index.md
@@ -1,0 +1,63 @@
+# Access control
+
+<aside class="beta">
+<p>
+<span class="badge badge-beta">Beta</span> <strong>This feature is currently in beta.</strong>
+</p>
+</aside>
+
+> NOTE: This page refers to in-product permissions, which determine who can, for example, create a batch change, or who is a site admin. This is *not* the same as [repository permissions](../permissions/index.md), which enforces the same repository access on Sourcegraph as your code host.
+
+<span class="badge badge-note">Sourcegraph 5.0+</span>
+
+Sourcegraph uses [Role-Based Access Control (RBAC)](https://en.wikipedia.org/wiki/Role-based_access_control) to enable fine-grained control over different features and abilities of Sourcegraph, without having to modify permissions for each user individually. Currently, the scope of permissions control is limited to [Batch Changes](batch_changes.md) functionality, but it will be expanded to other areas in the future.
+
+## Managing roles and permissions
+
+<img alt="Role management page" src="https://sourcegraphstatic.com/docs/images/administration/access_control/managing_roles_permissions_light.png" class="screenshot theme-light-only" />
+<img alt="Role management page" src="https://sourcegraphstatic.com/docs/images/administration/access_control/managing_roles_permissions_dark.png" class="screenshot theme-dark-only" />
+
+Site admins can control which features each type of user has access to by creating custom roles and assigning permissions to them. You can see all available roles and create new ones under **Site admin > Users & auth > Roles**.
+
+### System roles
+
+Every Sourcegraph instance ships with two built-in system roles:
+
+- **Site Administrator**: This role is granted to any user who is promoted to site admin. It always has all features and permissions of Sourcegraph granted to it and the set of permissions cannot be modified.
+- **User:** This role is granted to every user of the Sourcegraph instance and cannot be unassigned. By default, it has all features and permissions of Sourcegraph granted to it, but _the set of permissions can be modified_.
+
+### Creating a new role and assigning it permissions
+
+To create a new role, click the **+ Create role** button. Give the role a unique, descriptive name, then select which permissions to associate with it using the checkboxes. Then click **Create**.
+
+### Editing permissions for an existing role
+
+> NOTE: The **Site Administrator** role cannot be modified.
+
+To edit the permissions granted to a role, click the role to expand it, then select the new set of permissions you want to grant to it. Then click **Update** to save your changes.
+
+You can read about the specific permission types available for each RBAC-enabled product area below:
+
+- [Batch Changes](batch_changes.md)
+
+> NOTE: While Batch Changes is the only RBAC-enabled product area today, we will be working on migrating other product areas in future releases of Sourcegraph. Please reach out to our [support team](mailto:support@sourcegraph.com) if you have further questions. 
+
+### Deleting a role
+
+> NOTE: Built-in system roles cannot be deleted.
+
+To delete a role, click the **Delete** button on it. You will be prompted to confirm your choice. Once deleted, all users previously assigned that role will lose all permissions associated with it. Be aware, though, that the same permissions could still be granted by their other roles.
+
+## Managing user roles
+
+> NOTE: Built-in system roles cannot be assigned this way.
+
+Site admins can manage which roles are assigned to which users from **Site admin > Users & auth > Users**. To view or edit a user's roles, click the triple dots to open the context menu for that user, then click **Manage roles**. This will open a modal dialog where you can see the user's current roles, assign new ones, or unassign current ones. You can type in the input field to search roles by name. Click **Update** to save any changes, or **Cancel** to discard. Note that system roles cannot be revoked or assigned via this modal.
+
+To assign the **Site Administrator** system role to a user, open the same context menu from the triple dots, then click **Promote to site admin**. To unassign the **Site Administrator** role, open the same context menu from the triple dots, then click **Revoke site admin**.
+
+The **User** system role is automatically assigned to all users and cannot be revoked.
+
+<video alt="Video walkthrough of how to assign roles to a user" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/access_control/assign_roles_to_user_dark.mp4" type="video/mp4" controls class="theme-dark-only"> </video>
+
+<video alt="Video walkthrough of how to assign roles to a user" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/access_control/assign_roles_to_user_light.mp4" type="video/mp4" controls class="theme-light-only"></video>

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -1,6 +1,12 @@
 # Batch Changes site admin configuration reference
 
-[Batch Changes](../../batch_changes/index.md) is generally configured through the same [site configuration](site_config.md) and [code host configuration](../external_service/index.md) as the rest of Sourcegraph. However, Batch Changes features may require specific configuration, and those are documented here.
+Batch Changes is generally configured through the same [site configuration](site_config.md) and [code host configuration](../external_service/index.md) as the rest of Sourcegraph. However, Batch Changes features may require specific configuration, and those are documented here.
+
+## Access control
+
+<span class="badge badge-note">Sourcegraph 5.0+</span>
+
+Batch Changes is [RBAC-enabled](../../admin/access_control/index.md) <span class="badge badge-beta">Beta</span>. By default, all users have full read and write access for Batch Changes, but this can be restricted by changing the default role permissions, or by creating new custom roles.
 
 ## Rollout windows
 
@@ -121,13 +127,13 @@ To only allow changesets to be reconciled at 1 changeset per minute on (UTC) wee
 
 ## Incoming webhooks
 
-> NOTE: This feature was added in Sourcegraph 3.33.
+<span class="badge badge-note">Sourcegraph 3.33+</span>
 
 Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. Learn [how to setup webhooks and configure logging](../../admin/config/webhooks/incoming.md#webhook-logging).
 
 ## Forks
 
-> NOTE: This feature was added in Sourcegraph 3.36.
+<span class="badge badge-note">Sourcegraph 3.36+</span>
 
 Sourcegraph can be configured to push branches created by Batch Changes to a fork of the repository, rather than the repository itself, by enabling the `batchChanges.enforceForks` site configuration option.
 

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -38,6 +38,7 @@ Administration is usually handled by site administrators are the admins responsi
 - [User authentication](auth/index.md)
   - [User data deletion](user_data_deletion.md)
 - <span class="badge badge-beta">Beta</span> [Provision users through SCIM](scim.md)
+- <span class="badge badge-beta">Beta</span> [Access control](access_control/index.md)
 - [Setting the URL for your instance](url.md)
 - [Repository permissions](permissions/index.md)
   - [Row-level security](repo/row_level_security.md)

--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -1,16 +1,12 @@
 # Permissions
 
-Sourcegraph can be configured to enforce the same access to repositories and underlying 
-source files as your code  host. If configured, Sourcegraph will allow the user to only 
-see the entities that they can see on the code host. These permissions are enforced 
-accross the product for all the use cases that need to read data from a repository, including
- the existence of such repository on the code host.
+> NOTE: This page refers to repository access permissions synced between Sourcegraph and your code host, which has also historically been referred to as "authorization", "repository permissions", and "code host permissions". This is *not* the same as [in-product permissions](../access_control/index.md), which determine who can, for example, create a batch change or who is a site admin.
 
-> NOTE: Historically, we have referred to permissions-related features under different 
-names: "authorization", "repository permissions", "code host permissions". All of these 
-terms were used interchangeably, but in general we do call it permissions or repository 
-permissions. That's not to be confused with in-product permissions, which determine who 
-can, for example, create a batch change or who is a site admin.
+Sourcegraph can be configured to enforce the same access to repositories and underlying 
+source files as your code host. If configured, Sourcegraph will allow the user to only 
+see the entities that they can see on the code host. These permissions are enforced 
+across the product for all the use cases that need to read data from a repository, 
+including the existence of such repository on the code host.
 
 ## Example
 

--- a/doc/batch_changes/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/batch_changes/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -5,7 +5,7 @@
 .markdown-body pre.chroma { font-size: 0.75em; }
 </style>
 
-> NOTE: This feature is available in Sourcegraph 3.25 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.25.0 and later.</p>
+<span class="badge badge-note">Sourcegraph 3.25+</span>
 
 ## Overview
 

--- a/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
+++ b/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
@@ -1,6 +1,6 @@
 # Opting out of batch changes
 
-> NOTE: This feature requires [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) 3.26.3 or later.
+<span class="badge badge-note">Sourcegraph CLI 3.26.3+</span>
 
 Repository owners that are not interested in batch change changesets can opt out so that their repository will be skipped when a batch spec is executed.
 

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -173,13 +173,13 @@ See [`changesetTemplate.published`](../references/batch_spec_yaml_reference.md#c
 
 ### Within the UI
 
-> NOTE: This functionality requires Sourcegraph 3.30 or later, and also requires `src` 3.29.2 or later.
+<span class="badge badge-note">Sourcegraph 3.30+</span>
 
 To publish from the Sourcegraph UI, you'll need to remove (or omit) the `published` field from your batch spec. When you first apply a batch change without an explicit `published` field, all changesets are left unpublished.
 
 #### From the preview
 
-> NOTE: This feature requires Sourcegraph 3.31 or later.
+<span class="badge badge-note">Sourcegraph 3.31+</span>
 
 When you run `src batch preview` against your batch spec and open the preview link, you'll see the current states of each of your changesets, as well as a preview of the actions that will be performed when you apply:
 

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -4,6 +4,8 @@
 
 1. Using Batch Changes requires a [code host connection](../../admin/external_services/index.md) to a supported code host (currently GitHub, Bitbucket Server / Bitbucket Data Center, GitLab, and Bitbucket Cloud).
 
+1. (Optional) [Configure which users have access to Batch Changes](../../admin/access_control/batch-changes.md) <span class="badge badge-beta">Beta</span>. By default, all users can create and view batch changes.
+
 1. (Optional) [Configure repository permissions](../../admin/permissions/index.md), which Batch Changes will respect.
 
 1. [Configure credentials](configuring_credentials.md).

--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -103,7 +103,7 @@ They are evaluated before the execution of each entry in `steps`, except for the
 
 ### `changesetTemplate` context
 
-> NOTE: Templating in `changsetTemplate` is only supported in Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later.
+<span class="badge badge-note">Sourcegraph 3.24+<span>
 
 The following template variables are available in the fields under `changesetTemplate`.
 

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -199,7 +199,7 @@ steps:
 
 ### Environment array
 
-> NOTE: This feature is only available in Sourcegraph 3.23 and later.
+<span class="badge badge-note">Sourcegraph 3.23+</span>
 
 In this case, `steps.env` is an array. Each array item is either:
 
@@ -234,7 +234,7 @@ For instance, if `USER` is set to `adam`, this would append `Hello world! from a
 
 ## [`steps.files`](#steps-files)
 
-> NOTE: This feature is only available in Sourcegraph 3.22 and later.
+<span class="badge badge-note">Sourcegraph 3.22+</span>
 
 Files to create on the host machine and mount into the container when running `steps.run`.
 
@@ -275,7 +275,7 @@ steps:
 
 ## [`steps.outputs`](#steps-outputs)
 
-> NOTE: This feature is only available in Sourcegraph 3.24 and later.
+<span class="badge badge-note">Sourcegraph 3.24+</span>
 
 Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available in the global `outputs` namespace as `outputs.<name>` <a href="batch_spec_templating">template variables</a> in the `run`, `env`, and `outputs` properties of subsequent steps, and the [`changesetTemplate`](#changesettemplate). Two steps with the same output variable name will overwrite the previous contents.
 
@@ -350,7 +350,7 @@ Possible values: `text`, `yaml`, `json`. Default is `text`.
 
 ## [`steps.if`](#steps-if)
 
-> NOTE: This feature is only available in Sourcegraph 3.28 and later with Sourcegraph CLI 3.28 and later.
+<span class="badge badge-note">Sourcegraph 3.28+</span>with Sourcegraph CLI 3.28 and later.
 
 Condition to check before executing the step. If the value of the `if:` attribute is `true` (boolean) or `"true"` (string) then the step is executed in the given repository (or workspace, in case [workspaces](#workspaces) are used). Otherwise the step is skipped.
 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -55,6 +55,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Configuration](admin/config/index.md)
   - [Code hosts](admin/external_service/index.md)
   - [User authentication](admin/auth/index.md)
+  - [Access control](admin/access_control/index.md)
   - [Repository permissions](admin/permissions/index.md)
   - [Observability](admin/observability/index.md)
   - [Analytics](admin/analytics.md)


### PR DESCRIPTION
Backported from https://github.com/sourcegraph/sourcegraph/pull/49472.

Part 1 #46817

Initial draft of RBAC docs. Also updated the feature from "experimental" to "beta", which seems to be a better match for our [definitions](https://docs.sourcegraph.com/admin/beta_and_experimental_features).

### Notes

- This is just the PR for user-facing docs. We'll open a follow up for developer docs next week.
- I haven't included any of the screenshots yet but will add them before merging.

## Test plan

Mostly just docs changes. Checked site admin page changes locally and in Storybook story.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->