### PR TITLE
graphqlbackend: improve logging of email delivery failures

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -40,7 +40,7 @@ type UserEmailsService interface {
 func NewUserEmailsService(db database.DB, logger log.Logger) UserEmailsService {
 	return &userEmails{
 		db:     db,
-		logger: logger,
+		logger: logger.Scoped("UserEmails", "user emails handling service"),
 	}
 }
 
@@ -52,7 +52,7 @@ type userEmails struct {
 // Add adds an email address to a user. If email verification is required, it sends an email
 // verification email.
 func (e *userEmails) Add(ctx context.Context, userID int32, email string) error {
-	logger := e.logger.Scoped("UserEmails.Add", "handles addition of user emails")
+	logger := e.logger.Scoped("Add", "handles addition of user emails")
 	// 🚨 SECURITY: Only the user and site admins can add an email address to a user.
 	if err := auth.CheckSiteAdminOrSameUser(ctx, e.db, userID); err != nil {
 		return err
@@ -120,7 +120,8 @@ func (e *userEmails) Add(ctx context.Context, userID int32, email string) error 
 // Remove removes the e-mail from the specified user. Perforce external accounts
 // using the e-mail will also be removed.
 func (e *userEmails) Remove(ctx context.Context, userID int32, email string) error {
-	logger := e.logger.Scoped("UserEmails.Remove", "handles removal of user emails")
+	logger := e.logger.Scoped("Remove", "handles removal of user emails").
+		With(log.Int32("userID", userID))
 
 	// 🚨 SECURITY: Only the authenticated user and site admins can remove email
 	// from users' accounts.
@@ -144,8 +145,7 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 		}
 
 		if conf.CanSendEmail() {
-			svc := NewUserEmailsService(tx, logger)
-			if err := svc.SendUserEmailOnFieldUpdate(ctx, userID, "removed an email"); err != nil {
+			if err := e.SendUserEmailOnFieldUpdate(ctx, userID, "removed an email"); err != nil {
 				logger.Warn("Failed to send email to inform user of email removal", log.Error(err))
 			}
 		}
@@ -167,7 +167,8 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 // SetPrimaryEmail sets the supplied e-mail address as the primary address for
 // the given user.
 func (e *userEmails) SetPrimaryEmail(ctx context.Context, userID int32, email string) error {
-	logger := e.logger.Scoped("UserEmails.SetPrimaryEmail", "handles setting primary e-mail for user")
+	logger := e.logger.Scoped("SetPrimaryEmail", "handles setting primary e-mail for user").
+		With(log.Int32("userID", userID))
 
 	// 🚨 SECURITY: Only the authenticated user and site admins can set the primary
 	// email for users' accounts.
@@ -192,7 +193,7 @@ func (e *userEmails) SetPrimaryEmail(ctx context.Context, userID int32, email st
 // If verified is false, Perforce external accounts using the e-mail will be
 // removed.
 func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string, verified bool) error {
-	logger := e.logger.Scoped("UserEmails.SetVerified", "handles setting e-mail as verified")
+	logger := e.logger.Scoped("SetVerified", "handles setting e-mail as verified")
 
 	// 🚨 SECURITY: Only site admins (NOT users themselves) can manually set email
 	// verification status. Users themselves must go through the normal email
@@ -218,7 +219,7 @@ func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string
 			Perm:   authz.Read,
 			Type:   authz.PermRepos,
 		}); err != nil {
-			logger.Error("schemaResolver.SetUserEmailVerified: failed to grant user pending permissions", log.Int32("userID", userID), log.Error(err))
+			logger.Error("failed to grant user pending permissions", log.Int32("userID", userID), log.Error(err))
 		}
 
 		return nil

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -369,9 +369,12 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	logger := r.logger.Scoped("UpdatePassword", "password update").
+		With(log.Int32("userID", user.ID))
+
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, r.logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "updated the password"); err != nil {
-			log15.Warn("Failed to send email to inform user of password update", "error", err)
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "updated the password"); err != nil {
+			logger.Warn("Failed to send email to inform user of password update", log.Error(err))
 		}
 	}
 	return &EmptyResponse{}, nil
@@ -394,9 +397,12 @@ func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 		return nil, err
 	}
 
+	logger := r.logger.Scoped("CreatePassword", "password creation").
+		With(log.Int32("userID", user.ID))
+
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, r.logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "created a password"); err != nil {
-			log15.Warn("Failed to send email to inform user of password creation", "error", err)
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "created a password"); err != nil {
+			logger.Warn("Failed to send email to inform user of password creation", log.Error(err))
 		}
 	}
 	return &EmptyResponse{}, nil


### PR DESCRIPTION
We're seeing some email delivery failures on S2 - the logs are very nondescript at the moment, with no way of seeing the related user. This adds the user ID to some places where we send emails, and also improves scope/logger provenance in a few places.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a only logging changes