### PR TITLE
embeddings: configurable repo embedding index cache size

### DIFF
--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -12,9 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-const REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES = 5
+var cacheSize = env.MustGetInt("EMBEDDINGS_REPOSITORY_INDEX_CACHE_SIZE", 5, "Number of repository embedding indexes to cache in memory.")
 
 type downloadRepoEmbeddingIndexFn func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error)
 
@@ -28,7 +29,7 @@ func getCachedRepoEmbeddingIndex(
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn,
 ) (getRepoEmbeddingIndexFn, error) {
-	cache, err := lru.New[embeddings.RepoEmbeddingIndexName, repoEmbeddingIndexCacheEntry](REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES)
+	cache, err := lru.New[embeddings.RepoEmbeddingIndexName, repoEmbeddingIndexCacheEntry](cacheSize)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating repo embedding index cache")
 	}


### PR DESCRIPTION
## Test plan

* Set the `EMBEDDINGS_REPOSITORY_INDEX_CACHE_SIZE` in my shell and ran the embeddings service, and checked if it picked up the variable.