### PR TITLE
bazel: fix unbound var

### DIFF
--- a/cmd/migrator/build.sh
+++ b/cmd/migrator/build.sh
@@ -3,7 +3,7 @@
 # This script builds the migrator docker image.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
-set -eu
+set -ex
 
 OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {


### PR DESCRIPTION
Remove -u flag for this build script, as this currently breaks and is optional 


## Test plan

Local test without var works

