### PR TITLE
Code Insights: use month year on x axis if the chart spans a year or more

### DIFF
--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -38,11 +38,32 @@ const daysBetween = (date1: Date, date2: Date): number =>
  * @param scale - The time scale to base the decision on
  * @returns A function that formats a date to a string
  */
-const getFormatDateTick = (scale: ScaleTime<number, number>): ((date: Date) => string) => {
+const getFormatDateTick = (scale: ScaleTime<number, number>): ((tick: Date, index: number, ticks: Date[]) => string) => {
     if (scale.domain().length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
         return (date: Date) => timeFormat('%d %b')(date)
     }
-    return (date: Date) => timeFormat('%b %y')(date)
+    return (tick: Date, index: number, ticks: Date[]) => {
+        return timeFormat('%b %y')(tick)
+    }
+}
+
+const formatDateTick = (tick: Date, index: number, ticks: Date[]): string => {
+    if (index === 0 ) {
+        return timeFormat('%d %b')(tick)
+    }
+
+    if (ticks.length === 1) {
+        return timeFormat('%b %Y')(tick)
+    }
+
+    const currentTickYear = new Date(tick).getFullYear()
+    const prevTickYear = new Date(ticks[index - 1].value).getFullYear()
+
+    if (currentTickYear !== prevTickYear) {
+        return timeFormat('%b %Y')(tick)
+    }
+
+    return timeFormat('%d %b')(tick)
 }
 
 interface GetScaleTicksInput {
@@ -187,10 +208,10 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 <SvgAxisLeft />
 
                 <SvgAxisBottom
-                    pixelsPerTick={70}
+                    pixelsPerTick={80}
                     minRotateAngle={20}
                     maxRotateAngle={60}
-                    tickFormat={getFormatDateTick(xScale)}
+                    tickFormat={formatDateTick}
                     getScaleTicks={getXScaleTicks}
                 />
 

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -19,13 +19,29 @@ import { getSeriesData, getMinMaxBoundaries } from './utils'
 
 import styles from './LineChart.module.scss'
 
+/*
+ * Returns the number of days between two dates.
+ *
+ * @param date1 - The start date
+ * @param date2 - The end date
+ * @returns The number of days between the two dates
+ */
+const daysBetween = (date1: Date, date2: Date): number =>
+    Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
+
 /**
  * Returns a formatted time text. It's used primary for X axis tick's text nodes.
  * Number of month day + short name of month.
  *
  * Example: 01 Jan, 12 Feb, ...
  */
-const formatDateTick = timeFormat('%d %b')
+
+const getFormatDateTick = (scale: ScaleTime<number, number>): ((date: Date) => string) => {
+    if (scale.domain.length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
+        return (date: Date) => timeFormat('%d %b')(date)
+    }
+    return (date: Date) => timeFormat('%b %y')(date)
+}
 
 interface GetScaleTicksInput {
     scale: AnyD3Scale
@@ -39,7 +55,6 @@ export function getXScaleTicks<T>(input: GetScaleTicksInput): T[] {
     const numberTicks = Math.max(2, Math.floor(space / pixelsPerTick))
     return getTicks(scale, numberTicks) as T[]
 }
-
 interface GetLineGroupStyleOptions {
     /** Whether this series contains the active point */
     id: string
@@ -173,7 +188,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                     pixelsPerTick={70}
                     minRotateAngle={20}
                     maxRotateAngle={60}
-                    tickFormat={formatDateTick}
+                    tickFormat={getFormatDateTick(xScale)}
                     getScaleTicks={getXScaleTicks}
                 />
 

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -29,15 +29,17 @@ import styles from './LineChart.module.scss'
 const daysBetween = (date1: Date, date2: Date): number =>
     Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
 
-/**
- * Returns a formatted time text. It's used primary for X axis tick's text nodes.
- * Number of month day + short name of month.
+/*
+ * Returns a date tick formatter function based on the scale's domain.
  *
- * Example: 01 Jan, 12 Feb, ...
+ * If the domain spans less than a year, it returns a formatter that shows the day of month and month name (e.g. "01 Jan").
+ * Otherwise, it returns a formatter that shows just the month and year (e.g. "Jan 20").
+ *
+ * @param scale - The time scale to base the decision on
+ * @returns A function that formats a date to a string
  */
-
 const getFormatDateTick = (scale: ScaleTime<number, number>): ((date: Date) => string) => {
-    if (scale.domain.length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
+    if (scale.domain().length < 2 || daysBetween(scale.domain()[1], scale.domain()[0]) < 365) {
         return (date: Date) => timeFormat('%d %b')(date)
     }
     return (date: Date) => timeFormat('%b %y')(date)

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -19,7 +19,7 @@ import { getSeriesData, getMinMaxBoundaries } from './utils'
 
 import styles from './LineChart.module.scss'
 
-/*
+/**
  * Returns the number of days between two dates.
  *
  * @param date1 - The start date
@@ -29,7 +29,7 @@ import styles from './LineChart.module.scss'
 const daysBetween = (date1: Date, date2: Date): number =>
     Math.round(Math.abs((date2.getTime() - date1.getTime()) / (1000 * 60 * 60 * 24)))
 
-/*
+/**
  * Returns a date tick formatter function based on the scale's domain.
  *
  * If the domain spans less than a year, it returns a formatter that shows the day of month and month name (e.g. "01 Jan").

--- a/client/wildcard/src/components/Charts/components/line-chart/story/LineChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/story/LineChart.story.tsx
@@ -41,13 +41,13 @@ export const LineChartsDemo: Story = () => (
         }}
     >
         <PlainChartExample />
-        <FlatChartExample />
-        <PlainStackedChartExample />
-        <ResponsiveChartExample />
-        <WithLegendExample />
-        <WithHugeDataExample />
-        <WithZeroOneDataExample />
-        <StackedWithDataMissingValues />
+        {/*<FlatChartExample />*/}
+        {/*<PlainStackedChartExample />*/}
+        {/*<ResponsiveChartExample />*/}
+        {/*<WithLegendExample />*/}
+        {/*<WithHugeDataExample />*/}
+        {/*<WithZeroOneDataExample />*/}
+        {/*<StackedWithDataMissingValues />*/}
     </main>
 )
 

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -164,7 +164,7 @@ const defaultTruncatedTick = (tick: string): string => (tick.length >= 15 ? `${t
 export const reverseTruncatedTick = (tick: string): string => (tick.length >= 15 ? `...${tick.slice(-15)}` : tick)
 
 interface SvgAxisBottomProps<Tick> {
-    tickFormat?: (tick: Tick) => string
+    tickFormat?: (tick: Tick, index: number, ticks: Tick[]) => string
     pixelsPerTick?: number
     minRotateAngle?: number
     maxRotateAngle?: number


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/49957

## Test plan
- Check the x axis in code insights and search aggregation charts

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
