### PR TITLE
fix: grant pending permissions not working correctly

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -431,6 +431,10 @@ func (s *permsStore) LoadRepoPermissions(ctx context.Context, repoID int32) (p [
 
 // SetUserExternalAccountPerms sets the users permissions for repos in the database. Uses setUserRepoPermissions internally.
 func (s *permsStore) SetUserExternalAccountPerms(ctx context.Context, user authz.UserIDWithExternalAccountID, repoIDs []int32, source authz.PermsSource) (*database.SetPermissionsResult, error) {
+	return s.setUserExternalAccountPerms(ctx, user, repoIDs, source, true)
+}
+
+func (s *permsStore) setUserExternalAccountPerms(ctx context.Context, user authz.UserIDWithExternalAccountID, repoIDs []int32, source authz.PermsSource, deleteOldPerms bool) (*database.SetPermissionsResult, error) {
 	p := make([]authz.Permission, 0, len(repoIDs))
 
 	for _, repoID := range repoIDs {
@@ -446,7 +450,7 @@ func (s *permsStore) SetUserExternalAccountPerms(ctx context.Context, user authz
 		ExternalAccountID: user.ExternalAccountID,
 	}
 
-	return s.setUserRepoPermissions(ctx, p, entity, source)
+	return s.setUserRepoPermissions(ctx, p, entity, source, deleteOldPerms)
 }
 
 // SetRepoPerms sets the users that can access a repo. Uses setUserRepoPermissions internally.
@@ -465,7 +469,7 @@ func (s *permsStore) SetRepoPerms(ctx context.Context, repoID int32, userIDs []a
 		RepoID: repoID,
 	}
 
-	return s.setUserRepoPermissions(ctx, p, entity, source)
+	return s.setUserRepoPermissions(ctx, p, entity, source, true)
 }
 
 // setUserRepoPermissions performs a full update for p, new rows for pairs of user_id, repo_id
@@ -502,7 +506,7 @@ func (s *permsStore) SetRepoPerms(ctx context.Context, repoID int32, userIDs []a
 //	       1 |     233 |             42 | 2023-01-28T14:24:15Z | 2023-01-28T14:24:12Z | 'sync'
 //
 // So one repo {id:2} was removed and one was added {id:233} to the user
-func (s *permsStore) setUserRepoPermissions(ctx context.Context, p []authz.Permission, entity authz.PermissionEntity, source authz.PermsSource) (_ *database.SetPermissionsResult, err error) {
+func (s *permsStore) setUserRepoPermissions(ctx context.Context, p []authz.Permission, entity authz.PermissionEntity, source authz.PermsSource, deleteOldPerms bool) (_ *database.SetPermissionsResult, err error) {
 	ctx, save := s.observe(ctx, "setUserRepoPermissions", "")
 	defer func() {
 		f := []otlog.Field{}
@@ -529,11 +533,14 @@ func (s *permsStore) setUserRepoPermissions(ctx context.Context, p []authz.Permi
 		}
 	}
 
-	// Now delete rows that were updated before. This will delete all rows, that were not updated on the last update
-	// which was tried above.
-	deleted, err := txs.deleteOldUserRepoPermissions(ctx, entity, currentTime, source)
-	if err != nil {
-		return nil, errors.Wrap(err, "removing old user repo permissions")
+	deleted := []int{}
+	if deleteOldPerms {
+		// Now delete rows that were updated before. This will delete all rows, that were not updated on the last update
+		// which was tried above.
+		deleted, err = txs.deleteOldUserRepoPermissions(ctx, entity, currentTime, source)
+		if err != nil {
+			return nil, errors.Wrap(err, "removing old user repo permissions")
+		}
 	}
 
 	// count the number of added permissions
@@ -1351,7 +1358,7 @@ func (s *permsStore) GrantPendingPermissions(ctx context.Context, p *authz.UserG
 	allRepoIDs := maps.Keys(uniqueRepoIDs)
 
 	// Write to the unified user_repo_permissions table.
-	_, err = txs.SetUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: p.UserID, ExternalAccountID: p.UserExternalAccountID}, allRepoIDs, authz.SourceUserSync)
+	_, err = txs.setUserExternalAccountPerms(ctx, authz.UserIDWithExternalAccountID{UserID: p.UserID, ExternalAccountID: p.UserExternalAccountID}, allRepoIDs, authz.SourceUserSync, false)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -840,7 +840,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 		expectedPermissions []authz.Permission
 		entity              authz.PermissionEntity
 		expectedResult      *database.SetPermissionsResult
-		keepOldPerms        bool
+		keepPerms           bool
 	}{
 		{
 			name:                "empty",
@@ -929,7 +929,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 			},
 			entity:         authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
 			expectedResult: &database.SetPermissionsResult{Added: 2, Removed: 0, Found: 2},
-			keepOldPerms:   true,
+			keepPerms:      true,
 		},
 	}
 
@@ -944,7 +944,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 				cleanupReposTable(t, s)
 			})
 
-			deleteOldPerms := !test.keepOldPerms
+			replacePerms := !test.keepPerms
 
 			if len(test.origPermissions) > 0 {
 				setupPermsRelatedEntities(t, s, test.origPermissions)
@@ -958,9 +958,9 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 					}
 				}
 
