### PR TITLE
permissions-center: fix `column reference "id" is ambiguous` SQL error.

### DIFF
--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -545,13 +545,17 @@ FROM permission_sync_jobs
 func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSyncJobOpts) ([]*PermissionSyncJob, error) {
 	conds := opts.sqlConds()
 
-	paginationArgs := PaginationArgs{OrderBy: []OrderByOption{{Field: "permission_sync_jobs.id"}}, Ascending: true}
+	orderByID := []OrderByOption{{Field: "permission_sync_jobs.id"}}
+	paginationArgs := PaginationArgs{OrderBy: orderByID, Ascending: true}
 	// If pagination args contain only one OrderBy statement for "id" column, then it
 	// is added by generic pagination logic and we can continue with OrderBy above
 	// because it fixes ambiguity error for "id" column in case of joins with
 	// repo/users table.
-	if opts.PaginationArgs != nil && !paginationContainsOnlyIDColumn(opts.PaginationArgs) {
+	if opts.PaginationArgs != nil {
 		paginationArgs = *opts.PaginationArgs
+	}
+	if paginationOrderByContainsOnlyIDColumn(opts.PaginationArgs) {
+		paginationArgs.OrderBy = orderByID
 	}
 	pagination := paginationArgs.SQL()
 
@@ -601,7 +605,7 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 	return syncJobs, nil
 }
 
-func paginationContainsOnlyIDColumn(pagination *PaginationArgs) bool {
+func paginationOrderByContainsOnlyIDColumn(pagination *PaginationArgs) bool {
 	if pagination == nil {
 		return false
 	}

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -468,7 +468,7 @@ func (opts ListPermissionSyncJobOpts) sqlConds() []*sqlf.Query {
 	conds := make([]*sqlf.Query, 0)
 
 	if opts.ID != 0 {
-		conds = append(conds, sqlf.Sprintf("id = %s", opts.ID))
+		conds = append(conds, sqlf.Sprintf("permission_sync_jobs.id = %s", opts.ID))
 	}
 	if opts.UserID != 0 {
 		conds = append(conds, sqlf.Sprintf("user_id = %s", opts.UserID))
@@ -521,7 +521,7 @@ func (s *permissionSyncJobStore) GetLatestFinishedSyncJob(ctx context.Context, o
 		First:     &first,
 		Ascending: false,
 		OrderBy: []OrderByOption{{
-			Field: "finished_at",
+			Field: "permission_sync_jobs.finished_at",
 			Nulls: OrderByNullsLast,
 		}},
 	}
@@ -545,8 +545,12 @@ FROM permission_sync_jobs
 func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSyncJobOpts) ([]*PermissionSyncJob, error) {
 	conds := opts.sqlConds()
 
-	paginationArgs := PaginationArgs{OrderBy: []OrderByOption{{Field: "id"}}, Ascending: true}
-	if opts.PaginationArgs != nil {
+	paginationArgs := PaginationArgs{OrderBy: []OrderByOption{{Field: "permission_sync_jobs.id"}}, Ascending: true}
+	// If pagination args contain only one OrderBy statement for "id" column, then it
+	// is added by generic pagination logic and we can continue with OrderBy above
+	// because it fixes ambiguity error for "id" column in case of joins with
+	// repo/users table.
+	if opts.PaginationArgs != nil && !paginationContainsOnlyIDColumn(opts.PaginationArgs) {
 		paginationArgs = *opts.PaginationArgs
 	}
 	pagination := paginationArgs.SQL()
@@ -595,6 +599,20 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 	}
 
 	return syncJobs, nil
+}
+
+func paginationContainsOnlyIDColumn(pagination *PaginationArgs) bool {
+	if pagination == nil {
+		return false
+	}
+	columns := pagination.OrderBy.Columns()
+	if len(columns) != 1 {
+		return false
+	}
+	if columns[0] == "id" {
+		return true
+	}
+	return false
 }
 
 const countPermissionSyncJobsQuery = `

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -227,6 +227,11 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			opts:     ListPermissionSyncJobOpts{Query: "user-2", SearchType: PermissionsSyncSearchTypeUser, PaginationArgs: &PaginationArgs{First: intPtr(1)}},
 			wantJobs: jobs[2:3],
 		},
+		{
+			name:     "User name search with default OrderBy",
+			opts:     ListPermissionSyncJobOpts{Query: "user-2", SearchType: PermissionsSyncSearchTypeUser, PaginationArgs: &PaginationArgs{OrderBy: OrderBy{{Field: "id"}}}},
+			wantJobs: jobs[2:3],
+		},
 	}
 
 	for _, tt := range listTests {


### PR DESCRIPTION
Test plan:
Tests updated.

This happens because generic pagination code always add an OrderBy "id" when there are no OrderBy provided. This caused ambiguity while joining with other tables, having "id" column (repo/users).

This doesn't brake any other pagination clients because they don't join any tables with "id" columns.

A long term fix I can think of is to supply table name for `OrderBy.SQL()` function to remove a chance of having such ambiguity.

### Demo

https://user-images.githubusercontent.com/94846361/226594724-47ded67e-0d77-4f2b-abc1-88cda15f3cc0.mp4

