### PR TITLE
Add View Permissions link

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -8,6 +8,7 @@ import {
     mdiDotsVertical,
     mdiDatabaseRefresh,
     mdiRefresh,
+    mdiSecurity,
 } from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
@@ -207,6 +208,15 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiBrain} className="mr-1" />
                                     Code graph data
+                                </MenuItem>
+                                <MenuItem
+                                    as={Button}
+                                    disabled={!repoClonedAndHealthy(node)}
+                                    onSelect={() => navigate(`/${node.name}/-/settings/permissions`)}
+                                    className="p-2"
+                                >
+                                    <Icon aria-hidden={true} svgPath={mdiSecurity} className="mr-1" />
+                                    View Permissions
                                 </MenuItem>
                                 <MenuItem
                                     as={Button}


### PR DESCRIPTION
Added View Permissions link is the repositories page dropdown. 

<img width="1515" alt="image" src="https://user-images.githubusercontent.com/22571395/228301814-4d5fd2d5-6eec-4a5c-98f7-a3b2f39e026d.png">


## Test plan

- tested

## App preview:

- [Web](https://sg-web-naman-add-view-permissions-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
