### PR TITLE
Housekeeping: Remove unused go functions and variables

### DIFF
--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -23,11 +23,6 @@ var HubSpotAccessToken = env.Get("HUBSPOT_ACCESS_TOKEN", "", "HubSpot access tok
 // SurveyFormID is the ID for a satisfaction (NPS) survey.
 var SurveyFormID = "ee042306-491a-4b06-bd9c-1181774dfda0"
 
-// TrialFormID is ID for the request trial form.
-//
-// See https://app.hubspot.com/contacts/2762526/lists/244 for submissions.
-var TrialFormID = "0bbc9f90-3741-4c7a-b5f5-6c81f130ea9d"
-
 // HappinessFeedbackFormID is the ID for a Happiness survey.
 var HappinessFeedbackFormID = "417ec50b-39b4-41fa-a267-75da6f56a7cf"
 

--- a/cmd/symbols/squirrel/breadcrumbs.go
+++ b/cmd/symbols/squirrel/breadcrumbs.go
@@ -135,17 +135,3 @@ func (bs *Breadcrumbs) prettyString(readFile readFileFunc) string {
 	bs.pretty(sb, readFile)
 	return sb.String()
 }
-
-// Returns breadcrumbs that have one of the given messages.
-func pickBreadcrumbs(breadcrumbs []Breadcrumb, messages []string) []Breadcrumb {
-	var picked []Breadcrumb
-	for _, b := range breadcrumbs {
-		for _, message := range messages {
-			if strings.Contains(b.message(), message) {
-				picked = append(picked, b)
-				break
-			}
-		}
-	}
-	return picked
-}

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -125,8 +124,4 @@ func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc, readFile readFil
 			return
 		}
 	}
-}
-
-func sample[T any](xs []T) T {
-	return xs[rand.Intn(len(xs))]
 }

--- a/cmd/symbols/squirrel/lang_starlark.go
+++ b/cmd/symbols/squirrel/lang_starlark.go
@@ -117,23 +117,6 @@ var starlarkExportQuery = `
 )
 `
 
-var loadQueryKeywordArgument = `
-(
-	(module
-		(expression_statement
-			(call
-				function: (identifier) @_funcname
-				arguments: (argument_list
-                  (string) @path
-                  (keyword_argument name: (identifier) @named) @symbol
-                )
-			)
-		)
-	)
-	(#eq? @_funcname "load")
-)
-`
-
 var loadQuery = `
 (
 	(module

--- a/cmd/symbols/squirrel/lang_starlark.go
+++ b/cmd/symbols/squirrel/lang_starlark.go
@@ -117,6 +117,23 @@ var starlarkExportQuery = `
 )
 `
 
+var loadQueryKeywordArgument = `
+(
+	(module
+		(expression_statement
+			(call
+				function: (identifier) @_funcname
+				arguments: (argument_list
+                  (string) @path
+                  (keyword_argument name: (identifier) @named) @symbol
+                )
+			)
+		)
+	)
+	(#eq? @_funcname "load")
+)
+`
+
 var loadQuery = `
 (
 	(module

--- a/cmd/symbols/squirrel/local_code_intel_test.go
+++ b/cmd/symbols/squirrel/local_code_intel_test.go
@@ -2,7 +2,6 @@ package squirrel
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -512,22 +511,6 @@ func sortAnnotations(annotations []annotation) {
 			return len(tagsi) < len(tagsj)
 		}
 	})
-}
-
-func printRowColumnKind(annotations []annotation) string {
-	sortAnnotations(annotations)
-
-	lines := []string{}
-	for _, annotation := range annotations {
-		lines = append(lines, fmt.Sprintf(
-			"%d:%d %s",
-			annotation.repoCommitPathPoint.Row,
-			annotation.repoCommitPathPoint.Column,
-			annotation.tags,
-		))
-	}
-
-	return strings.Join(lines, "\n")
 }
 
 var compareAnnotations = cmp.Comparer(func(a, b annotation) bool {

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -176,17 +176,6 @@ func allCaptures(query string, node Node) ([]Node, error) {
 	return captures, nil
 }
 
-func firstCapture(query string, node Node) (*Node, error) {
-	captures, err := allCaptures(query, node)
-	if err != nil {
-		return nil, err
-	}
-	if len(captures) == 0 {
-		return nil, nil
-	}
-	return &captures[0], nil
-}
-
 // nodeToRange returns the range of the node.
 func nodeToRange(node *sitter.Node) types.Range {
 	length := 1


### PR DESCRIPTION
Just some housekeeping in our Go code, not related to anything.

Two small commits where I removed six entities that didn't seem to be used anywhere:

- [Remove four unused Go functions](https://github.com/sourcegraph/sourcegraph/pull/49994/commits/9b45e2f3b0811d3433deb770997fed31b9758b1d)
- [Remove two unused global Go variables](https://github.com/sourcegraph/sourcegraph/pull/49994/commits/90b2881995f6b26f1d7911f9fbe9c64fbce5e7ae)

## Test plan

CI should pass