### PR TITLE
site-admin code hosts page: fix wrong margin of loading spinner

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -58,7 +58,7 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     {EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.syncJobs?.nodes[0]?.state) ? (
                         <Tooltip content="Sync is running">
                             <div aria-label="Sync is running">
-                                <LoadingSpinner className="mr-2" inline={true} />
+                                <LoadingSpinner className="m-0 mr-2" inline={true} />
                             </div>
                         </Tooltip>
                     ) : node.lastSyncError === null ? (


### PR DESCRIPTION
This fixes the issue of the loading spinner having too much margin (on the left) and thus unaligning the page a bit.

If you wanna see what it looked like before, here you go, but... you might not sleep tonight:

![image](https://user-images.githubusercontent.com/1185253/227181630-af391264-6313-4f88-9e6e-81d5f035adda.png)


## Test plan

- Storybook and manually confirming that it's fixed:
![screenshot_2023-03-23_11 53 23@2x](https://user-images.githubusercontent.com/1185253/227181811-90c3697c-896d-4675-88ba-0eb482e37dca.png)


## App preview:

- [Web](https://sg-web-mrn-fix-wrong-margin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
