### PR TITLE
[feat][force-bazel] make unified perms not experimental

### DIFF
--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -7,7 +7,6 @@ import (
 	gh "github.com/google/go-github/v43/github"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -25,9 +24,6 @@ import (
 func handleGitHubRepoAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions) webhooks.Handler {
 	return func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
-			return nil
-		}
-		if globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions {
 			return nil
 		}
 

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
@@ -26,9 +25,6 @@ import (
 func handleGitHubUserAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions) webhooks.Handler {
 	return func(ctx context.Context, db database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
-			return nil
-		}
-		if globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions {
 			return nil
 		}
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -101,10 +103,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		}
 	}
 
-	userIDs := make(map[int32]struct{}, len(mapping))
-	for _, id := range mapping {
-		userIDs[id] = struct{}{}
-	}
+	userIDs := collections.NewSet(maps.Values(mapping)...)
 
 	p := &authz.RepoPermissions{
 		RepoID:  int32(repoID),

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -225,6 +225,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	if result, err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
 		return result, providerStates, errors.Wrapf(err, "set user repo permissions for repository %q (id: %d)", repo.Name, repo.ID)
 	}
+	// TODO @milan remove in the following PRs, keep writing to both tables for now
 	legacyResult, err := txs.SetRepoPermissions(ctx, p)
 	if err != nil {
 		return legacyResult, providerStates, errors.Wrapf(err, "set repository permissions for repository %q (id: %d)", repo.Name, repo.ID)
@@ -342,6 +343,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	s.permsUpdateLock.Lock()
 	defer s.permsUpdateLock.Unlock()
 
+	// TODO @milan remove in the following PRs, keep writing to both tables for now
 	legacyResult, err := s.permsStore.SetUserPermissions(ctx, p)
 	if err != nil {
 		return legacyResult, providerStates, errors.Wrapf(err, "set user permissions for user %q (id: %d)", user.Username, user.ID)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -15,7 +15,6 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -222,17 +221,13 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	}
 	defer func() { err = txs.Done(err) }()
 
-	// Write to new user_repo_permissions table by default.
-	var unifiedResult *database.SetPermissionsResult
-	if unifiedResult, err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
+	// Write to both user_repo_permissions and repo_permissions tables by default.
+	if result, err = txs.SetRepoPerms(ctx, int32(repoID), maps.Values(accountIDsToUserIDs), authz.SourceRepoSync); err != nil {
 		return result, providerStates, errors.Wrapf(err, "set user repo permissions for repository %q (id: %d)", repo.Name, repo.ID)
 	}
-	result, err = txs.SetRepoPermissions(ctx, p)
+	legacyResult, err := txs.SetRepoPermissions(ctx, p)
 	if err != nil {
-		return result, providerStates, errors.Wrapf(err, "set repository permissions for repository %q (id: %d)", repo.Name, repo.ID)
-	}
-	if edb.UnifiedPermsEnabled() {
-		result = unifiedResult
+		return legacyResult, providerStates, errors.Wrapf(err, "set repository permissions for repository %q (id: %d)", repo.Name, repo.ID)
 	}
 	regularCount := len(p.UserIDs)
 
@@ -311,16 +306,15 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		IDs:    map[int32]struct{}{},
 	}
 
