### PR TITLE
Add token instruction description to the access token setup wizard field

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -250,7 +250,7 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
                     <>
                         Create GitHub access token classic (
                         <Link
-                            to="https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
+                            to="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#personal-access-tokens-classic"
                             target="_blank"
                             rel="noopener noreferrer"
                         >

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -24,6 +24,7 @@ import {
     FORM_ERROR,
     AsyncValidator,
     FormChangeEvent,
+    Link,
 } from '@sourcegraph/wildcard'
 
 import { EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID } from '../../../../../../components/externalServices/backend'
@@ -245,7 +246,19 @@ function GithubFormView(props: GithubFormViewProps): ReactElement {
             <Input
                 label="Access token"
                 placeholder="Input your access token"
-                message="Create a new access token on GitHub.com with repo or public_repo scope."
+                description={
+                    <>
+                        Create GitHub access token classic (
+                        <Link
+                            to="https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            instructions
+                        </Link>
+                        ) with <b>repo</b> or <b>public_repo</b> scope.
+                    </>
+                }
                 type="password"
                 {...getDefaultInputProps(accessTokenField)}
             />

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -30,6 +30,9 @@ export interface InputProps {
     /** Description block shown below the input. */
     message?: ReactNode
 
+    /** Description block shown above the input (but below the label) */
+    description?: ReactNode
+
     /** Custom class name for input element. */
     inputClassName?: string
 
@@ -56,6 +59,7 @@ export const Input = forwardRef(function Input(props, reference) {
         variant = 'regular',
         label,
         message,
+        description,
         className,
         inputClassName,
         inputSymbol,
@@ -94,6 +98,7 @@ export const Input = forwardRef(function Input(props, reference) {
         return (
             <Label className={classNames(styles.label, className)}>
                 {label && <div className="mb-2">{variant === 'regular' ? label : <small>{label}</small>}</div>}
+                {description && <InputDescription className="ml-0 mb-2 mt-n1">{description}</InputDescription>}
                 {inputWithMessage}
             </Label>
         )


### PR DESCRIPTION
Based on feedback from Rob [here](https://sourcegraph.slack.com/archives/C04PE4H6XGT/p1679430740565109)

This PR adds a proper field description to the access token field 
<img width="1124" alt="Screenshot 2023-03-21 at 18 49 54" src="https://user-images.githubusercontent.com/18492575/226749957-74c734d1-a703-4acd-92fc-8b69ccad48b0.png">

## Test plan
- Check that you can see this instruction even if there is an error in the access token field 
- Check that link leads you to the github documentation about access token creation 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-token-instructions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
