### PR TITLE
Add user select for feature flag overrides

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -36,6 +36,7 @@ import { RadioButtons } from '../components/RadioButtons'
 
 import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
 import { getFeatureFlagReferences, parseProductReference } from './SiteAdminFeatureFlagsPage'
+import { UserSelect } from './user-select/UserSelect'
 
 import styles from './SiteAdminFeatureFlagConfigurationPage.module.scss'
 
@@ -368,13 +369,24 @@ const AddFeatureFlagOverride: FunctionComponent<
                             selected={overrideType}
                         />
                     </Label>
-                    <Input
-                        inputClassName="mt-2"
-                        label={`${overrideType} ID`}
-                        type="number"
-                        value={namespaceID}
-                        onChange={setInputValue}
-                    />
+                    {overrideType === 'User' && (
+                        <>
+                            <Label id="add-feature-flag--user">Select user</Label>
+                            <UserSelect
+                                onSelect={user => setNamespaceID(user?.databaseID ?? '')}
+                                htmlID="add-feature-flag--user"
+                            />
+                        </>
+                    )}
+                    {overrideType !== 'User' && (
+                        <Input
+                            inputClassName="mt-2"
+                            label={`${overrideType} ID`}
+                            type="number"
+                            value={namespaceID}
+                            onChange={setInputValue}
+                        />
+                    )}
                     <Label className="w-100">
                         <div className="mb-2 mt-2">Value</div>
                         <Toggle

--- a/client/web/src/site-admin/user-select/UserSelect.module.scss
+++ b/client/web/src/site-admin/user-select/UserSelect.module.scss
@@ -1,0 +1,74 @@
+.combobox {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-width: 25rem;
+    min-width: 22rem;
+
+    &--input-container {
+        padding: 0.5rem;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--dropdown-bg);
+    }
+
+    &--input {
+        font-size: 0.75rem;
+        padding-bottom: 0.25rem;
+    }
+
+    &--list {
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+        @-moz-document url-prefix('') {
+            scrollbar-width: thin;
+            scrollbar-color: var(--text-muted);
+        }
+    }
+
+    &--option {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 0.5rem;
+        padding-left: 1rem;
+
+        &-selected {
+            background-color: var(--color-bg-3);
+        }
+    }
+}
+
+.trigger-button {
+    display: flex;
+    align-items: center;
+    background-color: var(--input-bg);
+    font-weight: normal;
+    width: 100%;
+
+    &--text {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+
+        /*
+            Without min-width with value, the flex child containing the other text elements
+            won’t narrow past the “implied width” of those text elements.
+
+            More info (https://css-tricks.com/flexbox-truncated-text/)
+        */
+        min-width: 0;
+        white-space: nowrap;
+        margin-right: 0.25rem;
+    }
+
+    &--icon {
+        flex-shrink: 0;
+        margin-left: auto;
+        // Compensate inner view box SVG padding
+        margin-right: -0.25rem;
+        color: var(--icon-color);
+    }
+}

