### PR TITLE
site-admin: Show username if displayName is null

### DIFF
--- a/client/web/src/site-admin/SiteConfigurationChangeList.tsx
+++ b/client/web/src/site-admin/SiteConfigurationChangeList.tsx
@@ -90,7 +90,7 @@ function linesChanged(diffString: string): [number, number] {
         )
 }
 
-const SiteConfigurationHistoryItem: FC<SiteConfigurationHistoryItemProps> = ({ node }) => {
+export const SiteConfigurationHistoryItem: FC<SiteConfigurationHistoryItemProps> = ({ node }) => {
     const [open, setOpen] = useState<boolean>(false)
     const icon = open ? mdiChevronUp : mdiChevronDown
     const [removedLines, addedLines] = linesChanged(node.diff)

--- a/client/web/src/site-admin/SiteConfigurationChangeList.tsx
+++ b/client/web/src/site-admin/SiteConfigurationChangeList.tsx
@@ -97,7 +97,7 @@ const SiteConfigurationHistoryItem: FC<SiteConfigurationHistoryItemProps> = ({ n
 
     const editedBy = node.author ? (
         <Link to={`/users/${node.author.username}`} className="text-truncate">
-            {node.author.displayName}
+            {node.author.displayName ?? node.author.username}
         </Link>
     ) : (
         'Site configuration file set in SITE_CONFIG_FILE environment variable updated'

--- a/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
+++ b/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
@@ -11,15 +11,14 @@ const config: Meta = {
 
 export default config
 
-export const HistoryItemWithNoAuthor: Story = () => {
-    return (
-        <WebStory>
-            {() => (
-                <SiteConfigurationHistoryItem
-                    node={{
-                        author: null,
-                        createdAt: new Date().toISOString(),
-                        diff: `--- ID: 122
+export const HistoryItemWithNoAuthor: Story = () => (
+    <WebStory>
+        {() => (
+            <SiteConfigurationHistoryItem
+                node={{
+                    author: null,
+                    createdAt: new Date().toISOString(),
+                    diff: `--- ID: 122
 +++ ID: 123
 @@ -330,6 +330,7 @@
     "url": "https://github.com/"
@@ -29,61 +28,29 @@ export const HistoryItemWithNoAuthor: Story = () => {
     "clientID": "foo",
 -   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
     "displayName": "GitLab",`,
-                        id: '1',
-                    }}
-                />
-            )}
-        </WebStory>
-    )
-}
+                    id: '1',
+                }}
+            />
+        )}
+    </WebStory>
+)
 
-export const HistoryItemWithAuthor: Story = () => {
-    return (
-        <WebStory>
-            {() => (
-                <SiteConfigurationHistoryItem
-                    node={{
-                        author: {
-                            __typename: 'User',
-                            id: '1',
-                            displayName: 'Jane Doe',
-                            username: 'jdoe',
-                            avatarURL: null,
-                        },
-                        createdAt: new Date().toISOString(),
-                        diff: `--- ID: 122
-+++ ID: 123
-@@ -330,6 +330,7 @@
-    "url": "https://github.com/"
-    },
-    {
-+   "apiScope": "read_api",
-    "clientID": "foo",
--   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
-    "displayName": "GitLab",`,
-                        id: '1',
-                    }}
-                />
-            )}
-        </WebStory>
-    )
-}
+HistoryItemWithNoAuthor.storyName = 'History item with no author'
 
-export const HistoryItemWithAuthorButNoDisplayName: Story = () => {
-    return (
-        <WebStory>
-            {() => (
-                <SiteConfigurationHistoryItem
-                    node={{
-                        author: {
-                            __typename: 'User',
-                            id: '1',
-                            displayName: null,
-                            username: 'jdoe',
-                            avatarURL: null,
-                        },
-                        createdAt: new Date().toISOString(),
-                        diff: `--- ID: 122
+export const HistoryItemWithAuthor: Story = () => (
+    <WebStory>
+        {() => (
+            <SiteConfigurationHistoryItem
+                node={{
+                    author: {
+                        __typename: 'User',
+                        id: '1',
+                        displayName: 'Jane Doe',
+                        username: 'jdoe',
+                        avatarURL: null,
+                    },
+                    createdAt: new Date().toISOString(),
+                    diff: `--- ID: 122
 +++ ID: 123
 @@ -330,6 +330,7 @@
     "url": "https://github.com/"
@@ -93,29 +60,29 @@ export const HistoryItemWithAuthorButNoDisplayName: Story = () => {
     "clientID": "foo",
 -   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
     "displayName": "GitLab",`,
-                        id: '1',
-                    }}
-                />
-            )}
-        </WebStory>
-    )
-}
+                    id: '1',
+                }}
+            />
+        )}
+    </WebStory>
+)
 
-export const HistoryItemWithAuthorWithAvatarURL: Story = () => {
-    return (
-        <WebStory>
-            {() => (
-                <SiteConfigurationHistoryItem
-                    node={{
-                        author: {
-                            __typename: 'User',
-                            id: '1',
-                            displayName: 'Beyang Liu',
-                            username: 'beyang',
-                            avatarURL: 'https://avatars2.githubusercontent.com/u/1646931?v=4',
-                        },
-                        createdAt: new Date().toISOString(),
-                        diff: `--- ID: 122
+HistoryItemWithAuthor.storyName = 'History item with author'
+
+export const HistoryItemWithAuthorButNoDisplayName: Story = () => (
+    <WebStory>
+        {() => (
+            <SiteConfigurationHistoryItem
+                node={{
+                    author: {
+                        __typename: 'User',
+                        id: '1',
+                        displayName: null,
+                        username: 'jdoe',
+                        avatarURL: null,
+                    },
+                    createdAt: new Date().toISOString(),
+                    diff: `--- ID: 122
 +++ ID: 123
 @@ -330,6 +330,7 @@
     "url": "https://github.com/"
@@ -125,10 +92,43 @@ export const HistoryItemWithAuthorWithAvatarURL: Story = () => {
     "clientID": "foo",
 -   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
     "displayName": "GitLab",`,
+                    id: '1',
+                }}
+            />
+        )}
+    </WebStory>
+)
+
+HistoryItemWithAuthorButNoDisplayName.storyName = 'History item with author without display name'
+
+export const HistoryItemWithAuthorWithAvatarURL: Story = () => (
+    <WebStory>
+        {() => (
+            <SiteConfigurationHistoryItem
+                node={{
+                    author: {
+                        __typename: 'User',
                         id: '1',
-                    }}
-                />
-            )}
-        </WebStory>
-    )
-}
+                        displayName: 'Beyang Liu',
+                        username: 'beyang',
+                        avatarURL: 'https://avatars2.githubusercontent.com/u/1646931?v=4',
+                    },
+                    createdAt: new Date().toISOString(),
+                    diff: `--- ID: 122
++++ ID: 123
+@@ -330,6 +330,7 @@
+    "url": "https://github.com/"
+    },
+    {
++   "apiScope": "read_api",
+    "clientID": "foo",
+-   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
+    "displayName": "GitLab",`,
+                    id: '1',
+                }}
+            />
+        )}
+    </WebStory>
+)
+
+HistoryItemWithAuthorWithAvatarURL.storyName = 'History item with author and avatar URL'

--- a/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
+++ b/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
@@ -1,0 +1,134 @@
+import { Story, Meta } from '@storybook/react'
+
+import { WebStory } from '../components/WebStory'
+
+import { SiteConfigurationHistoryItem } from './SiteConfigurationChangeList'
+
+const config: Meta = {
+    title: 'web/site-admin/SiteConfigurationHistoryItem',
+    component: SiteConfigurationHistoryItem,
+}
+
+export default config
+
+export const HistoryItemWithNoAuthor: Story = () => {
+    return (
+        <WebStory>
+            {() => (
+                <SiteConfigurationHistoryItem
+                    node={{
+                        author: null,
+                        createdAt: new Date().toISOString(),
+                        diff: `--- ID: 122
++++ ID: 123
+@@ -330,6 +330,7 @@
+    "url": "https://github.com/"
+    },
+    {
++   "apiScope": "read_api",
+    "clientID": "foo",
+-   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
+    "displayName": "GitLab",`,
+                        id: '1',
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
+
+export const HistoryItemWithAuthor: Story = () => {
+    return (
+        <WebStory>
+            {() => (
+                <SiteConfigurationHistoryItem
+                    node={{
+                        author: {
+                            __typename: 'User',
+                            id: '1',
+                            displayName: 'Jane Doe',
+                            username: 'jdoe',
+                            avatarURL: null,
+                        },
+                        createdAt: new Date().toISOString(),
+                        diff: `--- ID: 122
++++ ID: 123
+@@ -330,6 +330,7 @@
+    "url": "https://github.com/"
+    },
+    {
++   "apiScope": "read_api",
+    "clientID": "foo",
+-   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
+    "displayName": "GitLab",`,
+                        id: '1',
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
+
+export const HistoryItemWithAuthorButNoDisplayName: Story = () => {
+    return (
+        <WebStory>
+            {() => (
+                <SiteConfigurationHistoryItem
+                    node={{
+                        author: {
+                            __typename: 'User',
+                            id: '1',
+                            displayName: null,
+                            username: 'jdoe',
+                            avatarURL: null,
+                        },
+                        createdAt: new Date().toISOString(),
+                        diff: `--- ID: 122
++++ ID: 123
+@@ -330,6 +330,7 @@
+    "url": "https://github.com/"
+    },
+    {
++   "apiScope": "read_api",
+    "clientID": "foo",
+-   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
+    "displayName": "GitLab",`,
+                        id: '1',
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}
+
+export const HistoryItemWithAuthorWithAvatarURL: Story = () => {
+    return (
+        <WebStory>
+            {() => (
+                <SiteConfigurationHistoryItem
+                    node={{
+                        author: {
+                            __typename: 'User',
+                            id: '1',
+                            displayName: 'Beyang Liu',
+                            username: 'beyang',
+                            avatarURL: 'https://avatars2.githubusercontent.com/u/1646931?v=4',
+                        },
+                        createdAt: new Date().toISOString(),
+                        diff: `--- ID: 122
++++ ID: 123
+@@ -330,6 +330,7 @@
+    "url": "https://github.com/"
+    },
+    {
++   "apiScope": "read_api",
+    "clientID": "foo",
+-   "clientSecret": "REDACTED-DATA-CHUNK-abcd1234",
+    "displayName": "GitLab",`,
+                        id: '1',
+                    }}
+                />
+            )}
+        </WebStory>
+    )
+}

--- a/internal/extsvc/gitlab/BUILD.bazel
+++ b/internal/extsvc/gitlab/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//internal/api",
         "//internal/conf",
         "//internal/encryption",


### PR DESCRIPTION
Fixes a bug when nothing is seen if the user does not have a display name. Example can be seen on S2:

<img width="969" alt="image" src="https://user-images.githubusercontent.com/2682729/228556372-b1511978-825c-476c-99e4-daa3bd075b17.png">

**Storybook**

![CleanShot 2023-04-05 at 17 09 05](https://user-images.githubusercontent.com/2682729/230070028-dffe11e5-669e-4b76-8831-2fee0cb1d479.gif)



## Test plan

1. Tested locally
1. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-bug-site-config-username.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
