### PR TITLE
batches: handle default reviewers for Bitbucket Cloud & Server

### DIFF
--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -145,6 +145,9 @@ func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset
 	targetRepo := cs.TargetRepo.Metadata.(*bitbucketcloud.Repo)
 
 	pr := cs.Metadata.(*bbcs.AnnotatedPullRequest)
+	// The endpoint for updating a bitbucket pullrequest is a PUT endpoint which means if a field isn't provided
+	// it'll override it's value to it's empty value. We always want to retain the reviewers assigned to a pull
+	// request when updating a pull request.
 	opts.Reviewers = pr.Reviewers
 
 	updated, err := s.client.UpdatePullRequest(ctx, targetRepo, pr.ID, opts)

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -143,7 +143,9 @@ func (s BitbucketCloudSource) CloseChangeset(ctx context.Context, cs *Changeset)
 func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset) error {
 	opts := s.changesetToPullRequestInput(cs)
 	targetRepo := cs.TargetRepo.Metadata.(*bitbucketcloud.Repo)
+
 	pr := cs.Metadata.(*bbcs.AnnotatedPullRequest)
+	opts.Reviewers = pr.Reviewers
 
 	updated, err := s.client.UpdatePullRequest(ctx, targetRepo, pr.ID, opts)
 	if err != nil {

--- a/enterprise/internal/batches/sources/bitbucketcloud_test.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -380,6 +381,10 @@ func TestBitbucketCloudSource_UpdateChangeset(t *testing.T) {
 			assert.Same(t, bbRepo, r)
 			assert.EqualValues(t, 420, i)
 			assert.Equal(t, cs.Title, pri.Title)
+
+			metadata := cs.Metadata.(*bbcs.AnnotatedPullRequest)
+			assert.Len(t, pri.Reviewers, len(metadata.Reviewers))
+
 			return nil, want
 		})
 
@@ -399,6 +404,10 @@ func TestBitbucketCloudSource_UpdateChangeset(t *testing.T) {
 			assert.Same(t, bbRepo, r)
 			assert.EqualValues(t, 420, i)
 			assert.Equal(t, cs.Title, pri.Title)
+
+			metadata := cs.Metadata.(*bbcs.AnnotatedPullRequest)
+			assert.Len(t, pri.Reviewers, len(metadata.Reviewers))
+
 			return pr, nil
 		})
 
@@ -418,6 +427,10 @@ func TestBitbucketCloudSource_UpdateChangeset(t *testing.T) {
 			assert.Same(t, bbRepo, r)
 			assert.EqualValues(t, 420, i)
 			assert.Equal(t, cs.Title, pri.Title)
+
+			metadata := cs.Metadata.(*bbcs.AnnotatedPullRequest)
+			assert.Len(t, pri.Reviewers, len(metadata.Reviewers))
+
 			return pr, nil
 		})
 
@@ -869,6 +882,18 @@ func mockBitbucketCloudChangeset() (*Changeset, *types.Repo, *bitbucketcloud.Rep
 	cs := &Changeset{
 		Changeset: &btypes.Changeset{
 			ExternalID: "42",
+			Metadata: &bbcs.AnnotatedPullRequest{
+				PullRequest: &bitbucketcloud.PullRequest{
+					Reviewers: []bitbucketcloud.Account{
+						{
+							Nickname:      "test-bbcloud-user",
+							AccountStatus: bitbucketcloud.AccountStatusActive,
+							DisplayName:   "test-bbcloud-user",
+							CreatedOn:     time.Now(),
+						},
+					},
+				},
+			},
 		},
 		RemoteRepo: repo,
 		TargetRepo: repo,

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -207,6 +207,7 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 		Title:         c.Title,
 		Description:   c.Body,
 		Version:       pr.Version,
+		Reviewers:     pr.Reviewers,
 	}
 	update.ToRef.ID = c.BaseRef
 	update.ToRef.Repository.Slug = pr.ToRef.Repository.Slug

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -207,7 +207,10 @@ func (s BitbucketServerSource) UpdateChangeset(ctx context.Context, c *Changeset
 		Title:         c.Title,
 		Description:   c.Body,
 		Version:       pr.Version,
-		Reviewers:     pr.Reviewers,
+		// The endpoint for updating a bitbucket pullrequest is a PUT endpoint which means if a field isn't provided
+		// it'll override it's value to it's empty value. We always want to retain the reviewers assigned to a pull
+		// request when updating a pull request.
+		Reviewers: pr.Reviewers,
 	}
 	update.ToRef.ID = c.BaseRef
 	update.ToRef.Repository.Slug = pr.ToRef.Repository.Slug

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -386,12 +386,26 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 		instanceURL = "https://bitbucket.sgdev.org"
 	}
 
