### PR TITLE
App + Setup Experience: Empty root path will ignore search/walk

### DIFF
--- a/internal/service/servegit/serve.go
+++ b/internal/service/servegit/serve.go
@@ -236,6 +236,11 @@ func (s *Serve) Repos(root string) ([]Repo, error) {
 
 // Walk is the core repos finding routine.
 func (s *Serve) Walk(root string, repoC chan<- Repo) error {
+	if root == "" {
+		s.Logger.Warn("root path cannot be searched if it is not an absolute path", log.String("path", root))
+		return nil
+	}
+
 	root, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		s.Logger.Warn("ignoring error searching", log.String("path", root), log.Error(err))


### PR DESCRIPTION
I believe the issue described in #49737 happens because when the user hits "reset path" in the setup wizard local repos step, we set the external service configuration to have:
`root: ""`

When this is passed to the serve-git `/list-repos-for-path/` endpoint we will run `EvalSymLinks()` which converts `""` to `"."` and assumes current working directory is the root that we're concerned with.

The local repository sync setup assumes user sets this up only via the setup wizard and therefore the user will always select a root path via the file picker. A path of empty string cannot be selected by this picker, so we can just ignore this use case when calling `Walk()`.

Note that `"/"` can be selected for root of the local system so we should support this as the means of defining the selection of root and empty string should not define root, but instead just be invalid input. There's an issue with `"/"` that I'll file a separate ticket for.

Issue: https://github.com/sourcegraph/sourcegraph/issues/49737

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

existing tests, add new tests