### PR TITLE
make access tokens more identifiable with sgp_ prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix.
 
 ### Fixed
 

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
@@ -46,6 +47,10 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertSecurityEventCount(t, db, SecurityEventAccessTokenCreated, 1)
+
+	if !strings.HasPrefix(tv0, "sgp_") {
+		t.Errorf("got %q, want prefix 'sgp_'", tv0)
+	}
 
 	got, err := db.AccessTokens().GetByID(ctx, tid0)
 	if err != nil {


### PR DESCRIPTION
Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix. It is also allowed to *omit* the `sgp_` prefix from an access token, for simplicity of backcompat (so that we do not need to distinguish between access tokens created prior to the introduction of this prefix).

See https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/ for an explanation of why GitHub made a similar change. Slack, Stripe, and many other companies have also made this change.

At some point, we should warn, deprecate, and eventually disable access tokens that do not contain this prefix.


![sgpaccesstoken](https://user-images.githubusercontent.com/1976/227696764-c35bdcc8-41df-47bc-89cf-707e2c5af05a.png)

(Note: This access token was deleted prior to this screenshot being uploaded.)


## Test plan

Create a new access token. Confirm it contains the `sgp_` prefix. Confirm it works. Confirm it works without the `sgp_` prefix as well (for backcompat).