### PR TITLE
Recursive implementation of searching for correct bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- GitHub `repositoryQuery` searches now respect date ranges and use API requests more efficiently. #[49969](https://github.com/sourcegraph/sourcegraph/pull/49969)
 
 ### Removed
 

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -491,6 +491,34 @@ query($query: String!, $type: SearchType!, $after: String, $first: Int!) {
 	return b.String()
 }
 
+// GetSearchReposCount returns the number of search result in the given query.
+func (c *V4Client) GetSearchReposCount(ctx context.Context, query string) (int, error) {
+	vars := map[string]any{
+		"query": query,
+		"type":  "REPOSITORY",
+	}
+
+	query = `
+query($query: String!, $type: SearchType!) {
+	search(query: $query, type: $type) {
+		repositoryCount
+	}	
+}`
+
+	var resp struct {
+		Search struct {
+			RepositoryCount int
+		}
+	}
+
+	err := c.requestGraphQL(ctx, query, vars, &resp)
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.Search.RepositoryCount, nil
+}
+
 // GetReposByNameWithOwner fetches the specified repositories (namesWithOwners)
 // from the GitHub GraphQL API and returns a slice of repositories.
 // If a repository is not found, it will return an error.

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -491,34 +491,6 @@ query($query: String!, $type: SearchType!, $after: String, $first: Int!) {
 	return b.String()
 }
 
