### PR TITLE
executors: return status `401` instead of `403` when general access token is incorrect

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -181,7 +181,7 @@ func validateExecutorToken(w http.ResponseWriter, r *http.Request, logger log.Lo
 	// code via timing attack. It is not important to avoid leaking the *length* of
 	// the code, because the length of verification codes is constant.
 	if subtle.ConstantTimeCompare([]byte(token), []byte(expectedAccessToken)) == 0 {
-		w.WriteHeader(http.StatusForbidden)
+		w.WriteHeader(http.StatusUnauthorized)
 		return false
 	}
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler_test.go
@@ -50,7 +50,7 @@ func TestAuthMiddleware(t *testing.T) {
 		{
 			name:               "Wrong token",
 			headers:            http.Header{"Authorization": {"token-executor foobar"}},
-			expectedStatusCode: http.StatusForbidden,
+			expectedStatusCode: http.StatusUnauthorized,
 		},
 		{
 			name:                 "Invalid prefix",


### PR DESCRIPTION
Status 403 implies a valid access token but lacking permissions to access the resource. When the submitted token doesn't match the configured token it's invalid and should return a status 401 instead.

## Test plan
Tests pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
