### PR TITLE
cody feature: store chat history locally

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -13,6 +13,9 @@ import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
+import { version as packageVersion } from '../../package.json'
+import { ChatHistory } from '../../webviews/utils/types'
+import { LocalStorage } from '../command/LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, SecretStorage } from '../command/secret-storage'
 import { updateConfiguration } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
@@ -31,7 +34,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     private cancelCompletionCallback: (() => void) | null = null
     private webview?: vscode.Webview
 
-    private tosVersion = 0
+    private tosVersion = packageVersion
+
+    private currentChatID = ''
+    private inputHistory: string[] = []
+    private chatHistory: ChatHistory = {}
 
     constructor(
         private extensionPath: string,
@@ -43,11 +50,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         private secretStorage: SecretStorage,
         private contextType: 'embeddings' | 'keyword' | 'none' | 'blended',
         private rgPath: string,
-        private mode: 'development' | 'production'
+        private mode: 'development' | 'production',
+        private localStorage: LocalStorage
     ) {
         if (TestSupport.instance) {
             TestSupport.instance.chatViewProvider.set(this)
         }
+        // chat id is used to identify chat session
+        this.createNewChatID()
     }
 
     public static async create(
@@ -56,7 +66,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         serverEndpoint: string,
         contextType: 'embeddings' | 'keyword' | 'none' | 'blended',
         debug: boolean,
-        secretStorage: SecretStorage
+        secretStorage: SecretStorage,
+        localStorage: LocalStorage
     ): Promise<ChatViewProvider> {
         const mode = debug ? 'development' : 'production'
         const rgPath = await getRgPath(extensionPath)
@@ -71,7 +82,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             contextType,
             mode
         )
-
         return new ChatViewProvider(
             extensionPath,
             new Transcript(),
@@ -82,18 +92,21 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             secretStorage,
             contextType,
             rgPath,
-            mode
+            mode,
+            localStorage
         )
     }
 
