### PR TITLE
[perms] Don't mark a job as failed in case of 404 or not implemented

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -1104,6 +1104,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		assert.Greater(t, len(providerStates), 0)
 		for _, ps := range providerStates {
 			if ps.Status == "ERROR" {
 				t.Fatal("Did not expect provider status of ERROR")


### PR DESCRIPTION
Repo permissions sync jobs should not be marked as failed in case of a 404 or ErrUnimplemented. This was the original behaviour of the permissions syncer.

## Test plan

Verified in my local environment.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
