### PR TITLE
extract viewHelpers in cody

### DIFF
--- a/client/cody-shared/src/chat/viewHelpers.ts
+++ b/client/cody-shared/src/chat/viewHelpers.ts
@@ -1,0 +1,22 @@
+// If the bot message ends with some prefix of the `Human:` stop
+// sequence, trim if from the end.
+const STOP_SEQUENCE_REGEXP = /(H|Hu|Hum|Huma|Human|Human:)$/
+
+export function reformatBotMessage(text: string, prefix: string): string {
+    let reformattedMessage = prefix + text.trimEnd()
+
+    const stopSequenceMatch = reformattedMessage.match(STOP_SEQUENCE_REGEXP)
+    if (stopSequenceMatch) {
+        reformattedMessage = reformattedMessage.slice(0, stopSequenceMatch.index)
+    }
+    // TODO: Detect if bot sent unformatted code without a markdown block.
+    return fixOpenMarkdownCodeBlock(reformattedMessage)
+}
+
+function fixOpenMarkdownCodeBlock(text: string): string {
+    const occurances = text.split('```').length - 1
+    if (occurances % 2 === 1) {
+        return text + '\n```'
+    }
+    return text
+}


### PR DESCRIPTION
These are useful to other clients, not just the VS Code extension.




## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-cody-shared-refactors.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
