### PR TITLE
gitserver: use -z for ListFiles

### DIFF
--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/regexp"
 	godiff "github.com/sourcegraph/go-diff/diff"
 
 	"github.com/google/go-cmp/cmp"
@@ -655,6 +656,17 @@ func TestLsFiles(t *testing.T) {
 	client := NewClient()
 	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) ([]string, error) {
 		return client.LsFiles(ctx, checker, repo, "HEAD")
+	})
+}
+
+func TestListFiles(t *testing.T) {
+	// TODO this test doesn't actually exercise recursive listing or the
+	// pattern regex. But better than nothing.
+	ClientMocks.LocalGitserver = true
+	defer ResetClientMocks()
+	client := NewClient()
+	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) ([]string, error) {
+		return client.ListFiles(ctx, checker, repo, "HEAD", regexp.MustCompile(""))
 	})
 }
 


### PR DESCRIPTION
If you do not pass -z to git ls-tree, it will quote filenames which contain special characters. This API isn't used much, so we have never noticed this issue before (most client code uses LsFiles). However, we Cody is using this API, and that is how we noticed it. Autoindexing uses it, and likely didn't encounter issues because the pattern passed in was likely specific enough to not include filenames with special characters.

In the future we should look into unifying ListFiles and LsFiles, but they are different enough right now. Right now we copy-paste how LsFiles parses the output.

Test Plan: added a test case