### PR TITLE
Fix bad error surfacing for git fetch

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -85,7 +85,7 @@ func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDi
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
 	if output, err := runWith(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
-		return errors.Wrapf(&GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}, "failed to update")
+		return &GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
 	}
 	return nil
 }


### PR DESCRIPTION
The error wrapping was causing the entirety of the output to get lost, meaning that we had no idea why a git fetch would fail.

## Test plan

Before:
![image](https://user-images.githubusercontent.com/20795805/227553807-5ac51a2f-2390-42d1-bb79-32964ea46532.png)

Now:
![image](https://user-images.githubusercontent.com/20795805/227554194-9a23ff71-3289-4075-9542-2f30d3ee1d11.png)
