### PR TITLE
Hide divider for empty section in UserNavItem

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -253,7 +253,9 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     Sign out
                                 </MenuLink>
                             )}
-                            <MenuDivider className={styles.dropdownDivider} />
+                            {(isSourcegraphDotCom || codeHostIntegrationMessaging === 'browser-extension') && (
+                                <MenuDivider className={styles.dropdownDivider} />
+                            )}
                             {isSourcegraphDotCom && (
                                 <MenuLink
                                     as={AnchorLink}


### PR DESCRIPTION
All items after are conditions, if none of the conditions are met, we should not show it.

<img width="239" alt="Screenshot 2023-03-23 at 14 06 18@2x" src="https://user-images.githubusercontent.com/19534377/227214043-78f8c3a8-2a99-4531-a39f-c36dd4f0fa01.png">

See the divider at the end. 

## Test plan

No divider no more.

## App preview:

- [Web](https://sg-web-es-hide-empty-divider.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
