### PR TITLE
gitserver: remove unneeded SELECT when updating repo sizes

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -602,21 +602,8 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 		reposNumber = 10000
 	}
 
-	// getting repo IDs for given repo names
-	foundRepos, err := s.fetchRepos(ctx, repoToSize, reposNumber)
-	if err != nil {
-		return err
-	}
-
-	reposToUpdate := make(map[api.RepoID]int64)
-	for _, repo := range foundRepos {
-		if size, exists := repoToSize[repo.Name]; exists {
-			reposToUpdate[repo.ID] = size
-		}
-	}
-
 	// updating repos
-	updatedRepos, err := s.DB.GitserverRepos().UpdateRepoSizes(ctx, s.Hostname, reposToUpdate)
+	updatedRepos, err := s.DB.GitserverRepos().UpdateRepoSizes(ctx, s.Hostname, repoToSize)
 	if err != nil {
 		return err
 	}

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -1066,10 +1066,10 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	})
 
 	// Setting repo sizes in DB
-	sizes := map[api.RepoID]int64{
-		repo1.ID: 100,
-		repo2.ID: 500,
-		repo3.ID: 800,
+	sizes := map[api.RepoName]int64{
+		repo1.Name: 100,
+		repo2.Name: 500,
+		repo3.Name: 800,
 	}
 	numUpdated, err := db.GitserverRepos().UpdateRepoSizes(ctx, shardID, sizes)
 	if err != nil {
@@ -1080,9 +1080,9 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	}
 
 	// Updating sizes in test data for further diff comparison
-	gitserverRepo1.RepoSizeBytes = sizes[gitserverRepo1.RepoID]
-	gitserverRepo2.RepoSizeBytes = sizes[gitserverRepo2.RepoID]
-	gitserverRepo3.RepoSizeBytes = sizes[gitserverRepo3.RepoID]
+	gitserverRepo1.RepoSizeBytes = sizes[repo1.Name]
+	gitserverRepo2.RepoSizeBytes = sizes[repo2.Name]
+	gitserverRepo3.RepoSizeBytes = sizes[repo3.Name]
 
 	// Checking repo diffs, excluding UpdatedAt. This is to verify that nothing except repo_size_bytes
 	// has changed
@@ -1114,8 +1114,8 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	}
 
 	// update subset
-	sizes = map[api.RepoID]int64{
-		repo3.ID: 900,
+	sizes = map[api.RepoName]int64{
+		repo3.Name: 900,
 	}
 	numUpdated, err = db.GitserverRepos().UpdateRepoSizes(ctx, shardID, sizes)
 	if err != nil {
@@ -1128,10 +1128,10 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	// update with different batch sizes
 	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithHandle(db.Handle())}
 	for _, batchSize := range []int64{1, 2, 3, 6} {
-		sizes = map[api.RepoID]int64{
-			repo1.ID: 123 + batchSize,
-			repo2.ID: 456 + batchSize,
-			repo3.ID: 789 + batchSize,
+		sizes = map[api.RepoName]int64{
+			repo1.Name: 123 + batchSize,
+			repo2.Name: 456 + batchSize,
+			repo3.Name: 789 + batchSize,
 		}
 
 		numUpdated, err = gitserverRepoStore.updateRepoSizesWithBatchSize(ctx, sizes, int(batchSize))

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -25114,7 +25114,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
-			defaultHook: func(context.Context, string, map[api.RepoID]int64) (r0 int, r1 error) {
+			defaultHook: func(context.Context, string, map[api.RepoName]int64) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -25212,7 +25212,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
-			defaultHook: func(context.Context, string, map[api.RepoID]int64) (int, error) {
+			defaultHook: func(context.Context, string, map[api.RepoName]int64) (int, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.UpdateRepoSizes")
 			},
 		},
@@ -27064,15 +27064,15 @@ func (c GitserverRepoStoreUpdateFuncCall) Results() []interface{} {
 // UpdateRepoSizes method of the parent MockGitserverRepoStore instance is
 // invoked.
 type GitserverRepoStoreUpdateRepoSizesFunc struct {
-	defaultHook func(context.Context, string, map[api.RepoID]int64) (int, error)
-	hooks       []func(context.Context, string, map[api.RepoID]int64) (int, error)
+	defaultHook func(context.Context, string, map[api.RepoName]int64) (int, error)
+	hooks       []func(context.Context, string, map[api.RepoName]int64) (int, error)
 	history     []GitserverRepoStoreUpdateRepoSizesFuncCall
 	mutex       sync.Mutex
 }
 
 // UpdateRepoSizes delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, v2 map[api.RepoID]int64) (int, error) {
+func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, v2 map[api.RepoName]int64) (int, error) {
 	r0, r1 := m.UpdateRepoSizesFunc.nextHook()(v0, v1, v2)
 	m.UpdateRepoSizesFunc.appendCall(GitserverRepoStoreUpdateRepoSizesFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -27081,7 +27081,7 @@ func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, 
 // SetDefaultHook sets function that is called when the UpdateRepoSizes
 // method of the parent MockGitserverRepoStore instance is invoked and the
 // hook queue is empty.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context.Context, string, map[api.RepoID]int64) (int, error)) {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context.Context, string, map[api.RepoName]int64) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -27090,7 +27090,7 @@ func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Context, string, map[api.RepoID]int64) (int, error)) {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Context, string, map[api.RepoName]int64) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -27099,19 +27099,19 @@ func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, map[api.RepoID]int64) (int, error) {
+	f.SetDefaultHook(func(context.Context, string, map[api.RepoName]int64) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, string, map[api.RepoID]int64) (int, error) {
+	f.PushHook(func(context.Context, string, map[api.RepoName]int64) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *GitserverRepoStoreUpdateRepoSizesFunc) nextHook() func(context.Context, string, map[api.RepoID]int64) (int, error) {
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) nextHook() func(context.Context, string, map[api.RepoName]int64) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -27153,7 +27153,7 @@ type GitserverRepoStoreUpdateRepoSizesFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 map[api.RepoID]int64
+	Arg2 map[api.RepoName]int64
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int


### PR DESCRIPTION
Turns out we can just join against `repo` and don't need to do another select to load all the repositories into memory.

## Test plan

- Existing tests