### PR TITLE
search results cache: fix regression from useObservable changes

### DIFF
--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -1,9 +1,18 @@
-import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react'
+import React, {
+    createContext,
+    createRef,
+    MutableRefObject,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
 
 import { isEqual } from 'lodash'
 import { useNavigationType, useLocation } from 'react-router-dom'
 import { merge, of } from 'rxjs'
-import { last, share, throttleTime } from 'rxjs/operators'
+import { last, share, tap, throttleTime } from 'rxjs/operators'
 
 import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -17,9 +26,7 @@ interface CachedResults {
     options: StreamSearchOptions
 }
 
-const SearchResultsCacheContext = createContext<[CachedResults | null, Dispatch<SetStateAction<CachedResults | null>>]>(
-    [null, () => null]
-)
+const SearchResultsCacheContext = createContext<MutableRefObject<CachedResults | null>>(createRef())
 
 /**
  * Returns the cached value if the options have not changed.
@@ -36,7 +43,7 @@ export function useCachedSearchResults(
     options: StreamSearchOptions,
     telemetryService: TelemetryService
 ): AggregateStreamingSearchResults | undefined {
-    const [cachedResults, setCachedResults] = useContext(SearchResultsCacheContext)
+    const cachedResults = useContext(SearchResultsCacheContext)
 
     const location = useLocation()
     const navigationType = useNavigationType()
@@ -45,8 +52,8 @@ export function useCachedSearchResults(
     const results = useObservable(
         useMemo(() => {
             // If query and options have not changed, return cached value
-            if (query === cachedResults?.query && isEqual(options, cachedResults?.options)) {
-                return of(cachedResults?.results)
+            if (query === cachedResults.current?.query && isEqual(options, cachedResults.current?.options)) {
+                return of(cachedResults.current.results)
             }
 
             const stream = streamSearch(of(query), options).pipe(share())
@@ -58,43 +65,47 @@ export function useCachedSearchResults(
             // and is discussed extensively in github issues. Instead, we just manually
             // merge throttleTime with only leading values and the final value.
             // See: https://github.com/ReactiveX/rxjs/issues/5732
-            return merge(stream.pipe(throttleTime(500)), stream.pipe(last()))
-        }, [query, cachedResults?.query, cachedResults?.options, cachedResults?.results, options, streamSearch])
+            return merge(stream.pipe(throttleTime(500)), stream.pipe(last())).pipe(
+                tap(results => {
+                    cachedResults.current = { results, query, options }
+                })
+            )
+            // We also need to pass `queryTimestamp` to the dependency array, because
+            // it's used in the `useEffect` below to reset the cache if a new search
+            // is made with the same query. Otherwise the new search will not be executed.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [query, options, streamSearch, cachedResults, queryTimestamp])
     )
 
     // Reset cached results if a new search is made with the same query
     // (e.g. to force refresh when the search button is clicked).
+    // The query timestamp is set when the search is submitted in `helpers.tsx` -> `submitSearch()`.
+    // Since the location state is of `any` type, we need to disable the eslint warnings.
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     useEffect(() => {
         if (cachedResults && location.state?.queryTimestamp !== queryTimestamp && navigationType === 'REPLACE') {
-            setCachedResults(null)
+            cachedResults.current = null
             setQueryTimestamp(location.state?.queryTimestamp)
         }
-    }, [location.state?.queryTimestamp, queryTimestamp, navigationType, cachedResults, setCachedResults])
+    }, [location.state?.queryTimestamp, queryTimestamp, navigationType, cachedResults])
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
+    // In case of back/forward navigation, log if the cache is being used.
     useEffect(() => {
-        if (results?.state === 'complete') {
-            setCachedResults({ results, query, options })
-        }
-        // Only update cached results if the results change
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [results])
-
-    useEffect(() => {
-        // In case of back/forward navigation, log if the cache is being used.
-        const cacheExists = query === cachedResults?.query && isEqual(options, cachedResults?.options)
+        const cacheExists = query === cachedResults.current?.query && isEqual(options, cachedResults.current?.options)
 
         if (navigationType === 'POP') {
             telemetryService.log('SearchResultsCacheRetrieved', { cacheHit: cacheExists }, { cacheHit: cacheExists })
         }
-        // Only log when query or options have changed
+        // Only log on first render
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [query, options])
+    }, [])
 
     return results
 }
 
 export const SearchResultsCacheProvider: React.FunctionComponent<React.PropsWithChildren<{}>> = ({ children }) => {
-    const cachedResultsState = useState<CachedResults | null>(null)
+    const cachedResultsState = useRef<CachedResults | null>(null)
 
     return (
         <SearchResultsCacheContext.Provider value={cachedResultsState}>{children}</SearchResultsCacheContext.Provider>


### PR DESCRIPTION
Fixes a regression in the search result cache that originated as a regression from https://github.com/sourcegraph/sourcegraph/pull/49838

The search results cache is used primarily in back-navigation scenarios: you make a search, click a result, and then click the back button; the same results should be rendered again without executing a new search and potentially changing the order of the results.

The order each React hook ran in was required to be in a specific order to make the cache work. The changes to the `useObservable` hook made that issue surface. This PR fixes that by clarifying the dependencies and removing one of the `useEffect`s to instead run its side-effect directly in the observable handling code. It also changes the cache to be stored in with `useRef` instead of `useState`, as re-renders are not desired when updating the cache.


## Test plan

Back button navigation:
1. Execute a search
2. Click on a result
3. Click back
Expected: Previous results should load, and no new search should be executed.

New search after clicking results:
1. Execute a search
2. Click on a result
3. Execute a new search from the search box at the top (don't reload the page)
Expected: The new search should be executed.

Re-execute the same search:
1. Execute a search
2. Click on the search box and press "Enter"
Expected: The same search should be re-executed and results should be loaded from scratch.