### PR TITLE
Search: small fixes to ranking dashboards

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4280,9 +4280,9 @@ Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h]))`
 
 <br />
 
-#### frontend: percent_file_clicks_on_top_search_result
+#### frontend: percent_clicks_on_top_search_result
 
-<p class="subtitle">Percent of file clicks on top search result over 6h</p>
+<p class="subtitle">Percent of clicks on top search result over 6h</p>
 
 The percent of clicks that were on the top search result, excluding searches with very few results (3 or fewer).
 
@@ -4295,17 +4295,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103101`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="1",resultsLength=">3",type="fileMatch"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count{type="fileMatch"}[6h])) * 100`
+Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="1",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100`
 
 </details>
 
 <br />
 
-#### frontend: percent_file_clicks_on_top_3_search_results
+#### frontend: percent_clicks_on_top_3_search_results
 
-<p class="subtitle">Percent of file clicks on top 3 search results over 6h</p>
+<p class="subtitle">Percent of clicks on top 3 search results over 6h</p>
 
-The percent of file clicks that were on the first 3 search results, excluding searches with very few results (3 or fewer).
+The percent of clicks that were on the first 3 search results, excluding searches with very few results (3 or fewer).
 
 This panel has no related alerts.
 
@@ -4316,7 +4316,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103102`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="3",resultsLength=">3",type="fileMatch"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count{type="fileMatch"}[6h])) * 100`
+Query: `sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le="3",resultsLength=">3"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100`
 
 </details>
 
@@ -4337,7 +4337,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103110`
 <details>
 <summary>Technical details</summary>
 
-Query: `round(sum(increase(src_search_ranking_result_clicked_count{type="repo"}[6h])) / sum (increase(src_search_ranking_result_clicked_count[6h]))) * 100`
+Query: `sum(increase(src_search_ranking_result_clicked_count{type="repo"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -676,42 +676,46 @@ func Frontend() *monitoring.Dashboard {
 							Interpretation: "The total number of search clicks across all search types over a 6 hour window.",
 						},
 						{
-							Name:           "percent_file_clicks_on_top_search_result",
-							Description:    "percent of file clicks on top search result over 6h",
-							Query:          "sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le=\"1\",resultsLength=\">3\",type=\"fileMatch\"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count{type=\"fileMatch\"}[6h])) * 100",
+							Name:           "percent_clicks_on_top_search_result",
+							Description:    "percent of clicks on top search result over 6h",
+							Query:          "sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le=\"1\",resultsLength=\">3\"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100",
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("ranked={{ranked}}").Unit(monitoring.Percentage),
 							Owner:          monitoring.ObservableOwnerSearchCore,
 							Interpretation: "The percent of clicks that were on the top search result, excluding searches with very few results (3 or fewer).",
 						},
 						{
-							Name:           "percent_file_clicks_on_top_3_search_results",
-							Description:    "percent of file clicks on top 3 search results over 6h",
-							Query:          "sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le=\"3\",resultsLength=\">3\",type=\"fileMatch\"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count{type=\"fileMatch\"}[6h])) * 100",
+							Name:           "percent_clicks_on_top_3_search_results",
+							Description:    "percent of clicks on top 3 search results over 6h",
+							Query:          "sum by (ranked) (increase(src_search_ranking_result_clicked_bucket{le=\"3\",resultsLength=\">3\"}[6h])) / sum by (ranked) (increase(src_search_ranking_result_clicked_count[6h])) * 100",
 							NoAlert:        true,
 							Panel:          monitoring.Panel().LegendFormat("ranked={{ranked}}").Unit(monitoring.Percentage),
 							Owner:          monitoring.ObservableOwnerSearchCore,
-							Interpretation: "The percent of file clicks that were on the first 3 search results, excluding searches with very few results (3 or fewer).",
+							Interpretation: "The percent of clicks that were on the first 3 search results, excluding searches with very few results (3 or fewer).",
 						},
 					}, {
 						{
 							Name:        "distribution_of_clicked_search_result_type_over_6h_in_percent",
 							Description: "distribution of clicked search result type over 6h",
-							Query:       "round(sum(increase(src_search_ranking_result_clicked_count{type=\"repo\"}[6h])) / sum (increase(src_search_ranking_result_clicked_count[6h]))) * 100",
+							Query:       "sum(increase(src_search_ranking_result_clicked_count{type=\"repo\"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100",
 							NoAlert:     true,
 							Panel: monitoring.Panel().With(
 								func(o monitoring.Observable, p *sdk.Panel) {
 									p.GraphPanel.Legend.Current = true
-									p.GraphPanel.Targets = []sdk.Target{{
-										Expr:         o.Query,
-										LegendFormat: "repo",
-									}, {
-										Expr:         "round(sum(increase(src_search_ranking_result_clicked_count{type=\"fileMatch\"}[6h])) / sum (increase(src_search_ranking_result_clicked_count[6h]))) * 100",
-										LegendFormat: "fileMatch",
-									}, {
-										Expr:         "round(sum(increase(src_search_ranking_result_clicked_count{type=\"filePathMatch\"}[6h])) / sum (increase(src_search_ranking_result_clicked_count[6h]))) * 100",
-										LegendFormat: "filePathMatch",
-									}}
+									p.GraphPanel.Targets = []sdk.Target{
+										{
+											RefID:        "0",
+											Expr:         o.Query,
+											LegendFormat: "repo",
+										}, {
+											RefID:        "1",
+											Expr:         "sum(increase(src_search_ranking_result_clicked_count{type=\"fileMatch\"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100",
+											LegendFormat: "fileMatch",
+										}, {
+											RefID:        "2",
+											Expr:         "sum(increase(src_search_ranking_result_clicked_count{type=\"filePathMatch\"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100",
+											LegendFormat: "filePathMatch",
+										}}
 									p.GraphPanel.Tooltip.Shared = true
 								}),
 							Owner:          monitoring.ObservableOwnerSearchCore,


### PR DESCRIPTION
This PR is a follow up to #49275 that fixes small issues with the ranking dashboards:
1. Fix a bug in 'Distribution of clicked search result type' where one type overwrote another. This bug snuck in at some point in the past, and is resolved if we use unique refIds.
2. For 'percent of top clicks' dashboards, report all result types instead of just file match. Since a single search results page can mix together multiple result types (for example first listing repo results, then file matches), it doesn't make sense to filter by only file matches.

## Test plan

Tested locally using `sg start monitoring`.