### PR TITLE
Fix Bitbucket Server exclude repo to use project key instead of name

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -221,7 +221,7 @@ func ExcludableRepoName(repository *types.Repo, logger log.Logger) (name string)
 			if repo.Project == nil {
 				return
 			}
-			name = fmt.Sprintf("%s/%s", repo.Project.Name, repo.Name)
+			name = fmt.Sprintf("%s/%s", repo.Project.Key, repo.Name)
 		} else {
 			logger.Error("invalid repo metadata schema", log.String("extSvcType", extsvc.TypeBitbucketServer))
 		}

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -153,7 +153,7 @@ func makeBitbucketServerRepo() *types.Repo {
 		Slug: "jsonrpc2",
 		Project: &bitbucketserver.Project{
 			Key:  "SOURCEGRAPH",
-			Name: "SOURCEGRAPH",
+			Name: "Sourcegraph e2e testing",
 		},
 	}
 


### PR DESCRIPTION
The excludable repo name should be created from the `Project.Key` (i.e. `pjlast`) and not the `Project.Name` (i.e. `Petri-Johan Last`)

## Test plan

Tests updated

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
