### PR TITLE
nix: tidy & static comby+ctags+p4-fusion on linux+darwin

### DIFF
--- a/dev/nix/comby.nix
+++ b/dev/nix/comby.nix
@@ -1,0 +1,34 @@
+{ nixpkgs, lib, utils }:
+lib.genAttrs utils.lib.defaultSystems (system:
+  let
+    inherit (import ./util.nix { inherit (nixpkgs) lib; }) makeStatic unNixifyDylibs;
+    pkgs = nixpkgs.legacyPackages.${system};
+    isMacOS = nixpkgs.legacyPackages.${system}.hostPlatform.isMacOS;
+    combyBuilder = ocamlPkgs: systemDepsPkgs:
+      (ocamlPkgs.comby.override {
+        sqlite = systemDepsPkgs.sqlite;
+        zlib = if isMacOS then systemDepsPkgs.zlib.static else systemDepsPkgs.zlib;
+        libev = (makeStatic (systemDepsPkgs.libev)).override { static = false; };
+        gmp = makeStatic systemDepsPkgs.gmp;
+        ocamlPackages = ocamlPkgs.ocamlPackages.overrideScope' (self: super: {
+          ocaml_pcre = super.ocaml_pcre.override {
+            pcre = makeStatic systemDepsPkgs.pcre;
+          };
+          ssl = super.ssl.override {
+            openssl = (makeStatic systemDepsPkgs.openssl).override { static = true; };
+          };
+        });
+      });
+  in
+  if isMacOS then {
+    comby = unNixifyDylibs pkgs (combyBuilder pkgs pkgs.pkgsStatic);
+  } else {
+    comby = (combyBuilder pkgs.pkgsMusl pkgs.pkgsStatic).overrideAttrs (_: {
+      postPatch = ''
+        cat >> src/dune <<EOF
+        (env (release (flags  :standard -ccopt -static)))
+        EOF
+      '';
+    });
+  }
+)

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -1,0 +1,49 @@
+{ nixpkgs, lib, utils }:
+let
+  inherit (import ./util.nix { inherit (nixpkgs) lib; }) makeStatic unNixifyDylibs;
+in
+rec {
+  overlay = self: super: rec {
+    universal-ctags = super.universal-ctags.overrideAttrs (old: {
+      version = "5.9.20220403.0";
+      src = super.fetchFromGitHub {
+        owner = "universal-ctags";
+        repo = "ctags";
+        rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
+        sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
+      };
+      # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
+      doCheck = false;
+      checkFlags = [ ];
+    });
+  };
+  packages = lib.genAttrs utils.lib.defaultSystems
+    (system:
+      let
+        isMacOS = nixpkgs.legacyPackages.${system}.hostPlatform.isMacOS;
+        pkg = if isMacOS then "pkgs" else "pkgsStatic";
+        pkgs = (import nixpkgs { inherit system; overlays = [ overlay ]; }).${pkg};
+        pkgOverrides = rec {
+          pcre2 = if isMacOS then (makeStatic pkgs.pcre2) else pkgs.pcre2;
+          libyaml = if isMacOS then (makeStatic pkgs.libyaml) else pkgs.libyaml;
+          jansson =
+            if isMacOS then
+              pkgs.jansson.overrideAttrs
+                (oldAttrs: {
+                  cmakeFlags = [ "-DJANSSON_BUILD_SHARED_LIBS=OFF" ];
+                }) else pkgs.jansson;
+        };
+      in
+      {
+        ctags = unNixifyDylibs pkgs ((pkgs.universal-ctags.override {
+          # static python is a hassle, and its only used for docs here so we dont care about
+          # it being static or not
+          python3 = nixpkgs.legacyPackages.${system}.python3;
+          inherit (pkgOverrides) pcre2 libyaml jansson;
+        }).overrideAttrs (_: {
+          # don't include libintl/gettext
+          dontAddExtraLibs = true;
+        }));
+      }
+    );
+}

