### PR TITLE
Revert "Bring back padding between git blame annotations and content …

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -219,7 +219,7 @@ const showGitBlameDecorations = Facet.define<BlameDecorationsFacetProps, BlameDe
                 // Move the start of the line to after the blame decoration.
                 // This is necessary because the start of the line is used for
                 // aligning tab characters.
-                paddingLeft: 'calc(var(--blame-decoration-width) + 1rem) !important',
+                paddingLeft: 'var(--blame-decoration-width) !important',
             },
             '.blame-decoration': {
                 // Remove the blame decoration from the content flow so that


### PR DESCRIPTION
This reverts the blame decorations spacing fix (#49027), introducing another regression: the gap between the blame decorations and selected lines content.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/25318659/227476831-486de689-d651-4a25-ba5a-42f47c001007.png)|<img width="1787" alt="Screenshot 2023-03-24 at 11 16 00" src="https://user-images.githubusercontent.com/25318659/227476765-f86129f5-b76f-4a85-baa5-95fc41867ee1.png">|



## Test plan
Tested manually (screenshots attached).




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-revert-blame.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
