### PR TITLE
all: remove frivolous errors from console for App

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -217,6 +218,9 @@ func unsafeSignUp(
 			// information.
 			message = defaultErrorMessage
 			statusCode = http.StatusInternalServerError
+		}
+		if deploy.IsApp() && strings.Contains(err.Error(), "site_already_initialized") {
+			return nil, http.StatusOK, nil
 		}
 		logger.Error("Error in user signup.", log.String("email", creds.Email), log.String("username", creds.Username), log.Error(err))
 		if err = usagestats.LogBackendEvent(db, sgactor.FromContext(ctx).UID, deviceid.FromContext(ctx), "SignUpFailed", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil); err != nil {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -95,7 +95,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	db := database.NewDB(logger, sqlDB)
 
 	if os.Getenv("SRC_DISABLE_OOBMIGRATION_VALIDATION") != "" {
-		logger.Warn("Skipping out-of-band migrations check")
+		if !deploy.IsApp() {
+			logger.Warn("Skipping out-of-band migrations check")
+		}
 	} else {
 		outOfBandMigrationRunner := oobmigration.NewRunnerWithDB(observationCtx, db, oobmigration.RefreshInterval)
 

--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/mountinfo"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -42,8 +43,12 @@ func (s *Server) RegisterMetrics(observationCtx *observation.Context, db dbutil.
 		return
 	}
 
+	logger := s.Logger
+	if deploy.IsApp() {
+		logger = logger.IncreaseLevel("mountinfo", "", log.LevelError)
+	}
 	opts := mountinfo.CollectorOpts{Namespace: "gitserver"}
-	m := mountinfo.NewCollector(s.Logger, opts, map[string]string{"reposDir": s.ReposDir})
+	m := mountinfo.NewCollector(logger, opts, map[string]string{"reposDir": s.ReposDir})
 	observationCtx.Registerer.MustRegister(m)
 
 	metrics.MustRegisterDiskMonitor(s.ReposDir)

--- a/cmd/worker/internal/migrations/init.go
+++ b/cmd/worker/internal/migrations/init.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -49,7 +50,9 @@ func (m *migrator) Routines(startupCtx context.Context, observationCtx *observat
 	}
 
 	if os.Getenv("SRC_DISABLE_OOBMIGRATION_VALIDATION") != "" {
-		observationCtx.Logger.Warn("Skipping out-of-band migrations check")
+		if !deploy.IsApp() {
+			observationCtx.Logger.Warn("Skipping out-of-band migrations check")
+		}
 	} else {
 		if err := oobmigration.ValidateOutOfBandMigrationRunner(startupCtx, db, outOfBandMigrationRunner); err != nil {
 			return nil, err


### PR DESCRIPTION
Prior to this change there were quite a few noisy errors/warnings in the console when App starts that do not really impact the user. This PR removes them.

Additionally, there is a small bugfix here where we would initialize the site admin account and it would 'fail' because the site was already initialized. In the case of app, this is not an error and was preventing the browser nonce URL from generating.

Helps #47992


## Test plan

Existing tests + ran `SRC_LOG_LEVEL=warn sg start app` and looked at what warnings were displayed.