### PR TITLE
rbac: fix bug with selecting permissions in PermissionList

### DIFF
--- a/client/web/src/enterprise/rbac/components/CreateRoleModal.tsx
+++ b/client/web/src/enterprise/rbac/components/CreateRoleModal.tsx
@@ -43,7 +43,7 @@ export const CreateRoleModal: React.FunctionComponent<React.PropsWithChildren<Cr
     afterCreate,
     allPermissions,
 }) => {
-    const labelId = 'addRole'
+    const labelId = 'createRole'
 
     const [createRole, { loading, error }] = useCreateRole(afterCreate)
     const onSubmit = (values: CreateRoleModalFormValues): SubmissionResult => {
@@ -97,6 +97,7 @@ export const CreateRoleModal: React.FunctionComponent<React.PropsWithChildren<Cr
                     isChecked={isChecked}
                     onBlur={onBlur}
                     onChange={onChange}
+                    roleName={nameInput.input.value}
                 />
                 {error && !loading && <ErrorAlert error={error} className="my-2" />}
 

--- a/client/web/src/enterprise/rbac/components/Permissions.story.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.story.tsx
@@ -27,6 +27,8 @@ const isChecked = (role: typeof roleWithAllPermissions): ((value: string) => boo
     return (value: string): boolean => rolePermissions[value]
 }
 
+const roleName = 'TEST-ROLE'
+
 export const NoPermissions: Story = () => (
     <WebStory>
         {() => (
@@ -36,6 +38,7 @@ export const NoPermissions: Story = () => (
                     onChange={noop}
                     onBlur={noop}
                     isChecked={isChecked(roleWithNoPermission)}
+                    roleName={roleName}
                 />
             </MockedTestProvider>
         )}
@@ -53,6 +56,7 @@ export const OnePermissionAssigned: Story = () => (
                     onChange={noop}
                     onBlur={noop}
                     isChecked={isChecked(roleWithOnePermission)}
+                    roleName={roleName}
                 />
             </MockedTestProvider>
         )}
@@ -70,6 +74,7 @@ export const AllPermissionsAssigned: Story = () => (
                     onChange={noop}
                     onBlur={noop}
                     isChecked={isChecked(roleWithAllPermissions)}
+                    roleName={roleName}
                 />
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/rbac/components/Permissions.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.tsx
@@ -14,6 +14,7 @@ interface PermissionListProps {
     onChange?: (event: ChangeEvent<HTMLInputElement>) => void
     onBlur?: FocusEventHandler<HTMLInputElement>
     disabled?: boolean
+    roleName: string
 }
 
 export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<PermissionListProps>> = ({
@@ -22,6 +23,7 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
     onChange,
     onBlur,
     disabled,
+    roleName,
 }) => (
     <>
         {allNamespaces.map(namespace => {
@@ -31,12 +33,17 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                     <Text className="font-weight-bold">{prettifyNamespace(namespace)}</Text>
                     <Grid columnCount={4}>
                         {namespacePermissions.map(permission => {
+                            // The checkbox component keeps its own state and because we reuse this component when rendering
+                            // multiple roles on a pege, we have to ensure the `id` and `key` are unique across all instances
+                            // rendered on a page.
+                            const key = `${permission.id}-${roleName}`
+
                             // This is a hack to disable the BatchChangesReadPermission
                             // from the UI for now until it's fully implemented.
                             if (permission.displayName === BatchChangesReadPermission) {
                                 return (
                                     <Checkbox
-                                        key={permission.id}
+                                        key={key}
                                         label={
                                             <>
                                                 {prettifyAction(permission.action)}
@@ -49,7 +56,7 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                                                 </Tooltip>
                                             </>
                                         }
-                                        id={permission.displayName}
+                                        id={key}
                                         checked={isChecked(permission.id)}
                                         value={permission.id}
                                         disabled={true}
@@ -58,9 +65,9 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                             }
                             return (
                                 <Checkbox
-                                    key={permission.id}
+                                    key={key}
                                     label={prettifyAction(permission.action)}
-                                    id={permission.displayName}
+                                    id={key}
                                     checked={isChecked(permission.id)}
                                     value={permission.id}
                                     onChange={onChange}

--- a/client/web/src/enterprise/rbac/components/Permissions.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.tsx
@@ -36,14 +36,14 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                             // The checkbox component keeps its own state and because we reuse this component when rendering
                             // multiple roles on a pege, we have to ensure the `id` and `key` are unique across all instances
                             // rendered on a page.
-                            const key = `${permission.id}-${roleName}`
+                            const checkboxId = `${permission.id}-${roleName}`
 
                             // This is a hack to disable the BatchChangesReadPermission
                             // from the UI for now until it's fully implemented.
                             if (permission.displayName === BatchChangesReadPermission) {
                                 return (
                                     <Checkbox
-                                        key={key}
+                                        key={permission.id}
                                         label={
                                             <>
                                                 {prettifyAction(permission.action)}
@@ -56,7 +56,7 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                                                 </Tooltip>
                                             </>
                                         }
-                                        id={key}
+                                        id={checkboxId}
                                         checked={isChecked(permission.id)}
                                         value={permission.id}
                                         disabled={true}
@@ -65,9 +65,9 @@ export const PermissionsList: React.FunctionComponent<React.PropsWithChildren<Pe
                             }
                             return (
                                 <Checkbox
-                                    key={key}
+                                    key={permission.id}
                                     label={prettifyAction(permission.action)}
-                                    id={key}
+                                    id={checkboxId}
                                     checked={isChecked(permission.id)}
                                     value={permission.id}
                                     onChange={onChange}

--- a/client/web/src/enterprise/rbac/components/RoleNode.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.tsx
@@ -259,7 +259,12 @@ const LockedRoleNode: React.FunctionComponent<Pick<RoleNodeProps, 'node' | 'allP
                 </div>
 
                 <CollapsePanel className={styles.roleNodePermissions} forcedRender={false}>
-                    <PermissionsList allPermissions={allPermissions} isChecked={isChecked} disabled={true} roleName={node.name} />
+                    <PermissionsList
+                        allPermissions={allPermissions}
+                        isChecked={isChecked}
+                        disabled={true}
+                        roleName={node.name}
+                    />
                 </CollapsePanel>
             </Collapse>
         </li>

--- a/client/web/src/enterprise/rbac/components/RoleNode.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.tsx
@@ -192,6 +192,7 @@ const ModifiableRoleNode: React.FunctionComponent<RoleNodeProps> = ({ node, refe
                         isChecked={isChecked}
                         onBlur={onBlur}
                         onChange={onChange}
+                        roleName={node.name}
                     />
                     <LoaderButton
                         alwaysShowLabel={true}
@@ -258,7 +259,7 @@ const LockedRoleNode: React.FunctionComponent<Pick<RoleNodeProps, 'node' | 'allP
                 </div>
 
                 <CollapsePanel className={styles.roleNodePermissions} forcedRender={false}>
-                    <PermissionsList allPermissions={allPermissions} isChecked={isChecked} disabled={true} />
+                    <PermissionsList allPermissions={allPermissions} isChecked={isChecked} disabled={true} roleName={node.name} />
                 </CollapsePanel>
             </Collapse>
         </li>


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C04M9JE73E1/p1679920662024729?thread_ts=1679919946.420289&cid=C04M9JE73E1)

When multiple role nodes are expanded, clicking on the label for any permissions toggles the `onClick` method for the most recently expanded role node.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Manually tested