### PR TITLE
Add a small invariant check on main for Bazel

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -16,12 +16,14 @@ The default run type.
 
 - Pipeline for `Go` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - **Go checks**: Test (all), Test (all (gRPC)), Test (enterprise/internal/insights), Test (enterprise/internal/insights (gRPC)), Test (internal/repos), Test (internal/repos (gRPC)), Test (enterprise/internal/batches), Test (enterprise/internal/batches (gRPC)), Test (cmd/frontend), Test (cmd/frontend (gRPC)), Test (enterprise/cmd/frontend/internal/batches/resolvers), Test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Test (dev/sg), Test (dev/sg (gRPC)), Test (internal/database), Test (enterprise/internal/database), Build
   - Upload build trace
 
 - Pipeline for `Client` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build (client/jetbrains), Build TS, Tests for VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
@@ -30,6 +32,7 @@ The default run type.
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: GraphQL lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build (client/jetbrains), Build TS, Tests for VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Go checks**: Test (all), Test (all (gRPC)), Test (enterprise/internal/insights), Test (enterprise/internal/insights (gRPC)), Test (internal/repos), Test (internal/repos (gRPC)), Test (enterprise/internal/batches), Test (enterprise/internal/batches (gRPC)), Test (cmd/frontend), Test (cmd/frontend (gRPC)), Test (enterprise/cmd/frontend/internal/batches/resolvers), Test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Test (dev/sg), Test (dev/sg (gRPC)), Test (internal/database), Test (enterprise/internal/database), Build
@@ -37,62 +40,75 @@ The default run type.
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **DB backcompat tests**: Backcompat test (all), Backcompat test (all (gRPC)), Backcompat test (enterprise/internal/insights), Backcompat test (enterprise/internal/insights (gRPC)), Backcompat test (internal/repos), Backcompat test (internal/repos (gRPC)), Backcompat test (enterprise/internal/batches), Backcompat test (enterprise/internal/batches (gRPC)), Backcompat test (cmd/frontend), Backcompat test (cmd/frontend (gRPC)), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Backcompat test (dev/sg), Backcompat test (dev/sg (gRPC)), Backcompat test (internal/database), Backcompat test (enterprise/internal/database)
   - Upload build trace
 
 - Pipeline for `Docs` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Dockerfiles` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `ExecutorVMImage` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `CIScripts` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **CI script tests**: test-trace-command.sh
   - Upload build trace
 
 - Pipeline for `Terraform` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `SVG` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Shell` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `DockerImages` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Test builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build blobstore, Build blobstore2, Build node-exporter, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build prometheus-gcp, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build executor-vm, Build batcheshelper, Build opentelemetry-collector, Build embeddings, Build dind, Build bundled-executor, Build server, Build sg
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan embeddings, Scan dind, Scan bundled-executor, Scan sg
   - Upload build trace
 
 - Pipeline for `WolfiPackages` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `WolfiBaseImages` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `Protobuf` changes:
   - **Metadata**: Pipeline metadata
+  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
@@ -259,6 +275,7 @@ The run type for branches matching `main` (exact match).
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
+- **Bazel (optional)**: Configure, Analysis phase
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build blobstore, Build blobstore2, Build node-exporter, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build prometheus-gcp, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build executor-vm, Build batcheshelper, Build opentelemetry-collector, Build embeddings, Build dind, Build bundled-executor, Build server, Build sg, Build executor image, Build executor binary
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan embeddings, Scan dind, Scan bundled-executor, Scan sg

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -16,14 +16,12 @@ The default run type.
 
 - Pipeline for `Go` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - **Go checks**: Test (all), Test (all (gRPC)), Test (enterprise/internal/insights), Test (enterprise/internal/insights (gRPC)), Test (internal/repos), Test (internal/repos (gRPC)), Test (enterprise/internal/batches), Test (enterprise/internal/batches (gRPC)), Test (cmd/frontend), Test (cmd/frontend (gRPC)), Test (enterprise/cmd/frontend/internal/batches/resolvers), Test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Test (dev/sg), Test (dev/sg (gRPC)), Test (internal/database), Test (enterprise/internal/database), Build
   - Upload build trace
 
 - Pipeline for `Client` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build (client/jetbrains), Build TS, Tests for VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
