### PR TITLE
Revert "diff search: Don't duplicate hunk body in memory (#49859)"

### DIFF
--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"bufio"
 	"bytes"
 	"unicode/utf8"
 
@@ -159,11 +158,7 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (CommitFilterResult, MatchedCommit,
 		var hunkHighlights map[int]MatchedHunk
 		for hunkIdx, hunk := range fileDiff.Hunks {
 			var lineHighlights map[int]result.Ranges
-			sc := bufio.NewScanner(bytes.NewReader(hunk.Body))
-			lineIdx := -1
-			for sc.Scan() {
-				lineIdx++
-				line := sc.Bytes()
+			for lineIdx, line := range bytes.Split(hunk.Body, []byte("\n")) {
 				if len(line) == 0 {
 					continue
 				}
@@ -182,9 +177,6 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (CommitFilterResult, MatchedCommit,
 					}
 					lineHighlights[lineIdx] = matchesToRanges(lineWithoutPrefix, matches)
 				}
-			}
-			if err := sc.Err(); err != nil {
-				return filterResult(false), MatchedCommit{}, err
 			}
 
 			if len(lineHighlights) > 0 {


### PR DESCRIPTION
This reverts commit e4aa8814475603437bc77f539fe2c3fc28486656.

Seeing

```
--- FAIL: TestSearch/graphql_with_file_ranking (3.06s)
  | --- FAIL: TestSearch/graphql_with_file_ranking/Select_Queries (0.34s)
  | --- FAIL: TestSearch/graphql_with_file_ranking/Select_Queries/select_diffs_with_removed_lines_containing_pattern (0.05s)
  | search_test.go:1445: request GraphQL: rpc error: code = Unknown desc = bufio.Scanner: token too long
```

## Test plan

Revert.