### PR TITLE
blobstore: implement ListObjectsV2 and DeleteObjects APIs

### DIFF
--- a/cmd/blobstore/internal/blobstore/blobstore.go
+++ b/cmd/blobstore/internal/blobstore/blobstore.go
@@ -206,8 +206,7 @@ func (s *Service) deleteObject(ctx context.Context, bucketName, objectName strin
 	return nil
 }
 
-func (s *Service) listObjects(ctx context.Context, bucketName string) ([]objectMetadata, error) {
-	_ = ctx
+func (s *Service) listObjects(_ context.Context, bucketName string) ([]objectMetadata, error) {
 
 	// Ensure the bucket cannot be created/deleted while we look at it.
 	bucketLock := s.bucketLock(bucketName)

--- a/cmd/blobstore/internal/blobstore/blobstore.go
+++ b/cmd/blobstore/internal/blobstore/blobstore.go
@@ -91,6 +91,7 @@ func (s *Service) createBucket(ctx context.Context, name string) error {
 
 type objectMetadata struct {
 	LastModified time.Time
+	Name         string
 }
 
 func (s *Service) putObject(ctx context.Context, bucketName, objectName string, data io.ReadCloser) (*objectMetadata, error) {
@@ -139,8 +140,14 @@ func (s *Service) putObject(ctx context.Context, bucketName, objectName string, 
 		return nil, errors.Wrap(err, "sync bucket dir")
 	}
 	s.Log.Debug("put object", sglog.String("key", bucketName+"/"+objectName))
+
+	age := time.Now().UTC() // logically right now, no reason to consult filesystem
+	if mock, ok := s.MockObjectAge[objectName]; ok {
+		age = mock
+	}
 	return &objectMetadata{
-		LastModified: time.Now().UTC(), // logically right now, no reason to consult filesystem
+		LastModified: age,
+		Name:         objectName,
 	}, nil
 }
 
@@ -199,6 +206,42 @@ func (s *Service) deleteObject(ctx context.Context, bucketName, objectName strin
 	return nil
 }
 
+func (s *Service) listObjects(ctx context.Context, bucketName string) ([]objectMetadata, error) {
+	_ = ctx
+
+	// Ensure the bucket cannot be created/deleted while we look at it.
+	bucketLock := s.bucketLock(bucketName)
+	bucketLock.RLock()
+	defer bucketLock.RUnlock()
+
+	entries, err := os.ReadDir(s.bucketDir(bucketName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoSuchBucket
+		}
+		return nil, errors.Wrap(err, "ReadDir")
+	}
+
+	var objects []objectMetadata
+	for _, entry := range entries {
+		objectName := fnameToObjectName(entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			s.Log.Warn("error listing objects in bucket (ignoring)", sglog.String("key", bucketName+"/"+objectName), sglog.Error(err))
+			continue
+		}
+		age := info.ModTime().UTC()
+		if mock, ok := s.MockObjectAge[objectName]; ok {
+			age = mock
+		}
+		objects = append(objects, objectMetadata{
+			Name:         objectName,
+			LastModified: age,
+		})
+	}
+	return objects, nil
+}
+
 // Returns a bucket-level lock
 //
 // When locked for reading, you have shared access to the bucket, for reading/writing objects to it.
@@ -231,6 +274,11 @@ func (s *Service) objectFilePath(bucketName, objectName string) string {
 // we be able to perform prefix matching on object keys.
 func objectFileName(objectName string) string {
 	return url.QueryEscape(objectName)
+}
+
+func fnameToObjectName(fname string) string {
+	v, _ := url.QueryUnescape(fname)
+	return v
 }
 
 var metricRunning = promauto.NewGauge(prometheus.GaugeOpts{

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -175,9 +175,6 @@ func TestDelete(t *testing.T) {
 
 // Initialize uploadstore, upload objects, expire them
 func TestExpireObjects(t *testing.T) {
-	// TODO(blobstore): Disabled because listing objects is not yet implemented.
-	t.SkipNow()
-
 	ctx := context.Background()
 	store, server, svc := initTestStore(ctx, t, t.TempDir())
 	defer server.Close()

--- a/cmd/blobstore/internal/blobstore/s3_routes.go
+++ b/cmd/blobstore/internal/blobstore/s3_routes.go
@@ -67,13 +67,13 @@ func (s *Service) serveS3(w http.ResponseWriter, r *http.Request) error {
 // GET /<bucket>
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 func (s *Service) serveListObjectsV2(w http.ResponseWriter, r *http.Request, bucketName string) error {
-	var contents []s3ListBucketResultContents
+	var contents []s3Object
 	objects, err := s.listObjects(r.Context(), bucketName)
 	if err != nil {
 		return writeS3Error(w, s3ErrorNoSuchBucket, bucketName, err, http.StatusConflict)
 	}
 	for _, obj := range objects {
-		contents = append(contents, s3ListBucketResultContents{
+		contents = append(contents, s3Object{
 			Key:          obj.Name,
 			LastModified: obj.LastModified.Format(time.RFC3339Nano),
 		})

--- a/cmd/blobstore/internal/blobstore/s3_routes.go
+++ b/cmd/blobstore/internal/blobstore/s3_routes.go
@@ -289,7 +289,7 @@ func (s *Service) serveDeleteObject(w http.ResponseWriter, r *http.Request, buck
 
 // POST /<bucket>?delete
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
-func (s *Service) serveDeleteObjects(w http.ResponseWriter, r *http.Request, bucketName string) error {
+func (s *Service) serveDeleteObjects(_ http.ResponseWriter, r *http.Request, bucketName string) error {
 	var req s3DeleteObjectsRequest
 	defer r.Body.Close()
 	if err := xml.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/cmd/blobstore/internal/blobstore/s3_types.go
+++ b/cmd/blobstore/internal/blobstore/s3_types.go
@@ -85,6 +85,18 @@ type s3ListBucketResult struct {
 	StartAfter            string
 }
 
+type s3ObjectIdentifier struct {
+	XMLName   xml.Name `xml:"Object"`
+	Key       string
+	VersionId string
+}
+
+type s3DeleteObjectsRequest struct {
+	XMLName xml.Name `xml:"Delete"`
+	Object  []s3ObjectIdentifier
+	Quiet   bool
+}
+
 func writeS3Error(w http.ResponseWriter, code, bucketName string, err error, statusCode int) error {
 	return writeXML(w, statusCode,
 		s3Error{Code: code},

--- a/cmd/blobstore/internal/blobstore/s3_types.go
+++ b/cmd/blobstore/internal/blobstore/s3_types.go
@@ -57,6 +57,34 @@ type s3CompleteMultipartUploadResult struct {
 	ChecksumSHA256 string
 }
 
+type s3ListBucketResultContentsOwner struct {
+	DisplayName string
+	ID          string
+}
+
+type s3ListBucketResultContents struct {
+	XMLName      xml.Name `xml:"Contents"`
+	Key          string
+	LastModified string
+	Owner        s3ListBucketResultContentsOwner
+	Size         int
+	StorageClass string
+}
+
+type s3ListBucketResult struct {
+	XMLName               xml.Name `xml:"ListBucketResult"`
+	IsTruncated           bool
+	Name                  string
+	Prefix                string
+	Delimiter             string
+	MaxKeys               int
+	KeyCount              int
+	Contents              []s3ListBucketResultContents
+	ContinuationToken     string
+	NextContinuationToken string
+	StartAfter            string
+}
+
 func writeS3Error(w http.ResponseWriter, code, bucketName string, err error, statusCode int) error {
 	return writeXML(w, statusCode,
 		s3Error{Code: code},

--- a/cmd/blobstore/internal/blobstore/s3_types.go
+++ b/cmd/blobstore/internal/blobstore/s3_types.go
@@ -57,16 +57,16 @@ type s3CompleteMultipartUploadResult struct {
 	ChecksumSHA256 string
 }
 
-type s3ListBucketResultContentsOwner struct {
+type s3ObjectOwner struct {
 	DisplayName string
 	ID          string
 }
 
-type s3ListBucketResultContents struct {
+type s3Object struct {
 	XMLName      xml.Name `xml:"Contents"`
 	Key          string
 	LastModified string
-	Owner        s3ListBucketResultContentsOwner
+	Owner        s3ObjectOwner
 	Size         int
 	StorageClass string
 }
@@ -79,7 +79,7 @@ type s3ListBucketResult struct {
 	Delimiter             string
 	MaxKeys               int
 	KeyCount              int
-	Contents              []s3ListBucketResultContents
+	Contents              []s3Object
 	ContinuationToken     string
 	NextContinuationToken string
 	StartAfter            string


### PR DESCRIPTION
This implements enough of the S3 API to make the lsifstore `ExpireObjects` tests pass! This was the last major blocker to shipping the Go blobstore implementation in all our deployments.

## Test plan

A new test which runs the lsifstore `ExpireObjects` codepath is enabled.

Once this merges, I will send another PR to switch us over to using the Go blobstore implementation in our dev environments. Then, after some time has passed and no major issues have occurred, I'll start switching our enterprise deployments over to this codebase instead of the old s3proxy one.

Note that Sourcegraph App is also already using the Go blobstore implementation, so there has already been some testing with the new implementation. I just want to make sure it's really solid before shipping to customers, so it doesn't cause more frustration than my work on blobstore already has.