-	unifiedResult := &database.SetPermissionsResult{}
 	for acctID, repoIDs := range results.repoPerms {
 		// Write to new user_repo_permissions table by default.
 		stats, err := s.saveUserPermsForAccount(ctx, userID, acctID, repoIDs)
 		if err != nil {
 			return result, providerStates, errors.Wrapf(err, "set user repo permissions for user %q (id: %d, external_account_id: %d)", user.Username, user.ID, acctID)
 		}
-		unifiedResult.Added += stats.Added
-		unifiedResult.Found += stats.Found
-		unifiedResult.Removed += stats.Removed
+		result.Added += stats.Added
+		result.Found += stats.Found
+		result.Removed += stats.Removed
 
 		for _, repoID := range repoIDs {
 			p.IDs[repoID] = struct{}{}
@@ -345,14 +339,9 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	s.permsUpdateLock.Lock()
 	defer s.permsUpdateLock.Unlock()
 
-	result, err = s.permsStore.SetUserPermissions(ctx, p)
+	legacyResult, err := s.permsStore.SetUserPermissions(ctx, p)
 	if err != nil {
-		return result, providerStates, errors.Wrapf(err, "set user permissions for user %q (id: %d)", user.Username, user.ID)
-	}
-
-	// Return result from unified table if flag enabled.
-	if edb.UnifiedPermsEnabled() {
-		result = unifiedResult
+		return legacyResult, providerStates, errors.Wrapf(err, "set user permissions for user %q (id: %d)", user.Username, user.ID)
 	}
 
 	logger.Debug("synced",
@@ -504,8 +493,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	results.subRepoPerms = make(map[api.ExternalRepoSpec]*authz.SubRepoPermissions)
 	results.repoPerms = make(map[int32][]int32, len(accts))
 
-	unifiedPermsEnabled := conf.ExperimentalFeatures().UnifiedPermissions
-
 	for _, acct := range accts {
 		var repoSpecs, includeContainsSpecs, excludeContainsSpecs []api.ExternalRepoSpec
 
@@ -580,18 +567,9 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 				}
 
 				// Load last synced repos for this user and account from user_repo_permissions table.
-				var currentRepos []api.RepoID
-				if unifiedPermsEnabled {
-					currentRepos, err = s.permsStore.FetchReposByExternalAccount(ctx, acct.ID)
-					if err != nil {
-						return results, errors.Wrap(err, "fetching existing repo permissions")
-					}
-				} else {
-					// Use the old user_permissions table if feature flag is off.
-					currentRepos, err = s.permsStore.FetchReposByUserAndExternalService(ctx, user.ID, provider.ServiceType(), provider.ServiceID())
-					if err != nil {
-						return results, errors.Wrap(err, "fetching existing repo permissions")
-					}
+				currentRepos, err := s.permsStore.FetchReposByExternalAccount(ctx, acct.ID)
+				if err != nil {
+					return results, errors.Wrap(err, "fetching existing repo permissions")
 				}
 				// Put all the repo IDs into the results.
 				for _, repoID := range currentRepos {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -312,6 +312,9 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		if err != nil {
 			return result, providerStates, errors.Wrapf(err, "set user repo permissions for user %q (id: %d, external_account_id: %d)", user.Username, user.ID, acctID)
 		}
+		if result == nil {
+			result = &database.SetPermissionsResult{}
+		}
 		result.Added += stats.Added
 		result.Found += stats.Found
 		result.Removed += stats.Removed

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -169,21 +169,6 @@ func ProvidersFromConfig(
 	initResult.Append(gerrit.NewAuthzProviders(gerritConns, cfg.SiteConfig().AuthProviders))
 	initResult.Append(azuredevops.NewAuthzProviders(db, azuredevopsConns))
 
-	// 🚨 SECURITY: Warn the admin when both code host authz provider and the permissions user mapping are configured.
-	// But only if the unified permissions is disabled
-	if cfg.SiteConfig().PermissionsUserMapping != nil &&
-		cfg.SiteConfig().PermissionsUserMapping.Enabled {
-		for _, p := range initResult.Providers {
-			if p.ServiceType() == extsvc.TypeBitbucketServer {
-				allowAccessByDefault = false
-				msg := fmt.Sprintf(
-					"The explicit permissions API (site configuration `permissions.userMapping`) cannot be enabled when %s authorization provider is in use. Blocking access to all repositories until the conflict is resolved.",
-					extsvc.TypeBitbucketServer)
-				initResult.Problems = append(initResult.Problems, msg)
-			}
-		}
-	}
-
 	return allowAccessByDefault, initResult.Providers, initResult.Problems, initResult.Warnings, initResult.InvalidConnections
 }
 

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -173,9 +173,9 @@ func ProvidersFromConfig(
 	// But only if the unified permissions is disabled
 	if cfg.SiteConfig().PermissionsUserMapping != nil &&
 		cfg.SiteConfig().PermissionsUserMapping.Enabled {
-		allowAccessByDefault = false
 		for _, p := range initResult.Providers {
 			if p.ServiceType() == extsvc.TypeBitbucketServer {
+				allowAccessByDefault = false
 				msg := fmt.Sprintf(
 					"The explicit permissions API (site configuration `permissions.userMapping`) cannot be enabled when %s authorization provider is in use. Blocking access to all repositories until the conflict is resolved.",
 					extsvc.TypeBitbucketServer)

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -3,13 +3,10 @@ package authz
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/azuredevops"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/bitbucketserver"
@@ -159,11 +156,9 @@ func ProvidersFromConfig(
 	}
 
 	enableGithubInternalRepoVisibility := false
-	unifiedPermissions := false
 	ef := cfg.SiteConfig().ExperimentalFeatures
 	if ef != nil {
 		enableGithubInternalRepoVisibility = ef.EnableGithubInternalRepoVisibility
-		unifiedPermissions = ef.UnifiedPermissions
 	}
 
 	initResult := github.NewAuthzProviders(db, gitHubConns, cfg.SiteConfig().AuthProviders, enableGithubInternalRepoVisibility)
@@ -177,18 +172,15 @@ func ProvidersFromConfig(
 	// 🚨 SECURITY: Warn the admin when both code host authz provider and the permissions user mapping are configured.
 	// But only if the unified permissions is disabled
 	if cfg.SiteConfig().PermissionsUserMapping != nil &&
-		cfg.SiteConfig().PermissionsUserMapping.Enabled &&
-		!unifiedPermissions {
+		cfg.SiteConfig().PermissionsUserMapping.Enabled {
 		allowAccessByDefault = false
-		if len(initResult.Providers) > 0 {
-			serviceTypes := make([]string, len(initResult.Providers))
-			for i := range initResult.Providers {
-				serviceTypes[i] = strconv.Quote(initResult.Providers[i].ServiceType())
+		for _, p := range initResult.Providers {
+			if p.ServiceType() == extsvc.TypeBitbucketServer {
+				msg := fmt.Sprintf(
+					"The explicit permissions API (site configuration `permissions.userMapping`) cannot be enabled when %s authorization provider is in use. Blocking access to all repositories until the conflict is resolved.",
+					extsvc.TypeBitbucketServer)
+				initResult.Problems = append(initResult.Problems, msg)
 			}
-			msg := fmt.Sprintf(
-				"The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when %s authorization providers are in use. Blocking access to all repositories until the conflict is resolved.",
-				strings.Join(serviceTypes, ", "))
-			initResult.Problems = append(initResult.Problems, msg)
 		}
 	}
 
@@ -206,13 +198,11 @@ func RefreshInterval() time.Duration {
 // PermissionSyncingDisabled returns true if the background permissions syncing is not enabled.
 // It is not enabled if:
 //   - There are no code host connections with authorization or enforcePermissions enabled
-//   - Permissions user mapping (aka explicit permissions API) is enabled and unified permissions model is not enabled
 //   - Not purchased with the current license
 //   - `disableAutoCodeHostSyncs` site setting is set to true
 func PermissionSyncingDisabled() bool {
 	_, p := authz.GetProviders()
 	return len(p) == 0 ||
-		(globals.PermissionsUserMapping().Enabled && !conf.ExperimentalFeatures().UnifiedPermissions) ||
 		licensing.Check(licensing.FeatureACLs) != nil ||
 		conf.Get().DisableAutoCodeHostSyncs
 }

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -441,37 +441,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				},
 			),
 		},
-		{
-			description: "Cannot enable explicit permissions with Bitbucket Server authz provider",
-			cfg: conf.Unified{
-				SiteConfiguration: schema.SiteConfiguration{
-					PermissionsUserMapping: &schema.PermissionsUserMapping{
-						Enabled: true,
-						BindID:  "email",
-					},
-				},
-			},
-			bitbucketServerConnections: []*schema.BitbucketServerConnection{
-				{
-					Authorization: &schema.BitbucketServerAuthorization{
-						IdentityProvider: schema.BitbucketServerIdentityProvider{
-							Username: &schema.BitbucketServerUsernameIdentity{
-								Type: "username",
-							},
-						},
-						Oauth: schema.BitbucketServerOAuth{
-							ConsumerKey: "sourcegraph",
-							SigningKey:  bogusKey,
-						},
-					},
-					Url:      "https://bitbucketserver.mycorp.org",
-					Username: "admin",
-					Token:    "secret-token",
-				},
-			},
-			expAuthzAllowAccessByDefault: false,
-			expSeriousProblems:           []string{errPermissionsUserMappingConflict.Error()},
-		},
 	}
 
 	for _, test := range tests {

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -448,9 +448,6 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 							Url:          "https://gitlab.mine",
 						},
 					}},
-					ExperimentalFeatures: &schema.ExperimentalFeatures{
-						UnifiedPermissions: true,
-					},
 				},
 			},
 			gitlabConnections: []*schema.GitLabConnection{
@@ -847,15 +844,6 @@ func mockExplicitPermissions(enabled bool) func() {
 	}
 }
 
-func mockUnifiedPermsConfig(val bool) {
-	cfg := &conf.Unified{SiteConfiguration: schema.SiteConfiguration{
-		ExperimentalFeatures: &schema.ExperimentalFeatures{
-			UnifiedPermissions: val,
-		},
-	}}
-	conf.Mock(cfg)
-}
-
 func TestPermissionSyncingDisabled(t *testing.T) {
 	authz.SetProviders(true, []authz.Provider{&mockProvider{}})
 	cleanupLicense := licensing.MockCheckFeatureError("")
@@ -874,20 +862,8 @@ func TestPermissionSyncingDisabled(t *testing.T) {
 		assert.True(t, PermissionSyncingDisabled())
 	})
 
-	t.Run("permissions user mapping enabled and unified permissions disabled", func(t *testing.T) {
+	t.Run("permissions user mapping enabled", func(t *testing.T) {
 		cleanup := mockExplicitPermissions(true)
-		mockUnifiedPermsConfig(false)
-		t.Cleanup(func() {
-			cleanup()
-			conf.Mock(nil)
-		})
-
-		assert.True(t, PermissionSyncingDisabled())
-	})
-
-	t.Run("permissions user mapping enabled and unified permissions enabled", func(t *testing.T) {
-		cleanup := mockExplicitPermissions(true)
-		mockUnifiedPermsConfig(true)
 		t.Cleanup(func() {
 			cleanup()
 			conf.Mock(nil)

--- a/enterprise/internal/codeintel/policies/internal/store/store_configuration_test.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store_configuration_test.go
@@ -55,10 +55,10 @@ func TestGetConfigurationPolicies(t *testing.T) {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}
 
-	insertRepo(t, db, 41, "gitlab.com/test1")
-	insertRepo(t, db, 42, "github.com/test2")
-	insertRepo(t, db, 43, "bitbucket.org/test3")
-	insertRepo(t, db, 44, "localhost/secret-repo")
+	insertRepo(t, db, 41, "gitlab.com/test1", false)
+	insertRepo(t, db, 42, "github.com/test2", false)
+	insertRepo(t, db, 43, "bitbucket.org/test3", false)
+	insertRepo(t, db, 44, "localhost/secret-repo", false)
 
 	for policyID, patterns := range map[int][]string{
 		106: {"gitlab.com/*"},
@@ -263,7 +263,7 @@ func testStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) Store {
 
 // insertRepo creates a repository record with the given id and name. If there is already a repository
 // with the given identifier, nothing happens
-func insertRepo(t testing.TB, db database.DB, id int, name string) {
+func insertRepo(t testing.TB, db database.DB, id int, name string, private bool) {
 	if name == "" {
 		name = fmt.Sprintf("n-%d", id)
 	}
@@ -274,10 +274,11 @@ func insertRepo(t testing.TB, db database.DB, id int, name string) {
 	}
 
 	query := sqlf.Sprintf(
-		`INSERT INTO repo (id, name, deleted_at) VALUES (%s, %s, %s) ON CONFLICT (id) DO NOTHING`,
+		`INSERT INTO repo (id, name, deleted_at, private) VALUES (%s, %s, %s, %s) ON CONFLICT (id) DO NOTHING`,
 		id,
 		name,
 		deletedAt,
+		private,
 	)
 	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error while upserting repository: %s", err)

--- a/enterprise/internal/codeintel/policies/internal/store/store_repo_test.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store_repo_test.go
@@ -25,12 +25,12 @@ func TestRepoIDsByGlobPatterns(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "Darth Vader")
-	insertRepo(t, db, 51, "Darth Venamis")
-	insertRepo(t, db, 52, "Darth Maul")
-	insertRepo(t, db, 53, "Anakin Skywalker")
-	insertRepo(t, db, 54, "Luke Skywalker")
-	insertRepo(t, db, 55, "7th Sky Corps")
+	insertRepo(t, db, 50, "Darth Vader", true)
+	insertRepo(t, db, 51, "Darth Venamis", true)
+	insertRepo(t, db, 52, "Darth Maul", true)
+	insertRepo(t, db, 53, "Anakin Skywalker", true)
+	insertRepo(t, db, 54, "Luke Skywalker", true)
+	insertRepo(t, db, 55, "7th Sky Corps", true)
 
 	testCases := []struct {
 		patterns              []string
@@ -74,9 +74,9 @@ func TestRepoIDsByGlobPatterns(t *testing.T) {
 	}
 
 	t.Run("enforce repository permissions", func(t *testing.T) {
-		// Enable permissions user mapping forces checking repository permissions
+		// Turning on explicit permissions forces checking repository permissions
 		// against permissions tables in the database, which should effectively block
-		// all access because permissions tables are empty.
+		// all access because permissions tables are empty and repos are private.
 		before := globals.PermissionsUserMapping()
 		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
 		defer globals.SetPermissionsUserMapping(before)
@@ -97,11 +97,11 @@ func TestUpdateReposMatchingPatterns(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "r1")
-	insertRepo(t, db, 51, "r2")
-	insertRepo(t, db, 52, "r3")
-	insertRepo(t, db, 53, "r4")
-	insertRepo(t, db, 54, "r5")
+	insertRepo(t, db, 50, "r1", false)
+	insertRepo(t, db, 51, "r2", false)
+	insertRepo(t, db, 52, "r3", false)
+	insertRepo(t, db, 53, "r4", false)
+	insertRepo(t, db, 54, "r5", false)
 
 	updates := []struct {
 		policyID int
@@ -171,7 +171,7 @@ func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 	}
 
 	for _, id := range ids {
-		insertRepo(t, db, id, fmt.Sprintf("r%03d", id))
+		insertRepo(t, db, id, fmt.Sprintf("r%03d", id), false)
 	}
 
 	if err := store.UpdateReposMatchingPatterns(ctx, []string{"r*"}, 100, &limit); err != nil {

--- a/enterprise/internal/codeintel/uploads/internal/store/store_commits_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_commits_test.go
@@ -307,7 +307,7 @@ func insertUploads(t testing.TB, db database.DB, uploads ...types.Upload) {
 		}
 
 		// Ensure we have a repo for the inner join in select queries
-		insertRepo(t, db, upload.RepositoryID, upload.RepositoryName)
+		insertRepo(t, db, upload.RepositoryID, upload.RepositoryName, true)
 
 		query := sqlf.Sprintf(`
 			INSERT INTO lsif_uploads (
@@ -426,7 +426,7 @@ func deleteUploads(t testing.TB, db database.DB, uploads ...int) {
 
 // insertRepo creates a repository record with the given id and name. If there is already a repository
 // with the given identifier, nothing happens
-func insertRepo(t testing.TB, db database.DB, id int, name string) {
+func insertRepo(t testing.TB, db database.DB, id int, name string, private bool) {
 	if name == "" {
 		name = fmt.Sprintf("n-%d", id)
 	}
@@ -436,10 +436,11 @@ func insertRepo(t testing.TB, db database.DB, id int, name string) {
 		deletedAt = sqlf.Sprintf("%s", time.Unix(1587396557, 0).UTC())
 	}
 	insertRepoQuery := sqlf.Sprintf(
-		`INSERT INTO repo (id, name, deleted_at) VALUES (%s, %s, %s) ON CONFLICT (id) DO NOTHING`,
+		`INSERT INTO repo (id, name, deleted_at, private) VALUES (%s, %s, %s, %s) ON CONFLICT (id) DO NOTHING`,
 		id,
 		name,
 		deletedAt,
+		private,
 	)
 	if _, err := db.ExecContext(context.Background(), insertRepoQuery.Query(sqlf.PostgresBindVar), insertRepoQuery.Args()...); err != nil {
 		t.Fatalf("unexpected error while upserting repository: %s", err)

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dependency_index_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dependency_index_test.go
@@ -18,7 +18,7 @@ func TestInsertDependencySyncingJob(t *testing.T) {
 	store := New(&observation.TestContext, db)
 
 	uploadID := 42
-	insertRepo(t, db, 50, "")
+	insertRepo(t, db, 50, "", false)
 	insertUploads(t, db, types.Upload{
 		ID:            uploadID,
 		Commit:        makeCommit(1),

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dumps_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dumps_test.go
@@ -727,9 +727,10 @@ func TestDefinitionDumps(t *testing.T) {
 	}
 
 	t.Run("enforce repository permissions", func(t *testing.T) {
-		// Enable permissions user mapping forces checking repository permissions
+		// Turning on explicit permissions forces checking repository permissions
 		// against permissions tables in the database, which should effectively block
-		// all access because permissions tables are empty.
+		// all access because permissions tables are empty and repo that dumps belong
+		// to are private.
 		before := globals.PermissionsUserMapping()
 		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
 		defer globals.SetPermissionsUserMapping(before)

--- a/enterprise/internal/codeintel/uploads/internal/store/store_indexes_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_indexes_test.go
@@ -539,7 +539,7 @@ func insertIndexes(t testing.TB, db database.DB, indexes ...types.Index) {
 		}
 
 		// Ensure we have a repo for the inner join in select queries
-		insertRepo(t, db, index.RepositoryID, index.RepositoryName)
+		insertRepo(t, db, index.RepositoryID, index.RepositoryName, true)
 
 		query := sqlf.Sprintf(`
 			INSERT INTO lsif_indexes (

--- a/enterprise/internal/codeintel/uploads/internal/store/store_repositories_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_repositories_test.go
@@ -25,10 +25,10 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
-	insertRepo(t, db, 50, "r0")
-	insertRepo(t, db, 51, "r1")
-	insertRepo(t, db, 52, "r2")
-	insertRepo(t, db, 53, "r3")
+	insertRepo(t, db, 50, "r0", false)
+	insertRepo(t, db, 51, "r1", false)
+	insertRepo(t, db, 52, "r2", false)
+	insertRepo(t, db, 53, "r3", false)
 	updateGitserverUpdatedAt(t, db, now)
 
 	query := `
@@ -85,7 +85,7 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	}
 
 	// Make new invisible repository
-	insertRepo(t, db, 54, "r4")
+	insertRepo(t, db, 54, "r4", false)
 
 	// 95 minutes later, new repository is not yet visible
 	if repositoryIDs, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*95)); err != nil {
@@ -133,10 +133,10 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
-	insertRepo(t, db, 50, "r0")
-	insertRepo(t, db, 51, "r1")
-	insertRepo(t, db, 52, "r2")
-	insertRepo(t, db, 53, "r3")
+	insertRepo(t, db, 50, "r0", false)
+	insertRepo(t, db, 51, "r1", false)
+	insertRepo(t, db, 52, "r2", false)
+	insertRepo(t, db, 53, "r3", false)
 	updateGitserverUpdatedAt(t, db, now)
 
 	query := `
@@ -205,10 +205,10 @@ func TestSelectRepositoriesForIndexScanInDifferentTable(t *testing.T) {
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
-	insertRepo(t, db, 50, "r0")
-	insertRepo(t, db, 51, "r1")
-	insertRepo(t, db, 52, "r2")
-	insertRepo(t, db, 53, "r3")
+	insertRepo(t, db, 50, "r0", false)
+	insertRepo(t, db, 51, "r1", false)
+	insertRepo(t, db, 52, "r2", false)
+	insertRepo(t, db, 53, "r3", false)
 	updateGitserverUpdatedAt(t, db, now)
 
 	query := `
@@ -284,7 +284,7 @@ func TestSetRepositoryAsDirty(t *testing.T) {
 	store := New(&observation.TestContext, db)
 
 	for _, id := range []int{50, 51, 52} {
-		insertRepo(t, db, id, "")
+		insertRepo(t, db, id, "", false)
 	}
 
 	for _, repositoryID := range []int{50, 51, 52, 51, 52} {
@@ -315,7 +315,7 @@ func TestGetRepositoriesMaxStaleAge(t *testing.T) {
 	store := New(&observation.TestContext, db)
 
 	for _, id := range []int{50, 51, 52} {
-		insertRepo(t, db, id, "")
+		insertRepo(t, db, id, "", false)
 	}
 
 	if _, err := db.ExecContext(context.Background(), `
@@ -449,10 +449,10 @@ func TestSkipsDeletedRepositories(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "should not be dirty")
+	insertRepo(t, db, 50, "should not be dirty", false)
 	deleteRepo(t, db, 50, time.Now())
 
-	insertRepo(t, db, 51, "should be dirty")
+	insertRepo(t, db, 51, "should be dirty", false)
 
 	// NOTE: We did not insert 52, so it should not show up as dirty, even though we mark it below.
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -1939,7 +1939,7 @@ func TestInsertUploadUploading(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "")
+	insertRepo(t, db, 50, "", false)
 
 	id, err := store.InsertUpload(context.Background(), types.Upload{
 		Commit:       makeCommit(1),
@@ -1989,7 +1989,7 @@ func TestInsertUploadQueued(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "")
+	insertRepo(t, db, 50, "", false)
 
 	id, err := store.InsertUpload(context.Background(), types.Upload{
 		Commit:        makeCommit(1),
@@ -2042,7 +2042,7 @@ func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, db)
 
-	insertRepo(t, db, 50, "")
+	insertRepo(t, db, 50, "", false)
 
 	associatedIndexIDArg := 42
 	id, err := store.InsertUpload(context.Background(), types.Upload{

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -223,31 +222,16 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			verify := func(t *testing.T) {
-				t.Helper()
+			p, err := s.store.LoadUserPermissions(ctx, user.ID)
+			require.NoError(t, err)
 
-				p, err := s.store.LoadUserPermissions(ctx, user.ID)
-				require.NoError(t, err)
-
-				gotIDs := make([]int32, len(p))
-				for i, perm := range p {
-					gotIDs[i] = perm.RepoID
-				}
-				slices.Sort(gotIDs)
-
-				equal(t, "p.IDs", test.expectRepoIDs, gotIDs)
+			gotIDs := make([]int32, len(p))
+			for i, perm := range p {
+				gotIDs[i] = perm.RepoID
 			}
+			slices.Sort(gotIDs)
 
-			t.Run("works with legacy perms tables", func(t *testing.T) {
-				verify(t)
-			})
-
-			t.Run("works with unified perms tables", func(t *testing.T) {
-				// verify that it also works with unified permissions
-				mockUnifiedPermsConfig(true)
-				t.Cleanup(func() { conf.Mock(nil) })
-				verify(t)
-			})
+			equal(t, "p.IDs", test.expectRepoIDs, gotIDs)
 		})
 	}
 }

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -656,7 +656,7 @@ func TestPermsStore_SetUserPermissions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotIDs, _, err := s.legacyLoadUserPermissions(context.Background(), up.UserID, "")
+		gotIDs, err := s.legacyLoadUserPermissions(context.Background(), up.UserID, "")
 		require.NoError(t, err)
 
 		equal(t, "up.IDs", []int32{1}, gotIDs)
@@ -1541,7 +1541,7 @@ func TestPermsStore_SetRepoPermissions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotIDs, _, _, err := s.legacyLoadRepoPermissions(context.Background(), 1, "")
+		gotIDs, _, err := s.legacyLoadRepoPermissions(context.Background(), 1, "")
 		require.NoError(t, err)
 		equal(t, "rp.UserIDs", []int32{2}, gotIDs)
 	})
@@ -1560,7 +1560,7 @@ func TestPermsStore_SetRepoPermissions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, _, unrestricted, err := s.legacyLoadRepoPermissions(context.Background(), 1, "")
+		_, unrestricted, err := s.legacyLoadRepoPermissions(context.Background(), 1, "")
 		require.NoError(t, err)
 
 		require.Truef(t, unrestricted, "Want unrestricted, got %v", unrestricted)

--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -9,10 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-var errPermissionsUserMappingConflict = errors.New("The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it.")
 
 type BypassAuthzReasonsMap struct {
 	SiteAdmin       bool

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -85,7 +85,7 @@ func TestAuthzQueryConds(t *testing.T) {
 		got, err := AuthzQueryConds(context.Background(), db)
 		require.Nil(t, err, "unexpected error, should have passed without conflict")
 
-		want := authzQuery(false, true, int32(0))
+		want := authzQuery(false, int32(0))
 		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
@@ -101,7 +101,7 @@ func TestAuthzQueryConds(t *testing.T) {
 
 		got, err := AuthzQueryConds(context.Background(), db)
 		require.NoError(t, err)
-		want := authzQuery(false, true, int32(0))
+		want := authzQuery(false, int32(0))
 		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
@@ -119,14 +119,14 @@ func TestAuthzQueryConds(t *testing.T) {
 			setup: func(t *testing.T) (context.Context, DB) {
 				return actor.WithInternalActor(context.Background()), db
 			},
-			wantQuery: authzQuery(true, false, int32(0)),
+			wantQuery: authzQuery(true, int32(0)),
 		},
 		{
 			name: "no authz provider and not allow by default",
 			setup: func(t *testing.T) (context.Context, DB) {
 				return context.Background(), db
 			},
-			wantQuery: authzQuery(false, false, int32(0)),
+			wantQuery: authzQuery(false, int32(0)),
 		},
 		{
 			name: "no authz provider but allow by default",
@@ -134,7 +134,7 @@ func TestAuthzQueryConds(t *testing.T) {
 				return context.Background(), db
 			},
 			authzAllowByDefault: true,
-			wantQuery:           authzQuery(true, false, int32(0)),
+			wantQuery:           authzQuery(true, int32(0)),
 		},
 		{
 			name: "authenticated user is a site admin",
@@ -145,7 +145,7 @@ func TestAuthzQueryConds(t *testing.T) {
 				mockDB.UsersFunc.SetDefaultReturn(users)
 				return actor.WithActor(context.Background(), &actor.Actor{UID: 1}), mockDB
 			},
-			wantQuery: authzQuery(true, false, int32(1)),
+			wantQuery: authzQuery(true, int32(1)),
 		},
 		{
 			name: "authenticated user is a site admin and AuthzEnforceForSiteAdmins is set",
@@ -160,7 +160,7 @@ func TestAuthzQueryConds(t *testing.T) {
 				})
 				return actor.WithActor(context.Background(), &actor.Actor{UID: 1}), mockDB
 			},
-			wantQuery: authzQuery(false, false, int32(1)),
+			wantQuery: authzQuery(false, int32(1)),
 		},
 		{
 			name: "authenticated user is not a site admin",
@@ -171,7 +171,7 @@ func TestAuthzQueryConds(t *testing.T) {
 				mockDB.UsersFunc.SetDefaultReturn(users)
 				return actor.WithActor(context.Background(), &actor.Actor{UID: 1}), mockDB
 			},
-			wantQuery: authzQuery(false, false, int32(1)),
+			wantQuery: authzQuery(false, int32(1)),
 		},
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -814,8 +814,6 @@ type ExperimentalFeatures struct {
 	SubRepoPermissions *SubRepoPermissions `json:"subRepoPermissions,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
 	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
-	// UnifiedPermissions description: Enables the new unified permissions model, which stores repository permissions in a single table and a row for each permission instead of postgres arrays.
-	UnifiedPermissions bool           `json:"unifiedPermissions,omitempty"`
 	Additional         map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
 }
 
@@ -880,7 +878,6 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "structuralSearch")
 	delete(m, "subRepoPermissions")
 	delete(m, "tls.external")
-	delete(m, "unifiedPermissions")
 	if len(m) > 0 {
 		v.Additional = make(map[string]any, len(m))
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -813,8 +813,8 @@ type ExperimentalFeatures struct {
 	StructuralSearch   string              `json:"structuralSearch,omitempty"`
 	SubRepoPermissions *SubRepoPermissions `json:"subRepoPermissions,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
-	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
-	Additional         map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
+	TlsExternal *TlsExternal   `json:"tls.external,omitempty"`
+	Additional  map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
 }
 
 func (v ExperimentalFeatures) MarshalJSON() ([]byte, error) {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -510,14 +510,6 @@
           },
           "group": "AccessRequest",
           "default": true
-        },
-        "unifiedPermissions": {
-          "description": "Enables the new unified permissions model, which stores repository permissions in a single table and a row for each permission instead of postgres arrays.",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": false
-          }
         }
       },
       "examples": [


### PR DESCRIPTION
## Description

Make unified perms the only way to read permissions. This PR cleans up the legacy way of doing things in most places, but for the sake of trying to keep it shorter, only tackles the read path. So it still keeps some of the legacy methods in perms_syncer.go and perms_store.go. I want to create a followup PR for cleaning that up.

## Test plan

Unit tests, which already cover all the changed functionality.
