### PR TITLE
Implement methods to count users/repos with failing latest sync job

### DIFF
--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -38100,6 +38100,14 @@ type MockPermissionSyncJobStore struct {
 	// CountFunc is an instance of a mock function object controlling the
 	// behavior of the method Count.
 	CountFunc *PermissionSyncJobStoreCountFunc
+	// CountReposWithFailingSyncJobFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// CountReposWithFailingSyncJob.
+	CountReposWithFailingSyncJobFunc *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc
+	// CountUsersWithFailingSyncJobFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// CountUsersWithFailingSyncJob.
+	CountUsersWithFailingSyncJobFunc *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc
 	// CreateRepoSyncJobFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateRepoSyncJob.
 	CreateRepoSyncJobFunc *PermissionSyncJobStoreCreateRepoSyncJobFunc
@@ -38141,6 +38149,16 @@ func NewMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 		},
 		CountFunc: &PermissionSyncJobStoreCountFunc{
 			defaultHook: func(context.Context, ListPermissionSyncJobOpts) (r0 int, r1 error) {
+				return
+			},
+		},
+		CountReposWithFailingSyncJobFunc: &PermissionSyncJobStoreCountReposWithFailingSyncJobFunc{
+			defaultHook: func(context.Context) (r0 int32, r1 error) {
+				return
+			},
+		},
+		CountUsersWithFailingSyncJobFunc: &PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc{
+			defaultHook: func(context.Context) (r0 int32, r1 error) {
 				return
 			},
 		},
@@ -38207,6 +38225,16 @@ func NewStrictMockPermissionSyncJobStore() *MockPermissionSyncJobStore {
 				panic("unexpected invocation of MockPermissionSyncJobStore.Count")
 			},
 		},
