### PR TITLE
remove needless empty URLSearchParams

### DIFF
--- a/client/web/src/enterprise/cody/api.ts
+++ b/client/web/src/enterprise/cody/api.ts
@@ -16,10 +16,9 @@ const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<CompletionRequest, 'messages'> = 
 }
 
 export function getCodyCompletionOneShot(messages: CompletionRequest['messages']): Promise<string> {
-    const params = new URLSearchParams()
     return new Promise<string>((resolve, reject) => {
         let lastCompletion: string | undefined
-        fetchEventSource(`/.api/completions/stream?${params.toString()}`, {
+        fetchEventSource('/.api/completions/stream', {
             method: 'POST',
             headers: { 'X-Requested-With': 'Sourcegraph', 'Content-Type': 'application/json; charset=utf-8' },
             body: JSON.stringify({


### PR DESCRIPTION
## Test plan

n/a; experimental feature flag code only

## App preview:

- [Web](https://sg-web-sqs-rm-needless-urlsearchparams.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
