### PR TITLE
executors: add authorization token to config validation

### DIFF
--- a/enterprise/cmd/executor/internal/run/validate.go
+++ b/enterprise/cmd/executor/internal/run/validate.go
@@ -76,7 +76,7 @@ func RunValidate(cliCtx *cli.Context, logger log.Logger, config *config.Config) 
 	return nil
 }
 
-var AuthorizationFailedErr = errors.New("failed to authorize with frontend, is the authorization token set correctly?")
+var AuthorizationFailedErr = errors.New("failed to authorize with frontend, is executors.accessToken set correctly in the site-config?")
 
 func validateAuthorizationToken(ctx context.Context, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
 	req, err := apiclient.NewRequest(http.MethodGet, options.URL, ".executors/test/auth", nil)

--- a/enterprise/cmd/executor/internal/run/validate.go
+++ b/enterprise/cmd/executor/internal/run/validate.go
@@ -40,7 +40,12 @@ func RunValidate(cliCtx *cli.Context, logger log.Logger, config *config.Config) 
 	if err != nil {
 		return err
 	}
-	// TODO: Validate access token.
+
+	// Validate frontend access token returns status 200.
+	if err = validateAuthorizationToken(cliCtx.Context, client, copts.BaseClientOptions.EndpointOptions); err != nil {
+		return err
+	}
+
 	// Validate src-cli is of a good version, rely on the connected instance to tell
 	// us what "good" means.
 	if err = validateSrcCLIVersion(cliCtx.Context, client, copts.BaseClientOptions.EndpointOptions); err != nil {
@@ -67,6 +72,26 @@ func RunValidate(cliCtx *cli.Context, logger log.Logger, config *config.Config) 
 	}
 
 	fmt.Print("All checks passed!\n")
+
+	return nil
+}
+
+var AuthorizationFailedErr = errors.New("failed to authorize with frontend, is the authorization token set correctly?")
+
+func validateAuthorizationToken(ctx context.Context, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
+	req, err := apiclient.NewRequest(http.MethodGet, options.URL, ".executors/test/auth", nil)
+	if err != nil {
+		return err
+	}
+
+	if err = client.DoAndDrop(ctx, req); err != nil {
+		var unexpectedStatusCodeError *apiclient.UnexpectedStatusCodeErr
+		if errors.As(err, &unexpectedStatusCodeError) && unexpectedStatusCodeError.StatusCode == http.StatusUnauthorized {
+			return AuthorizationFailedErr
+		} else {
+			return errors.Wrap(err, "failed to validate authorization token")
+		}
+	}
 
 	return nil
 }

--- a/enterprise/cmd/executor/internal/run/validate.go
+++ b/enterprise/cmd/executor/internal/run/validate.go
@@ -76,7 +76,7 @@ func RunValidate(cliCtx *cli.Context, logger log.Logger, config *config.Config) 
 	return nil
 }
 
-var AuthorizationFailedErr = errors.New("failed to authorize with frontend, is executors.accessToken set correctly in the site-config?")
+var authorizationFailedErr = errors.New("failed to authorize with frontend, is executors.accessToken set correctly in the site-config?")
 
 func validateAuthorizationToken(ctx context.Context, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
 	req, err := apiclient.NewRequest(http.MethodGet, options.URL, ".executors/test/auth", nil)


### PR DESCRIPTION
- Part of https://github.com/sourcegraph/sourcegraph/issues/49718

This PR adds validation of the authorization token by calling the API endpoint introduced in the upstream PR.

## Test plan
- [x] Tests pass
- [ ] Tested on dogfood

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
