### PR TITLE
[Backport 5.0] Fix setup banner link to the wizard (#49811)

### DIFF
--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -20,7 +20,7 @@ import styles from './Setup.module.scss'
 
 const CORE_STEPS: StepConfiguration[] = [
     {
-        id: 'remote-repositoires',
+        id: 'remote-repositories',
         name: 'Add remote repositories',
         path: '/setup/remote-repositories',
         component: RemoteRepositoriesStep,

--- a/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
+++ b/client/web/src/site/NeedsRepositoryConfigurationAlert.tsx
@@ -24,9 +24,9 @@ export const NeedsRepositoryConfigurationAlert: React.FunctionComponent<
         variant="success"
         className={classNames('d-flex align-items-center', className)}
     >
-        <Link className="site-alert__link" to={PageRoutes.SetupWizard} onClick={onClickCTA}>
-            <span className="underline">Connect a code host</span>
+        <Link className="site-alert__link" to={`${PageRoutes.SetupWizard}/remote-repositories`} onClick={onClickCTA}>
+            <span className="underline">Go to setup wizard</span>
         </Link>
-        &nbsp;to connect repositories to Sourcegraph.
+        &nbsp;to add remote repositories from GitHub, GitLab, etc.
     </DismissibleAlert>
 )


### PR DESCRIPTION
backport for https://github.com/sourcegraph/sourcegraph/pull/49811

## Test plan
- Check that link leads to the setup wizard connected to remote repositories step
