### PR TITLE
nix: use bazelisk without influence from CC and CXX envvars

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,19 @@ let
     #!${pkgs.stdenv.shell}
     exec ${pkgs.universal-ctags}/bin/ctags "$@"
   '';
+
+  # We let bazelisk manage the bazel version since we actually need to run two
+  # different versions thanks to aspect. Additionally bazelisk allows us to do
+  # things like "bazel configure". So we just install a script called bazel
+  # which calls bazelisk.
+  #
+  # Additionally bazel seems to break when CC and CXX is set to a nix managed
+  # compiler on darwin. So the script unsets those.
+  bazelisk = pkgs.writeScriptBin "bazel" ''
+    #!${pkgs.stdenv.shell}
+    unset CC CXX
+    exec ${pkgs.bazelisk}/bin/bazelisk "$@"
+  '';
 in
 pkgs.mkShell {
   name = "sourcegraph-dev";
@@ -68,8 +81,7 @@ pkgs.mkShell {
     libiconv
     clippy
 
-    # The future?
-    bazel_6
+    bazelisk
   ];
 
   # Startup postgres


### PR DESCRIPTION
This is the result of William and I debugging getting bazel to work on my nix-darwin managed M2 macbook to work with bazel. This is the output of a full morning of work :)

The root cause of the issue we ran into was we could not get bazel to compile protobuf, it would fail to find the C++ std headers. We had many misteps here, it turned out that unsetting CC and CXX would lead to bazel using the system installed toolchain. We are unsure why we can't use nix's clang-wrapped, maybe it has to do with that respecting special NIX_ envvars for building nix packages?

This might break bazel on NixOS, but it wasn't working for me anyways. I imagine it should continue to work on nix on linux.

Test Plan: "bazel test //cmd/frontend/internal/search:search_test" and "bazel configure" works.