-	successPR := &bitbucketserver.PullRequest{ID: 154, Version: 5}
+	reviewers := []bitbucketserver.Reviewer{
+		{
+			Role:               "REVIEWER",
+			LastReviewedCommit: "7549846524f8aed2bd1c0249993ae1bf9d3c9998",
+			Approved:           false,
+			Status:             "UNAPPROVED",
+			User: &bitbucketserver.User{
+				Name: "batch-change-buddy",
+				Slug: "batch-change-buddy",
+				ID:   403,
+			},
+		},
+	}
+
+	successPR := &bitbucketserver.PullRequest{ID: 154, Version: 22, Reviewers: reviewers}
 	successPR.ToRef.Repository.Slug = "automation-testing"
 	successPR.ToRef.Repository.Project.Key = "SOUR"
 
 	// This version is too low
-	outdatedPR := &bitbucketserver.PullRequest{ID: 155, Version: 1}
+	outdatedPR := &bitbucketserver.PullRequest{ID: 155, Version: 13, Reviewers: reviewers}
 	outdatedPR.ToRef.Repository.Slug = "automation-testing"
 	outdatedPR.ToRef.Repository.Project.Key = "SOUR"
 

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_outdated
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_outdated
@@ -1,13 +1,13 @@
 {
   "id": 155,
-  "version": 7,
+  "version": 14,
   "title": "This is a new title",
   "description": "This is a new body",
-  "state": "OPEN",
-  "open": true,
-  "closed": false,
+  "state": "DECLINED",
+  "open": false,
+  "closed": true,
   "createdDate": 1639650896484,
-  "updatedDate": 1639652359748,
+  "updatedDate": 1679586242934,
   "fromRef": {
    "id": "refs/heads/hello-world-18",
    "repository": {
@@ -43,8 +43,38 @@
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
-  "participants": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "batch-change-buddy",
+     "emailAddress": "batch-changes@sourcegraph.com",
+     "id": 403,
+     "displayName": "Batch Change Buddy",
+     "active": true,
+     "slug": "batch-change-buddy",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
+  "participants": [
+   {
+    "user": {
+     "name": "bitbucket.system-user",
+     "id": 303,
+     "displayName": "Bitbucket",
+     "active": true,
+     "slug": "bitbucket.system-user",
+     "type": "SERVICE"
+    },
+    "role": "PARTICIPANT",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "links": {
    "self": [
     {

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_success
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_UpdateChangeset_success
@@ -1,13 +1,13 @@
 {
   "id": 154,
-  "version": 6,
+  "version": 23,
   "title": "This is a new title",
   "description": "This is a new body",
-  "state": "OPEN",
-  "open": true,
-  "closed": false,
+  "state": "DECLINED",
+  "open": false,
+  "closed": true,
   "createdDate": 1639582116883,
-  "updatedDate": 1639652359417,
+  "updatedDate": 1679586242492,
   "fromRef": {
    "id": "refs/heads/hello-world",
    "repository": {
@@ -43,8 +43,38 @@
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
-  "participants": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "batch-change-buddy",
+     "emailAddress": "batch-changes@sourcegraph.com",
+     "id": 403,
+     "displayName": "Batch Change Buddy",
+     "active": true,
+     "slug": "batch-change-buddy",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
+  "participants": [
+   {
+    "user": {
+     "name": "bitbucket.system-user",
+     "id": 303,
+     "displayName": "Bitbucket",
+     "active": true,
+     "slug": "bitbucket.system-user",
+     "type": "SERVICE"
+    },
+    "role": "PARTICIPANT",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "links": {
    "self": [
     {

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_outdated.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_outdated.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"version":1,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}}}
+      {"version":12,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"reviewers":[{"user":{"name":"batch-change-buddy","id":403,"slug":"batch-change-buddy"},"lastReviewedCommit":"7549846524f8aed2bd1c0249993ae1bf9d3c9998","role":"REVIEWER","approved":false,"status":"UNAPPROVED"}]}
     form: {}
     headers:
       Content-Type:
@@ -12,8 +12,9 @@ interactions:
     method: PUT
   response:
     body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
-      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":6,"expectedVersion":1,"pullRequest":{"id":155,"version":6,"title":"This
-      is a new title","description":"This is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639650896484,"updatedDate":1639652173617,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}}]}'
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":13,"expectedVersion":12,"pullRequest":{"id":155,"version":13,"title":"This
+      is a new title","description":"This is a new body","state":"DECLINED","open":false,"closed":true,"createdDate":1639650896484,"updatedDate":1679586216183,"closedDate":1642136347501,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"batch-change-buddy","emailAddress":"batch-changes@sourcegraph.com","id":403,"displayName":"Batch
+      Change Buddy","active":true,"slug":"batch-change-buddy","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/batch-change-buddy"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[{"user":{"name":"bitbucket.system-user","id":303,"displayName":"Bitbucket","active":true,"slug":"bitbucket.system-user","type":"SERVICE","links":{"self":[{"href":"https://bitbucket.sgdev.org/bots/bitbucket.system-user"}]}},"role":"PARTICIPANT","approved":false,"status":"UNAPPROVED"}],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}}]}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -21,21 +22,21 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 16 Dec 2021 10:59:19 GMT
+      - Thu, 23 Mar 2023 15:44:02 GMT
       Pragma:
       - no-cache
       Server:
       - Caddy
       Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@9KC48Ux659x13091408x0'
+      - '@1OD3BOQx944x4694884x0'
       X-Asessionid:
-      - 1im3mtm
+      - fz2t6d
       X-Auserid:
-      - "104"
+      - "253"
       X-Ausername:
-      - thorsten
+      - engineers
       X-Content-Type-Options:
       - nosniff
     status: 409 Conflict
@@ -43,7 +44,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"version":6,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}}}
+      {"version":13,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"reviewers":[{"user":{"name":"batch-change-buddy","id":403,"slug":"batch-change-buddy"},"lastReviewedCommit":"7549846524f8aed2bd1c0249993ae1bf9d3c9998","role":"REVIEWER","approved":false,"status":"UNAPPROVED"}]}
     form: {}
     headers:
       Content-Type:
@@ -51,8 +52,9 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/155
     method: PUT
   response:
-    body: '{"id":155,"version":7,"title":"This is a new title","description":"This
-      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639650896484,"updatedDate":1639652359748,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}'
+    body: '{"id":155,"version":14,"title":"This is a new title","description":"This
+      is a new body","state":"DECLINED","open":false,"closed":true,"createdDate":1639650896484,"updatedDate":1679586242934,"closedDate":1642136347501,"fromRef":{"id":"refs/heads/hello-world-18","displayId":"hello-world-18","latestCommit":"e2c9d5c55e423f44ada99645132dd80da3904269","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"batch-change-buddy","emailAddress":"batch-changes@sourcegraph.com","id":403,"displayName":"Batch
+      Change Buddy","active":true,"slug":"batch-change-buddy","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/batch-change-buddy"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[{"user":{"name":"bitbucket.system-user","id":303,"displayName":"Bitbucket","active":true,"slug":"bitbucket.system-user","type":"SERVICE","links":{"self":[{"href":"https://bitbucket.sgdev.org/bots/bitbucket.system-user"}]}},"role":"PARTICIPANT","approved":false,"status":"UNAPPROVED"}],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/155"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -60,21 +62,21 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 16 Dec 2021 10:59:19 GMT
+      - Thu, 23 Mar 2023 15:44:02 GMT
       Pragma:
       - no-cache
       Server:
       - Caddy
       Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@9KC48Ux659x13091409x0'
+      - '@1OD3BOQx944x4694885x0'
       X-Asessionid:
-      - 1tgf1pb
+      - t6be8u
       X-Auserid:
-      - "104"
+      - "253"
       X-Ausername:
-      - thorsten
+      - engineers
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_UpdateChangeset_success.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"version":5,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}}}
+      {"version":22,"title":"This is a new title","description":"This is a new body","toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"reviewers":[{"user":{"name":"batch-change-buddy","id":403,"slug":"batch-change-buddy"},"lastReviewedCommit":"7549846524f8aed2bd1c0249993ae1bf9d3c9998","role":"REVIEWER","approved":false,"status":"UNAPPROVED"}]}
     form: {}
     headers:
       Content-Type:
@@ -11,8 +11,9 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/154
     method: PUT
   response:
-    body: '{"id":154,"version":6,"title":"This is a new title","description":"This
-      is a new body","state":"OPEN","open":true,"closed":false,"createdDate":1639582116883,"updatedDate":1639652359417,"fromRef":{"id":"refs/heads/hello-world","displayId":"hello-world","latestCommit":"fbb818b2ba432f906a8f5fa58cadcc74dc1bf865","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"433511c512c568a6dbc308c2347879f9d6095849","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/154"}]}}'
+    body: '{"id":154,"version":23,"title":"This is a new title","description":"This
+      is a new body","state":"DECLINED","open":false,"closed":true,"createdDate":1639582116883,"updatedDate":1679586242492,"closedDate":1642222747498,"fromRef":{"id":"refs/heads/hello-world","displayId":"hello-world","latestCommit":"fbb818b2ba432f906a8f5fa58cadcc74dc1bf865","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"batch-change-buddy","emailAddress":"batch-changes@sourcegraph.com","id":403,"displayName":"Batch
+      Change Buddy","active":true,"slug":"batch-change-buddy","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/batch-change-buddy"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[{"user":{"name":"bitbucket.system-user","id":303,"displayName":"Bitbucket","active":true,"slug":"bitbucket.system-user","type":"SERVICE","links":{"self":[{"href":"https://bitbucket.sgdev.org/bots/bitbucket.system-user"}]}},"role":"PARTICIPANT","approved":false,"status":"UNAPPROVED"}],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/154"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -20,21 +21,21 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 16 Dec 2021 10:59:19 GMT
+      - Thu, 23 Mar 2023 15:44:02 GMT
       Pragma:
       - no-cache
       Server:
       - Caddy
       Vary:
