### PR TITLE
SCIM: Unique primary email fix

### DIFF
--- a/enterprise/internal/scim/test_util.go
+++ b/enterprise/internal/scim/test_util.go
@@ -4,9 +4,21 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // createDummyRequest creates a dummy request with a body that is not empty.
 func createDummyRequest() *http.Request {
 	return &http.Request{Body: io.NopCloser(strings.NewReader("test"))}
+}
+
+// makeEmail creates a new UserEmail with the given parameters.
+func makeEmail(userID int32, address string, primary, verified bool) *database.UserEmail {
+	var vDate *time.Time
+	if verified {
+		vDate = &verifiedDate
+	}
+	return &database.UserEmail{UserID: userID, Email: address, VerifiedAt: vDate, Primary: primary}
 }

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -202,6 +202,7 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 			if subAttrName != "" {
 				attributeToSet = subAttrName
 			}
+			matchedItems := []interface{}{}
 			for i := 0; i < len(attributeItems); i++ {
 				item, ok := attributeItems[i].(map[string]interface{})
 				if !ok {
@@ -213,6 +214,7 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 					newlyChanged := applyAttributeChange(item, attributeToSet, v, op.Op)
 					if newlyChanged {
 						attributeItems[i] = item //attribute items are updated
+						matchedItems = append(matchedItems, item)
 					}
 					changed = changed || newlyChanged
 				}
@@ -223,6 +225,9 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 				if err != nil {
 					return
 				}
+			}
+			if attributeToSet == "primary" && v == true {
+				ensureSinglePrimaryItem(matchedItems, userRes.Attributes, attrName)
 			}
 			userRes.Attributes[attrName] = attributeItems
 		}

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -186,6 +186,7 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 					newlyChanged = applyAttributeChange(userRes.Attributes, attrName, v, op.Op)
 				}
 				changed = changed || newlyChanged
+				return
 			}
 
 			// We have a valueExpression to apply which means this must be a slice

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -173,10 +173,10 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 		case []interface{}: // this value has multiple items → append or replace
 			if op.Op == "add" {
 				userRes.Attributes[attrName] = append(old.([]interface{}), v...)
+				ensureSinglePrimaryItem(v, userRes.Attributes, attrName)
 			} else { // replace
 				userRes.Attributes[attrName] = v
 			}
-			ensureSinglePrimaryItem(v, userRes.Attributes, attrName)
 			changed = true
 		default: // this value has a single item
 			var newlyChanged bool

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -294,7 +294,7 @@ func applyAttributeChange(attributes scim.ResourceAttributes, attrName string, v
 	return true
 }
 