-    private async onDidReceiveMessage(message: any, webview: vscode.Webview): Promise<void> {
+    private async onDidReceiveMessage(message: any): Promise<void> {
         switch (message.command) {
             case 'initialized':
                 await this.sendToken()
                 await this.sendTranscript()
+                await this.sendChatHistory()
                 break
             case 'reset':
                 await this.onResetChat()
+                await this.sendChatHistory()
                 break
             case 'submit':
                 await this.onHumanMessageSubmitted(message.text)
@@ -116,6 +129,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             case 'removeToken':
                 await this.secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
                 break
+            case 'removeHistory':
+                await this.localStorage.removeChatHistory()
+                break
             case 'links':
                 await vscode.env.openExternal(vscode.Uri.parse(message.value))
                 break
@@ -124,9 +140,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         }
     }
 
-    private async acceptTOS(version: number): Promise<void> {
+    private async acceptTOS(version: string): Promise<void> {
         this.tosVersion = version
         await vscode.commands.executeCommand('cody.accept-tos', version)
+    }
+
+    private createNewChatID(): void {
+        this.currentChatID = new Date(Date.now()).toUTCString()
     }
 
     private sendPrompt(promptMessages: Message[], responsePrefix = ''): void {
@@ -151,6 +171,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     private async onResetChat(): Promise<void> {
+        this.createNewChatID()
         this.cancelCompletion()
         this.isMessageInProgress = false
         this.transcript.reset()
@@ -158,6 +179,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     private async onHumanMessageSubmitted(text: string): Promise<void> {
+        this.inputHistory.push(text)
         await this.executeRecipe('chat-question', text)
     }
 
@@ -200,6 +222,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         this.isMessageInProgress = false
         this.cancelCompletionCallback = null
         await this.sendTranscript()
+        await this.saveChatHistory()
     }
 
     private async showTab(tab: string): Promise<void> {
@@ -218,7 +241,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     private async sendLogin(isValid: boolean): Promise<void> {
         await this.webview?.postMessage({ type: 'login', isValid })
     }
-
+    /**
+     * Sends access token to webview
+     */
     private async sendToken(): Promise<void> {
         await this.webview?.postMessage({
             type: 'token',
@@ -226,7 +251,36 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             mode: this.mode,
         })
     }
-
+    /**
+     * Save chat history
+     */
+    private async saveChatHistory(): Promise<void> {
+        if (this.transcript) {
+            this.chatHistory[this.currentChatID] = this.transcript.toChat()
+            const userHistory = {
+                chat: this.chatHistory,
+                input: this.inputHistory,
+            }
+            await this.localStorage.setChatHistory(userHistory)
+        }
+    }
+    /**
+     * Sends chat history to webview
+     */
+    private async sendChatHistory(): Promise<void> {
+        const localHistory = this.localStorage.getChatHistory()
+        if (localHistory) {
+            this.chatHistory = localHistory.chat
+            this.inputHistory = localHistory.input
+        }
+        await this.webview?.postMessage({
+            type: 'history',
+            messages: localHistory,
+        })
+    }
+    /**
+     * create webview resources
+     */
     public async resolveWebviewView(
         webviewView: vscode.WebviewView,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -235,6 +289,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         _token: vscode.CancellationToken
     ): Promise<void> {
         this.webview = webviewView.webview
+
         const extensionPath = vscode.Uri.parse(this.extensionPath)
         const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist')
 
@@ -243,22 +298,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             localResourceRoots: [webviewPath],
         }
 
-        // await vscode.commands.executeCommand('cody.get-accepted-tos-version')
-
         //   Create Webview
         const root = vscode.Uri.joinPath(webviewPath, 'index.html')
         const bytes = await vscode.workspace.fs.readFile(root)
         const decoded = new TextDecoder('utf-8').decode(bytes)
         const resources = webviewView.webview.asWebviewUri(webviewPath)
-
-        const nonce = getNonce()
+        const nonce = this.getNonce()
 
         webviewView.webview.html = decoded
             .replaceAll('./', `${resources.toString()}/`)
             .replace('/nonce/', nonce)
             .replace('/tos-version/', this.tosVersion.toString())
-
-        webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message, webviewView.webview))
+        webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message))
     }
 
     public transcriptForTesting(testing: TestSupport): ChatMessage[] {
@@ -287,19 +338,24 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                 this.codebaseContext = codebaseContext
                 this.chat = chatClient
 
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                vscode.window.showInformationMessage('Cody configuration has been updated.')
+                const action = await vscode.window.showInformationMessage(
+                    'Cody configuration has been updated.',
+                    'Reload Window'
+                )
+                if (action === 'Reload Window') {
+                    await vscode.commands.executeCommand('workbench.action.reloadWindow')
+                }
                 break
             }
         }
     }
-}
 
-function getNonce(): string {
-    let text = ''
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length))
+    private getNonce(): string {
+        let text = ''
+        const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+        for (let i = 0; i < 32; i++) {
+            text += possible.charAt(Math.floor(Math.random() * possible.length))
+        }
+        return text
     }
-    return text
 }

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -73,13 +73,11 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
         ),
         // TOS
