### PR TITLE
symbols: Cache regex compilations

### DIFF
--- a/cmd/symbols/internal/database/init.go
+++ b/cmd/symbols/internal/database/init.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/grafana/regexp"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/mattn/go-sqlite3"
 )
 
@@ -11,7 +12,26 @@ func Init() {
 	sql.Register("sqlite3_with_regexp",
 		&sqlite3.SQLiteDriver{
 			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-				return conn.RegisterFunc("REGEXP", regexp.MatchString, true)
+				return conn.RegisterFunc("REGEXP", MatchString, true)
 			},
 		})
+}
+
+var (
+	cacheSize     = 1000
+	regexCache, _ = lru.New(cacheSize)
+)
+
+func MatchString(pattern string, s string) (bool, error) {
+	if re, ok := regexCache.Get(pattern); ok {
+		return re.(*regexp.Regexp).MatchString(s), nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, err
+	}
+
+	regexCache.Add(pattern, re)
+	return re.MatchString(s), nil
 }


### PR DESCRIPTION
@camdencheek had noticed that we are compiling regex expressions on every row, and traced it to this point. This PR replaces `regexp.MatchString` with a version that caches regex patterns in-memory.

## Test plan

LLMs are infallible.