### PR TITLE
ListMinimalRepos: Preallocate memory based on ID count

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -883,6 +883,8 @@ func (s *repoStore) ListMinimalRepos(ctx context.Context, opt ReposListOptions) 
 	preallocSize := 128
 	if opt.LimitOffset != nil {
 		preallocSize = opt.Limit
+	} else if len(opt.IDs) > 0 {
+		preallocSize = len(opt.IDs)
 	}
 	if preallocSize > 4096 {
 		preallocSize = 4096


### PR DESCRIPTION
This should help a bit with queries where we query by a large set of IDs.

## Test plan

Test suite should find issues.