### PR TITLE
Fix sync repositories (last setup wizard) links

### DIFF
--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -24,13 +24,9 @@ const CORE_STEPS: StepConfiguration[] = [
         name: 'Add remote repositories',
         path: '/setup/remote-repositories',
         component: RemoteRepositoriesStep,
-    },
-    {
-        id: 'sync-repositories',
-        name: 'Sync repositories',
-        path: '/setup/sync-repositories',
-        nextURL: '/search',
-        component: SyncRepositoriesStep,
+        // If user clicked next button in setup remote repositories
+        // this mean that setup was completed, and they're ready to go
+        // to app UI. See https://github.com/sourcegraph/sourcegraph/issues/50122
         onNext: (client: ApolloClient<{}>) => {
             // Mutate initial needsRepositoryConfiguration value
             // in order to avoid loop in Layout page redirection logic
@@ -44,6 +40,13 @@ const CORE_STEPS: StepConfiguration[] = [
                 () => {}
             )
         },
+    },
+    {
+        id: 'sync-repositories',
+        name: 'Sync repositories',
+        path: '/setup/sync-repositories',
+        nextURL: '/search',
+        component: SyncRepositoriesStep,
     },
 ]
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/50122

Prior to this PR, we update the logic check about redirection only when you click the start searching button, in this PR, we tune the redirection logic when you click the next button on the step before the last one, it fixes the problem described in this issue https://github.com/sourcegraph/sourcegraph/issues/50122

## Test plan
- Run fresh sourcegraph instance 
- Fill out the remote repositories setup step 
- On the sync repositories step, you should be possible to open the repo page by clicking on the repo links 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-sync-repositories-step.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
