### PR TITLE
Reword "Not cloned" to "Queued" in setup wizard

### DIFF
--- a/client/web/src/setup-wizard/components/ProgressBar.tsx
+++ b/client/web/src/setup-wizard/components/ProgressBar.tsx
@@ -32,7 +32,7 @@ export const ProgressBar: FC<{}> = () => {
             },
             {
                 value: Math.max(data?.repositoryStats.notCloned ?? 0, 0),
-                description: 'Not cloned',
+                description: 'Queued',
             },
             {
                 value: Math.max(data?.repositoryStats.cloning ?? 0, 0),

--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -289,10 +289,10 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent = () => {
             },
             {
                 value: data.repositoryStats.notCloned,
-                description: 'Not cloned',
+                description: 'Queued',
                 color: 'var(--body-color)',
                 position: 'right',
-                tooltip: 'The number of repositories that have not been cloned yet.',
+                tooltip: 'The number of repositories that are queued to be cloned.',
                 onClick: () =>
                     setFilterValues(values => {
                         const newValues = new Map(values)


### PR DESCRIPTION
Hello! 👋🏼 This is my first pull request, so apologies if I might be missing some required information/process.

As a first time user, it was easy to misunderstand the setup wizard "Not cloned" label to mean that the repositories were being skipped (i.e. they were in a permanent state):

<img width="670" alt="Screenshot 2023-03-28 at 4 28 01 pm" src="https://user-images.githubusercontent.com/153/228140653-401c8558-bde0-4198-9e33-fa74097885a2.png">

<img width="971" alt="Screenshot 2023-03-28 at 5 09 57 pm" src="https://user-images.githubusercontent.com/153/228144432-00a0aec1-7846-4755-8ad6-dbe9fe0d0493.png">

The underlying behaviour is that they're just waiting, or queued, to be cloned.

This pull request changes the label from "Not cloned" to "Queued", to help clarify that those repositories are just waiting for cloning to begin:

<img width="698" alt="Screenshot 2023-03-28 at 4 56 09 pm" src="https://user-images.githubusercontent.com/153/228141718-0a87af75-2d93-495f-9b95-fccde9896b71.png">

<img width="975" alt="Screenshot 2023-03-28 at 5 10 30 pm" src="https://user-images.githubusercontent.com/153/228144451-e1ac1247-649f-421c-8468-8314521c1e51.png">

No other pieces of UI needed to be updated, as there didn't seem to be any more references to this concept of "Not cloned".

## Alternatives considered

"Queued for Cloning" could have been a more verbose alternative, and would clarify that they weren't queued for indexing. But I think a single word here, given the proximity to all the other cloning labels, is probably sufficient.

## Test plan

No automated tests were updated, as I couldn't find any that referred to the label "Not cloned". This change was also not tested manually, as I haven't yet got the application running locally for development. Manual testing could be done, but perhaps not required as it's a small label change.