### PR TITLE
ctags: remove conflicting build flag

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -17,5 +17,4 @@ echo "Building ctags docker image"
 docker build -f cmd/symbols/Dockerfile -t ctags . \
   --platform linux/amd64 \
   --target=ctags \
-  --progress=plain \
-  --quiet >/dev/null
+  --progress=plain


### PR DESCRIPTION
`sg start` fails with the following error message:

```shell
--------------------------------------------------------------------------------
Failed to build symbols: 'bash -c if [ -n "$DELVE" ]; then
  export GCFLAGS='all=-N -l'
fi

./cmd/symbols/build-ctags.sh &&
go build -gcflags="$GCFLAGS" -o .bin/symbols github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols' failed: Building ctags docker image
ERROR: progress=plain and quiet cannot be used together: exit status 1:
Building ctags docker image
ERROR: progress=plain and quiet cannot be used together
--------------------------------------------------------------------------------
❌ failed to run symbols
```

It makes sense that `--progress=plain` and `--quiet` can't be defined both. I've removed `--quiet` to bring the flags in line with how we build our other images.

## Test plan
Tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
