### PR TITLE
fix unified perms oob migrator

### DIFF
--- a/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/iam/unified_permissions_migrator.go
@@ -133,10 +133,10 @@ ins AS (
 -- Mark the user_permissions rows as migrated
 UPDATE user_permissions
 SET migrated = TRUE
-FROM s
-WHERE user_permissions.user_id = s.user_id
-	AND user_permissions.permission = s.permission
-	AND user_permissions.object_type = s.object_type
+FROM candidates AS c
+WHERE user_permissions.user_id = c.user_id
+	AND user_permissions.permission = c.permission
+	AND user_permissions.object_type = c.object_type
 `
 
 func (m *unifiedPermissionsMigrator) Down(_ context.Context) error {


### PR DESCRIPTION
Turns out our progress was not reporting correctly, because certain rows were not migrated. This was caused by bad query in migrator itself, because if there were no permissions (empty `object_ids_ints` array), we had no rows in the `s` set of the subquery. This `s` subquery was subsequently used to update the `migrated` column, but we should have instead used the `candidates` subquery.

Hope the description makes sense, code change should be self explanatory.

## Test plan

- [x] Unit tested
- [x] Verify on S2 that this is the case
