### PR TITLE
app: CI: fix version numbers (yyyy.mm.yy -> yyyy.mm.dd)

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -629,7 +629,7 @@ func addAppReleaseSteps(c Config, insiders bool) operations.Operation {
 	if insiders {
 		insidersStr = "-insiders"
 	}
-	version := fmt.Sprintf("%s%s+%d.%.6s", c.Time.Format("2006.01.06"), insidersStr, c.BuildNumber, c.Commit)
+	version := fmt.Sprintf("%s%s+%d.%.6s", c.Time.Format("2006.01.02"), insidersStr, c.BuildNumber, c.Commit)
 
 	return func(pipeline *bk.Pipeline) {
 		// Release App (.zip/.deb/.rpm to Google Cloud Storage, new tap for Homebrew, etc.).


### PR DESCRIPTION
There was a typo here where our version numbers were accidently `yyyy.mm.yy` format, I didn't notice the mistake because the `yy` is `23` (latter part of 2023) which is eerily close to our Starship launch date.

## Test plan

manually tested the code locally & confirmed date matches my system time.
