### PR TITLE
bazel: add anntotation when `lint configure` step fails

### DIFF
--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
         "//dev/build-tracker/notify",
         "//dev/team",
         "@com_github_buildkite_go_buildkite_v3//buildkite",
-        "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
     ],

--- a/dev/build-tracker/BUILD.bazel
+++ b/dev/build-tracker/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//dev/build-tracker/notify",
         "//dev/team",
         "@com_github_buildkite_go_buildkite_v3//buildkite",
+        "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
     ],

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -7,7 +7,7 @@ bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/
 echo "--- Checking if BUILD.bazel files were updated"
 git diff --exit-code
 
-EXIT_CODE=$(echo $?)
+EXIT_CODE=$?
 
 # if we get a non-zero exit code, bazel configure updated files
 if [[ $EXIT_CODE -ne 0 ]]; then
@@ -24,4 +24,4 @@ if [[ $EXIT_CODE -ne 0 ]]; then
 END
 fi
 
-exit $EXIT_CODE
+exit "$EXIT_CODE"

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
+bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc run :gazelle
+
+git diff --exit-code
+
+EXIT_CODE=$(echo $?)
+
+# if we get a non-zero exit code, bazel configure updated files
+if [[ $EXIT_CODE -ne 0 ]]; then
+  cat > ./annotation/bazel-configure.md <<- 'EOF'
+  BUILD.bazel files need to be updated to match the repository state. You should run the following command and commit the result
+
+  ```
+  bazel configure
+  ```
+
+  #### For more information please see the [Bazel FAQ](https://docs.sourcegraph.com/dev/background-information/bazel#faq)
+  EOF
+fi
+
+exit $EXIT_CODE

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
 # We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
+echo "--- Running bazel run :gazelle"
 bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc run :gazelle
 
+echo "--- Checking if BUILD.bazel files were updated"
 git diff --exit-code
 
 EXIT_CODE=$(echo $?)
 
 # if we get a non-zero exit code, bazel configure updated files
 if [[ $EXIT_CODE -ne 0 ]]; then
-  cat > ./annotation/bazel-configure.md <<- 'EOF'
+  mkdir -p ./anntations
+  cat <<-'END' > ./annotations/bazel-configure.md
   BUILD.bazel files need to be updated to match the repository state. You should run the following command and commit the result
 
   ```
@@ -17,7 +20,8 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   ```
 
   #### For more information please see the [Bazel FAQ](https://docs.sourcegraph.com/dev/background-information/bazel#faq)
-  EOF
+
+END
 fi
 
 exit $EXIT_CODE

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -108,7 +108,7 @@ sg ci build bzl
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel**: Configure, Build && Test
+- **Bazel**: Ensure buildfiles are up to date, Build && Test
 - Upload build trace
 
 ### Wolfi Exp Branch

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -67,7 +67,7 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 		bk.AnnotatedCmd("dev/ci/bazel-configure.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{
 				Type:         bk.AnnotationTypeWarning,
-				IncludeNames: true,
+				IncludeNames: false,
 			},
 		}),
 	}

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -32,7 +32,6 @@ func BazelIncrementalMainOperations() *operations.Set {
 // bazelAnalysisPhase only runs the analasys phase, ensure that the buildfiles
 // are correct, but do not actually build anything.
 func bazelAnalysisPhase(optional bool) func(*bk.Pipeline) {
-	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmd := []string{
 		"bazel",
 		"--bazelrc=.bazelrc",
@@ -61,23 +60,16 @@ func bazelAnalysisPhase(optional bool) func(*bk.Pipeline) {
 	}
 }
 func bazelConfigure(optional bool) func(*bk.Pipeline) {
-	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
-	configureCmd := []string{
-		"bazel",
-		"--bazelrc=.bazelrc",
-		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
-		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
-		"run :gazelle",
-	}
-
-	// if there are changes diff will exit with 1, and 0 otherwise
-	gitDiff := "git diff --exit-code"
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-configure"),
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
-		bk.RawCmd(strings.Join(configureCmd, " ")),
-		bk.RawCmd(gitDiff),
+		bk.AnnotatedCmd("dev/ci/bazel-configure.sh", bk.AnnotatedCmdOpts{
+			Annotations: &bk.AnnotationOpts{
+				Type:         bk.AnnotationTypeWarning,
+				IncludeNames: true,
+			},
+		}),
 	}
 
 	return func(pipeline *bk.Pipeline) {
@@ -85,7 +77,7 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 			cmds = append(cmds, bk.SoftFail())
 		}
 
-		pipeline.AddStep(":bazel: Configure",
+		pipeline.AddStep(":bazel: Lint configure",
 			cmds...,
 		)
 	}

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -77,7 +77,7 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 			cmds = append(cmds, bk.SoftFail())
 		}
 
-		pipeline.AddStep(":bazel: Lint configure",
+		pipeline.AddStep(":bazel: Ensure buildfiles are up to date",
 			cmds...,
 		)
 	}


### PR DESCRIPTION
The wording probably needs some work 🤔 

Example:
![Screenshot 2023-03-23 at 15 35 24](https://user-images.githubusercontent.com/1001709/227220576-1f2215d8-c515-4d6e-afa4-35e932764d51.png)

## Test plan
ran a few builds and induced some failures
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
