### PR TITLE
[sentinel] Adding filters to vulnerability matches

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.sentinel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.sentinel.graphql
@@ -27,6 +27,21 @@ extend type Query {
         If supplied, indicates which results to skip over during pagination.
         """
         after: String
+
+        """
+        Programming language of the vulnerability.
+        """
+        language: String
+
+        """
+        Severity of the vulnerability.
+        """
+        severity: String
+
+        """
+        The name of the repository to filter by.
+        """
+        repositoryName: String
     ): VulnerabilityMatchConnection!
 }
 

--- a/enterprise/internal/codeintel/sentinel/shared/types.go
+++ b/enterprise/internal/codeintel/sentinel/shared/types.go
@@ -50,8 +50,11 @@ type AffectedSymbol struct {
 }
 
 type GetVulnerabilityMatchesArgs struct {
-	Limit  int
-	Offset int
+	Limit          int
+	Offset         int
+	Severity       string
+	Language       string
+	RepositoryName string
 }
 
 type VulnerabilityMatch struct {

--- a/enterprise/internal/codeintel/sentinel/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/sentinel/transport/graphql/root_resolver.go
@@ -93,6 +93,21 @@ func (r *rootResolver) VulnerabilityMatches(ctx context.Context, args resolverst
 		return nil, err
 	}
 
+	language := ""
+	if args.Language != nil {
+		language = *args.Language
+	}
+
+	severity := ""
+	if args.Severity != nil {
+		severity = *args.Severity
+	}
+
+	repositoryName := ""
+	if args.RepositoryName != nil {
+		repositoryName = *args.RepositoryName
+	}
+
 	matches, totalCount, err := r.sentinelSvc.GetVulnerabilityMatches(ctx, shared.GetVulnerabilityMatchesArgs{
 		Limit:  int(limit),
 		Offset: int(offset),

--- a/enterprise/internal/codeintel/sentinel/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/sentinel/transport/graphql/root_resolver.go
@@ -109,8 +109,11 @@ func (r *rootResolver) VulnerabilityMatches(ctx context.Context, args resolverst
 	}
 
 	matches, totalCount, err := r.sentinelSvc.GetVulnerabilityMatches(ctx, shared.GetVulnerabilityMatchesArgs{
-		Limit:  int(limit),
-		Offset: int(offset),
+		Limit:          int(limit),
+		Offset:         int(offset),
+		Language:       language,
+		Severity:       severity,
+		RepositoryName: repositoryName,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/codeintel/resolvers/sentinel.go
+++ b/internal/codeintel/resolvers/sentinel.go
@@ -20,10 +20,16 @@ type SentinelServiceResolver interface {
 
 type (
 	GetVulnerabilitiesArgs               = PagedConnectionArgs
-	GetVulnerabilityMatchesArgs          = PagedConnectionArgs
 	VulnerabilityConnectionResolver      = PagedConnectionWithTotalCountResolver[VulnerabilityResolver]
 	VulnerabilityMatchConnectionResolver = PagedConnectionWithTotalCountResolver[VulnerabilityMatchResolver]
 )
+
+type GetVulnerabilityMatchesArgs struct {
+	PagedConnectionArgs
+	Severity       *string
+	Language       *string
+	RepositoryName *string
+}
 
 type VulnerabilityResolver interface {
 	ID() graphql.ID


### PR DESCRIPTION
Adds filters to sql query and resolvers to be able filter by severity, language and repository name.

## Test plan
Tested manually. Additional tests incoming.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
