### PR TITLE
change primary dotcom CTAs to point to App

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -140,9 +140,16 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                         New to Sourcegraph? <Link to="/sign-up">Sign up.</Link>{' '}
                         {isSourcegraphDotCom && (
                             <>
-                                To use Sourcegraph on private repositories,
+                                To use Sourcegraph on private repositories,{' '}
                                 <Link
-                                    to="https://signup.sourcegraph.com"
+                                    to="https://about.sourcegraph.com/app"
+                                    onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
+                                >
+                                    download Sourcegraph app
+                                </Link>{' '}
+                                or{' '}
+                                <Link
+                                    to="https://sourcegraph.com/get-started?t=enterprise"
                                     onClick={() =>
                                         eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })
                                     }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -16,7 +16,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
-import { Button, Link, ButtonLink, useWindowSize } from '@sourcegraph/wildcard'
+import { Button, Link, ButtonLink, useWindowSize, Tooltip } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -312,13 +312,15 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                     )}
                     {isSourcegraphDotCom && (
                         <NavAction>
-                            <Link
-                                to="https://about.sourcegraph.com"
-                                className={styles.link}
-                                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'NavBar' })}
-                            >
-                                {props.authenticatedUser && 'Get '} Enterprise
-                            </Link>
+                            <Tooltip content="The Sourcegraph desktop app runs locally and works on your own private code.">
+                                <Link
+                                    to="https://about.sourcegraph.com/app"
+                                    className={classNames(styles.link, 'small')}
+                                    onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'NavBar' })}
+                                >
+                                    Download app
+                                </Link>
+                            </Tooltip>
                         </NavAction>
                     )}
                     {fuzzyFinderNavbar && FuzzyFinderNavItem(props.setFuzzyFinderIsVisible)}

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -69,14 +69,14 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                         Searching millions of public repositories
                     </div>
                     <div className="mt-3">
-                        <Link
-                            to="https://about.sourcegraph.com"
-                            onClick={() =>
-                                telemetryService.log('ClickedOnEnterpriseCTA', { location: 'HomeAboveSearch' })
-                            }
-                        >
-                            Get Sourcegraph Enterprise <Icon svgPath={mdiArrowRight} aria-hidden={true} />
-                        </Link>
+                        <Tooltip content="The Sourcegraph desktop app runs locally and works on your own private code.">
+                            <Link
+                                to="https://about.sourcegraph.com/app"
+                                onClick={() => telemetryService.log('ClickedOnAppCTA', { location: 'HomeAboveSearch' })}
+                            >
+                                Download Sourcegraph app <Icon svgPath={mdiArrowRight} aria-hidden={true} />
+                            </Link>
+                        </Tooltip>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
The global navbar, `/search`, and `/sign-in` now all point to App as the primary call-to-action instead of Sourcegraph Enterprise.




## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-dotcom-app-cta.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