-        vscode.commands.registerCommand(
-            'cody.accept-tos',
-            async version => await localStorage.set('cody.tos-version-accepted', version)
+        vscode.commands.registerCommand('cody.accept-tos', version =>
+            localStorage.set('cody.tos-version-accepted', version)
         ),
-        vscode.commands.registerCommand(
-            'cody.get-accepted-tos-version',
-            async () => await localStorage.get('cody.tos-version-accepted')
+        vscode.commands.registerCommand('cody.get-accepted-tos-version', () =>
+            localStorage.get('cody.tos-version-accepted')
         ),
         // Commands
         vscode.commands.registerCommand('cody.recipe.explain-code', async () => executeRecipe('explain-code-detailed')),
@@ -135,14 +133,16 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
     )
 
     context.subscriptions.push(
-        secretStorage.onDidChange(async key => {
+        secretStorage.onDidChange(key => {
             if (key === CODY_ACCESS_TOKEN_SECRET) {
                 const config = getConfiguration(vscode.workspace.getConfiguration())
-                await chatProvider.onConfigChange(
-                    'token',
-                    sanitizeCodebase(config.codebase),
-                    sanitizeServerEndpoint(config.serverEndpoint)
-                )
+                chatProvider
+                    .onConfigChange(
+                        'token',
+                        sanitizeCodebase(config.codebase),
+                        sanitizeServerEndpoint(config.serverEndpoint)
+                    )
+                    .catch(error => console.error(error))
             }
         })
     )

--- a/client/cody/src/command/LocalStorageProvider.ts
+++ b/client/cody/src/command/LocalStorageProvider.ts
@@ -1,0 +1,44 @@
+// VS Code Docs https://code.visualstudio.com/api/references/vscode-api#Memento
+// A memento represents a storage utility. It can store and retrieve values.
+import { Memento } from 'vscode'
+
+import { UserLocalHistory } from '../../webviews/utils/types'
+
+export class LocalStorage {
+    private KEY_LOCAL_HISTORY = 'cody-local-chatHistory'
+
+    constructor(private storage: Memento) {}
+
+    public getChatHistory(): UserLocalHistory | null {
+        const history = this.storage.get(this.KEY_LOCAL_HISTORY, null)
+        return history
+    }
+
+    public async setChatHistory(history: UserLocalHistory): Promise<void> {
+        try {
+            await this.storage.update(this.KEY_LOCAL_HISTORY, history)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+
+    public async removeChatHistory(): Promise<void> {
+        try {
+            await this.storage.update(this.KEY_LOCAL_HISTORY, null)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+
+    public get(key: string): string | null {
+        return this.storage.get(key, null)
+    }
+
+    public async set(key: string, value: string): Promise<void> {
+        try {
+            await this.storage.update(key, value)
+        } catch (error) {
+            console.error(error)
+        }
+    }
+}

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -104,7 +104,13 @@ export function App(): React.ReactElement {
             {view && view !== 'login' && <NavBar view={view} setView={setView} devMode={devMode} />}
             {view === 'about' && <About />}
             {view === 'debug' && devMode && <Debug debugLog={debugLog} />}
-            {view === 'history' && <UserHistory userHistory={userHistory} setUserHistory={setUserHistory} />}
+            {view === 'history' && (
+                <UserHistory
+                    userHistory={userHistory}
+                    setUserHistory={setUserHistory}
+                    setInputHistory={setInputHistory}
+                />
+            )}
             {view === 'recipes' && <Recipes />}
             {view === 'settings' && <Settings setView={setView} onLogout={onLogout} />}
             {view === 'chat' && (

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -11,7 +11,8 @@ import { Login } from './Login'
 import { NavBar } from './NavBar'
 import { Recipes } from './Recipes'
 import { Settings } from './Settings'
-import { ChatMessage, View } from './utils/types'
+import { UserHistory } from './UserHistory'
+import { ChatHistory, ChatMessage, View } from './utils/types'
 import { vscodeAPI } from './utils/VSCodeApi'
 
 export function App(): React.ReactElement {
@@ -21,14 +22,18 @@ export function App(): React.ReactElement {
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
     const [isValidLogin, setIsValidLogin] = useState<boolean>()
+    const [formInput, setFormInput] = useState('')
+    const [inputHistory, setInputHistory] = useState<string[] | []>([])
+    const [userHistory, setUserHistory] = useState<ChatHistory | null>(null)
 
     useEffect(() => {
         vscodeAPI.onMessage(message => {
             switch (message.data.type) {
                 case 'transcript': {
                     if (message.data.isMessageInProgress) {
-                        setTranscript(message.data.messages.slice(0, -1))
-                        setMessageInProgress(message.data.messages[message.data.messages.length - 1])
+                        const msgLength = message.data.messages.length - 1
+                        setTranscript(message.data.messages.slice(0, msgLength))
+                        setMessageInProgress(message.data.messages[msgLength])
                     } else {
                         setTranscript(message.data.messages)
                         setMessageInProgress(null)
@@ -55,6 +60,10 @@ export function App(): React.ReactElement {
                 case 'debug':
                     setDebugLog([...debugLog, message.data.message])
                     break
+                case 'history':
+                    setInputHistory(message.data.messages.input)
+                    setUserHistory(message.data.messages.chat)
+                    break
             }
         })
 
@@ -78,6 +87,7 @@ export function App(): React.ReactElement {
     const onResetClick = useCallback(() => {
         setView('chat')
         setDebugLog([])
+        setFormInput('')
         setMessageInProgress(null)
         setTranscript([])
         vscodeAPI.postMessage({ command: 'reset' })
@@ -94,9 +104,19 @@ export function App(): React.ReactElement {
             {view && view !== 'login' && <NavBar view={view} setView={setView} devMode={devMode} />}
             {view === 'about' && <About />}
             {view === 'debug' && devMode && <Debug debugLog={debugLog} />}
+            {view === 'history' && <UserHistory userHistory={userHistory} setUserHistory={setUserHistory} />}
             {view === 'recipes' && <Recipes />}
             {view === 'settings' && <Settings setView={setView} onLogout={onLogout} />}
-            {view === 'chat' && <Chat messageInProgress={messageInProgress} transcript={transcript} />}
+            {view === 'chat' && (
+                <Chat
+                    messageInProgress={messageInProgress}
+                    transcript={transcript}
+                    formInput={formInput}
+                    setFormInput={setFormInput}
+                    inputHistory={inputHistory}
+                    setInputHistory={setInputHistory}
+                />
+            )}
         </div>
     )
 }

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -17,14 +18,22 @@ const SCROLL_THRESHOLD = 15
 interface ChatboxProps {
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
+    formInput: string
+    setFormInput: (input: string) => void
+    inputHistory: string[]
+    setInputHistory: (history: string[]) => void
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
     messageInProgress,
     transcript,
+    formInput,
+    setFormInput,
+    inputHistory,
+    setInputHistory,
 }) => {
     const [inputRows, setInputRows] = useState(5)
-    const [formInput, setFormInput] = useState('')
+    const [historyIndex, setHistoryIndex] = useState(inputHistory.length)
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
 
     const inputHandler = useCallback(
@@ -36,23 +45,43 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 setInputRows(5)
             }
             setFormInput(inputValue)
+            if (inputValue !== inputHistory[historyIndex]) {
+                setHistoryIndex(inputHistory.length)
+            }
         },
-        [setFormInput]
+        [historyIndex, inputHistory, setFormInput]
     )
 
-    const onChatKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-        if (event.key === 'Enter' && !event.shiftKey) {
-            event.preventDefault()
-            event.stopPropagation()
-            onChatSubmit()
-        }
-    }
-
     const onChatSubmit = useCallback(() => {
-        vscodeAPI.postMessage({ command: 'submit', text: formInput })
-        setInputRows(5)
-        setFormInput('')
-    }, [formInput, setFormInput])
+        // Submit chat only when input is not empty
+        if (formInput !== undefined) {
+            vscodeAPI.postMessage({ command: 'submit', text: formInput })
+            setHistoryIndex(inputHistory.length + 1)
+            setInputHistory([...inputHistory, formInput])
+            setInputRows(5)
+            setFormInput('')
+        }
+    }, [formInput, inputHistory, setFormInput, setInputHistory])
+
+    const onChatKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLDivElement>): void => {
+            // Submit input on Enter press (without shift)
+            if (event.key === 'Enter' && !event.shiftKey && formInput) {
+                event.preventDefault()
+                event.stopPropagation()
+                onChatSubmit()
+            }
+            // Loop through input history on up arrow press
+            if (event.key === 'ArrowUp' && inputHistory.length) {
+                if (formInput === inputHistory[historyIndex] || !formInput) {
+                    const newIndex = historyIndex - 1 < 0 ? inputHistory.length - 1 : historyIndex - 1
+                    setHistoryIndex(newIndex)
+                    setFormInput(inputHistory[newIndex])
+                }
+            }
+        },
+        [inputHistory, onChatSubmit, formInput, historyIndex, setFormInput]
+    )
 
     const bubbleClassName = (speaker: string): string => (speaker === 'human' ? 'human' : 'bot')
 
@@ -134,7 +163,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     name="user-query"
                     value={formInput}
                     autofocus={true}
-                    disabled={!!messageInProgress}
                     required={true}
                     onInput={({ target }) => {
                         const { value } = target as HTMLInputElement
@@ -142,7 +170,13 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     }}
                     onKeyDown={onChatKeyDown}
                 />
-                <VSCodeButton className="submit-button" appearance="icon" type="button" onClick={onChatSubmit}>
+                <VSCodeButton
+                    className="submit-button"
+                    appearance="icon"
+                    type="button"
+                    onClick={onChatSubmit}
+                    disabled={!!messageInProgress}
+                >
                     <SubmitSvg />
                 </VSCodeButton>
             </form>
@@ -150,7 +184,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 }
 
-const ContextFiles: React.FunctionComponent<{ contextFiles: string[] }> = ({ contextFiles }) => {
+export const ContextFiles: React.FunctionComponent<{ contextFiles: string[] }> = ({ contextFiles }) => {
     const [isExpanded, setIsExpanded] = useState(false)
 
     if (contextFiles.length === 1) {

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -16,6 +16,9 @@ export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsP
                 <VSCodeButton className="logout-button" type="button" onClick={() => setView('about')}>
                     About
                 </VSCodeButton>
+                <VSCodeButton className="logout-button" type="button" onClick={() => setView('history')}>
+                    Chat History
+                </VSCodeButton>
                 <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
                     Logout
                 </VSCodeButton>

--- a/client/cody/webviews/Tips.tsx
+++ b/client/cody/webviews/Tips.tsx
@@ -4,12 +4,6 @@ import { ResetIcon } from './utils/icons'
 
 export const Tips: React.FunctionComponent<{}> = () => (
     <div className="tips-container">
-        <h3>Example questions</h3>
-        <ul>
-            <li>What are the most popular Go CLI libraries?</li>
-            <li>Write a function that parses JSON in Python.</li>
-            <li>Which files handle SAML authentication?</li>
-        </ul>
         <h3>Recommendations</h3>
         <ul>
             <li>
@@ -18,7 +12,7 @@ export const Tips: React.FunctionComponent<{}> = () => (
                 name as listed on your Sourcegraph instance.
             </li>
             <li>
-                Visit the Recipes tab for special actions like Generate a unit test or Summarize recent code changes.
+                Visit the `Recipes` tab for special actions like Generate a unit test or Summarize recent code changes.
             </li>
             <li>
                 Use the <ResetIcon /> button in the upper right to reset the chat when you want to start a new line of
@@ -39,5 +33,11 @@ export const Tips: React.FunctionComponent<{}> = () => (
                 <span>Explain the code above (or your question).</span>
             </code>
         </div>
+        <h3>Example questions</h3>
+        <ul>
+            <li>What are the most popular Go CLI libraries?</li>
+            <li>Write a function that parses JSON in Python.</li>
+            <li>Which files handle SAML authentication?</li>
+        </ul>
     </div>
 )

--- a/client/cody/webviews/UserHistory.css
+++ b/client/cody/webviews/UserHistory.css
@@ -1,0 +1,35 @@
+.history-bubble-container {
+    padding: 1rem;
+    border-radius: 1rem;
+    margin-bottom: 1em;
+    margin-top: 1em;
+}
+
+.history-convo-container {
+    margin-bottom: 1rem !important;
+}
+
+.history-bubble-container:nth-child(odd) {
+    background: var(--human-bubble-color);
+}
+
+.history-bubble-container:nth-child(even) {
+    background: var(--bot-bubble-color);
+}
+
+.history-btn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.5rem 0rem;
+    font-weight: bold;
+    color: var(--vscode-foreground);
+}
+
+.history-item-container {
+    margin: 1rem;
+}
+
+.history-remove-btn {
+    margin-bottom: 1rem;
+    cursor: pointer;
+}

--- a/client/cody/webviews/UserHistory.tsx
+++ b/client/cody/webviews/UserHistory.tsx
@@ -13,11 +13,13 @@ import { vscodeAPI } from './utils/VSCodeApi'
 interface HistoryProps {
     userHistory: ChatHistory | null
     setUserHistory: (history: ChatHistory | null) => void
+    setInputHistory: (inputHistory: string[] | []) => void
 }
 
 export const UserHistory: React.FunctionComponent<React.PropsWithChildren<HistoryProps>> = ({
     userHistory,
     setUserHistory,
+    setInputHistory,
 }) => {
     const [chatHistory, setChatHistory] = useState('')
 
@@ -26,8 +28,9 @@ export const UserHistory: React.FunctionComponent<React.PropsWithChildren<Histor
             vscodeAPI.postMessage({ command: 'removeHistory' })
             setChatHistory('removed')
             setUserHistory(null)
+            setInputHistory([])
         }
-    }, [setUserHistory, userHistory])
+    }, [setInputHistory, setUserHistory, userHistory])
 
     return (
         <div className="inner-container">

--- a/client/cody/webviews/UserHistory.tsx
+++ b/client/cody/webviews/UserHistory.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable react/no-array-index-key */
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
+
+import './UserHistory.css'
+import './Chat.css'
+
+import { useCallback, useState } from 'react'
+
+import { ContextFiles } from './Chat'
+import { ChatHistory, ChatMessage } from './utils/types'
+import { vscodeAPI } from './utils/VSCodeApi'
+
+interface HistoryProps {
+    userHistory: ChatHistory | null
+    setUserHistory: (history: ChatHistory | null) => void
+}
+
+export const UserHistory: React.FunctionComponent<React.PropsWithChildren<HistoryProps>> = ({
+    userHistory,
+    setUserHistory,
+}) => {
+    const [chatHistory, setChatHistory] = useState('')
+
+    const onRemoveHistoryClick = useCallback(() => {
+        if (userHistory) {
+            vscodeAPI.postMessage({ command: 'removeHistory' })
+            setChatHistory('removed')
+            setUserHistory(null)
+        }
+    }, [setUserHistory, userHistory])
+
+    return (
+        <div className="inner-container">
+            <div className="non-transcript-container">
+                <div className="bubble-container">
+                    <div className="history-item-container">
+                        <h3>Remove Chat & Input History</h3>
+                        <VSCodeButton
+                            className="history-btn history-remove-btn"
+                            type="button"
+                            appearance="secondary"
+                            onClick={onRemoveHistoryClick}
+                            disabled={userHistory === null || chatHistory === 'removed'}
+                        >
+                            {userHistory === null || chatHistory === 'removed'
+                                ? 'Chat history is empty'
+                                : 'Remove all local history'}
+                        </VSCodeButton>
+                        <h3>Local Chat History</h3>
+                    </div>
+                    {chatHistory !== 'removed' &&
+                        userHistory &&
+                        [...Object.entries(userHistory)].reverse().map(chat => (
+                            <div key={chat[0]} className="history-item-container">
+                                <VSCodeButton
+                                    className="history-btn"
+                                    type="button"
+                                    onClick={() => setChatHistory(chatHistory === chat[0] ? '' : chat[0])}
+                                >
+                                    {chat[0]}
+                                </VSCodeButton>
+                                {chatHistory === chat[0] && (
+                                    <div className="history-convo-container">
+                                        {chat[1].map((message: ChatMessage, index: number) => (
+                                            <div key={index} className="history-bubble-container bubble-content">
+                                                {message.displayText && (
+                                                    <p dangerouslySetInnerHTML={{ __html: message.displayText }} />
+                                                )}
+                                                {message.contextFiles && message.contextFiles.length > 0 && (
+                                                    <ContextFiles contextFiles={message.contextFiles} />
+                                                )}
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/client/cody/webviews/utils/VSCodeApi.ts
+++ b/client/cody/webviews/utils/VSCodeApi.ts
@@ -49,6 +49,10 @@ interface ExecuteRecipeWebviewMessage {
     recipe: string
 }
 
+interface RemoveChatHistoryWebviewMessage {
+    command: 'removeHistory'
+}
+
 type WebviewMessage =
     | IntializedWebviewMessage
     | ResetWebviewMessage
@@ -56,3 +60,4 @@ type WebviewMessage =
     | SettingsWebviewMessage
     | SubmitWebviewMessage
     | ExecuteRecipeWebviewMessage
+    | RemoveChatHistoryWebviewMessage

--- a/client/cody/webviews/utils/types.ts
+++ b/client/cody/webviews/utils/types.ts
@@ -9,4 +9,13 @@ export interface ChatMessage extends Message {
     contextFiles?: string[]
 }
 
-export type View = 'chat' | 'recipes' | 'about' | 'login' | 'settings' | 'debug'
+export interface UserLocalHistory {
+    chat: ChatHistory
+    input: string[]
+}
+
+export interface ChatHistory {
+    [chatID: string]: ChatMessage[]
+}
+
+export type View = 'chat' | 'recipes' | 'about' | 'login' | 'settings' | 'debug' | 'history'


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/96 & https://github.com/sourcegraph/sourcegraph/issues/49471
Moved from https://github.com/sourcegraph/sourcegraph/pull/49818


This PR adds abilities to:

- use Up arrow to flip through message history ([detail in slack](https://sourcegraph.slack.com/archives/C04NPH6SZMW/p1679065279873119))
- add new chat history view
- store chat history locally in vs code local storage (persist across VS Code restarts)
- access historical conversation log ([detail in slack](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1678871145190109))
- Persist chatbox input on view change (see below)
- Fix: do not submit chat without input ([issue](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1679871393608399))

#### demo

![cody_history](https://user-images.githubusercontent.com/68532117/226769556-914ee9c6-4c41-401e-b1fb-de79ce7b7c33.gif)

#### new chat history view

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/68532117/228047358-b65e592b-9ab0-44e4-8d99-8127ce4a5189.png">

#### Persist chatbox input on view change 

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="425" alt="image" src="https://user-images.githubusercontent.com/68532117/226772801-c96011bb-85cc-4dfd-bf79-27688219f2ae.gif">
</td>
<td>
<img width="425" alt="image" src="https://user-images.githubusercontent.com/68532117/226772666-34a0fb18-cc79-4056-8271-471b38bac0e5.gif">
</td>
</tr>
</table>

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. clone and pull the latest commit from this branch
2. run `pnpm install` from root
3. Select `Launch Cody Extension` from the dropdown menu in the `RUN AND DEBUG` sidebar in VS Code
4. Type something in the chatbox to start a conversation with Cody
5. Press `up arrow` to retrieve last-sent message **when the chatbox is empty**
6. Reset a conversation
7. Go to `Settings` > `Chat History` to  access historical conversation log 

## App preview:

- [Web](https://sg-web-bee-history.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
