### PR TITLE
file view: Fix in-file search behavior wrt selections

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -13,16 +13,24 @@ import {
     SearchQuery,
     setSearchQuery,
 } from '@codemirror/search'
-import { Compartment, Extension, StateEffect } from '@codemirror/state'
+import {
+    Compartment,
+    Extension,
+    StateEffect,
+    TransactionSpec,
+    type Text as CodeMirrorText,
+    SelectionRange,
+} from '@codemirror/state'
 import { EditorView, KeyBinding, keymap, Panel, runScopeHandlers, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { mdiChevronDown, mdiChevronUp, mdiFormatLetterCase, mdiInformationOutline, mdiRegex } from '@mdi/js'
 import { createRoot, Root } from 'react-dom/client'
 import { NavigateFunction } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
-import { debounceTime, distinctUntilChanged, startWith } from 'rxjs/operators'
+import { debounceTime, distinctUntilChanged, startWith, tap } from 'rxjs/operators'
 
 import { QueryInputToggle } from '@sourcegraph/branded'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
+import { pluralize } from '@sourcegraph/common'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { Button, Icon, Input, Label, Text, Tooltip } from '@sourcegraph/wildcard'
@@ -52,17 +60,23 @@ type SearchMatches = Map<number, number>
 
 export const BLOB_SEARCH_CONTAINER_ID = 'blob-search-container'
 
+interface SearchPanelState {
+    searchQuery: SearchQuery
+    // The input value is usually derived from searchQuery. But we are
+    // debouncing updating the searchQuery and without tracking the input value
+    // separately user input would be lossing characters and feel laggy.
+    inputValue: string
+    overrideBrowserSearch: boolean
+    matches: SearchMatches
+    // Currently selected 1-based match index.
+    currentMatchIndex: number | null
+}
+
 class SearchPanel implements Panel {
     public dom: HTMLElement
     public top = true
 
-    private state: {
-        searchQuery: SearchQuery
-        overrideBrowserSearch: boolean
-        matches: SearchMatches
-        // Currently selected 1-based match index.
-        currentMatchIndex: number | null
-    }
+    private state: SearchPanelState
     private root: Root | null = null
     private input: HTMLInputElement | null = null
     private searchTerm = new Subject<string>()
@@ -77,16 +91,28 @@ class SearchPanel implements Panel {
         })
         this.navigate = view.state.facet(blobPropsFacet).navigate
 
+        const searchQuery = getSearchQuery(this.view.state)
+        const matches = calculateMatches(searchQuery, view.state.doc)
         this.state = {
-            searchQuery: getSearchQuery(this.view.state),
+            searchQuery,
+            inputValue: searchQuery.search,
             overrideBrowserSearch: this.view.state.field(overrideBrowserFindInPageShortcut),
-            matches: this.view.state.field(searchMatches),
-            currentMatchIndex: this.view.state.field(currentSearchMatchIndex),
+            matches,
+            currentMatchIndex: getMatchIndexForSelection(matches, view.state.selection.main),
         }
 
         this.subscriptions.add(
             this.searchTerm
-                .pipe(startWith(this.state.searchQuery.search), debounceTime(100), distinctUntilChanged())
+                .pipe(
+                    startWith(this.state.searchQuery.search),
+                    distinctUntilChanged(),
+                    // Immediately update input for fast feedback
+                    tap(value => {
+                        this.state = { ...this.state, inputValue: value }
+                        this.render(this.state)
+                    }),
+                    debounceTime(100)
+                )
                 .subscribe(searchTerm => this.commit({ search: searchTerm }))
         )
     }
