### PR TITLE
Fix panic if codeowners file is invalid

### DIFF
--- a/enterprise/internal/own/codeowners/file.go
+++ b/enterprise/internal/own/codeowners/file.go
@@ -85,5 +85,9 @@ func (r *CompiledRule) match(filePath string) bool {
 		// For now, we ignore errors.
 		r.glob, _ = paths.Compile(r.proto.GetPattern())
 	})
+	// If we saw any error on compiling the glob, we just treat this as a no-match case.
+	if r.glob == nil {
+		return false
+	}
 	return r.glob.Match(filePath)
 }


### PR DESCRIPTION
From a panic on dotcom,

Looking at the code, I think it’s that r.glob can be nil
```
	r.compileOnce.Do(func() {
		// For now, we ignore errors.
		r.glob, _ = paths.Compile(r.proto.GetPattern())
	})
	return r.glob.Match(filePath)
```

This is the only error case I think.

```
	for _, part := range strings.Split(strings.Trim(pattern, separator), separator) {
		switch part {
		case "":
			return nil, errors.New("two consecutive forward slashes")
```

## Test plan

CI.