### PR TITLE
Add permissions syncying stats api.

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -27,6 +27,7 @@ type AuthzResolver interface {
 	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
 	AuthzProviderTypes(ctx context.Context) ([]string, error)
 	PermissionsSyncJobs(ctx context.Context, args ListPermissionsSyncJobsArgs) (*graphqlutil.ConnectionResolver[PermissionsSyncJobResolver], error)
+	PermissionsSyncingStats(ctx context.Context) (PermissionsSyncingStatsResolver, error)
 
 	// RepositoryPermissionsInfo and UserPermissionsInfo are helpers functions.
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
@@ -159,3 +160,13 @@ const (
 )
 
 type CancelPermissionsSyncJobResultMessage string
+
+type PermissionsSyncingStatsResolver interface {
+	QueueSize(ctx context.Context) (int32, error)
+	UsersWithLatestJobFailing(ctx context.Context) (int32, error)
+	ReposWithLatestJobFailing(ctx context.Context) (int32, error)
+	UsersWithNoPermissions(ctx context.Context) (int32, error)
+	ReposWithNoPermissions(ctx context.Context) (int32, error)
+	UsersWithStalePermissions(ctx context.Context) (int32, error)
+	ReposWithStalePermissions(ctx context.Context) (int32, error)
+}

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -217,6 +217,11 @@ extend type Query {
     ): PermissionsSyncJobsConnection!
 
     """
+    Returns various permissions syncing statistics.
+    """
+    permissionsSyncingStats: PermissionsSyncingStats!
+
+    """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
     """
     bitbucketProjectPermissionJobs(
@@ -822,4 +827,38 @@ type BitbucketProjectPermissionJob {
     Shows that current project is accessible by any user of the project.
     """
     Unrestricted: Boolean!
+}
+
+"""
+Various permissions syncing statistics.
+"""
+type PermissionsSyncingStats {
+    """
+    The number of permissions sync jobs in the queue.
+    """
+    queueSize: Int!
+    """
+    The number of users with latest permissions sync job failing.
+    """
+    usersWithLatestJobFailing: Int!
+    """
+    The number of repositories with latest permissions sync job failing.
+    """
+    reposWithLatestJobFailing: Int!
+    """
+    The number of users with no permissions.
+    """
+    usersWithNoPermissions: Int!
+    """
+    The number of repositories with no permissions.
+    """
+    reposWithNoPermissions: Int!
+    """
+    The number of users with old permissions.
+    """
+    usersWithStalePermissions: Int!
+    """
+    The number of repository with old permissions.
+    """
+    reposWithStalePermissions: Int!
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
+        "//enterprise/cmd/frontend/worker/auth",
         "//enterprise/internal/database",
         "//enterprise/internal/licensing",
         "//internal/actor",

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	authworker "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/worker/auth"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -682,4 +683,61 @@ func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args graphqlbackend.
 	}
 
 	return NewPermissionsSyncJobsResolver(r.db, args)
+}
+
+func (r *Resolver) PermissionsSyncingStats(ctx context.Context) (graphqlbackend.PermissionsSyncingStatsResolver, error) {
+	stats := permissionsSyncingStats{
+		db:    r.db,
+		ossDB: r.ossDB,
+	}
+
+	// 🚨 SECURITY: Only site admins can query permissions syncing stats.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return stats, err
+	}
+
+	return stats, nil
+}
+
+type permissionsSyncingStats struct {
+	db    edb.EnterpriseDB
+	ossDB database.DB
+}
+
+func (s permissionsSyncingStats) QueueSize(ctx context.Context) (int32, error) {
+	count, err := s.ossDB.PermissionSyncJobs().Count(ctx, database.ListPermissionSyncJobOpts{State: database.PermissionsSyncJobStateQueued})
+
+	return int32(count), err
+}
+
+func (s permissionsSyncingStats) UsersWithLatestJobFailing(ctx context.Context) (int32, error) {
+	return s.ossDB.PermissionSyncJobs().CountUsersWithFailingSyncJob(ctx)
+}
+
+func (s permissionsSyncingStats) ReposWithLatestJobFailing(ctx context.Context) (int32, error) {
+	return s.ossDB.PermissionSyncJobs().CountReposWithFailingSyncJob(ctx)
+}
+
+func (s permissionsSyncingStats) UsersWithNoPermissions(ctx context.Context) (int32, error) {
+	count, err := s.db.Perms().CountUsersWithNoPerms(ctx)
+
+	return int32(count), err
+}
+
+func (s permissionsSyncingStats) ReposWithNoPermissions(ctx context.Context) (int32, error) {
+	count, err := s.db.Perms().CountReposWithNoPerms(ctx)
+
+	return int32(count), err
+}
+
+func (s permissionsSyncingStats) UsersWithStalePermissions(ctx context.Context) (int32, error) {
+	count, err := s.db.Perms().CountUsersWithStalePerms(ctx, authworker.SyncUserBackoff())
+
+	return int32(count), err
+}
+
+func (s permissionsSyncingStats) ReposWithStalePermissions(ctx context.Context) (int32, error) {
+	count, err := s.db.Perms().CountReposWithStalePerms(ctx, authworker.SyncRepoBackoff())
+
+	return int32(count), err
 }

--- a/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
+++ b/enterprise/cmd/frontend/worker/auth/perms_syncer_scheduler.go
@@ -172,13 +172,13 @@ func getSchedule(ctx context.Context, store edb.PermsStore) (*schedule, error) {
 
 	userLimit, repoLimit := oldestUserPermissionsBatchSize(), oldestRepoPermissionsBatchSize()
 
-	usersWithOldestPerms, err := scheduleUsersWithOldestPerms(ctx, store, userLimit, syncUserBackoff())
+	usersWithOldestPerms, err := scheduleUsersWithOldestPerms(ctx, store, userLimit, SyncUserBackoff())
 	if err != nil {
 		return nil, errors.Wrap(err, "load users with oldest permissions")
 	}
 	schedule.Users = append(schedule.Users, usersWithOldestPerms...)
 
-	reposWithOldestPerms, err := scheduleReposWithOldestPerms(ctx, store, repoLimit, syncRepoBackoff())
+	reposWithOldestPerms, err := scheduleReposWithOldestPerms(ctx, store, repoLimit, SyncRepoBackoff())
 	if err != nil {
 		return nil, errors.Wrap(err, "scan repositories with oldest permissions")
 	}
@@ -283,7 +283,7 @@ func oldestRepoPermissionsBatchSize() int {
 
 var zeroBackoffDuringTest = false
 
-func syncUserBackoff() time.Duration {
+func SyncUserBackoff() time.Duration {
 	if zeroBackoffDuringTest {
 		return time.Duration(0)
 	}
@@ -295,7 +295,7 @@ func syncUserBackoff() time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
-func syncRepoBackoff() time.Duration {
+func SyncRepoBackoff() time.Duration {
 	if zeroBackoffDuringTest {
 		return time.Duration(0)
 	}

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -14187,17 +14187,15 @@ type MockPermsStore struct {
 	// CountReposWithNoPermsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountReposWithNoPerms.
 	CountReposWithNoPermsFunc *PermsStoreCountReposWithNoPermsFunc
-	// CountReposWithOldestPermsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// CountReposWithOldestPerms.
-	CountReposWithOldestPermsFunc *PermsStoreCountReposWithOldestPermsFunc
+	// CountReposWithStalePermsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountReposWithStalePerms.
+	CountReposWithStalePermsFunc *PermsStoreCountReposWithStalePermsFunc
 	// CountUsersWithNoPermsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountUsersWithNoPerms.
 	CountUsersWithNoPermsFunc *PermsStoreCountUsersWithNoPermsFunc
-	// CountUsersWithOldestPermsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// CountUsersWithOldestPerms.
-	CountUsersWithOldestPermsFunc *PermsStoreCountUsersWithOldestPermsFunc
+	// CountUsersWithStalePermsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountUsersWithStalePerms.
+	CountUsersWithStalePermsFunc *PermsStoreCountUsersWithStalePermsFunc
 	// DeleteAllUserPendingPermissionsFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// DeleteAllUserPendingPermissions.
@@ -14294,7 +14292,7 @@ func NewMockPermsStore() *MockPermsStore {
 				return
 			},
 		},
-		CountReposWithOldestPermsFunc: &PermsStoreCountReposWithOldestPermsFunc{
+		CountReposWithStalePermsFunc: &PermsStoreCountReposWithStalePermsFunc{
 			defaultHook: func(context.Context, time.Duration) (r0 int, r1 error) {
 				return
 			},
@@ -14304,7 +14302,7 @@ func NewMockPermsStore() *MockPermsStore {
 				return
 			},
 		},
-		CountUsersWithOldestPermsFunc: &PermsStoreCountUsersWithOldestPermsFunc{
+		CountUsersWithStalePermsFunc: &PermsStoreCountUsersWithStalePermsFunc{
 			defaultHook: func(context.Context, time.Duration) (r0 int, r1 error) {
 				return
 			},
@@ -14451,9 +14449,9 @@ func NewStrictMockPermsStore() *MockPermsStore {
 				panic("unexpected invocation of MockPermsStore.CountReposWithNoPerms")
 			},
 		},
-		CountReposWithOldestPermsFunc: &PermsStoreCountReposWithOldestPermsFunc{
+		CountReposWithStalePermsFunc: &PermsStoreCountReposWithStalePermsFunc{
 			defaultHook: func(context.Context, time.Duration) (int, error) {
-				panic("unexpected invocation of MockPermsStore.CountReposWithOldestPerms")
+				panic("unexpected invocation of MockPermsStore.CountReposWithStalePerms")
 			},
 		},
 		CountUsersWithNoPermsFunc: &PermsStoreCountUsersWithNoPermsFunc{
@@ -14461,9 +14459,9 @@ func NewStrictMockPermsStore() *MockPermsStore {
 				panic("unexpected invocation of MockPermsStore.CountUsersWithNoPerms")
 			},
 		},
-		CountUsersWithOldestPermsFunc: &PermsStoreCountUsersWithOldestPermsFunc{
+		CountUsersWithStalePermsFunc: &PermsStoreCountUsersWithStalePermsFunc{
 			defaultHook: func(context.Context, time.Duration) (int, error) {
-				panic("unexpected invocation of MockPermsStore.CountUsersWithOldestPerms")
+				panic("unexpected invocation of MockPermsStore.CountUsersWithStalePerms")
 			},
 		},
 		DeleteAllUserPendingPermissionsFunc: &PermsStoreDeleteAllUserPendingPermissionsFunc{
@@ -14606,14 +14604,14 @@ func NewMockPermsStoreFrom(i PermsStore) *MockPermsStore {
 		CountReposWithNoPermsFunc: &PermsStoreCountReposWithNoPermsFunc{
 			defaultHook: i.CountReposWithNoPerms,
 		},
-		CountReposWithOldestPermsFunc: &PermsStoreCountReposWithOldestPermsFunc{
-			defaultHook: i.CountReposWithOldestPerms,
+		CountReposWithStalePermsFunc: &PermsStoreCountReposWithStalePermsFunc{
+			defaultHook: i.CountReposWithStalePerms,
 		},
 		CountUsersWithNoPermsFunc: &PermsStoreCountUsersWithNoPermsFunc{
 			defaultHook: i.CountUsersWithNoPerms,
 		},
-		CountUsersWithOldestPermsFunc: &PermsStoreCountUsersWithOldestPermsFunc{
-			defaultHook: i.CountUsersWithOldestPerms,
+		CountUsersWithStalePermsFunc: &PermsStoreCountUsersWithStalePermsFunc{
+			defaultHook: i.CountUsersWithStalePerms,
 		},
 		DeleteAllUserPendingPermissionsFunc: &PermsStoreDeleteAllUserPendingPermissionsFunc{
 			defaultHook: i.DeleteAllUserPendingPermissions,
@@ -14804,37 +14802,37 @@ func (c PermsStoreCountReposWithNoPermsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// PermsStoreCountReposWithOldestPermsFunc describes the behavior when the
-// CountReposWithOldestPerms method of the parent MockPermsStore instance is
+// PermsStoreCountReposWithStalePermsFunc describes the behavior when the
+// CountReposWithStalePerms method of the parent MockPermsStore instance is
 // invoked.
-type PermsStoreCountReposWithOldestPermsFunc struct {
+type PermsStoreCountReposWithStalePermsFunc struct {
 	defaultHook func(context.Context, time.Duration) (int, error)
 	hooks       []func(context.Context, time.Duration) (int, error)
-	history     []PermsStoreCountReposWithOldestPermsFuncCall
+	history     []PermsStoreCountReposWithStalePermsFuncCall
 	mutex       sync.Mutex
 }
 
-// CountReposWithOldestPerms delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) CountReposWithOldestPerms(v0 context.Context, v1 time.Duration) (int, error) {
-	r0, r1 := m.CountReposWithOldestPermsFunc.nextHook()(v0, v1)
-	m.CountReposWithOldestPermsFunc.appendCall(PermsStoreCountReposWithOldestPermsFuncCall{v0, v1, r0, r1})
+// CountReposWithStalePerms delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockPermsStore) CountReposWithStalePerms(v0 context.Context, v1 time.Duration) (int, error) {
+	r0, r1 := m.CountReposWithStalePermsFunc.nextHook()(v0, v1)
+	m.CountReposWithStalePermsFunc.appendCall(PermsStoreCountReposWithStalePermsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// CountReposWithOldestPerms method of the parent MockPermsStore instance is
+// CountReposWithStalePerms method of the parent MockPermsStore instance is
 // invoked and the hook queue is empty.
-func (f *PermsStoreCountReposWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, time.Duration) (int, error)) {
+func (f *PermsStoreCountReposWithStalePermsFunc) SetDefaultHook(hook func(context.Context, time.Duration) (int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// CountReposWithOldestPerms method of the parent MockPermsStore instance
+// CountReposWithStalePerms method of the parent MockPermsStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreCountReposWithOldestPermsFunc) PushHook(hook func(context.Context, time.Duration) (int, error)) {
+func (f *PermsStoreCountReposWithStalePermsFunc) PushHook(hook func(context.Context, time.Duration) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -14842,20 +14840,20 @@ func (f *PermsStoreCountReposWithOldestPermsFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreCountReposWithOldestPermsFunc) SetDefaultReturn(r0 int, r1 error) {
+func (f *PermsStoreCountReposWithStalePermsFunc) SetDefaultReturn(r0 int, r1 error) {
 	f.SetDefaultHook(func(context.Context, time.Duration) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreCountReposWithOldestPermsFunc) PushReturn(r0 int, r1 error) {
+func (f *PermsStoreCountReposWithStalePermsFunc) PushReturn(r0 int, r1 error) {
 	f.PushHook(func(context.Context, time.Duration) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *PermsStoreCountReposWithOldestPermsFunc) nextHook() func(context.Context, time.Duration) (int, error) {
+func (f *PermsStoreCountReposWithStalePermsFunc) nextHook() func(context.Context, time.Duration) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -14868,27 +14866,27 @@ func (f *PermsStoreCountReposWithOldestPermsFunc) nextHook() func(context.Contex
 	return hook
 }
 
-func (f *PermsStoreCountReposWithOldestPermsFunc) appendCall(r0 PermsStoreCountReposWithOldestPermsFuncCall) {
+func (f *PermsStoreCountReposWithStalePermsFunc) appendCall(r0 PermsStoreCountReposWithStalePermsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of PermsStoreCountReposWithOldestPermsFuncCall
+// History returns a sequence of PermsStoreCountReposWithStalePermsFuncCall
 // objects describing the invocations of this function.
-func (f *PermsStoreCountReposWithOldestPermsFunc) History() []PermsStoreCountReposWithOldestPermsFuncCall {
+func (f *PermsStoreCountReposWithStalePermsFunc) History() []PermsStoreCountReposWithStalePermsFuncCall {
 	f.mutex.Lock()
-	history := make([]PermsStoreCountReposWithOldestPermsFuncCall, len(f.history))
+	history := make([]PermsStoreCountReposWithStalePermsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// PermsStoreCountReposWithOldestPermsFuncCall is an object that describes
-// an invocation of method CountReposWithOldestPerms on an instance of
+// PermsStoreCountReposWithStalePermsFuncCall is an object that describes an
+// invocation of method CountReposWithStalePerms on an instance of
 // MockPermsStore.
-type PermsStoreCountReposWithOldestPermsFuncCall struct {
+type PermsStoreCountReposWithStalePermsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -14905,13 +14903,13 @@ type PermsStoreCountReposWithOldestPermsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PermsStoreCountReposWithOldestPermsFuncCall) Args() []interface{} {
+func (c PermsStoreCountReposWithStalePermsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PermsStoreCountReposWithOldestPermsFuncCall) Results() []interface{} {
+func (c PermsStoreCountReposWithStalePermsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -15023,37 +15021,37 @@ func (c PermsStoreCountUsersWithNoPermsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// PermsStoreCountUsersWithOldestPermsFunc describes the behavior when the
-// CountUsersWithOldestPerms method of the parent MockPermsStore instance is
+// PermsStoreCountUsersWithStalePermsFunc describes the behavior when the
+// CountUsersWithStalePerms method of the parent MockPermsStore instance is
 // invoked.
-type PermsStoreCountUsersWithOldestPermsFunc struct {
+type PermsStoreCountUsersWithStalePermsFunc struct {
 	defaultHook func(context.Context, time.Duration) (int, error)
 	hooks       []func(context.Context, time.Duration) (int, error)
-	history     []PermsStoreCountUsersWithOldestPermsFuncCall
+	history     []PermsStoreCountUsersWithStalePermsFuncCall
 	mutex       sync.Mutex
 }
 
-// CountUsersWithOldestPerms delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) CountUsersWithOldestPerms(v0 context.Context, v1 time.Duration) (int, error) {
-	r0, r1 := m.CountUsersWithOldestPermsFunc.nextHook()(v0, v1)
-	m.CountUsersWithOldestPermsFunc.appendCall(PermsStoreCountUsersWithOldestPermsFuncCall{v0, v1, r0, r1})
+// CountUsersWithStalePerms delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockPermsStore) CountUsersWithStalePerms(v0 context.Context, v1 time.Duration) (int, error) {
+	r0, r1 := m.CountUsersWithStalePermsFunc.nextHook()(v0, v1)
+	m.CountUsersWithStalePermsFunc.appendCall(PermsStoreCountUsersWithStalePermsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// CountUsersWithOldestPerms method of the parent MockPermsStore instance is
+// CountUsersWithStalePerms method of the parent MockPermsStore instance is
 // invoked and the hook queue is empty.
-func (f *PermsStoreCountUsersWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, time.Duration) (int, error)) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) SetDefaultHook(hook func(context.Context, time.Duration) (int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// CountUsersWithOldestPerms method of the parent MockPermsStore instance
+// CountUsersWithStalePerms method of the parent MockPermsStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreCountUsersWithOldestPermsFunc) PushHook(hook func(context.Context, time.Duration) (int, error)) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) PushHook(hook func(context.Context, time.Duration) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -15061,20 +15059,20 @@ func (f *PermsStoreCountUsersWithOldestPermsFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreCountUsersWithOldestPermsFunc) SetDefaultReturn(r0 int, r1 error) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) SetDefaultReturn(r0 int, r1 error) {
 	f.SetDefaultHook(func(context.Context, time.Duration) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreCountUsersWithOldestPermsFunc) PushReturn(r0 int, r1 error) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) PushReturn(r0 int, r1 error) {
 	f.PushHook(func(context.Context, time.Duration) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *PermsStoreCountUsersWithOldestPermsFunc) nextHook() func(context.Context, time.Duration) (int, error) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) nextHook() func(context.Context, time.Duration) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -15087,27 +15085,27 @@ func (f *PermsStoreCountUsersWithOldestPermsFunc) nextHook() func(context.Contex
 	return hook
 }
 
-func (f *PermsStoreCountUsersWithOldestPermsFunc) appendCall(r0 PermsStoreCountUsersWithOldestPermsFuncCall) {
+func (f *PermsStoreCountUsersWithStalePermsFunc) appendCall(r0 PermsStoreCountUsersWithStalePermsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of PermsStoreCountUsersWithOldestPermsFuncCall
+// History returns a sequence of PermsStoreCountUsersWithStalePermsFuncCall
 // objects describing the invocations of this function.
-func (f *PermsStoreCountUsersWithOldestPermsFunc) History() []PermsStoreCountUsersWithOldestPermsFuncCall {
+func (f *PermsStoreCountUsersWithStalePermsFunc) History() []PermsStoreCountUsersWithStalePermsFuncCall {
 	f.mutex.Lock()
-	history := make([]PermsStoreCountUsersWithOldestPermsFuncCall, len(f.history))
+	history := make([]PermsStoreCountUsersWithStalePermsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// PermsStoreCountUsersWithOldestPermsFuncCall is an object that describes
-// an invocation of method CountUsersWithOldestPerms on an instance of
+// PermsStoreCountUsersWithStalePermsFuncCall is an object that describes an
+// invocation of method CountUsersWithStalePerms on an instance of
 // MockPermsStore.
-type PermsStoreCountUsersWithOldestPermsFuncCall struct {
+type PermsStoreCountUsersWithStalePermsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -15124,13 +15122,13 @@ type PermsStoreCountUsersWithOldestPermsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PermsStoreCountUsersWithOldestPermsFuncCall) Args() []interface{} {
+func (c PermsStoreCountUsersWithStalePermsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PermsStoreCountUsersWithOldestPermsFuncCall) Results() []interface{} {
+func (c PermsStoreCountUsersWithStalePermsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
- Added permissions syncing stats API. 
- Fixed count users/repos with no perms to only consider `user_repo_permissions` table.

<img width="1355" alt="image" src="https://user-images.githubusercontent.com/22571395/228839395-5400dfea-b14c-420a-8e90-bf002abbbe2b.png">


## Test plan

- unit tests added