-// GetSearchReposCount returns the number of search result in the given query.
-func (c *V4Client) GetSearchReposCount(ctx context.Context, query string) (int, error) {
-	vars := map[string]any{
-		"query": query,
-		"type":  "REPOSITORY",
-	}
-
-	query = `
-query($query: String!, $type: SearchType!) {
-	search(query: $query, type: $type) {
-		repositoryCount
-	}	
-}`
-
-	var resp struct {
-		Search struct {
-			RepositoryCount int
-		}
-	}
-
-	err := c.requestGraphQL(ctx, query, vars, &resp)
-	if err != nil {
-		return 0, err
-	}
-
-	return resp.Search.RepositoryCount, nil
-}
-
 // GetReposByNameWithOwner fetches the specified repositories (namesWithOwners)
 // from the GitHub GraphQL API and returns a slice of repositories.
 // If a repository is not found, it will return an error.

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -1002,6 +1002,8 @@ func (q *repositoryQuery) split(ctx context.Context, results chan *githubResult)
 // 3. If the number of search results returned is less than or equal to the query limit, iterate over the results and return them to the channel.
 func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githubResult) error {
 	// If we know that the number of repos in this query is greater than the limit, we can immediately split the query
+	// Also, GitHub createdAt time stamps are only accurate to 1 second. So if the time difference is no longer
+	// greater than 2 seconds, we should stop refining as it cannot get more precise.
 	if q.RepoCount.known && q.RepoCount.count > q.Limit && q.Created.To.Sub(q.Created.From) >= 2*time.Second {
 		return q.split(ctx, results)
 	}

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -802,14 +802,6 @@ func (s *GitHubSource) listSearch(ctx context.Context, q string, results chan *g
 	// First we need to parse the query to see if it is querying within a date range,
 	// and if so, strip that date range from the query.
 	dr := stripDateRange(&q)
-	if dr != nil {
-		if dr.From.IsZero() {
-			dr.From = minCreated
-		}
-		if dr.To.IsZero() {
-			dr.To = time.Now()
-		}
-	}
 
 	newRepositoryQuery(q, s.v4Client, s.logger, dr).DoWithRefinedWindow(ctx, results)
 }
@@ -926,6 +918,15 @@ type repositoryQuery struct {
 }
 
 func newRepositoryQuery(query string, searcher *github.V4Client, logger log.Logger, created *dateRange) *repositoryQuery {
+	if created == nil {
+		created = &dateRange{}
+	}
+	if created.From.IsZero() {
+		created.From = minCreated
+	}
+	if created.To.IsZero() {
+		created.To = time.Now()
+	}
 	return &repositoryQuery{
 		Query:    query,
 		Searcher: searcher,

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -826,7 +827,7 @@ func stripDateRange(s *string) (*dateRange, error) {
 	re := regexp.MustCompile(`created:([^\s]+)`)
 	matches := re.FindStringSubmatch(*s)
 	if len(matches) < 2 {
-		return nil, fmt.Errorf("no date range found in string")
+		return nil, errors.New("no date range found in string")
 	}
 	dateStr := matches[1]
 
@@ -879,7 +880,7 @@ func stripDateRange(s *string) (*dateRange, error) {
 	default:
 		rangeParts := strings.Split(dateStr, "..")
 		if len(rangeParts) != 2 {
-			return nil, fmt.Errorf("invalid date range format")
+			return nil, errors.New("invalid date range format")
 		}
 		var fromDate time.Time
 		var toDate time.Time

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -913,6 +913,10 @@ func (q *repositoryQuery) split(ctx context.Context, results chan *githubResult)
 	return q2.doRecursively(ctx, results)
 }
 
+// doRecursively performs a query with the following procedure:
+// 1. Perform the query.
+// 2. If the number of search results returned is greater than the query limit, split the query in half by filtering by repo creation date, and perform those two queries. Do so recursively.
+// 3. If the number of search results returned is less than or equal to the query limit, iterate over the results and return them to the channel.
 func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githubResult) error {
 	// If we know that the number of repos in this query is greater than the limit, we can immediately split the query
 	if q.RepoCount.known && q.RepoCount.count > q.Limit && q.Created.To.Sub(q.Created.From) >= 2*time.Second {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -802,6 +802,12 @@ func (s *GitHubSource) listSearch(ctx context.Context, q string, results chan *g
 	// and if so, strip that date range from the query.
 	dr, err := stripDateRange(&q)
 	if err == nil {
+		if dr.From.IsZero() {
+			dr.From = minCreated
+		}
+		if dr.To.IsZero() {
+			dr.To = time.Now()
+		}
 		(&repositoryQuery{Query: q, Searcher: s.v4Client, Logger: s.logger, Created: dr}).DoWithRefinedWindow(ctx, results)
 	} else {
 		(&repositoryQuery{Query: q, Searcher: s.v4Client, Logger: s.logger}).DoWithRefinedWindow(ctx, results)

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -101,14 +101,22 @@ func TestGitHub_stripDateRange(t *testing.T) {
 				To: mustParse(t, "2015-12-12T23:59:59"),
 			},
 		},
+		"no date query": {
+			query:         "just some random things",
+			wantQuery:     "just some random things",
+			wantDateRange: nil,
+		},
 	}
 
 	for tname, tcase := range testCases {
 		t.Run(tname, func(t *testing.T) {
-			date, err := stripDateRange(&tcase.query)
-			require.NoError(t, err)
-			assert.True(t, date.From.Equal(tcase.wantDateRange.From), "got %q want %q", date.From, tcase.wantDateRange.From)
-			assert.True(t, date.To.Equal(tcase.wantDateRange.To), "got %q want %q", date.To, tcase.wantDateRange.To)
+			date := stripDateRange(&tcase.query)
+			if tcase.wantDateRange == nil {
+				assert.Nil(t, date)
+			} else {
+				assert.True(t, date.From.Equal(tcase.wantDateRange.From), "got %q want %q", date.From, tcase.wantDateRange.From)
+				assert.True(t, date.To.Equal(tcase.wantDateRange.To), "got %q want %q", date.To, tcase.wantDateRange.To)
+			}
 			if tcase.wantQuery != "" {
 				assert.Equal(t, tcase.wantQuery, tcase.query)
 			}

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -39,9 +39,12 @@ import (
 func mustParse(t *testing.T, dateStr string) time.Time {
 	date, err := time.Parse(time.RFC3339, dateStr)
 	if err != nil {
-		date, err = time.Parse("2006-01-02", dateStr)
+		date, err = time.Parse("2006-01-02T15:04:05", dateStr)
 		if err != nil {
-			t.Fatal("Failed to parse date from", dateStr)
+			date, err = time.Parse("2006-01-02", dateStr)
+			if err != nil {
+				t.Fatal("Failed to parse date from", dateStr)
+			}
 		}
 	}
 	return date
@@ -88,14 +91,14 @@ func TestGitHub_stripDateRange(t *testing.T) {
 		"to with <=": {
 			query: "created:<=2015-12-12",
 			wantDateRange: &dateRange{
-				To: mustParse(t, "2015-12-12T00:00:00+00:00"),
+				To: mustParse(t, "2015-12-12T23:59:59+00:00"),
 			},
 		},
 		"to with *..": {
-			query:     "created:*..2015-12-12T00:01:30",
+			query:     "created:*..2015-12-12",
 			wantQuery: "",
 			wantDateRange: &dateRange{
-				To: mustParse(t, "2015-12-12T00:01:30+00:00"),
+				To: mustParse(t, "2015-12-12T23:59:59"),
 			},
 		},
 	}

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
@@ -34,6 +35,83 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+func mustParse(t *testing.T, dateStr string) time.Time {
+	date, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		date, err = time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			t.Fatal("Failed to parse date from", dateStr)
+		}
+	}
+	return date
+}
+
+func TestGitHub_stripDateRange(t *testing.T) {
+	testCases := map[string]struct {
+		query         string
+		wantQuery     string
+		wantDateRange *dateRange
+	}{
+		"from and to with ..": {
+			query:     "some part of query created:2008-11-10T01:23:45+00:00..2010-01-30T23:45:59+02:00 and others",
+			wantQuery: "some part of query  and others",
+			wantDateRange: &dateRange{
+				From: mustParse(t, "2008-11-10T01:23:45+00:00"),
+				To:   mustParse(t, "2010-01-30T23:45:59+02:00"),
+			},
+		},
+		"from with >": {
+			query: "created:>2011-01-01T00:00:00+00:00 and other stuff",
+			wantDateRange: &dateRange{
+				From: mustParse(t, "2011-01-01T00:00:01+00:00"),
+			},
+		},
+		"from with >=": {
+			query: "created:>=2011-01-01T00:00:00+00:00 and other stuff",
+			wantDateRange: &dateRange{
+				From: mustParse(t, "2011-01-01T00:00:00+00:00"),
+			},
+		},
+		"from with ..*": {
+			query: "created:2010-01-01..*",
+			wantDateRange: &dateRange{
+				From: mustParse(t, "2010-01-01T00:00:00+00:00"),
+			},
+		},
+		"to with <": {
+			query: "created:<2015-12-12",
+			wantDateRange: &dateRange{
+				To: mustParse(t, "2015-12-11T23:59:59+00:00"),
+			},
+		},
+		"to with <=": {
+			query: "created:<=2015-12-12",
+			wantDateRange: &dateRange{
+				To: mustParse(t, "2015-12-12T00:00:00+00:00"),
+			},
+		},
+		"to with *..": {
+			query:     "created:*..2015-12-12T00:01:30",
+			wantQuery: "",
+			wantDateRange: &dateRange{
+				To: mustParse(t, "2015-12-12T00:01:30+00:00"),
+			},
+		},
+	}
+
+	for tname, tcase := range testCases {
+		t.Run(tname, func(t *testing.T) {
+			date, err := stripDateRange(&tcase.query)
+			require.NoError(t, err)
+			assert.True(t, date.From.Equal(tcase.wantDateRange.From), "got %q want %q", date.From, tcase.wantDateRange.From)
+			assert.True(t, date.To.Equal(tcase.wantDateRange.To), "got %q want %q", date.To, tcase.wantDateRange.To)
+			if tcase.wantQuery != "" {
+				assert.Equal(t, tcase.wantQuery, tcase.query)
+			}
+		})
+	}
+}
 
 func TestGithubSource_GetRepo(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
**Before this PR**
When a GitHub `repositoryQuery` encounters more than 1000 repositories in a search result, it would start refining the search window by halving the search window for the creation time of the repositories. Then, when there are less than 1000 repositories in the search results, it would return those repositories, adjust the lower bound of the search window, and start search all over again. For a GitHub Starburst sync's first 10 minutes, it would do 134 such refinement queries, and discover ~10,500 repositories.

**After this PR**
We do the search window refining recursively, splitting a search into two halves each time if a response contains more than 1000 results. This allows us to keep track of the window splits, and start the next search within the bounds of the split.
For example, if the bounds were from 1 January to 30 January, it would be split into two searches between 1 January to 14 January, and 15 January to 30 January. If the first result still returned too many results, it will split into two searches again: 1 January to 6 January, and 7 January to 14 January, until a search returns an acceptable amount of results.
For a GitHub Starburst sync's first 10 minutes, it does 36 such refinement queries, and discovers ~21,000 repositories.

So that's about a 2x speed increase for the first ten minutes of the sync. This does not mean it extrapolates linearly over the rest of the sync, since I don't think the creation dates of GitHub repositories are linearly distributed. But I do think it would improve even further as the sync progresses, since the compound effect of not having to start from scratch every time should add up.

## Test plan

I did some local testing, original tests still passing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
