### PR TITLE
gitserver: cleanup & fix test for setting repo sizes

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -1541,10 +1541,10 @@ func TestCleanup_setRepoSizes(t *testing.T) {
 		t.Skip()
 	}
 
-	s := &Server{Logger: logtest.Scoped(t), ObservationCtx: observation.TestContextTB(t), DB: database.NewMockDB()}
-	s.Handler() // Handler as a side-effect sets up Server
 	db := dbtest.NewDB(logger, t)
-	s.DB = database.NewDB(logger, db)
+
+	s := &Server{Logger: logger, ObservationCtx: observation.TestContextTB(t), DB: database.NewDB(logger, db)}
+	s.Handler() // Handler as a side-effect sets up Server
 
 	// inserting info about repos to DB. Repo with ID = 1 already has its size
 	if _, err := db.Exec(`


### PR DESCRIPTION
I just read through that code and looked at the test. It had a few problems:

- It used an elaborate setup that was copy&pasted from another test but that was irrelevant to this test
- It only wants to test the `setRepoSizes` method but did it by calling the huge cleanup function.
- In the assertion part it only looked at repo with ID 1. So if the behaviour was broken it actually wouldn't have detected it.

Fixed all of these and changed assertions slightly.

## Test plan

- Ran this test