### PR TITLE
own: add notice that deleting a parent team cascades to child teams

### DIFF
--- a/client/web/src/team/list/DeleteTeamModal.tsx
+++ b/client/web/src/team/list/DeleteTeamModal.tsx
@@ -44,7 +44,7 @@ export const DeleteTeamModal: React.FunctionComponent<React.PropsWithChildren<De
         <Modal onDismiss={onCancel} aria-labelledby={labelId}>
             <H3 id={labelId}>Delete team {team.name}?</H3>
 
-            <strong className="d-block text-danger my-3">Removing teams is irreversible.</strong>
+            <strong className="d-block text-danger my-3">Removing teams is irreversible and will cascade to existing child teams.</strong>
 
             {error && <ErrorAlert error={error} />}
 

--- a/client/web/src/team/list/DeleteTeamModal.tsx
+++ b/client/web/src/team/list/DeleteTeamModal.tsx
@@ -44,7 +44,9 @@ export const DeleteTeamModal: React.FunctionComponent<React.PropsWithChildren<De
         <Modal onDismiss={onCancel} aria-labelledby={labelId}>
             <H3 id={labelId}>Delete team {team.name}?</H3>
 
-            <strong className="d-block text-danger my-3">Removing teams is irreversible and will cascade to existing child teams.</strong>
+            <strong className="d-block text-danger my-3">
+                Removing teams is irreversible and will cascade to existing child teams.
+            </strong>
 
             {error && <ErrorAlert error={error} />}
 


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/49412

| before | after |
| -- | -- |
| <img width="532" alt="Screenshot 2023-03-23 at 11 48 40" src="https://user-images.githubusercontent.com/29406849/227194987-fa08b653-4a2b-47fd-9722-1422d08513a8.png"> | <img width="529" alt="Screenshot 2023-03-23 at 11 48 57" src="https://user-images.githubusercontent.com/29406849/227194996-88e02b8e-3064-4f0d-be4e-7ac7ced20ad3.png"> |

## Test plan

`sg start enterprise`

## App preview:

- [Web](https://sg-web-leo-team-notice.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
