### PR TITLE
app" Hide user avatar and name in Settings in app

### DIFF
--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -39,20 +39,23 @@ export const UserAreaHeader: React.FunctionComponent<React.PropsWithChildren<Pro
      * (every location change, for example). This prevents it from flickering.
      */
     const path = useMemo(
-        () => ({
-            text: (
-                <span className="align-middle">
-                    {props.user.displayName ? (
-                        <>
-                            {props.user.displayName} ({props.user.username})
-                        </>
-                    ) : (
-                        props.user.username
-                    )}
-                </span>
-            ),
-            icon: () => <UserAvatar className={styles.avatar} user={props.user} />,
-        }),
+        () =>
+            props.isSourcegraphApp
+                ? { text: 'Settings' }
+                : {
+                      text: (
+                          <span className="align-middle">
+                              {props.user.displayName ? (
+                                  <>
+                                      {props.user.displayName} ({props.user.username})
+                                  </>
+                              ) : (
+                                  props.user.username
+                              )}
+                          </span>
+                      ),
+                      icon: () => <UserAvatar className={styles.avatar} user={props.user} />,
+                  },
         [props.user]
     )
 


### PR DESCRIPTION
In App, replace the avatar and username in the Settings page with just a "Settings" header.

<img width="882" alt="Screenshot 2023-03-22 at 7 51 36 PM" src="https://user-images.githubusercontent.com/602886/227064672-4aa5582a-35b1-4e02-a980-850440127efe.png">

# Test plan

- Manually check settings page in App
- Check that nothing is broken in non-app mode

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
