### PR TITLE
cody: clickable context

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -101,6 +101,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     private async onDidReceiveMessage(message: any): Promise<void> {
+        const rootPath = getRootPath()
         switch (message.command) {
             case 'initialized':
                 await this.sendToken()
@@ -139,13 +140,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                 await vscode.env.openExternal(vscode.Uri.parse(message.value))
                 break
             case 'openFile':
-                const rootPath = getRootPath()
                 if (rootPath !== null) {
                     const uri = vscode.Uri.file(path.join(rootPath, message.filePath))
                     // This opens the file in the active column.
-                    vscode.workspace.openTextDocument(uri).then(doc => {
-                        vscode.window.showTextDocument(doc)
-                    })
+                    try {
+                        const doc = await vscode.workspace.openTextDocument(uri)
+                        await vscode.window.showTextDocument(doc)
+                    } catch (err) {
+                        console.error(`Could not open file: ${err}`)
+                    }
                 } else {
                     console.error('Could not open file because rootPath is null')
                 }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -146,8 +146,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                     try {
                         const doc = await vscode.workspace.openTextDocument(uri)
                         await vscode.window.showTextDocument(doc)
-                    } catch (err) {
-                        console.error(`Could not open file: ${err}`)
+                    } catch (error) {
+                        console.error(`Could not open file: ${error}`)
                     }
                 } else {
                     console.error('Could not open file because rootPath is null')

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import * as vscode from 'vscode'
 
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
@@ -20,6 +22,7 @@ import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, SecretStorage } from '../comm
 import { updateConfiguration } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { configureExternalServices } from '../external-services'
+import { getRootPath } from '../keyword-context/local-keyword-context-fetcher'
 import { getRgPath } from '../rg'
 import { TestSupport } from '../test-support'
 
@@ -134,6 +137,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                 break
             case 'links':
                 await vscode.env.openExternal(vscode.Uri.parse(message.value))
+                break
+            case 'openFile':
+                const rootPath = getRootPath()
+                if (rootPath !== null) {
+                    const uri = vscode.Uri.file(path.join(rootPath, message.filePath))
+                    // This opens the file in the active column.
+                    vscode.workspace.openTextDocument(uri).then(doc => {
+                        vscode.window.showTextDocument(doc)
+                    })
+                } else {
+                    console.error('Could not open file because rootPath is null')
+                }
                 break
             default:
                 console.error('Invalid request type from Webview')

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
@@ -211,7 +211,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
     }
 }
 
-function getRootPath(): string | null {
+export function getRootPath(): string | null {
     const uri = vscode.window.activeTextEditor?.document.uri
     if (uri) {
         const wsFolder = vscode.workspace.getWorkspaceFolder(uri)

--- a/client/cody/webviews/Chat.css
+++ b/client/cody/webviews/Chat.css
@@ -214,3 +214,12 @@
     top: 0;
     right: 0;
 }
+
+.link-button {
+    background: none;
+    border: none;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    font-size: inherit;
+    text-decoration: underline;
+}

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -210,14 +210,15 @@ export const ContextFiles: React.FunctionComponent<{ contextFiles: string[] }> =
                         {contextFiles.map(file => (
                             <li key={file}>
                                 <code className="context-file">
-                                    <a
-                                        href="#"
+                                    <button
+                                        className="link-button"
+                                        type="button"
                                         onClick={() => {
                                             vscodeAPI.postMessage({ command: 'openFile', filePath: file })
                                         }}
                                     >
                                         {file}
-                                    </a>
+                                    </button>
                                 </code>
                             </li>
                         ))}

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -209,7 +209,16 @@ export const ContextFiles: React.FunctionComponent<{ contextFiles: string[] }> =
                     <ul className="context-files-list-container">
                         {contextFiles.map(file => (
                             <li key={file}>
-                                <code className="context-file">{file}</code>
+                                <code className="context-file">
+                                    <a
+                                        href="#"
+                                        onClick={() => {
+                                            vscodeAPI.postMessage({ command: 'openFile', filePath: file })
+                                        }}
+                                    >
+                                        {file}
+                                    </a>
+                                </code>
                             </li>
                         ))}
                     </ul>

--- a/client/cody/webviews/utils/VSCodeApi.ts
+++ b/client/cody/webviews/utils/VSCodeApi.ts
@@ -53,7 +53,7 @@ interface RemoveChatHistoryWebviewMessage {
     command: 'removeHistory'
 }
 
-interface OpenFile {
+interface OpenFileWebviewMessage {
     command: 'openFile'
     filePath: string
 }
@@ -66,4 +66,4 @@ type WebviewMessage =
     | SubmitWebviewMessage
     | ExecuteRecipeWebviewMessage
     | RemoveChatHistoryWebviewMessage
-    | OpenFile
+    | OpenFileWebviewMessage

--- a/client/cody/webviews/utils/VSCodeApi.ts
+++ b/client/cody/webviews/utils/VSCodeApi.ts
@@ -53,6 +53,11 @@ interface RemoveChatHistoryWebviewMessage {
     command: 'removeHistory'
 }
 
+interface OpenFile {
+    command: 'openFile'
+    filePath: string
+}
+
 type WebviewMessage =
     | IntializedWebviewMessage
     | ResetWebviewMessage
@@ -61,3 +66,4 @@ type WebviewMessage =
     | SubmitWebviewMessage
     | ExecuteRecipeWebviewMessage
     | RemoveChatHistoryWebviewMessage
+    | OpenFile


### PR DESCRIPTION
With this change we display files in the context as links. The files are opened in the active tab.

![image](https://user-images.githubusercontent.com/26413131/228523370-47e2afb5-1672-4ce3-9a06-768bb2613aa9.png)

## Test plan
- manual testing
  - I clicked on the links and verified that the opened files match the context. 

## App preview:

- [Web](https://sg-web-sh-clickable-context.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

