### PR TITLE
bazel: build worker with bazel

### DIFF
--- a/cmd/worker/build.sh
+++ b/cmd/worker/build.sh
@@ -3,13 +3,32 @@
 # This script builds the worker docker image.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
-set -eu
+set -ex
 
 OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {
   rm -rf "$OUTPUT"
 }
 trap cleanup EXIT
+
+
+if [[ "$DOCKER_BAZEL" == "true" ]]; then
+
+  bazel build //cmd/worker \
+    --stamp \
+    --workspace_status_command=./dev/bazel_stamp_vars.sh \
+    --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+
+  out=$(bazel cquery //cmd/worker --output=files)
+  cp "$out" "$OUTPUT"
+
+  docker build -f cmd/worker/Dockerfile -t "$IMAGE" "$OUTPUT" \
+    --progress=plain \
+    --build-arg COMMIT_SHA \
+    --build-arg DATE \
+    --build-arg VERSION
+  exit $?
+fi
 
 # Environment for building linux binaries
 export GO111MODULE=on


### PR DESCRIPTION
use bazel to get the worker output and use it in the docker container



## Test plan
green ci and tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
