### PR TITLE
Fix unkown reason ui

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -64,6 +64,8 @@ const JOB_REASON_TO_READABLE_REASON: Record<PermissionsSyncJobReason, string> = 
     REASON_USER_NO_PERMS: 'User had no permissions',
     REASON_USER_OUTDATED_PERMS: 'Regular refresh of user permissions',
     REASON_USER_REMOVED_FROM_ORG: 'User removed from organization',
+    REASON_EXTERNAL_ACCOUNT_ADDED: 'Third-party login service added for the user',
+    REASON_EXTERNAL_ACCOUNT_DELETED: 'Third-party login service removed for the user',
 }
 
 export const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStateMetadata> = {
@@ -202,11 +204,19 @@ export const PermissionsSyncJobSubject: React.FunctionComponent<{ job: Permissio
     )
 }
 
+const getReadableReason = (reason: PermissionsSyncJobReason | null): string => {
+    if (reason !== null) {
+        return JOB_REASON_TO_READABLE_REASON[reason] || 'Unknown reason'
+    }
+
+    return 'Unknown reason'
+}
+
 export const PermissionsSyncJobReasonByline: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
     const message =
         job.reason.group === PermissionsSyncJobReasonGroup.MANUAL && job.triggeredByUser?.username
             ? `by ${job.triggeredByUser.username}`
