### PR TITLE
webhooks: trigger `changeset:update` events on push-only operations

### DIFF
--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -83,6 +83,15 @@ func (ops Operations) ExecutionOrder() []btypes.ReconcilerOperation {
 	return uniqueOps
 }
 
+func (ops Operations) Contains(op btypes.ReconcilerOperation) bool {
+	for _, o := range ops {
+		if o == op {
+			return true
+		}
+	}
+	return false
+}
+
 // Plan represents the possible operations the reconciler needs to do
 // to reconcile the current and the desired state of a changeset.
 type Plan struct {


### PR DESCRIPTION
Noticed `changeset:update` events weren't triggered by operations that only push new commits to an existing changeset's branch, since we don't actually call that "updating" the changeset internally. I think an end user would still classify this as an update, however. So in this PR, I've added logic to trigger `changeset:update` from `executor.pushChangesetPatch`, but only if it's not part of a plan that also publishes or updates the changeset.

NB, as a follow up for post-Starship, I'm experimenting with a refactor that would enable us to declaratively define which webhook event(s) should trigger at the time that we `DeterminePlan`, rather than by repeatedly injecting code to enqueue it for every code path of the `executor` methods. So if all the `if trigger { enqueueWebhook() }` blocks make you nauseous by how repetitive they are, don't worry, a better alternative may soon be on its way. 🙏

## Test plan

Manually tested that `changeset:update` triggers once per changeset under the following circumstances:
- Applying a new spec to a batch change with open changesets that only generates a new diff (Push)
- Applying a new spec to a batch change with open changesets that generates a new diff and updates changeset metadata (Push & Update)
- Applying a new spec to a batch change with open changesets that only updates changeset metadata (Update)

And does not trigger under the following circumstances:
- Publishing a new changeset (Push & Publish) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
