### PR TITLE
ux: improve site admin code host page path

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -124,17 +124,18 @@ export const ExternalServiceEditPage: FC<Props> = ({
                             { icon: mdiCog },
                             { to: '/site-admin/external-services', text: 'Code hosts' },
                             {
+                                to: `/site-admin/external-services/${externalService.id}`,
                                 text: (
                                     <>
-                                        {externalService.displayName}
                                         {externalServiceCategory && (
                                             <Icon
                                                 inline={true}
                                                 as={externalServiceCategory.icon}
                                                 aria-label="Code host logo"
-                                                className="ml-2"
+                                                className="mr-2"
                                             />
                                         )}
+                                        {externalService.displayName}
                                     </>
                                 ),
                             },

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -183,7 +183,21 @@ export const ExternalServicePage: FC<Props> = props => {
                         path={[
                             { icon: mdiCog },
                             { to: '/site-admin/external-services', text: 'Code hosts' },
-                            { text: externalService.displayName },
+                            {
+                                text: (
+                                    <>
+                                        {externalServiceCategory && (
+                                            <Icon
+                                                inline={true}
+                                                as={externalServiceCategory.icon}
+                                                aria-label="Code host logo"
+                                                className="mr-2"
+                                            />
+                                        )}
+                                        {externalService.displayName}
+                                    </>
+                                ),
+                            },
                         ]}
                         byline={
                             <CreatedByAndUpdatedByInfoByline


### PR DESCRIPTION
## Description

added the icon of the code host to the path on both normal page and edit page, to make it more consistent

changed the code host display name to be a link on the edit page so that it is easier for the user to navigate away from the edit mode and also visually show that it is edit mode (link is blue)

## Screenshots

### Before

<img width="899" alt="Screenshot 2023-03-22 at 17 18 38" src="https://user-images.githubusercontent.com/9974711/226970166-fc7214e5-9a9a-4a90-961d-e622d702c9cd.png">
<img width="900" alt="Screenshot 2023-03-22 at 17 18 47" src="https://user-images.githubusercontent.com/9974711/226970174-a49b0579-c069-499f-bf85-612ccea657c7.png">


### After

<img width="899" alt="Screenshot 2023-03-22 at 17 18 20" src="https://user-images.githubusercontent.com/9974711/226970216-431e8c3f-17a9-44ef-92bc-6b68c570f996.png">
<img width="902" alt="Screenshot 2023-03-22 at 17 18 28" src="https://user-images.githubusercontent.com/9974711/226970212-a423aa05-c14f-4e1e-8060-698f03e71b2b.png">

## Test plan

Tested locally, UI changes only

## App preview:

- [Web](https://sg-web-milan-code-host-paths.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
