### PR TITLE
bazel: remove bazel configure step - flakey

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -108,7 +108,7 @@ sg ci build bzl
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel**: Configure, Build && Test
+- **Bazel**: Build && Test
 - Upload build trace
 
 ### Wolfi Exp Branch


### PR DESCRIPTION
The Bazel configure step (which runs`bazel run :gazelle`) has some issue when multiple builds run together:
* https://buildkite.com/sourcegraph/sourcegraph/builds/209004#018704bc-30ce-48c0-af8d-527beec45b2e
* https://buildkite.com/sourcegraph/sourcegraph/builds/208972#01870479-4452-4084-8454-14c8edc3b5bd (four retries in a row)



## Test plan
No `Bazel Configure` step should exist on the CI pipeline
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
