### PR TITLE
fix Apollo GraphQL cache warnings

### DIFF
--- a/client/shared/src/backend/repo.ts
+++ b/client/shared/src/backend/repo.ts
@@ -63,6 +63,7 @@ export const fetchTreeEntries = memoizeObservable(
                     $first: Int
                 ) {
                     repository(name: $repoName) {
+                        id
                         commit(rev: $commitID, inputRevspec: $revision) {
                             tree(path: $filePath) {
                                 ...TreeFields

--- a/client/web/src/enterprise/codeintel/dashboard/backend.ts
+++ b/client/web/src/enterprise/codeintel/dashboard/backend.ts
@@ -20,6 +20,7 @@ export const globalCodeIntelStatusQuery = gql`
             repositoriesWithErrors {
                 nodes {
                     repository {
+                        id
                         name
                         url
                         externalRepository {
@@ -33,6 +34,7 @@ export const globalCodeIntelStatusQuery = gql`
             repositoriesWithConfiguration {
                 nodes {
                     repository {
+                        id
                         name
                         url
                         externalRepository {
@@ -101,6 +103,7 @@ export const repoCodeIntelStatusSummaryFragment = gql`
 export const repoCodeIntelStatusQuery = gql`
     query RepoCodeIntelStatus($repository: String!) {
         repository(name: $repository) {
+            id
             codeIntelSummary {
                 ...RepoCodeIntelStatusSummaryFields
             }

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -14,6 +14,7 @@ import {
 
 export const createTreeEntriesResult = (url: string, toplevelFiles: string[]): TreeEntriesResult => ({
     repository: {
+        id: `$repo-id-${url}`,
         commit: {
             tree: {
                 isRoot: true,

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -476,6 +476,7 @@ describe('Repository', () => {
 
             const TreeEntries = {
                 repository: {
+                    id: 'test-repo-id',
                     commit: {
                         tree: {
                             isRoot: false,


### PR DESCRIPTION
Fixes console warnings from the Apollo GraphQL library: `Cache data may be lost when replacing the repository field of a Query object. ...`




## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-fix-apollogql-cache-warn.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
