### PR TITLE
Remove trace.SQL

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -923,8 +923,6 @@ func (s *repoStore) list(ctx context.Context, tr *trace.Trace, opt ReposListOpti
 		return err
 	}
 
-	tr.LogFields(trace.SQL(q)) //nolint:staticcheck // TODO when updating observation package
-
 	rows, err := s.Query(ctx, q)
 	if err != nil {
 		if e, ok := err.(*net.OpError); ok && e.Timeout() {

--- a/internal/trace/fields.go
+++ b/internal/trace/fields.go
@@ -3,7 +3,6 @@ package trace
 import (
 	"fmt"
 
-	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 )
 
@@ -52,17 +51,6 @@ func LazyFields(lazyFields func() []log.Field) log.Field {
 	return log.Lazy(func(fv log.Encoder) {
 		for _, field := range lazyFields() {
 			field.Marshal(fv)
-		}
-	})
-}
-
-// SQL is an opentracing log.Field which is a LazyLogger. It will log the
-// query as well as each argument.
-func SQL(q *sqlf.Query) log.Field {
-	return log.Lazy(func(fv log.Encoder) {
-		fv.EmitString("sql", q.Query(sqlf.PostgresBindVar))
-		for i, arg := range q.Args() {
-			fv.EmitObject(fmt.Sprintf("arg%d", i+1), arg)
 		}
 	})
 }


### PR DESCRIPTION
We should use the otelsql in dbconn instead. This should be redundant.

See https://sourcegraph.slack.com/archives/C04MYFW01NV/p1679435638206579 for more context.



## Test plan

Just tracing, CI should tell if something broke.