### PR TITLE
txemail: add ability to set sender name

### DIFF
--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -151,7 +151,6 @@ func TestSendUserEmailVerificationEmail(t *testing.T) {
 		t.Fatal("want sent != nil")
 	}
 	if want := (txemail.Message{
-		FromName: "",
 		To:       []string{"a@example.com"},
 		Template: verifyEmailTemplates,
 		Data: struct {
@@ -195,7 +194,6 @@ func TestSendUserEmailOnFieldUpdate(t *testing.T) {
 		t.Fatal("want sent != nil")
 	}
 	if want := (txemail.Message{
-		FromName: "",
 		To:       []string{"a@example.com"},
 		Template: updateAccountEmailTemplate,
 		Data: struct {

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"net/textproto"
 	"strconv"
@@ -29,14 +30,12 @@ var emailSendCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 
 // render returns the rendered message contents without sending email.
 func render(fromAddress, fromName string, message Message) (*email.Email, error) {
-	from := fromAddress
-	if fromName != "" {
-		from = fmt.Sprintf(`"%s" <%s>`, fromName, fromAddress)
-	}
-
 	m := email.Email{
-		To:      message.To,
-		From:    from,
+		To: message.To,
+		From: (&mail.Address{
+			Name:    fromName,
+			Address: fromAddress,
+		}).String(),
 		Headers: make(textproto.MIMEHeader),
 	}
 	if message.ReplyTo != nil {

--- a/internal/txemail/txemail_test.go
+++ b/internal/txemail/txemail_test.go
@@ -1,11 +1,10 @@
 package txemail
 
 import (
-	"net/textproto"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/jordan-wright/email"
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
@@ -15,7 +14,6 @@ func TestRender(t *testing.T) {
 	messageID := "1"
 
 	msg := Message{
-		FromName:   "foo",
 		To:         []string{"bar1@sourcegraph.com", "bar2@sourcegraph.com"},
 		ReplyTo:    &replyTo,
 		MessageID:  &messageID,
@@ -38,24 +36,65 @@ func TestRender(t *testing.T) {
 		},
 	}
 
-	got, err := render(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("only email", func(t *testing.T) {
+		got, err := render("foo@sourcegraph.com", "", msg)
+		require.NoError(t, err)
+		b, err := got.Bytes()
+		require.NoError(t, err)
+		autogold.Expect(`References: <ref1> <ref2>
+Message-ID: 1
+Reply-To: admin@sourcegraph.com
+Date: Thu, 23 Mar 2023 22:04:44 +0900
+Message-Id: <1679576684882150000.76848.6468314242858748196@bobbook-sourcegraph.local>
+From: <foo@sourcegraph.com>
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary=8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
+To: <bar1@sourcegraph.com>, <bar2@sourcegraph.com>
+Subject: a subject <b>
 
-	want := &email.Email{
-		ReplyTo: []string{replyTo},
-		From:    "foo",
-		To:      []string{"bar1@sourcegraph.com", "bar2@sourcegraph.com"},
-		Subject: "a subject <b>",
-		Text:    []byte("a text body <b>"),
-		HTML:    []byte(`a html body <span class="&lt;b&gt;" />`),
-		Headers: textproto.MIMEHeader{
-			"Message-ID": []string{messageID},
-			"References": []string{"<ref1> <ref2>"},
-		},
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
-	}
+--8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+a text body <b>
+--8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+a html body <span class=3D"&lt;b&gt;" />
+--8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31--
+`).Equal(t, string(b))
+	})
+
+	t.Run("email and sender name", func(t *testing.T) {
+		got, err := render("foo@sourcegraph.com", "foo", msg)
+		require.NoError(t, err)
+		b, err := got.Bytes()
+		require.NoError(t, err)
+		autogold.Expect(`Content-Type: multipart/alternative;
+ boundary=9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
+Date: Thu, 23 Mar 2023 22:04:45 +0900
+Message-ID: 1
+References: <ref1> <ref2>
+Message-Id: <1679576685006321000.76848.5675638794021296688@bobbook-sourcegraph.local>
+From: "foo" <foo@sourcegraph.com>
+Mime-Version: 1.0
+Reply-To: admin@sourcegraph.com
+To: <bar1@sourcegraph.com>, <bar2@sourcegraph.com>
+Subject: a subject <b>
+
+--9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+a text body <b>
+--9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+a html body <span class=3D"&lt;b&gt;" />
+--9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06--
+`).Equal(t, string(b))
+	})
 }

--- a/internal/txemail/txemail_test.go
+++ b/internal/txemail/txemail_test.go
@@ -1,9 +1,11 @@
 package txemail
 
 import (
+	"net/textproto"
 	"testing"
 
-	"github.com/hexops/autogold/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jordan-wright/email"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
@@ -39,62 +41,38 @@ func TestRender(t *testing.T) {
 	t.Run("only email", func(t *testing.T) {
 		got, err := render("foo@sourcegraph.com", "", msg)
 		require.NoError(t, err)
-		b, err := got.Bytes()
-		require.NoError(t, err)
-		autogold.Expect(`References: <ref1> <ref2>
-Message-ID: 1
-Reply-To: admin@sourcegraph.com
-Date: Thu, 23 Mar 2023 22:04:44 +0900
-Message-Id: <1679576684882150000.76848.6468314242858748196@bobbook-sourcegraph.local>
-From: <foo@sourcegraph.com>
-Mime-Version: 1.0
-Content-Type: multipart/alternative;
- boundary=8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
-To: <bar1@sourcegraph.com>, <bar2@sourcegraph.com>
-Subject: a subject <b>
-
---8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
-Content-Transfer-Encoding: quoted-printable
-Content-Type: text/plain; charset=UTF-8
-
-a text body <b>
---8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31
-Content-Transfer-Encoding: quoted-printable
-Content-Type: text/html; charset=UTF-8
-
-a html body <span class=3D"&lt;b&gt;" />
---8a2ba19880a8635f7a824113c5c07af4dec92ea6b5a2a856a0adfa2a5d31--
-`).Equal(t, string(b))
+		if diff := cmp.Diff(&email.Email{
+			ReplyTo: []string{replyTo},
+			From:    "<foo@sourcegraph.com>",
+			To:      []string{"bar1@sourcegraph.com", "bar2@sourcegraph.com"},
+			Subject: "a subject <b>",
+			Text:    []byte("a text body <b>"),
+			HTML:    []byte(`a html body <span class="&lt;b&gt;" />`),
+			Headers: textproto.MIMEHeader{
+				"Message-ID": []string{messageID},
+				"References": []string{"<ref1> <ref2>"},
+			},
+		}, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
 	})
 
 	t.Run("email and sender name", func(t *testing.T) {
 		got, err := render("foo@sourcegraph.com", "foo", msg)
 		require.NoError(t, err)
-		b, err := got.Bytes()
-		require.NoError(t, err)
-		autogold.Expect(`Content-Type: multipart/alternative;
- boundary=9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
-Date: Thu, 23 Mar 2023 22:04:45 +0900
-Message-ID: 1
-References: <ref1> <ref2>
-Message-Id: <1679576685006321000.76848.5675638794021296688@bobbook-sourcegraph.local>
-From: "foo" <foo@sourcegraph.com>
-Mime-Version: 1.0
-Reply-To: admin@sourcegraph.com
-To: <bar1@sourcegraph.com>, <bar2@sourcegraph.com>
-Subject: a subject <b>
-
---9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
-Content-Transfer-Encoding: quoted-printable
-Content-Type: text/plain; charset=UTF-8
-
-a text body <b>
---9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06
-Content-Transfer-Encoding: quoted-printable
-Content-Type: text/html; charset=UTF-8
-
-a html body <span class=3D"&lt;b&gt;" />
---9120bd2820650184967d3cbb88e56ae66d34b0f8905cc194f0c517004b06--
-`).Equal(t, string(b))
+		if diff := cmp.Diff(&email.Email{
+			ReplyTo: []string{replyTo},
+			From:    `"foo" <foo@sourcegraph.com>`,
+			To:      []string{"bar1@sourcegraph.com", "bar2@sourcegraph.com"},
+			Subject: "a subject <b>",
+			Text:    []byte("a text body <b>"),
+			HTML:    []byte(`a html body <span class="&lt;b&gt;" />`),
+			Headers: textproto.MIMEHeader{
+				"Message-ID": []string{messageID},
+				"References": []string{"<ref1> <ref2>"},
+			},
+		}, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
 	})
 }

--- a/internal/txemail/txtypes/types.go
+++ b/internal/txemail/txtypes/types.go
@@ -14,7 +14,6 @@ type InternalAPIMessage struct {
 
 // Message describes an email message to be sent.
 type Message struct {
-	FromName   string   // email "From" address proper name
 	To         []string // email "To" recipients
 	ReplyTo    *string  // optional "ReplyTo" address
 	MessageID  *string  // optional "Message-ID" header

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2408,6 +2408,8 @@ type SiteConfiguration struct {
 	// EmailAddress description: The "from" address for emails sent by this server.
 	// Please see https://docs.sourcegraph.com/admin/config/email
 	EmailAddress string `json:"email.address,omitempty"`
+	// EmailSenderName description: The name to use in the "from" address for emails sent by this server.
+	EmailSenderName string `json:"email.senderName,omitempty"`
 	// EmailSmtp description: The SMTP server used to send transactional emails.
 	// Please see https://docs.sourcegraph.com/admin/config/email
 	EmailSmtp *SMTPServerConfig `json:"email.smtp,omitempty"`
@@ -2633,6 +2635,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "disablePublicRepoRedirects")
 	delete(m, "dotcom")
 	delete(m, "email.address")
+	delete(m, "email.senderName")
 	delete(m, "email.smtp")
 	delete(m, "email.templates")
 	delete(m, "embeddings")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1200,7 +1200,13 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "default": "noreply@sourcegraph.com"
+      "examples": ["noreply@sourcegraph.example.com"]
+    },
+    "email.senderName": {
+      "description": "The name to use in the \"from\" address for emails sent by this server.",
+      "type": "string",
+      "group": "Email",
+      "examples": ["Sourcegraph"]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",


### PR DESCRIPTION
Adds a new site config field, `email.senderName`, that can be used to configure a more human-friendly name for when receiving emails.

Thread: https://sourcegraph.slack.com/archives/C03JR7S7KRP/p1679517939835699

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
{
  "email.address": "noreply+dev@cloud.sourcegraph.com",
  "email.senderName": "Robert's Personal Sourcegraph",
  "email.smtp": { ... }
}
```

![image](https://user-images.githubusercontent.com/23356519/227213875-724d0378-19cf-45be-a505-c94867636229.png)

Also verified not setting `email.senderName` still works.