### PR TITLE
Home Page: Fix Search box UI and notice UI visual overlaps

### DIFF
--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -28,7 +28,9 @@
 }
 
 .search-nav-bar {
-    z-index: 1;
+    // It has level 2 because of repo container page elements operate with
+    // first level of z-indexes
+    z-index: 2;
     width: 100%;
     padding: 0.75rem 1rem;
     border-bottom: 1px solid var(--border-color);

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.module.scss
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.module.scss
@@ -1,6 +1,8 @@
 .input-container {
     width: 100%;
     display: flex;
+    position: relative;
+    z-index: 1;
 }
 
 .input-sub-container {


### PR DESCRIPTION
| Befofe | After | 
| ------- | ------- | 
| <img width="1124" alt="Screenshot 2023-03-21 at 15 24 42" src="https://user-images.githubusercontent.com/18492575/226706144-c07f0066-6817-4a66-bd4f-a06c0d8d00f2.png"> | <img width="1124" alt="Screenshot 2023-03-21 at 15 24 36" src="https://user-images.githubusercontent.com/18492575/226706124-403963c2-43fc-4c7f-a17d-f2585df86d2e.png"> |

## Test plan
- Check that search box UI when you have at least one notice UI (k8s has the default one)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-notice-search-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
