### PR TITLE
searcher: always call Wait on comby processes

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -578,7 +578,7 @@ func runCombyAgainstZip(ctx context.Context, args comby.Args, zipPath comby.ZipP
 // killAndWait is a helper to kill a started cmd and release its resources.
 // This is used when returning from a function after calling Start but before
 // calling Wait. This can be called in a goroutine.
-func killAndWait(cmd *exec.Command) {
+func killAndWait(cmd *exec.Cmd) {
 	proc := cmd.Process
 	if proc == nil {
 		return


### PR DESCRIPTION
If you call Start you _must_ always call Wait to free up resources. In particular this is the likely cause of a huge goroutine leak in the searcher process which all blames to the os/exec package waiting on a context.

This was an accidental regression introduced when this code was ported to using conc. Previously it would always call Wait, but now if something in the introduced pool fails, we don't call Wait.

Test Plan: CI

Likely fix for https://github.com/sourcegraph/sourcegraph/issues/49987