--- a/client/web/src/site-admin/user-select/UserSelect.tsx
+++ b/client/web/src/site-admin/user-select/UserSelect.tsx
@@ -1,0 +1,168 @@
+import React, { ButtonHTMLAttributes, forwardRef, useEffect, useState } from 'react'
+
+import classNames from 'classnames'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
+import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
+
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import {
+    Button,
+    Combobox,
+    ComboboxInput,
+    ComboboxList,
+    ComboboxOption,
+    ComboboxOptionText,
+    createRectangle,
+    Flipping,
+    Popover,
+    PopoverContent,
+    PopoverOpenEvent,
+    PopoverTrigger,
+    Strategy,
+    usePopoverContext,
+} from '@sourcegraph/wildcard'
+
+import { UserSelectSearchFields } from '../../graphql-operations'
+
+import { useUserSelectSearch } from './backend'
+
+import styles from './UserSelect.module.scss'
+
+const POPOVER_PADDING = createRectangle(0, 0, 5, 5)
+
+export interface UserSelectProps {
+    disabled?: boolean
+    htmlID?: string
+    initialUsername?: string
+    onSelect: (user: UserSelectSearchFields | null) => void
+}
+
+export const UserSelect: React.FunctionComponent<UserSelectProps> = ({
+    htmlID,
+    onSelect,
+    initialUsername,
+    disabled = false,
+}) => {
+    const [isOpen, setOpen] = useState(false)
+
+    const [selectedUser, setSelectedUser] = useState<UserSelectSearchFields>()
+
+    const handleOpenChange = (event: PopoverOpenEvent): void => {
+        setOpen(event.isOpen)
+    }
+
+    const handleSelect = (user: UserSelectSearchFields | undefined): void => {
+        setSelectedUser(user)
+        setOpen(false)
+        onSelect(user || null)
+    }
+
+    return (
+        <Popover isOpen={isOpen} onOpenChange={handleOpenChange}>
+            <PopoverTrigger
+                as={UserSelectButton}
+                id={htmlID}
+                title={selectedUser?.username ?? initialUsername}
+                disabled={disabled}
+            />
+
+            <PopoverContent
+                targetPadding={POPOVER_PADDING}
+                flipping={Flipping.opposite}
+                strategy={Strategy.Fixed}
+                className="d-flex"
+            >
+                <UserSelectContent selectedUser={selectedUser} onSelect={handleSelect} />
+            </PopoverContent>
+        </Popover>
+    )
+}
+
+export interface UserSelectContentProps {
+    selectedUser: UserSelectSearchFields | undefined
+    onSelect: (user: UserSelectSearchFields) => void
+}
+
+export const UserSelectContent: React.FunctionComponent<UserSelectContentProps> = ({ onSelect }) => {
+    const [search, setSearch] = useState<string>('')
+
+    const { data, loading, error } = useUserSelectSearch(search)
+
+    const selectHandler = (username: string): void => {
+        const user = data?.users.nodes.find(user => user.username === username)
+        if (user) {
+            onSelect(user)
+        }
+    }
+
+    useEffect(() => {
+        if (error) {
+            // eslint-disable-next-line no-console
+            console.error(error)
+        }
+    }, [error])
+
+    const suggestions: UserSelectSearchFields[] = data?.users.nodes || []
+
+    return (
+        <Combobox openOnFocus={true} className={styles.combobox} onSelect={selectHandler}>
+            <ComboboxInput
+                value={search}
+                autoFocus={true}
+                spellCheck={false}
+                placeholder="Search users"
+                aria-label="Search users"
+                inputClassName={styles.comboboxInput}
+                className={styles.comboboxInputContainer}
+                onChange={event => setSearch(event.target.value)}
+                status={loading ? 'loading' : error ? 'error' : 'initial'}
+            />
+
+            <ComboboxList className={styles.comboboxList}>
+                {suggestions.map((item, index) => (
+                    <UserOption key={item.id} item={item} index={index} />
+                ))}
+            </ComboboxList>
+        </Combobox>
+    )
+}
+
+interface UserOptionProps {
+    item: UserSelectSearchFields
+    index: number
+}
+
+const UserOption: React.FunctionComponent<UserOptionProps> = ({ item, index }) => (
+    <ComboboxOption value={item.username} index={index} className={styles.comboboxOption}>
+        <UserAvatar user={item} inline={true} className="mr-1" />{' '}
+        <span>
+            <ComboboxOptionText />
+        </span>
+    </ComboboxOption>
+)
+
+interface UserSelectButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    title: string | undefined
+}
+
+const UserSelectButton = forwardRef<HTMLButtonElement, UserSelectButtonProps>(function UserSelectButton(props, ref) {
+    const { title, className, ...attributes } = props
+    const { isOpen } = usePopoverContext()
+
+    const Icon = isOpen ? ChevronUpIcon : ChevronDownIcon
+
+    return (
+        <Button
+            {...attributes}
+            ref={ref}
+            variant="secondary"
+            outline={true}
+            aria-label="Choose a user"
+            className={classNames(className, styles.triggerButton)}
+        >
+            <span className={styles.triggerButtonText}>{title ?? 'No user'}</span>
+
+            <Icon className={styles.triggerButtonIcon} />
+        </Button>
+    )
+})

--- a/client/web/src/site-admin/user-select/backend.ts
+++ b/client/web/src/site-admin/user-select/backend.ts
@@ -1,0 +1,35 @@
+import { QueryResult } from '@apollo/client'
+
+import { gql, useQuery } from '@sourcegraph/http-client'
+
+import { UserSelectSearchResult, UserSelectSearchVariables } from '../../graphql-operations'
+
+const USER_SELECT_SEARCH_FIELDS = gql`
+    fragment UserSelectSearchFields on User {
+        id
+        username
+        displayName
+        avatarURL
+        databaseID
+    }
+`
+
+const USER_SELECT_SEARCH = gql`
+    query UserSelectSearch($search: String!) {
+        users(query: $search, first: 15) {
+            nodes {
+                ...UserSelectSearchFields
+            }
+        }
+    }
+
+    ${USER_SELECT_SEARCH_FIELDS}
+`
+
+export function useUserSelectSearch(search: string): QueryResult<UserSelectSearchResult, UserSelectSearchVariables> {
+    return useQuery<UserSelectSearchResult, UserSelectSearchVariables>(USER_SELECT_SEARCH, {
+        variables: {
+            search,
+        },
+    })
+}

