### PR TITLE
Update to a pinned commit of rules_jest fixing the timeout attr issue

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,9 +36,9 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_jest",
-    sha256 = "fa103b278137738ef08fd23d3c8c9157897a7159af2aa22714bc71680da58583",
-    strip_prefix = "rules_jest-0.16.1",
-    url = "https://github.com/aspect-build/rules_jest/archive/refs/tags/v0.16.1.tar.gz",
+    sha256 = "11f6685db09c54d401e084ab588b2dbc77913627bb3cde98576fa4c1be183853",
+    strip_prefix = "rules_jest-e78c8113b83436973e53384e5339f994d1103959",
+    url = "https://github.com/aspect-build/rules_jest/archive/e78c8113b83436973e53384e5339f994d1103959.tar.gz"
 )
 
 http_archive(

--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -257,6 +257,7 @@ npm_package(
 
 jest_test(
     name = "test",
+    timeout = "moderate",
     data = [
         ":branded_tests",
     ],

--- a/client/browser/BUILD.bazel
+++ b/client/browser/BUILD.bazel
@@ -293,6 +293,7 @@ ts_project(
 
 jest_test(
     name = "test",
+    timeout = "moderate",
     data = [
         ":browser_tests",
     ],

--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -514,6 +514,8 @@ filegroup(
 
 jest_test(
     name = "test",
+    size = "enormous",  # make sure bazel reserves enough RAM for this.
+    timeout = "long",
     data = [
         ":shared_tests",
         ":snapshots",

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1847,10 +1847,10 @@ npm_package(
 
 jest_test(
     name = "test",
+    timeout = "long",
     data = [
         ":web_tests",
     ],
-    timeout = "long",
 )
 
 # webpack dev environment -------------------

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1850,9 +1850,7 @@ jest_test(
     data = [
         ":web_tests",
     ],
-    # The tests takes are timing out, due to taking too much time.
-    # but there is no "timeout" attribute we can use here.
-    tags = ["manual"],
+    timeout = "long",
 )
 
 # webpack dev environment -------------------

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1847,6 +1847,7 @@ npm_package(
 
 jest_test(
     name = "test",
+    size = "enormous",  # make sure bazel reserves enough RAM for this.
     timeout = "long",
     data = [
         ":web_tests",

--- a/client/wildcard/BUILD.bazel
+++ b/client/wildcard/BUILD.bazel
@@ -545,6 +545,7 @@ npm_package(
 
 jest_test(
     name = "test",
+    timeout = "moderate",
     data = [
         ":wildcard_tests",
     ],


### PR DESCRIPTION
See https://github.com/aspect-build/rules_jest/pull/110, which fixes the timeout issue that we've seen on `//client/web:test`. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 

## App preview:

- [Web](https://sg-web-jh-bump-rules-jest.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
