### PR TITLE
Enhancement: CloudInfo icon for No Repo alert

### DIFF
--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -191,6 +191,28 @@ export const CloudSyncIconRefresh = React.forwardRef((props, reference) => (
 )) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>
 CloudSyncIconRefresh.displayName = 'CloudSyncIconRefresh'
 
+export const CloudInfoIconRefresh = React.forwardRef((props, reference) => (
+    <svg
+        ref={reference}
+        {...props}
+        {...sizeProps(props)}
+        className={classNames('phabricator-icon mdi-icon', props.className)}
+        viewBox="0 -4 20 20"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M10.3872 11.9168H4.96484C3.18134 11.9168 1.71484 10.4503 1.71484 8.66683C1.71484 7.00907 2.9321 5.62911 4.68879 5.40244L5.61324 5.28316L6.03009 4.44945C6.7313 3.04703 8.20576 2.0835 9.96484 2.0835C11.4816 2.0835 12.7994 2.80509 13.6199 3.90816L15.3998 3.43124C14.3159 1.58578 12.3089 0.333496 9.96484 0.333496C7.54818 0.333496 5.46484 1.66683 4.46484 3.66683C1.88151 4.00016 -0.0351562 6.0835 -0.0351562 8.66683C-0.0351562 11.4168 2.21484 13.6668 4.96484 13.6668H10.3872V11.9168Z"
+            fill="#798BAF"
+        />
+        <path
+            d="M19.9649 9.49464C19.9649 11.7987 18.097 13.6665 15.793 13.6665C13.4889 13.6665 11.6211 11.7987 11.6211 9.49464C11.6211 7.19057 13.4889 5.32275 15.793 5.32275C18.097 5.32275 19.9649 7.19057 19.9649 9.49464Z"
+            fill="#0BB3CA"
+        />
+    </svg>
+)) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>
+CloudInfoIconRefresh.displayName = 'CloudInfoIconRefresh'
+
 // TODO: Rename name when refresh design is complete
 // eslint-disable-next-line react/display-name
 export const CloudCheckIconRefresh = React.forwardRef((props, reference) => (

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -207,7 +207,7 @@ export const CloudInfoIconRefresh = React.forwardRef((props, reference) => (
         />
         <path
             d="M19.9649 9.49464C19.9649 11.7987 18.097 13.6665 15.793 13.6665C13.4889 13.6665 11.6211 11.7987 11.6211 9.49464C11.6211 7.19057 13.4889 5.32275 15.793 5.32275C18.097 5.32275 19.9649 7.19057 19.9649 9.49464Z"
-            fill="#0b70db"
+            fill="#72dbe8"
         />
     </svg>
 )) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -207,7 +207,7 @@ export const CloudInfoIconRefresh = React.forwardRef((props, reference) => (
         />
         <path
             d="M19.9649 9.49464C19.9649 11.7987 18.097 13.6665 15.793 13.6665C13.4889 13.6665 11.6211 11.7987 11.6211 9.49464C11.6211 7.19057 13.4889 5.32275 15.793 5.32275C18.097 5.32275 19.9649 7.19057 19.9649 9.49464Z"
-            fill="#0BB3CA"
+            fill="#0b70db"
         />
     </svg>
 )) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>

--- a/client/web/src/nav/StatusMessagesNavItem.module.scss
+++ b/client/web/src/nav/StatusMessagesNavItem.module.scss
@@ -29,6 +29,10 @@
         border-left: 2px solid var(--warning);
     }
 
+    &--border-info {
+        border-left: 2px solid var(--info);
+    }
+
     &--border-progress {
         border-left: 2px solid var(--primary);
     }

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -103,7 +103,7 @@ function entryIcon(entryType: EntryType): JSX.Element {
             return (
                 <Icon
                     {...sharedProps}
-                    className={classNames('text-primary', styles.icon)}
+                    className={classNames('text-info', styles.icon)}
                     svgPath={mdiInformationOutline}
                     aria-label="Information"
                 />
@@ -134,6 +134,8 @@ const getBorderClassname = (entryType: EntryType): string => {
             return styles.entryBorderProgress
         case 'indexing':
             return styles.entryBorderProgress
+        case 'info':
+            return styles.entryBorderInfo
         default:
             return ''
     }

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useMemo } from 'react'
 
-import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle, mdiDatabaseSyncOutline } from '@mdi/js'
+import {
+    mdiInformation,
+    mdiAlert,
+    mdiSync,
+    mdiCheckboxMarkedCircle,
+    mdiDatabaseSyncOutline,
+    mdiInformationOutline,
+} from '@mdi/js'
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
@@ -8,6 +15,7 @@ import {
     CloudAlertIconRefresh,
     CloudSyncIconRefresh,
     CloudCheckIconRefresh,
+    CloudInfoIconRefresh,
 } from '@sourcegraph/shared/src/components/icons'
 import {
     Button,
@@ -30,7 +38,7 @@ import { STATUS_AND_REPO_COUNT } from './StatusMessagesNavItemQueries'
 
 import styles from './StatusMessagesNavItem.module.scss'
 
-type EntryType = 'progress' | 'warning' | 'success' | 'error' | 'indexing'
+type EntryType = 'progress' | 'warning' | 'success' | 'error' | 'indexing' | 'info'
 
 interface StatusMessageEntryProps {
     title: string
@@ -89,6 +97,15 @@ function entryIcon(entryType: EntryType): JSX.Element {
                     className={classNames('text-primary', styles.icon)}
                     svgPath={mdiDatabaseSyncOutline}
                     aria-label="Indexing"
+                />
+            )
+        case 'info':
+            return (
+                <Icon
+                    {...sharedProps}
+                    className={classNames('text-primary', styles.icon)}
+                    svgPath={mdiInformationOutline}
+                    aria-label="Information"
                 />
             )
     }
@@ -193,7 +210,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
             iconProps = { as: CloudSyncIconRefresh }
         } else if (data.statusMessages.length === 0 && data.repositoryStats.total === 0) {
             codeHostMessage = 'No repositories detected'
-            iconProps = { as: CloudAlertIconRefresh }
+            iconProps = { as: CloudInfoIconRefresh }
         } else {
             codeHostMessage = 'Repositories up to date'
             iconProps = { as: CloudCheckIconRefresh }
@@ -226,7 +243,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                         linkTo="/setup"
                         linkText="Setup code hosts"
                         linkOnClick={toggleIsOpen}
-                        entryType="warning"
+                        entryType="info"
                     />
                 )
             }

--- a/client/wildcard/src/global-styles/utilities/text.scss
+++ b/client/wildcard/src/global-styles/utilities/text.scss
@@ -83,9 +83,8 @@
         color: $value !important;
     }
 
-    a.text-#{$color} {
-        &:hover,
-        &:focus {
+    a.text-#{$color}:hover {
+        .theme-light & {
             color: darken($value, 15%) !important;
         }
     }


### PR DESCRIPTION
Small enhancement following up [this feedback](https://sourcegraph.slack.com/archives/C04J6HSHVJ5/p1679320207795339). Changes the No Repo alert icon to **info** status instead of **warning**.

### BEFORE
![image](https://user-images.githubusercontent.com/59381432/226754756-61f1700a-8e1b-4dc3-b79e-589da13bbac4.png)

### AFTER
<img width="364" alt="image" src="https://user-images.githubusercontent.com/59381432/226766819-e6d21e8a-ee89-4f2e-bcb3-a8b8a6f59dba.png">

## Test plan
- Run `EXTSVC_CONFIG_ALLOW_EDITS=1 sg start`
- Remove any connected code hosts
- Ensure No Repo alert icon in upper right nav reflects as expected

## App preview:

- [Web](https://sg-web-becca-cloud-status-info.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
