### PR TITLE
bzl: tune other jest tests

### DIFF
--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -261,4 +261,7 @@ jest_test(
     data = [
         ":branded_tests",
     ],
+    patch_node_fs = False,
+    shard_count = 6,
+    tags = ["no-sandbox"],
 )

--- a/client/browser/BUILD.bazel
+++ b/client/browser/BUILD.bazel
@@ -297,4 +297,7 @@ jest_test(
     data = [
         ":browser_tests",
     ],
+    patch_node_fs = False,
+    shard_count = 6,
+    tags = ["no-sandbox"],
 )

--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -515,9 +515,12 @@ filegroup(
 jest_test(
     name = "test",
     size = "enormous",  # make sure bazel reserves enough RAM for this.
-    timeout = "long",
+    timeout = "moderate",
     data = [
         ":shared_tests",
         ":snapshots",
     ],
+    patch_node_fs = False,
+    shard_count = 6,
+    tags = ["no-sandbox"],
 )

--- a/client/wildcard/BUILD.bazel
+++ b/client/wildcard/BUILD.bazel
@@ -549,4 +549,7 @@ jest_test(
     data = [
         ":wildcard_tests",
     ],
+    patch_node_fs = False,
+    shard_count = 6,
+    tags = ["no-sandbox"],
 )


### PR DESCRIPTION
Apply the same tactic from https://github.com/sourcegraph/sourcegraph/pull/49897 to other targets.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI. 

## App preview:

- [Web](https://sg-web-jh-bzl-tune-other-jest-tests.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
