### PR TITLE
[GitHub repositoryQuery] Retry searches with missed results

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -1056,11 +1056,12 @@ func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githu
 			return err
 		}
 		for i := range res.Repos {
-			if _, ok := seen[res.Repos[i].DatabaseID]; !ok {
-				select {
-				case <-ctx.Done():
-					break
-				case results <- &githubResult{repo: &res.Repos[i]}:
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				if _, ok := seen[res.Repos[i].DatabaseID]; !ok {
+					results <- &githubResult{repo: &res.Repos[i]}
 					seen[res.Repos[i].DatabaseID] = struct{}{}
 					if len(seen) >= res.TotalCount {
 						break

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -1047,6 +1047,7 @@ func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githu
 		return q.split(ctx, results)
 	}
 
+	const maxTries = 3
 	numTries := 0
 	seen := make(map[int64]struct{}, res.TotalCount)
 	// If the number of repos is lower than the limit, we perform the actual search
@@ -1072,14 +1073,14 @@ func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githu
 
 		// Only break if we've seen a number of repositories equal to the expected count
 		// res.EndCursor will loop by itself
-		if len(seen) >= res.TotalCount {
+		if len(seen) >= res.TotalCount || len(seen) >= q.Limit {
 			break
 		}
 
 		// Set a hard cap on the number of retries
 		if res.EndCursor == "" {
 			numTries += 1
-			if numTries >= 3 {
+			if numTries >= maxTries {
 				break
 			}
 		}

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -1047,6 +1047,8 @@ func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githu
 		return q.split(ctx, results)
 	}
 
+  numTries := 0
+  seen := map[int64]struct{}{}
 	// If the number of repos is lower than the limit, we perform the actual search
 	// and iterate over the results
 	for {
@@ -1054,16 +1056,33 @@ func (q *repositoryQuery) doRecursively(ctx context.Context, results chan *githu
 			return err
 		}
 		for i := range res.Repos {
-			select {
-			case <-ctx.Done():
-				break
-			case results <- &githubResult{repo: &res.Repos[i]}:
-			}
+      if _, ok := seen[res.Repos[i].DatabaseID]; !ok {
+        select {
+        case <-ctx.Done():
+          break
+        case results <- &githubResult{repo: &res.Repos[i]}:
+          seen[res.Repos[i].DatabaseID] = struct{}{}
+          if len(seen) >= res.TotalCount {
+            break
+          }
+        }
+      }
 		}
 
-		if res.EndCursor == "" {
-			break
-		}
+    // Only break if we've seen a number of repositories equal to the expected count
+    // res.EndCursor will loop by itself
+    if len(seen) >= res.TotalCount {
+      break
+    }
+
+    // Set a hard cap on the number of retries
+    if res.EndCursor == "" {
+      numTries += 1
+      if numTries > 3 {
+        break
+      }
+    }
+
 		res, err = q.Searcher.SearchRepos(ctx, github.SearchReposParams{
 			Query: q.String(),
 			First: q.First,

--- a/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
+++ b/internal/repos/testdata/golden/TestRepositoryQuery_DoWithRefinedWindow/exceeds-limit
@@ -1237,53 +1237,6 @@
   },
   {
    "Repo": {
-    "ID": "MDEwOlJlcG9zaXRvcnkxNTk1NDA0NDA=",
-    "DatabaseID": 159540440,
-    "NameWithOwner": "google/wire",
-    "Description": "Compile-time Dependency Injection for Go",
-    "URL": "https://github.com/google/wire",
-    "IsPrivate": false,
-    "IsFork": false,
-    "IsArchived": false,
-    "IsLocked": false,
-    "IsDisabled": false,
-    "ViewerPermission": "READ",
-    "RepositoryTopics": {
-     "Nodes": [
-      {
-       "Topic": {
-        "Name": "go"
-       }
-      },
-      {
-       "Topic": {
-        "Name": "golang"
-       }
-      },
-      {
-       "Topic": {
-        "Name": "dependency-injection"
-       }
-      },
-      {
-       "Topic": {
-        "Name": "codegen"
-       }
-      },
-      {
-       "Topic": {
-        "Name": "initialization"
-       }
-      }
-     ]
-    },
-    "StargazerCount": 10008,
-    "ForkCount": 550
-   },
-   "Error": ""
-  },
-  {
-   "Repo": {
     "ID": "MDEwOlJlcG9zaXRvcnkzNjk2MDMyMQ==",
     "DatabaseID": 36960321,
     "NameWithOwner": "opencontainers/runc",


### PR DESCRIPTION
While iterating over a search result, because of GitHub search inconsistencies, we can miss some results.

But, because we know how many results we're supposed to get, thanks to the `repositoryCount` field, we can retry the request again until we've seen all the repositories.

Missing results should not happen with every search, and we won't have to iterate over ALL the results to find the missing ones. As soon as we've seen enough, we immediately break.

We also put a limit on the number of times we can iterate over a search.

## Test plan

Fundamentally the same.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
