### PR TITLE
docs: update `sourcegraph.sourcegraph.com` links to public version + use SG links instead of GH

### DIFF
--- a/doc/admin/executors/deploy_executors.md
+++ b/doc/admin/executors/deploy_executors.md
@@ -17,7 +17,7 @@
 
 ## Requirements
 
-Executors by default use KVM-based micro VMs powered by [Firecracker](https://github.com/firecracker-microvm/firecracker) in accordance with our [sandboxing model](index.md#how-it-works) to isolate jobs from each other and the host.
+Executors by default use KVM-based micro VMs powered by [Firecracker](https://sourcegraph.com/github.com/firecracker-microvm/firecracker) in accordance with our [sandboxing model](index.md#how-it-works) to isolate jobs from each other and the host.
 This requires executors to be run on machines capable of running Linux KVM extensions. On the most popular cloud providers, this either means running executors on bare-metal machines (AWS) or machines capable of nested virtualization (GCP).
 
 Optionally, executors can be run without using KVM-based isolation, which is less secure but might be easier to run on common machines.

--- a/doc/admin/executors/deploy_executors_terraform.md
+++ b/doc/admin/executors/deploy_executors_terraform.md
@@ -9,8 +9,8 @@
 </aside>
 
 [Terraform modules](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules) are provided to
-provision machines running executors on [AWS](https://github.com/sourcegraph/terraform-aws-executors)
-and [Google Cloud](https://github.com/sourcegraph/terraform-google-executors).
+provision machines running executors on [AWS](https://sourcegraph.com/github.com/sourcegraph/terraform-aws-executors)
+and [Google Cloud](https://sourcegraph.com/github.com/sourcegraph/terraform-google-executors).
 
 ## Basic Definition
 
@@ -59,7 +59,7 @@ See the Terraform Modules for additional configurations.
 
 Terraform modules `4.2.x` and above allow Terraform from `1.1.x` to `< 2.x` to be used.
 
-If using a Terraform module `4.1.x` or below, use [tfenv](https://github.com/tfutils/tfenv) to install Terraform
+If using a Terraform module `4.1.x` or below, use [tfenv](https://sourcegraph.com/github.com/tfutils/tfenv) to install Terraform
 1.1+.
 
 ```shell
@@ -160,16 +160,16 @@ All regions are supported.
 
 The following examples provision a single executor to pull from the `codeintel` queue.
 
-- [AWS example](https://github.com/sourcegraph/terraform-aws-executors/tree/master/examples/single-executor)
-- [Google example](https://github.com/sourcegraph/terraform-google-executors/tree/master/examples/single-executor)
-
+- [AWS example](https://sourcegraph.com/github.com/sourcegraph/terraform-aws-executors/-/tree/examples/single-executor)
+- [Google example](https://sourcegraph.com/github.com/sourcegraph/terraform-google-executors/-/tree/examples/single-executor)
+                    
 ### Multiple Executors
 
 The following examples provision two executors, one to pull from the `codeintel` queue and the other for the `batches`
 queue.
 
-- [AWS example](https://github.com/sourcegraph/terraform-aws-executors/tree/master/examples/multiple-executors)
-- [Google example](https://github.com/sourcegraph/terraform-google-executors/tree/master/examples/multiple-executors)
+- [AWS example](https://sourcegraph.com/github.com/sourcegraph/terraform-aws-executors/-/tree/examples/multiple-executors)
+- [Google example](https://sourcegraph.com/github.com/sourcegraph/terraform-google-executors/-/tree/examples/multiple-executors)
 
 ### Step-by-step Guide
 
@@ -193,7 +193,7 @@ The following is a step-by-step guide on provisioning a single `codeintel` execu
         - `"codeIntelAutoIndexing.enabled": true`
             - *This is only for `codeintel` executors.*
 5. Download
-   the [example files](https://github.com/sourcegraph/terraform-google-executors/blob/master/examples/single-executor)
+   the [example files](https://sourcegraph.com/github.com/sourcegraph/terraform-google-executors/-/blob/examples/single-executor)
 6. Change the following in `providers.tf`
     - `project` to the GCP project to provision the executor in
     - `region` to the GCP region to provision the executor in

--- a/doc/api/graphql/index.md
+++ b/doc/api/graphql/index.md
@@ -75,7 +75,7 @@ A command line interface to Sourcegraph's API is available. Today, it is roughly
 - Pipe multi-line GraphQL queries into it easily.
 - Get any API query written using the CLI as a `curl` command using the `src api -get-curl` flag.
 
-To learn more, see [github.com/sourcegraph/src-cli](https://github.com/sourcegraph/src-cli)
+To learn more, see [sourcegraph/src-cli](https://sourcegraph.com/github.com/sourcegraph/src-cli)
 
 ### Using the API via curl
 

--- a/doc/api/graphql/search.md
+++ b/doc/api/graphql/search.md
@@ -6,7 +6,7 @@ For general information about the GraphQL API and how to use it, see [this page 
 
 ## `src` CLI usage (easier than GraphQL)
 
-Putting together a comprehensive GraphQL search query can be difficult. For this reason, we created the [`src` CLI tool](https://github.com/sourcegraph/src-cli) which allows you to simply run a search query and get the JSON results without constructing the GraphQL query:
+Putting together a comprehensive GraphQL search query can be difficult. For this reason, we created the [`src` CLI tool](https://sourcegraph.com/github.com/sourcegraph/src-cli) which allows you to simply run a search query and get the JSON results without constructing the GraphQL query:
 
 ```
 export SRC_ENDPOINT=https://sourcegraph.com
@@ -15,5 +15,5 @@ export SRC_ACCESS_TOKEN=secret
 src search -json 'repo:pallets/flask error'
 ```
 
-You can then consume the JSON output directly, add `--get-curl` to get a `curl` execution line, and more. See [the `src` CLI tool](https://github.com/sourcegraph/src-cli) for more details.
+You can then consume the JSON output directly, add `--get-curl` to get a `curl` execution line, and more. See [the `src` CLI tool](https://sourcegraph.com/github.com/sourcegraph/src-cli) for more details.
 

--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -4,7 +4,7 @@
 > The Stream API is still evolving. Although parts of it can be considered
 > stable, we don't guarantee backward compatibility just yet. This means it is
 > possible that fields are added, removed, or renamed. All backward incompatible changes to the
-> event stream format will be documented in the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md).
+> event stream format will be documented in the [CHANGELOG](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md).
 
 
 With the Stream API you can consume search results and related metadata as
@@ -110,7 +110,7 @@ To search a pattern over all indexed repositories, add `count:all` and remove al
 curl --header "Accept:text/event-stream" --get --url "https://sourcegraph.com/.api/search/stream" --data-urlencode "q=secret count:all"
 ```
 
-If you don't want to write your own client, you can also use Sourcegraph's [src-cli](https://github.com/sourcegraph/src-cli).
+If you don't want to write your own client, you can also use Sourcegraph's [src-cli](https://sourcegraph.com/github.com/sourcegraph/src-cli).
 
 ```bash
 src search -stream "secret count:all"

--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -67,7 +67,7 @@ Your browser should automatically open to http://localhost:3080 - this is the ad
 
 Batch changes and precise code intel require the following optional dependencies be installed and on your PATH:
 
-- The `src` CLI ([installation](https://github.com/sourcegraph/src-cli))
+- The `src` CLI ([installation](https://sourcegraph.com/github.com/sourcegraph/src-cli))
 - `docker`
 
 ### Troubleshooting

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -162,7 +162,7 @@ steps:
 The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>steps.run</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> <code>steps.run</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ## [`steps.container`](#steps-container)
@@ -171,7 +171,7 @@ The Docker image used to launch the Docker container in which the shell command 
 
 The image has to have either the `/bin/sh` or the `/bin/bash` shell.
 
-It is executed using `docker` on the machine on which the [Sourcegraph CLI (`src`)](https://github.com/sourcegraph/src-cli) is executed. If the image exists locally, that is used. Otherwise it's pulled using `docker pull`.
+It is executed using `docker` on the machine on which the [Sourcegraph CLI (`src`)](https://sourcegraph.com/github.com/sourcegraph/src-cli) is executed. If the image exists locally, that is used. Otherwise it's pulled using `docker pull`.
 
 ## [`steps.env`](#steps-env)
 
@@ -180,7 +180,7 @@ Environment variables to set in the environment when running this command.
 These may be defined either as an [object](#environment-object) or (in Sourcegraph 3.23 and later) as an [array](#environment-array).
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.env</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.env</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ### Environment object
@@ -241,7 +241,7 @@ Files to create on the host machine and mount into the container when running `s
 `steps.files` is an object, where the key is the name of the file _inside the container_ and the value is the content of the file.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.files</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.files</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ### Examples
@@ -422,10 +422,10 @@ steps:
 ## [`steps.mount`](#steps-mount)
 
 <aside class="note">
-<span class="badge badge-note">New</span> <code>mount</code> is a new feature. Using <code>mount</code> locally is supported in Sourcegraph 3.41 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.41. Using <code>mount</code> in batch changes server-side is supported in Sourcegraph 4.1 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 4.0.1. It's a <b>preview</b> of functionality we're currently exploring to make running custom scripts/binaries easier. If you have any feedback, please let us know!
+<span class="badge badge-note">New</span> <code>mount</code> is a new feature. Using <code>mount</code> locally is supported in Sourcegraph 3.41 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.41. Using <code>mount</code> in batch changes server-side is supported in Sourcegraph 4.1 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 4.0.1. It's a <b>preview</b> of functionality we're currently exploring to make running custom scripts/binaries easier. If you have any feedback, please let us know!
 </aside>
 
-> NOTE: This feature is currently only available for <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a>.
+> NOTE: This feature is currently only available for <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a>.
 
 Mounts a local path to a path in a Docker container. Mounted paths are accessible to the step's `run` command.
 
@@ -738,7 +738,7 @@ changesetTemplate:
 ## [`transformChanges`](#transformchanges)
 
 <aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> <code>transformChanges</code> is an experimental feature in Sourcegraph 3.23 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
+<span class="badge badge-experimental">Experimental</span> <code>transformChanges</code> is an experimental feature in Sourcegraph 3.23 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
 </aside>
 
 A description of how to transform the changes (diffs) produced in each repository before turning them into separate changeset specs by inserting them into the [`changesetTemplate`](#changesettemplate).
@@ -801,7 +801,7 @@ Optional: the file diffs matching the given directory will only be grouped in a 
 ## [`workspaces`](#workspaces)
 
 <aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> <code>workspaces</code> is an experimental feature in Sourcegraph 3.25 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.25. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
+<span class="badge badge-experimental">Experimental</span> <code>workspaces</code> is an experimental feature in Sourcegraph 3.25 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.25. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
 </aside>
 
 The optional `workspaces` property allows users to define where projects are located in repositories and cause the [`steps`](#steps) to be executed for each project, instead of once per repository. That allows easier creation of multiple changesets in large repositories.

--- a/doc/cli/quickstart.md
+++ b/doc/cli/quickstart.md
@@ -8,7 +8,7 @@ In this guide, you'll install the Sourcegraph CLI, `src`, connect it to your Sou
 
 ## Installation
 
-`src` is shipped as a single, standalone binary. You can get the latest release by following the instructions for your operating system below (check out the [GitHub page](https://github.com/sourcegraph/src-cli) for additional documentation):
+`src` is shipped as a single, standalone binary. You can get the latest release by following the instructions for your operating system below (check out the [repository](https://sourcegraph.com/github.com/sourcegraph/src-cli) for additional documentation):
 
 ### macOS
 

--- a/doc/code_navigation/index.md
+++ b/doc/code_navigation/index.md
@@ -71,47 +71,47 @@ Code navigation is made up of multiple features that build on top of each other:
    <tbody>
       <tr>
         <td>Go</td>
-        <td><a href="https://github.com/sourcegraph/lsif-go">lsif-go</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/lsif-go">lsif-go</a></td>
         <td>🟢 GA</td>
       </tr>
       <tr>
         <td>TypeScript/JavaScript</td>
-        <td><a href="https://github.com/sourcegraph/scip-typescript">scip-typescript</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-typescript">scip-typescript</a></td>
         <td>🟢 GA</td>
       </tr>
       <tr>
         <td>C/C++</td>
-        <td><a href="https://github.com/sourcegraph/lsif-clang">lsif-clang</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/lsif-clang">lsif-clang</a></td>
         <td>🟡 Partially available</td>
       </tr>
       <tr>
          <td>Java</td>
-        <td><a href="https://github.com/sourcegraph/scip-java">scip-java</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-java">scip-java</a></td>
         <td>🟢 GA</td>
       </tr>
       <tr>
         <td>Scala</td>
-        <td><a href="https://github.com/sourcegraph/scip-java">scip-java</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-java">scip-java</a></td>
         <td>🟢 GA</td>
       </tr>
       <tr>
         <td>Kotlin</td>
-        <td><a href="https://github.com/sourcegraph/scip-java">scip-java</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-java">scip-java</a></td>
         <td>🟢 GA</td>
       </tr>
       <tr>
         <td>Rust</td>
-        <td><a href="https://github.com/rust-lang/rust-analyzer">rust-analyzer</a></td>
+        <td><a href="https://sourcegraph.com/github.com/rust-lang/rust-analyzer">rust-analyzer</a></td>
         <td>🟢 GA</td>
       </tr>
      <tr>
         <td>Python</td>
-        <td><a href="https://github.com/sourcegraph/scip-python">scip-python</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-python">scip-python</a></td>
         <td>🟢 GA</td>
       </tr>
      <tr>
         <td>Ruby</td>
-        <td><a href="https://github.com/sourcegraph/scip-ruby">scip-ruby</a></td>
+        <td><a href="https://sourcegraph.com/github.com/sourcegraph/scip-ruby">scip-ruby</a></td>
         <td>🟡 Partially available</td>
       </tr>
    </tbody>
@@ -130,8 +130,8 @@ Here's how you go from search-based code navigation to **automatically-updating,
     - [Index a Go repository](how-to/index_a_go_repository.md#manual-indexing)
     - [Index a TypeScript or JavaScript repository](how-to/index_a_typescript_and_javascript_repository.md#manual-indexing)
     - [Index a Java, Scala & Kotlin repository](https://sourcegraph.github.io/scip-java/docs/getting-started.html)
-    - [Index a Python repository](https://github.com/sourcegraph/scip-python)
-    - [Index a Ruby repository](https://github.com/sourcegraph/scip-ruby)
+    - [Index a Python repository](https://sourcegraph.com/github.com/sourcegraph/scip-python)
+    - [Index a Ruby repository](https://sourcegraph.com/github.com/sourcegraph/scip-ruby)
     - [Index a C++ repository](how-to/index_a_cpp_repository.md)
 
 

--- a/doc/dev/background-information/adding_event_level_data.md
+++ b/doc/dev/background-information/adding_event_level_data.md
@@ -4,7 +4,7 @@ This document outlines the process for adding or changing the raw user event dat
 
 ### User event data philosophy
 
-[Raw user event data](https://docs.sourcegraph.com/dev/background-information/data-usage-pipeline) is collected from logs in the `event_logs` table in the instance primary database and sent to Sourcegraph centralized analytics. These [events](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:internal/database/event_logs.go+Event+type:symbol+select:symbol.struct&patternType=standard) are a product of events performed by users or the system and represent our customers’ most sensitive data. We must preserve and build trust through only careful additions and changes to events added to the egress pipeline.
+[Raw user event data](https://docs.sourcegraph.com/dev/background-information/data-usage-pipeline) is collected from logs in the `event_logs` table in the instance primary database and sent to Sourcegraph centralized analytics. These [events](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:internal/database/event_logs.go+Event+type:symbol+select:symbol.struct&patternType=standard) are a product of events performed by users or the system and represent our customers’ most sensitive data. We must preserve and build trust through only careful additions and changes to events added to the egress pipeline.
 
 All user event data must be:
 1. Anonymous (with only one exception, the email address of the initial site installer)

--- a/doc/dev/background-information/data-usage-pipeline.md
+++ b/doc/dev/background-information/data-usage-pipeline.md
@@ -6,22 +6,22 @@ to certain managed instances (cloud) where the customer has signed a correspondi
 ### What is it?
 
 This process is a background job that can be enabled that will periodically scrape the `event_logs` table in the primary database
-and send it to Sourcegraph centralized analytics. [Events](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:internal/database/event_logs.go+Event+type:symbol+select:symbol.struct&patternType=standard) stored in `event_logs` are product events performed by users or the system. More information can be found in [RFC 719: Managed Instance Telemetry](https://docs.google.com/document/d/1N9aO0uTlvwXI7FzdPjIUCn_d1tRkJUfsc0urWigRf6s/edit).
+and send it to Sourcegraph centralized analytics. [Events](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:internal/database/event_logs.go+Event+type:symbol+select:symbol.struct&patternType=standard) stored in `event_logs` are product events performed by users or the system. More information can be found in [RFC 719: Managed Instance Telemetry](https://docs.google.com/document/d/1N9aO0uTlvwXI7FzdPjIUCn_d1tRkJUfsc0urWigRf6s/edit).
 
-The [job interval](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+JobCooldownDuration&patternType=standard) determines how often the job is executed. The [batch size option](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+getBatchSize+type:symbol&patternType=standard) determines how many records can be pulled in a single scrape. The batch size has a [default value](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+MaxEventsCountDefault&patternType=standard) and can be overridden with a site setting:
+The [job interval](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+JobCooldownDuration&patternType=standard) determines how often the job is executed. The [batch size option](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+getBatchSize+type:symbol&patternType=standard) determines how many records can be pulled in a single scrape. The batch size has a [default value](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/cmd/worker/internal/telemetry/telemetry_job%5C.go+MaxEventsCountDefault&patternType=standard) and can be overridden with a site setting:
 ``` json
   "exportUsageTelemetry": {
     "batchSize": 100,
   }
 ```
 
-The scraping job maintains state using a bookmark stored in the primary postgres database in the table `event_logs_scrape_state`. [If the bookmark is not found, one will be inserted](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/worker/internal/telemetry/telemetry_job.go?L424-440) such that the bookmark is the most recent event at the time.
+The scraping job maintains state using a bookmark stored in the primary postgres database in the table `event_logs_scrape_state`. [If the bookmark is not found, one will be inserted](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/worker/internal/telemetry/telemetry_job.go?L424-440) such that the bookmark is the most recent event at the time.
 
 The scraping process has a crude at-least once semantics guarantee. If any scrape should fail, the bookmark state will not be updated causing future scrapes to retry the same set of events.
 
 ### Allow list
 
-Only events that [exist in an allow list](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@735bc0f69ce417ecce55a9194dbf349c954043e3/-/blob/internal/database/event_logs.go?L321-324) will be scraped. Events are keyed in the allow list by the `event_logs.name` column. The allow list can be found in the primary
+Only events that [exist in an allow list](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@735bc0f69ce417ecce55a9194dbf349c954043e3/-/blob/internal/database/event_logs.go?L321-324) will be scraped. Events are keyed in the allow list by the `event_logs.name` column. The allow list can be found in the primary
 postgres database in the table `event_logs_export_allowlist`.
 
 #### Adding to the allow list
@@ -48,7 +48,7 @@ Currently, there is not a single document that shows the entire allow list. Ther
 ```postgresql
 select * from event_logs_export_allowlist;
 ```
-2. [Look through migration files](https://sourcegraph.sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:migrations+lang:sql+MY_EVENT_NAME&patternType=standard) to see if the event you are looking for has been added and not deleted
+2. [Look through migration files](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:migrations+lang:sql+MY_EVENT_NAME&patternType=standard) to see if the event you are looking for has been added and not deleted
 
 
 ### How to enable for a managed instance

--- a/doc/dev/background-information/web/web_app.md
+++ b/doc/dev/background-information/web/web_app.md
@@ -5,8 +5,8 @@ Guide to contribute to the Sourcegraph web app. Please also see our general [Typ
 ## Local development
 
 See [common commands for local development](../../setup/quickstart.md).
-Commands specifically useful for the web team can be found in the root [package.json](https://github.com/sourcegraph/sourcegraph/blob/main/package.json).
-Also, check out the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
+Commands specifically useful for the web team can be found in the root [package.json](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/package.json).
+Also, check out the web app [README](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/README.md).
 
 ### Prerequisites
 
@@ -16,7 +16,7 @@ To install it, [see the instructions](../../setup/quickstart.md).
 
 ### Commands
 
-1. Start the web server and point it to any deployed API instance. See more info in the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
+1. Start the web server and point it to any deployed API instance. See more info in the web app [README](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/README.md).
 
     ```sh
     sg start web-standalone
@@ -130,7 +130,7 @@ If you don't do this (and just use a normal `import`), it will still work, but i
 
 ## Formatting
 
-We use [Prettier](https://github.com/prettier/prettier) so you never have to worry about how to format your code.
+We use [Prettier](https://sourcegraph.com/github.com/prettier/prettier) so you never have to worry about how to format your code.
 `pnpm run format` will check & autoformat all code.
 
 ## Tests
@@ -158,4 +158,4 @@ See [testing.md](../../how-to/testing.md).
     - Forward errors to the error monitoring services.
     - Dynamically change logging level depending on the environment.
 
-Use [the `logger` service](https://sourcegraph.sourcegraph.com/search?q=context:sourcegraph+export+const+logger:+Logger+%3D&patternType=standard) that wraps console methods where we want to preserve console output in non-development environments. E.g., logging helpful information during an integration test execution. Feel free to disable the `no-console` ESLint rule for node.js environments via [the `overrides` configuration key](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns). Check out [the Unified logger service RFC](https://docs.google.com/document/d/1PolGRDS9XfKj-IJEBi7BTbVZeUsQfM-3qpjLsLlB-yw/edit) for more context.
+Use [the `logger` service](https://https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+export+const+logger:+Logger+%3D&patternType=standard&sm=1&groupBy=path) that wraps console methods where we want to preserve console output in non-development environments. E.g., logging helpful information during an integration test execution. Feel free to disable the `no-console` ESLint rule for node.js environments via [the `overrides` configuration key](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns). Check out [the Unified logger service RFC](https://docs.google.com/document/d/1PolGRDS9XfKj-IJEBi7BTbVZeUsQfM-3qpjLsLlB-yw/edit) for more context.

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -146,4 +146,4 @@ While the [Cache Buildkite Plugin](https://github.com/sourcegraph/cache-buildkit
            <<: *s3-settings
       ```
 
-   Add every plugin definition to the relevant steps in your `pipeline.yaml`. An example of a valid pipeline step with a plugin configured can be found [here](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/image-updater-pipeline/-/blob/.buildkite/image-updater/pipeline.yaml?L25).
+   Add every plugin definition to the relevant steps in your `pipeline.yaml`. An example of a valid pipeline step with a plugin configured can be found [here](https://sourcegraph.com/github.com/sourcegraph/image-updater-pipeline/-/blob/.buildkite/image-updater/pipeline.yaml?L25).

--- a/doc/dev/how-to/ci_soft_failure_and_still_notify.md
+++ b/doc/dev/how-to/ci_soft_failure_and_still_notify.md
@@ -8,7 +8,7 @@ Therefore a good solution for that is to also enable custom step notifications, 
 
 ## Editing your step to make it soft failing
 
-In the [CI pipeline generator](../background-information/ci/development.md), you'll find the code that declare all steps, usually located in [ci/operations.go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/operations.go)
+In the [CI pipeline generator](../background-information/ci/development.md), you'll find the code that declare all steps, usually located in [ci/operations.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/operations.go)
 
 A good way to find all of them is the following search query:
 


### PR DESCRIPTION
* Changes a bunch of private links to the public instance. A few remain that point to private repos.
* Makes a tiny cut in the amount of github.com links in our docs.. which are.. many. URLs for new/existing issues, PRs, etc are untouched.

A batch change could rewrite eligible GH URLs to SG URLs, but there's quite a few edge cases that need to be covered, so that's something for the backlog.

## Test plan
Tested with `sg run docsite`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
