### PR TITLE
wildcard: add `useAnimatedAlert` hook

### DIFF
--- a/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.module.scss
@@ -11,3 +11,8 @@
         align-items: center;
     }
 }
+
+.close-button {
+    height: 1.25rem;
+    color: var(--icon-color);
+}

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -182,18 +182,23 @@ const PublicationStatesUpdateAlerts: React.FunctionComponent<React.PropsWithChil
     return (
         <div className="mt-2">
             {recalculationUpdates.map(([timestamp, status]) => (
-                <AnimatedDismissibleAlert key={timestamp} status={status}>
-                    Publication state actions were recalculated.
-                </AnimatedDismissibleAlert>
+                <AnimatedDismissibleAlert
+                    key={timestamp}
+                    status={status}
+                    message="Publication state actions were recalculated."
+                />
             ))}
         </div>
     )
 }
 
 const AnimatedDismissibleAlert: React.FunctionComponent<
-    React.PropsWithChildren<{ status: 'pending' | 'complete' }>
-> = ({ children, status }) => {
-    const { ref, style, show, dismiss } = useAnimatedAlert({ autoDuration: 'short' })
+    React.PropsWithChildren<{ status: 'pending' | 'complete'; message: string }>
+> = ({ message, status }) => {
+    const { ref, style, isShown, show, dismiss } = useAnimatedAlert({
+        autoDuration: 'short',
+        ariaAnnouncement: { message },
+    })
 
     useEffect(() => {
         // Wait to show publication state update alerts until the connection query
@@ -205,8 +210,14 @@ const AnimatedDismissibleAlert: React.FunctionComponent<
 
     return (
         <animated.div style={style}>
-            <Alert ref={ref} variant="success" className="mb-3 d-flex align-items-center justify-content-between">
-                {children}
+            <Alert
+                ref={ref}
+                variant="success"
+                className="mb-3 d-flex align-items-center justify-content-between"
+                aria-hidden={isShown}
+                aria-live="off"
+            >
+                {message}
                 <Button aria-label="Dismiss alert" variant="icon" className={styles.closeButton} onClick={dismiss}>
                     <Icon aria-hidden={true} svgPath={mdiClose} />
                 </Button>

--- a/client/web/src/enterprise/rbac/components/RoleNode.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.tsx
@@ -46,7 +46,13 @@ const ModifiableRoleNode: React.FunctionComponent<RoleNodeProps> = ({ node, refe
     const [isExpanded, setIsExpanded] = useState<boolean>(false)
     const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState<boolean>(false)
 
-    const { show: showAlert, ref: alertRef, style: alertStyle } = useAnimatedAlert({ autoDuration: 'short' })
+    const successMessage = 'Permissions successfully updated.'
+    const {
+        isShown: alertIsShown,
+        show: showAlert,
+        ref: alertRef,
+        style: alertStyle,
+    } = useAnimatedAlert({ autoDuration: 'short', ariaAnnouncement: { message: successMessage } })
 
     const handleOpenChange = (isOpen: boolean): void => {
         setIsExpanded(isOpen)
@@ -170,8 +176,15 @@ const ModifiableRoleNode: React.FunctionComponent<RoleNodeProps> = ({ node, refe
                     onSubmit={handleSubmit}
                 >
                     <animated.div style={alertStyle}>
-                        <Alert ref={alertRef} variant="success" className="mb-3">
-                            Permissions successfully updated.
+                        <Alert
+                            ref={alertRef}
+                            variant="success"
+                            className="mb-3"
+                            // The alert announcement is handled by the useAnimatedAlert hook
+                            aria-live="off"
+                            aria-hidden={!alertIsShown}
+                        >
+                            {successMessage}
                         </Alert>
                     </animated.div>
                     <PermissionsList

--- a/client/wildcard/src/components/Alert/Alert.story.tsx
+++ b/client/wildcard/src/components/Alert/Alert.story.tsx
@@ -49,8 +49,19 @@ const config: Meta = {
 export default config
 
 export const Alerts: Story = () => {
-    const { isShown, show, ref, style } = useAnimatedAlert({ autoDuration: 'short' })
-    const { show: showManual, dismiss, ref: refManual, style: styleManual } = useAnimatedAlert()
+    const alertMessage = 'Success! This alert will now be shown for a couple seconds!'
+    const manualAlertMessage = 'Warning! This alert will stay visible until it is dismissed.'
+    const { isShown, show, ref, style } = useAnimatedAlert({
+        autoDuration: 'short',
+        ariaAnnouncement: { message: alertMessage },
+    })
+    const {
+        isShown: manualIsShown,
+        show: showManual,
+        dismiss,
+        ref: refManual,
+        style: styleManual,
+    } = useAnimatedAlert({ ariaAnnouncement: { message: manualAlertMessage } })
 
     return (
         <>
@@ -84,11 +95,12 @@ export const Alerts: Story = () => {
                 <div className="w-100 d-flex align-items-center justify-content-between mb-3">
                     <Text className="m-0">
                         Alerts can be automatically dismissed with an animation using the <Code>useAnimatedAlert</Code>{' '}
-                        hook.
+                        hook. Make sure the alert is still properly hidden and visible to screenreaders when it should
+                        be by following the example below.
                     </Text>
                     <Button
                         variant="primary"
-                        className="ml-2"
+                        className="ml-2 flex-shrink-0"
                         onClick={() => {
                             show()
                             showManual()
@@ -99,8 +111,15 @@ export const Alerts: Story = () => {
                     </Button>
                 </div>
                 <animated.div style={style}>
-                    <Alert ref={ref} variant="success" className="my-2">
-                        Success! This alert will now be shown for a couple seconds!
+                    <Alert
+                        ref={ref}
+                        variant="success"
+                        className="my-2"
+                        // The alert announcement is handled by the useAnimatedAlert hook
+                        aria-live="off"
+                        aria-hidden={!isShown}
+                    >
+                        {alertMessage}
                     </Alert>
                 </animated.div>
                 <Text>I'm some text to demonstrate what happens when alerts appear around me.</Text>
@@ -109,8 +128,11 @@ export const Alerts: Story = () => {
                         ref={refManual}
                         variant="warning"
                         className="my-2 d-flex align-items-center justify-content-between"
+                        // The alert announcement is handled by the useAnimatedAlert hook
+                        aria-live="off"
+                        aria-hidden={!manualIsShown}
                     >
-                        Warning! This alert will stay visible until it is dismissed.
+                        {manualAlertMessage}
                         <Button variant="icon" onClick={dismiss}>
                             <Icon aria-hidden={true} svgPath={mdiClose} />
                         </Button>

--- a/client/wildcard/src/components/Alert/Alert.story.tsx
+++ b/client/wildcard/src/components/Alert/Alert.story.tsx
@@ -4,13 +4,16 @@ import { action } from '@storybook/addon-actions'
 import { Story, Meta } from '@storybook/react'
 import classNames from 'classnames'
 import { flow } from 'lodash'
+import { animated } from 'react-spring'
 
 import 'storybook-addon-designs'
 
-import { H1, H4, Text } from '..'
+import { mdiClose } from '@mdi/js'
+
+import { Button, Code, H1, H2, H4, Icon, Text } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
 
-import { AlertLink } from '.'
+import { AlertLink, useAnimatedAlert } from '.'
 import { Alert } from './Alert'
 import { ALERT_VARIANTS } from './constants'
 
@@ -45,29 +48,76 @@ const config: Meta = {
 
 export default config
 
-export const Alerts: Story = () => (
-    <>
-        <H1>Alerts</H1>
-        <Text>
-            Provide contextual feedback messages for typical user actions with the handful of available and flexible
-            alert messages.
-        </Text>
-        <div className="mb-2">
-            {ALERT_VARIANTS.map(variant => (
-                <Alert key={variant} variant={variant}>
-                    <H4>Too many matching repositories</H4>
-                    Use a 'repo:' filter to narrow your search.
+export const Alerts: Story = () => {
+    const { isShown, show, ref, style } = useAnimatedAlert({ autoDuration: 'short' })
+    const { show: showManual, dismiss, ref: refManual, style: styleManual } = useAnimatedAlert()
+
+    return (
+        <>
+            <H1>Alerts</H1>
+            <Text>
+                Provide contextual feedback messages for typical user actions with the handful of available and flexible
+                alert messages.
+            </Text>
+            <div className="mb-2">
+                {ALERT_VARIANTS.map(variant => (
+                    <Alert key={variant} variant={variant}>
+                        <H4>Too many matching repositories</H4>
+                        Use a 'repo:' filter to narrow your search.
+                    </Alert>
+                ))}
+                <Alert variant="info" className="d-flex align-items-center">
+                    <div className="flex-grow-1">
+                        <H4>Too many matching repositories</H4>
+                        Use a 'repo:' filter to narrow your search.
+                    </div>
+                    <AlertLink
+                        className="mr-2"
+                        to="/"
+                        onClick={flow(preventDefault, action(classNames('link clicked')))}
+                    >
+                        Dismiss
+                    </AlertLink>
                 </Alert>
-            ))}
-            <Alert variant="info" className="d-flex align-items-center">
-                <div className="flex-grow-1">
-                    <H4>Too many matching repositories</H4>
-                    Use a 'repo:' filter to narrow your search.
+                <hr className="my-4" />
+                <H2>Auto-dismissing alerts</H2>
+                <div className="w-100 d-flex align-items-center justify-content-between mb-3">
+                    <Text className="m-0">
+                        Alerts can be automatically dismissed with an animation using the <Code>useAnimatedAlert</Code>{' '}
+                        hook.
+                    </Text>
+                    <Button
+                        variant="primary"
+                        className="ml-2"
+                        onClick={() => {
+                            show()
+                            showManual()
+                        }}
+                        disabled={isShown}
+                    >
+                        Show alert
+                    </Button>
                 </div>
-                <AlertLink className="mr-2" to="/" onClick={flow(preventDefault, action(classNames('link clicked')))}>
-                    Dismiss
-                </AlertLink>
-            </Alert>
-        </div>
-    </>
-)
+                <animated.div style={style}>
+                    <Alert ref={ref} variant="success" className="my-2">
+                        Success! This alert will now be shown for a couple seconds!
+                    </Alert>
+                </animated.div>
+                <Text>I'm some text to demonstrate what happens when alerts appear around me.</Text>
+                <animated.div style={styleManual}>
+                    <Alert
+                        ref={refManual}
+                        variant="warning"
+                        className="my-2 d-flex align-items-center justify-content-between"
+                    >
+                        Warning! This alert will stay visible until it is dismissed.
+                        <Button variant="icon" onClick={dismiss}>
+                            <Icon aria-hidden={true} svgPath={mdiClose} />
+                        </Button>
+                    </Alert>
+                </animated.div>
+                <Text>I'm some text to demonstrate what happens when an alert appears above me.</Text>
+            </div>
+        </>
+    )
+}

--- a/client/wildcard/src/components/Alert/index.ts
+++ b/client/wildcard/src/components/Alert/index.ts
@@ -1,2 +1,3 @@
 export * from './Alert'
 export * from './AlertLink'
+export * from './useAnimatedAlert'

--- a/client/wildcard/src/components/Alert/useAnimatedAlert.ts
+++ b/client/wildcard/src/components/Alert/useAnimatedAlert.ts
@@ -1,10 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { Assertiveness } from '@react-aria/live-announcer'
 import { SpringValue, useSpring } from 'react-spring'
 
 import { useStopwatch } from '../../hooks'
+import { screenReaderAnnounce } from '../../utils'
 
 interface AnimatedAlertOptions {
+    ariaAnnouncement: {
+        /** The message to announce to screen readers when the alert is shown. */
+        message: string
+        /** The politeness level of the announcement. Defaults 'polite'. */
+        politeness?: Assertiveness
+    }
     /** Whether the alert starts visible or not. Defaults false. */
     defaultShown?: boolean
     /**
@@ -38,17 +46,18 @@ const DURATION_LONG_S = 10
 const APPROX_MIN_BANNER_HEIGHT_PX = 40
 
 /**
- * Custom hook to show and hide an alert with an animated transition. The alert can be
- * controlled with the callback functions returned by this hook, or it can be
+ * Custom hook to show and hide an accessible alert with an animated transition. The alert
+ * can be controlled with the callback functions returned by this hook, or it can be
  * automatically hidden after a certain duration by passing an autoDuration option.
  *
  * @param opts any AnimatedAlertOptions to apply to the controls for this alert
  * @returns the AnimatedAlertControls for this alert
  */
-export const useAnimatedAlert = (opts?: AnimatedAlertOptions): AnimatedAlertControls => {
-    const defaultShown = opts?.defaultShown || false
-    const autoDuration = opts?.autoDuration
-
+export const useAnimatedAlert = ({
+    defaultShown = false,
+    autoDuration,
+    ariaAnnouncement,
+}: AnimatedAlertOptions): AnimatedAlertControls => {
     const [showAlert, setShowAlert] = useState<boolean>(defaultShown)
 
     // Use a stopwatch to show the alert for a certain duration.
@@ -68,9 +77,10 @@ export const useAnimatedAlert = (opts?: AnimatedAlertOptions): AnimatedAlertCont
     }, [isRunning, stopTimer, seconds, autoDuration])
 
     const show = useCallback(() => {
+        screenReaderAnnounce(ariaAnnouncement.message, ariaAnnouncement.politeness)
         setShowAlert(true)
         startTimer()
-    }, [startTimer])
+    }, [startTimer, ariaAnnouncement.message, ariaAnnouncement.politeness])
 
     const dismiss = useCallback(() => {
         setShowAlert(false)

--- a/client/wildcard/src/components/Alert/useAnimatedAlert.ts
+++ b/client/wildcard/src/components/Alert/useAnimatedAlert.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { SpringValue, useSpring } from 'react-spring'
+
+import { useStopwatch } from '../../hooks'
+
+interface AnimatedAlertOptions {
+    /** Whether the alert starts visible or not. Defaults false. */
+    defaultShown?: boolean
+    /**
+     * How long the alert should be visible for before auto-hiding. Leave out to manually
+     * control dismissal.
+     */
+    autoDuration?: 'short' | 'long'
+}
+
+interface AnimatedAlertControls {
+    /** Whether or not the alert is currently visible. */
+    isShown: boolean
+    /** Callback to show the alert. */
+    show: () => void
+    /** Callback to manually dismiss the alert. */
+    dismiss: () => void
+    /** Ref to the alert element. */
+    ref: React.RefObject<HTMLDivElement>
+    /** Style object to be passed to the react-spring animated element. */
+    style: {
+        height: SpringValue<string>
+        opacity: SpringValue<number>
+    }
+}
+
+// The duration in seconds the alert should be shown before it is automatically hidden
+const DURATION_SHORT_S = 4
+const DURATION_LONG_S = 10
+// Used as a default in case the Alert is not yet rendered. Is the approximate height of a
+// standard Alert with a single line of text.
+const APPROX_MIN_BANNER_HEIGHT_PX = 40
+
+/**
+ * Custom hook to show and hide an alert with an animated transition. The alert can be
+ * controlled with the callback functions returned by this hook, or it can be
+ * automatically hidden after a certain duration by passing an autoDuration option.
+ *
+ * @param opts any AnimatedAlertOptions to apply to the controls for this alert
+ * @returns the AnimatedAlertControls for this alert
+ */
+export const useAnimatedAlert = (opts?: AnimatedAlertOptions): AnimatedAlertControls => {
+    const defaultShown = opts?.defaultShown || false
+    const autoDuration = opts?.autoDuration
+
+    const [showAlert, setShowAlert] = useState<boolean>(defaultShown)
+
+    // Use a stopwatch to show the alert for a certain duration.
+    const {
+        time: { seconds },
+        start: startTimer,
+        stop: stopTimer,
+        isRunning,
+    } = useStopwatch(defaultShown)
+
+    // Automatically hide the alert after a certain duration if autoDuration is set.
+    useEffect(() => {
+        if (isRunning && autoDuration && seconds > (autoDuration === 'short' ? DURATION_SHORT_S : DURATION_LONG_S)) {
+            stopTimer()
+            setShowAlert(false)
+        }
+    }, [isRunning, stopTimer, seconds, autoDuration])
+
+    const show = useCallback(() => {
+        setShowAlert(true)
+        startTimer()
+    }, [startTimer])
+
+    const dismiss = useCallback(() => {
+        setShowAlert(false)
+        stopTimer()
+    }, [stopTimer])
+
+    const ref = useRef<HTMLDivElement>(null)
+    let height = ref.current?.offsetHeight || APPROX_MIN_BANNER_HEIGHT_PX
+    if (ref.current) {
+        height += parseInt(window.getComputedStyle(ref.current).getPropertyValue('margin-top'), 10)
+        height += parseInt(window.getComputedStyle(ref.current).getPropertyValue('margin-bottom'), 10)
+    }
+
+    const style = useSpring({
+        height: showAlert ? `${height}px` : '0px',
+        opacity: showAlert ? 1 : 0,
+    })
+
+    return {
+        isShown: showAlert,
+        show,
+        dismiss,
+        ref,
+        style,
+    }
+}

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -1,7 +1,7 @@
 /** Component exports */
 export { BeforeUnloadPrompt } from './BeforeUnloadPrompt'
 export { Button, ButtonGroup, BUTTON_SIZES } from './Button'
-export { Alert, AlertLink } from './Alert'
+export { Alert, AlertLink, useAnimatedAlert } from './Alert'
 export { Container } from './Container'
 export { ErrorAlert } from './ErrorAlert'
 export { ErrorMessage, renderError } from './ErrorMessage'


### PR DESCRIPTION
Recently while building the RBAC admin UI, we had a need for a toast-like alert: one which appears on the page after some action is taken to announce either the success of failure of that action, disappears automatically after a few seconds, but is clearly scoped to one item on one part of the page and thus appears in close proximity to it. Having items pop in and out of visibility is obviously bad UX in a number of regards, so we implemented a simple animation with `react-spring` to fade the alert in and grow its height as it appears, the fade it out and shrink the height once more as it disappears.

I realized after implementing this that there were several other places in the Batch Changes area that could benefit from such an animated, auto-dismissing alert, and thus the `useAnimatedAlert` hook was born. This hook simply provides a common interface for controlling the animation and auto-dismissing behavior of an alert, if such behavior is desired, as demonstrated in the new Storybook story section:

https://user-images.githubusercontent.com/8942601/227121360-724426b4-21ef-4903-81b0-efb88754ea62.mov

---

**The hook is screenreader-friendly.** As demonstrated in the Storybook story examples, screenreader announcements for the alert are enabled by passing a screenreader message to the hook, turning off `aria-live` for the actual `Alert` component (since it's always going to be rendered), and syncing `aria-hidden` of the `Alert` to the hook's `isShown` state. The hook will call `screenReaderAnnounce` with the provided message when the alert is shown.

**The hook is not officially ordained by design.** I kinda just made up values for the duration the alert lasts based on what felt right. 😅 The main goal was just something reusable for auto-dismissibility without jarring layout shift. In most cases, I expect auto-dismissibility is _not_ the best choice for alerts. And maybe there's a more toast-y alternative that we would eventually design for. If it doesn't feel right to incorporate this into Wildcard proper, I'm also happy to move it somewhere less visible where its usage wouldn't be as strongly encouraged.

## Test plan

Storybook story coverage. Tested with a screenreader. Manually tested the RBAC roles page and batch changes preview list for functionality.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-reusable-animated-alert-hook.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
