### PR TITLE
Fuzzy finder: boost ranking of symbols with shorter names

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyLocalCache.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyLocalCache.ts
@@ -11,6 +11,7 @@ export interface PersistableQueryResult {
     text: string
     url?: string
     symbolKind?: SymbolKind
+    symbolName?: string
     stars?: number
     repoName?: string
     filePath?: string


### PR DESCRIPTION
Previously, the "Symbols" tab of the fuzzy finder didn't use any ranking to break ties between symbols that had the same fuzzy matching score. This was problematic because if you wanted to match against a symbol with short names then you could encounter a situation where you needed to use the arrow keys to move through the results to reach the result because you can't narrow down the query the match the symbol with the short name.

This PR changes the ranking to break fuzzy matching ties by prioritizing symbols with short names. If the user wants to match against a symbol with a longer name then the user can add more characters to the query.


## Test plan

Manually validated with a local build and the query `DependentTemplate` in the repo github.com/llvm/llvm-project

![CleanShot 2023-03-23 at 14 09 00@2x](https://user-images.githubusercontent.com/1408093/227214271-63e7db80-b24f-44e0-ab82-8b25bd1cb7d5.png)
![CleanShot 2023-03-23 at 14 07 02@2x](https://user-images.githubusercontent.com/1408093/227214284-91fae940-4e8a-497f-a5da-4177863976bd.png)

Just to verify that the ranking works as expected, I flipped the ranking to see if long names would get boosted
![CleanShot 2023-03-23 at 14 07 45@2x](https://user-images.githubusercontent.com/1408093/227214279-3821bffc-92a9-4a8f-a15f-b8e14cbb0219.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-symbol-ranking.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
