### PR TITLE
own: add search integration test for own predicates

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -84,6 +84,10 @@ func TestSearch(t *testing.T) {
 		testListingSearchContexts(t, client)
 	})
 
+	// Run the tests with ownership enabled
+	if err := client.SetFeatureFlag("search-ownership", true); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("graphql", func(t *testing.T) {
 		testSearchClient(t, client)
 	})

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1307,7 +1307,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `predicate logic does not conflict with unrecognized patterns`,
 				query:  `repo:sg(test)`,
-				counts: counts{Repo: 6},
+				counts: counts{Repo: 7},
 			},
 			{
 				name:   `repo has commit after`,


### PR DESCRIPTION
closes #49082

created https://ghe.sgdev.org/sgtest/own (credentials are in 1Password)

## Test plan

`sg ci build backend-integration`