--- a/client/web/src/team/members/user-select/UserSelect.tsx
+++ b/client/web/src/team/members/user-select/UserSelect.tsx
@@ -10,7 +10,7 @@ import {
     ComboboxOptionText,
 } from '@sourcegraph/wildcard'
 
-import { Scalars, UserSelectSearchFields } from '../../../graphql-operations'
+import { Scalars, TeamMemberUserSelectSearchFields } from '../../../graphql-operations'
 
 import { useUserSelectSearch } from './backend'
 
@@ -30,7 +30,7 @@ export const UserSelect: React.FunctionComponent<UserSelectProps> = ({
     setSelectedMembers,
 }) => {
     const [search, setSearch] = useState<string>('')
-    const [selectedItems, setSelectedItems] = useState<UserSelectSearchFields[]>([])
+    const [selectedItems, setSelectedItems] = useState<TeamMemberUserSelectSearchFields[]>([])
 
     useEffect(() => {
         setSelectedMembers(selectedItems.map(item => item.id))
@@ -45,7 +45,7 @@ export const UserSelect: React.FunctionComponent<UserSelectProps> = ({
         }
     }, [error])
 
-    const suggestions: UserSelectSearchFields[] = data?.users.nodes || []
+    const suggestions: TeamMemberUserSelectSearchFields[] = data?.users.nodes || []
 
     const suggestionsWithExcludes = suggestions.filter(
         item => !selectedItems.find(selectedItem => selectedItem.id === item.id)
@@ -78,7 +78,7 @@ export const UserSelect: React.FunctionComponent<UserSelectProps> = ({
 }
 
 interface UserOptionProps {
-    item: UserSelectSearchFields
+    item: TeamMemberUserSelectSearchFields
     index: number
 }
 

--- a/client/web/src/team/members/user-select/backend.ts
+++ b/client/web/src/team/members/user-select/backend.ts
@@ -2,10 +2,10 @@ import { QueryResult } from '@apollo/client'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
 
-import { UserSelectSearchResult, UserSelectSearchVariables } from '../../../graphql-operations'
+import { TeamMemberUserSelectSearchResult, TeamMemberUserSelectSearchVariables } from '../../../graphql-operations'
 
 const USER_SELECT_SEARCH_FIELDS = gql`
-    fragment UserSelectSearchFields on User {
+    fragment TeamMemberUserSelectSearchFields on User {
         id
         username
         displayName
@@ -14,10 +14,10 @@ const USER_SELECT_SEARCH_FIELDS = gql`
 `
 
 const USER_SELECT_SEARCH = gql`
-    query UserSelectSearch($search: String!) {
+    query TeamMemberUserSelectSearch($search: String!) {
         users(query: $search, first: 15) {
             nodes {
-                ...UserSelectSearchFields
+                ...TeamMemberUserSelectSearchFields
             }
         }
     }
@@ -27,8 +27,8 @@ const USER_SELECT_SEARCH = gql`
 
 export function useUserSelectSearch(
     searchTerm: string
-): QueryResult<UserSelectSearchResult, UserSelectSearchVariables> {
-    return useQuery<UserSelectSearchResult, UserSelectSearchVariables>(USER_SELECT_SEARCH, {
+): QueryResult<TeamMemberUserSelectSearchResult, TeamMemberUserSelectSearchVariables> {
+    return useQuery<TeamMemberUserSelectSearchResult, TeamMemberUserSelectSearchVariables>(USER_SELECT_SEARCH, {
         variables: {
             search: searchTerm,
         },


### PR DESCRIPTION
This adds a component to make users selectable by name, instead of id. This should be easier to use. Not the most polished implementation without also overhauling the org selector, but this should be a quick QOL improvement.

<img width="640" alt="Screenshot 2023-03-23 at 22 02 37@2x" src="https://user-images.githubusercontent.com/19534377/227360162-dd24894b-9a34-45cf-947c-f054a05f3f92.png">


## Test plan

Verified things work manually.

## App preview:

- [Web](https://sg-web-es-select-user-ff.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
