### PR TITLE
Speed up deletes from cm_trigger_jobs table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -5449,6 +5449,16 @@
           "IndexDefinition": "CREATE INDEX cm_action_jobs_state_idx ON cm_action_jobs USING btree (state)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "cm_action_jobs_trigger_event",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX cm_action_jobs_trigger_event ON cm_action_jobs USING btree (trigger_event)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -536,6 +536,7 @@ Triggers:
 Indexes:
     "cm_action_jobs_pkey" PRIMARY KEY, btree (id)
     "cm_action_jobs_state_idx" btree (state)
+    "cm_action_jobs_trigger_event" btree (trigger_event)
 Check constraints:
     "cm_action_jobs_only_one_action_type" CHECK ((
 CASE

--- a/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/down.sql
+++ b/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS cm_action_jobs_trigger_event;

--- a/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/metadata.yaml
+++ b/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/metadata.yaml
@@ -1,0 +1,3 @@
+name: Speed up deletes from cm_trigger_jobs
+parents: [1679428966]
+createIndexConcurrently: true

--- a/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/up.sql
+++ b/migrations/frontend/1679432506_speed_up_deletes_from_cm_trigger_jobs/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS cm_action_jobs_trigger_event ON cm_action_jobs (trigger_event);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5106,6 +5106,8 @@ CREATE INDEX changesets_reconciler_state_idx ON changesets USING btree (reconcil
 
 CREATE INDEX cm_action_jobs_state_idx ON cm_action_jobs USING btree (state);
 
+CREATE INDEX cm_action_jobs_trigger_event ON cm_action_jobs USING btree (trigger_event);
+
 CREATE INDEX cm_slack_webhooks_monitor ON cm_slack_webhooks USING btree (monitor);
 
 CREATE INDEX cm_trigger_jobs_finished_at ON cm_trigger_jobs USING btree (finished_at);


### PR DESCRIPTION
We regularly run this query, and we also have a good number of trigger jobs in the table on dotcom (seemingly hundreds of thousands a day):

```sql
DELETE FROM cm_trigger_jobs WHERE finished_at < (NOW() - (30 * '1 day'::interval));
```

The query plan for this:

```
 Delete on cm_trigger_jobs  (cost=0.44..64412.76 rows=83451 width=6) (actual time=938.293..938.294 rows=0 loops=1)
   ->  Index Scan using cm_trigger_jobs_finished_at on cm_trigger_jobs  (cost=0.44..64412.76 rows=83451 width=6) (actual time=696.217..820.782 rows=10279 loops=1)
         Index Cond: (finished_at < (now() - '30 days'::interval))
 Planning Time: 0.059 ms
 Trigger for constraint cm_action_jobs_trigger_event_fk: time=78842.057 calls=10279
 Execution Time: 79787.323 ms
(6 rows)
```

After this index is added, the lookups of the target to delete via the foreign key on action jobs are much faster, giving us this plan (careful, not comparable, different row counts):

```
 Delete on cm_trigger_jobs  (cost=0.44..198311.30 rows=349313 width=6) (actual time=2400.412..2400.413 rows=0 loops=1)
   ->  Index Scan using cm_trigger_jobs_finished_at on cm_trigger_jobs  (cost=0.44..198311.30 rows=349313 width=6) (actual time=3.989..1819.169 rows=241877 loops=1)
         Index Cond: (finished_at < (now() - '29 days'::interval))
 Planning Time: 0.074 ms
 Trigger for constraint cm_action_jobs_trigger_event_fk: time=1912.328 calls=241877
 Execution Time: 4328.218 ms
(6 rows)
```

Now, doing some quick math 4328.218/(241877/10279), we see that the 10k rows from the first query would now have taken 183.9354416584 ms, vs 79787.323 ms before.



## Test plan

See proof in PR body.