### PR TITLE
add ID to fix apollo graphql client cache warning

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -43,6 +43,7 @@ const QUERY = gql`
         $first: Int
     ) {
         repository(name: $repoName) {
+            id
             commit(rev: $commitID, inputRevspec: $revision) {
                 tree(path: $filePath) {
                     isRoot


### PR DESCRIPTION
## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-rm-another-gql-missing-id.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
