### PR TITLE
dbconn: explicitly type cast args where possible

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -345,30 +345,30 @@ func argsAsAttributes(ctx context.Context, _ otelsql.Method, _ string, args []dr
 			attrs[i] = attribute.String(key, v.String())
 
 		// pq.Array types
-		case pq.BoolArray:
-			attrs[i] = attribute.BoolSlice(key, truncateSliceValue([]bool(v)))
-		case pq.Float64Array:
-			attrs[i] = attribute.Float64Slice(key, truncateSliceValue([]float64(v)))
-		case pq.Float32Array:
-			vals := truncateSliceValue([]float32(v))
+		case *pq.BoolArray:
+			attrs[i] = attribute.BoolSlice(key, truncateSliceValue([]bool(*v)))
+		case *pq.Float64Array:
+			attrs[i] = attribute.Float64Slice(key, truncateSliceValue([]float64(*v)))
+		case *pq.Float32Array:
+			vals := truncateSliceValue([]float32(*v))
 			floats := make([]float64, len(vals))
 			for i, v := range vals {
 				floats[i] = float64(v)
 			}
 			attrs[i] = attribute.Float64Slice(key, floats)
-		case pq.Int64Array:
-			attrs[i] = attribute.Int64Slice(key, truncateSliceValue([]int64(v)))
-		case pq.Int32Array:
-			vals := truncateSliceValue([]int32(v))
+		case *pq.Int64Array:
+			attrs[i] = attribute.Int64Slice(key, truncateSliceValue([]int64(*v)))
+		case *pq.Int32Array:
+			vals := truncateSliceValue([]int32(*v))
 			ints := make([]int, len(vals))
 			for i, v := range vals {
 				ints[i] = int(v)
 			}
 			attrs[i] = attribute.IntSlice(key, ints)
-		case pq.StringArray:
-			attrs[i] = attribute.StringSlice(key, truncateSliceValue([]string(v)))
-		case pq.ByteaArray:
-			vals := truncateSliceValue([][]byte(v))
+		case *pq.StringArray:
+			attrs[i] = attribute.StringSlice(key, truncateSliceValue([]string(*v)))
+		case *pq.ByteaArray:
+			vals := truncateSliceValue([][]byte(*v))
 			strings := make([]string, len(vals))
 			for i, v := range vals {
 				strings[i] = string(v)


### PR DESCRIPTION
`driver.Value` documents a small set of known types - casting explicitly should save us on some `fmt.Sprintf`-ing, which can be quite expensive.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI, and random selection of traces:

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/23356519/226770427-1b06c051-9a86-4e24-8df3-6490bba1cc2f.png">

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/23356519/226770450-7ca9d324-39b2-4a87-ab03-79ac4d08fb6b.png">

