### PR TITLE
site config: Show realistic total count

### DIFF
--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -252,7 +252,7 @@ func TestSiteConfigConnection(t *testing.T) {
 					"configuration": {
 						"id": 6,
 						"history": {
-							"totalCount": 6,
+							"totalCount": 5,
 							"nodes": [
 								{
 									"id": %[1]q,
@@ -327,7 +327,7 @@ func TestSiteConfigConnection(t *testing.T) {
 							"configuration": {
 								"id": 6,
 								"history": {
-									"totalCount": 6,
+									"totalCount": 5,
 									"nodes": [
 										{
 											"id": %[1]q,
@@ -406,7 +406,7 @@ func TestSiteConfigConnection(t *testing.T) {
 					"configuration": {
 						"id": 6,
 						"history": {
-							"totalCount": 6,
+							"totalCount": 5,
 							"nodes": [
 								{
 									"id": %[1]q,
@@ -481,7 +481,7 @@ func TestSiteConfigConnection(t *testing.T) {
 					"configuration": {
 						"id": 6,
 						"history": {
-							"totalCount": 6,
+							"totalCount": 5,
 							"nodes": [
 								{
 									"id": %[1]q,

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -184,11 +184,11 @@ func (s *confStore) ListSiteConfigs(ctx context.Context, paginationArgs *Paginat
 
 const getSiteConfigCount = `
 SELECT
-	count(*)
+	COUNT(*)
 FROM (
 	SELECT
 		*,
-		lag(redacted_contents) OVER (ORDER BY id) AS prev_redacted_contents
+		LAG(redacted_contents) OVER (ORDER BY id) AS prev_redacted_contents
 	FROM
 		critical_and_site_config) t
 WHERE (prev_redacted_contents IS NULL

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -376,8 +376,9 @@ func TestGetSiteConfigCount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 5 {
-		t.Fatalf("Expected 5 site config entries, but got %d", count)
+	// We have 5 entries in the DB, but we skip redundant ones so this returns 4.
+	if count != 4 {
+		t.Fatalf("Expected 4 site config entries, but got %d", count)
 	}
 }
 


### PR DESCRIPTION
Follow up for #46032.

Since we list only non-redundant site configs from the list function, the count should also follow the same conditions. Without this, the total count is misleading, while there will not be enough configs to paginate through that will match the total count.


For example, on dotcom we see ~35k as the total count, but have only two pages to iterate though till the end of the history.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/2682729/227446791-93f48812-4322-4c8e-8415-d4f644d73311.png">


## Test plan

**Before**

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/2682729/227447534-102287d1-85e1-4362-a5d2-6db7a72dad87.png">




**After**

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/2682729/227447243-d5504e2a-ea9d-4ffd-aa61-2dba4a47c068.png">


1. Tested locally
1. Updated tests
1. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
