### PR TITLE
permissions-center: add a dot to status badge if some provider syncs failed.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -102,24 +102,31 @@ export const JOB_STATE_METADATA_MAPPING: Record<PermissionsSyncJobState, JobStat
 }
 
 interface PermissionsSyncJobStatusBadgeProps {
-    state: PermissionsSyncJobState
-    cancellationReason: string | null
-    failureMessage: string | null
+    job: PermissionsSyncJob
 }
 
-export const PermissionsSyncJobStatusBadge: React.FunctionComponent<PermissionsSyncJobStatusBadgeProps> = ({
-    state,
-    cancellationReason,
-    failureMessage,
-}) => (
-    <Badge
-        className={classNames(styles.statusContainer, 'mr-1')}
-        tooltip={cancellationReason ?? failureMessage ?? undefined}
-        variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}
-    >
-        {state}
-    </Badge>
-)
+export const PermissionsSyncJobStatusBadge: React.FunctionComponent<PermissionsSyncJobStatusBadgeProps> = ({ job }) => {
+    const { state, cancellationReason, failureMessage, codeHostStates } = job
+    const needsWarning =
+        state === PermissionsSyncJobState.COMPLETED &&
+        codeHostStates.find(codeHostState => codeHostState.status) !== undefined
+    const warningMessage = needsWarning ? 'Some of provider syncs were not successful' : undefined
+    return (
+        <Badge
+            className={classNames(
+                styles.statusContainer,
+                {
+                    [styles.badgeDot]: needsWarning,
+                },
+                'mr-1'
+            )}
+            tooltip={cancellationReason ?? failureMessage ?? warningMessage ?? undefined}
+            variant={JOB_STATE_METADATA_MAPPING[state].badgeVariant}
+        >
+            {state}
+        </Badge>
+    )
+}
 
 export const PermissionsSyncJobSubject: React.FunctionComponent<{ job: PermissionsSyncJob }> = ({ job }) => {
     const [isOpen, setIsOpen] = useState<boolean>(false)

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -400,13 +400,7 @@ const TableColumns: IColumn<PermissionsSyncJob>[] = [
     {
         key: 'Status',
         header: 'Status',
-        render: ({ state, cancellationReason, failureMessage }: PermissionsSyncJob) => (
-            <PermissionsSyncJobStatusBadge
-                state={state}
-                cancellationReason={cancellationReason}
-                failureMessage={failureMessage}
-            />
-        ),
+        render: job => <PermissionsSyncJobStatusBadge job={job} />,
     },
     {
         key: 'Name',

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -83,3 +83,20 @@
     max-width: 1.5rem;
     max-height: 1.5rem;
 }
+
+.badge-dot {
+    position: relative;
+
+    &::before {
+        content: '';
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+
+        position: absolute;
+        right: -0.25rem;
+        top: -0.25rem;
+        transform: translate(0%, 0%);
+        background-color: var(--warning);
+    }
+}

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -84,19 +84,3 @@
     max-height: 1.5rem;
 }
 
-.badge-dot {
-    position: relative;
-
-    &::before {
-        content: '';
-        width: 0.5rem;
-        height: 0.5rem;
-        border-radius: 50%;
-
-        position: absolute;
-        right: -0.25rem;
-        top: -0.25rem;
-        transform: translate(0%, 0%);
-        background-color: var(--warning);
-    }
-}

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -83,4 +83,3 @@
     max-width: 1.5rem;
     max-height: 1.5rem;
 }
-


### PR DESCRIPTION
Test plan:
Local sg run and test.

### Demo

https://user-images.githubusercontent.com/94846361/227566230-db15292c-9058-4399-8e42-eaa08160a43e.mp4

Closes https://github.com/sourcegraph/sourcegraph/issues/49909

## App preview:

- [Web](https://sg-web-ao-ui-pc-add-warning-dot.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