-            : JOB_REASON_TO_READABLE_REASON[job.reason.reason]
+            : getReadableReason(job.reason.reason)
 
     return (
         <Tooltip content={message}>

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -553,7 +553,7 @@ type PermissionsSyncJobReasonWithGroup {
     """
     Reason with details about why/how the sync was triggered.
     """
-    reason: PermissionsSyncJobReason!
+    reason: PermissionsSyncJobReason
 }
 
 """
@@ -583,6 +583,8 @@ enum PermissionsSyncJobReason {
     REASON_GITHUB_REPO_MADE_PRIVATE_EVENT
     REASON_MANUAL_REPO_SYNC
     REASON_MANUAL_USER_SYNC
+    REASON_EXTERNAL_ACCOUNT_ADDED
+    REASON_EXTERNAL_ACCOUNT_DELETED
 }
 
 """
@@ -593,6 +595,7 @@ enum PermissionsSyncJobReasonGroup {
     WEBHOOK
     SCHEDULE
     SOURCEGRAPH
+    UNKNOWN
 }
 
 """

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -144,6 +144,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 
 	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{
 		UserIDs: []int32{account.UserID},
+		Reason:  database.ReasonExternalAccountDeleted,
 	})
 
 	return &EmptyResponse{}, nil
@@ -178,6 +179,7 @@ func (r *schemaResolver) AddExternalAccount(ctx context.Context, args *struct {
 
 	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{
 		UserIDs: []int32{a.UID},
+		Reason:  database.ReasonExternalAccountAdded,
 	})
 
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -58,6 +58,11 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 		}{
 			ExternalAccount: graphql.ID(base64.URLEncoding.EncodeToString([]byte("ExternalAccount:1"))),
 		}
+		permssync.MockSchedulePermsSync = func(_ context.Context, _ log.Logger, _ database.DB, req protocol.PermsSyncRequest) {
+			if req.Reason != database.ReasonExternalAccountDeleted {
+				t.Errorf("got reason %s, want %s", req.Reason, database.ReasonExternalAccountDeleted)
+			}
+		}
 		_, err = sr.DeleteExternalAccount(ctx, &graphqlArgs)
 		require.NoError(t, err)
 
@@ -182,6 +187,9 @@ func TestExternalAccounts_AddExternalAccount(t *testing.T) {
 			permssync.MockSchedulePermsSync = func(_ context.Context, _ log.Logger, _ database.DB, req protocol.PermsSyncRequest) {
 				if req.UserIDs[0] != tc.user.ID {
 					t.Errorf("got userID %d, want %d", req.UserIDs[0], tc.user.ID)
+				}
+				if req.Reason != database.ReasonExternalAccountAdded {
+					t.Errorf("got reason %s, want %s", req.Reason, database.ReasonExternalAccountAdded)
 				}
 			}
 

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -42,7 +42,7 @@ type PermissionsSyncJobResolver interface {
 
 type PermissionsSyncJobReasonResolver interface {
 	Group() string
-	Reason() string
+	Reason() *string
 }
 
 type CodeHostStateResolver interface {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -281,8 +281,14 @@ type permissionSyncJobReasonResolver struct {
 func (p permissionSyncJobReasonResolver) Group() string {
 	return string(p.group)
 }
-func (p permissionSyncJobReasonResolver) Reason() string {
-	return string(p.reason)
+func (p permissionSyncJobReasonResolver) Reason() *string {
+	if p.reason == "" {
+		return nil
+	}
+
+	reason := string(p.reason)
+
+	return &reason
 }
 
 type subject struct {

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -162,7 +162,9 @@ func (r PermissionsSyncJobReason) ResolveGroup() PermissionsSyncJobReasonGroup {
 		ReasonUserEmailVerified,
 		ReasonUserAddedToOrg,
 		ReasonUserRemovedFromOrg,
-		ReasonUserAcceptedOrgInvite:
+		ReasonUserAcceptedOrgInvite,
+		ReasonExternalAccountAdded,
+		ReasonExternalAccountDeleted:
 		return PermissionsSyncJobReasonGroupSourcegraph
 	default:
 		return PermissionsSyncJobReasonGroupUnknown
@@ -180,11 +182,13 @@ const (
 
 	// ReasonUserEmailRemoved and below are reasons of permission syncs scheduled due
 	// to Sourcegraph internal events.
-	ReasonUserEmailRemoved      PermissionsSyncJobReason = "REASON_USER_EMAIL_REMOVED"
-	ReasonUserEmailVerified     PermissionsSyncJobReason = "REASON_USER_EMAIL_VERIFIED"
-	ReasonUserAddedToOrg        PermissionsSyncJobReason = "REASON_USER_ADDED_TO_ORG"
-	ReasonUserRemovedFromOrg    PermissionsSyncJobReason = "REASON_USER_REMOVED_FROM_ORG"
-	ReasonUserAcceptedOrgInvite PermissionsSyncJobReason = "REASON_USER_ACCEPTED_ORG_INVITE"
+	ReasonUserEmailRemoved       PermissionsSyncJobReason = "REASON_USER_EMAIL_REMOVED"
+	ReasonUserEmailVerified      PermissionsSyncJobReason = "REASON_USER_EMAIL_VERIFIED"
+	ReasonUserAddedToOrg         PermissionsSyncJobReason = "REASON_USER_ADDED_TO_ORG"
+	ReasonUserRemovedFromOrg     PermissionsSyncJobReason = "REASON_USER_REMOVED_FROM_ORG"
+	ReasonUserAcceptedOrgInvite  PermissionsSyncJobReason = "REASON_USER_ACCEPTED_ORG_INVITE"
+	ReasonExternalAccountAdded   PermissionsSyncJobReason = "REASON_EXTERNAL_ACCOUNT_ADDED"
+	ReasonExternalAccountDeleted PermissionsSyncJobReason = "REASON_EXTERNAL_ACCOUNT_DELETED"
 
 	// ReasonGitHubUserEvent and below are reasons of permission syncs triggered by
 	// webhook events.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22571395/226717923-bea5f844-99d7-49ac-804b-2c3a13f741d1.png)

Some unknown trigger passes nil reason while creating sync job which breaks graphql API. 

This is the quick fix before we find the actual place which is causing the reason to be nil. 


## Update

The two events missing the reason were External Account Added & Deleted. Fixed and added tests. 

## Test plan

- delete external account, there should be a sync job triggered. 