### PR TITLE
Cody: locally configure embedding upload URL

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -98,6 +98,9 @@ env:
   PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:9000
   PRECISE_CODE_INTEL_UPLOAD_BACKEND: blobstore
 
+  # Required for embeddings job upload
+  EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:9000
+
   # Disable auto-indexing the CNCF repo group (this only works in Cloud)
   # This setting will be going away soon
   DISABLE_CNCF: notonmybox


### PR DESCRIPTION
This config is required when running `sg start embeddings`, since the embeddings job uploads the embedding vectors to blobstore.

## Test plan

Manually tested local set-up:
* Pull latest `dev-private` to fetch embedding site config
* Run `sg start embeddings`
* Go to Site Admin and check the embeddings job runs to completion (takes ~15 min)
