### PR TITLE
Housekeeping: fix some code smells in the Go code

### DIFF
--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -40,7 +40,7 @@ type Provider interface {
 	// Refresh refreshes the provider's information with an external service, if any.
 	Refresh(ctx context.Context) error
 
-	// Provides basic external account from this auth provider
+	// ExternalAccountInfo provides basic external account from this auth provider
 	ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error)
 }
 

--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -72,7 +72,7 @@ func (e *externalServices) SyncExternalService(ctx context.Context, svc *types.E
 	return err
 }
 
-// ExcludeRepoFromExternalService excludes given repo from given external service config.
+// ExcludeRepoFromExternalServices excludes given repo from given external service config.
 //
 // Function is pretty beefy, what it does is:
 // - finds an external service by ID and checks if it supports repo exclusion

--- a/cmd/frontend/graphqlbackend/bigint.go
+++ b/cmd/frontend/graphqlbackend/bigint.go
@@ -10,12 +10,12 @@ import (
 // BigInt implements the BigInt GraphQL scalar type.
 type BigInt int64
 
-func (BigInt) ImplementsGraphQLType(name string) bool {
+func (*BigInt) ImplementsGraphQLType(name string) bool {
 	return name == "BigInt"
 }
 
-func (v BigInt) MarshalJSON() ([]byte, error) {
-	return json.Marshal(strconv.FormatInt(int64(v), 10))
+func (v *BigInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatInt(int64(*v), 10))
 }
 
 func (v *BigInt) UnmarshalGraphQL(input any) error {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -728,7 +728,7 @@ var EnterpriseResolvers = struct {
 	ownResolver                 OwnResolver
 }{}
 
-// DEPRECATED
+// Root is DEPRECATED
 func (r *schemaResolver) Root() *schemaResolver {
 	return newSchemaResolver(r.db, r.gitserverClient, r.enterpriseSearchJobs)
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -167,7 +167,7 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 	}
 }
 
-func (requestTracer) TraceField(ctx context.Context, _, typeName, fieldName string, _ bool, _ map[string]any) (context.Context, func(*gqlerrors.QueryError)) {
+func (*requestTracer) TraceField(ctx context.Context, _, typeName, fieldName string, _ bool, _ map[string]any) (context.Context, func(*gqlerrors.QueryError)) {
 	// We don't call into t.OpenTracingTracer.TraceField since it generates too many spans which is really hard to read.
 	start := time.Now()
 	return ctx, func(err *gqlerrors.QueryError) {
@@ -182,7 +182,7 @@ func (requestTracer) TraceField(ctx context.Context, _, typeName, fieldName stri
 	}
 }
 
-func (t requestTracer) TraceValidation(ctx context.Context) func([]*gqlerrors.QueryError) {
+func (t *requestTracer) TraceValidation(ctx context.Context) func([]*gqlerrors.QueryError) {
 	var finish func([]*gqlerrors.QueryError)
 	if policy.ShouldTrace(ctx) {
 		finish = t.tracer.TraceValidation(ctx)

--- a/cmd/frontend/graphqlbackend/json.go
+++ b/cmd/frontend/graphqlbackend/json.go
@@ -10,7 +10,7 @@ import (
 // representation of its Go value.
 type JSONValue struct{ Value any }
 
-func (JSONValue) ImplementsGraphQLType(name string) bool {
+func (*JSONValue) ImplementsGraphQLType(name string) bool {
 	return name == "JSONValue"
 }
 
@@ -19,7 +19,7 @@ func (v *JSONValue) UnmarshalGraphQL(input any) error {
 	return nil
 }
 
-func (v JSONValue) MarshalJSON() ([]byte, error) {
+func (v *JSONValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.Value)
 }
 

--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -17,17 +17,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// Refer to SearchQueryOutputPhase in GQL definitions.
 const (
-	// cf. SearchQueryOutputPhase in GQL definitions.
 	ParseTree = "PARSE_TREE"
 	JobTree   = "JOB_TREE"
+)
 
-	// cf. SearchQueryOutputFormat in GQL definitions.
+// Refer to SearchQueryOutputFormat in GQL definitions.
+const (
 	Json    = "JSON"
 	Sexp    = "SEXP"
 	Mermaid = "MERMAID"
+)
 
-	// cf. SearchQueryOutputVerbosity in GQL definitions.
+// Refer to SearchQueryOutputVerbosity in GQL definitions.
+const (
 	Minimal = "MINIMAL"
 	Basic   = "BASIC"
 	Maximal = "MAXIMAL"

--- a/cmd/frontend/graphqlbackend/phabricator.go
+++ b/cmd/frontend/graphqlbackend/phabricator.go
@@ -15,6 +15,7 @@ func (p *phabricatorRepoResolver) Name() string {
 }
 
 // TODO(chris): Remove URI in favor of Name.
+
 func (p *phabricatorRepoResolver) URI() string {
 	return string(p.PhabricatorRepo.Name)
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -284,6 +284,7 @@ func (r *RepositoryResolver) Language(ctx context.Context) (string, error) {
 
 func (r *RepositoryResolver) Enabled() bool { return true }
 
+// CreatedAt is deprecated and will be removed in a future release.
 // No clients that we know of read this field. Additionally on performance profiles
 // the marshalling of timestamps is significant in our postgres client. So we
 // deprecate the fields and return fake data for created_at.

--- a/cmd/frontend/graphqlbackend/slow_requests_tracer.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer.go
@@ -164,7 +164,7 @@ func (r *slowRequestConnectionResolver) PageInfo(ctx context.Context) (*graphqlu
 	}
 }
 
-// ID returns an opaque ID for that node.
+// Index returns an opaque ID for that node.
 func (r *slowRequestResolver) Index() string {
 	return r.req.Index
 }

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -132,7 +132,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-// FeedbackSubmissionInput contains a happiness feedback response.
+// HappinessFeedbackSubmissionInput contains a happiness feedback response.
 type HappinessFeedbackSubmissionInput struct {
 	// Score is the user's happiness rating, from 1-4.
 	Score int32

--- a/cmd/frontend/graphqlbackend/teams_test.go
+++ b/cmd/frontend/graphqlbackend/teams_test.go
@@ -1140,7 +1140,7 @@ func TestTeamsPaginated(t *testing.T) {
 		}
 	}
 	var (
-		hasNextPage bool = true
+		hasNextPage = true
 		cursor      string
 	)
 	query := `query Teams($cursor: String!) {
@@ -1443,7 +1443,7 @@ func TestMembersPaginated(t *testing.T) {
 		}
 	}
 	var (
-		hasNextPage bool = true
+		hasNextPage = true
 		cursor      string
 	)
 	query := `query Members($cursor: String!) {

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -69,7 +69,7 @@ func (s *userUsageStatisticsResolver) LastActiveCodeHostIntegrationTime() *strin
 	return nil
 }
 
-// No longer used, only here for backwards compatibility with IDE and browser extensions.
+// LogUserEvent is no longer used, only here for backwards compatibility with IDE and browser extensions.
 // Functionality removed in https://github.com/sourcegraph/sourcegraph/pull/38826.
 func (*schemaResolver) LogUserEvent(ctx context.Context, args *struct {
 	Event        string

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// webhookLogArgs are the arguments common to the two queries that provide
+// WebhookLogsArgs are the arguments common to the two queries that provide
 // access to webhook logs: the webhookLogs method on the top level query, and on
 // the ExternalService type.
 type WebhookLogsArgs struct {

--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
-// Creates the static asset handler. The handler should be wrapped into a middleware
+// NewAssetHandler creates the static asset handler. The handler should be wrapped into a middleware
 // that enables cross-origin requests to allow the loading of the Phabricator native extension assets.
 func NewAssetHandler(mux *http.ServeMux) http.Handler {
 	fs := httpgzip.FileServer(assets.Assets, httpgzip.FileServerOptions{DisableDirListing: true})

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Represents an endpoint
+// Endpoint represents an endpoint
 type Endpoint struct {
 	// Service to which the endpoint belongs
 	Service string
@@ -53,7 +53,7 @@ func startClusterScannerWithClient(client *kubernetes.Clientset, ns string, cons
 	return nil
 }
 
-// Starts a cluster scanner with the specified consumer. Does not block.
+// StartClusterScanner starts a cluster scanner with the specified consumer. Does not block.
 func StartClusterScanner(consumer ScanConsumer) error {
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -381,14 +381,14 @@ func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) h
 			return
 		}
 
-		valid, error := store.VerifyUnlockAccountTokenAndReset(unlockAccountInfo.Token)
+		valid, err := store.VerifyUnlockAccountTokenAndReset(unlockAccountInfo.Token)
 
-		if !valid || error != nil {
-			err := "invalid token provided"
-			if error != nil {
-				err = error.Error()
+		if !valid || err != nil {
+			errStr := "invalid token provided"
+			if err != nil {
+				errStr = err.Error()
 			}
-			httpLogError(logger.Warn, w, err, http.StatusUnauthorized)
+			httpLogError(logger.Warn, w, errStr, http.StatusUnauthorized)
 			return
 		}
 	}

--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -36,7 +36,7 @@ type LockoutStore interface {
 	// SendUnlockAccountEmail sends an email to the locked account email providing a
 	// temporary unlock link.
 	SendUnlockAccountEmail(ctx context.Context, userID int32, userEmail string) error
-	// Returns true if the unlock account email has already been sent
+	// UnlockEmailSent returns true if the unlock account email has already been sent
 	UnlockEmailSent(userID int32) bool
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/lockout_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout_test.go
@@ -187,9 +187,9 @@ func TestLockoutStore(t *testing.T) {
 
 		assert.Empty(t, err)
 
-		valid, error := s.VerifyUnlockAccountTokenAndReset(token)
+		valid, err := s.VerifyUnlockAccountTokenAndReset(token)
 
-		assert.Empty(t, error)
+		assert.Empty(t, err)
 
 		if !valid {
 			t.Fatalf("provided token is invalid")
@@ -212,9 +212,9 @@ func TestLockoutStore(t *testing.T) {
 
 		s.Reset(1)
 
-		valid, error := s.VerifyUnlockAccountTokenAndReset(token)
+		valid, err := s.VerifyUnlockAccountTokenAndReset(token)
 
-		assert.EqualError(t, error, "No previously generated token exists for the specified user")
+		assert.EqualError(t, err, "No previously generated token exists for the specified user")
 		assert.False(t, valid)
 	})
 

--- a/cmd/frontend/internal/bg/update_permissions.go
+++ b/cmd/frontend/internal/bg/update_permissions.go
@@ -15,7 +15,7 @@ import (
 // in the rbac schema config located in internal/rbac/schema.yaml. It ensures the permissions in the
 // database are always up to date, using the schema config as it's source of truth.
 
-// This method is called as part of the background process by the `frontend` service.
+// UpdatePermissions is called as part of the background process by the `frontend` service.
 func UpdatePermissions(ctx context.Context, logger log.Logger, db database.DB) {
 	scopedLog := logger.Scoped("permission_update", "Updates the permission in the database based on the rbac schema configuration.")
 	err := db.WithTransact(ctx, func(tx database.DB) error {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -1,4 +1,4 @@
-// package search is search specific logic for the frontend. Also see
+// Package search is search specific logic for the frontend. Also see
 // github.com/sourcegraph/sourcegraph/internal/search for more generic search
 // code.
 package search

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -170,7 +170,7 @@ func TestDisplayLimit(t *testing.T) {
 	}
 
 	// any returns item, true if skipped contains an item matching reason.
-	any := func(reason api.SkippedReason, skipped []api.Skipped) (api.Skipped, bool) {
+	anySkipped := func(reason api.SkippedReason, skipped []api.Skipped) (api.Skipped, bool) {
 		for _, s := range skipped {
 			if s.Reason == reason {
 				return s, true
@@ -233,7 +233,7 @@ func TestDisplayLimit(t *testing.T) {
 			var matchCount int
 			decoder := streamhttp.FrontendStreamDecoder{
 				OnProgress: func(progress *api.Progress) {
-					if skipped, ok := any(api.DisplayLimit, progress.Skipped); ok {
+					if skipped, ok := anySkipped(api.DisplayLimit, progress.Skipped); ok {
 						displayLimitHit = true
 						message = skipped.Message
 					}

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -320,7 +320,7 @@ func InvalidateSessionCurrentUser(w http.ResponseWriter, r *http.Request, db dat
 	return deleteSession(w, r)
 }
 
-// Bulk "InvalidateSessionsByID" action.
+// InvalidateSessionsByIDs is a bulk action.
 func InvalidateSessionsByIDs(ctx context.Context, db database.DB, ids []int32) error {
 	return db.Users().InvalidateSessionsByIDs(ctx, ids)
 }

--- a/cmd/server/internal/goreman/rpc.go
+++ b/cmd/server/internal/goreman/rpc.go
@@ -7,7 +7,7 @@ import (
 
 type Goreman struct{}
 
-// rpc: restart all (stop all, then start all)
+// RestartAll restarts all processes (stop all, then start all).
 func (Goreman) RestartAll(args struct{}, ret *string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16,7 +16,7 @@ func (Goreman) RestartAll(args struct{}, ret *string) (err error) {
 	}()
 
 	// Stop and start the processes. We do this with an artificially
-	// incremented wg, so that the server does not shutdown when stopProcs
+	// incremented wg, so that the server does not shut down when stopProcs
 	// completes (the server shuts down when all processes are stopped).
 	//
 	// Note that we do not invoke waitProcs, as the original waitProcs
@@ -29,7 +29,7 @@ func (Goreman) RestartAll(args struct{}, ret *string) (err error) {
 	return nil
 }
 
-// start rpc server.
+// startServer starts the RPC server.
 func startServer(addr string) error {
 	if err := rpc.Register(Goreman{}); err != nil {
 		return err

--- a/cmd/server/shared/copy.go
+++ b/cmd/server/shared/copy.go
@@ -144,6 +144,6 @@ func (e *execer) RunWithFilter(errorFilter errorFilter, cmd *exec.Cmd) {
 }
 
 // Error returns the first error encountered.
-func (e execer) Error() error {
+func (e *execer) Error() error {
 	return e.err
 }

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -103,12 +103,12 @@ func (c *gitserverClient) ReadFile(ctx context.Context, repoCommitPath types.Rep
 	return data, nil
 }
 
-func (g *gitserverClient) LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error {
-	return g.innerClient.LogReverseEach(ctx, repo, commit, n, onLogEntry)
+func (c *gitserverClient) LogReverseEach(ctx context.Context, repo string, commit string, n int, onLogEntry func(entry gitdomain.LogEntry) error) error {
+	return c.innerClient.LogReverseEach(ctx, repo, commit, n, onLogEntry)
 }
 
-func (g *gitserverClient) RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	return g.innerClient.RevList(ctx, repo, commit, onCommit)
+func (c *gitserverClient) RevList(ctx context.Context, repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
+	return c.innerClient.RevList(ctx, repo, commit, onCommit)
 }
 
 var NUL = []byte{0}

--- a/cmd/symbols/internal/database/store/meta.go
+++ b/cmd/symbols/internal/database/store/meta.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
-func (w *store) CreateMetaTable(ctx context.Context) error {
-	return w.Exec(ctx, sqlf.Sprintf(`
+func (s *store) CreateMetaTable(ctx context.Context) error {
+	return s.Exec(ctx, sqlf.Sprintf(`
 		CREATE TABLE IF NOT EXISTS meta (
 			id INTEGER PRIMARY KEY CHECK (id = 0),
 			revision TEXT NOT NULL

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Responds to /localCodeIntel
+// LocalCodeIntelHandler responds to /localCodeIntel
 func LocalCodeIntelHandler(readFile readFileFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Read the args from the request body.
@@ -75,7 +75,7 @@ func LocalCodeIntelHandler(readFile readFileFunc) func(w http.ResponseWriter, r 
 	}
 }
 
-// Responds to /symbolInfo
+// NewSymbolInfoHandler responds to /symbolInfo
 func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc, readFile readFileFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Read the args from the request body.

--- a/cmd/symbols/squirrel/languages.go
+++ b/cmd/symbols/squirrel/languages.go
@@ -44,7 +44,7 @@ var extToLang = func() map[string]string {
 	return m
 }()
 
-// Info about a language.
+// LangSpec contains info about a language.
 type LangSpec struct {
 	name         string
 	language     *sitter.Language
@@ -54,7 +54,7 @@ type LangSpec struct {
 	topLevelSymbolsQuery string
 }
 
-// Info about comments in a language.
+// CommentStyle contains info about comments in a language.
 type CommentStyle struct {
 	ignoreRegex   *regexp.Regexp
 	stripRegex    *regexp.Regexp

--- a/cmd/symbols/squirrel/local_code_intel.go
+++ b/cmd/symbols/squirrel/local_code_intel.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// Nominal type for symbol names.
+// SymbolName is a nominal type for symbol names.
 type SymbolName string
 
 // Scope is a mapping from symbol name to symbol.

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -45,8 +45,8 @@ func New(readFile readFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelS
 
 // Close frees memory allocated by tree-sitter.
 func (squirrel *SquirrelService) Close() {
-	for _, close := range squirrel.closables {
-		close()
+	for _, c := range squirrel.closables {
+		c()
 	}
 	squirrel.parser.Close()
 }

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -31,7 +31,7 @@ type SquirrelService struct {
 	depth               int
 }
 
-// Creates a new SquirrelService.
+// New creates a new SquirrelService.
 func New(readFile readFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelService {
 	return &SquirrelService{
 		readFile:            readFile,
@@ -43,7 +43,7 @@ func New(readFile readFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelS
 	}
 }
 
-// Remember to free memory allocated by tree-sitter.
+// Close frees memory allocated by tree-sitter.
 func (squirrel *SquirrelService) Close() {
 	for _, close := range squirrel.closables {
 		close()

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -62,14 +62,14 @@ func tabsToSpaces(s string) string {
 	return strings.ReplaceAll(s, "\t", "    ")
 }
 
-const TAB_SIZE = 4
+const tabSize = 4
 
-// lengthInSpaces returns the length of the string in spaces (using TAB_SIZE).
+// lengthInSpaces returns the length of the string in spaces (using tabSize).
 func lengthInSpaces(s string) int {
 	total := 0
 	for i := 0; i < len(s); i++ {
 		if s[i] == '\t' {
-			total += TAB_SIZE
+			total += tabSize
 		} else {
 			total++
 		}
@@ -86,7 +86,7 @@ func spacesToColumn(s string, column int) int {
 		}
 
 		if s[i] == '\t' {
-			total += TAB_SIZE
+			total += tabSize
 		} else {
 			total++
 		}

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Nominal type for the ID of a tree-sitter node.
+// NodeId is a nominal type for the ID of a tree-sitter node.
 type NodeId string
 
 // walk walks every node in the tree-sitter tree, calling f(node) on each node.
@@ -227,7 +227,7 @@ func contains(slice []string, str string) bool {
 	return false
 }
 
-// A sitter.Node plus convenient info.
+// Node is a sitter.Node plus convenient info.
 type Node struct {
 	RepoCommitPath types.RepoCommitPath
 	*sitter.Node

--- a/cmd/worker/internal/encryption/encrypter.go
+++ b/cmd/worker/internal/encryption/encrypter.go
@@ -63,12 +63,12 @@ func (e *recordEncrypter) handleDecryptBatch(ctx context.Context, config databas
 	return nil
 }
 
-func (m *recordEncrypter) HandleError(err error) {
+func (e *recordEncrypter) HandleError(err error) {
 	verb := "encrypt"
-	if m.decrypt {
+	if e.decrypt {
 		verb = "decrypt"
 	}
 
-	m.metrics.numErrors.Add(1)
-	m.logger.Error(fmt.Sprintf("failed to %s batch of records", verb), log.Error(err))
+	e.metrics.numErrors.Add(1)
+	e.logger.Error(fmt.Sprintf("failed to %s batch of records", verb), log.Error(err))
 }

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -777,7 +777,7 @@ func logUserDeletionEvents(ctx context.Context, db DB, ids []int32, name Securit
 	db.EventLogs().BulkInsert(ctx, logEvents)
 }
 
-// RecoverList recovers a list of users by their IDs.
+// RecoverUsersList recovers a list of users by their IDs.
 func (u *userStore) RecoverUsersList(ctx context.Context, ids []int32) (_ []int32, err error) {
 	tx, err := u.transact(ctx)
 	if err != nil {


### PR DESCRIPTION
Changes in order of commits:
- Use consistent receivers in go functions (pointers vs. values)
- Unify receiver names (should be the same for all functions on a struct)
- Fix constant name format (camelCase is idiomatic)
- Remove unneeded type def (was redundant)
- Fix comments that start with an invalid name (it's a Go convention to start with the entity name)
- Resolve clashes with built-in functions (just some local renames)

## Test plan

CI covers these
