### PR TITLE
executors: validate frontend URL

### DIFF
--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"net/url"
 	"runtime"
 	"strconv"
 	"time"
@@ -95,6 +96,14 @@ func (c *Config) Load() {
 func (c *Config) Validate() error {
 	if c.QueueName != "" && c.QueueName != "batches" && c.QueueName != "codeintel" {
 		c.AddError(errors.New("EXECUTOR_QUEUE_NAME must be set to 'batches' or 'codeintel'"))
+	}
+
+	u, err := url.Parse(c.FrontendURL)
+	if err != nil {
+		c.AddError(errors.Wrap(err, "failed to parse EXECUTOR_FRONTEND_URL"))
+	}
+	if u.Scheme == "" || u.Host == "" {
+		c.AddError(errors.New("EXECUTOR_FRONTEND_URL must be in the format scheme://host (and optionally :port)"))
 	}
 
 	if c.dockerAuthConfigUnmarshalError != nil {

--- a/enterprise/cmd/executor/internal/config/config_test.go
+++ b/enterprise/cmd/executor/internal/config/config_test.go
@@ -1,7 +1,42 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 func TestValidateConfig(t *testing.T) {
-	
+	t.Run("Frontend URL", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			frontendURL string
+			expectedErr error
+		}{
+			{
+				name:        "Valid URL",
+				frontendURL: "https://sourcegraph.example.com",
+				expectedErr: nil,
+			},
+			{
+				name:        "Missing scheme",
+				frontendURL: "sourcegraph.example.com",
+				expectedErr: errors.New("EXECUTOR_FRONTEND_URL must be in the format scheme://host (and optionally :port)"),
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				conf := Config{
+					FrontendURL:    test.frontendURL,
+					QueueName:      "batches",
+					UseFirecracker: false,
+				}
+
+				err := conf.Validate()
+				if !errors.Is(err, test.expectedErr) {
+					t.Errorf("Unexpected error returned: expected '%v', got '%v'", test.expectedErr, err)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
- Part of https://github.com/sourcegraph/sourcegraph/issues/49718

This PR adds validation that the frontend URL contains a protocol.

## Test plan
- [x] Tests pass
- [ ] Tested on dogfood
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