@@ -95,8 +121,14 @@ class SearchPanel implements Panel {
         let newState = this.state
 
         const searchQuery = getSearchQuery(update.state)
-        if (!searchQuery.eq(this.state.searchQuery)) {
-            newState = { ...newState, searchQuery }
+        const searchQueryChanged = !searchQuery.eq(this.state.searchQuery)
+        if (searchQueryChanged) {
+            newState = {
+                ...newState,
+                inputValue: searchQuery.search,
+                searchQuery,
+                matches: calculateMatches(searchQuery, update.view.state.doc),
+            }
         }
 
         const overrideBrowserSearch = update.state.field(overrideBrowserFindInPageShortcut)
@@ -104,27 +136,22 @@ class SearchPanel implements Panel {
             newState = { ...newState, overrideBrowserSearch }
         }
 
-        const currentMatchIndex = update.state.field(currentSearchMatchIndex)
-        if (currentMatchIndex !== this.state.currentMatchIndex) {
-            newState = { ...newState, currentMatchIndex }
-        }
-
-        const matches = update.state.field(searchMatches)
-        if (matches !== this.state.matches) {
-            newState = { ...newState, matches }
+        // It looks like update.SelectionSet is not set when the search query changes
+        if (searchQueryChanged || update.selectionSet) {
+            newState = {
+                ...newState,
+                currentMatchIndex: getMatchIndexForSelection(newState.matches, update.view.state.selection.main),
+            }
         }
 
         if (newState !== this.state) {
             this.state = newState
-            this.render({
-                ...newState,
-                totalMatches: this.state.matches.size,
-            })
+            this.render(this.state)
         }
     }
 
     public mount(): void {
-        this.render({ ...this.state, totalMatches: this.state.matches.size })
+        this.render(this.state)
     }
 
     public destroy(): void {
@@ -133,18 +160,16 @@ class SearchPanel implements Panel {
 
     private render({
         searchQuery,
+        inputValue,
         overrideBrowserSearch,
         currentMatchIndex,
-        totalMatches,
-    }: {
-        searchQuery: SearchQuery
-        overrideBrowserSearch: boolean
-        currentMatchIndex: number | null
-        totalMatches: number
-    }): void {
+        matches,
+    }: SearchPanelState): void {
         if (!this.root) {
             this.root = createRoot(this.dom)
         }
+
+        const totalMatches = matches.size
 
         this.root.render(
             <CodeMirrorContainer
@@ -163,6 +188,7 @@ class SearchPanel implements Panel {
                         placeholder="Find..."
                         autoComplete="off"
                         inputClassName={searchQuery.search && totalMatches === 0 ? 'text-danger' : ''}
+                        value={inputValue}
                         onChange={event => this.searchTerm.next(event.target.value)}
                         main-field="true"
                     />
@@ -210,9 +236,8 @@ class SearchPanel implements Panel {
                 {searchQuery.search ? (
                     <div>
                         <Text className="m-0">
-                            {currentMatchIndex !== null && totalMatches > 0
-                                ? `${currentMatchIndex} / ${totalMatches}`
-                                : '0 results'}
+                            {currentMatchIndex !== null && `${currentMatchIndex} / `}
+                            {totalMatches} {pluralize('result', totalMatches)}
                         </Text>
                     </div>
                 ) : null}
@@ -237,19 +262,12 @@ class SearchPanel implements Panel {
             effects: setOverrideBrowserFindInPageShortcut.of(override),
         })
 
-    private updateSelectedSearchMatch = ({ from }: { from: number }): void =>
-        this.view.dispatch({
-            effects: setCurrentSearchMatchIndex.of(this.state.matches.get(from) ?? null),
-        })
-
     private findNext = (): void => {
         findNext(this.view)
-        this.updateSelectedSearchMatch(this.view.state.selection.ranges[0])
     }
 
     private findPrevious = (): void => {
         findPrevious(this.view)
-        this.updateSelectedSearchMatch(this.view.state.selection.ranges[0])
     }
 
     // Taken from CodeMirror's default search panel implementation. This is
@@ -269,19 +287,6 @@ class SearchPanel implements Panel {
         }
     }
 
-    private calculateMatches = (query: SearchQuery): void => {
-        const newSearchMatches: SearchMatches = new Map()
-        let index = 1
-        let result = query.getCursor(this.view.state.doc).next()
-        while (!result.done) {
-            newSearchMatches.set(result.value.from, index++)
-            result = query.getCursor(this.view.state.doc, result.value.to).next()
-        }
-        this.view.dispatch({
-            effects: [setSearchMatches.of(newSearchMatches), setCurrentSearchMatchIndex.of(null)],
-        })
-    }
-
     private commit = ({
         search,
         caseSensitive,
@@ -298,11 +303,10 @@ class SearchPanel implements Panel {
         })
 
         if (!query.eq(this.state.searchQuery)) {
-            this.view.dispatch({ effects: setSearchQuery.of(query) })
+            let transactionSpec: TransactionSpec = {}
+            const effects: StateEffect<any>[] = [setSearchQuery.of(query)]
 
             if (query.search) {
-                this.calculateMatches(query)
-
                 // The following code scrolls next match into view if there is no
                 // match in the visible viewport. This is done by searching for the
                 // text from the currently top visible line and determining whether
@@ -322,25 +326,43 @@ class SearchPanel implements Panel {
                 if (result.done) {
                     // No match in the remainder of the document, wrap around
                     result = query.getCursor(this.view.state.doc).next()
-                    if (result.done) {
-                        // Search term is not in the document, nothing to do
-                        return
-                    }
                 }
 
-                this.updateSelectedSearchMatch(result.value)
+                if (!result.done) {
+                    // Taken from the original `findPrevious` and `findNext` CodeMirror implementation:
+                    // https://github.com/codemirror/search/blob/affb772655bab706e08f99bd50a0717bfae795f5/src/search.ts#L385-L416
 
-                // Taken from the original `findPrevious` and `findNext` CodeMirror implementation:
-                // https://github.com/codemirror/search/blob/affb772655bab706e08f99bd50a0717bfae795f5/src/search.ts#L385-L416
-                this.view.dispatch({
-                    selection: { anchor: result.value.from, head: result.value.to },
-                    scrollIntoView: true,
-                    effects: announceMatch(this.view, result.value),
-                    userEvent: 'select.search',
-                })
+                    transactionSpec = {
+                        selection: { anchor: result.value.from, head: result.value.to },
+                        scrollIntoView: true,
+                        userEvent: 'select.search',
+                    }
+                    effects.push(announceMatch(this.view, result.value))
+                }
+                // Search term is not in the document, nothing to do
             }
+
+            this.view.dispatch({
+                ...transactionSpec,
+                effects,
+            })
         }
     }
+}
+
+function calculateMatches(query: SearchQuery, document: CodeMirrorText): SearchMatches {
+    const newSearchMatches: SearchMatches = new Map()
+    let index = 1
+    let result = query.getCursor(document).next()
+    while (!result.done) {
+        newSearchMatches.set(result.value.from, index++)
+        result = query.getCursor(document, result.value.to).next()
+    }
+    return newSearchMatches
+}
+
+function getMatchIndexForSelection(matches: SearchMatches, range: SelectionRange): number | null {
+    return range.empty ? null : matches.get(range.from) ?? null
 }
 
 // Announce the current match to screen readers.
@@ -382,8 +404,6 @@ interface SearchConfig {
 }
 
 const [overrideBrowserFindInPageShortcut, , setOverrideBrowserFindInPageShortcut] = createUpdateableField(true)
-const [searchMatches, , setSearchMatches] = createUpdateableField<SearchMatches>(new Map())
-const [currentSearchMatchIndex, , setCurrentSearchMatchIndex] = createUpdateableField<number | null>(null)
 
 export function search(config: SearchConfig): Extension {
     const keymapCompartment = new Compartment()
@@ -396,8 +416,6 @@ export function search(config: SearchConfig): Extension {
     }
 
     return [
-        searchMatches,
-        currentSearchMatchIndex,
         overrideBrowserFindInPageShortcut.init(() => config.overrideBrowserFindInPageShortcut),
         EditorView.updateListener.of(update => {
             const override = update.state.field(overrideBrowserFindInPageShortcut)


### PR DESCRIPTION
There are a couple of issues with our custom in-file search UI implementation:

- Selecting a word and then triggering a search will highlight the matches but not populate the UI correctly. The input is empty and no result count is shown.
- Similarly if the search is already open (and shows correct data), selecting a different term in the file and triggering the search will update the match highlights but not the input or result count.
- Navigating to the next/previous match via the keyboard (e.g. with `F3`) does not update the selected match index.


I believe the core problems with the current implementation are:

- The input is not controlled, i.e. we are not deriving the value from `searchQuery`. This causes the input not to be populated correctly when the search query is changed externally.
- The matches and selected match index are updated from state fields, which in turn are updated when the input changes. This is problematic for two reasons:
  - As in the previous point, the UI will show incorrect values when the search query is changed externally.
  - Even when we compute the matches and index when the component is first created, the (outdated) state field values will overwrite the correct values on the next update.

This PR makes the following changes:

- Remove state fields for matches and selected index in favor of computing those when the searchQuery changes. I don't think state fields are necessary here, the view component can track this state itself. It also makes data flow simpler.
- Update the selected index when the selection changes. This also means that the index is cleared when the user selects a different text while the search is open. Given that CodeMirror changes the highlighting though I'd say this is the more correct behavior.
- The UI will now show `x / x results` instead of just `x / x`. This is the consequence of simplifying how this part is rendered. I can change that if it's not desired.

Before|after (trigger search after text selection):

https://user-images.githubusercontent.com/179026/227575214-be6f837f-888d-4da9-a532-1d6d8c6eed6b.mp4

Before|after (updating selected match):

https://user-images.githubusercontent.com/179026/227575281-51c2a83c-41b1-4d6f-978d-0610e992aad1.mp4



## Test plan

- Open a file, select a word and press `Mod-F` -> search component opens with populated input and correct result count
- Click anywhere outside of a highlight -> result count updates from `x / x results` to `x results`.
- Click previous/next buttons -> result count updates to `x / x results`
- Press F3 to go to the next match -> selected result updates

## App preview:

- [Web](https://sg-web-fkling-file-search-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
