### PR TITLE
Fix setup banner link to the wizard

### DIFF
--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -20,7 +20,7 @@ import styles from './Setup.module.scss'
 
 const CORE_STEPS: StepConfiguration[] = [
     {
-        id: 'remote-repositoires',
+        id: 'remote-repositories',
         name: 'Add remote repositories',
         path: '/setup/remote-repositories',
         component: RemoteRepositoriesStep,

--- a/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
+++ b/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
@@ -24,7 +24,7 @@ export const NeedsRepositoryConfigurationAlert: React.FunctionComponent<
         variant="success"
         className={classNames('d-flex align-items-center', className)}
     >
-        <Link className="site-alert__link" to={`${PageRoutes.SetupWizard}/remote-repositoires`} onClick={onClickCTA}>
+        <Link className="site-alert__link" to={`${PageRoutes.SetupWizard}/remote-repositories`} onClick={onClickCTA}>
             <span className="underline">Go to setup wizard</span>
         </Link>
         &nbsp;to add remote repositories from GitHub, GitLab, etc.

--- a/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
+++ b/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
@@ -24,7 +24,7 @@ export const NeedsRepositoryConfigurationAlert: React.FunctionComponent<
         variant="success"
         className={classNames('d-flex align-items-center', className)}
     >
-        <Link className="site-alert__link" to={PageRoutes.SetupWizard} onClick={onClickCTA}>
+        <Link className="site-alert__link" to={`${PageRoutes.SetupWizard}/remote-repositoires`} onClick={onClickCTA}>
             <span className="underline">Go to setup wizard</span>
         </Link>
         &nbsp;to add remote repositories from GitHub, GitLab, etc.


### PR DESCRIPTION

## Test plan
- Check that link leads to the setup wizard connected to remote repositories step

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-banner-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
