### PR TITLE
Site admin / repos - no overflow

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -34,13 +34,12 @@
     max-width: 600px;
 }
 
-.repo-description {
-    @media (--xs-breakpoint-down) {
-        overflow: hidden;
-    }
-}
-
 .alert-overflow {
     max-height: 300px;
     overflow-y: auto;
+}
+
+.repo-icon {
+    min-height: 24px;
+    min-width: 24px;
 }

--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -38,8 +38,3 @@
     max-height: 300px;
     overflow-y: auto;
 }
-
-.repo-icon {
-    min-height: 24px;
-    min-width: 24px;
-}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -124,7 +124,7 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                 {/* that col-md-8 is a little too large for the two buttons in a row */}
                 <div className="d-flex flex-column justify-content-between flex-md-row col px-0">
                     <div className="d-flex col align-items-center px-0">
-                        <ExternalRepositoryIcon externalRepo={node.externalRepository} className={styles.repoIcon} />
+                        <ExternalRepositoryIcon externalRepo={node.externalRepository} />
                         <RepoLink repoName={node.name} to={node.url} />
                     </div>
 

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -123,8 +123,8 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
             <div className="d-flex flex-row">
                 {/* that col-md-8 is a little too large for the two buttons in a row */}
                 <div className="d-flex flex-column justify-content-between flex-md-row col px-0">
-                    <div className={classNames('d-flex col align-items-center px-0', styles.repoDescription)}>
-                        <ExternalRepositoryIcon externalRepo={node.externalRepository} />
+                    <div className="d-flex col align-items-center px-0">
+                        <ExternalRepositoryIcon externalRepo={node.externalRepository} className={styles.repoIcon} />
                         <RepoLink repoName={node.name} to={node.url} />
                     </div>
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/39327

Follow-up to #50010:

Drop overflow-auto from repo name as per @st0nebraker 's [comment](https://github.com/sourcegraph/sourcegraph/pull/50010#discussion_r1152144643)

## Test plan

Visual assessment.

## App preview:

- [Web](https://sg-web-cb-site-admin-repos-no-overflow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
