### PR TITLE
Mention the default endpoint if the SRC_ENDPOINT environment variable is not set

### DIFF
--- a/doc/cli/explanations/env.md
+++ b/doc/cli/explanations/env.md
@@ -14,6 +14,8 @@ https://sourcegraph.com
 
 If you're unsure what the URL for your Sourcegraph instance is, please contact your site administrator.
 
+If the environment variable is not set, it'll default to "https://sourcegraph.com"
+
 ## `SRC_ACCESS_TOKEN`
 
 `src` uses an access token to authenticate as you to your Sourcegraph instance. This token needs to be in the `SRC_ACCESS_TOKEN` environment variable.


### PR DESCRIPTION
Just a quick update to the docs. Let's mention that the default endpoint will be Sourcegraph's main instance if the SRC_ENDPOINT environment variable is not set. This came up here:

- https://github.com/1Password/shell-plugins/pull/218

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Just a small update to the docs, so I haven't tested with `sg run docsite`.