### PR TITLE
experimental search input: Properly submit query when using toggle buttons

### DIFF
--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -114,6 +114,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                         setSearchMode={setSearchMode}
                         settingsCascade={props.settingsCascade}
                         navbarSearchQuery={queryState.query}
+                        submitSearch={submitSearchOnChange}
                     />
                 </LazyExperimentalSearchInput>
             </Form>


### PR DESCRIPTION
Selecting a toggle button on the search results page will trigger a new search but not update the URL, causing the toggle to not persist when navigating to/from the URL/page.

Slack thread: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1679426439501639


## Test plan
Go to https://sourcegraph.test:3443/search?q=context:global+test, click the regexp toggle button -> the URL updates to include the regexp pattern type.

## App preview:

- [Web](https://sg-web-fkling-search-input-submit-on.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

