### PR TITLE
set embeddings endpoint to localhost in App

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -52,9 +52,10 @@ func Init(logger log.Logger) {
 	//
 	// setDefaultEnv(logger, "JAEGER_SERVER_URL", "http://localhost:16686")
 
-	// The s3proxy blobstore does need to be running. TODO(sqs): TODO(single-binary): bundle this somehow?
+	// Use blobstore on localhost.
 	setDefaultEnv(logger, "PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://localhost:9000")
 	setDefaultEnv(logger, "PRECISE_CODE_INTEL_UPLOAD_BACKEND", "blobstore")
+	setDefaultEnv(logger, "EMBEDDINGS_UPLOAD_AWS_ENDPOINT", "http://localhost:9000")
 
 	// Need to override this because without a host (eg ":3080") it listens only on localhost, which
 	// is not accessible from the containers


### PR DESCRIPTION
Need to do this for embeddings in App just as we do for precise code intel. Otherwise it defaults to the hostname `blobstore`.




## Test plan

Run `sg start app`. Try to enqueue a new repo for embeddings.