-				_, err := s.setUserRepoPermissions(ctx, syncedPermissions, test.entity, source, deleteOldPerms)
+				_, err := s.setUserRepoPermissions(ctx, syncedPermissions, test.entity, source, replacePerms)
 				require.NoError(t, err)
-				_, err = s.setUserRepoPermissions(ctx, explicitPermissions, test.entity, authz.SourceAPI, deleteOldPerms)
+				_, err = s.setUserRepoPermissions(ctx, explicitPermissions, test.entity, authz.SourceAPI, replacePerms)
 				require.NoError(t, err)
 			}
 
@@ -969,7 +969,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 			}
 			var stats *database.SetPermissionsResult
 			var err error
-			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, source, deleteOldPerms); err != nil {
+			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, source, replacePerms); err != nil {
 				t.Fatal("testing user repo permissions", err)
 			}
 

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -840,6 +840,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 		expectedPermissions []authz.Permission
 		entity              authz.PermissionEntity
 		expectedResult      *database.SetPermissionsResult
+		keepOldPerms        bool
 	}{
 		{
 			name:                "empty",
@@ -910,6 +911,26 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 			entity:         authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
 			expectedResult: &database.SetPermissionsResult{Added: 1, Removed: 2, Found: 1},
 		},
+		{
+			name: "does not delete old permissions when bool is false",
+			origPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3},
+			},
+			permissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 4},
+			},
+			expectedPermissions: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 3, Source: source},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 4, Source: source},
+			},
+			entity:         authz.PermissionEntity{UserID: 1, ExternalAccountID: 1},
+			expectedResult: &database.SetPermissionsResult{Added: 2, Removed: 0, Found: 2},
+			keepOldPerms:   true,
+		},
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
@@ -923,6 +944,8 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 				cleanupReposTable(t, s)
 			})
 
+			deleteOldPerms := !test.keepOldPerms
+
 			if len(test.origPermissions) > 0 {
 				setupPermsRelatedEntities(t, s, test.origPermissions)
 				syncedPermissions := []authz.Permission{}
@@ -935,9 +958,9 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 					}
 				}
 
-				_, err := s.setUserRepoPermissions(ctx, syncedPermissions, test.entity, source)
+				_, err := s.setUserRepoPermissions(ctx, syncedPermissions, test.entity, source, deleteOldPerms)
 				require.NoError(t, err)
-				_, err = s.setUserRepoPermissions(ctx, explicitPermissions, test.entity, authz.SourceAPI)
+				_, err = s.setUserRepoPermissions(ctx, explicitPermissions, test.entity, authz.SourceAPI, deleteOldPerms)
 				require.NoError(t, err)
 			}
 
@@ -946,7 +969,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 			}
 			var stats *database.SetPermissionsResult
 			var err error
-			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, source); err != nil {
+			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, source, deleteOldPerms); err != nil {
 				t.Fatal("testing user repo permissions", err)
 			}
 
