### PR TITLE
insights: use month year on x axis if the chart spans a year or more

### DIFF
--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -19,13 +19,29 @@ import { getSeriesData, getMinMaxBoundaries } from './utils'
 
 import styles from './LineChart.module.scss'
 
+/*
+ * Returns the number of days between two dates.
+ *
+ * @param date1 - The start date
+ * @param date2 - The end date
+ * @returns The number of days between the two dates
+ */
+const daysBetween = (date1: Date, date2: Date): number =>
+    Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
+
 /**
  * Returns a formatted time text. It's used primary for X axis tick's text nodes.
  * Number of month day + short name of month.
  *
  * Example: 01 Jan, 12 Feb, ...
  */
-const formatDateTick = timeFormat('%d %b')
+
+const getFormatDateTick = (scale: ScaleTime<number, number>): ((date: Date) => string) => {
+    if (scale.domain.length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
+        return (date: Date) => timeFormat('%d %b')(date)
+    }
+    return (date: Date) => timeFormat('%b %y')(date)
+}
 
 interface GetScaleTicksInput {
     scale: AnyD3Scale
@@ -39,7 +55,6 @@ export function getXScaleTicks<T>(input: GetScaleTicksInput): T[] {
     const numberTicks = Math.max(2, Math.floor(space / pixelsPerTick))
     return getTicks(scale, numberTicks) as T[]
 }
-
 interface GetLineGroupStyleOptions {
     /** Whether this series contains the active point */
     id: string
@@ -173,7 +188,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                     pixelsPerTick={70}
                     minRotateAngle={20}
                     maxRotateAngle={60}
-                    tickFormat={formatDateTick}
+                    tickFormat={getFormatDateTick(xScale)}
                     getScaleTicks={getXScaleTicks}
                 />
 

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -29,15 +29,17 @@ import styles from './LineChart.module.scss'
 const daysBetween = (date1: Date, date2: Date): number =>
     Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
 
-/**
- * Returns a formatted time text. It's used primary for X axis tick's text nodes.
- * Number of month day + short name of month.
+/*
+ * Returns a date tick formatter function based on the scale's domain.
  *
- * Example: 01 Jan, 12 Feb, ...
+ * If the domain spans less than a year, it returns a formatter that shows the day of month and month name (e.g. "01 Jan").
+ * Otherwise, it returns a formatter that shows just the month and year (e.g. "Jan 20").
+ *
+ * @param scale - The time scale to base the decision on
+ * @returns A function that formats a date to a string
  */
-
 const getFormatDateTick = (scale: ScaleTime<number, number>): ((date: Date) => string) => {
-    if (scale.domain.length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
+    if (scale.domain().length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
         return (date: Date) => timeFormat('%d %b')(date)
     }
     return (date: Date) => timeFormat('%b %y')(date)

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -19,7 +19,7 @@ import { getSeriesData, getMinMaxBoundaries } from './utils'
 
 import styles from './LineChart.module.scss'
 
-/*
+/**
  * Returns the number of days between two dates.
  *
  * @param date1 - The start date
@@ -29,7 +29,7 @@ import styles from './LineChart.module.scss'
 const daysBetween = (date1: Date, date2: Date): number =>
     Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
 
-/*
+/**
  * Returns a date tick formatter function based on the scale's domain.
  *
  * If the domain spans less than a year, it returns a formatter that shows the day of month and month name (e.g. "01 Jan").


### PR DESCRIPTION
It has been a reoccurring issue that causes confusion with users when the values on the x axis are all the same because the year is excluded. The d3 logic for picking tick marks encourages it so it is the default state for most insights.

This change switches the label to show Month Year if the chart spans at least a year while keeping the current Day Month if it doesn't.

resolves https://github.com/sourcegraph/sourcegraph/issues/28766
## Test plan
Before:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/6098507/227521354-82d46b9d-ffaf-42a8-8ce6-b30dc4cd844b.png">
After:
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/6098507/227519112-127afe98-73e4-4f8d-b38e-e668183632c1.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-x-axis-year.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
