### PR TITLE
app: Update CTAs in App for get-started interstitial form

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -187,7 +187,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         For unlimited access to Batch Changes,{' '}
                         <Link
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=enterprise',
+                                'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
                                 'batch-changes'
                             )}
                         >

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -187,7 +187,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         For unlimited access to Batch Changes,{' '}
                         <Link
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
+                                'https://about.sourcegraph.com/get-started?app=enterprise',
                                 'batch-changes'
                             )}
                         >

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -187,7 +187,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         For unlimited access to Batch Changes,{' '}
                         <Link
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=enterprise',
+                                'https://about.sourcegraph.com/get-started?t=enterprise',
                                 'batch-changes'
                             )}
                         >

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -76,7 +76,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
         eventLogger.log('CodeMonitoringExampleMonitorClicked')
     }, [])
 
-    let ctaBannerUrl = 'https://about.sourcegraph.com/get-started?app=enterprise'
+    let ctaBannerUrl = 'https://about.sourcegraph.com/get-started?t=enterprise'
     if (isSourcegraphApp) {
         ctaBannerUrl = addSourcegraphAppOutboundUrlParameters(ctaBannerUrl, 'monitoring')
     }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -76,7 +76,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
         eventLogger.log('CodeMonitoringExampleMonitorClicked')
     }, [])
 
-    let ctaBannerUrl = 'https://about.sourcegraph.com/get-started?app=entrerprise_trial'
+    let ctaBannerUrl = 'https://about.sourcegraph.com/get-started?app=enterprise'
     if (isSourcegraphApp) {
         ctaBannerUrl = addSourcegraphAppOutboundUrlParameters(ctaBannerUrl, 'monitoring')
     }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -76,9 +76,9 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
         eventLogger.log('CodeMonitoringExampleMonitorClicked')
     }, [])
 
-    let ctaBannerUrl = 'https://about.sourcegraph.com'
+    let ctaBannerUrl = 'https://about.sourcegraph.com/get-started?app=entrerprise_trial'
     if (isSourcegraphApp) {
-        ctaBannerUrl = addSourcegraphAppOutboundUrlParameters(ctaBannerUrl)
+        ctaBannerUrl = addSourcegraphAppOutboundUrlParameters(ctaBannerUrl, 'monitoring')
     }
 
     return (

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -16,7 +16,7 @@ export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
             For unlimited access to Insights,{' '}
             <Link
                 to={addSourcegraphAppOutboundUrlParameters(
-                    'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
+                    'https://about.sourcegraph.com/get-started?app=enterprise',
                     'code-insights'
                 )}
             >

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -16,7 +16,7 @@ export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
             For unlimited access to Insights,{' '}
             <Link
                 to={addSourcegraphAppOutboundUrlParameters(
-                    'https://about.sourcegraph.com/get-started?app=enterprise',
+                    'https://about.sourcegraph.com/get-started?t=enterprise',
                     'code-insights'
                 )}
             >

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -16,7 +16,7 @@ export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
             For unlimited access to Insights,{' '}
             <Link
                 to={addSourcegraphAppOutboundUrlParameters(
-                    'https://about.sourcegraph.com/get-started?app=enterprise',
+                    'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
                     'code-insights'
                 )}
             >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -299,7 +299,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             variant="secondary"
                             outline={true}
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
+                                'https://about.sourcegraph.com/get-started?app=enterprise',
                                 'navbar'
                             )}
                             size="sm"

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -299,7 +299,8 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             variant="secondary"
                             outline={true}
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=enterprise'
+                                'https://about.sourcegraph.com/get-started?app=entrerprise_trial',
+                                'navbar'
                             )}
                             size="sm"
                             onClick={() =>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -299,7 +299,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             variant="secondary"
                             outline={true}
                             to={addSourcegraphAppOutboundUrlParameters(
-                                'https://about.sourcegraph.com/get-started?app=enterprise',
+                                'https://about.sourcegraph.com/get-started?t=enterprise',
                                 'navbar'
                             )}
                             size="sm"


### PR DESCRIPTION
Update App CTA's that go to the new interstitial `about.sourcegraph.com/get-started` form page, which is being added in this PR on About:
- https://github.com/sourcegraph/about/pull/6091

URL scheme described in this comment
- https://github.com/sourcegraph/about/pull/6091#discussion_r1144963761

Also the Monitoring CTA in App to the new form.

Also add `navbar` as the `utm_campaign` value for the navbar CTA.

More details:

- The full URL of the destination link for these CTAs will be https://about.sourcegraph.com/get-started?t=enterprise
- This new page is replacing the use of `signup.sourcegraph.com`

## Test plan

- Check URLs manually in App

## App preview:

- [Web](https://sg-web-marek-change-get-started-cta-url.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