@@ -1072,12 +1095,12 @@ func TestPermsStore_UnionExplicitAndSyncedPermissions(t *testing.T) {
 
 			if len(test.origExplicitPermissions) > 0 {
 				setupPermsRelatedEntities(t, s, test.origExplicitPermissions)
-				_, err := s.setUserRepoPermissions(ctx, test.origExplicitPermissions, test.entity, authz.SourceAPI)
+				_, err := s.setUserRepoPermissions(ctx, test.origExplicitPermissions, test.entity, authz.SourceAPI, true)
 				require.NoError(t, err)
 			}
 			if len(test.origSyncedPermissions) > 0 {
 				setupPermsRelatedEntities(t, s, test.origSyncedPermissions)
-				_, err := s.setUserRepoPermissions(ctx, test.origSyncedPermissions, test.entity, authz.SourceUserSync)
+				_, err := s.setUserRepoPermissions(ctx, test.origSyncedPermissions, test.entity, authz.SourceUserSync, true)
 				require.NoError(t, err)
 			}
 
@@ -1087,7 +1110,7 @@ func TestPermsStore_UnionExplicitAndSyncedPermissions(t *testing.T) {
 
 			var stats *database.SetPermissionsResult
 			var err error
-			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, test.source); err != nil {
+			if stats, err = s.setUserRepoPermissions(ctx, test.permissions, test.entity, test.source, true); err != nil {
 				t.Fatal("testing user repo permissions", err)
 			}
 
@@ -1181,7 +1204,7 @@ func TestPermsStore_FetchReposByExternalAccount(t *testing.T) {
 
 			if test.origPermissions != nil && len(test.origPermissions) > 0 {
 				setupPermsRelatedEntities(t, s, test.origPermissions)
-				_, err := s.setUserRepoPermissions(ctx, test.origPermissions, authz.PermissionEntity{UserID: 42}, source)
+				_, err := s.setUserRepoPermissions(ctx, test.origPermissions, authz.PermissionEntity{UserID: 42}, source, true)
 				if err != nil {
 					t.Fatal("setup test permissions before actual test", err)
 				}
@@ -2528,6 +2551,53 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{},
 			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
 				1: {},
+			},
+		},
+		{
+			name: "grant pending permission with existing permissions",
+			updates: []update{
+				{
+					regulars: []*authz.RepoPermissions{
+						{
+							RepoID:  1,
+							Perm:    authz.Read,
+							UserIDs: toMapset(1),
+						},
+					},
+					pendings: []pending{{
+						accounts: &extsvc.Accounts{
+							ServiceType: authz.SourcegraphServiceType,
+							ServiceID:   authz.SourcegraphServiceID,
+							AccountIDs:  []string{"alice"},
+						},
+						perm: &authz.RepoPermissions{
+							RepoID: 2,
+							Perm:   authz.Read,
+						},
+					}},
+				},
+			},
+			grants: []*authz.UserGrantPermissions{{
+				UserID:                1,
+				UserExternalAccountID: 1,
+				ServiceType:           authz.SourcegraphServiceType,
+				ServiceID:             authz.SourcegraphServiceID,
+				AccountID:             "alice",
+			}},
+			expectUserRepoPerms: []authz.Permission{
+				{UserID: 1, ExternalAccountID: 1, RepoID: 1, Source: authz.SourceRepoSync},
+				{UserID: 1, ExternalAccountID: 1, RepoID: 2, Source: authz.SourceUserSync},
+			},
+			expectUserPerms: map[int32][]uint32{
+				1: {1, 2},
+			},
+			expectRepoPerms: map[int32][]uint32{
+				1: {1},
+				2: {1},
+			},
+			expectUserPendingPerms: map[extsvc.AccountSpec][]uint32{},
+			expectRepoPendingPerms: map[int32][]extsvc.AccountSpec{
+				2: {},
 			},
 		},
 		{


### PR DESCRIPTION
## Description

GrantPendingPermissions can be called multiple times in a loop. When using unified perms, it uses a method that by default removed old records from the table, effectively replacing existing records with new records.

However this behavior is not correct for granting pending permissions, which should only add new records, not remove old ones. Fixing this allows us to call GrantPendingPermissions in a loop without causing incosistencies in the database.

## Test plan

extensively unit tested so that we are sure it works for both legacy and unified permissions
