### PR TITLE
add privacy policy to feedback prompts

### DIFF
--- a/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
+++ b/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
@@ -42,21 +42,22 @@ export const SurveyUserRatingToast: React.FunctionComponent<SurveyUserRatingToas
         }
         footer={
             <>
-            <Text className="d-flex align-items-center justify-content-between mb-1">
-                <span>
-                    By submitting your feedback, you agree to the <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
-                </span>
-            </Text>
-            <div className="d-flex align-items-center justify-content-between">
-                <Checkbox
-                    id="survey-toast-refuse"
-                    label={<span className={styles.checkboxLabel}>Don't show this again</span>}
-                    onChange={event => setToggledPermanentlyDismiss(event.target.checked)}
-                />
-                <Button variant="secondary" size="sm" onClick={onContinue}>
-                    Continue
-                </Button>
-            </div>
+                <Text className="d-flex align-items-center justify-content-between mb-1">
+                    <span>
+                        By submitting your feedback, you agree to the{' '}
+                        <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
+                    </span>
+                </Text>
+                <div className="d-flex align-items-center justify-content-between">
+                    <Checkbox
+                        id="survey-toast-refuse"
+                        label={<span className={styles.checkboxLabel}>Don't show this again</span>}
+                        onChange={event => setToggledPermanentlyDismiss(event.target.checked)}
+                    />
+                    <Button variant="secondary" size="sm" onClick={onContinue}>
+                        Continue
+                    </Button>
+                </div>
             </>
         }
         onDismiss={onDismiss}

--- a/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
+++ b/client/web/src/marketing/toast/SurveyUserRatingToast.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Button, Checkbox } from '@sourcegraph/wildcard'
+import { Button, Checkbox, Link, Text } from '@sourcegraph/wildcard'
 
 import { SurveyRatingRadio } from '../components/SurveyRatingRadio'
 
@@ -41,6 +41,12 @@ export const SurveyUserRatingToast: React.FunctionComponent<SurveyUserRatingToas
             </>
         }
         footer={
+            <>
+            <Text className="d-flex align-items-center justify-content-between mb-1">
+                <span>
+                    By submitting your feedback, you agree to the <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
+                </span>
+            </Text>
             <div className="d-flex align-items-center justify-content-between">
                 <Checkbox
                     id="survey-toast-refuse"
@@ -51,6 +57,7 @@ export const SurveyUserRatingToast: React.FunctionComponent<SurveyUserRatingToas
                     Continue
                 </Button>
             </div>
+            </>
         }
         onDismiss={onDismiss}
     />

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -134,6 +134,11 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
                             prefix="Error submitting feedback"
                         />
                     )}
+<Text className="d-flex align-items-center justify-content-between mt-2">
+                        <span>
+                            By submitting your feedback, you agree to the <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
+                        </span>
+                    </Text>
                     <Button
                         disabled={!text || submitting}
                         role="menuitem"
@@ -144,6 +149,7 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
                     >
                         {submitting ? <LoadingSpinner /> : 'Send'}
                     </Button>
+
                 </Form>
             )}
         </>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.tsx
@@ -134,9 +134,10 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
                             prefix="Error submitting feedback"
                         />
                     )}
-<Text className="d-flex align-items-center justify-content-between mt-2">
+                    <Text className="d-flex align-items-center justify-content-between mt-2">
                         <span>
-                            By submitting your feedback, you agree to the <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
+                            By submitting your feedback, you agree to the{' '}
+                            <Link to="https://about.sourcegraph.com/terms/privacy">Sourcegraph Privacy Policy</Link>.
                         </span>
                     </Text>
                     <Button
@@ -149,7 +150,6 @@ const FeedbackPromptContent: React.FunctionComponent<React.PropsWithChildren<Fee
                     >
                         {submitting ? <LoadingSpinner /> : 'Send'}
                     </Button>
-
                 </Form>
             )}
         </>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -69,6 +69,21 @@ exports[`FeedbackPrompt should render correctly 1`] = `
         >
           You're not signed in. Please tell us how to contact you if you want a reply.
         </p>
+        <p
+          class="d-flex align-items-center justify-content-between mt-2"
+        >
+          <span>
+            By submitting your feedback, you agree to the
+             
+            <a
+              class="anchorLink"
+              href="https://about.sourcegraph.com/terms/privacy"
+            >
+              Sourcegraph Privacy Policy
+            </a>
+            .
+          </span>
+        </p>
         <button
           aria-disabled="true"
           class="btn btnSecondary btnBlock button"
@@ -175,6 +190,21 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
             Something went really wrong
           </span>
         </div>
+        <p
+          class="d-flex align-items-center justify-content-between mt-2"
+        >
+          <span>
+            By submitting your feedback, you agree to the
+             
+            <a
+              class="anchorLink"
+              href="https://about.sourcegraph.com/terms/privacy"
+            >
+              Sourcegraph Privacy Policy
+            </a>
+            .
+          </span>
+        </p>
         <button
           aria-disabled="false"
           class="btn btnSecondary btnBlock button"


### PR DESCRIPTION
adds  our privacy policy link to our nps and feedback forms per legal request
![Screenshot 2023-03-20 at 5 41 16 PM](https://user-images.githubusercontent.com/78464298/226495705-540b7609-406b-4e19-bb16-8f64a9befca3.png)
![Screenshot 2023-03-20 at 5 46 40 PM](https://user-images.githubusercontent.com/78464298/226495729-b39f46ba-fe85-478c-a7b3-674e0eb8c54c.png)

## Test plan
sg start 
set nps visibility to true 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mucles-sg-privacy-policy.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
