### PR TITLE
batches: hide list page tabs on dotcom

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -83,17 +83,23 @@ const MOCKS_FOR_NAMESPACE = new WildcardMockLink([
     },
 ])
 
-export const ListOfBatchChanges: Story = args => (
+interface Args {
+    canCreate: boolean
+    isDotCom: boolean
+    isApp: boolean
+}
+
+export const ListOfBatchChanges: Story<Args> = args => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
                 <BatchChangeListPage
                     {...props}
                     headingElement="h1"
-                    canCreate={args.canCreate}
+                    canCreate={args.canCreate || "You don't have permission to create batch changes"}
                     settingsCascade={EMPTY_SETTINGS_CASCADE}
-                    isSourcegraphDotCom={false}
-                    isSourcegraphApp={false}
+                    isSourcegraphDotCom={args.isDotCom}
+                    isSourcegraphApp={args.isApp}
                     authenticatedUser={null}
                 />
             </MockedTestProvider>
@@ -105,6 +111,16 @@ ListOfBatchChanges.argTypes = {
         name: 'can create batch changes',
         control: { type: 'boolean' },
         defaultValue: true,
+    },
+    isDotCom: {
+        name: 'is sourcegraph.com',
+        control: { type: 'boolean' },
+        defaultValue: false,
+    },
+    isApp: {
+        name: 'is Sourcegraph App',
+        control: { type: 'boolean' },
+        defaultValue: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -330,7 +330,7 @@ const BatchChangeListTabHeader: React.FunctionComponent<
         selectedTab: SelectedTab
         setSelectedTab: (selectedTab: SelectedTab) => void
     }>
-> = ({ selectedTab, setSelectedTab, isSourcegraphDotCom }) => {
+> = ({ selectedTab, setSelectedTab }) => {
     const onSelectBatchChanges = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -197,11 +197,9 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 </LimitedAccessBanner>
             )}
             <BatchChangesListIntro isLicensed={licenseAndUsageInfo?.batchChanges || licenseAndUsageInfo?.campaigns} />
-            <BatchChangeListTabHeader
-                selectedTab={selectedTab}
-                setSelectedTab={setSelectedTab}
-                isSourcegraphDotCom={isSourcegraphDotCom}
-            />
+            {!isSourcegraphDotCom && (
+                <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+            )}
             {selectedTab === 'gettingStarted' && (
                 <GettingStarted
                     canCreate={canCreate}
@@ -331,7 +329,6 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     React.PropsWithChildren<{
         selectedTab: SelectedTab
         setSelectedTab: (selectedTab: SelectedTab) => void
-        isSourcegraphDotCom: boolean
     }>
 > = ({ selectedTab, setSelectedTab, isSourcegraphDotCom }) => {
     const onSelectBatchChanges = useCallback<React.MouseEventHandler>(
@@ -351,21 +348,19 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     return (
         <nav className="overflow-auto mb-2" aria-label="Batch Changes">
             <div className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap" role="tablist">
-                {!isSourcegraphDotCom && (
-                    <div className="nav-item">
-                        <Link
-                            to=""
-                            onClick={onSelectBatchChanges}
-                            className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
-                            aria-selected={selectedTab === 'batchChanges'}
-                            role="tab"
-                        >
-                            <span className="text-content" data-tab-content="All batch changes">
-                                All batch changes
-                            </span>
-                        </Link>
-                    </div>
-                )}
+                <div className="nav-item">
+                    <Link
+                        to=""
+                        onClick={onSelectBatchChanges}
+                        className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
+                        aria-selected={selectedTab === 'batchChanges'}
+                        role="tab"
+                    >
+                        <span className="text-content" data-tab-content="All batch changes">
+                            All batch changes
+                        </span>
+                    </Link>
+                </div>
                 <div className="nav-item">
                     <Link
                         to=""


### PR DESCRIPTION
We only show the single "Getting Started" tab on sourcegraph.com, so there's not much value to showing the tab headers for it. This PR hides them on dotcom and additionally adds Storybook story coverage for the variant of that page on dotcom.

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/8942601/226993942-6f305f8d-c521-4c88-9dce-0a07473cb3a5.png">

## Test plan

Verified in Storybook.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-hide-tab-dotcom.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
