### PR TITLE
Logging of `Ask Cody Right Click Menu Events` and `Recipes Clicked From Menu Events`

### DIFF
--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -11,6 +11,9 @@ import { EventLogger } from './eventLogger'
 import { LocalStorage } from './LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, InMemorySecretStorage, SecretStorage, VSCodeSecretStorage } from './secret-storage'
 
+// eventLogger const
+const eventLogger = new EventLogger.getInstance()
+
 function getSecretStorage(context: vscode.ExtensionContext): SecretStorage {
     return process.env.CODY_TESTING === 'true' ? new InMemorySecretStorage() : new VSCodeSecretStorage(context.secrets)
 }
@@ -63,7 +66,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             await config.update('cody.enabled', !config.get('cody.enabled'), vscode.ConfigurationTarget.Global)
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyToggleEnabled:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyToggleEnabled:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -77,11 +80,11 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, tokenInput)
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked')
+                eventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked')
                 if (tokenInput) {
-                    EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:tokenSet')
+                    eventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:tokenSet')
                 } else {
-                    EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:noTokenSet')
+                    eventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:noTokenSet')
                 }
             } catch (error) {
                 console.log(error)
@@ -90,11 +93,11 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
         vscode.commands.registerCommand('cody.delete-access-token', async () => {
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked')
                 if (!secretStorage.get(CODY_ACCESS_TOKEN_SECRET)) {
-                    EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:noToken')
+                    eventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:noToken')
                 } else {
-                    EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:tokenExists')
+                    eventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:tokenExists')
                 }
             } catch (error) {
                 console.log(error)
@@ -113,7 +116,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('explain-code-detailed')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyExplainCode:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyExplainCode:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -122,7 +125,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('explain-code-high-level')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyExplainCodeHighLevel:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyExplainCodeHighLevel:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -131,7 +134,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('generate-unit-test')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyGenerateUnitTest:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyGenerateUnitTest:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -140,7 +143,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('generate-docstring')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyGenerateDocstring:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyGenerateDocstring:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -149,7 +152,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('translate-to-language')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyTranslateToLanguage:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyTranslateToLanguage:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -158,7 +161,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('git-history')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyGitHistory:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyGitHistory:clicked')
             } catch (error) {
                 console.log(error)
             }
@@ -167,7 +170,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             executeRecipe('improve-variable-names')
             // log event
             try {
-                EventLogger.log('CodyVSCodeExtension:codyImproveVariableNames:clicked')
+                eventLogger.log('CodyVSCodeExtension:codyImproveVariableNames:clicked')
             } catch (error) {
                 console.log(error)
             }

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -7,6 +7,7 @@ import { CompletionsDocumentProvider } from '../completions/docprovider'
 import { getConfiguration } from '../configuration'
 import { ExtensionApi } from '../extension-api'
 
+import { EventLogger } from './eventLogger'
 import { LocalStorage } from './LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, InMemorySecretStorage, SecretStorage, VSCodeSecretStorage } from './secret-storage'
 
@@ -60,6 +61,12 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
         vscode.commands.registerCommand('cody.toggle-enabled', async () => {
             const config = vscode.workspace.getConfiguration()
             await config.update('cody.enabled', !config.get('cody.enabled'), vscode.ConfigurationTarget.Global)
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyToggleEnabled:clicked')
+            } catch (error) {
+                console.log(error)
+            }
         }),
         // Access token
         vscode.commands.registerCommand('cody.set-access-token', async (args: any[]) => {
@@ -68,10 +75,32 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
                 return
             }
             await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, tokenInput)
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked')
+                if (tokenInput) {
+                    EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:tokenSet')
+                } else {
+                    EventLogger.log('CodyVSCodeExtension:codySetAccessToken:clicked:noTokenSet')
+                }
+            } catch (error) {
+                console.log(error)
+            }
         }),
-        vscode.commands.registerCommand('cody.delete-access-token', async () =>
+        vscode.commands.registerCommand('cody.delete-access-token', async () => {
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked')
+                if (!secretStorage.get(CODY_ACCESS_TOKEN_SECRET)) {
+                    EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:noToken')
+                } else {
+                    EventLogger.log('CodyVSCodeExtension:codyDeleteAccessToken:clicked:tokenExists')
+                }
+            } catch (error) {
+                console.log(error)
+            }
             secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
-        ),
+        }),
         // TOS
         vscode.commands.registerCommand('cody.accept-tos', version =>
             localStorage.set('cody.tos-version-accepted', version)
@@ -80,23 +109,69 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             localStorage.get('cody.tos-version-accepted')
         ),
         // Commands
