### PR TITLE
Add index to speed up deletions from codeintel_ranking_references

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7881,6 +7881,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_ranking_references_processed_pkey ON codeintel_ranking_references_processed USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "codeintel_ranking_references_processed_reference_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_ranking_references_processed_reference_id ON codeintel_ranking_references_processed USING btree (codeintel_ranking_reference_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -976,6 +976,7 @@ References for a given upload proceduced by background job consuming SCIP indexe
 Indexes:
     "codeintel_ranking_references_processed_pkey" PRIMARY KEY, btree (id)
     "codeintel_ranking_references_processed_graph_key_codeintel_rank" UNIQUE, btree (graph_key, codeintel_ranking_reference_id)
+    "codeintel_ranking_references_processed_reference_id" btree (codeintel_ranking_reference_id)
 Foreign-key constraints:
     "fk_codeintel_ranking_reference" FOREIGN KEY (codeintel_ranking_reference_id) REFERENCES codeintel_ranking_references(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/down.sql
+++ b/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_ranking_references_processed_reference_id;

--- a/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/metadata.yaml
+++ b/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/metadata.yaml
@@ -1,0 +1,3 @@
+name: Speed up deletes from ranking table
+parents: [1679404397]
+createIndexConcurrently: true

--- a/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/up.sql
+++ b/migrations/frontend/1679428966_speed_up_deletes_from_ranking_table/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_references_processed_reference_id ON codeintel_ranking_references_processed (codeintel_ranking_reference_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5148,6 +5148,8 @@ CREATE INDEX codeintel_ranking_references_graph_key_last_scanned_at_id ON codein
 
 CREATE UNIQUE INDEX codeintel_ranking_references_processed_graph_key_codeintel_rank ON codeintel_ranking_references_processed USING btree (graph_key, codeintel_ranking_reference_id);
 
+CREATE INDEX codeintel_ranking_references_processed_reference_id ON codeintel_ranking_references_processed USING btree (codeintel_ranking_reference_id);
+
 CREATE INDEX codeintel_ranking_references_upload_id ON codeintel_ranking_references USING btree (upload_id);
 
 CREATE INDEX configuration_policies_audit_logs_policy_id ON configuration_policies_audit_logs USING btree (policy_id);


### PR DESCRIPTION
There's a FK to this table on the codeintel_ranking_references_processed table but no suitable index to check this constraint so it's effectively doing a seq scan over that table for every deleted record. This fixes it. Deleting 100 records went from 10s to 20ms. A query to delete 8.5M records that was running for 2d now and didn't finish yet finished in 2 or 3 minutes now.

## Test plan

Tested this has the desired impact on dotcom, see description.