### PR TITLE
improve search query examples on homepage

### DIFF
--- a/client/branded/src/search-ui/components/QueryExamples.constants.ts
+++ b/client/branded/src/search-ui/components/QueryExamples.constants.ts
@@ -1,97 +1,70 @@
 /** Static query examples */
 
+import { isDefined } from '@sourcegraph/common'
+
+import type { QueryExamplesSection } from './useQueryExamples'
+
 export const exampleQueryColumns = [
     [
         {
-            title: 'Find to-dos on a specific repository',
+            title: 'Find usage examples',
             queryExamples: [
-                {
-                    id: 'find-todos',
-                    query: 'repo:facebook/react content:TODO',
-                    slug: '?q=context%3Aglobal+repo%3Afacebook%2Freact+content%3ATODO',
-                },
-            ],
-        },
-        {
-            title: 'Error boundaries in React',
-            queryExamples: [
-                {
-                    id: 'error-boundaries',
-                    query: 'static getDerivedStateFromError(',
-                    slug: '?q=context%3Aglobal+static+getDerivedStateFromError%28',
-                },
+                { query: 'context.WithCancel lang:go' },
+                { query: '<Suspense lang:typescript' },
+                { query: 'readFileSync lang:javascript' },
+                { query: 'import torch lang:python' },
             ],
         },
     ],
     [
         {
-            title: 'Discover how developers are using hooks',
-            queryExamples: [
-                {
-                    id: 'hooks',
-                    query: 'useState AND useRef lang:javascript',
-                    slug: '?q=context:global+useState+AND+useRef+lang:javascript',
-                },
-            ],
+            title: 'Find TODOs in a repository',
+            queryExamples: [{ query: 'repo:facebook/react TODO' }],
         },
         {
-            title: "Type check, find what's passed to propTypes",
-            queryExamples: [
-                {
-                    id: 'prop-types',
-                    query: '.propTypes = {...} patterntype:structural',
-                    slug: '?q=context:global+.propTypes+%3D+%7B...%7D',
-                },
-            ],
+            title: 'See API usage and changes over time',
+            queryExamples: [{ query: 'repo:pytorch/pytorch type:diff is_cpu' }],
         },
     ],
 ]
 
-export const basicSyntaxColumns = [
+export const basicSyntaxColumns = (
+    fileName: string,
+    singleRepoExample: string,
+    orgReposExample: string | undefined
+): QueryExamplesSection[][] => [
     [
         {
-            title: 'Scope search to specific repos',
+            title: 'Search in files',
             queryExamples: [
-                { id: 'org-repos', query: 'repo:sourcegraph/.*' },
-                { id: 'single-repo', query: 'repo:facebook/react' },
+                { query: 'fetch(' },
+                { query: 'some error message', helperText: '(no quotes needed)' },
+                { query: 'foo AND bar' },
+                { query: '/open(File|Dir)/', helperText: '(regular expression)' },
             ],
         },
         {
-            title: 'Jump into code navigation',
-            queryExamples: [
-                { id: 'file-filter', query: 'file:README.md' },
-                { id: 'type-symbol', query: 'type:symbol SymbolName' },
-            ],
-        },
-        {
-            title: 'Get logical',
-            queryExamples: [
-                { id: 'not-operator', query: 'lang:go NOT file:main.go' },
-                { id: 'or-operator', query: 'lang:javascript OR lang:typescript' },
-                { id: 'and-operator', query: 'hello AND world' },
-            ],
+            title: 'Search in commit diffs',
+            queryExamples: [{ query: 'type:diff after:1week fix' }, { query: 'type:diff author:alice add' }],
         },
     ],
     [
         {
-            title: 'Find content or patterns',
+            title: 'Filter by...',
             queryExamples: [
-                { id: 'exact-matches', query: 'some exact error message', helperText: 'No quotes needed' },
-                { id: 'regex-pattern', query: '/regex.*pattern/' },
-            ],
+                { query: `file:${fileName} foo` },
+                { query: `repo:${singleRepoExample}` },
+                orgReposExample ? { query: `repo:${orgReposExample}`, helperText: '(all repositories in org)' } : null,
+                { query: 'lang:javascript' },
+            ].filter(isDefined),
         },
         {
-            title: 'Explore code history',
+            title: 'Advanced',
             queryExamples: [
-                { id: 'type-diff-author', query: 'type:diff author:torvalds' },
-                { id: 'type-commit-message', query: 'type:commit some message' },
-            ],
-        },
-        {
-            title: 'Get advanced',
-            queryExamples: [
-                { id: 'repo-has-description', query: 'repo:has.description(scientific computing)' },
-                { id: 'commit-search', query: 'repo:has.commit.after(june 25 2017)' },
+                { query: 'repo:has.description(foo)' },
+                { query: 'file:^some_path file:has.owner(alice)' },
+                { query: 'file:^some_path select:file.owners' },
+                { query: 'file:has.commit.after(1week)' },
             ],
         },
     ],

--- a/client/branded/src/search-ui/components/QueryExamples.module.scss
+++ b/client/branded/src/search-ui/components/QueryExamples.module.scss
@@ -67,25 +67,6 @@
     }
 }
 
