### PR TITLE
permissions-center: use typed `CodeHostStatus` in API.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -39,6 +39,7 @@ import {
     CancelPermissionsSyncJobResultMessage,
     CancelPermissionsSyncJobVariables,
     CodeHostState,
+    CodeHostStatus,
     PermissionsSyncJob,
     PermissionsSyncJobReasonGroup,
     PermissionsSyncJobsResult,
@@ -596,8 +597,8 @@ const CodeHostStatesTableColumns: IColumn<CodeHostState>[] = [
         header: 'Status',
         render: (state: CodeHostState) => (
             <Badge
-                tooltip={state.status.toLowerCase() === 'error' ? state.message : undefined}
-                variant={CodeHostStateStatusVariants[state.status.toLowerCase()] || 'secondary'}
+                tooltip={state.status === CodeHostStatus.ERROR ? state.message : undefined}
+                variant={CodeHostStateStatusVariants[state.status]}
             >
                 {state.status}
             </Badge>
@@ -605,9 +606,9 @@ const CodeHostStatesTableColumns: IColumn<CodeHostState>[] = [
     },
 ]
 
-const CodeHostStateStatusVariants: Record<string, BadgeVariantType> = {
-    success: 'success',
-    error: 'danger',
+const CodeHostStateStatusVariants: Record<CodeHostStatus, BadgeVariantType> = {
+    SUCCESS: 'success',
+    ERROR: 'danger',
 }
 
 const JobPriorityBadgeVariants: Record<PermissionsSyncJobPriority, BadgeVariantType> = {

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -613,6 +613,14 @@ enum PermissionsSyncJobPriority {
 }
 
 """
+Describes the status of a permissions sync for a given provider (code host).
+"""
+enum CodeHostStatus {
+    SUCCESS
+    ERROR
+}
+
+"""
 Describes the state of a provider (code host) during a permission sync job.
 """
 type CodeHostState {
@@ -627,7 +635,7 @@ type CodeHostState {
     """
     Status of permission sync of a given provider.
     """
-    status: String!
+    status: CodeHostStatus!
     """
     Status message.
     """
@@ -734,37 +742,6 @@ type PermissionsSyncJob implements Node {
     State of providers (code hosts) during permission sync job.
     """
     codeHostStates: [CodeHostState!]!
-}
-
-"""
-Status types of permissions providers.
-"""
-enum PermissionsProviderStatus {
-    ERROR
-    SUCCESS
-}
-
-"""
-State of a permissions provider during a sync job.
-"""
-type PermissionsProviderState {
-    """
-    Type of the provider.
-    """
-    type: String!
-    """
-    ID representing the provider.
-    """
-    id: String!
-    """
-    Type of the sync job.
-    """
-    status: PermissionsProviderStatus!
-    """
-    Message describing the status of the provider during a sync job - for example, the
-    contents of any errors and during which operation they occured.
-    """
-    message: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -48,7 +48,7 @@ type PermissionsSyncJobReasonResolver interface {
 type CodeHostStateResolver interface {
 	ProviderID() string
 	ProviderType() string
-	Status() string
+	Status() database.CodeHostStatus
 	Message() string
 }
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -265,8 +265,8 @@ func (c codeHostStateResolver) ProviderType() string {
 	return c.state.ProviderType
 }
 
-func (c codeHostStateResolver) Status() string {
-	return string(c.state.Status)
+func (c codeHostStateResolver) Status() database.CodeHostStatus {
+	return c.state.Status
 }
 
 func (c codeHostStateResolver) Message() string {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -2067,7 +2067,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			PermissionsAdded:   1337,
 			PermissionsRemoved: 42,
 			PermissionsFound:   404,
-			CodeHostStates:     []database.PermissionSyncCodeHostState{},
+			CodeHostStates:     []database.PermissionSyncCodeHostState{{ProviderID: "1", ProviderType: "github", Status: database.CodeHostStatusSuccess, Message: "success!"}},
 		},
 		{
 			ID:               4,
@@ -2081,7 +2081,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			Priority:         database.HighPriorityPermissionsSync,
 			NoPerms:          false,
 			InvalidateCaches: false,
-			CodeHostStates:   []database.PermissionSyncCodeHostState{},
+			CodeHostStates:   []database.PermissionSyncCodeHostState{{ProviderID: "1", ProviderType: "github", Status: database.CodeHostStatusError, Message: "error!"}},
 		},
 	}
 	permissionSyncJobStore.ListFunc.SetDefaultReturn(jobs, nil)
@@ -2145,6 +2145,9 @@ query {
 		permissionsFound
 		codeHostStates {
 			providerID
+			providerType
+			status
+			message
 		}
 	}
   }
@@ -2185,7 +2188,14 @@ query {
 				"permissionsAdded": 1337,
 				"permissionsRemoved": 42,
 				"permissionsFound": 404,
-				"codeHostStates": []
+				"codeHostStates": [
+					{
+						"providerID": "1",
+						"providerType": "github",
+						"status": "SUCCESS",
+						"message": "success!"
+					}
+				]
 			},
 			{
 				"id": "UGVybWlzc2lvbnNTeW5jSm9iOjQ=",
@@ -2216,7 +2226,14 @@ query {
 				"permissionsAdded": 0,
 				"permissionsRemoved": 0,
 				"permissionsFound": 0,
-				"codeHostStates": []
+				"codeHostStates": [
+					{
+						"providerID": "1",
+						"providerType": "github",
+						"status": "ERROR",
+						"message": "error!"
+					}
+				]
 			}
 		],
 		"pageInfo": {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_worker.go
@@ -120,15 +120,13 @@ func (h *permsSyncerWorker) handlePermsSync(ctx context.Context, reqType request
 		h.logger.Error("failed to sync permissions", providerStates.SummaryField(), log.Error(err))
 	} else {
 		h.logger.Debug("succeeded in syncing permissions", providerStates.SummaryField())
+	}
 
-		// NOTE(naman): here we are saving permissions added, removed and found results
-		// as well as the code host sync status to the job record.
-		if result != nil {
-			err = h.jobsStore.SaveSyncResult(ctx, recordID, result, providerStates)
-			if err != nil {
-				h.logger.Error(fmt.Sprintf("failed to save permissions sync job(%d) results", recordID), log.Error(err))
-			}
-		}
+	// NOTE(naman): here we are saving permissions added, removed and found results
+	// as well as the code host sync status to the job record.
+	err = h.jobsStore.SaveSyncResult(ctx, recordID, result, providerStates)
+	if err != nil {
+		h.logger.Error(fmt.Sprintf("failed to save permissions sync job(%d) results", recordID), log.Error(err))
 	}
 
 	return err

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -437,6 +437,12 @@ type SetPermissionsResult struct {
 }
 
 func (s *permissionSyncJobStore) SaveSyncResult(ctx context.Context, id int, result *SetPermissionsResult, statuses CodeHostStatusesSet) error {
+	var added, removed, found int
+	if result != nil {
+		added = result.Added
+		removed = result.Removed
+		found = result.Found
+	}
 	q := sqlf.Sprintf(`
 		UPDATE permission_sync_jobs
 		SET
@@ -445,7 +451,7 @@ func (s *permissionSyncJobStore) SaveSyncResult(ctx context.Context, id int, res
 			permissions_found = %d,
 			code_host_states = %s
 		WHERE id = %d
-		`, result.Added, result.Removed, result.Found, pq.Array(statuses), id)
+		`, added, removed, found, pq.Array(statuses), id)
 
 	_, err := s.ExecResult(ctx, q)
 	return err
@@ -659,15 +665,15 @@ func (s *permissionSyncJobStore) Count(ctx context.Context, opts ListPermissionS
 }
 
 const countUsersWithFailingSyncJobsQuery = `
-SELECT COUNT(*) 
+SELECT COUNT(*)
 FROM (
-  SELECT DISTINCT ON (user_id) id, state 
-  FROM permission_sync_jobs 
-  WHERE 
-	user_id is NOT NULL 
+  SELECT DISTINCT ON (user_id) id, state
+  FROM permission_sync_jobs
+  WHERE
+	user_id is NOT NULL
 	AND state IN ('completed', 'failed')
   ORDER BY user_id, finished_at DESC
-) AS tmp 
+) AS tmp
 WHERE state = 'failed';
 `
 
@@ -681,15 +687,15 @@ func (s *permissionSyncJobStore) CountUsersWithFailingSyncJob(ctx context.Contex
 }
 
 const countReposWithFailingSyncJobsQuery = `
-SELECT COUNT(*) 
+SELECT COUNT(*)
 FROM (
-  SELECT DISTINCT ON (repository_id) id, state 
-  FROM permission_sync_jobs 
-  WHERE 
-	repository_id is NOT NULL 
+  SELECT DISTINCT ON (repository_id) id, state
+  FROM permission_sync_jobs
+  WHERE
+	repository_id is NOT NULL
 	AND state IN ('completed', 'failed')
   ORDER BY repository_id, finished_at DESC
-) AS tmp 
+) AS tmp
 WHERE state = 'failed';
 `
 

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -646,6 +646,20 @@ func TestPermissionSyncJobs_SaveSyncResult(t *testing.T) {
 	require.Equal(t, 2, theJob.PermissionsRemoved)
 	require.Equal(t, 5, theJob.PermissionsFound)
 	require.Equal(t, codeHostStates, theJob.CodeHostStates)
+
+	// Saving nil result (in case of errors from code host) should be also successful.
+	err = store.SaveSyncResult(ctx, 1, nil, codeHostStates[1:])
+	require.NoError(t, err)
+
+	// Checking that all the results are set.
+	jobs, err = store.List(ctx, ListPermissionSyncJobOpts{RepoID: int(repo1.ID)})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	theJob = jobs[0]
+	require.Equal(t, 0, theJob.PermissionsAdded)
+	require.Equal(t, 0, theJob.PermissionsRemoved)
+	require.Equal(t, 0, theJob.PermissionsFound)
+	require.Equal(t, codeHostStates[1:], theJob.CodeHostStates)
 }
 
 func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {


### PR DESCRIPTION
This commit also fixes a bug when provider stats were not saved if there were errors connecting to provider, which resulted in absence of results, which prevented stats from saving.

Test plan:
Unit tests updated.
GraphQL tests updated.
Local sg run and check.