### PR TITLE
Make use of new bytesutil.LineReader helper

### DIFF
--- a/dev/depgraph/internal/graph/imports.go
+++ b/dev/depgraph/internal/graph/imports.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 )
 
 const rootPackage = "github.com/sourcegraph/sourcegraph"
@@ -86,9 +87,12 @@ func extractImports(path string) (map[string]struct{}, error) {
 
 	inImportGroup := false
 	importMap := map[string]struct{}{}
-	lines := bytes.Split(contents, []byte{'\n'})
 
-	for _, line := range lines {
+	lr := byteutils.NewLineReader(contents)
+
+	for lr.Scan() {
+		line := lr.Line()
+
 		// See if we need to flip parse states
 		if extractionControlMap[inImportGroup].stateChangePattern.Match(line) {
 			inImportGroup = !inImportGroup

--- a/dev/depgraph/internal/graph/names.go
+++ b/dev/depgraph/internal/graph/names.go
@@ -1,12 +1,13 @@
 package graph
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 )
 
 // parseNames returns a map from package paths to the name declared by that package.
@@ -57,7 +58,11 @@ func extractPackageName(path string) (string, error) {
 		return "", err
 	}
 
-	for _, line := range bytes.Split(contents, []byte{'\n'}) {
+	lr := byteutils.NewLineReader(contents)
+
+	for lr.Scan() {
+		line := lr.Line()
+
 		if matches := packagePattern.FindSubmatch(line); len(matches) > 0 {
 			return string(matches[1]), nil
 		}

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -316,7 +317,11 @@ func parseCrateInformation(contents []byte) ([]shared.MinimalPackageRepoRef, err
 
 	instant := time.Now()
 
-	for _, line := range bytes.Split(contents, []byte("\n")) {
+	lr := byteutils.NewLineReader(contents)
+
+	for lr.Scan() {
+		line := lr.Line()
+
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -1893,7 +1894,7 @@ func (c *clientImplementor) FirstEverCommit(ctx context.Context, checker authz.S
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", args, out))
 	}
 	lines := bytes.TrimSpace(out)
-	tokens := bytes.Split(lines, []byte("\n"))
+	tokens := bytes.SplitN(lines, []byte("\n"), 2)
 	if len(tokens) == 0 {
 		return nil, errors.New("FirstEverCommit returned no revisions")
 	}
@@ -2251,12 +2252,13 @@ var refPrefixes = map[string]gitdomain.RefType{
 // - %(HEAD) is `*` if the branch is the default branch (and whitesace otherwise)
 // - %(creatordate) is the ISO-formatted date the object was created
 func parseRefDescriptions(out []byte) (map[string][]gitdomain.RefDescription, error) {
-	lines := bytes.Split(out, []byte("\n"))
-	refDescriptions := make(map[string][]gitdomain.RefDescription, len(lines))
+	refDescriptions := make(map[string][]gitdomain.RefDescription, bytes.Count(out, []byte("\n")))
+
+	lr := byteutils.NewLineReader(out)
 
 lineLoop:
-	for _, line := range lines {
-		line = bytes.TrimSpace(line)
+	for lr.Scan() {
+		line := bytes.TrimSpace(lr.Line())
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -76,8 +77,12 @@ func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (s
 			loc.Line++
 			loc.Column = 0
 
-			lines := bytes.Split(hunk.Body, []byte("\n"))
-			for lineIdx, line := range lines {
+			lr := byteutils.NewLineReader(hunk.Body)
+			lineIdx := -1
+			for lr.Scan() {
+				line := lr.Line()
+				lineIdx++
+
 				if len(line) == 0 {
 					continue
 				}

--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"unicode/utf8"
 
+	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/casetransform"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -158,7 +159,12 @@ func (dm *DiffMatches) Match(lc *LazyCommit) (CommitFilterResult, MatchedCommit,
 		var hunkHighlights map[int]MatchedHunk
 		for hunkIdx, hunk := range fileDiff.Hunks {
 			var lineHighlights map[int]result.Ranges
-			for lineIdx, line := range bytes.Split(hunk.Body, []byte("\n")) {
+			lr := byteutils.NewLineReader(hunk.Body)
+			lineIdx := -1
+			for lr.Scan() {
+				line := lr.Line()
+				lineIdx++
+
 				if len(line) == 0 {
 					continue
 				}


### PR DESCRIPTION
This applies this new helper tool where it felt easily applicable. There are more things where it'd be useful, but those aren't as easily convertible.

cc @camdencheek this also reintroduces the optimization we made earlier that failed CI because of a buffer length error. https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/7a7075d42b6835b6da9c23ff33157fef02e8568f?visible=1

## Test plan

Existing test suites.