### PR TITLE
Chore: upgrade to golang-lru/v2

### DIFF
--- a/cmd/symbols/internal/database/init.go
+++ b/cmd/symbols/internal/database/init.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/grafana/regexp"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mattn/go-sqlite3"
 )
 
@@ -19,12 +19,12 @@ func Init() {
 
 var (
 	cacheSize     = 1000
-	regexCache, _ = lru.New(cacheSize)
+	regexCache, _ = lru.New[string, *regexp.Regexp](cacheSize)
 )
 
 func MatchString(pattern string, s string) (bool, error) {
 	if re, ok := regexCache.Get(pattern); ok {
-		return re.(*regexp.Regexp).MatchString(s), nil
+		return re.MatchString(s), nil
 	}
 
 	re, err := regexp.Compile(pattern)

--- a/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
+++ b/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
@@ -1,7 +1,7 @@
 package shared
 
 import (
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -11,14 +11,14 @@ const QUERY_EMBEDDING_RETRIES = 3
 const QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES = 128
 
 func getCachedQueryEmbeddingFn(client embed.EmbeddingsClient) (getQueryEmbeddingFn, error) {
-	cache, err := lru.New(QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES)
+	cache, err := lru.New[string, []float32](QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating query embeddings cache")
 	}
 
 	return func(query string) (queryEmbedding []float32, err error) {
 		if cachedQueryEmbedding, ok := cache.Get(query); ok {
-			queryEmbedding = cachedQueryEmbedding.([]float32)
+			queryEmbedding = cachedQueryEmbedding
 		} else {
 			queryEmbedding, err = client.GetEmbeddingsWithRetries([]string{query}, QUERY_EMBEDDING_RETRIES)
 			if err != nil {

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -28,7 +28,7 @@ func getCachedRepoEmbeddingIndex(
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn,
 ) (getRepoEmbeddingIndexFn, error) {
-	cache, err := lru.New(REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES)
+	cache, err := lru.New[embeddings.RepoEmbeddingIndexName, repoEmbeddingIndexCacheEntry](REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating repo embedding index cache")
 	}
@@ -59,12 +59,11 @@ func getCachedRepoEmbeddingIndex(
 		// Check if the index is in the cache.
 		if ok {
 			// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
-			repoEmbeddingIndexCacheEntry := cacheEntry.(repoEmbeddingIndexCacheEntry)
-			if lastFinishedRepoEmbeddingJob.FinishedAt.After(repoEmbeddingIndexCacheEntry.finishedAt) {
+			if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
 				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
 			}
 			// Otherwise, return the cached index.
-			return repoEmbeddingIndexCacheEntry.index, nil
+			return cacheEntry.index, nil
 		}
 		// We do not have the index in the cache. Download and cache it.
 		return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/graph-gophers/graphql-go v1.5.0
 	github.com/graphql-go/graphql v0.8.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hexops/valast v1.4.3
 	github.com/honeycombio/libhoney-go v1.15.8
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
@@ -219,6 +219,7 @@ require (
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20210128111500-3ff779b52992 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect

--- a/go.sum
+++ b/go.sum
@@ -948,6 +948,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
+github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/internal/encryption/cache/cache.go
+++ b/internal/encryption/cache/cache.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"hash/fnv"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 )
 
 // New returns a cache.Key with an LRU cache of `size` values, wrapping the passed key.
 func New(k encryption.Key, size int) (*Key, error) {
-	c, err := lru.NewWithEvict(size, func(key, value any) { evictTotal.WithLabelValues().Inc() })
+	c, err := lru.NewWithEvict(size, func(key uint64, value encryption.Secret) { evictTotal.WithLabelValues().Inc() })
 	if err != nil {
 		return nil, err
 	}
@@ -26,16 +26,15 @@ func New(k encryption.Key, size int) (*Key, error) {
 type Key struct {
 	encryption.Key
 
-	cache *lru.Cache
+	cache *lru.Cache[uint64, encryption.Secret]
 }
 
 // Decrypt attempts to find the decrypted ciphertext in the cache, if it is not found, the
 // underlying key implementation is used, and the result is added to the cache.
 func (k *Key) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Secret, error) {
 	key := hash(ciphertext)
-	v, found := k.cache.Get(key)
-	s, ok := v.(encryption.Secret)
-	if !ok || !found {
+	s, found := k.cache.Get(key)
+	if !found {
 		missTotal.WithLabelValues().Inc()
 		s, err := k.Key.Decrypt(ctx, ciphertext)
 		if err != nil {


### PR DESCRIPTION
We are using a pre-1.0 version of golang-lru. This upgrades the package to v2, which also adds support for generics, which is particularly nice because we don't have to deal with fallible type switches.

## Test plan

It compiles + existing tests. This only moves more of the logic into the typesystem.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
