### PR TITLE
Setup Wizard: Reset last visited step id when setup is finished

### DIFF
--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -75,10 +75,15 @@ export const SetupWizard: FC<SetupWizardProps> = props => {
     const steps = useMemo(() => (isSourcegraphApp ? SOURCEGRAPH_APP_STEPS : CORE_STEPS), [isSourcegraphApp])
 
     const handleStepChange = useCallback(
-        (step: StepConfiguration): void => {
-            setStepId(step.id)
+        (nextStep: StepConfiguration): void => {
+            const currentStepIndex = steps.findIndex(step => step.id === nextStep.id)
+            const isLastStep = currentStepIndex === steps.length - 1
+
+            // Reset the last visited step if you're on the last step in the
+            // setup pipeline
+            setStepId(!isLastStep ? nextStep.id : '')
         },
-        [setStepId]
+        [setStepId, steps]
     )
 
     const handleSkip = useCallback(() => {


### PR DESCRIPTION
This PR improves the setup URL redirection a little bit. Prior to this if you completed your setup flow in the wizard and go back to the wizard (/setup) later, you will see the last visited setup step (the last step in the wizard, sync repositories) 

But resetting the last visited step info makes more sense if you have completed the setup, and the next visit to /setup will lead you to the first setup step page.

## Test plan
- Check in this Sourcegraph App that we still preserve steps if you haven't finished the setup (for example, skip the wizard on the second step and click go to setup wizard in the menu); it should lead you to the second step 
- Check that if you've finished the setup flow, the next visit /setup will lead you to the first step UI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-reset-last-visited-setup-step.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
