### PR TITLE
ranking: Perf pass

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking.go
@@ -593,28 +593,36 @@ WITH
 locked_definitions AS (
 	SELECT
 		rd.id,
-		rd.upload_id,
-		EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip uvt WHERE uvt.upload_id = rd.upload_id AND uvt.is_default_branch) AS safe
+		u.repository_id,
+		rd.upload_id
 	FROM codeintel_ranking_definitions rd
+	JOIN lsif_uploads u ON u.id = rd.upload_id
 	WHERE
 		rd.graph_key = %s AND
 		(rd.last_scanned_at IS NULL OR NOW() - rd.last_scanned_at >= %s * '1 hour'::interval)
-	ORDER BY rd.last_scanned_at ASC NULLS FIRST
+	ORDER BY rd.last_scanned_at ASC NULLS FIRST, rd.id
 	FOR UPDATE SKIP LOCKED
 	LIMIT %s
+),
+candidates AS (
+	SELECT
+		ld.id,
+		uvt.is_default_branch IS TRUE AS safe
+	FROM locked_definitions ld
+	LEFT JOIN lsif_uploads_visible_at_tip uvt ON  uvt.upload_id = ld.upload_id
 ),
 updated_definitions AS (
 	UPDATE codeintel_ranking_definitions
 	SET last_scanned_at = NOW()
-	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE ld.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE c.safe)
 ),
 deleted_definitions AS (
 	DELETE FROM codeintel_ranking_definitions
-	WHERE id IN (SELECT ld.id FROM locked_definitions ld WHERE NOT ld.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE NOT c.safe)
 	RETURNING 1
 )
 SELECT
-	(SELECT COUNT(*) FROM locked_definitions),
+	(SELECT COUNT(*) FROM candidates),
 	(SELECT COUNT(*) FROM deleted_definitions)
 `
 
@@ -652,28 +660,36 @@ WITH
 locked_references AS (
 	SELECT
 		rr.id,
-		rr.upload_id,
-		EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip uvt WHERE uvt.upload_id = rr.upload_id AND uvt.is_default_branch) AS safe
+		u.repository_id,
+		rr.upload_id
 	FROM codeintel_ranking_references rr
+	JOIN lsif_uploads u ON u.id = rr.upload_id
 	WHERE
 		rr.graph_key = %s AND
 		(rr.last_scanned_at IS NULL OR NOW() - rr.last_scanned_at >= %s * '1 hour'::interval)
-	ORDER BY rr.last_scanned_at ASC NULLS FIRST
+	ORDER BY rr.last_scanned_at ASC NULLS FIRST, rr.id
 	FOR UPDATE SKIP LOCKED
 	LIMIT %s
+),
+candidates AS (
+	SELECT
+		lr.id,
+		uvt.is_default_branch IS TRUE AS safe
+	FROM locked_references lr
+	LEFT JOIN lsif_uploads_visible_at_tip uvt ON uvt.repository_id = lr.repository_id AND uvt.upload_id = lr.upload_id
 ),
 updated_references AS (
 	UPDATE codeintel_ranking_references
 	SET last_scanned_at = NOW()
-	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE lr.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE c.safe)
 ),
 deleted_references AS (
 	DELETE FROM codeintel_ranking_references
-	WHERE id IN (SELECT lr.id FROM locked_references lr WHERE NOT lr.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE NOT c.safe)
 	RETURNING 1
 )
 SELECT
-	(SELECT COUNT(*) FROM locked_references),
+	(SELECT COUNT(*) FROM candidates),
 	(SELECT COUNT(*) FROM deleted_references)
 `
 
