### PR TITLE
Repository page: Fix side file panel spacings

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -99,7 +99,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                             isSourcegraphDotCom={props.isSourcegraphDotCom}
                         />
                         <Tabs
-                            className="w-100 test-repo-revision-sidebar pr-3 h-25 d-flex flex-column flex-grow-1"
+                            className="w-100 test-repo-revision-sidebar h-25 d-flex flex-column flex-grow-1"
                             index={persistedTabIndex}
                             onChange={setPersistedTabIndex}
                             lazy={true}
@@ -108,6 +108,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                             behavior="memoize"
                         >
                             <TabList
+                                wrapperClassName="mr-3"
                                 actions={
                                     <Tooltip content="Hide sidebar" placement="right">
                                         <Button
@@ -132,7 +133,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                                 </Tab>
                             </TabList>
                             <div
-                                className={classNames('flex w-100 overflow-auto explorer', styles.tabpanels)}
+                                className={classNames('flex w-100 overflow-auto explorer pr-2', styles.tabpanels)}
                                 tabIndex={-1}
                             >
                                 {/* TODO: See if we can render more here, instead of waiting for these props */}


### PR DESCRIPTION
From the slack feedback [here](https://sourcegraph.slack.com/archives/C04931KQVRC/p1679116428641199)

| Before | After |
| --------- | --------- |
| <img width="1054" alt="Screenshot 2023-03-20 at 23 11 21" src="https://user-images.githubusercontent.com/18492575/226503557-a05cc9af-4398-4a5c-a600-4c2cebcf9736.png"> | <img width="1054" alt="Screenshot 2023-03-20 at 23 10 29" src="https://user-images.githubusercontent.com/18492575/226503575-2dbc9791-8c37-4ea8-b3fb-55d80079cfc3.png"> |

## Test plan
- Check that side panel file tree looks good

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
