### PR TITLE
do not open browser to App in local dev mode

### DIFF
--- a/cmd/frontend/internal/bg/app_ready.go
+++ b/cmd/frontend/internal/bg/app_ready.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 // AppReady is called once the frontend has reported it is ready to serve
@@ -37,21 +38,23 @@ func AppReady(db database.DB, logger log.Logger) {
 		browserURL = signInURL
 	}
 
-	// See cmd/frontend/graphqlbackend/site_flags.go:needsRepositoryConfiguration
-	// There is technically a small race condition where we need repository discovery
-	// to finish before we decide whether or not to render the setup wizard.
-	//
-	// The impact of this race condition is very minimal (worst case scenario it
-	// displays the setup wizard when the user doesn't need it to.) We sleep for a second
-	// before opening the browser just to reduce the chance of it.
-	//
-	// https://github.com/sourcegraph/sourcegraph/pull/49820#issuecomment-1479959514
-	time.Sleep(1 * time.Second)
-	if err := browser.OpenURL(browserURL); err != nil {
-		logger.Error("failed to open browser", log.String("url", browserURL), log.Error(err))
-		// We failed to open the browser, so rather display that URL so the
-		// user can click it.
-		displayURL = browserURL
+	if !version.IsDev(version.Version()) {
+		// See cmd/frontend/graphqlbackend/site_flags.go:needsRepositoryConfiguration
+		// There is technically a small race condition where we need repository discovery
+		// to finish before we decide whether or not to render the setup wizard.
+		//
+		// The impact of this race condition is very minimal (worst case scenario it
+		// displays the setup wizard when the user doesn't need it to.) We sleep for a second
+		// before opening the browser just to reduce the chance of it.
+		//
+		// https://github.com/sourcegraph/sourcegraph/pull/49820#issuecomment-1479959514
+		time.Sleep(1 * time.Second)
+		if err := browser.OpenURL(browserURL); err != nil {
+			logger.Error("failed to open browser", log.String("url", browserURL), log.Error(err))
+			// We failed to open the browser, so rather display that URL so the
+			// user can click it.
+			displayURL = browserURL
+		}
 	}
 
 	printExternalURL(displayURL)


### PR DESCRIPTION
This env var defaults to true. If false, `sg start app` does not open a new browser tab each time the Go program recompiles.




## Test plan

n/a