### PR TITLE
cody: do not include editor context if codebase context is not required

### DIFF
--- a/client/cody/src/chat/recipes/chat-question.ts
+++ b/client/cody/src/chat/recipes/chat-question.ts
@@ -39,18 +39,18 @@ export class ChatQuestion implements Recipe {
         intentDetector: IntentDetector,
         codebaseContext: CodebaseContext
     ): Promise<ContextMessage[]> {
-        const contextMessages = this.getEditorContext(editor)
-
         const isCodebaseContextRequired = await intentDetector.isCodebaseContextRequired(text)
-        if (isCodebaseContextRequired) {
-            const codebaseContextMessages = await codebaseContext.getContextMessages(text, {
-                numCodeResults: 8,
-                numTextResults: 2,
-            })
-            contextMessages.push(...codebaseContextMessages)
+        if (!isCodebaseContextRequired) {
+            return []
         }
 
-        return contextMessages
+        const editorContextMessages = this.getEditorContext(editor)
+        const codebaseContextMessages = await codebaseContext.getContextMessages(text, {
+            numCodeResults: 8,
+            numTextResults: 2,
+        })
+
+        return editorContextMessages.concat(codebaseContextMessages)
     }
 
     private getEditorContext(editor: Editor): ContextMessage[] {

--- a/client/cody/src/test/unit/transcript.test.ts
+++ b/client/cody/src/test/unit/transcript.test.ts
@@ -192,14 +192,8 @@ describe('Transcript', () => {
         const editor = new MockEditor({
             getActiveTextEditorVisibleContent: () => ({ fileName: 'internal/lib.go', content: 'package lib' }),
         })
-        const embeddings = new MockEmbeddingsClient({
-            search: async () => ({
-                codeResults: [{ fileName: 'src/main.go', startLine: 0, endLine: 1, content: 'package main' }],
-                textResults: [{ fileName: 'docs/README.md', startLine: 0, endLine: 1, content: '# Main' }],
-            }),
-        })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => false })
-        const codebaseContext = new CodebaseContext('embeddings', embeddings, defaultKeywordContextFetcher)
+        const codebaseContext = new CodebaseContext('embeddings', defaultEmbeddingsClient, defaultKeywordContextFetcher)
 
         const transcript = new Transcript()
         const interaction = await new ChatQuestion().getInteraction(


### PR DESCRIPTION
Fixes Slack thread: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1679609880766339

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Green tests: `pnpm run build && pnpm run test:unit`

## App preview:

- [Web](https://sg-web-rn-cody-do-not-include-editor.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
