### PR TITLE
webhooks: add note about current limitation

### DIFF
--- a/doc/admin/config/webhooks/outgoing.md
+++ b/doc/admin/config/webhooks/outgoing.md
@@ -35,6 +35,8 @@ The outgoing webhook will now be created and active. To view or edit its details
 - **batch_change:close** - Triggered when a batch change is closed.
 - **batch_change:delete** - Triggered when a batch change is deleted.
 
+> NOTE: There is one notable limitation in the initial release of outgoing webhooks: the payloads of batch changes sent will appear to "lag behind" the events that trigger them slightly. For example, if you close a batch change, the `batch_change:close` event will be sent immediately, but the payload will contain the batch change in the state as it was _just before_ it was closed. This is because the webhook payload is constructed before the batch change is updated in the database. This will be fixed in a future release.
+
 #### Example payload
 
 The batch change webhook event payload mirrors the [GraphQL API](../../../api/graphql/index.md) `BatchChange` type and contains the following fields:
@@ -70,11 +72,13 @@ The batch change webhook event payload mirrors the [GraphQL API](../../../api/gr
 
 ### Changeset
 
-- **changeset:close** - Triggered when a changeset is closed by Sourcegraph.
+- **changeset:close** - Triggered when a changeset is closed or merged by Sourcegraph.
 - **changeset:publish** - Triggered when a changeset is successfully published to the code host.
 - **changeset:publish_error** - Triggered when an attempt to publish a changeset to the code host fails.
 - **changeset:update** - Triggered when a changeset is updated on the code host by Sourcegraph.
 - **changeset:update_error** - Triggered when an attempt to update a changeset on the code host fails.
+
+> NOTE: There is one notable limitation in the initial release of outgoing webhooks: the payloads of changesets sent will appear to "lag behind" the events that trigger them slightly. For example, if you publish a changeset, the `changeset:publish` event will be sent immediately, but the payload will contain the changeset in the state as it was _just before_ it was published. This is because the webhook payload is constructed before the changeset is updated in the database. This will be fixed in a future release.
 
 #### Example payload
 


### PR DESCRIPTION
During QA of outgoing webhooks, we uncovered a quirk of the initial implementation. There was not sufficient time to understand and address the quirk, and it isn't a blocker for shipping outgoing webhooks, so we've documented it here instead and probably will plan a patch release with the proper fix to the problem.

## Test plan

N/A just a docs change.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
