### PR TITLE
Fix alert overlapping first row issue

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -389,9 +389,11 @@ const AnimatedAlert: React.FunctionComponent<React.PropsWithChildren<{ className
     return (
         <animated.div style={style}>
             {/* Keep this in sync with calculation above: mb-3 = 1rem */}
-            <Alert ref={ref} variant="success" className={classNames(className, 'mb-3')}>
-                {children}
-            </Alert>
+            {visible && (
+                <Alert ref={ref} variant="success" className={classNames(className, 'mb-3')}>
+                    {children}
+                </Alert>
+            )}
         </animated.div>
     )
 }


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/50025

The alert box is always rendered to show the animation but overlaps the first-row causing hover to behave weirdly. 


Now the alert takes 0px height by default and does not overlap any other element. 

https://www.loom.com/share/042713bb0a9e42b2b2ae2e42606b397a


## Test plan

- manually tested

## App preview:

- [Web](https://sg-web-naman-fix-perms-sync-jobs-table.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

