### PR TITLE
Fix useObservable

### DIFF
--- a/client/wildcard/src/hooks/useObservable.ts
+++ b/client/wildcard/src/hooks/useObservable.ts
@@ -17,6 +17,8 @@ export function useObservable<T>(observable: Observable<T>): T | undefined {
     const [error, setError] = useState<any>()
     const [currentValue, setCurrentValue] = useState<T>()
 
+    // We use a layout effect to avoid UI tearing when the observable is updated because otherwise
+    // the page will be rendered with the old value after the first render pass.
     useLayoutEffect(() => {
         setCurrentValue(undefined)
         const subscription = observable.subscribe({ next: setCurrentValue, error: setError })

--- a/client/wildcard/src/hooks/useObservable.ts
+++ b/client/wildcard/src/hooks/useObservable.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useLayoutEffect, useEffect, useState, useMemo, useCallback } from 'react'
 
 import { Observable, Observer, Subject } from 'rxjs'
 
@@ -17,7 +17,7 @@ export function useObservable<T>(observable: Observable<T>): T | undefined {
     const [error, setError] = useState<any>()
     const [currentValue, setCurrentValue] = useState<T>()
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         setCurrentValue(undefined)
         const subscription = observable.subscribe({ next: setCurrentValue, error: setError })
         return () => subscription.unsubscribe()


### PR DESCRIPTION
This fixes an issue with `useObservable`. The previous implementation would always render with the incorrect `observable` during the first render pass which caused some significant layout flickering all over the app.

Here's an example where stale data causes the content list to disappear between navigation of the tree view:

https://user-images.githubusercontent.com/458591/226912011-35be0df6-c785-48fc-b23b-7c1337d49db1.mov

To fix this, we need to make sure the setCurrentValue callback is called before we yield the rendering to the browser so that the content is in sync with the observable.

I assume this to also prevent some similar tearing in other parts of the app.  

For reference, I also found this open-source implementation that was [going through the same issue](https://github.com/streamich/react-use/commit/376eea322d11ecca5c9d48ab09e83a29f4e4c687). 

## Test plan

https://user-images.githubusercontent.com/458591/226912124-33fbbc9d-7238-428f-9f5e-10309e3827d6.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-useobservable.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