-.tip {
-    color: var(--text-muted);
-    display: flex;
-    align-items: baseline;
-    align-content: center;
-    justify-content: center;
-    flex-wrap: wrap;
-    min-height: 2rem;
-    margin-bottom: 2.25rem;
-    visibility: hidden;
-    opacity: 0;
-    transition: opacity 0.25s;
-
-    &--visible {
-        visibility: visible;
-        opacity: 1;
-    }
-}
-
 .tab-header {
     border: none !important;
 

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -1,24 +1,12 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
-import { useNavigate } from 'react-router-dom'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
-import { EditorHint, type QueryState } from '@sourcegraph/shared/src/search'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import {
-    Button,
-    H2,
-    Link,
-    Icon,
-    Tabs,
-    TabList,
-    TabPanels,
-    TabPanel,
-    Tab,
-    ProductStatusBadge,
-} from '@sourcegraph/wildcard'
+import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { H2, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab, ButtonLink } from '@sourcegraph/wildcard'
 
 import { exampleQueryColumns } from './QueryExamples.constants'
 import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
@@ -28,179 +16,59 @@ import styles from './QueryExamples.module.scss'
 
 export interface QueryExamplesProps extends TelemetryProps {
     selectedSearchContextSpec?: string
-    queryState?: QueryState
-    setQueryState: (newState: QueryState) => void
     isSourcegraphDotCom?: boolean
-}
-
-type Tip = 'rev' | 'lang' | 'before'
-
-export const queryToTip = (id: string | undefined): Tip | null => {
-    switch (id) {
-        case 'single-repo':
-        case 'org-repos':
-            return 'rev'
-        case 'exact-matches':
-        case 'regex-pattern':
-            return 'lang'
-        case 'type-diff-author':
-        case 'type-commit-message':
-        case 'type-diff-after':
-            return 'before'
-    }
-    return null
 }
 
 export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     selectedSearchContextSpec,
     telemetryService,
-    queryState = { query: '' },
-    setQueryState,
     isSourcegraphDotCom = false,
 }) => {
-    const [selectedTip, setSelectedTip] = useState<Tip | null>(null)
-    const [selectTipTimeout, setSelectTipTimeout] = useState<NodeJS.Timeout>()
-    const [queryExampleTabActive, setQueryExampleTabActive] = useState<boolean>(false)
-    const navigate = useNavigate()
-
     const exampleSyntaxColumns = useQueryExamples(selectedSearchContextSpec ?? 'global', isSourcegraphDotCom)
 
-    const handleTabChange = (selectedTab: number): void => {
-        setQueryExampleTabActive(!!selectedTab)
-    }
-
     const onQueryExampleClick = useCallback(
-        (id: string | undefined, query: string, slug: string | undefined) => {
-            // Run search for dotcom longer query examples
-            if (isSourcegraphDotCom && queryExampleTabActive) {
-                telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
-                navigate(slug!)
-            }
-
-            setQueryState({ query: `${queryState.query} ${query}`.trimStart(), hint: EditorHint.Focus })
-
+        (query: string) => {
             telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
-
-            // Clear any previously set timeout.
-            if (selectTipTimeout) {
-                clearTimeout(selectTipTimeout)
-            }
-
-            const newSelectedTip = queryToTip(id)
-            if (newSelectedTip) {
-                // If the user selected a query with a different tip, reset the currently selected tip, so that we
-                // can apply the fade-in transition.
-                if (newSelectedTip !== selectedTip) {
-                    setSelectedTip(null)
-                }
-
-                const timeoutId = setTimeout(() => setSelectedTip(newSelectedTip), 1000)
-                setSelectTipTimeout(timeoutId)
-            } else {
-                // Immediately reset the selected tip if the query does not have an associated tip.
-                setSelectedTip(null)
-            }
         },
-        [
-            telemetryService,
-            queryState.query,
-            setQueryState,
-            selectedTip,
-            setSelectedTip,
-            selectTipTimeout,
-            setSelectTipTimeout,
-            queryExampleTabActive,
-            navigate,
-            isSourcegraphDotCom,
-        ]
+        [telemetryService]
     )
 
-    return (
-        <div>
-            {isSourcegraphDotCom ? (
-                <>
-                    <Tabs size="medium" onChange={handleTabChange}>
-                        <TabList wrapperClassName={classNames('mb-4', styles.tabHeader)}>
-                            <Tab key="Code search basics">Code search basics</Tab>
-                            <Tab key="Search query examples">Search query examples</Tab>
-                        </TabList>
-                        <TabPanels>
-                            <TabPanel className={styles.tabPanel}>
-                                <QueryExamplesLayout
-                                    queryColumns={exampleSyntaxColumns}
-                                    onQueryExampleClick={onQueryExampleClick}
-                                />
-                            </TabPanel>
-                            <TabPanel className={styles.tabPanel}>
-                                <QueryExamplesLayout
-                                    queryColumns={exampleQueryColumns}
-                                    onQueryExampleClick={onQueryExampleClick}
-                                />
-                            </TabPanel>
-                        </TabPanels>
-                    </Tabs>
-                </>
-            ) : (
-                <div>
-                    <div className={classNames(styles.tip, selectedTip && styles.tipVisible)}>
-                        <strong>Tip</strong>
-                        <span className="mx-1">–</span>
-                        {selectedTip === 'rev' && (
-                            <>
-                                Add{' '}
-                                <QueryExampleChip
-                                    query="rev:branchname"
-                                    onClick={onQueryExampleClick}
-                                    className="mx-1"
-                                />{' '}
-                                to query accross a specific branch or commit
-                            </>
-                        )}
-                        {selectedTip === 'lang' && (
-                            <>
-                                Use <QueryExampleChip query="lang:" onClick={onQueryExampleClick} className="mx-1" /> to
-                                query for matches only in a given language
-                            </>
-                        )}
-                        {selectedTip === 'before' && (
-                            <>
-                                Use{' '}
-                                <QueryExampleChip
-                                    query={'before:"last week"'}
-                                    onClick={onQueryExampleClick}
-                                    className="mx-1"
-                                />{' '}
-                                to query within a time range
-                            </>
-                        )}
-                    </div>
+    return isSourcegraphDotCom ? (
+        <Tabs size="medium">
+            <TabList wrapperClassName={classNames('mb-4', styles.tabHeader)}>
+                <Tab>How to search</Tab>
+                <Tab>Popular queries</Tab>
+            </TabList>
+            <TabPanels>
+                <TabPanel className={styles.tabPanel}>
                     <QueryExamplesLayout
                         queryColumns={exampleSyntaxColumns}
                         onQueryExampleClick={onQueryExampleClick}
                     />
-                </div>
-            )}
-        </div>
+                </TabPanel>
+                <TabPanel className={styles.tabPanel}>
+                    <QueryExamplesLayout queryColumns={exampleQueryColumns} onQueryExampleClick={onQueryExampleClick} />
+                </TabPanel>
+            </TabPanels>
+        </Tabs>
+    ) : (
+        <QueryExamplesLayout queryColumns={exampleSyntaxColumns} onQueryExampleClick={onQueryExampleClick} />
     )
 }
 
 interface QueryExamplesLayout {
     queryColumns: QueryExamplesSection[][]
-    onQueryExampleClick: (id: string | undefined, query: string, slug: string | undefined) => void
+    onQueryExampleClick: (query: string) => void
 }
 
-export const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({
-    queryColumns,
-    onQueryExampleClick,
-}) => (
+const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({ queryColumns, onQueryExampleClick }) => (
     <div className={styles.queryExamplesSectionsColumns}>
         {queryColumns.map((column, index) => (
             <div key={`column-${queryColumns[index][0].title}`}>
-                {column.map(({ title, productStatus, queryExamples }) => (
+                {column.map(({ title, queryExamples }) => (
                     <ExamplesSection
                         key={title}
                         title={title}
-                        productStatus={productStatus}
                         queryExamples={queryExamples}
                         onQueryExampleClick={onQueryExampleClick}
                     />
@@ -220,66 +88,46 @@ export const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> =
 )
 
 interface ExamplesSection extends QueryExamplesSection {
-    onQueryExampleClick: (id: string | undefined, query: string, slug: string | undefined) => void
+    onQueryExampleClick: (query: string) => void
 }
 
-export const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({
-    title,
-    productStatus,
-    queryExamples,
-    onQueryExampleClick,
-}) => (
+const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, queryExamples, onQueryExampleClick }) => (
     <div className={styles.queryExamplesSection}>
-        <H2 className={styles.queryExamplesSectionTitle}>
-            {title}
-            {productStatus && (
-                <>
-                    {' '}
-                    <ProductStatusBadge status={productStatus} />
-                </>
-            )}
-        </H2>
+        <H2 className={styles.queryExamplesSectionTitle}>{title}</H2>
         <ul className={classNames('list-unstyled', styles.queryExamplesItems)}>
             {queryExamples
                 .filter(({ query }) => query.length > 0)
-                .map(({ id, query, helperText, slug }) => (
-                    <QueryExampleChip
-                        id={id}
-                        key={query}
-                        query={query}
-                        slug={slug}
-                        helperText={helperText}
-                        onClick={onQueryExampleClick}
-                    />
+                .map(({ query, helperText }) => (
+                    <QueryExampleChip key={query} query={query} helperText={helperText} onClick={onQueryExampleClick} />
                 ))}
         </ul>
     </div>
 )
 
 interface QueryExample {
-    id?: string
     query: string
     helperText?: string
-    slug?: string | undefined
 }
 
 interface QueryExampleChipProps extends QueryExample {
     className?: string
-    onClick: (id: string | undefined, query: string, slug: string | undefined) => void | undefined
+    onClick: (query: string) => void | undefined
 }
 
-export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
-    id,
+const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
     query,
     helperText,
-    slug,
     className,
     onClick,
 }) => (
     <li className={classNames('d-flex align-items-center', className)}>
-        <Button type="button" className={styles.queryExampleChip} onClick={() => onClick(id, query, slug || '')}>
+        <ButtonLink
+            className={styles.queryExampleChip}
+            to={`/search?${buildSearchURLQuery(query, SearchPatternType.standard, false)}`}
+            onClick={() => onClick(query)}
+        >
             <SyntaxHighlightedSearchQuery query={query} searchPatternType={SearchPatternType.standard} />
-        </Button>
+        </ButtonLink>
         {helperText && (
             <span className="text-muted ml-2">
                 <small>{helperText}</small>

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -4,24 +4,19 @@ import { differenceInHours, formatISO, parseISO } from 'date-fns'
 
 import { streamComputeQuery } from '@sourcegraph/shared/src/search/stream'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
-import type { ProductStatusType } from '@sourcegraph/wildcard'
 
 import { basicSyntaxColumns } from './QueryExamples.constants'
 
 export interface QueryExamplesContent {
     repositoryName: string
     filePath: string
-    author: string
 }
 
 export interface QueryExamplesSection {
     title: string
-    productStatus?: ProductStatusType
     queryExamples: {
-        id: string
         query: string
         helperText?: string
-        slug?: string
     }[]
 }
 
@@ -31,9 +26,8 @@ interface ComputeResult {
 }
 
 const defaultQueryExamplesContent = {
-    repositoryName: 'organization/repo-name',
-    author: 'Logan Smith',
-    filePath: 'filename.go',
+    repositoryName: 'org/repo',
+    filePath: 'file.go',
 }
 
 function hasQueryExamplesContentCacheExpired(lastCachedTimestamp: string): boolean {
@@ -45,11 +39,10 @@ function quoteIfNeeded(value: string): string {
 }
 
 function getQueryExamplesContentFromComputeOutput(computeOutput: string): QueryExamplesContent {
-    const [repositoryName, author, filePath] = computeOutput.trim().split(',|')
+    const [repositoryName, filePath] = computeOutput.trim().split(',|')
     return {
         repositoryName,
         filePath,
-        author,
     }
 }
 
@@ -64,7 +57,7 @@ function getRepoFilterExamples(repositoryName: string): { singleRepoExample: str
     const repoOrg = repositoryNameParts[repositoryNameParts.length - 2]
     return {
         singleRepoExample: quoteIfNeeded(`${repoOrg}/${repoName}`),
-        orgReposExample: quoteIfNeeded(`${repoOrg}/.*`),
+        orgReposExample: quoteIfNeeded(`${repoOrg}/`),
     }
 }
 
@@ -80,7 +73,7 @@ export function useQueryExamples(
         (selectedSearchContextSpec: string) =>
             // We are using `,|` as the separator so we can "safely" split the compute output.
             streamComputeQuery(
-                `context:${selectedSearchContextSpec} type:diff count:1 content:output((.|\n)* -> $repo,|$author,|$path)`
+                `context:${selectedSearchContextSpec} type:diff count:1 content:output((.|\n)* -> $repo,|$path)`
             ).subscribe(
                 results => {
                     const firstComputeOutput = results
@@ -141,74 +134,19 @@ export function useQueryExamples(
     }, [selectedSearchContextSpec])
 
     return useMemo(() => {
-        // Static examples for DotCom
+        // Static examples for Sourcegraph.com.
         if (isSourcegraphDotCom) {
-            return basicSyntaxColumns
+            return basicSyntaxColumns('test', 'facebook/react', 'kubernetes/')
         }
         if (!queryExamplesContent) {
             return []
         }
-        const { repositoryName, filePath, author } = queryExamplesContent
+        const { repositoryName, filePath } = queryExamplesContent
 
         const { singleRepoExample, orgReposExample } = getRepoFilterExamples(repositoryName)
         const filePathParts = filePath.split('/')
         const fileName = quoteIfNeeded(filePathParts[filePathParts.length - 1])
-        const quotedAuthor = quoteIfNeeded(author)
 
-        return [
-            [
-                {
-                    title: 'Scope search to specific repos',
-                    queryExamples: [
-                        { id: 'single-repo', query: `repo:${singleRepoExample}` },
-                        { id: 'org-repos', query: orgReposExample ? `repo:${orgReposExample}` : '' },
-                    ],
-                },
-                {
-                    title: 'Jump into code navigation',
-                    queryExamples: [
-                        { id: 'file-filter', query: `file:${fileName}` },
-                        { id: 'type-symbol', query: 'type:symbol SymbolName' },
-                    ],
-                },
-                {
-                    title: 'Explore code history',
-                    queryExamples: [
-                        { id: 'type-diff-author', query: `type:diff author:${quotedAuthor}` },
-                        { id: 'type-commit-message', query: 'type:commit some message' },
-                        { id: 'type-diff-after', query: 'type:diff after:"1 year ago"' },
-                    ],
-                },
-            ],
-            [
-                {
-                    title: 'Find content or patterns',
-                    queryExamples: [
-                        { id: 'exact-matches', query: 'some exact error message', helperText: 'No quotes needed' },
-                        { id: 'regex-pattern', query: '/regex.*pattern/' },
-                    ],
-                },
-                {
-                    title: 'Get logical',
-                    queryExamples: [
-                        { id: 'or-operator', query: 'lang:javascript OR lang:typescript' },
-                        { id: 'and-operator', query: 'hello AND world' },
-                        { id: 'not-operator', query: 'lang:go NOT file:main.go' },
-                    ],
-                },
-                {
-                    title: 'Explore code ownership',
-                    productStatus: 'experimental' as const,
-                    queryExamples: [
-                        { id: 'type-has-owner', query: 'file:^some_path file:has.owner(johndoe)' },
-                        { id: 'type-select-file-owners', query: 'file:^some_path select:file.owners' },
-                    ],
-                },
-                {
-                    title: 'Get advanced',
-                    queryExamples: [{ id: 'repo-has-description', query: 'repo:has.description(hello world)' }],
-                },
-            ],
-        ]
+        return basicSyntaxColumns(fileName, singleRepoExample, orgReposExample)
     }, [queryExamplesContent, isSourcegraphDotCom])
 }

--- a/client/branded/src/search-ui/results/NoResultsPage.tsx
+++ b/client/branded/src/search-ui/results/NoResultsPage.tsx
@@ -114,7 +114,6 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                         <QueryExamples
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
-                            setQueryState={setQueryState}
                             isSourcegraphDotCom={isSourcegraphDotCom}
                         />
                     </div>

--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -57,7 +57,6 @@ export interface TemporarySettingsSchema {
         lastCachedTimestamp: string
         repositoryName: string
         filePath: string
-        author: string
     }
     'search.results.collapseSmartSearch': boolean
     'search.results.collapseUnownedResultsAlert': boolean

--- a/client/web-sveltekit/src/lib/search/queryExamples.ts
+++ b/client/web-sveltekit/src/lib/search/queryExamples.ts
@@ -4,7 +4,7 @@ export function getQueryExamples(): { title: string; columns: typeof basicSyntax
     return [
         {
             title: 'Code search basics',
-            columns: basicSyntaxColumns,
+            columns: basicSyntaxColumns('test', 'repo', 'org/repo'),
         },
         {
             title: 'Search query examples',

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -147,8 +147,6 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                         <QueryExamples
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
-                            queryState={queryState}
-                            setQueryState={setQueryState}
                             isSourcegraphDotCom={isSourcegraphDotCom}
                         />
                     )}


### PR DESCRIPTION
- Fix typos and other imperfections (eg in `repo:foo/.*`, the `.*` is unnecessary)
- Regroup and re-label the examples
- Make diff search examples more prominent
- Remove the diff search pre-populated author because it is unlikely to return results (given that diff search is slow and non-deterministic with respect to order)
- Make queries clickable as links instead of adding to query input

## Test plan

Run with dotcom mode on and off and confirm that the queries make sense and are clickable.

## New (instance)

![image](https://github.com/sourcegraph/sourcegraph/assets/1976/d55b19b4-19f8-471d-b6c8-53ea4624bf68)


## New (dotcom)

![image](https://github.com/sourcegraph/sourcegraph/assets/1976/babe4640-6d4c-47bf-aed2-85ae8e1f8dcd)
![image](https://github.com/sourcegraph/sourcegraph/assets/1976/8d29e2a0-b873-4522-9e16-32ae23bed037)

## Old

![image](https://github.com/sourcegraph/sourcegraph/assets/1976/82a7a786-d899-428c-ac41-161142f00653)
![image](https://github.com/sourcegraph/sourcegraph/assets/1976/7cb85e5b-9975-4a7f-a3b1-afbfb3e7802f)

