### PR TITLE
add embeddings service to App

### DIFF
--- a/enterprise/cmd/sourcegraph/main.go
+++ b/enterprise/cmd/sourcegraph/main.go
@@ -10,6 +10,7 @@ import (
 	blobstore_shared "github.com/sourcegraph/sourcegraph/cmd/blobstore/shared"
 	githubproxy_shared "github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared"
 	searcher_shared "github.com/sourcegraph/sourcegraph/cmd/searcher/shared"
+	embeddings_shared "github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/shared"
 	executor_singlebinary "github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/singlebinary"
 	frontend_shared "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/shared"
 	gitserver_shared "github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver/shared"
@@ -32,6 +33,7 @@ var services = []service.Service{
 	precise_code_intel_worker_shared.Service,
 	executor_singlebinary.Service,
 	servegit.Service,
+	embeddings_shared.Service,
 }
 
 func main() {


### PR DESCRIPTION
This will make it easier to try out the Cody server instructions without needing to deploy an instance.




## Test plan

Start App and ensure it does not fail.