### PR TITLE
batches: address missing changeset author

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -405,6 +405,7 @@ type ExternalChangeset implements Node & Changeset {
     * GitLab - only author.name
     * Bitbucket Server - author is not always available
     * Bitbucket Cloud - author is never available
+    * Azure DevOps - author is always available
     """
     author: Person
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -402,9 +402,9 @@ type ExternalChangeset implements Node & Changeset {
 
     Note that author is not fully supported by some code host APIs:
     * GitHub - only author.name
-    * GitLab - author.name is always available, author.email is only avaiable if a GitLab admin's credentials are used
+    * GitLab - only author.name
     * Bitbucket Server - author is not always available
-    * Bitbucket Cloud - not supported
+    * Bitbucket Cloud - author is never available
     """
     author: Person
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -397,8 +397,14 @@ type ExternalChangeset implements Node & Changeset {
     body: String
 
     """
-    The author of the changeset, or null if the data hasn't been synced from the code host yet,
-    or the changeset has not yet been published.
+    The author of the changeset, or null if the data is unavailable or hasn't been synced
+    from the code host yet.
+
+    Note that author is not fully supported by some code host APIs:
+    * GitHub - only author.name
+    * GitLab - author.name is always available, author.email is only avaiable if a GitLab admin's credentials are used
+    * Bitbucket Server - author is not always available
+    * Bitbucket Cloud - not supported
     """
     author: Person
 

--- a/doc/admin/config/webhooks/outgoing.md
+++ b/doc/admin/config/webhooks/outgoing.md
@@ -98,8 +98,10 @@ The changeset webhook event payload mirrors the [GraphQL API](../../../api/graph
   "title": "Hello World",
   // The body of the changese (as Markdown).
   "body": "My first batch change!",
-  // The author of the changeset. Note that this is only available after the changeset has been published.
+  // The username of the author of the changeset. Note that this is only available after the changeset has been published and is not available on some code hosts.
   "author_name": "my-username",
+  // The email of the author of the changeset. Note that this is only available after the changeset has been published and is not available on most code hosts.
+  "author_email": "me@myorganization.com",
   // The state of the changeset on Sourcegraph.
   "state": "OPEN",
   // Any labels attached to the changeset on the code host.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -266,6 +266,11 @@ func (r *changesetResolver) Author() (*graphqlbackend.PersonResolver, error) {
 		return nil, err
 	}
 
+	// For many code hosts, we can't get the author information from the API.
+	if name == "" && email == "" {
+		return nil, nil
+	}
+
 	return graphqlbackend.NewPersonResolver(
 		r.store.DatabaseDB(),
 		name,

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -499,7 +499,7 @@ func (c *Changeset) AuthorName() (string, error) {
 	case *gitlab.MergeRequest:
 		return m.Author.Username, nil
 	case *bbcs.AnnotatedPullRequest:
-		// BitBucket cloud no longer exposes username in its API.
+		// Bitbucket Cloud no longer exposes username in its API.
 		return "", nil
 	case *adobatches.AnnotatedPullRequest:
 		return m.CreatedBy.UniqueName, nil

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -499,8 +499,9 @@ func (c *Changeset) AuthorName() (string, error) {
 	case *gitlab.MergeRequest:
 		return m.Author.Username, nil
 	case *bbcs.AnnotatedPullRequest:
-		// Bitbucket Cloud no longer exposes username in its API.
-		return "", nil
+		// Bitbucket Cloud no longer exposes username in its API, but we can still try to
+		// check this field for backwards compatibility.
+		return m.Author.Username, nil
 	case *adobatches.AnnotatedPullRequest:
 		return m.CreatedBy.UniqueName, nil
 	default:

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -499,7 +499,8 @@ func (c *Changeset) AuthorName() (string, error) {
 	case *gitlab.MergeRequest:
 		return m.Author.Username, nil
 	case *bbcs.AnnotatedPullRequest:
-		return m.Author.Username, nil
+		// BitBucket cloud no longer exposes username in its API.
+		return "", nil
 	case *adobatches.AnnotatedPullRequest:
 		return m.CreatedBy.UniqueName, nil
 	default:
@@ -524,6 +525,8 @@ func (c *Changeset) AuthorEmail() (string, error) {
 		}
 		return m.Author.User.EmailAddress, nil
 	case *gitlab.MergeRequest:
+		// Only GitLab admins can get the e-mail of a user so most of the time we won't
+		// have this.
 		return m.Author.Email, nil
 	case *bbcs.AnnotatedPullRequest:
 		// Bitbucket Cloud does not provide the e-mail of the author under any

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -526,8 +526,8 @@ func (c *Changeset) AuthorEmail() (string, error) {
 		}
 		return m.Author.User.EmailAddress, nil
 	case *gitlab.MergeRequest:
-		// Only GitLab admins can get the e-mail of a user so most of the time we won't
-		// have this.
+		// This doesn't seem to be available in the GitLab response anymore, but we can
+		// still try to check this field for backwards compatibility.
 		return m.Author.Email, nil
 	case *bbcs.AnnotatedPullRequest:
 		// Bitbucket Cloud does not provide the e-mail of the author under any

--- a/enterprise/internal/batches/webhooks/changeset.go
+++ b/enterprise/internal/batches/webhooks/changeset.go
@@ -23,6 +23,7 @@ type changeset struct {
 	Title              *string      `json:"title"`
 	Body               *string      `json:"body"`
 	AuthorName         *string      `json:"author_name"`
+	AuthorEmail        *string      `json:"author_email"`
 	State              string       `json:"state"`
 	Labels             []string     `json:"labels"`
 	ExternalURL        *string      `json:"external_url"`
@@ -54,6 +55,7 @@ const gqlChangesetQuery = `query Changeset($id: ID!) {
 			body
 			author {
 				name
+				email
 			}
 			state
 			labels {
@@ -91,7 +93,8 @@ type gqlChangesetResponse struct {
 			Title     *string   `json:"title"`
 			Body      *string   `json:"body"`
 			Author    *struct {
-				Name string `json:"name"`
+				Name  string `json:"name"`
+				Email string `json:"email"`
 			} `json:"author"`
 			State  string `json:"state"`
 			Labels []struct {
@@ -101,11 +104,11 @@ type gqlChangesetResponse struct {
 				URL string `json:"url"`
 			} `json:"externalURL"`
 			ForkNamespace      *string     `json:"forkNamespace"`
+			ForkName           *string     `json:"forkName"`
 			ReviewState        *string     `json:"reviewState"`
 			CheckState         *string     `json:"checkState"`
 			Error              *string     `json:"error"`
 			SyncerError        *string     `json:"syncerError"`
-			ForkName           *string     `json:"forkName"`
 			OwnedByBatchChange *graphql.ID `json:"ownedByBatchChange"`
 		}
 	}
@@ -149,6 +152,11 @@ func marshalChangeset(ctx context.Context, client httpcli.Doer, id graphql.ID) (
 		authorName = &node.Author.Name
 	}
 
+	var authorEmail *string
+	if node.Author != nil {
+		authorEmail = &node.Author.Email
+	}
+
 	var externalURL *string
 	if node.ExternalURL != nil {
 		externalURL = &node.ExternalURL.URL
@@ -164,15 +172,16 @@ func marshalChangeset(ctx context.Context, client httpcli.Doer, id graphql.ID) (
 		Title:              node.Title,
 		Body:               node.Body,
 		AuthorName:         authorName,
+		AuthorEmail:        authorEmail,
 		State:              node.State,
 		Labels:             labels,
 		ExternalURL:        externalURL,
 		ForkNamespace:      node.ForkNamespace,
+		ForkName:           node.ForkName,
 		ReviewState:        node.ReviewState,
 		CheckState:         node.CheckState,
 		Error:              node.Error,
 		SyncerError:        node.SyncerError,
-		ForkName:           node.ForkName,
 		OwnedByBatchChange: node.OwnedByBatchChange,
 	})
 }

--- a/enterprise/internal/batches/webhooks/changeset_test.go
+++ b/enterprise/internal/batches/webhooks/changeset_test.go
@@ -84,6 +84,7 @@ func TestMarshalChangeset(t *testing.T) {
 	icReviewState := string(btypes.ChangesetReviewStateChangesRequested)
 
 	authorName := "TestUser"
+	authorEmail := "test@sourcegraph.com"
 
 	testcases := []struct {
 		changeset    *btypes.Changeset
@@ -95,7 +96,7 @@ func TestMarshalChangeset(t *testing.T) {
 			changeset: uc,
 			name:      "unimported changeset",
 			httpResponse: fmt.Sprintf(
-				`{"data": {"node": {"id": "%s","externalID": "%s","batchChanges": {"nodes": [{"id": "%s"}]},"repository": {"id": "%s","name": "github.com/test/test"},"createdAt": "2023-02-25T00:53:50Z","updatedAt": "2023-02-25T00:53:50Z","title": "%s","body": "%s","author": {"name": "%s"},"state": "%s","labels": [],"externalURL": {"url": "%s"},"forkNamespace": null,"reviewState": "%s","checkState": null,"error": null,"syncerError": null,"forkName": null,"ownedByBatchChange": "%s"}}}`,
+				`{"data": {"node": {"id": "%s","externalID": "%s","batchChanges": {"nodes": [{"id": "%s"}]},"repository": {"id": "%s","name": "github.com/test/test"},"createdAt": "2023-02-25T00:53:50Z","updatedAt": "2023-02-25T00:53:50Z","title": "%s","body": "%s","author": {"name": "%s", "email": "%s"},"state": "%s","labels": [],"externalURL": {"url": "%s"},"forkNamespace": null,"reviewState": "%s","checkState": null,"error": null,"syncerError": null,"forkName": null,"ownedByBatchChange": "%s"}}}`,
 				mucID,
 				uc.ExternalID,
 				mbID,
@@ -103,6 +104,7 @@ func TestMarshalChangeset(t *testing.T) {
 				ucTitle,
 				ucBody,
 				authorName,
+				authorEmail,
 				uc.State,
 				ucExternalURL,
 				ucReviewState,
@@ -120,6 +122,7 @@ func TestMarshalChangeset(t *testing.T) {
 				Title:              &ucTitle,
 				Body:               &ucBody,
 				AuthorName:         &authorName,
+				AuthorEmail:        &authorEmail,
 				ExternalURL:        &ucExternalURL,
 				ReviewState:        &ucReviewState,
 			},
@@ -128,7 +131,7 @@ func TestMarshalChangeset(t *testing.T) {
 			changeset: ic,
 			name:      "imported changeset",
 			httpResponse: fmt.Sprintf(
-				`{"data": {"node": {"id": "%s","externalID": "%s","batchChanges": {"nodes": [{"id": "%s"}]},"repository": {"id": "%s","name": "github.com/test/test"},"createdAt": "2023-02-25T00:53:50Z","updatedAt": "2023-02-25T00:53:50Z","title": "%s","body": "%s","author": {"name": "%s"},"state": "%s","labels": [],"externalURL": {"url": "%s"},"forkNamespace": null,"reviewState": "%s","checkState": null,"error": null,"syncerError": null,"forkName": null,"ownedByBatchChange": null}}}`,
+				`{"data": {"node": {"id": "%s","externalID": "%s","batchChanges": {"nodes": [{"id": "%s"}]},"repository": {"id": "%s","name": "github.com/test/test"},"createdAt": "2023-02-25T00:53:50Z","updatedAt": "2023-02-25T00:53:50Z","title": "%s","body": "%s","author": {"name": "%s", "email": "%s"},"state": "%s","labels": [],"externalURL": {"url": "%s"},"forkNamespace": null,"reviewState": "%s","checkState": null,"error": null,"syncerError": null,"forkName": null,"ownedByBatchChange": null}}}`,
 				micID,
 				ic.ExternalID,
 				mbID,
@@ -136,6 +139,7 @@ func TestMarshalChangeset(t *testing.T) {
 				icTitle,
 				icBody,
 				authorName,
+				authorEmail,
 				ic.State,
 				icExternalURL,
 				icReviewState,
@@ -152,6 +156,7 @@ func TestMarshalChangeset(t *testing.T) {
 				Title:              &icTitle,
 				Body:               &icBody,
 				AuthorName:         &authorName,
+				AuthorEmail:        &authorEmail,
 				ExternalURL:        &icExternalURL,
 				ReviewState:        &icReviewState,
 			},

--- a/internal/extsvc/bitbucketcloud/types.go
+++ b/internal/extsvc/bitbucketcloud/types.go
@@ -10,7 +10,11 @@ import (
 // Types that are returned by Bitbucket Cloud calls.
 
 type Account struct {
-	Links         Links         `json:"links"`
+	Links Links `json:"links"`
+	// BitBucket cloud no longer exposes username in its API, favoring account_id instead.
+	// This field should be removed and updated in the places where it is currently
+	// depended upon.
+	// https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#removal-of-usernames-from-user-referencing-apis
 	Username      string        `json:"username"`
 	Nickname      string        `json:"nickname"`
 	AccountStatus AccountStatus `json:"account_status"`

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -46,7 +46,10 @@ type MergeRequest struct {
 	WebURL                 string            `json:"web_url"`
 	WorkInProgress         bool              `json:"work_in_progress"`
 	Draft                  bool              `json:"draft"`
-	Author                 User              `json:"author"`
+	// We only get a partial User object back from the REST API. For example, it lacks
+	// `Email` and `Identities`. If we need more, we need to issue an additional API
+	// request. Otherwise, we should use a different type here.
+	Author User `json:"author"`
 
 	DiffRefs DiffRefs `json:"diff_refs"`
 


### PR DESCRIPTION
While testing outgoing webhooks for changesets, I noticed changesets seemed to be frequently missing the `AuthorName`. For these changesets, the author was also empty when queried over GraphQL:

![image](https://user-images.githubusercontent.com/8942601/226447056-fd5a439c-e5bb-4979-ba1f-ccdf2ef898b2.png)

As I traced how the author is typically resolved back to the changeset metadata, I came to realize that not every code host provides this information back in its API. Furthermore, several code hosts that we thought _did_ provide this information, actually don't anymore, or only do under select circumstances.

This PR:
- Clarifies in several places across both internal and external docs when the author fields may not be available
- Updates the GraphQL resolver for the `Author` field to only resolve the author if we have _at least one_ of the username or the email
- Adds `author_email` to the payload body for changeset webhooks, to help in the cases when `author_name` is unavailable

## Test plan

Unit test coverage for webhook payload. Manually tested that `author_email` is properly available for a `changeset:close` event on a supported code host:

<img width="364" alt="image" src="https://user-images.githubusercontent.com/8942601/226448588-8042b5e5-b02a-44bf-abe8-c0c37e17a7b7.png">
 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
