### PR TITLE
repoupdater: fix error handling responses

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -419,6 +419,7 @@ func (s *Server) handleExternalServiceNamespaces(w http.ResponseWriter, r *http.
 		logger.Error("server.query-external-service-namespaces", log.Error(err))
 		httpCode := codeToStatus(status.Code(err))
 		s.respond(w, httpCode, &protocol.ExternalServiceNamespacesResult{Error: err.Error()})
+		return
 	}
 	s.respond(w, http.StatusOK, protocol.ExternalServiceNamespacesResultFromProto(result))
 }
@@ -497,6 +498,7 @@ func (s *Server) handleExternalServiceRepositories(w http.ResponseWriter, r *htt
 		logger.Error("server.query-external-service-repositories", log.Error(err))
 		httpCode := codeToStatus(status.Code(err))
 		s.respond(w, httpCode, &protocol.ExternalServiceRepositoriesResult{Error: err.Error()})
+		return
 	}
 	s.respond(w, http.StatusOK, protocol.ExternalServiceRepositoriesResultFromProto(result))
 }


### PR DESCRIPTION
I'm not sure who/how this got introduced, but these two instances of error handling seem clearly incorrect without a return statement (all others in the file have this.)

This is obscuring an error that people are getting in App; this won't fix the error but hopefully will let us see what it is..

(Thanks Quinn for spotting this)

## Test plan

existing tests