### PR TITLE
site-config: Remove reproducedDiff and make diff non-nullable

### DIFF
--- a/client/web/src/site-admin/SiteConfigurationChangeListPage.tsx
+++ b/client/web/src/site-admin/SiteConfigurationChangeListPage.tsx
@@ -72,11 +72,7 @@ export const SiteConfigurationChangeListPage: FC = () => {
 interface SiteConfigurationHistoryItemProps {
     node: SiteConfigurationChangeNode
 }
-function linesChanged(diffString: string | null): [number, number] {
-    if (diffString === null) {
-        return [0, 0]
-    }
-
+function linesChanged(diffString: string): [number, number] {
     return diffString
         .split('\n')
         .slice(3)
@@ -93,63 +89,52 @@ function linesChanged(diffString: string | null): [number, number] {
             [0, 0]
         )
 }
+
 const SiteConfigurationHistoryItem: FC<SiteConfigurationHistoryItemProps> = ({ node }) => {
     const [open, setOpen] = useState<boolean>(false)
     const icon = open ? mdiChevronUp : mdiChevronDown
+    const [removedLines, addedLines] = linesChanged(node.diff)
 
-    if (node.reproducedDiff) {
-        const [removedLines, addedLines] = linesChanged(node.diff)
-
-        return (
-            <>
-                <Collapse key={node.id} isOpen={open} onOpenChange={setOpen}>
-                    <CollapseHeader
-                        as={Button}
-                        aria-expanded={open}
-                        type="button"
-                        className="d-flex p-0 justify-content-start w-100"
-                    >
-                        <Icon aria-hidden={true} svgPath={icon} />
-                        <span>
-                            Changed <Timestamp date={node.createdAt} />
-                            {node.author ? (
-                                <>
-                                    <span className="ml-1">
-                                        by{' '}
-                                        <Link to={`/users/${node.author.username}`} className="text-truncate">
-                                            {node.author.displayName}
-                                        </Link>
-                                    </span>
-                                </>
-                            ) : (
-                                <Tooltip content="Author information is not available because this change was made directly by editing the SITE_CONFIG_FILE">
-                                    <Icon
-                                        className="ml-1"
-                                        svgPath={mdiInformationOutline}
-                                        aria-label="Author information is not available because this change was made directly by editing the SITE_CONFIG_FILE"
-                                    />
-                                </Tooltip>
-                            )}
-                        </span>
-                        {node.diff && (
-                            <span className="ml-auto">
-                                <DiffStatStack className="mr-1" added={addedLines} deleted={removedLines} />
-                            </span>
-                        )}
-                    </CollapseHeader>
-                    <CollapsePanel>
-                        <Code className={classNames('p-2', 'mt-2', styles.diffblock)}>{node.diff}</Code>
-                    </CollapsePanel>
-                </Collapse>
-                <hr className="mb-3 mt-3" />
-            </>
-        )
-    }
     return (
-        <CollapseHeader className="d-block mb-3">
-            <>
-                {node.author} {node.createdAt}
-            </>
-        </CollapseHeader>
+        <>
+            <Collapse key={node.id} isOpen={open} onOpenChange={setOpen}>
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={open}
+                    type="button"
+                    className="d-flex p-0 justify-content-start w-100"
+                >
+                    <Icon aria-hidden={true} svgPath={icon} />
+                    <span>
+                        Changed <Timestamp date={node.createdAt} />
+                        {node.author ? (
+                            <>
+                                <span className="ml-1">
+                                    by{' '}
+                                    <Link to={`/users/${node.author.username}`} className="text-truncate">
+                                        {node.author.displayName}
+                                    </Link>
+                                </span>
+                            </>
+                        ) : (
+                            <Tooltip content="Author information is not available because this change was made directly by editing the SITE_CONFIG_FILE">
+                                <Icon
+                                    className="ml-1"
+                                    svgPath={mdiInformationOutline}
+                                    aria-label="Author information is not available because this change was made directly by editing the SITE_CONFIG_FILE"
+                                />
+                            </Tooltip>
+                        )}
+                    </span>
+                    <span className="ml-auto">
+                        <DiffStatStack className="mr-1" added={addedLines} deleted={removedLines} />
+                    </span>
+                </CollapseHeader>
+                <CollapsePanel>
+                    <Code className={classNames('p-2', 'mt-2', styles.diffblock)}>{node.diff}</Code>
+                </CollapsePanel>
+            </Collapse>
+            <hr className="mb-3 mt-3" />
+        </>
     )
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1020,7 +1020,6 @@ export const SITE_CONFIGURATION_CHANGE_CONNECTION_QUERY = gql`
             username
             displayName
         }
-        reproducedDiff
         diff
         createdAt
     }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7033,7 +7033,9 @@ type SiteConfiguration {
 }
 
 """
-A list of site config diffs.
+A list of site config diffs. Diff generation may not be available from the very
+start depending on when the value of redacted_contents is available in the
+database.
 """
 type SiteConfigurationChangeConnection implements Connection {
     """
@@ -7066,17 +7068,9 @@ type SiteConfigurationChange implements Node {
     author: User
 
     """
-    A flag to indicate if the diff of changes to the previous site configuration
-    was reproduced or not. Sometimes it may not be possible to generate a diff
-    (for example the redacted contents are not available) in which case the
-    value of the flag will be false.
+    The diff string when diffed against the previous site config.
     """
-    reproducedDiff: Boolean!
-
-    """
-    The diff string when diffed against the previous site config. When this is null there was no diff to the previous change.
-    """
-    diff: String
+    diff: String!
     """
     The timestamp when this change in the site config was applied.
     """

--- a/cmd/frontend/graphqlbackend/site_config_change.go
+++ b/cmd/frontend/graphqlbackend/site_config_change.go
@@ -38,30 +38,7 @@ func (r SiteConfigurationChangeResolver) Author(ctx context.Context) (*UserResol
 	return user, nil
 }
 
-func (r SiteConfigurationChangeResolver) ReproducedDiff() bool {
-	// If we were able to redact contents for both siteConfig and previousSiteConfig and store it in
-	// the DB, then we can generate a diff.
-	if r.siteConfig != nil {
-		// As a special case, if previousSiteConfig is nil (first entry in the DB) and we also have
-		// redactedContents available for this siteConfig, we can generate a diff (it will be all
-		// lines added).
-		if r.previousSiteConfig == nil && r.siteConfig.RedactedContents != "" {
-			return true
-		}
-
-		if r.siteConfig.RedactedContents != "" && r.previousSiteConfig.RedactedContents != "" {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (r SiteConfigurationChangeResolver) Diff() *string {
-	if !r.ReproducedDiff() {
-		return nil
-	}
-
+func (r SiteConfigurationChangeResolver) Diff() string {
 	var prevID int32
 	var prevRedactedContents string
 	if r.previousSiteConfig != nil {
@@ -79,7 +56,7 @@ func (r SiteConfigurationChangeResolver) Diff() *string {
 	edits := myers.ComputeEdits("", prevRedactedContents, r.siteConfig.RedactedContents)
 	diff := fmt.Sprint(gotextdiff.ToUnified(prettyID(prevID), prettyID(r.siteConfig.ID), prevRedactedContents, edits))
 
-	return &diff
+	return diff
 }
 
 func (r SiteConfigurationChangeResolver) CreatedAt() gqlutil.DateTime {

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -231,7 +231,6 @@ func TestSiteConfigConnection(t *testing.T) {
 								  username,
 								  displayName
 							  }
-							  reproducedDiff
 							  diff
 						  }
 						  pageInfo {
@@ -261,7 +260,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-									"reproducedDiff": true,
 									"diff": %[3]q
 								},
 								{
@@ -271,7 +269,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-									"reproducedDiff": true,
 									"diff": %[4]q
 								}
 							],
@@ -306,7 +303,6 @@ func TestSiteConfigConnection(t *testing.T) {
 											username,
 											displayName
 										}
-										reproducedDiff
 										diff
 									}
 									pageInfo {
@@ -336,19 +332,19 @@ func TestSiteConfigConnection(t *testing.T) {
 												"username": "bar",
 												"displayName": "bar user"
 											},
-											"reproducedDiff": true,
+
 											"diff": %[4]q
 										},
 										{
 											"id": %[2]q,
 											"author": null,
-											"reproducedDiff": true,
+
 											"diff": %[5]q
 										},
 										{
 											"id": %[3]q,
 											"author": null,
-											"reproducedDiff": true,
+
 											"diff": %[6]q
 										}
 									],
@@ -385,7 +381,6 @@ func TestSiteConfigConnection(t *testing.T) {
 									username,
 									displayName
 								}
-								reproducedDiff
 								diff
 							}
 							pageInfo {
@@ -415,7 +410,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-									"reproducedDiff": true,
 									"diff": %[3]q
 								},
 								{
@@ -425,7 +419,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "bar",
 										"displayName": "bar user"
 									},
-									"reproducedDiff": true,
 									"diff": %[4]q
 								}
 							],
@@ -460,7 +453,6 @@ func TestSiteConfigConnection(t *testing.T) {
 									username,
 									displayName
 								}
-								reproducedDiff
 								diff
 							}
 							pageInfo {
@@ -490,7 +482,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-									"reproducedDiff": true,
 									"diff": %[3]q
 								},
 								{
@@ -500,7 +491,6 @@ func TestSiteConfigConnection(t *testing.T) {
 										"username": "foo",
 										"displayName": "foo user"
 									},
-									"reproducedDiff": true,
 									"diff": %[4]q
 								}
 							],

--- a/cmd/frontend/graphqlbackend/site_config_change_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_test.go
@@ -8,92 +8,9 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 )
-
-func TestSiteConfigurationChangeResolverReproducedDiff(t *testing.T) {
-	testCases := []struct {
-		name     string
-		resolver SiteConfigurationChangeResolver
-		expected bool
-	}{
-		{
-			name:     "both siteConfig and previousSiteConfig are nil",
-			resolver: SiteConfigurationChangeResolver{},
-			expected: false,
-		},
-		{
-			name: "siteConfig is nil",
-			resolver: SiteConfigurationChangeResolver{
-				previousSiteConfig: &database.SiteConfig{},
-			},
-			expected: false,
-		},
-		{
-			name: "previousSiteConfig is nil",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig: &database.SiteConfig{},
-			},
-			expected: false,
-		},
-
-		{
-			name: "siteConfig.RedactedContents is non-empty but previousSiteConfig is nil",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig: &database.SiteConfig{
-					RedactedContents: "foo",
-				},
-			},
-			expected: true,
-		},
-
-		{
-			name: "both siteConfig.RedactedContents and previousSiteConfig.RedactedContents are empty",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig:         &database.SiteConfig{},
-				previousSiteConfig: &database.SiteConfig{},
-			},
-			expected: false,
-		},
-
-		{
-			name: "siteConfig.RedactedContents is empty",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig:         &database.SiteConfig{},
-				previousSiteConfig: &database.SiteConfig{RedactedContents: "foo"},
-			},
-			expected: false,
-		},
-		{
-			name: "previousSiteConfig.RedactedContents is empty",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig:         &database.SiteConfig{RedactedContents: "foo"},
-				previousSiteConfig: &database.SiteConfig{},
-			},
-			expected: false,
-		},
-
-		{
-			name: "both siteConfig.RedactedContents and previousSiteConfig.RedactedContents is non-empty",
-			resolver: SiteConfigurationChangeResolver{
-				siteConfig:         &database.SiteConfig{RedactedContents: "foo"},
-				previousSiteConfig: &database.SiteConfig{RedactedContents: "foo"},
-			},
-			expected: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.resolver.ReproducedDiff() != tc.expected {
-				t.Errorf("mismatched value for ReproducedDiff, expected %v, but got %v", tc.expected, tc.resolver.ReproducedDiff())
-			}
-		})
-	}
-
-}
 
 func TestSiteConfigurationDiff(t *testing.T) {
 	stubs := setupSiteConfigStubs(t)
@@ -109,32 +26,32 @@ func TestSiteConfigurationDiff(t *testing.T) {
 	expectedNodes := []struct {
 		ID           int32
 		AuthorUserID int32
-		Diff         *string
+		Diff         string
 	}{
 		{
 			ID:           6,
 			AuthorUserID: 1,
-			Diff:         stringPtr(expectedDiffs[6]),
+			Diff:         expectedDiffs[6],
 		},
 		{
 			ID:           4,
 			AuthorUserID: 1,
-			Diff:         stringPtr(expectedDiffs[4]),
+			Diff:         expectedDiffs[4],
 		},
 		{
 			ID:           3,
 			AuthorUserID: 2,
-			Diff:         stringPtr(expectedDiffs[3]),
+			Diff:         expectedDiffs[3],
 		},
 		{
 			ID:           2,
 			AuthorUserID: 0,
-			Diff:         stringPtr(expectedDiffs[2]),
+			Diff:         expectedDiffs[2],
 		},
 		{
 			ID:           1,
 			AuthorUserID: 0,
-			Diff:         stringPtr(expectedDiffs[1]),
+			Diff:         expectedDiffs[1],
 		},
 	}
 
@@ -182,11 +99,7 @@ func TestSiteConfigurationDiff(t *testing.T) {
 					t.Errorf("mismatched node AuthorUserID, expected: %d, but got: %d", siteConfig.ID, expectedNode.ID)
 				}
 
-				if !nodes[i].ReproducedDiff() {
-					t.Fatal("expected reproducedDiff to be true but got false")
-				}
-
-				if diff := cmp.Diff(*expectedNode.Diff, *nodes[i].Diff()); diff != "" {
+				if diff := cmp.Diff(expectedNode.Diff, nodes[i].Diff()); diff != "" {
 					t.Errorf("mismatched node diff (-want, +got):\n%s ", diff)
 				}
 			}


### PR DESCRIPTION
Follow up on #46032 for cleanups.

In this commit we trip and modify the site config change API:

- With the changes in the backend to skip redundant entries to the critical_and_site_config table, we no longer require the reporoudcedDiff boolean to indicate if we were able to reproduce a diff or not. We simply do not return elements where we cannot reproduce a diff any more.

- Consequently, it is now guaranteed that diff will be non null for every node in the response.

Finally, we update the frontend compoenent to:
- Not check reproducedDiff
- Not handle null diff



## Test plan

1. Tested locally that UI still works as expected
1. Updated unit tests
1. Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
