### PR TITLE
bazel: add a bazel nudge when the step that failed is `bazel configure`

### DIFF
--- a/dev/build-tracker/integration_test.go
+++ b/dev/build-tracker/integration_test.go
@@ -428,6 +428,23 @@ func TestSlackNotification(t *testing.T) {
 			t.Fatalf("failed to send slack notification: %v", err)
 		}
 	})
+	t.Run("baze nudege if one of the failed steps is :bazel: Configure", func(t *testing.T) {
+		// setup the build
+		msg := "one where :bazel: Configure failed"
+		b.Message = &msg
+		buildNumber++
+		b.Number = &buildNumber
+		b.Steps = map[string]*build.Step{
+			":bazel: Configure": build.NewStepFromJob(newJob(t, ":bazel: Configure", exit)),
+		}
+
+		// post a new notification
+		info := toBuildNotification(b)
+		err := client.Send(info)
+		if err != nil {
+			t.Fatalf("failed to send slack notification: %v", err)
+		}
+	})
 }
 
 func TestServerNotify(t *testing.T) {

--- a/dev/build-tracker/notify/slack.go
+++ b/dev/build-tracker/notify/slack.go
@@ -284,8 +284,9 @@ _Disable flakes on sight and save your fellow teammate some time!_`,
 			&slack.TextBlockObject{
 				Type: slack.MarkdownType,
 				Text: fmt.Sprintf(`:bazel: *Bazel resolution tip*
-%s the ":bazel: Configure" step failed for your build. You need to run %s to update the build files and commit the result.
-For more information please see the Bazel FAQ.`, author, "`bazel configure`"),
+When the *configure* step fails, you need to run %s to update the build files and commit the result.
+
+For more information please see the <https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@b07a465f6e392cd55c24c28d24ef903269e45689/-/blob/doc/dev/background-information/bazel.md|Bazel FAQ>.`, "`bazel configure`"),
 			},
 			nil,
 			nil,


### PR DESCRIPTION
When one of the steps that have failed is `:bazel: Configure` change the nudge of the notification to be show a tip on how to resolve it.

TODO:
- [ ] we need to know when a step has soft failed, since the Bazel configure step will be a soft failing step

## Test plan
integration tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