@@ -711,28 +727,36 @@ WITH
 locked_initial_path_ranks AS (
 	SELECT
 		ipr.id,
-		ipr.upload_id,
-		EXISTS (SELECT 1 FROM lsif_uploads_visible_at_tip uvt WHERE uvt.upload_id = ipr.upload_id AND uvt.is_default_branch) AS safe
+		u.repository_id,
+		ipr.upload_id
 	FROM codeintel_initial_path_ranks ipr
+	JOIN lsif_uploads u ON u.id = ipr.upload_id
 	WHERE
 		ipr.graph_key = %s AND
 		(ipr.last_scanned_at IS NULL OR NOW() - ipr.last_scanned_at >= %s * '1 hour'::interval)
-	ORDER BY ipr.last_scanned_at ASC NULLS FIRST
+	ORDER BY ipr.last_scanned_at ASC NULLS FIRST, ipr.id
 	FOR UPDATE SKIP LOCKED
 	LIMIT %s
+),
+candidates AS (
+	SELECT
+		lipr.id,
+		uvt.is_default_branch IS TRUE AS safe
+	FROM locked_initial_path_ranks lipr
+	LEFT JOIN lsif_uploads_visible_at_tip uvt ON uvt.upload_id = lipr.upload_id
 ),
 updated_initial_path_ranks AS (
 	UPDATE codeintel_initial_path_ranks
 	SET last_scanned_at = NOW()
-	WHERE id IN (SELECT lr.id FROM locked_initial_path_ranks lr WHERE lr.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE c.safe)
 ),
 deleted_initial_path_ranks AS (
 	DELETE FROM codeintel_initial_path_ranks
-	WHERE id IN (SELECT lr.id FROM locked_initial_path_ranks lr WHERE NOT lr.safe)
+	WHERE id IN (SELECT c.id FROM candidates c WHERE NOT c.safe)
 	RETURNING 1
 )
 SELECT
-	(SELECT COUNT(*) FROM locked_initial_path_ranks),
+	(SELECT COUNT(*) FROM candidates),
 	(SELECT COUNT(*) FROM deleted_initial_path_ranks)
 `
 

--- a/enterprise/internal/codeintel/ranking/internal/store/ranking_test.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/ranking_test.go
@@ -413,6 +413,12 @@ func TestVacuumStaleDefinitionsAndReferences(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
+	insertUploads(t, db,
+		types.Upload{ID: 1},
+		types.Upload{ID: 2},
+		types.Upload{ID: 3},
+	)
+
 	mockDefinitions := []shared.RankingDefinitions{
 		{UploadID: 1, SymbolName: "foo", DocumentPath: "foo.go"},
 		{UploadID: 1, SymbolName: "bar", DocumentPath: "bar.go"},

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7679,6 +7679,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "codeintel_ranking_path_counts_inputs_graph_key_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_id ON codeintel_ranking_path_counts_inputs USING btree (graph_key, id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "codeintel_ranking_path_counts_inputs_graph_key_repository_id_id",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -940,6 +940,7 @@ Foreign-key constraints:
  repository_id | integer |           | not null | 
 Indexes:
     "codeintel_ranking_path_counts_inputs_pkey" PRIMARY KEY, btree (id)
+    "codeintel_ranking_path_counts_inputs_graph_key_id" btree (graph_key, id)
     "codeintel_ranking_path_counts_inputs_graph_key_repository_id_id" btree (graph_key, repository_id, id) WHERE NOT processed
 
 ```

--- a/migrations/frontend/1679404397_add_missing_index_for_vacuum/down.sql
+++ b/migrations/frontend/1679404397_add_missing_index_for_vacuum/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_id;

--- a/migrations/frontend/1679404397_add_missing_index_for_vacuum/metadata.yaml
+++ b/migrations/frontend/1679404397_add_missing_index_for_vacuum/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing index for vacuum
+parents: [1678899992, 1678994673, 1679058200]
+createIndexConcurrently: true

--- a/migrations/frontend/1679404397_add_missing_index_for_vacuum/up.sql
+++ b/migrations/frontend/1679404397_add_missing_index_for_vacuum/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_id ON codeintel_ranking_path_counts_inputs(graph_key, id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5138,6 +5138,8 @@ CREATE INDEX codeintel_ranking_definitions_graph_key_symbol_search ON codeintel_
 
 CREATE UNIQUE INDEX codeintel_ranking_exports_graph_key_upload_id ON codeintel_ranking_exports USING btree (graph_key, upload_id);
 
+CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_id ON codeintel_ranking_path_counts_inputs USING btree (graph_key, id);
+
 CREATE INDEX codeintel_ranking_path_counts_inputs_graph_key_repository_id_id ON codeintel_ranking_path_counts_inputs USING btree (graph_key, repository_id, id) WHERE (NOT processed);
 
 CREATE INDEX codeintel_ranking_references_graph_key_id ON codeintel_ranking_references USING btree (graph_key, id);


### PR DESCRIPTION
Changes in this PR:

- Add a missing index so that vacuum doesn't have to seq scan
- Break apart queries that do an `EXISTS` on `lsif_uploads_visible_at_tip` to a subsequent OUTER JOIN. This new CTE also queries `repository_id` (not just `upload_id`) so that we can use an index.

## Test plan

Existing and updated unit tests, ran query plans on prod to show an em-betterment, etc