-        vscode.commands.registerCommand('cody.recipe.explain-code', async () => executeRecipe('explain-code-detailed')),
-        vscode.commands.registerCommand('cody.recipe.explain-code-high-level', async () =>
+        vscode.commands.registerCommand('cody.recipe.explain-code', async () => {
+            executeRecipe('explain-code-detailed')
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyExplainCode:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.explain-code-high-level', async () => {
             executeRecipe('explain-code-high-level')
-        ),
-        vscode.commands.registerCommand('cody.recipe.generate-unit-test', async () =>
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyExplainCodeHighLevel:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.generate-unit-test', async () => {
             executeRecipe('generate-unit-test')
-        ),
-        vscode.commands.registerCommand('cody.recipe.generate-docstring', async () =>
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyGenerateUnitTest:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.generate-docstring', async () => {
             executeRecipe('generate-docstring')
-        ),
-        vscode.commands.registerCommand('cody.recipe.translate-to-language', async () =>
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyGenerateDocstring:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.translate-to-language', async () => {
             executeRecipe('translate-to-language')
-        ),
-        vscode.commands.registerCommand('cody.recipe.git-history', async () => executeRecipe('git-history')),
-        vscode.commands.registerCommand('cody.recipe.improve-variable-names', async () =>
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyTranslateToLanguage:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.git-history', async () => {
+            executeRecipe('git-history')
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyGitHistory:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        }),
+        vscode.commands.registerCommand('cody.recipe.improve-variable-names', async () => {
             executeRecipe('improve-variable-names')
-        )
+            // log event
+            try {
+                EventLogger.log('CodyVSCodeExtension:codyImproveVariableNames:clicked')
+            } catch (error) {
+                console.log(error)
+            }
+        })
     )
 
     if (config.experimentalSuggest && config.openaiKey) {

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -12,7 +12,7 @@ import { LocalStorage } from './LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, InMemorySecretStorage, SecretStorage, VSCodeSecretStorage } from './secret-storage'
 
 // eventLogger const
-const eventLogger = new EventLogger.getInstance()
+const eventLogger = EventLogger.getInstance()
 
 function getSecretStorage(context: vscode.ExtensionContext): SecretStorage {
     return process.env.CODY_TESTING === 'true' ? new InMemorySecretStorage() : new VSCodeSecretStorage(context.secrets)

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -4,6 +4,11 @@ import { vscodeAPI } from './utils/VSCodeApi'
 
 import './Recipes.css'
 
+import { EventLogger } from './eventLogger'
+
+// eventLogger is used to log events
+const eventLogger = new EventLogger('https://sourcegraph.com/')
+
 export const recipesList = {
     'explain-code-detailed': 'Explain selected code (detailed)',
     'explain-code-high-level': 'Explain selected code (high level)',
@@ -16,6 +21,14 @@ export const recipesList = {
 
 export function Recipes(): React.ReactElement {
     const onRecipeClick = (recipeID: string): void => {
+        // log event
+        try {
+            eventLogger.logEvent({
+                event: 'CodyVSCodeExtenstion:recipe:" + recipeID + ":clicked',
+            })
+        } catch (error) {
+            console.log(error)
+        }
         vscodeAPI.postMessage({ command: 'executeRecipe', recipe: recipeID })
     }
 

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -7,7 +7,7 @@ import './Recipes.css'
 import { EventLogger } from './eventLogger'
 
 // eventLogger is used to log events
-const eventLogger = new EventLogger('https://sourcegraph.com/')
+const eventLogger = new EventLogger.getInstance()
 
 export const recipesList = {
     'explain-code-detailed': 'Explain selected code (detailed)',

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -7,7 +7,7 @@ import './Recipes.css'
 import { EventLogger } from './eventLogger'
 
 // eventLogger is used to log events
-const eventLogger = new EventLogger.getInstance()
+const eventLogger = EventLogger.getInstance()
 
 export const recipesList = {
     'explain-code-detailed': 'Explain selected code (detailed)',


### PR DESCRIPTION
Merge this only after Nathan has added eventLogger to `./client/cody`. May need to reformat a few things depending on the final version of eventLogger we add to Cody

Logs the following:
Recipes used from menu events:
`CodyVSCodeExtension:recipeGenerateCode:clicked`
`CodyVSCodeExtension:recipeGenerateUnitTest:clicked`
`CodyVSCodeExtension:recipeGenerateDocstring:clicked`
`CodyVSCodeExtension:recipeImproveVariableNames:clicked`
`CodyVSCodeExtension:recipeTranslateToLanguage:clicked`
`CodyVSCodeExtension:recipeGitHistoryt:clicked`

Ask Cody right click menu events:
`CodyVSCodeExtension:codyToggleEnabled:clicked`
`CodyVSCodeExtension:askCodyExplainCode:clicked`
`CodyVSCodeExtension:askCodyExplainCodeHighLevel:clicked`
`CodyVSCodeExtension:askCodyGenerateUnitTest:clicked`
`CodyVSCodeExtension:askCodyGenerateDocstring:clicked`
`CodyVSCodeExtension:askCodyTranslateToLanguage:clicked`
`CodyVSCodeExtension:askCodyGitHistory:clicked`
`CodyVSCodeExtension:askCodyImproveVariableNames:clicked`
`CodyVSCodeExtension:codySetAccessToken:clicked`
`CodyVSCodeExtension:codyDeleteAccessToken:clicked`
`CodyVSCodeExtension:askCodyViewSuggestions:clicked`
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Once eventLogger is added, test this locally and verify 

## App preview:

- [Web](https://sg-web-aditya-codylogevents.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

