### PR TITLE
teams: add storybook tests

### DIFF
--- a/client/web/src/search/suggestion/SmartSearch.story.tsx
+++ b/client/web/src/search/suggestion/SmartSearch.story.tsx
@@ -9,7 +9,7 @@ import { WebStory } from '../../components/WebStory'
 import { SmartSearch } from './SmartSearch'
 
 const config: Meta = {
-    title: 'web/searc/suggestion/SmartSearch',
+    title: 'web/search/suggestion/SmartSearch',
     parameters: {
         chromatic: { viewports: [480, 993], disableSnapshot: false },
     },

--- a/client/web/src/team/area/TeamChildTeamsPage.story.tsx
+++ b/client/web/src/team/area/TeamChildTeamsPage.story.tsx
@@ -1,0 +1,22 @@
+import { Meta, Story } from '@storybook/react'
+
+import { WebStory } from '../../components/WebStory'
+
+import { TeamChildTeamsPage } from './TeamChildTeamsPage'
+import { testContext } from './test-utils'
+
+const config: Meta = {
+    title: 'web/teams/TeamChildTeamsPage',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+export default config
+
+export const Default: Story = function Default() {
+    return (
+        <WebStory initialEntries={['/teams/team-1/child-teams']}>
+            {() => <TeamChildTeamsPage {...testContext} />}
+        </WebStory>
+    )
+}

--- a/client/web/src/team/area/TeamChildTeamsPage.story.tsx
+++ b/client/web/src/team/area/TeamChildTeamsPage.story.tsx
@@ -1,6 +1,11 @@
+import { MockedResponse } from '@apollo/client/testing'
 import { Meta, Story } from '@storybook/react'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
+
 import { WebStory } from '../../components/WebStory'
+import { ListTeamsOfParentResult } from '../../graphql-operations'
+import { LIST_TEAMS_OF_PARENT } from '../list/backend'
 
 import { TeamChildTeamsPage } from './TeamChildTeamsPage'
 import { testContext } from './test-utils'
@@ -13,9 +18,72 @@ const config: Meta = {
 }
 export default config
 
+const mockResponse: MockedResponse<ListTeamsOfParentResult> = {
+    request: {
+        query: getDocumentNode(LIST_TEAMS_OF_PARENT),
+    },
+    result: {
+        data: {
+            __typename: 'Query',
+            team: {
+                __typename: 'Team',
+                childTeams: {
+                    __typename: 'TeamConnection',
+                    totalCount: 2,
+                    pageInfo: {
+                        __typename: 'PageInfo',
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                    nodes: [
+                        {
+                            __typename: 'Team',
+                            id: 'team-2',
+                            name: 'team-2',
+                            displayName: 'Team 2',
+                            url: '/teams/team-2',
+                            avatarURL: null,
+                            readonly: false,
+                            viewerCanAdminister: true,
+                            parentTeam: null,
+                            childTeams: {
+                                __typename: 'TeamConnection',
+                                totalCount: 0,
+                            },
+                            members: {
+                                __typename: 'TeamMemberConnection',
+                                totalCount: 2,
+                            },
+                        },
+                        {
+                            __typename: 'Team',
+                            id: 'team-3',
+                            name: 'team-3',
+                            displayName: 'Team 3',
+                            url: '/teams/team-3',
+                            avatarURL: null,
+                            readonly: false,
+                            viewerCanAdminister: true,
+                            parentTeam: null,
+                            childTeams: {
+                                __typename: 'TeamConnection',
+                                totalCount: 1,
+                            },
+                            members: {
+                                __typename: 'TeamMemberConnection',
+                                totalCount: 0,
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    },
+}
+
 export const Default: Story = function Default() {
     return (
-        <WebStory initialEntries={['/teams/team-1/child-teams']}>
+        <WebStory mocks={[mockResponse]} initialEntries={['/teams/team-1/child-teams']}>
             {() => <TeamChildTeamsPage {...testContext} />}
         </WebStory>
     )

--- a/client/web/src/team/area/TeamHeader.tsx
+++ b/client/web/src/team/area/TeamHeader.tsx
@@ -48,7 +48,7 @@ export const TeamHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                             </Alert>
                         )}
 
-                        <nav className="d-flex align-items-end justify-content-between" aria-label="Org">
+                        <nav className="d-flex align-items-end justify-content-between">
                             <ul className="nav nav-tabs w-100">
                                 <li className="nav-item">
                                     <NavLink to={url} className="nav-link" end={true}>

--- a/client/web/src/team/area/TeamMembersPage.story.tsx
+++ b/client/web/src/team/area/TeamMembersPage.story.tsx
@@ -2,10 +2,11 @@ import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
-import { NewTeamPage } from './NewTeamPage'
+import { TeamMembersPage } from './TeamMembersPage'
+import { testContext } from './test-utils'
 
 const config: Meta = {
-    title: 'web/teams/NewTeamPage',
+    title: 'web/teams/TeamMembersPage',
     parameters: {
         chromatic: { disableSnapshot: false },
     },
@@ -13,5 +14,5 @@ const config: Meta = {
 export default config
 
 export const Default: Story = function Default() {
-    return <WebStory>{() => <NewTeamPage />}</WebStory>
+    return <WebStory initialEntries={['/teams/team-1/members']}>{() => <TeamMembersPage {...testContext} />}</WebStory>
 }

--- a/client/web/src/team/area/TeamMembersPage.story.tsx
+++ b/client/web/src/team/area/TeamMembersPage.story.tsx
@@ -1,6 +1,11 @@
+import { MockedResponse } from '@apollo/client/testing'
 import { Meta, Story } from '@storybook/react'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
+
 import { WebStory } from '../../components/WebStory'
+import { ListTeamMembersResult } from '../../graphql-operations'
+import { LIST_TEAM_MEMBERS } from '../members/backend'
 
 import { TeamMembersPage } from './TeamMembersPage'
 import { testContext } from './test-utils'
@@ -13,6 +18,52 @@ const config: Meta = {
 }
 export default config
 
+const mockResponse: MockedResponse<ListTeamMembersResult> = {
+    request: {
+        query: getDocumentNode(LIST_TEAM_MEMBERS),
+    },
+    result: {
+        data: {
+            __typename: 'Query',
+            team: {
+                __typename: 'Team',
+                id: 'team-1',
+                members: {
+                    __typename: 'TeamMemberConnection',
+                    totalCount: 2,
+                    pageInfo: {
+                        __typename: 'PageInfo',
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                    nodes: [
+                        {
+                            __typename: 'User',
+                            id: 'user-1',
+                            username: 'user-1',
+                            displayName: 'User 1',
+                            avatarURL: null,
+                            url: '/users/user-1',
+                        },
+                        {
+                            __typename: 'User',
+                            id: 'user-2',
+                            username: 'user-2',
+                            displayName: 'User 2',
+                            avatarURL: null,
+                            url: '/users/user-2',
+                        },
+                    ],
+                },
+            },
+        },
+    },
+}
+
 export const Default: Story = function Default() {
-    return <WebStory initialEntries={['/teams/team-1/members']}>{() => <TeamMembersPage {...testContext} />}</WebStory>
+    return (
+        <WebStory initialEntries={['/teams/team-1/members']} mocks={[mockResponse]}>
+            {() => <TeamMembersPage {...testContext} />}
+        </WebStory>
+    )
 }

--- a/client/web/src/team/area/TeamProfilePage.story.tsx
+++ b/client/web/src/team/area/TeamProfilePage.story.tsx
@@ -2,10 +2,11 @@ import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
-import { NewTeamPage } from './NewTeamPage'
+import { TeamProfilePage } from './TeamProfilePage'
+import { testContext } from './test-utils'
 
 const config: Meta = {
-    title: 'web/teams/NewTeamPage',
+    title: 'web/teams/TeamProfilePage',
     parameters: {
         chromatic: { disableSnapshot: false },
     },
@@ -13,5 +14,5 @@ const config: Meta = {
 export default config
 
 export const Default: Story = function Default() {
-    return <WebStory>{() => <NewTeamPage />}</WebStory>
+    return <WebStory initialEntries={['/teams/team-1']}>{() => <TeamProfilePage {...testContext} />}</WebStory>
 }

--- a/client/web/src/team/area/test-utils.ts
+++ b/client/web/src/team/area/test-utils.ts
@@ -1,0 +1,34 @@
+import { mockAuthenticatedUser } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
+
+import { TeamAreaRouteContext } from './TeamArea'
+
+export const testContext: TeamAreaRouteContext = {
+    authenticatedUser: mockAuthenticatedUser,
+    team: {
+        __typename: 'Team',
+        id: '1',
+        name: 'team-1',
+        displayName: 'Team 1',
+        avatarURL: null,
+        url: '/teams/team-1',
+        readonly: false,
+        viewerCanAdminister: true,
+        parentTeam: null,
+        childTeams: {
+            __typename: 'TeamConnection',
+            totalCount: 1,
+        },
+        members: {
+            __typename: 'TeamMemberConnection',
+            totalCount: 2,
+        },
+        creator: {
+            __typename: 'User',
+            username: 'alice',
+            displayName: 'Alice',
+            avatarURL: null,
+            url: '/users/alice',
+        },
+    },
+    onTeamUpdate: () => {},
+}

--- a/client/web/src/team/list/TeamListPage.story.tsx
+++ b/client/web/src/team/list/TeamListPage.story.tsx
@@ -1,0 +1,107 @@
+import { MockedResponse } from '@apollo/client/testing'
+import { Meta, Story } from '@storybook/react'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+
+import { WebStory } from '../../components/WebStory'
+import { ListTeamsResult } from '../../graphql-operations'
+
+import { LIST_TEAMS } from './backend'
+import { TeamListPage } from './TeamListPage'
+
+const config: Meta = {
+    title: 'web/teams/TeamListPage',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+export default config
+
+export const EmptyList: Story = function EmptyList() {
+    const mockResponse: MockedResponse<ListTeamsResult> = {
+        request: {
+            query: getDocumentNode(LIST_TEAMS),
+        },
+        result: {
+            data: {
+                __typename: 'Query',
+                teams: {
+                    __typename: 'TeamConnection',
+                    nodes: [],
+                    pageInfo: {
+                        __typename: 'PageInfo',
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                    totalCount: 0,
+                },
+            },
+        },
+    }
+
+    return <WebStory mocks={[mockResponse]}>{() => <TeamListPage />}</WebStory>
+}
+
+export const ListWithItems: Story = function ListWithItems() {
+    const mockResponse: MockedResponse<ListTeamsResult> = {
+        request: {
+            query: getDocumentNode(LIST_TEAMS),
+        },
+        result: {
+            data: {
+                __typename: 'Query',
+                teams: {
+                    __typename: 'TeamConnection',
+                    nodes: [
+                        {
+                            __typename: 'Team',
+                            id: 'team-1',
+                            name: 'team-1',
+                            displayName: 'Team 1',
+                            avatarURL: null,
+                            url: '/teams/team-1',
+                            readonly: false,
+                            viewerCanAdminister: true,
+                            parentTeam: null,
+                            childTeams: {
+                                __typename: 'TeamConnection',
+                                totalCount: 1,
+                            },
+                            members: {
+                                __typename: 'TeamMemberConnection',
+                                totalCount: 1,
+                            },
+                        },
+                        {
+                            __typename: 'Team',
+                            id: 'team-2',
+                            name: 'team-2',
+                            displayName: 'Team 2',
+                            avatarURL: null,
+                            url: '/teams/team-2',
+                            readonly: true,
+                            viewerCanAdminister: false,
+                            parentTeam: null,
+                            childTeams: {
+                                __typename: 'TeamConnection',
+                                totalCount: 0,
+                            },
+                            members: {
+                                __typename: 'TeamMemberConnection',
+                                totalCount: 5,
+                            },
+                        },
+                    ],
+                    pageInfo: {
+                        __typename: 'PageInfo',
+                        endCursor: null,
+                        hasNextPage: false,
+                    },
+                    totalCount: 2,
+                },
+            },
+        },
+    }
+
+    return <WebStory mocks={[mockResponse]}>{() => <TeamListPage />}</WebStory>
+}

--- a/client/web/src/team/list/backend.ts
+++ b/client/web/src/team/list/backend.ts
@@ -57,7 +57,7 @@ export const LIST_TEAMS = gql`
     ${LIST_TEAM_FIELDS}
 `
 
-const LIST_TEAMS_OF_PARENT = gql`
+export const LIST_TEAMS_OF_PARENT = gql`
     query ListTeamsOfParent($first: Int, $after: String, $search: String, $teamName: String!) {
         team(name: $teamName) {
             childTeams(first: $first, after: $after, search: $search) {

--- a/client/web/src/team/list/backend.ts
+++ b/client/web/src/team/list/backend.ts
@@ -40,7 +40,7 @@ const LIST_TEAM_FIELDS = gql`
     }
 `
 
-const LIST_TEAMS = gql`
+export const LIST_TEAMS = gql`
     query ListTeams($first: Int, $after: String, $search: String) {
         teams(first: $first, after: $after, search: $search) {
             totalCount

--- a/client/web/src/team/members/backend.ts
+++ b/client/web/src/team/members/backend.ts
@@ -30,7 +30,7 @@ const LIST_TEAM_MEMBER_FIELDS = gql`
     }
 `
 
-const LIST_TEAM_MEMBERS = gql`
+export const LIST_TEAM_MEMBERS = gql`
     query ListTeamMembers($first: Int, $after: String, $search: String, $teamName: String!) {
         team(name: $teamName) {
             id


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/50081

Add storybook tests for teams list, create, profile, members, and child teams pages.

## Test plan

The whole PR is tests :) Verify using Chromatic in CI.

## App preview:

- [Web](https://sg-web-jp-teamstorybooktests.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
