### PR TITLE
Add env variable to embeddings cmd in sg.config.yaml

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -372,7 +372,9 @@ commands:
       - enterprise/internal/rockskip
 
   embeddings:
-    cmd: .bin/embeddings
+    cmd: |
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      .bin/embeddings
     install: |
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'


### PR DESCRIPTION
Seems like the `embeddings` service needs the license verification environment variable set for local dev.

## Test plan

sg.config.yaml update.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
