### PR TITLE
app: Update 2 product links for App

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -203,7 +203,12 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 isSourcegraphDotCom={isSourcegraphDotCom}
             />
             {selectedTab === 'gettingStarted' && (
-                <GettingStarted canCreate={canCreate} isSourcegraphDotCom={isSourcegraphDotCom} className="mb-4" />
+                <GettingStarted
+                    canCreate={canCreate}
+                    isSourcegraphApp={isSourcegraphApp}
+                    isSourcegraphDotCom={isSourcegraphDotCom}
+                    className="mb-4"
+                />
             )}
             {selectedTab === 'batchChanges' && (
                 <>

--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 
+import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { Alert, Container, H2, H3, Link, Text, Icon, useReducedMotion } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
@@ -11,6 +12,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 
 export interface GettingStartedProps {
     isSourcegraphDotCom: boolean
+    isSourcegraphApp?: boolean
     // canCreate indicates whether or not the currently-authenticated user has sufficient
     // permissions to create a batch change in whatever context this getting started
     // section is being presented. If not, canCreate will be a string reason why the user
@@ -19,8 +21,11 @@ export interface GettingStartedProps {
     className?: string
 }
 
+const productPageUrl = 'https://about.sourcegraph.com/batch-changes'
+
 export const GettingStarted: React.FunctionComponent<React.PropsWithChildren<GettingStartedProps>> = ({
     isSourcegraphDotCom,
+    isSourcegraphApp,
     canCreate,
     className,
 }) => {
@@ -80,7 +85,15 @@ export const GettingStarted: React.FunctionComponent<React.PropsWithChildren<Get
                                 </Link>
                             </li>
                             <li>
-                                <Link to="https://about.sourcegraph.com/batch-changes" target="_blank" rel="noopener">
+                                <Link
+                                    to={
+                                        isSourcegraphApp
+                                            ? addSourcegraphAppOutboundUrlParameters(productPageUrl)
+                                            : productPageUrl
+                                    }
+                                    target="_blank"
+                                    rel="noopener"
+                                >
                                     Product page{' '}
                                     <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
                                 </Link>

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -110,7 +110,10 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
                     </TabPanel>
                     <TabPanel tabIndex={-1}>
                         <Suspense fallback={<LoadingSpinner aria-label="Loading Code Insights Getting started page" />}>
-                            <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                            <LazyCodeInsightsGettingStartedPage
+                                isSourcegraphApp={props.isSourcegraphApp}
+                                telemetryService={telemetryService}
+                            />
                         </Suspense>
                     </TabPanel>
                 </TabPanels>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -10,12 +10,14 @@ import { DynamicCodeInsightExample } from './components/dynamic-code-insight-exa
 
 import styles from './CodeInsightsGettingStartedPage.module.scss'
 
-interface CodeInsightsGettingStartedPageProps extends TelemetryProps {}
+interface CodeInsightsGettingStartedPageProps extends TelemetryProps {
+    isSourcegraphApp?: boolean
+}
 
 export const CodeInsightsGettingStartedPage: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsGettingStartedPageProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, isSourcegraphApp } = props
 
     useEffect(() => {
         telemetryService.logViewEvent('InsightsGetStartedPage')
@@ -24,7 +26,7 @@ export const CodeInsightsGettingStartedPage: React.FunctionComponent<
     return (
         <main className="pb-5">
             <PageTitle title="Code Insights" />
-            <DynamicCodeInsightExample telemetryService={telemetryService} />
+            <DynamicCodeInsightExample isSourcegraphApp={isSourcegraphApp} telemetryService={telemetryService} />
             <CodeInsightsExamples telemetryService={telemetryService} className={styles.section} />
             <CodeInsightsTemplates telemetryService={telemetryService} className={styles.section} />
         </main>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-description/CodeInsightsDescription.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-description/CodeInsightsDescription.tsx
@@ -2,16 +2,20 @@ import React from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 
+import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
 import { H2, H3, Icon, Text, Link } from '@sourcegraph/wildcard'
 
 interface Props {
     className?: string
+    isSourcegraphApp?: boolean
 }
+
+const productPageUrl = 'https://about.sourcegraph.com/code-insights'
 
 /**
  * The product description for Code Insights.
  */
-export const CodeInsightsDescription: React.FunctionComponent<Props> = ({ className }) => (
+export const CodeInsightsDescription: React.FunctionComponent<Props> = ({ className, isSourcegraphApp }) => (
     <section className={className}>
         <H2>Track what matters in your code</H2>
 
@@ -44,7 +48,11 @@ export const CodeInsightsDescription: React.FunctionComponent<Props> = ({ classN
                 </Link>
             </li>
             <li>
-                <Link to="https://about.sourcegraph.com/code-insights" target="_blank" rel="noopener">
+                <Link
+                    to={isSourcegraphApp ? addSourcegraphAppOutboundUrlParameters(productPageUrl) : productPageUrl}
+                    target="_blank"
+                    rel="noopener"
+                >
                     Product page <Icon role="img" aria-label="Open in a new tab" svgPath={mdiOpenInNew} />
                 </Link>
             </li>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -39,10 +39,12 @@ const INITIAL_INSIGHT_VALUES: CodeInsightExampleFormValues = {
     query: 'TODO',
 }
 
-interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttributes<HTMLDivElement> {}
+interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttributes<HTMLDivElement> {
+    isSourcegraphApp?: boolean
+}
 
 export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, isSourcegraphApp, ...otherProps } = props
 
     const { repositoryUrl, loading: repositoryValueLoading } = useExampleRepositoryUrl()
 
@@ -136,7 +138,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
             </form>
 
             <div>
-                <CodeInsightsDescription />
+                <CodeInsightsDescription isSourcegraphApp={isSourcegraphApp} />
                 <footer className={styles.footer}>
                     <Button variant="primary" as={Link} to="/insights/create" onClick={handleGetStartedClick}>
                         <Icon aria-hidden={true} svgPath={mdiPlus} /> Create your first insight


### PR DESCRIPTION
Update the 2 last remaining product links with tracking parameters for App.

Links updated: (by adding `addSourcegraphAppOutboundUrlParameters`)

- "Product page" link on Batch Changes -> https://about.sourcegraph.com/batch-changes
- "Product page" link on Code Insights -> https://about.sourcegraph.com/code-insights

Most of the change is making the `isSourcegraphApp` prop available in these components.

## Test plan

- Check links in App manually

## App preview:

- [Web](https://sg-web-marek-app-product-links-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

