### PR TITLE
Setup Experience: Empty string path should be treated as invalid path

### DIFF
--- a/cmd/frontend/graphqlbackend/app.go
+++ b/cmd/frontend/graphqlbackend/app.go
@@ -88,6 +88,11 @@ func (r *appResolver) LocalDirectory(ctx context.Context, args *LocalDirectoryAr
 		return nil, err
 	}
 
+	// we will not assume current working directory when localDirectoryResolver conducts discovery on path
+	if args.Dir == "" {
+		return nil, nil
+	}
+
 	path, err := filepath.Abs(args.Dir)
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/app.go
+++ b/cmd/frontend/graphqlbackend/app.go
@@ -90,7 +90,7 @@ func (r *appResolver) LocalDirectory(ctx context.Context, args *LocalDirectoryAr
 
 	// we will not assume current working directory when localDirectoryResolver conducts discovery on path
 	if args.Dir == "" {
-		return nil, nil
+		return nil, errors.New("Path must be non-empty string")
 	}
 
 	path, err := filepath.Abs(args.Dir)


### PR DESCRIPTION
TLDR: we have several scenarios (described in more detail in another comment) where `root` property of the Other local repo configuration is empty string, usually when we want to skip discovery/sync of local repos altogether. `filepath.Abs("")` call means we'll end up discovering on current working directory. This is a swift fix and we can revisit empty string + local sync'd repos behavior after Starship.

---- 

In setup wizard we display currently sync'd local repos on step 1:
![image](https://user-images.githubusercontent.com/105310278/226998408-09de03d8-90e0-4fdf-b840-a2e7d935ed01.png)

This is done by calling [`localDiscovery()`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/app.go?L85) graphql query and using the path obtained from [`localExternalServices() `](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/app.go?L147). 

In this previous [PR]( https://github.com/sourcegraph/sourcegraph/pull/49744) we skip discovery in `Walk()` when path is empty string, and in this new PR we add a similar check for the graphql discovery call. Without this new check we'll report repos in cwd even if we're not sync'ing them. E.g. in the above screenshot my service has `root:""` but still says we've got repos sync'ing. With the fix I get:

![image](https://user-images.githubusercontent.com/105310278/226999468-556c6b94-2657-4ed0-8092-4b22e0ef6102.png)

In this new check I return an error which is not displaying in the setup wizard but can be viewed in api console at least:
![image](https://user-images.githubusercontent.com/105310278/226999570-608a8871-5bc4-40fe-9937-25f0c17eba59.png)

Predecessor / Related PR: https://github.com/sourcegraph/sourcegraph/pull/49744


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

sg start app SRC=""
run setup wizard -> check step 1 for currently sync'd local repos
