### PR TITLE
webhooks: fix up publish vs update events, count merge as close event

### DIFF
--- a/enterprise/internal/batches/processor/bulk_processor.go
+++ b/enterprise/internal/batches/processor/bulk_processor.go
@@ -183,6 +183,8 @@ func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.Changese
 		return err
 	}
 
+	b.enqueueWebhook(ctx, webhooks.ChangesetClose)
+
 	events, err := cs.Changeset.Events()
 	if err != nil {
 		b.logger.Error("Events", log.Error(err))
@@ -218,6 +220,8 @@ func (b *bulkProcessor) closeChangeset(ctx context.Context) (err error) {
 		return err
 	}
 
+	b.enqueueWebhook(ctx, webhooks.ChangesetClose)
+
 	events, err := cs.Changeset.Events()
 	if err != nil {
 		b.logger.Error("Events", log.Error(err))
@@ -235,7 +239,6 @@ func (b *bulkProcessor) closeChangeset(ctx context.Context) (err error) {
 		return errcode.MakeNonRetryable(err)
 	}
 
-	webhooks.EnqueueChangeset(ctx, b.logger, b.tx, webhooks.ChangesetClose, bgql.MarshalChangesetID(cs.Changeset.ID))
 	return nil
 }
 
@@ -286,4 +289,8 @@ func (b *bulkProcessor) publishChangeset(ctx context.Context, job *btypes.Change
 	}
 
 	return nil
+}
+
+func (b *bulkProcessor) enqueueWebhook(ctx context.Context, eventType string) {
+	webhooks.EnqueueChangeset(ctx, b.logger, b.tx, eventType, bgql.MarshalChangesetID(b.ch.ID))
 }

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -410,6 +410,7 @@ func (e *executor) reopenChangeset(ctx context.Context) (err error) {
 
 	remoteRepo, err := e.remoteRepo(ctx)
 	if err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return err
 	}
 
@@ -423,8 +424,11 @@ func (e *executor) reopenChangeset(ctx context.Context) (err error) {
 		Changeset:  e.ch,
 	}
 	if err := css.ReopenChangeset(ctx, &cs); err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return errors.Wrap(err, "reopening changeset")
 	}
+	e.enqueueWebhook(ctx, webhooks.ChangesetUpdate)
+
 	return nil
 }
 
@@ -494,16 +498,19 @@ func (e *executor) closeChangeset(ctx context.Context) (err error) {
 func (e *executor) undraftChangeset(ctx context.Context) (err error) {
 	css, err := e.changesetSource(ctx)
 	if err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return err
 	}
 
 	draftCss, err := sources.ToDraftChangesetSource(css)
 	if err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return err
 	}
 
 	remoteRepo, err := e.remoteRepo(ctx)
 	if err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return nil
 	}
 
@@ -518,8 +525,11 @@ func (e *executor) undraftChangeset(ctx context.Context) (err error) {
 	}
 
 	if err := draftCss.UndraftChangeset(ctx, cs); err != nil {
+		e.enqueueWebhook(ctx, webhooks.ChangesetUpdateError)
 		return errors.Wrap(err, "undrafting changeset")
 	}
+
+	e.enqueueWebhook(ctx, webhooks.ChangesetUpdate)
 	return nil
 }
 


### PR DESCRIPTION
- Trigger `changeset:close` webhook event when a changeset is merged from a bulk merge operation
- The `changeset:close` webhook event was already being triggered when a changeset is closed from a bulk close operation, but I moved the trigger higher up so that it still sends even if the changeset event processing fails
- When reconciling a changeset for publishing, only trigger `changeset:update` if we _know_ the changeset was already published
  - For most code hosts, when `exists, err = css.CreateChangeset(ctx, cs)` is called, `exists` is true if the `ChangesetSource` does not have sufficient information to tell if the changeset was already published on the code host.
  - This meant that for many code hosts, publishing a changeset was actually emitting a `changeset:update` webhook event. 
  - Therefore, we will default to triggering `changeset:publish` events, unless we have also determined the changeset is outdated.

## Test plan

Manually tested that bulk merge, bulk close, and publish events triggered webhooks of the corresponding type.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
