### PR TITLE
azuredevops: avoid shadowing in TestRateLimitRetry

### DIFF
--- a/internal/extsvc/azuredevops/client_test.go
+++ b/internal/extsvc/azuredevops/client_test.go
@@ -96,6 +96,7 @@ func TestRateLimitRetry(t *testing.T) {
 	}
 
 	for name, tt := range tests {
+		tt := tt
 		t.Run(name, func(t *testing.T) {
 			numRequests := 0
 			succeeded := false


### PR DESCRIPTION
I had a flake on this test. I inspected the test code and this is the only possible thing I could imagine causing the flake. The test mutates tt, and tt is shadowed.

Test Plan: CI and hope
