### PR TITLE
Olafurpg/upload s2

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -43,6 +43,10 @@ jobs:
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload SCIP to S2
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
       - name: Upload lsif to Dogfood
         run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -626,6 +626,7 @@ interface ProgressBarProps {
     value: number
     max: number
 }
+
 const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ value, max }) => {
     if (max === 0) {
         return <></>


### PR DESCRIPTION
Previously, we didn't upload scip-typescript indexes to S2 resulting in different navigation on S2 and dotcom. This PR fixes the immediate issue and in this quarter we are planning to fix the auto-indexing inference script so that we no longer need to maintain a custom scip-typescript CI job for the sourcegraph/sourcegraph monorepo.


## Test plan
Verify that the scip-typescript CI job uploads to S2.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
