### PR TITLE
fix doc path in release tool

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -677,7 +677,7 @@ cc @${release.captainGitHubUsername}
                             // Update Sourcegraph versions in installation guides
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E 's/SOURCEGRAPH_VERSION="v${versionRegex}"/SOURCEGRAPH_VERSION="v${release.version.version}"/g' {} +`,
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E 's/--version ${versionRegex}/--version ${release.version.version}/g' {} +`,
-                            `${sed} -i -E 's/${versionRegex}/${release.version.version}/g' ./doc/admin/deploy_executors_kubernetes.md`,
+                            `${sed} -i -E 's/${versionRegex}/${release.version.version}/g' ./doc/admin/executors/deploy_executors_kubernetes.md`,
                             // Update fork variables in installation guides
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E "s/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${versionRegex}'/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${release.version.version}'/g" {} +`,
 


### PR DESCRIPTION
Docs were moved breaking the release tool.

## Test plan
I ran the 5.0 release and tested it live

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-fix-doc-path.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
