### PR TITLE
app: Update CTA url in Sourcegraph App

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -11,7 +11,6 @@ import {
 import { Position } from '@sourcegraph/extension-api-types'
 
 import { WorkspaceRootWithMetadata } from '../api/extension/extensionHostApi'
-import { AuthenticatedUser } from '../auth'
 import { SearchPatternType } from '../graphql-operations'
 import { discreteValueAliases } from '../search/query/filters'
 import { findFilter, FilterKind } from '../search/query/query'
@@ -558,32 +557,6 @@ export function buildSearchURLQuery(
     searchParameters.set('sm', (searchMode || SearchMode.Precise).toString())
 
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
-}
-
-/**
- *
- * @param authenticatedUser - User email/name for Enterprise form prefill
- * @param product - CTA source product page, determines dynamic Enterprise description
- * @returns signup UR string with relevant params attached
- */
-export const buildEnterpriseTrialURL = (
-    authenticatedUser: Pick<AuthenticatedUser, 'displayName' | 'emails'> | null | undefined,
-    product?: string
-): string => {
-    const url = new URL('https://signup.sourcegraph.com/')
-
-    if (product) {
-        url.searchParams.append('p', product)
-    }
-    const primaryEmail = authenticatedUser?.emails.find(email => email.isPrimary)
-    if (primaryEmail) {
-        url.searchParams.append('email', primaryEmail.email)
-    }
-    if (authenticatedUser?.displayName) {
-        url.searchParams.append('name', authenticatedUser.displayName)
-    }
-
-    return url.toString()
 }
 
 /**

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -8,7 +8,7 @@ import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { buildEnterpriseTrialURL, addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
+import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Button, PageHeader, Link, Container, H3, Text, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
@@ -187,7 +187,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         For unlimited access to Batch Changes,{' '}
                         <Link
                             to={addSourcegraphAppOutboundUrlParameters(
-                                buildEnterpriseTrialURL(authenticatedUser),
+                                'https://about.sourcegraph.com/get-started?app=enterprise',
                                 'batch-changes'
                             )}
                         >

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -1,5 +1,5 @@
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { addSourcegraphAppOutboundUrlParameters, buildEnterpriseTrialURL } from '@sourcegraph/shared/src/util/url'
+import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Link } from '@sourcegraph/wildcard'
 
 import { LimitedAccessBanner } from '../../../../../components/LimitedAccessBanner'
@@ -16,7 +16,7 @@ export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
             For unlimited access to Insights,{' '}
             <Link
                 to={addSourcegraphAppOutboundUrlParameters(
-                    buildEnterpriseTrialURL(props.authenticatedUser),
+                    'https://about.sourcegraph.com/get-started?app=enterprise',
                     'code-insights'
                 )}
             >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -15,7 +15,7 @@ import { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { addSourcegraphAppOutboundUrlParameters, buildEnterpriseTrialURL } from '@sourcegraph/shared/src/util/url'
+import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -299,7 +299,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             variant="secondary"
                             outline={true}
                             to={addSourcegraphAppOutboundUrlParameters(
-                                buildEnterpriseTrialURL(props.authenticatedUser)
+                                'https://about.sourcegraph.com/get-started?app=enterprise'
                             )}
                             size="sm"
                             onClick={() =>


### PR DESCRIPTION
Update the deprecated links that pointed to `signup.sourcegraph.com` to the new interstitial page at `https://about.sourcegraph.com/get-started?app=enterprise`

## Test plan

- Check links

## App preview:

- [Web](https://sg-web-marek-update-app-cta.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