-      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      - x-ausername,x-auserid,cookie,accept-encoding
       X-Arequestid:
-      - '@9KC48Ux659x13091406x0'
+      - '@1OD3BOQx944x4694883x0'
       X-Asessionid:
-      - ygdxwm
+      - 65rlgz
       X-Auserid:
-      - "104"
+      - "253"
       X-Ausername:
-      - thorsten
+      - engineers
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/internal/extsvc/bitbucketcloud/pull_requests.go
+++ b/internal/extsvc/bitbucketcloud/pull_requests.go
@@ -15,6 +15,7 @@ type PullRequestInput struct {
 	Title        string
 	Description  string
 	SourceBranch string
+	Reviewers    []Account
 
 	// The following fields are optional.
 	//

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -474,9 +474,10 @@ type UpdatePullRequestInput struct {
 	PullRequestID string `json:"-"`
 	Version       int    `json:"version"`
 
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	ToRef       Ref    `json:"toRef"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	ToRef       Ref        `json:"toRef"`
+	Reviewers   []Reviewer `json:"reviewers"`
 }
 
 func (c *Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error) {


### PR DESCRIPTION
Closes #46970

The endpoints for updating a Pull request on both Bitbucket {Server, Cloud} will remove reviewers when they aren't included in the payload for the update. This PR handles that  by making sure, we always pass in the reviewers assigned to a changeset as part of the payload during an update.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Manual testing