### PR TITLE
chore: use Apollo cache eviction instead of `location.reload()`

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -36,7 +36,13 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
         } catch (error) {
             setIsDeleting(asError(error))
         } finally {
-            window.location.reload()
+            const deletedCodeHostId = client.cache.identify({
+                __typename: 'ExternalService',
+                id: node.id,
+            })
+
+            // Remove deleted code host from the apollo cache.
+            client.cache.evict({ id: deletedCodeHostId })
         }
     }, [node, client])
 


### PR DESCRIPTION
_Modern problems require modern solutions._

Test plan:
Local sg run and verify that removed code host is removed from the list without manual reload.

Follow-up to @vovakulikov's finding [here](https://github.com/sourcegraph/sourcegraph/pull/46383#discussion_r1142687432)

## App preview:

- [Web](https://sg-web-ao-ui-chore-use-bleeding-edge-tecc.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
