### PR TITLE
Replace link to deprecated signup url

### DIFF
--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -286,7 +286,7 @@ export const visitorsTasksWithNotebookExtraTask: TourTaskType = {
             action: {
                 type: 'new-tab-link',
                 variant: 'button-primary',
-                value: 'https://signup.sourcegraph.com',
+                value: 'https://about.sourcegraph.com/get-started?t=enterprise',
             },
             // This is done to mimic user creating an account, and signed in there is a different tour
             completeAfterEvents: ['non-existing-event'],


### PR DESCRIPTION
Replace the last remaining link to the deprecated signup.sourcegraph.com

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Link URL is updated

## App preview:

- [Web](https://sg-web-marek-replace-signup-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
