### PR TITLE
CodeMirror: Render URLs as links

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -36,6 +36,7 @@ import { createBlameDecorationsExtension } from './codemirror/blame-decorations'
 import { codeFoldingExtension } from './codemirror/code-folding'
 import { syntaxHighlight } from './codemirror/highlight'
 import { selectableLineNumbers, SelectedLineRange, selectLines } from './codemirror/linenumbers'
+import { buildLinks } from './codemirror/links'
 import { lockFirstVisibleLine } from './codemirror/lock-line'
 import { navigateToLineOnAnyClickExtension } from './codemirror/navigate-to-any-line-on-click'
 import { occurrenceAtPosition, positionAtCmPosition } from './codemirror/occurrence-utils'
@@ -285,6 +286,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             navigateToLineOnAnyClick ? navigateToLineOnAnyClickExtension : tokenSelectionExtension(),
             syntaxHighlight.of(blobInfo),
             languageSupport.of(blobInfo),
+            buildLinks.of(blobInfo),
             pin.init(() => (hasPin ? position : null)),
             extensionsController !== null && !navigateToLineOnAnyClick
                 ? sourcegraphExtensions({

--- a/client/web/src/repo/blob/codemirror/links.module.scss
+++ b/client/web/src/repo/blob/codemirror/links.module.scss
@@ -1,0 +1,3 @@
+.link {
+    text-decoration: underline;
+}

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -1,0 +1,114 @@
+import { Facet, RangeSetBuilder } from '@codemirror/state'
+import { Decoration, DecorationSet, EditorView, PluginValue, ViewUpdate, ViewPlugin } from '@codemirror/view'
+import classNames from 'classnames'
+
+import { logger } from '@sourcegraph/common'
+import { SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
+
+import { BlobInfo } from '../CodeMirrorBlob'
+
+import { syntaxHighlight } from './highlight'
+
+import styles from './links.module.scss'
+
+const SUPPORTED_KINDS = new Set<SyntaxKind>([SyntaxKind.Comment, SyntaxKind.StringLiteral])
+
+const LINK_REGEX =
+    /(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([\w!#$%&+,./:=?@|~-]*\)|[\w!#$%&+,./:=?@|~-])*(?:\([\w!#$%&+,./:=?@|~-]*\)|[\w#$%&+/=@|~])/gim
+
+/**
+ * Iterates through highlighting occurrences and match any URLs in `SUPPORTED_KINDS`.
+ * Converts matches into <a> tags with a permanent underline and a relevant href.
+ */
+class LinkBuilder implements PluginValue {
+    // private decorationCache: Partial<Record<SyntaxKind, Decoration>> = {}
+    public decorations: DecorationSet = Decoration.none
+
+    constructor(view: EditorView) {
+        this.decorations = this.computeDecorations(view)
+    }
+
+    public update(update: ViewUpdate): void {
+        if (update.viewportChanged) {
+            this.decorations = this.computeDecorations(update.view)
+        }
+    }
+
+    private computeDecorations(view: EditorView): DecorationSet {
+        const builder = new RangeSetBuilder<Decoration>()
+        try {
+            const { from, to } = view.viewport
+
+            // Determine the start and end lines of the current viewport
+            const fromLine = view.state.doc.lineAt(from)
+            const toLine = view.state.doc.lineAt(to)
+
+            const { occurrences, lineIndex } = view.state.facet(syntaxHighlight)
+
+            // Find index of first relevant token
+            let startIndex: number | undefined
+            {
+                let line = fromLine.number - 1
+                do {
+                    startIndex = lineIndex[line++]
+                } while (startIndex === undefined && line < lineIndex.length)
+            }
+
+            if (startIndex !== undefined) {
+                // Iterate over the rendered line (numbers) and get the
+                // corresponding occurrences from the highlighting table.
+                const textDocument = view.state.doc
+
+                for (let index = startIndex; index < occurrences.length; index++) {
+                    const occurrence = occurrences[index]
+                    const occurrenceStartLine = occurrence.range.start.line + 1
+
+                    // Skip if out of viewport
+                    if (occurrenceStartLine > toLine.number) {
+                        break
+                    }
+
+                    // Skip if the syntax kind is not supported.
+                    if (occurrence.kind === undefined || !SUPPORTED_KINDS.has(occurrence.kind)) {
+                        continue
+                    }
+
+                    // Skip if the range is not on a single line.
+                    // We know that we will not match a link here.
+                    if (!occurrence.range.isSingleLine()) {
+                        continue
+                    }
+
+                    const line = textDocument.line(occurrenceStartLine)
+                    const matches = line.text.matchAll(LINK_REGEX)
+
+                    for (const match of matches) {
+                        if (match.index) {
+                            const from = Math.min(line.from + match.index, line.to)
+                            const to = Math.min(line.from + match.index + match[0].length, line.to)
+
+                            const decoration = Decoration.mark({
+                                tagName: 'a',
+                                class: classNames(styles.link, `hl-typed-${SyntaxKind[occurrence.kind]}`),
+                                attributes: {
+                                    href: match[0],
+                                },
+                            })
+
+                            builder.add(from, to, decoration)
+                        }
+                    }
+                }
+            }
+        } catch (error) {
+            logger.error('Failed to build links', error)
+        }
+        return builder.finish()
+    }
+}
+
+export const buildLinks = Facet.define<BlobInfo>({
+    static: true,
+    compareInput: (blobInfoA, blobInfoB) => blobInfoA.lsif === blobInfoB.lsif,
+    enables: ViewPlugin.fromClass(LinkBuilder, { decorations: plugin => plugin.decorations }),
+})

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -92,6 +92,7 @@ class LinkBuilder implements PluginValue {
                                 class: classNames(styles.link, `hl-typed-${SyntaxKind[occurrence.kind]}`),
                                 attributes: {
                                     href: match[0],
+                                    rel: 'noreferrer noopener',
                                 },
                             })
 

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -17,11 +17,10 @@ const LINK_REGEX =
     /(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([\w!#$%&+,./:=?@|~-]*\)|[\w!#$%&+,./:=?@|~-])*(?:\([\w!#$%&+,./:=?@|~-]*\)|[\w#$%&+/=@|~])/gim
 
 /**
- * Iterates through highlighting occurrences and match any URLs in `SUPPORTED_KINDS`.
+ * Iterates through `SUPPORTED_KINDS` highlighting occurrences and match any URLs within.
  * Converts matches into <a> tags with a permanent underline and a relevant href.
  */
 class LinkBuilder implements PluginValue {
-    // private decorationCache: Partial<Record<SyntaxKind, Decoration>> = {}
     public decorations: DecorationSet = Decoration.none
 
     constructor(view: EditorView) {
@@ -83,6 +82,7 @@ class LinkBuilder implements PluginValue {
                     const matches = line.text.matchAll(LINK_REGEX)
 
                     for (const match of matches) {
+                        // https://github.com/microsoft/TypeScript/issues/36788
                         if (match.index) {
                             const from = Math.min(line.from + match.index, line.to)
                             const to = Math.min(line.from + match.index + match[0].length, line.to)

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -81,11 +81,15 @@ class LinkBuilder implements PluginValue {
                     }
 
                     const line = textDocument.line(occurrenceStartLine)
-                    const links = getLinksFromString({ input: line.text })
+                    const start = line.from + occurrence.range.start.character
+                    const end = line.from + occurrence.range.end.character
+                    const links = getLinksFromString({
+                        input: textDocument.sliceString(start, end),
+                    })
 
                     for (const link of links) {
-                        const from = Math.min(line.from + link.start, line.to)
-                        const to = Math.min(line.from + link.end, line.to)
+                        const from = Math.min(start + link.start, line.to)
+                        const to = Math.min(start + link.end, line.to)
 
                         const decoration = Decoration.mark({
                             tagName: 'a',

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -78,7 +78,10 @@ class LinkBuilder implements PluginValue {
                     }
 
                     const line = textDocument.line(occurrenceStartLine)
-                    const links = getLinksFromString({ input: line.text, externalURLs: blobInfo[0].externalURLs })
+                    const links = getLinksFromString({
+                        input: line.text,
+                        externalURLs: occurrence.kind === SyntaxKind.Comment ? blobInfo[0].externalURLs : undefined,
+                    })
 
                     for (const link of links) {
                         const from = Math.min(line.from + link.start, line.to)

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -92,6 +92,7 @@ class LinkBuilder implements PluginValue {
                             class: classNames(styles.link, `hl-typed-${SyntaxKind[occurrence.kind]}`),
                             attributes: {
                                 href: link.href,
+                                target: '_blank',
                                 rel: 'noreferrer noopener',
                             },
                         })

--- a/client/web/src/repo/blob/codemirror/token-selection/extension.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/extension.ts
@@ -94,12 +94,6 @@ export function tokenSelectionExtension(): Extension {
                     goToDefinitionOnMouseEvent(view, event, { isLongClick: true })
                 }, LONG_CLICK_DURATION)
             },
-            click(event: MouseEvent) {
-                // Prevent click handlers because we handle events on mouseup.
-                // Without the line below, Cmd+Click gets unpredicable behavior
-                // where it sporadically opens goto-def links in a new tab.
-                event.preventDefault()
-            },
         }),
     ]
 }

--- a/client/web/src/repo/commit/__snapshots__/CommitMessageWithLinks.test.tsx.snap
+++ b/client/web/src/repo/commit/__snapshots__/CommitMessageWithLinks.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CommitMessageWithLinks works with a commit link 1`] = `
     class="anchorLink"
     href="https://github.com/sourcegraph/sourcegraph/pull/1234"
     rel="noreferrer noopener"
-    target="blank"
+    target="_blank"
   >
     #1234
   </a>
@@ -40,7 +40,7 @@ exports[`CommitMessageWithLinks works with a repo link 1`] = `
     class="anchorLink"
     href="https://github.com/sourcegraph/sourcegraph/pull/1234"
     rel="noreferrer noopener"
-    target="blank"
+    target="_blank"
   >
     #1234
   </a>

--- a/client/web/src/repo/linkifiy/Linkified.tsx
+++ b/client/web/src/repo/linkifiy/Linkified.tsx
@@ -33,7 +33,7 @@ export const Linkified = forwardRef((props, ref) => {
                 )
             }
             result.push(
-                <Link key={`${start}-${end}`} to={href} target="blank" rel="noreferrer noopener">
+                <Link key={`${start}-${end}`} to={href} target="_blank" rel="noreferrer noopener">
                     {value}
                 </Link>
             )


### PR DESCRIPTION
This PR will transform URLs within code comments or string literals into valid `<a>` tags

## In comments

<img width="802" alt="image" src="https://user-images.githubusercontent.com/9516420/227162711-695ceeca-1caf-42e3-8512-29d3af5f18ec.png">

## In string literals

<img width="632" alt="image" src="https://user-images.githubusercontent.com/9516420/227163421-4d7ad07a-4e70-4b52-b963-8455d4fbbc8f.png">



## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-tr-codemirror-urls.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