+		CountReposWithFailingSyncJobFunc: &PermissionSyncJobStoreCountReposWithFailingSyncJobFunc{
+			defaultHook: func(context.Context) (int32, error) {
+				panic("unexpected invocation of MockPermissionSyncJobStore.CountReposWithFailingSyncJob")
+			},
+		},
+		CountUsersWithFailingSyncJobFunc: &PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc{
+			defaultHook: func(context.Context) (int32, error) {
+				panic("unexpected invocation of MockPermissionSyncJobStore.CountUsersWithFailingSyncJob")
+			},
+		},
 		CreateRepoSyncJobFunc: &PermissionSyncJobStoreCreateRepoSyncJobFunc{
 			defaultHook: func(context.Context, api.RepoID, PermissionSyncJobOpts) error {
 				panic("unexpected invocation of MockPermissionSyncJobStore.CreateRepoSyncJob")
@@ -38265,6 +38293,12 @@ func NewMockPermissionSyncJobStoreFrom(i PermissionSyncJobStore) *MockPermission
 		},
 		CountFunc: &PermissionSyncJobStoreCountFunc{
 			defaultHook: i.Count,
+		},
+		CountReposWithFailingSyncJobFunc: &PermissionSyncJobStoreCountReposWithFailingSyncJobFunc{
+			defaultHook: i.CountReposWithFailingSyncJob,
+		},
+		CountUsersWithFailingSyncJobFunc: &PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc{
+			defaultHook: i.CountUsersWithFailingSyncJob,
 		},
 		CreateRepoSyncJobFunc: &PermissionSyncJobStoreCreateRepoSyncJobFunc{
 			defaultHook: i.CreateRepoSyncJob,
@@ -38513,6 +38547,226 @@ func (c PermissionSyncJobStoreCountFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c PermissionSyncJobStoreCountFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// PermissionSyncJobStoreCountReposWithFailingSyncJobFunc describes the
+// behavior when the CountReposWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance is invoked.
+type PermissionSyncJobStoreCountReposWithFailingSyncJobFunc struct {
+	defaultHook func(context.Context) (int32, error)
+	hooks       []func(context.Context) (int32, error)
+	history     []PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall
+	mutex       sync.Mutex
+}
+
+// CountReposWithFailingSyncJob delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockPermissionSyncJobStore) CountReposWithFailingSyncJob(v0 context.Context) (int32, error) {
+	r0, r1 := m.CountReposWithFailingSyncJobFunc.nextHook()(v0)
+	m.CountReposWithFailingSyncJobFunc.appendCall(PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// CountReposWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance is invoked and the hook queue is
+// empty.
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) SetDefaultHook(hook func(context.Context) (int32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountReposWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance invokes the hook at the front of the
+// queue and discards it. After the queue is empty, the default hook
+// function is invoked for any future action.
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) PushHook(hook func(context.Context) (int32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context) (int32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context) (int32, error) {
+		return r0, r1
+	})
+}
+
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) nextHook() func(context.Context) (int32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) appendCall(r0 PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall objects
+// describing the invocations of this function.
+func (f *PermissionSyncJobStoreCountReposWithFailingSyncJobFunc) History() []PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall {
+	f.mutex.Lock()
+	history := make([]PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall is an object
+// that describes an invocation of method CountReposWithFailingSyncJob on an
+// instance of MockPermissionSyncJobStore.
+type PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c PermissionSyncJobStoreCountReposWithFailingSyncJobFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc describes the
+// behavior when the CountUsersWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance is invoked.
+type PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc struct {
+	defaultHook func(context.Context) (int32, error)
+	hooks       []func(context.Context) (int32, error)
+	history     []PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall
+	mutex       sync.Mutex
+}
+
+// CountUsersWithFailingSyncJob delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockPermissionSyncJobStore) CountUsersWithFailingSyncJob(v0 context.Context) (int32, error) {
+	r0, r1 := m.CountUsersWithFailingSyncJobFunc.nextHook()(v0)
+	m.CountUsersWithFailingSyncJobFunc.appendCall(PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// CountUsersWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance is invoked and the hook queue is
+// empty.
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) SetDefaultHook(hook func(context.Context) (int32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountUsersWithFailingSyncJob method of the parent
+// MockPermissionSyncJobStore instance invokes the hook at the front of the
+// queue and discards it. After the queue is empty, the default hook
+// function is invoked for any future action.
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) PushHook(hook func(context.Context) (int32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) SetDefaultReturn(r0 int32, r1 error) {
+	f.SetDefaultHook(func(context.Context) (int32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) PushReturn(r0 int32, r1 error) {
+	f.PushHook(func(context.Context) (int32, error) {
+		return r0, r1
+	})
+}
+
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) nextHook() func(context.Context) (int32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) appendCall(r0 PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall objects
+// describing the invocations of this function.
+func (f *PermissionSyncJobStoreCountUsersWithFailingSyncJobFunc) History() []PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall {
+	f.mutex.Lock()
+	history := make([]PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall is an object
+// that describes an invocation of method CountUsersWithFailingSyncJob on an
+// instance of MockPermissionSyncJobStore.
+type PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c PermissionSyncJobStoreCountUsersWithFailingSyncJobFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -659,24 +659,16 @@ func (s *permissionSyncJobStore) Count(ctx context.Context, opts ListPermissionS
 }
 
 const countUsersWithFailingSyncJobsQuery = `
-WITH sync_jobs_with_row_number AS (
-	SELECT
-		state,
-		ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY finished_at DESC) AS row_num
-	FROM
-		permission_sync_jobs
-	WHERE
-		user_id IS NOT NULL
-		AND finished_at IS NOT NULL
-		AND state IN ('completed', 'failed')
-)
-SELECT
-	COUNT(*)
-FROM
-	sync_jobs_with_row_number
-WHERE 
-	state = 'failed'
-	AND row_num = 1
+SELECT COUNT(*) 
+FROM (
+  SELECT DISTINCT ON (user_id) id, state 
+  FROM permission_sync_jobs 
+  WHERE 
+	user_id is NOT NULL 
+	AND state IN ('completed', 'failed')
+  ORDER BY user_id, finished_at DESC
+) AS tmp 
+WHERE state = 'failed';
 `
 
 // CountUsersWithFailingSyncJob returns count of users with LATEST sync job failing.
@@ -689,24 +681,16 @@ func (s *permissionSyncJobStore) CountUsersWithFailingSyncJob(ctx context.Contex
 }
 
 const countReposWithFailingSyncJobsQuery = `
-WITH sync_jobs_with_row_number AS (
-	SELECT
-		state,
-		ROW_NUMBER() OVER (PARTITION BY repository_id ORDER BY finished_at DESC) AS row_num
-	FROM
-		permission_sync_jobs
-	WHERE
-		repository_id IS NOT NULL
-		AND finished_at IS NOT NULL
-		AND state IN ('completed', 'failed')
-)
-SELECT
-	COUNT(*)
-FROM
-	sync_jobs_with_row_number
-WHERE 
-	state = 'failed'
-	AND row_num = 1
+SELECT COUNT(*) 
+FROM (
+  SELECT DISTINCT ON (repository_id) id, state 
+  FROM permission_sync_jobs 
+  WHERE 
+	repository_id is NOT NULL 
+	AND state IN ('completed', 'failed')
+  ORDER BY repository_id, finished_at DESC
+) AS tmp 
+WHERE state = 'failed';
 `
 
 // CountReposWithFailingSyncJob returns count of repos with LATEST sync job failing.

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -823,6 +823,248 @@ func TestPermissionSyncJobs_Count(t *testing.T) {
 	require.Equal(t, 0, count)
 }
 
+func TestPermissionSyncJobs_CountUsersWithFailingSyncJob(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	clock := timeutil.NewFakeClock(time.Now(), 0)
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+
+	store := PermissionSyncJobsWith(logger, db)
+	usersStore := UsersWith(logger, db)
+
+	// Create users.
+	user1, err := usersStore.Create(ctx, NewUser{Username: "test-user-1", DisplayName: "t0pc0d3r"})
+	require.NoError(t, err)
+	user2, err := usersStore.Create(ctx, NewUser{Username: "test-user-2"})
+	require.NoError(t, err)
+
+	createJob := func(t *testing.T, userID int32) {
+		t.Helper()
+
+		opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionsSync, InvalidateCaches: true, Reason: ReasonUserNoPermissions, NoPerms: true}
+		err := store.CreateUserSyncJob(ctx, userID, opts)
+		require.NoError(t, err)
+	}
+
+	finishJobWithFailure := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s WHERE id = %d", finishedAt, PermissionsSyncJobStateFailed, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	finishJobWithCancel := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s, cancel = true WHERE id = %d", finishedAt, PermissionsSyncJobStateCanceled, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	finishJob := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s WHERE id = %d", finishedAt, PermissionsSyncJobStateCompleted, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	cleanupJobs := func(t *testing.T) {
+		t.Helper()
+
+		if t.Failed() {
+			return
+		}
+
+		_, err = db.ExecContext(ctx, "TRUNCATE TABLE permission_sync_jobs; ALTER SEQUENCE permission_sync_jobs_id_seq RESTART WITH 1")
+		require.NoError(t, err)
+	}
+
+	t.Run("No jobs", func(t *testing.T) {
+		count, err := store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("No failining sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, user1.ID) // id = 1
+		createJob(t, user2.ID) // id = 2
+
+		finishJob(t, 1, clock.Now())
+
+		count, err := store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("No latest failing sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, user1.ID) // id = 1
+		finishJob(t, 1, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, user1.ID) // id = 2
+		finishJobWithFailure(t, 2, clock.Now().Add(-1*time.Hour))
+
+		createJob(t, user2.ID) // id = 3
+		finishJob(t, 3, clock.Now())
+
+		count, err := store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("With latest failing sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, user1.ID) // id = 1
+		finishJob(t, 1, clock.Now().Add(-1*time.Hour))
+
+		createJob(t, user1.ID) // id = 2
+		finishJobWithFailure(t, 2, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, user1.ID) // id = 3
+		finishJobWithCancel(t, 3, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, user2.ID) // id = 4
+		finishJobWithFailure(t, 4, clock.Now())
+
+		count, err := store.CountUsersWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), count, "wrong count")
+	})
+}
+
+func TestPermissionSyncJobs_CountReposWithFailingSyncJob(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	clock := timeutil.NewFakeClock(time.Now(), 0)
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+
+	store := PermissionSyncJobsWith(logger, db)
+	reposStore := ReposWith(logger, db)
+
+	// Create repos.
+	repo1 := types.Repo{Name: "test-repo-1", ID: 101}
+	err := reposStore.Create(ctx, &repo1)
+	require.NoError(t, err)
+	repo2 := types.Repo{Name: "test-repo-2", ID: 201}
+	err = reposStore.Create(ctx, &repo2)
+	require.NoError(t, err)
+
+	createJob := func(t *testing.T, repoID api.RepoID) {
+		t.Helper()
+
+		opts := PermissionSyncJobOpts{Priority: HighPriorityPermissionsSync, InvalidateCaches: true, Reason: ReasonRepoNoPermissions, NoPerms: true}
+		err := store.CreateRepoSyncJob(ctx, repoID, opts)
+		require.NoError(t, err)
+	}
+
+	finishJobWithFailure := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s WHERE id = %d", finishedAt, PermissionsSyncJobStateFailed, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	finishJobWithCancel := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s, cancel = true WHERE id = %d", finishedAt, PermissionsSyncJobStateCanceled, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	finishJob := func(t *testing.T, id int, finishedAt time.Time) {
+		t.Helper()
+
+		query := sqlf.Sprintf("UPDATE permission_sync_jobs SET finished_at = %s, state = %s WHERE id = %d", finishedAt, PermissionsSyncJobStateCompleted, id)
+
+		_, err = db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		require.NoError(t, err)
+	}
+
+	cleanupJobs := func(t *testing.T) {
+		t.Helper()
+
+		if t.Failed() {
+			return
+		}
+
+		_, err = db.ExecContext(ctx, "TRUNCATE TABLE permission_sync_jobs; ALTER SEQUENCE permission_sync_jobs_id_seq RESTART WITH 1")
+		require.NoError(t, err)
+	}
+
+	t.Run("No jobs", func(t *testing.T) {
+		count, err := store.CountReposWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("No failining sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, repo1.ID) // id = 1
+		createJob(t, repo2.ID) // id = 2
+
+		finishJob(t, 1, clock.Now())
+
+		count, err := store.CountReposWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("No latest failing sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, repo1.ID) // id = 1
+		finishJob(t, 1, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, repo1.ID) // id = 2
+		finishJobWithFailure(t, 2, clock.Now().Add(-1*time.Hour))
+
+		createJob(t, repo2.ID) // id = 3
+		finishJob(t, 3, clock.Now())
+
+		count, err := store.CountReposWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), count, "wrong count")
+	})
+
+	t.Run("With latest failing sync job", func(t *testing.T) {
+		cleanupJobs(t)
+		createJob(t, repo1.ID) // id = 1
+		finishJob(t, 1, clock.Now().Add(-1*time.Hour))
+
+		createJob(t, repo1.ID) // id = 2
+		finishJobWithFailure(t, 2, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, repo1.ID) // id = 3
+		finishJobWithCancel(t, 3, clock.Now().Add(-1*time.Minute))
+
+		createJob(t, repo2.ID) // id = 4
+		finishJobWithFailure(t, 4, clock.Now())
+
+		count, err := store.CountReposWithFailingSyncJob(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), count, "wrong count")
+	})
+}
+
 // createSyncJobs creates 10 sync jobs, half with the ReasonManualUserSync reason
 // and half with the ReasonGitHubUserMembershipRemovedEvent reason.
 func createSyncJobs(t *testing.T, ctx context.Context, userID int32, store PermissionSyncJobStore) {


### PR DESCRIPTION
Add db store methods to find the count of users/repos with the latest sync job failing. 

## Test plan

- unit tests added