### PR TITLE
users: fix nil panic

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -9310,6 +9310,20 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1678994673,
+				"Name": "package_repos_last_checked_at_index",
+				"UpQuery": "DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;\nDROP INDEX IF EXISTS package_repo_versions_last_checked_at;\n\nCREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at\nON lsif_dependency_repos\nUSING btree (last_checked_at ASC NULLS FIRST);\n\nCREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at\nON package_repo_versions\nUSING btree (last_checked_at ASC NULLS FIRST);",
+				"DownQuery": "DROP INDEX IF EXISTS lsif_dependency_repos_last_checked_at;\nDROP INDEX IF EXISTS package_repo_versions_last_checked_at;\n\nCREATE INDEX IF NOT EXISTS lsif_dependency_repos_last_checked_at\nON lsif_dependency_repos\nUSING btree (last_checked_at);\n\nCREATE INDEX IF NOT EXISTS package_repo_versions_last_checked_at\nON package_repo_versions\nUSING btree (last_checked_at);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678601228,
+					1678832491
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -9540,7 +9554,7 @@
 				"RootID": 1648051770,
 				"LeafIDs": [
 					1678899992,
-					1678832491
+					1678994673
 				],
 				"PreCreation": false
 			}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1538,8 +1538,10 @@ func LogPasswordEvent(ctx context.Context, db DB, r *http.Request, name Security
 	})
 
 	var path string
+	var host string
 	if r != nil {
 		path = r.URL.Path
+		host = r.URL.Host
 	}
 	event := &SecurityEvent{
 		Name:      name,
@@ -1563,12 +1565,10 @@ func LogPasswordEvent(ctx context.Context, db DB, r *http.Request, name Security
 	logEvent := &Event{
 		Name:            string(name),
 		AnonymousUserID: "backend",
+		URL:             host,
 		Argument:        eArgs,
 		Source:          "BACKEND",
 		Timestamp:       time.Now(),
-	}
-	if r != nil && r.URL != nil {
-		logEvent.URL = r.URL.Host
 	}
 
 	db.EventLogs().Insert(ctx, logEvent)

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -748,13 +748,11 @@ func logUserDeletionEvents(ctx context.Context, db DB, ids []int32, name Securit
 	events := make([]*SecurityEvent, len(ids))
 	for index, id := range ids {
 		events[index] = &SecurityEvent{
-			Name:            name,
-			URL:             "",
-			UserID:          uint32(id),
-			AnonymousUserID: "",
-			Argument:        arg,
-			Source:          "BACKEND",
-			Timestamp:       now,
+			Name:      name,
+			UserID:    uint32(id),
+			Argument:  arg,
+			Source:    "BACKEND",
+			Timestamp: now,
 		}
 	}
 	db.SecurityEventLogs().LogEventList(ctx, events)
@@ -770,7 +768,6 @@ func logUserDeletionEvents(ctx context.Context, db DB, ids []int32, name Securit
 		})
 		logEvents[index] = &Event{
 			Name:            string(name),
-			URL:             "",
 			AnonymousUserID: "backend",
 			Argument:        eArg,
 			Source:          "BACKEND",
@@ -893,7 +890,6 @@ func (u *userStore) SetIsSiteAdmin(ctx context.Context, id int32, isSiteAdmin bo
 			})
 			logEvent := &Event{
 				Name:            "RoleChangeGranted",
-				URL:             "",
 				AnonymousUserID: "backend",
 				Argument:        arg,
 				Source:          "BACKEND",
@@ -1566,11 +1562,13 @@ func LogPasswordEvent(ctx context.Context, db DB, r *http.Request, name Security
 	})
 	logEvent := &Event{
 		Name:            string(name),
-		URL:             r.URL.Host,
 		AnonymousUserID: "backend",
 		Argument:        eArgs,
 		Source:          "BACKEND",
 		Timestamp:       time.Now(),
+	}
+	if r != nil && r.URL != nil {
+		logEvent.URL = r.URL.Host
 	}
 
 	db.EventLogs().Insert(ctx, logEvent)


### PR DESCRIPTION
The `LogPasswordEvent` function can be called with `nil` as the request. This fixes the nil panic from this call: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/users.go?L1531:3

It also removes the deafult values that don't need to be set to remove references to the field.

The regression was introduced in https://github.com/sourcegraph/sourcegraph/pull/49174

## Test plan

- Existing tests and manual testing