-// applyMapChanges applies changes to an existing attribute which is a map (for example, name).
+// applyMapChanges applies changes to an existing attribute which is a map.
 func applyMapChanges(m map[string]interface{}, items map[string]interface{}) (changed bool) {
 	for attr, value := range items {
 		if value == nil {
@@ -358,6 +358,12 @@ func standardMultiValueReplaceNotFoundStrategy(
 	return nil, scimerrors.ScimErrorNoTarget
 }
 
+// azureMultiValueReplaceNotFoundStrategy is a multiValueReplaceNotFoundStrategy that is used when the
+// IdP is Azure AD. It is used to handle the case where a filter is used to replace a value in a
+// multi-valued attribute that does not exist. According to the standard, this should return a 400
+// error. However, Azure AD does not follow the standard and instead returns a 200 with the
+// attribute value set to the value that was passed in. This function is used to replicate that
+// behavior.
 func azureMultiValueReplaceNotFoundStrategy(multiValueAttribute []interface{},
 	propertyToSet string,
 	value interface{},
@@ -378,6 +384,8 @@ func azureMultiValueReplaceNotFoundStrategy(multiValueAttribute []interface{},
 	}
 }
 
+// getMultiValueReplaceNotFoundStrategy returns the multiValueReplaceNotFoundStrategy that matches
+// the provided IdentityProvider.
 func getMultiValueReplaceNotFoundStrategy(provider IdentityProvider) multiValueReplaceNotFoundStrategy {
 	switch provider {
 	case IDPAzureAd:

--- a/enterprise/internal/scim/user_patch.go
+++ b/enterprise/internal/scim/user_patch.go
@@ -232,9 +232,9 @@ func (h *UserResourceHandler) applyOperation(op scim.PatchOperation, userRes *sc
 }
 
 // ensureSinglePrimaryItem ensures that only one item in a slice of items is marked as "primary".
-func ensureSinglePrimaryItem(v []interface{}, attributes scim.ResourceAttributes, attrName string) {
+func ensureSinglePrimaryItem(changedItems []interface{}, attributes scim.ResourceAttributes, attrName string) {
 	var primaryItem map[string]interface{}
-	for _, item := range v {
+	for _, item := range changedItems {
 		mapItem, ok := item.(map[string]interface{})
 		if !ok {
 			continue

--- a/enterprise/internal/scim/user_patch_test.go
+++ b/enterprise/internal/scim/user_patch_test.go
@@ -186,7 +186,7 @@ func Test_UserResourceHandler_PatchRemoveNonExistingField(t *testing.T) {
 	assert.Nil(t, userRes.Attributes[AttrNickName])
 }
 
-func Test_UserResourceHandler_PatchAddEmail(t *testing.T) {
+func Test_UserResourceHandler_PatchAddPrimaryEmail(t *testing.T) {
 	db := createMockDB()
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
 	operations := []scim.PatchOperation{
@@ -201,6 +201,22 @@ func Test_UserResourceHandler_PatchAddEmail(t *testing.T) {
 	assert.False(t, emails[0].(map[string]interface{})["primary"].(bool))
 	assert.False(t, emails[1].(map[string]interface{})["primary"].(bool))
 	assert.True(t, emails[2].(map[string]interface{})["primary"].(bool))
+}
+
+func Test_UserResourceHandler_PatchReplacePrimaryEmailWithFilter(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails[value eq \"secondary@work.com\"].primary"), Value: true},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check emails
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 2)
+	assert.False(t, emails[0].(map[string]interface{})["primary"].(bool))
+	assert.True(t, emails[1].(map[string]interface{})["primary"].(bool))
 }
 
 func Test_UserResourceHandler_PatchAddNonExistingField(t *testing.T) {

--- a/enterprise/internal/scim/user_patch_test.go
+++ b/enterprise/internal/scim/user_patch_test.go
@@ -186,6 +186,23 @@ func Test_UserResourceHandler_PatchRemoveNonExistingField(t *testing.T) {
 	assert.Nil(t, userRes.Attributes[AttrNickName])
 }
 
+func Test_UserResourceHandler_PatchAddEmail(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "add", Path: createPath(AttrEmails, nil), Value: toInterfaceSlice(map[string]interface{}{"value": "new@work.com", "type": "home", "primary": true})},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check emails
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 3)
+	assert.False(t, emails[0].(map[string]interface{})["primary"].(bool))
+	assert.False(t, emails[1].(map[string]interface{})["primary"].(bool))
+	assert.True(t, emails[2].(map[string]interface{})["primary"].(bool))
+}
+
 func Test_UserResourceHandler_PatchAddNonExistingField(t *testing.T) {
 	db := createMockDB()
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)

--- a/enterprise/internal/scim/user_patch_test.go
+++ b/enterprise/internal/scim/user_patch_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/scim2/filter-parser/v2"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -44,334 +42,288 @@ const sampleAccountData = `{
 	"userName": "faye@rippinkozey.com"
   }`
 
-func makeEmail(userID int32, address string, primary, verified bool) *database.UserEmail {
-	var vDate *time.Time
-	if verified {
-		vDate = &verifiedDate
-	}
-	return &database.UserEmail{UserID: userID, Email: address, VerifiedAt: vDate, Primary: primary}
-}
-
-func Test_UserResourceHandler_Patch(t *testing.T) {
-	db := getMockDB([]*types.UserForSCIM{
-		{User: types.User{ID: 1}},
-		{User: types.User{ID: 2, Username: "test-user2", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id2"},
-		{User: types.User{ID: 3}},
-		{User: types.User{ID: 4, Username: "test-user4"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id4", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 5, Username: "test-user5"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id5", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 6, Username: "test-user6"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id6", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 7, Username: "test-user7"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id7", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 8, Username: "test-user8"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id8", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 9, Username: "test-user9"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id9", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 10, Username: "test-user10"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id10", SCIMAccountData: sampleAccountData},
-	},
-		map[int32][]*database.UserEmail{
-			2:  {},
-			4:  {makeEmail(4, "primary@work.com", true, true), makeEmail(4, "secondary@work.com", false, true)},
-			5:  {makeEmail(5, "primary@work.com", true, true), makeEmail(5, "secondary@work.com", false, true)},
-			6:  {makeEmail(6, "primary@work.com", true, true), makeEmail(6, "secondary@work.com", false, true)},
-			7:  {makeEmail(7, "primary@work.com", true, true), makeEmail(7, "secondary@work.com", false, true)},
-			8:  {makeEmail(8, "primary@work.com", true, true), makeEmail(8, "secondary@work.com", false, true)},
-			9:  {makeEmail(9, "primary@work.com", true, true), makeEmail(9, "secondary@work.com", false, true)},
-			10: {makeEmail(10, "primary@work.com", true, true), makeEmail(10, "secondary@work.com", false, false)},
-		})
-	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
-
-	testCases := []struct {
-		name       string
-		userId     string
-		operations []scim.PatchOperation
-		testFunc   func(userRes scim.Resource)
-	}{
-		{
-			name:   "patch username with replace operation",
-			userId: "2",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: createPath(AttrUserName, nil), Value: "test-user2-patched"},
-			},
-			testFunc: func(userRes scim.Resource) {
-				assert.Equal(t, "test-user2-patched", userRes.Attributes[AttrUserName])
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-				assert.Equal(t, "test-user2-patched", user.Username)
-			},
-		},
-		{
-			name:   "patch username with add operation",
-			userId: "2",
-			operations: []scim.PatchOperation{
-				{Op: "add", Path: createPath(AttrUserName, nil), Value: "test-user2-added"},
-			},
-			testFunc: func(userRes scim.Resource) {
-				assert.Equal(t, "test-user2-added", userRes.Attributes[AttrUserName])
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-				assert.Equal(t, "test-user2-added", user.Username)
-			},
-		},
-		{
-			name:   "patch replace with filter",
-			userId: "4",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "nicolas@breitenbergbartell.uk"},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq false].type"), Value: "home"},
-				{Op: "replace", Value: map[string]interface{}{
-					"userName":        "updatedUN",
-					"name.givenName":  "Gertrude",
-					"name.familyName": "Everett",
-					"name.formatted":  "Manuela",
-					"name.middleName": "Ismael",
-				}},
-				{Op: "replace", Path: createPath(AttrNickName, nil), Value: "nickName"},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check toplevel attributes
-				assert.Equal(t, "updatedUN", userRes.Attributes[AttrUserName])
-				assert.Equal(t, "N0LBQ9P0TTH4", userRes.Attributes["displayName"])
-
-				// Check filtered email changes
-				emails := userRes.Attributes[AttrEmails].([]interface{})
-				assert.Contains(t, emails, map[string]interface{}{"value": "nicolas@breitenbergbartell.uk", "primary": true, "type": "work"})
-				assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": false, "type": "home"})
-
-				// Check name attributes
-				name := userRes.Attributes[AttrName].(map[string]interface{})
-				assert.Equal(t, "Gertrude", name[AttrNameGiven])
-				assert.Equal(t, "Everett", name[AttrNameFamily])
-				assert.Equal(t, "Manuela", name[AttrNameFormatted])
-				assert.Equal(t, "Ismael", name[AttrNameMiddle])
-
-				// Check nickName added
-				assert.Equal(t, "nickName", userRes.Attributes[AttrNickName])
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-				assert.Equal(t, "updatedUN", user.Username)
-
-				// Check db email changes
-				dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
-				assert.Len(t, dbEmails, 2)
-				assert.True(t, containsEmail(dbEmails, "nicolas@breitenbergbartell.uk", true, true))
-				assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, false))
-			},
-		},
-		{
-			name:   "remove with filter",
-			userId: "5",
-			operations: []scim.PatchOperation{
-				{Op: "remove", Path: parseStringPath("emails[type eq \"work\" and primary eq false]")},
-				{Op: "remove", Path: createPath(AttrName, strPtr(AttrNameMiddle))},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check only one email remains
-				emails := userRes.Attributes[AttrEmails].([]interface{})
-				assert.Len(t, emails, 1)
-				assert.Contains(t, emails, map[string]interface{}{"value": "primary@work.com", "primary": true, "type": "work"})
-
-				// Check name attributes
-				name := userRes.Attributes[AttrName].(map[string]interface{})
-				assert.Nil(t, name[AttrNameMiddle])
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-
-				// Check db email changes
-				dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
-				assert.Len(t, dbEmails, 1)
-				assert.True(t, containsEmail(dbEmails, "primary@work.com", true, true))
-			},
-		},
-		{
-			name:   "replace whole array field",
-			userId: "6",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath("emails"), Value: toInterfaceSlice(map[string]interface{}{"value": "replaced@work.com", "type": "home", "primary": true})},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check if it has only one email
-				emails := userRes.Attributes[AttrEmails].([]interface{})
-				assert.Len(t, emails, 1)
-				assert.Contains(t, emails, map[string]interface{}{"value": "replaced@work.com", "primary": true, "type": "home"})
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-
-				// Check db email changes
-				dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
-				assert.Len(t, dbEmails, 1)
-				assert.True(t, containsEmail(dbEmails, "replaced@work.com", true, true))
-			},
-		},
-		{
-			name:   "remove non-existing field",
-			userId: "7",
-			operations: []scim.PatchOperation{
-				{Op: "remove", Path: createPath(AttrNickName, nil)},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check nickname still empty
-				assert.Nil(t, userRes.Attributes[AttrNickName])
-			},
-		},
-		{
-			name:   "add non-existing field",
-			userId: "8",
-			operations: []scim.PatchOperation{
-				{Op: "add", Path: createPath(AttrNickName, nil), Value: "sampleNickName"},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check nickname
-				assert.Equal(t, "sampleNickName", userRes.Attributes[AttrNickName])
-			},
-		},
-		{
-			name:   "no change",
-			userId: "9",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: createPath(AttrName, strPtr(AttrNameGiven)), Value: "Nannie"},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check name the same
-				name := userRes.Attributes[AttrName].(map[string]interface{})
-				assert.Equal(t, "Nannie", name[AttrNameGiven])
-			},
-		},
-		{
-			name:   "Move existing unverified email to primary with filter",
-			userId: "10",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath("emails[value eq \"primary@work.com\"].primary"), Value: false},
-				{Op: "replace", Path: parseStringPath("emails[value eq \"secondary@work.com\"].primary"), Value: true},
-			},
-			testFunc: func(userRes scim.Resource) {
-				// Check both emails remain and primary value flipped
-				emails := userRes.Attributes[AttrEmails].([]interface{})
-				assert.Len(t, emails, 2)
-				assert.Contains(t, emails, map[string]interface{}{"value": "primary@work.com", "primary": false, "type": "work"})
-				assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": true, "type": "work"})
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-
-				// Check db email changes and both marked verified
-				dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
-				assert.Len(t, dbEmails, 2)
-				assert.True(t, containsEmail(dbEmails, "primary@work.com", true, false))
-				assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, true))
-			},
-		},
-		{
-			name:   "Trigger hard delete with soft delete",
-			userId: "10",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath(AttrActive), Value: false},
-			},
-			testFunc: func(userRes scim.Resource) {
-				assert.Equal(t, userRes.Attributes[AttrActive], false)
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				_, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.Error(t, err, "user not found")
-			},
-		},
-	}
+func Test_UserResourceHandler_PatchUsername(t *testing.T) {
+	testCases := []struct{ op string }{{op: "replace"}, {op: "add"}}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			userRes, err := userResourceHandler.Patch(createDummyRequest(), tc.userId, tc.operations)
+		t.Run(tc.op, func(t *testing.T) {
+			user := types.UserForSCIM{User: types.User{ID: 1, Username: "test-user1", DisplayName: "First Last"}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"}
+			db := getMockDB([]*types.UserForSCIM{&user}, map[int32][]*database.UserEmail{1: {makeEmail(1, "a@example.com", true, true)}})
+			userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+			operations := []scim.PatchOperation{{Op: tc.op, Path: createPath(AttrUserName, nil), Value: "test-user1-patched"}}
+
+			userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+
 			assert.NoError(t, err)
-			tc.testFunc(userRes)
+			assert.Equal(t, "test-user1-patched", userRes.Attributes[AttrUserName])
+			userID, _ := strconv.Atoi(userRes.ID)
+			resultUser, err := db.Users().GetByID(context.Background(), int32(userID))
+			assert.NoError(t, err)
+			assert.Equal(t, "test-user1-patched", resultUser.Username)
 		})
 	}
 }
 
-func Test_UserResourceHandler_Patch_ReplaceStrategies(t *testing.T) {
-	db := getMockDB([]*types.UserForSCIM{
-		{User: types.User{ID: 1, Username: "test-user1"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData},
-		{User: types.User{ID: 2, Username: "test-user2"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData},
-	},
-		map[int32][]*database.UserEmail{
-			1: {makeEmail(1, "primary@work.com", true, true), makeEmail(1, "secondary@work.com", false, false)},
-			2: {makeEmail(1, "primary@work.com", true, true), makeEmail(2, "secondary@work.com", false, false)},
-		})
+func Test_UserResourceHandler_PatchReplaceWithFilter(t *testing.T) {
+	db := createMockDB()
 	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
-
-	testCases := []struct {
-		name       string
-		userId     string
-		operations []scim.PatchOperation
-		testFunc   func(userRes scim.Resource, err error)
-		config     *conf.Unified
-	}{
-		{
-			config: &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ScimIdentityProvider: string(IDPAzureAd)}},
-			name:   "Add email with replace Azure",
-			userId: "1",
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].value"), Value: "home@work.com"},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].primary"), Value: false},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].display"), Value: "home email"},
-			},
-			testFunc: func(userRes scim.Resource, err error) {
-				// Check both emails remain and primary value flipped
-				assert.NoError(t, err)
-				emails, _ := userRes.Attributes[AttrEmails].([]interface{})
-				assert.Len(t, emails, 3)
-				assert.Contains(t, emails, map[string]interface{}{"value": "work@work.com", "primary": true, "type": "work"})
-				assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": false, "type": "work"})
-				assert.Contains(t, emails, map[string]interface{}{"value": "home@work.com", "primary": false, "type": "home", "display": "home email"})
-
-				// Check user in DB
-				userID, _ := strconv.Atoi(userRes.ID)
-				user, err := db.Users().GetByID(context.Background(), int32(userID))
-				assert.NoError(t, err)
-
-				// Check db email changes and both marked verified
-				dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
-				assert.Len(t, dbEmails, 3)
-				assert.True(t, containsEmail(dbEmails, "work@work.com", true, true))
-				assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, false))
-				assert.True(t, containsEmail(dbEmails, "home@work.com", true, false))
-
-			},
-		},
-		{
-			name:   "Add email with replace SCIM Standard",
-			userId: "2",
-			config: &conf.Unified{},
-			operations: []scim.PatchOperation{
-				{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].value"), Value: "home@work.com"},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].primary"), Value: false},
-				{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].display"), Value: "home email"},
-			},
-			testFunc: func(_ scim.Resource, err error) {
-				assert.Error(t, err)
-				assert.True(t, errors.Is(err, scimerrors.ScimErrorNoTarget))
-			},
-		},
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "nicolas@breitenbergbartell.uk"},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq false].type"), Value: "home"},
+		{Op: "replace", Value: map[string]interface{}{
+			"userName":        "updatedUN",
+			"name.givenName":  "Gertrude",
+			"name.familyName": "Everett",
+			"name.formatted":  "Manuela",
+			"name.middleName": "Ismael",
+		}},
+		{Op: "replace", Path: createPath(AttrNickName, nil), Value: "nickName"},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			conf.Mock(tc.config)
-			defer conf.Mock(nil)
-			userRes, err := userResourceHandler.Patch(createDummyRequest(), tc.userId, tc.operations)
-			tc.testFunc(userRes, err)
-		})
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+
+	assert.NoError(t, err)
+
+	// Check toplevel attributes
+	assert.Equal(t, "updatedUN", userRes.Attributes[AttrUserName])
+	assert.Equal(t, "N0LBQ9P0TTH4", userRes.Attributes["displayName"])
+
+	// Check filtered email changes
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Contains(t, emails, map[string]interface{}{"value": "nicolas@breitenbergbartell.uk", "primary": true, "type": "work"})
+	assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": false, "type": "home"})
+
+	// Check name attributes
+	name := userRes.Attributes[AttrName].(map[string]interface{})
+	assert.Equal(t, "Gertrude", name[AttrNameGiven])
+	assert.Equal(t, "Everett", name[AttrNameFamily])
+	assert.Equal(t, "Manuela", name[AttrNameFormatted])
+	assert.Equal(t, "Ismael", name[AttrNameMiddle])
+
+	// Check nickName added
+	assert.Equal(t, "nickName", userRes.Attributes[AttrNickName])
+
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	user, err := db.Users().GetByID(context.Background(), int32(userID))
+	assert.NoError(t, err)
+	assert.Equal(t, "updatedUN", user.Username)
+
+	// Check db email changes
+	dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
+	assert.Len(t, dbEmails, 2)
+	assert.True(t, containsEmail(dbEmails, "nicolas@breitenbergbartell.uk", true, true))
+	assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, false))
+}
+
+func Test_UserResourceHandler_PatchRemoveWithFilter(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "remove", Path: parseStringPath("emails[type eq \"work\" and primary eq false]")},
+		{Op: "remove", Path: createPath(AttrName, strPtr(AttrNameMiddle))},
 	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+
+	// Check only one email remains
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 1)
+	assert.Contains(t, emails, map[string]interface{}{"value": "primary@work.com", "primary": true, "type": "work"})
+
+	// Check name attributes
+	name := userRes.Attributes[AttrName].(map[string]interface{})
+	assert.Nil(t, name[AttrNameMiddle])
+
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	user, err := db.Users().GetByID(context.Background(), int32(userID))
+	assert.NoError(t, err)
+
+	// Check DB email changes
+	dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
+	assert.Len(t, dbEmails, 1)
+	assert.True(t, containsEmail(dbEmails, "primary@work.com", true, true))
+}
+
+func Test_UserResourceHandler_PatchReplaceWholeArrayField(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails"), Value: toInterfaceSlice(map[string]interface{}{"value": "replaced@work.com", "type": "home", "primary": true})},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+
+	// Check if it has only one email
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 1)
+	assert.Contains(t, emails, map[string]interface{}{"value": "replaced@work.com", "primary": true, "type": "home"})
+
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	user, err := db.Users().GetByID(context.Background(), int32(userID))
+	assert.NoError(t, err)
+
+	// Check db email changes
+	dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
+	assert.Len(t, dbEmails, 1)
+	assert.True(t, containsEmail(dbEmails, "replaced@work.com", true, true))
+}
+
+func Test_UserResourceHandler_PatchRemoveNonExistingField(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "remove", Path: createPath(AttrNickName, nil)},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check nickname still empty
+	assert.Nil(t, userRes.Attributes[AttrNickName])
+}
+
+func Test_UserResourceHandler_PatchAddNonExistingField(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "add", Path: createPath(AttrNickName, nil), Value: "sampleNickName"},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check nickname
+	assert.Equal(t, "sampleNickName", userRes.Attributes[AttrNickName])
+}
+
+func Test_UserResourceHandler_PatchNoChange(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: createPath(AttrName, strPtr(AttrNameGiven)), Value: "Nannie"},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check name the same
+	name := userRes.Attributes[AttrName].(map[string]interface{})
+	assert.Equal(t, "Nannie", name[AttrNameGiven])
+}
+
+func Test_UserResourceHandler_PatchMoveUnverifiedEmailToPrimaryWithFilter(t *testing.T) {
+	user1 := types.UserForSCIM{User: types.User{ID: 1, Username: "test-user1"}, Emails: []string{"primary@work.com", "secondary@work.com"}, SCIMExternalID: "id1", SCIMAccountData: sampleAccountData}
+	usersEmails := map[int32][]*database.UserEmail{1: {makeEmail(1, "primary@work.com", true, true), makeEmail(1, "secondary@work.com", false, false)}}
+	db := getMockDB([]*types.UserForSCIM{&user1}, usersEmails)
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails[value eq \"primary@work.com\"].primary"), Value: false},
+		{Op: "replace", Path: parseStringPath("emails[value eq \"secondary@work.com\"].primary"), Value: true},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	// Check both emails remain and primary value flipped
+	emails := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 2)
+	assert.Contains(t, emails, map[string]interface{}{"value": "primary@work.com", "primary": false, "type": "work"})
+	assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": true, "type": "work"})
+
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	user, err := db.Users().GetByID(context.Background(), int32(userID))
+	assert.NoError(t, err)
+
+	// Check db email changes and both marked verified
+	dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
+	assert.Len(t, dbEmails, 2)
+	assert.True(t, containsEmail(dbEmails, "primary@work.com", true, false))
+	assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, true))
+}
+
+func Test_UserResourceHandler_PatchHardDeleteWithSoftDelete(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath(AttrActive), Value: false},
+	}
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+	assert.NoError(t, err)
+	assert.Equal(t, userRes.Attributes[AttrActive], false)
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	_, err = db.Users().GetByID(context.Background(), int32(userID))
+	assert.Error(t, err, "user not found")
+}
+
+func Test_UserResourceHandler_Patch_ReplaceStrategies_Azure(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	config := &conf.Unified{SiteConfiguration: schema.SiteConfiguration{ScimIdentityProvider: string(IDPAzureAd)}}
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].value"), Value: "home@work.com"},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].primary"), Value: false},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].display"), Value: "home email"},
+	}
+	conf.Mock(config)
+	defer conf.Mock(nil)
+
+	userRes, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+
+	// Check both emails remain and primary value flipped
+	assert.NoError(t, err)
+	emails, _ := userRes.Attributes[AttrEmails].([]interface{})
+	assert.Len(t, emails, 3)
+	assert.Contains(t, emails, map[string]interface{}{"value": "work@work.com", "primary": true, "type": "work"})
+	assert.Contains(t, emails, map[string]interface{}{"value": "secondary@work.com", "primary": false, "type": "work"})
+	assert.Contains(t, emails, map[string]interface{}{"value": "home@work.com", "primary": false, "type": "home", "display": "home email"})
+
+	// Check user in DB
+	userID, _ := strconv.Atoi(userRes.ID)
+	user, err := db.Users().GetByID(context.Background(), int32(userID))
+	assert.NoError(t, err)
+
+	// Check db email changes and both marked verified
+	dbEmails, _ := db.UserEmails().ListByUser(context.Background(), database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: false})
+	assert.Len(t, dbEmails, 3)
+	assert.True(t, containsEmail(dbEmails, "work@work.com", true, true))
+	assert.True(t, containsEmail(dbEmails, "secondary@work.com", true, false))
+	assert.True(t, containsEmail(dbEmails, "home@work.com", true, false))
+}
+
+func Test_UserResourceHandler_Patch_ReplaceStrategies_Standard(t *testing.T) {
+	db := createMockDB()
+	userResourceHandler := NewUserResourceHandler(context.Background(), &observation.TestContext, db)
+	operations := []scim.PatchOperation{
+		{Op: "replace", Path: parseStringPath("emails[type eq \"work\" and primary eq true].value"), Value: "work@work.com"},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].value"), Value: "home@work.com"},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].primary"), Value: false},
+		{Op: "replace", Path: parseStringPath("emails[type eq \"home\"].display"), Value: "home email"},
+	}
+
+	_, err := userResourceHandler.Patch(createDummyRequest(), "1", operations)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, scimerrors.ScimErrorNoTarget))
+}
+
+// createMockDB creates a mock database with the given number of users and two emails for each user.
+func createMockDB() *database.MockDB {
+	user := &types.UserForSCIM{
+		User:            types.User{ID: 1, Username: "test-user1"},
+		Emails:          []string{"primary@work.com", "secondary@work.com"},
+		SCIMExternalID:  "id1",
+		SCIMAccountData: sampleAccountData,
+	}
+	emails := map[int32][]*database.UserEmail{1: {
+		makeEmail(1, "primary@work.com", true, true),
+		makeEmail(1, "secondary@work.com", false, true),
+	}}
+	return getMockDB([]*types.UserForSCIM{user}, emails)
 }
 
 // createPath creates a path for a given attribute and sub-attribute.
@@ -399,6 +351,7 @@ func toInterfaceSlice(maps ...map[string]interface{}) []interface{} {
 	return s
 }
 
+// containsEmail returns true if the given slice of emails contains an email with the given properties.
 func containsEmail(emails []*database.UserEmail, email string, verified bool, primary bool) bool {
 	for _, e := range emails {
 		if e.Email == email && ((e.VerifiedAt != nil) == verified && e.Primary == primary) {


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/49210

This is a tiny edge case that I _don't_ intend to backport to 5.0!

**For the reviewer:** I suggest you go commit by commit! The commit messages are descriptive, and the changes are pretty simple.

- In "Refactor PATCH tests for clarity", I split up the large test into individual functions because there was no point in doing all those different tests in a single function. It's a pretty trivial change, and the tests passed at each stage of this refactor, I'm confident about it
- The single-line "Return after handling "no value expression" case" commit doesn't do a lot because there is an "if-then-return" right after it, but returning here still feels more logical.
- In "Docs" I added some missing docs at some tricky parts
- In "Add test and solution. THIS IS THE MEAT", I added a failing test for the "primary: true" PATCH, and a function that makes the new test pass.

## Test plan

Tests pass, added new test for the new case that used to fail and now it doesn't.