### PR TITLE
cody: skip broken test

### DIFF
--- a/client/cody/src/integration-test/extension.test.ts
+++ b/client/cody/src/integration-test/extension.test.ts
@@ -59,7 +59,7 @@ suite('End-to-end', () => {
         assert.ok(codyCommands.length)
     })
 
-    test('Explain Code', async () => {
+    test.skip('Explain Code', async () => {
         await enableCodyWithAccessToken('test-token')
         await setMockServerConfig()
 


### PR DESCRIPTION
The test consistently times out
## Test plan
none - skipping broken test until it is fixed. Running experiments on this branch wb/cody/integration-test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-wb-cody-skip-broken.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
