### PR TITLE
own: styling tweaks to 'no owners' search alert

### DIFF
--- a/client/web/src/search/results/UnownedResultsAlert.tsx
+++ b/client/web/src/search/results/UnownedResultsAlert.tsx
@@ -72,20 +72,17 @@ export const UnownedResultsAlert: React.FunctionComponent<React.PropsWithChildre
     return (
         <Alert className="my-2" variant="info">
             <Collapse isOpen={!isCollapsed} onOpenChange={opened => setIsCollapsed(!opened)}>
-                <div className="d-flex align-items-baseline">
+                <CollapseHeader
+                    as={Button}
+                    outline={false}
+                    className="w-100 align-items-center justify-content-between"
+                    aria-label={isCollapsed ? 'Show alert details' : 'Hide alert details'}
+                    variant="icon"
+                >
                     <H3 className="mb-0">{alertTitle}</H3>
-                    <CollapseHeader
-                        as={Button}
-                        outline={false}
-                        className="ml-2"
-                        aria-label={isCollapsed ? 'Show alert details' : 'Hide alert details'}
-                        variant="link"
-                        size="sm"
-                    >
-                        <Icon aria-hidden={true} svgPath={isCollapsed ? mdiChevronDown : mdiChevronUp} />
-                    </CollapseHeader>
-                </div>
-                <CollapsePanel>
+                    <Icon aria-hidden={true} svgPath={isCollapsed ? mdiChevronDown : mdiChevronUp} />
+                </CollapseHeader>
+                <CollapsePanel className="mt-2">
                     {alertDescription && (
                         <Markdown
                             className="mb-2"
@@ -96,8 +93,8 @@ export const UnownedResultsAlert: React.FunctionComponent<React.PropsWithChildre
                             })}
                         />
                     )}
-                    <Text className="d-flex align-items-center mb-0">
-                        <span>See unowned files</span>
+                    <Text className="d-flex align-items-baseline mb-0">
+                        <span>See unowned files:</span>
                         <small>
                             <Button
                                 variant="secondary"


### PR DESCRIPTION
Tweaks to the collapse button and alignment on the 'no owners' search alert. The whole header is now clickable for expand/collapse

|  | Before | After |
|-|-|-|
| Expanded | ![image](https://user-images.githubusercontent.com/206864/228014225-2d03f95c-436f-4e5d-bbf6-9df7eeecd739.png) | ![image](https://user-images.githubusercontent.com/206864/228013636-f5c65dcf-e64e-4e70-8646-ed5488e83dfc.png) |
| Collapsed | ![image](https://user-images.githubusercontent.com/206864/228014117-529d7a00-92a4-40ba-985c-a8b76cadafea.png) | ![image](https://user-images.githubusercontent.com/206864/228013860-8f06c02b-4039-4186-a3a3-1a75534d88b5.png) |

## Test plan

Storybook tests

## App preview:

- [Web](https://sg-web-jp-searchowneralerttweaks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
