### PR TITLE
Add error state to code host navigation items in setup wizard UI

### DIFF
--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -81,7 +81,8 @@
             color: var(--light-text);
         }
 
-        .delete-button {
+        .delete-button,
+        .error-button {
             color: var(--light-text);
 
             &:hover,
@@ -115,4 +116,31 @@
     &-status {
         color: var(--text-muted);
     }
+}
+
+.error-button {
+    font-size: var(--small-size-font);
+    padding: 0.15rem 0.25rem;
+    margin: -0.15rem -0.25rem;
+    color: var(--danger);
+    border: none;
+    font-weight: normal;
+
+    &:hover,
+    &:focus {
+        color: var(--danger);
+        background-color: var(--danger-4);
+    }
+
+    :global(.theme-dark) & {
+        &:hover,
+        &:focus {
+            color: var(--light-text);
+            background-color: var(--danger-2);
+        }
+    }
+}
+
+.error-popover {
+    max-width: 26rem;
 }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -119,12 +119,13 @@
 }
 
 .error-button {
-    font-size: var(--small-size-font);
     padding: 0.15rem 0.25rem;
     margin: -0.15rem -0.25rem;
-    color: var(--danger);
     border: none;
+    font-size: var(--small-size-font);
     font-weight: normal;
+    color: var(--danger);
+    border-radius: var(--border-radius);
 
     &:hover,
     &:focus {

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.tsx
@@ -1,11 +1,22 @@
 import { FC, ReactElement } from 'react'
 
 import { QueryResult } from '@apollo/client'
-import { mdiDelete, mdiInformationOutline, mdiPlus } from '@mdi/js'
+import { mdiDelete, mdiInformationOutline, mdiPlus, mdiAlertCircle } from '@mdi/js'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
-import { Button, ErrorAlert, Icon, Link, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
+import {
+    Button,
+    ErrorAlert,
+    Icon,
+    Link,
+    LoadingSpinner,
+    Popover,
+    PopoverTrigger,
+    PopoverContent,
+    PopoverTail,
+    Tooltip,
+} from '@sourcegraph/wildcard'
 
 import { CodeHost, ExternalServiceKind, GetCodeHostsResult } from '../../../../../graphql-operations'
 import { CodeHostIcon, getCodeHostKindFromURLParam, getCodeHostName } from '../../helpers'
@@ -93,8 +104,10 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                                 )}
                             </span>
                             <small className={styles.itemDescriptionStatus}>
-                                {codeHost.lastSyncAt !== null && <>Synced, {codeHost.repoCount} repositories found</>}
-                                {codeHost.lastSyncAt === null && (
+                                {codeHost.lastSyncAt !== null && codeHost.lastSyncError === null && (
+                                    <>Synced, {codeHost.repoCount} repositories found</>
+                                )}
+                                {codeHost.lastSyncAt === null && codeHost.lastSyncError === null && (
                                     <>
                                         Syncing
                                         {codeHost.repoCount > 0 && (
@@ -104,6 +117,24 @@ export const CodeHostsNavigation: FC<CodeHostsNavigationProps> = props => {
                                             </>
                                         )}
                                     </>
+                                )}
+                                {codeHost.lastSyncError !== null && (
+                                    <Popover>
+                                        <PopoverTrigger as="span" className={styles.errorButton}>
+                                            Sync error appeared{' '}
+                                            <Icon svgPath={mdiAlertCircle} aria-label="Sync error icon" />
+                                        </PopoverTrigger>
+
+                                        <PopoverContent position="right" className={styles.errorPopover}>
+                                            <ErrorAlert
+                                                error={codeHost.lastSyncError}
+                                                variant="danger"
+                                                className="m-3"
+                                            />
+                                        </PopoverContent>
+
+                                        <PopoverTail size="sm" />
+                                    </Popover>
                                 )}
                             </small>
                         </span>

--- a/client/web/src/setup-wizard/queries.ts
+++ b/client/web/src/setup-wizard/queries.ts
@@ -9,6 +9,7 @@ export const CODE_HOST_FRAGMENT = gql`
         displayName
         lastSyncAt
         nextSyncAt
+        lastSyncError
         config
     }
 `


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/50123

| Error state | State with expanded popover |
| ------ | ------- |
| <img width="1101" alt="Screenshot 2023-03-29 at 14 40 47" src="https://user-images.githubusercontent.com/18492575/228624073-4d8e9ed3-dc0f-45c2-bd84-e4ecdc838eaf.png"> | <img width="1101" alt="Screenshot 2023-03-29 at 14 40 43" src="https://user-images.githubusercontent.com/18492575/228624099-ebce9959-75ac-4ebe-b7b0-e314388b8fd1.png"> |

## Test plan
- Go to the setup wizard
- Try to create any code host with an invalid JSON schema (like with an invalid access token)
- See that after attempting to connect and initial sync, you see code host with an error state in the aside panel 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-improve-error-state-in-code.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
