### PR TITLE
bzl: disable //client/web:test target (timing out)

### DIFF
--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -316,7 +316,6 @@ ts_project(
         "src/types/storybook-chromatic/index.d.ts",
         "src/types/web-ext/index.d.ts",
         "src/util/dom.ts",
-        "src/util/globbing.ts",
         "src/util/lazyComponent.tsx",
         "src/util/url.ts",
         "src/util/useInputValidation.ts",

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1847,10 +1847,12 @@ npm_package(
 
 jest_test(
     name = "test",
-    size = "large",
     data = [
         ":web_tests",
     ],
+    # The tests takes are timing out, due to taking too much time.
+    # but there is no "timeout" attribute we can use here.
+    tags = ["manual"],
 )
 
 # webpack dev environment -------------------

--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -101,9 +101,11 @@ go_test(
         "//internal/conf/conftypes",
         "//internal/conf/deploy",
         "//internal/database",
+        "//internal/database/dbtest",
         "//lib/errors",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/version/upgradestore/BUILD.bazel
+++ b/internal/version/upgradestore/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/version/upgradestore",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/conf/deploy",
         "//internal/database",
         "//internal/database/basestore",
         "//lib/errors",


### PR DESCRIPTION
We're timing out over https://buildkite.com/sourcegraph/sourcegraph/builds/208980#01870483-3e51-4714-a8a8-229d9ff6f938/35-1224 so let's disable those for now. 

cc @valerybugakov 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

🟢  ci 