### PR TITLE
cody: experimental feature flag for .com

### DIFF
--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -17,12 +17,12 @@ import (
 func Init(
 	ctx context.Context,
 	observationCtx *observation.Context,
-	db database.DB,
+	_ database.DB,
 	_ codeintel.Services,
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
 	logger := log.Scoped("completions", "")
-	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger, db) }
+	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -17,12 +17,12 @@ import (
 func Init(
 	ctx context.Context,
 	observationCtx *observation.Context,
-	_ database.DB,
+	db database.DB,
 	_ codeintel.Services,
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
 	logger := log.Scoped("completions", "")
-	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger) }
+	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger, db) }
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -44,18 +44,18 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), maxRequestDuration)
 	defer cancel()
 
+	completionsConfig := conf.Get().Completions
+	if completionsConfig == nil || !completionsConfig.Enabled {
+		http.Error(w, "completions are not configured or disabled", http.StatusInternalServerError)
+		return
+	}
+
 	if envvar.SourcegraphDotComMode() {
 		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
 		if !isEnabled {
 			http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
 			return
 		}
-	}
-
-	completionsConfig := conf.Get().Completions
-	if completionsConfig == nil || !completionsConfig.Enabled {
-		http.Error(w, "completions are not configured or disabled", http.StatusInternalServerError)
-		return
 	}
 
 	if r.Method != "POST" {

--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -3,20 +3,9 @@ package cody
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
-func IsCodyExperimentalFeatureFlagEnabled(ctx context.Context, db database.DB) (bool, error) {
-	a := actor.FromContext(ctx)
-	if !a.IsAuthenticated() {
-		return false, nil
-	}
-
-	userFlags, err := db.FeatureFlags().GetUserFlags(ctx, a.UID)
-	if err != nil {
-		return false, err
-	}
-
-	return userFlags["cody-experimental"], nil
+func IsCodyExperimentalFeatureFlagEnabled(ctx context.Context) bool {
+	return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
 }

--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -1,0 +1,22 @@
+package cody
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func IsCodyExperimentalFeatureFlagEnabled(ctx context.Context, db database.DB) (bool, error) {
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return false, nil
+	}
+
+	userFlags, err := db.FeatureFlags().GetUserFlags(ctx, a.UID)
+	if err != nil {
+		return false, err
+	}
+
+	return userFlags["cody-experimental"], nil
+}


### PR DESCRIPTION
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Non-dotcom instances should work as before
* If `cody-experimental` feature flag is not created, dotcom users will not be able to use completions endpoint and embeddings GQL API
* If `cody-experimental` feature flag override is created for a user, that user should have access to completions and embeddings on dot com
* Unauthorized users should not have access to either