### PR TITLE
embeddings: add scoring function

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -128,9 +128,9 @@ func NewHandler(
 			return
 		}
 
-		res, err := searchRepoEmbeddingIndex(r.Context(), args, readFile, getRepoEmbeddingIndex, getQueryEmbedding)
+		res, err := searchRepoEmbeddingIndex(r.Context(), args, readFile, getRepoEmbeddingIndex, getQueryEmbedding, args.Debug)
 		if err != nil {
-			http.Error(w, "error searching embedding index", http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("error searching embedding index: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
 

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -76,7 +76,7 @@ func searchEmbeddingIndex(
 			EndLine:   row.EndLine,
 			Content:   strings.Join(lines[startLine:endLine], "\n"),
 		}
-		if debug {
+		if debug && len(res.Debug) > idx {
 			results[idx].Debug = res.Debug[idx]
 		}
 	}

--- a/enterprise/internal/embeddings/client.go
+++ b/enterprise/internal/embeddings/client.go
@@ -50,6 +50,9 @@ type EmbeddingsSearchParameters struct {
 	Query            string       `json:"query"`
 	CodeResultsCount int          `json:"codeResultsCount"`
 	TextResultsCount int          `json:"textResultsCount"`
+
+	// If set to "True", EmbeddingSearchResult.Debug will contain useful information about scoring.
+	Debug bool `json:"debug"`
 }
 
 type IsContextRequiredForChatQueryParameters struct {

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -62,8 +62,8 @@ func EmbedRepo(
 	return &embeddings.RepoEmbeddingIndex{RepoName: repoName, Revision: revision, CodeIndex: codeIndex, TextIndex: textIndex}, nil
 }
 
-func createEmptyEmbeddingIndex(columnDimension int) embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata] {
-	return embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata]{
+func createEmptyEmbeddingIndex(columnDimension int) embeddings.EmbeddingIndex {
+	return embeddings.EmbeddingIndex{
 		Embeddings:      []float32{},
 		RowMetadata:     []embeddings.RepoEmbeddingRowMetadata{},
 		ColumnDimension: columnDimension,
@@ -80,7 +80,7 @@ func embedFiles(
 	readFile readFile,
 	maxEmbeddingVectors int,
 	repoPathRanks types.RepoPathRanks,
-) (embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata], error) {
+) (embeddings.EmbeddingIndex, error) {
 	dimensions, err := client.GetDimensions()
 	if err != nil {
 		return createEmptyEmbeddingIndex(dimensions), err
@@ -90,7 +90,7 @@ func embedFiles(
 		return createEmptyEmbeddingIndex(dimensions), nil
 	}
 
-	index := embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata]{
+	index := embeddings.EmbeddingIndex{
 		Embeddings:      make([]float32, 0, len(fileNames)*dimensions),
 		RowMetadata:     make([]embeddings.RepoEmbeddingRowMetadata, 0, len(fileNames)),
 		ColumnDimension: dimensions,

--- a/enterprise/internal/embeddings/index_storage_test.go
+++ b/enterprise/internal/embeddings/index_storage_test.go
@@ -61,12 +61,12 @@ func TestEmbeddingIndexStorage(t *testing.T) {
 	index := &RepoEmbeddingIndex{
 		RepoName: api.RepoName("repo"),
 		Revision: api.CommitID("commit"),
-		CodeIndex: EmbeddingIndex[RepoEmbeddingRowMetadata]{
+		CodeIndex: EmbeddingIndex{
 			Embeddings:      []float32{0.0, 0.1, 0.2},
 			ColumnDimension: 3,
 			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "a.go", StartLine: 0, EndLine: 1}},
 		},
-		TextIndex: EmbeddingIndex[RepoEmbeddingRowMetadata]{
+		TextIndex: EmbeddingIndex{
 			Embeddings:      []float32{1.0, 2.1, 3.2},
 			ColumnDimension: 3,
 			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "b.py", StartLine: 0, EndLine: 1}},
@@ -85,7 +85,7 @@ func TestEmbeddingIndexStorage(t *testing.T) {
 	require.Equal(t, index, downloadedIndex)
 }
 
-func getMockEmbeddingIndex(nRows int, columnDimension int) EmbeddingIndex[RepoEmbeddingRowMetadata] {
+func getMockEmbeddingIndex(nRows int, columnDimension int) EmbeddingIndex {
 	embeddings := make([]float32, nRows*columnDimension)
 	for idx := range embeddings {
 		embeddings[idx] = rand.Float32()
@@ -98,7 +98,7 @@ func getMockEmbeddingIndex(nRows int, columnDimension int) EmbeddingIndex[RepoEm
 		row.FileName = fmt.Sprintf("path/to/file/%d_%d.go", row.StartLine, row.EndLine)
 	}
 
-	return EmbeddingIndex[RepoEmbeddingRowMetadata]{
+	return EmbeddingIndex{
 		Embeddings:      embeddings,
 		ColumnDimension: columnDimension,
 		RowMetadata:     rowMetadata,

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -173,8 +173,8 @@ type score struct {
 }
 
 const (
-	scoreFileRankWeight   float32 = 0.5
-	scoreSimilarityWeight float32 = 0.5
+	scoreFileRankWeight   float32 = 1.0 / 3.0
+	scoreSimilarityWeight float32 = 2.0 / 3.0
 )
 
 func (index *EmbeddingIndex[T]) score(query []float32, i int, debug bool) score {

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -129,15 +129,16 @@ func (index *EmbeddingIndex[T]) SimilaritySearch(query []float32, numResults int
 		RowMetadata: make([]*T, numResults),
 	}
 
-	if debug {
-		results.Debug = make([]string, numResults)
-	}
 	for idx := 0; idx < min(numResults, len(neighbors)); idx++ {
 		results.RowMetadata[idx] = &index.RowMetadata[neighbors[idx].index]
 		if debug {
+			if results.Debug == nil {
+				results.Debug = make([]string, numResults)
+			}
 			results.Debug[idx] = neighbors[idx].score.debug
 		}
 	}
+
 	return results
 }
 

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -2,6 +2,7 @@ package embeddings
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestSimilaritySearch(t *testing.T) {
 			for q := 0; q < numQueries; q++ {
 				t.Run(fmt.Sprintf("find nearest neighbors query=%d numResults=%d numWorkers=%d", q, numResults, numWorkers), func(t *testing.T) {
 					query := queries[q*columnDimension : (q+1)*columnDimension]
-					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0})
+					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, false).RowMetadata
 					expectedResults := getExpectedResults(ranks[q])
 					require.Equal(t, expectedResults[:min(numResults, len(expectedResults))], results)
 				})
@@ -152,8 +153,35 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 	for _, numWorkers := range []int{1, 2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("numWorkers=%d", numWorkers), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers})
+				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, false)
 			}
 		})
+	}
+}
+
+func TestScore(t *testing.T) {
+	var ranks []float32
+	for i := 1; i < len(embeddings); i++ {
+		ranks = append(ranks, float32(i))
+	}
+
+	columnDimension := 3
+	index := &EmbeddingIndex[RepoEmbeddingRowMetadata]{
+		Embeddings:      embeddings,
+		ColumnDimension: columnDimension,
+		Ranks:           ranks,
+	}
+	// embeddings[0] = 0.5061, 0.6595, 0.5558
+	// queries[0:3] = 0.4227, 0.4874, 0.7641
+	result := index.score(queries[0:columnDimension], 0, true)
+
+	// Check that the score is correct
+	expectedScore := scoreSimilarityWeight*((0.5061*0.4227)+(0.6595*0.4874)+(0.5558*0.7641)) + scoreFileRankWeight*(1.0/32.0)
+	if math.Abs(float64(result.score-expectedScore)) > 0.0001 {
+		t.Fatalf("Expected score %.4f, but got %.4f", expectedScore, result.score)
+	}
+
+	if result.debug == "" {
+		t.Fatal("Expected a non-empty debug string")
 	}
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -173,15 +173,15 @@ func TestScore(t *testing.T) {
 	}
 	// embeddings[0] = 0.5061, 0.6595, 0.5558
 	// queries[0:3] = 0.4227, 0.4874, 0.7641
-	result := index.score(queries[0:columnDimension], 0, true)
+	score, debugInfo := index.score(queries[0:columnDimension], 0, true)
 
 	// Check that the score is correct
 	expectedScore := scoreSimilarityWeight*((0.5061*0.4227)+(0.6595*0.4874)+(0.5558*0.7641)) + scoreFileRankWeight*(1.0/32.0)
-	if math.Abs(float64(result.score-expectedScore)) > 0.0001 {
-		t.Fatalf("Expected score %.4f, but got %.4f", expectedScore, result.score)
+	if math.Abs(float64(score-expectedScore)) > 0.0001 {
+		t.Fatalf("Expected score %.4f, but got %.4f", expectedScore, score)
 	}
 
-	if result.debug == "" {
+	if debugInfo == "" {
 		t.Fatal("Expected a non-empty debug string")
 	}
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -47,7 +47,7 @@ var ranks = [][]int{
 
 func TestSimilaritySearch(t *testing.T) {
 	numRows, numQueries, columnDimension := 16, 3, 3
-	index := EmbeddingIndex[RepoEmbeddingRowMetadata]{
+	index := EmbeddingIndex{
 		Embeddings:      embeddings,
 		ColumnDimension: columnDimension,
 		RowMetadata:     []RepoEmbeddingRowMetadata{},
@@ -57,10 +57,10 @@ func TestSimilaritySearch(t *testing.T) {
 		index.RowMetadata = append(index.RowMetadata, RepoEmbeddingRowMetadata{FileName: fmt.Sprintf("%d", i)})
 	}
 
-	getExpectedResults := func(queryRanks []int) []*RepoEmbeddingRowMetadata {
-		results := make([]*RepoEmbeddingRowMetadata, len(queryRanks))
+	getExpectedResults := func(queryRanks []int) []EmbeddingSearchResult {
+		results := make([]EmbeddingSearchResult, len(queryRanks))
 		for idx, rank := range queryRanks {
-			results[rank] = &index.RowMetadata[idx]
+			results[rank].RepoEmbeddingRowMetadata = index.RowMetadata[idx]
 		}
 		return results
 	}
@@ -70,7 +70,7 @@ func TestSimilaritySearch(t *testing.T) {
 			for q := 0; q < numQueries; q++ {
 				t.Run(fmt.Sprintf("find nearest neighbors query=%d numResults=%d numWorkers=%d", q, numResults, numWorkers), func(t *testing.T) {
 					query := queries[q*columnDimension : (q+1)*columnDimension]
-					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, false).RowMetadata
+					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, false)
 					expectedResults := getExpectedResults(ranks[q])
 					require.Equal(t, expectedResults[:min(numResults, len(expectedResults))], results)
 				})
@@ -141,7 +141,7 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 	numRows := 1_000_000
 	numResults := 100
 	columnDimension := 1536
-	index := &EmbeddingIndex[RepoEmbeddingRowMetadata]{
+	index := &EmbeddingIndex{
 		Embeddings:      getRandomEmbeddings(prng, numRows*columnDimension),
 		ColumnDimension: columnDimension,
 		RowMetadata:     make([]RepoEmbeddingRowMetadata, numRows),
@@ -166,7 +166,7 @@ func TestScore(t *testing.T) {
 	}
 
 	columnDimension := 3
-	index := &EmbeddingIndex[RepoEmbeddingRowMetadata]{
+	index := &EmbeddingIndex{
 		Embeddings:      embeddings,
 		ColumnDimension: columnDimension,
 		Ranks:           ranks,

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -1,12 +1,19 @@
 package embeddings
 
-import "github.com/sourcegraph/sourcegraph/internal/api"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
 
 type EmbeddingIndex[T any] struct {
 	Embeddings      []float32
 	ColumnDimension int
 	RowMetadata     []T
 	Ranks           []float32
+}
+
+type SimilaritySearchResult[T any] struct {
+	RowMetadata []*T
+	Debug       []string
 }
 
 type RepoEmbeddingRowMetadata struct {
@@ -37,4 +44,6 @@ type EmbeddingSearchResult struct {
 	StartLine int    `json:"startLine"`
 	EndLine   int    `json:"endLine"`
 	Content   string `json:"content"`
+	// Experimental: Clients should not rely on any particular format of debug
+	Debug string `json:"debug,omitempty"`
 }

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -4,29 +4,24 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-type EmbeddingIndex[T any] struct {
+type EmbeddingIndex struct {
 	Embeddings      []float32
 	ColumnDimension int
-	RowMetadata     []T
+	RowMetadata     []RepoEmbeddingRowMetadata
 	Ranks           []float32
 }
 
-type SimilaritySearchResult[T any] struct {
-	RowMetadata []*T
-	Debug       []string
-}
-
 type RepoEmbeddingRowMetadata struct {
-	FileName  string
-	StartLine int
-	EndLine   int
+	FileName  string `json:"fileName"`
+	StartLine int    `json:"startLine"`
+	EndLine   int    `json:"endLine"`
 }
 
 type RepoEmbeddingIndex struct {
 	RepoName  api.RepoName
 	Revision  api.CommitID
-	CodeIndex EmbeddingIndex[RepoEmbeddingRowMetadata]
-	TextIndex EmbeddingIndex[RepoEmbeddingRowMetadata]
+	CodeIndex EmbeddingIndex
+	TextIndex EmbeddingIndex
 }
 
 type ContextDetectionEmbeddingIndex struct {
@@ -40,10 +35,8 @@ type EmbeddingSearchResults struct {
 }
 
 type EmbeddingSearchResult struct {
-	FileName  string `json:"fileName"`
-	StartLine int    `json:"startLine"`
-	EndLine   int    `json:"endLine"`
-	Content   string `json:"content"`
+	RepoEmbeddingRowMetadata
+	Content string `json:"content"`
 	// Experimental: Clients should not rely on any particular format of debug
 	Debug string `json:"debug,omitempty"`
 }


### PR DESCRIPTION
related to #49710

This adds a scoring function which computes the weighted sum of cosine similarity and document rank.

For now, the similarity and file rank weights are in a  2:1 ratio. 

Anecdotically, I saw in my experiments how a 'go.sum' file (with high similarity) was ranked down because of its low document rank.

I also added a new field "debug" (bool) to the API which, similarily to Zoekt, adds debug information about the score to the response if set to `true`.

The API change is backward compatible.

## Test plan
- new unit test
- manual testing:
  - Tested embeddings API for the following scenarios
    - repo has ranks but no embeddings -> error
    - repo has embeddings but no document ranks -> reponse with ranking based soley on embeddings
    - repo has embeddings and document ranks   -> response with ranking based on weighted sum
  - Confirmed that not setting `Debug=true` omits `Debug` from the response
  - Confirmed that "old" indexes continue to work
