### PR TITLE
auto create backport label on branch cut

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -405,12 +405,15 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 // create backport label for major / minor versions
                 const params = {
                     owner: 'sourcegraph',
-                    repo: 'sourcegraph'
+                    repo: 'sourcegraph',
                 }
                 const labelName = `backport ${release.version.major}.${release.version.minor}`
-                const labelExists = await client.issues.getLabel({name: labelName, ...params}).then(resp => resp.status === 200).catch(() => false)
+                const labelExists = await client.issues
+                    .getLabel({ name: labelName, ...params })
+                    .then(resp => resp.status === 200)
+                    .catch(() => false)
                 if (!labelExists) {
-                    console.log(await client.issues.createLabel({name: labelName, color: 'e69138', ...params}))
+                    console.log(await client.issues.createLabel({ name: labelName, color: 'e69138', ...params }))
                     console.log(`Label ${labelName} created`)
                 } else {
                     console.log(`label ${labelName} already exists`)

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -69,7 +69,6 @@ import {
     validateNoReleaseBlockers,
     verifyWithInput,
 } from './util'
-import { IssuesGetLabelParams} from '@octokit/rest';
 
 const sed = process.platform === 'linux' ? 'sed' : 'gsed'
 
@@ -1304,18 +1303,6 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
         description: 'test patch dates',
         run: () => {
             console.log(newRelease(new SemVer('1.0.0'), DateTime.fromISO('2023-03-22'), 'test', 'test'))
-        },
-    },
-    {
-        id: '_test:create-label',
-        description: 'test patch dates',
-        run: async () => {
-            const client = await getAuthenticatedGitHubClient()
-            const got = await client.issues.getLabel({name: 'release-tool-test-please-ignore', owner: 'sourcegraph', repo:'sourcegraph'} as IssuesGetLabelParams)
-            // const resp = await client.issues.createLabel({color:'e69138', name: `release-tool-test-please-ignore`, owner: 'sourcegraph', repo: 'sourcegraph', description: 'release tool testing'} as IssuesCreateLabelParams)
-            // client.issues.updateLabel({} as IssuesUpdateLabelParams)
-            // console.log(resp)
-            console.log(got)
         },
     },
 ]


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/49213
Create the backport label when cutting a major / minor branch.

## Test plan

Tested by modifying the label name, commenting out the non-label code in the branch-cut step and running the command.

For 5.0:

```
> @sourcegraph/dev-release@0.0.1 release /Users/coury@sourcegraph.com/Documents/code/sourcegraph/dev/release
> ts-node --transpile-only ./src/main.ts "release:branch-cut"

label backport 5.0 already exists
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-create-backport-on-branch.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