@@ -32,7 +30,6 @@ The default run type.
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: GraphQL lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build (client/jetbrains), Build TS, Tests for VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Go checks**: Test (all), Test (all (gRPC)), Test (enterprise/internal/insights), Test (enterprise/internal/insights (gRPC)), Test (internal/repos), Test (internal/repos (gRPC)), Test (enterprise/internal/batches), Test (enterprise/internal/batches (gRPC)), Test (cmd/frontend), Test (cmd/frontend (gRPC)), Test (enterprise/cmd/frontend/internal/batches/resolvers), Test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Test (dev/sg), Test (dev/sg (gRPC)), Test (internal/database), Test (enterprise/internal/database), Build
@@ -40,75 +37,62 @@ The default run type.
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **DB backcompat tests**: Backcompat test (all), Backcompat test (all (gRPC)), Backcompat test (enterprise/internal/insights), Backcompat test (enterprise/internal/insights (gRPC)), Backcompat test (internal/repos), Backcompat test (internal/repos (gRPC)), Backcompat test (enterprise/internal/batches), Backcompat test (enterprise/internal/batches (gRPC)), Backcompat test (cmd/frontend), Backcompat test (cmd/frontend (gRPC)), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Backcompat test (dev/sg), Backcompat test (dev/sg (gRPC)), Backcompat test (internal/database), Backcompat test (enterprise/internal/database)
   - Upload build trace
 
 - Pipeline for `Docs` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Dockerfiles` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `ExecutorVMImage` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `CIScripts` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **CI script tests**: test-trace-command.sh
   - Upload build trace
 
 - Pipeline for `Terraform` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `SVG` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Shell` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `DockerImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Test builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build blobstore, Build blobstore2, Build node-exporter, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build prometheus-gcp, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build executor-vm, Build batcheshelper, Build opentelemetry-collector, Build embeddings, Build dind, Build bundled-executor, Build server, Build sg
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan embeddings, Scan dind, Scan bundled-executor, Scan sg
   - Upload build trace
 
 - Pipeline for `WolfiPackages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `WolfiBaseImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - Upload build trace
 
 - Pipeline for `Protobuf` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel (optional)**: Configure, Analysis phase
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
@@ -275,7 +259,7 @@ The run type for branches matching `main` (exact match).
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel (optional)**: Configure, Analysis phase
+- **Bazel (optional)**: Analysis phase
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build blobstore, Build blobstore2, Build node-exporter, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build prometheus-gcp, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build executor-vm, Build batcheshelper, Build opentelemetry-collector, Build embeddings, Build dind, Build bundled-executor, Build server, Build sg, Build executor image, Build executor binary
 - **Image security scans**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan embeddings, Scan dind, Scan bundled-executor, Scan sg

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -24,7 +24,6 @@ func BazelIncrementalMainOperations() *operations.Set {
 	optional := true
 
 	ops := operations.NewNamedSet("Bazel (optional)")
-	ops.Append(bazelConfigure(optional))
 	ops.Append(bazelAnalysisPhase(optional))
 
 	return ops

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -38,8 +38,9 @@ func bazelAnalysisPhase(optional bool) func(*bk.Pipeline) {
 		"--bazelrc=.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
-		"--nobuild", // this is the key flag to enable this.
 		"build",
+		"--nobuild", // this is the key flag to enable this.
+		"//...",
 	}
 
 	cmds := []bk.StepOpt{

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -12,12 +12,55 @@ const bazelRemoteCacheURL = "https://storage.googleapis.com/sourcegraph_bazel_ca
 
 func BazelOperations(optional bool) *operations.Set {
 	ops := operations.NewNamedSet("Bazel")
-	ops.Append(bazelConfigure())
+	ops.Append(bazelConfigure(optional))
 	ops.Append(bazelBuildAndTest(optional, "//..."))
 	return ops
 }
 
-func bazelConfigure() func(*bk.Pipeline) {
+// BazelIncrementalMainOperations is a set of operations that only run on the main
+// branch and whose purpose is to gradually introduce invariants as we progress through
+// the migration.
+func BazelIncrementalMainOperations() *operations.Set {
+	optional := true
+
+	ops := operations.NewNamedSet("Bazel (optional)")
+	ops.Append(bazelConfigure(optional))
+	ops.Append(bazelAnalysisPhase(optional))
+
+	return ops
+}
+
+// bazelAnalysisPhase only runs the analasys phase, ensure that the buildfiles
+// are correct, but do not actually build anything.
+func bazelAnalysisPhase(optional bool) func(*bk.Pipeline) {
+	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
+	cmd := []string{
+		"bazel",
+		"--bazelrc=.bazelrc",
+		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
+		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
+		"--nobuild", // this is the key flag to enable this.
+		"build",
+	}
+
+	cmds := []bk.StepOpt{
+		bk.Key("bazel-analysis"),
+		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
+		bk.Agent("queue", "bazel"),
+		bk.RawCmd(strings.Join(cmd, " ")),
+	}
+
+	return func(pipeline *bk.Pipeline) {
+		if optional {
+			cmds = append(cmds, bk.SoftFail())
+		}
+
+		pipeline.AddStep(":bazel: Analysis phase",
+			cmds...,
+		)
+	}
+}
+func bazelConfigure(optional bool) func(*bk.Pipeline) {
 	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	configureCmd := []string{
 		"bazel",
@@ -38,6 +81,10 @@ func bazelConfigure() func(*bk.Pipeline) {
 	}
 
 	return func(pipeline *bk.Pipeline) {
+		if optional {
+			cmds = append(cmds, bk.SoftFail())
+		}
+
 		pipeline.AddStep(":bazel: Configure",
 			cmds...,
 		)

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -274,6 +274,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		)
 
 	default:
+		if c.RunType.Is(runtype.MainBranch) {
+			// If we're on the main branch, we test a few Bazel invariants.
+			ops.Merge(BazelIncrementalMainOperations())
+		}
 		// Slow async pipeline
 		ops.Merge(operations.NewNamedSet(operations.PipelineSetupSetName,
 			triggerAsync(buildOptions)))

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -107,9 +107,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 
 	case runtype.PullRequest:
-		// TODO remove, QA'ing this
-		ops.Merge(BazelIncrementalMainOperations())
-
 		// First, we set up core test operations that apply both to PRs and to other run
 		// types such as main.
 		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -107,6 +107,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}
 
 	case runtype.PullRequest:
+		// TODO remove, QA'ing this
+		ops.Merge(BazelIncrementalMainOperations())
+
 		// First, we set up core test operations that apply both to PRs and to other run
 		// types such as main.
 		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{


### PR DESCRIPTION
Adds a soft failing invariant check on `main`, only build the analysis phase. This will also stress test the bazel agent autoscaling. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

I added a QA commit to trigger this on this branch. 