--- a/dev/nix/p4-fusion.nix
+++ b/dev/nix/p4-fusion.nix
@@ -1,124 +1,137 @@
-{ pkgs
-, lib
-, stdenv
-, fetchzip
-, fetchFromGitHub
-, cmake
-, http-parser
-, libcxx
-, libcxxabi
-, libiconv
-, libssh2
-, openssl_1_1
-, patchelf
-, pcre
-, pkg-config
-, zlib
-, darwin
-, hostPlatform
-}:
+{ nixpkgs, lib, utils }:
 let
-  # utility function to add some best-effort flags for emitting static objects instead of dynamic
-  makeStatic = pkg: pkg.overrideAttrs (oldAttrs: {
-    configureFlags = (oldAttrs.configureFlags or [ ]) ++ [ "--without-shared" "--disable-shared" "--enable-static" ];
-  });
-  http-parser-static = ((makeStatic http-parser).overrideAttrs (oldAttrs: {
-    # http-parser makefile is a bit incomplete, so fill in the gaps here
-    # to move the static object and header files to the right location
-    # https://github.com/nodejs/http-parser/issues/310
-    buildFlags = [ "package" ];
-    installTargets = "package";
-    postInstall = ''
-      install -D libhttp_parser.a $out/lib/libhttp_parser.a
-      install -D  http_parser.h $out/include/http_parser.h
-      ls -la $out/lib $out/include
-    '';
-  }));
-  libiconv-static = (libiconv.override { enableStatic = true; enableShared = false; });
-  openssl-static = (openssl_1_1.override { static = true; }).dev;
-  pcre-static = (makeStatic pcre).dev;
+  inherit (import ./util.nix { inherit (nixpkgs) lib; }) makeStatic unNixifyDylibs;
+  mkP4Fusion =
+    { pkgs
+    , lib
+    , stdenv
+    , fetchzip
+    , fetchFromGitHub
+    , cmake
+    , http-parser
+    , libcxx
+    , libcxxabi
+    , libiconv
+    , libssh2
+    , openssl_1_1
+    , patchelf
+    , pcre
+    , pkg-config
+    , zlib
+    , darwin
+    , targetPlatform
+    }:
+    let
+      http-parser-static = ((makeStatic http-parser).overrideAttrs (oldAttrs: {
+        # http-parser makefile is a bit incomplete, so fill in the gaps here
+        # to move the static object and header files to the right location
+        # https://github.com/nodejs/http-parser/issues/310
+        buildFlags = [ "package" ];
+        installTargets = "package";
+        postInstall = ''
+          install -D libhttp_parser.a $out/lib/libhttp_parser.a
+          install -D  http_parser.h $out/include/http_parser.h
+          ls -la $out/lib $out/include
+        '';
+      }));
+      libiconv-static = makeStatic libiconv;
+      openssl-static = (openssl_1_1.override { static = true; }).dev;
+      pcre-static = (makeStatic pcre).dev;
+    in
+    pkgs.gccStdenv.mkDerivation rec {
+      name = "p4-fusion";
+      version = "v1.12";
+
+      srcs = [
+        (fetchFromGitHub {
+          inherit name;
+          owner = "salesforce";
+          repo = "p4-fusion";
+          rev = "3ee482466464c18e6a635ff4f09cd75a2e1bfe0f";
+          hash = "sha256-rUXuBoXuOUanWxutd7dNgjn2vLFvHQ0IgCIn9vG5dgs=";
+        })
+        (
+          if targetPlatform.isMacOS then
+            if targetPlatform.isAarch64 then
+              fetchzip
+                {
+                  name = "helix-core-api";
+                  url = "https://cdist2.perforce.com/perforce/r22.2/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
+                  hash = "sha256-YO7p24PuedTn2pVq/roF2u5zqS6byaG9N2gCbGVrpv0=";
+                }
+            else
+              fetchzip {
+                name = "helix-core-api";
+                url = "https://cdist2.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
+                hash = "sha256-gaYvQOX8nvMIMHENHB0+uklyLcmeXT5gjGGcVC9TTtE=";
+              }
+          else if targetPlatform.isLinux then
+            fetchzip
+              {
+                name = "helix-core-api";
+                url = "https://cdist2.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
+                hash = "sha256-JkWG4ImrTzN0UuSMelG8zsH7YRlL1mXs9lpB5GptUb4=";
+              }
+          else throw "unsupported platform ${stdenv.targetPlatform.parsed.kernel.name}"
+        )
+      ];
+
+      sourceRoot = name;
+
+      nativeBuildInputs = [
+        patchelf
+        pkg-config
+        cmake
+      ];
+
+      buildInputs = [
+        zlib.static
+        zlib.dev
+        http-parser-static
+        pcre-static
+        openssl-static
+      ] ++ lib.optional targetPlatform.isMacOS [
+        # iconv is bundled with glibc and apparently only needed for osx
+        # https://sourcegraph.com/github.com/salesforce/p4-fusion@3ee482466464c18e6a635ff4f09cd75a2e1bfe0f/-/blob/vendor/libgit2/README.md?L178:3
+        libiconv-static
+        darwin.apple_sdk.frameworks.CFNetwork
+        darwin.apple_sdk.frameworks.Cocoa
+      ];
+
+      # copy helix-core-api stuff into the expected directories, and statically link libstdc++
+      preBuild = let dir = if targetPlatform.isMacOS then "mac" else "linux"; in
+        ''
+          mkdir -p $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}
+          cp -R $NIX_BUILD_TOP/helix-core-api/* $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}
+
+          sed -i "s/target_link_libraries(p4-fusion PUBLIC/target_link_libraries(p4-fusion PUBLIC -static-libstdc++/" \
+            $NIX_BUILD_TOP/$sourceRoot/p4-fusion/CMakeLists.txt
+        '';
+
+      cmakeFlags = [
+        # we want to statically link
+        "-DBUILD_SHARED_LIBS=OFF"
+        # Copied from upstream, where relevant
+        # https://sourcegraph.com/github.com/salesforce/p4-fusion@3ee482466464c18e6a635ff4f09cd75a2e1bfe0f/-/blob/generate_cache.sh?L7-21
+        "-DUSE_SSH=OFF"
+        "-DUSE_HTTPS=OFF"
+        "-DBUILD_CLAR=OFF"
+        # salesforce don't link against GSSAPI in CI, so I won't either
+        "-DUSE_GSSAPI=OFF"
+        # prefer nix-provided http-parser instead of bundled
+        "-DUSE_HTTP_PARSER=system"
+      ];
+
+      postInstall = ''
+        mkdir -p "$out/bin"
+        cp p4-fusion/p4-fusion "$out/bin/p4-fusion"
+      '';
+    };
 in
-stdenv.mkDerivation rec {
-  name = "p4-fusion";
-  version = "v1.12";
-
-  srcs = [
-    (fetchFromGitHub {
-      inherit name;
-      owner = "salesforce";
-      repo = "p4-fusion";
-      rev = "3ee482466464c18e6a635ff4f09cd75a2e1bfe0f";
-      hash = "sha256-rUXuBoXuOUanWxutd7dNgjn2vLFvHQ0IgCIn9vG5dgs=";
-    })
-    (
-      if hostPlatform.isMacOS then
-        if hostPlatform.isAarch64 then
-          fetchzip {
-              name = "helix-core-api";
-              url = "https://cdist2.perforce.com/perforce/r22.2/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
-              hash = "sha256-YO7p24PuedTn2pVq/roF2u5zqS6byaG9N2gCbGVrpv0=";
-            }
-        else
-          fetchzip {
-            name = "helix-core-api";
-            url = "https://cdist2.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
-            hash = "sha256-gaYvQOX8nvMIMHENHB0+uklyLcmeXT5gjGGcVC9TTtE=";
-          }
-      else if hostPlatform.isLinux then
-        fetchzip {
-            name = "helix-core-api";
-            url = "https://cdist2.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
-            hash = "sha256-JkWG4ImrTzN0UuSMelG8zsH7YRlL1mXs9lpB5GptUb4=";
-          }
-      else throw "unsupported platform ${stdenv.targetPlatform.parsed.kernel.name}"
-    )
-  ];
-
-  sourceRoot = name;
-
-  nativeBuildInputs = [
-    patchelf
-    pkg-config
-    cmake
-  ];
-
-  buildInputs = [
-    zlib.static
-    zlib.dev
-    http-parser-static
-    pcre-static
-    openssl-static
-  ] ++ lib.optional hostPlatform.isMacOS [
-    # iconv is bundled with glibc and apparently only needed for osx
-    # https://sourcegraph.com/github.com/salesforce/p4-fusion@3ee482466464c18e6a635ff4f09cd75a2e1bfe0f/-/blob/vendor/libgit2/README.md?L178:3
-    libiconv-static
-    darwin.apple_sdk.frameworks.CFNetwork
-    darwin.apple_sdk.frameworks.Cocoa
-  ];
-
-  # copy helix-core-api stuff into the expected directories
-  preBuild = let dir = if hostPlatform.isMacOS then "mac" else "linux"; in
-    ''
-      mkdir -p $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}
-      cp -R $NIX_BUILD_TOP/helix-core-api/* $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}
-    '';
-
-  cmakeFlags = [
-    # we want to statically link
-    "-DBUILD_SHARED_LIBS=OFF"
-    # Copied from upstream, where relevant
-    # https://sourcegraph.com/github.com/salesforce/p4-fusion@3ee482466464c18e6a635ff4f09cd75a2e1bfe0f/-/blob/generate_cache.sh?L7-21
-    "-DUSE_SSH=OFF"
-    "-DUSE_HTTPS=OFF"
-    "-DBUILD_CLAR=OFF"
-    # salesforce don't link against GSSAPI in CI, so I won't either
-    "-DUSE_GSSAPI=OFF"
-    # prefer nix-provided http-parser instead of bundled
-    "-DUSE_HTTP_PARSER=system"
-  ];
-
-  postInstall = ''
-    mkdir -p "$out/bin"
-    cp p4-fusion/p4-fusion "$out/bin/p4-fusion"
-  '';
-}
+with lib;
+# no aarch64-linux helix-core-api
+genAttrs (remove "aarch64-linux" utils.lib.defaultSystems) (system:
+  {
+    p4-fusion = (import nixpkgs { inherit system; }).pkgsStatic.callPackage mkP4Fusion { };
+  }
+)

--- a/dev/nix/util.nix
+++ b/dev/nix/util.nix
@@ -1,0 +1,28 @@
+{ lib }:
+{
+  # utility function to add some best-effort flags for emitting static objects instead of dynamic
+  makeStatic = pkg:
+    let
+      auto = builtins.intersectAttrs pkg.override.__functionArgs { withStatic = true; static = true; enableStatic = true; enableShared = false; };
+      overridden = pkg.overrideAttrs (oldAttrs: {
+        dontDisableStatic = true;
+      } // lib.optionalAttrs (!(oldAttrs.dontAddStaticConfigureFlags or false)) {
+        configureFlags = (oldAttrs.configureFlags or [ ]) ++ [ "--disable-shared" "--enable-static" "--enable-shared=false" ];
+      });
+    in
+    overridden.override auto;
+
+  # doesn't actually change anything in practice, just makes otool -L not display nix store paths for libiconv and libxml.
+  # they exist in macos dydl cache anyways, so where they point to is irrelevant. worst case, this will let you catch earlier
+  # when a library that should be statically linked or that isnt in dydl cache is dynamically linked.
+  unNixifyDylibs = pkgs: drv:
+    drv.overrideAttrs (oldAttrs: {
+      postFixup = with pkgs; (oldAttrs.postFixup or "") + lib.optionalString pkgs.hostPlatform.isMacOS ''
+        for bin in $(${findutils}/bin/find $out/bin -type f); do
+          for lib in $(otool -L $bin | ${coreutils}/bin/tail -n +2 | ${coreutils}/bin/cut -d' ' -f1 | ${gnugrep}/bin/grep nix); do
+            install_name_tool -change "$lib" "@rpath/$(basename $lib)" $bin
+          done
+        done
+      '';
+    });
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1682268651,
+        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
         "type": "github"
       },
       "original": {
@@ -17,7 +17,41 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,61 +1,29 @@
 {
-  description = "The Sourcegraph developer environment Nix Flake";
+  description = "The Sourcegraph developer environment & packages Nix Flake";
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs }:
-    {
-      devShells = nixpkgs.lib.genAttrs
-        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ]
-        (system:
-          let
-            pkgs = import nixpkgs {
-              inherit system;
-              overlays = [ self.overlays.ctags ];
-            };
-          in
-          {
-            default = import ./shell.nix { inherit pkgs; };
-          }
-        );
-      # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
-      overlays.ctags = self: super: rec {
-        universal-ctags = super.universal-ctags.overrideAttrs (old: {
-          version = "5.9.20220403.0";
-          src = super.fetchFromGitHub {
-            owner = "universal-ctags";
-            repo = "ctags";
-            rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
-            sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
-          };
-          # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
-          doCheck = false;
-          checkFlags = [ ];
-        });
-      };
-
-      # recursiveUpdate is just for recursively merging sets
-      packages = nixpkgs.lib.recursiveUpdate
+  outputs = { self, nixpkgs, utils }:
+    with nixpkgs.lib; with utils.lib; {
+      devShells = eachDefaultSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.ctags ]; };
+        in
         {
-          x86_64-linux.p4-fusion-portable = self.packages.x86_64-linux.p4-fusion.overrideAttrs (oldAttrs: {
-            # patch the ELF interpreter for non-nix(os) distros.
-            postFixup = ''
-              patchelf \
-                --set-interpreter /lib64/ld-linux-x86-64.so.2 \
-                $out/bin/p4-fusion
-            '';
-          });
+          default = pkgs.callPackage ./shell.nix { };
         }
-        (
-          nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
-            let pkgs = import nixpkgs { inherit system; };
-            in
-            {
-              p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
-            }
-          )
-        );
+      );
+
+      # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
+      overlays.ctags = (import ./dev/nix/ctags.nix { inherit nixpkgs utils; }).overlay;
+
+      packages = fold recursiveUpdate { } [
+        ((import ./dev/nix/ctags.nix { inherit nixpkgs utils; inherit (nixpkgs) lib; }).packages)
+        (import ./dev/nix/p4-fusion.nix { inherit nixpkgs utils; inherit (nixpkgs) lib; })
+        (import ./dev/nix/comby.nix { inherit nixpkgs utils; inherit (nixpkgs) lib; })
+      ];
     };
 }


### PR DESCRIPTION
## How to build

`nix build .#ctags .#p4-fusion .#comby` with outputs in `./result{,-1,-2}/bin`

## Static? Prove it

Linux:
```
$ ldd ./result/bin/comby ./result-1/bin/p4-fusion ./result-2/bin/ctags 
./result/bin/comby:
        not a dynamic executable
./result-1/bin/p4-fusion:
        not a dynamic executable
./result-2/bin/ctags:
        not a dynamic executable
```

Darwin (libiconv and libxml are in dylib cache, libSystem.B cannot be statically linked, and the rest are core system libraries):
```
otool -L ./result-1/bin/p4-fusion ./result/bin/comby ./result-2/bin/ctags
./result-1/bin/p4-fusion:
        /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork (compatibility version 1.0.0, current version 1209.1.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1770.255.0)
        /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59754.60.13)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
./result/bin/comby:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
./result-2/bin/ctags:
        @rpath/libxml2.2.dylib (compatibility version 13.0.0, current version 13.3.0)
        @rpath/libiconv.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
```

Review with whitespace changes hidden

## Test plan

Built many many times, checked ldd & otool many many times
