### PR TITLE
cody: add debug logger

### DIFF
--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -23,7 +23,7 @@ export class CodebaseContext {
     ) {}
 
     public async getContextMessages(query: string, options: ContextSearchOptions): Promise<ContextMessage[]> {
-        Logger.getInstance().log('context type: ' + this.contextType)
+        await Logger.getInstance().log('context type: ' + this.contextType)
         switch (this.contextType) {
             case 'blended':
                 return this.embeddings
@@ -55,7 +55,7 @@ export class CodebaseContext {
             options.numTextResults
         )
 
-        Logger.getInstance().logJSON(
+        await Logger.getInstance().logJSON(
             embeddingsSearchResults,
             (key, value) => (key === 'content' ? undefined : value),
             2

--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import { EmbeddingsSearch } from '../embeddings'
 import { KeywordContextFetcher } from '../keyword-context'
+import { Logger } from '../logger'
 import { populateCodeContextTemplate, populateMarkdownContextTemplate } from '../prompt/templates'
 import { Message } from '../sourcegraph-api'
 import { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
@@ -22,6 +23,7 @@ export class CodebaseContext {
     ) {}
 
     public async getContextMessages(query: string, options: ContextSearchOptions): Promise<ContextMessage[]> {
+        Logger.getInstance().log('context type: ' + this.contextType)
         switch (this.contextType) {
             case 'blended':
                 return this.embeddings
@@ -52,6 +54,13 @@ export class CodebaseContext {
             options.numCodeResults,
             options.numTextResults
         )
+
+        Logger.getInstance().logJSON(
+            embeddingsSearchResults,
+            (key, value) => (key === 'content' ? undefined : value),
+            2
+        )
+
         if (isError(embeddingsSearchResults)) {
             console.error('Error retrieving embeddings:', embeddingsSearchResults)
             return []

--- a/client/cody-shared/src/logger.ts
+++ b/client/cody-shared/src/logger.ts
@@ -1,10 +1,10 @@
-interface LogFunc {
-    (msg: string): void
-}
+type LogFunc = (msg: string) => void
 
 // Logger is a singleton class that allows us to log messages to the Debug tab.
 // To use it, call Logger.getInstance().log('message') and make sure that
 // setLogFunc() has been called upstream.
+//
+/* eslint no-empty-function: ["error", { "allow": ["constructors"] }]*/
 export class Logger {
     private static logFunc: LogFunc | undefined
     private static instance: Logger
@@ -18,15 +18,19 @@ export class Logger {
         return Logger.instance
     }
 
-    public setLogFunc(logFunc: LogFunc) {
+    public setLogFunc(logFunc: LogFunc): void {
         Logger.logFunc = logFunc
     }
 
-    log(message: string) {
+    public log(message: string): void {
         Logger.logFunc?.(message)
     }
 
-    logJSON(message: any, replacer?: (this: any, key: string, value: any) => any, space?: string | number) {
+    public logJSON(
+        message: any,
+        replacer?: (this: any, key: string, value: any) => any,
+        space?: string | number
+    ): void {
         Logger.logFunc?.(JSON.stringify(message, replacer, 2))
     }
 }

--- a/client/cody-shared/src/logger.ts
+++ b/client/cody-shared/src/logger.ts
@@ -1,15 +1,13 @@
-type LogFunc = (msg: string) => void
+type LogFunc = (msg: string) => Promise<void>
 
 // Logger is a singleton class that allows us to log messages to the Debug tab.
 // To use it, call Logger.getInstance().log('message') and make sure that
 // setLogFunc() has been called upstream.
-//
-/* eslint no-empty-function: ["error", { "allow": ["constructors"] }]*/
 export class Logger {
     private static logFunc: LogFunc | undefined
     private static instance: Logger
 
-    private constructor() {}
+    private constructor() {} // eslint-disable-line @typescript-eslint/no-empty-function
 
     public static getInstance(): Logger {
         if (!Logger.instance) {
@@ -22,15 +20,16 @@ export class Logger {
         Logger.logFunc = logFunc
     }
 
-    public log(message: string): void {
-        Logger.logFunc?.(message)
+    public async log(message: string): Promise<void> {
+        return Logger.logFunc?.(message)
     }
 
-    public logJSON(
+    // logJson has the same signature as JSON.stringify
+    public async logJSON(
         message: any,
         replacer?: (this: any, key: string, value: any) => any,
         space?: string | number
-    ): void {
-        Logger.logFunc?.(JSON.stringify(message, replacer, 2))
+    ): Promise<void> {
+        return Logger.logFunc?.(JSON.stringify(message, replacer, 2))
     }
 }

--- a/client/cody-shared/src/logger.ts
+++ b/client/cody-shared/src/logger.ts
@@ -1,0 +1,32 @@
+interface LogFunc {
+    (msg: string): void
+}
+
+// Logger is a singleton class that allows us to log messages to the Debug tab.
+// To use it, call Logger.getInstance().log('message') and make sure that
+// setLogFunc() has been called upstream.
+export class Logger {
+    private static logFunc: LogFunc | undefined
+    private static instance: Logger
+
+    private constructor() {}
+
+    public static getInstance(): Logger {
+        if (!Logger.instance) {
+            Logger.instance = new Logger()
+        }
+        return Logger.instance
+    }
+
+    public setLogFunc(logFunc: LogFunc) {
+        Logger.logFunc = logFunc
+    }
+
+    log(message: string) {
+        Logger.logFunc?.(message)
+    }
+
+    logJSON(message: any, replacer?: (this: any, key: string, value: any) => any, space?: string | number) {
+        Logger.logFunc?.(JSON.stringify(message, replacer, 2))
+    }
+}

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -217,14 +217,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
         const logger = Logger.getInstance()
         if (this.mode === 'development') {
-            logger.setLogFunc((msg: string): void => {
+            logger.setLogFunc(async (msg: string): Promise<void> => {
                 if (this.mode === 'development') {
                     const timestamp = new Date().toLocaleTimeString('en-US', {
                         hour: '2-digit',
                         minute: '2-digit',
                         second: '2-digit',
                     })
-                    this.webview?.postMessage({ type: 'debug', message: `(${timestamp}) ${msg}` })
+                    await this.webview?.postMessage({ type: 'debug', message: `(${timestamp}) ${msg}` })
                 }
             })
         }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -11,6 +11,7 @@ import { reformatBotMessage } from '@sourcegraph/cody-shared/src/chat/viewHelper
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
+import { Logger } from '@sourcegraph/cody-shared/src/logger'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
@@ -212,6 +213,20 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         const recipe = getRecipe(recipeId)
         if (!recipe) {
             return
+        }
+
+        const logger = Logger.getInstance()
+        if (this.mode === 'development') {
+            logger.setLogFunc((msg: string): void => {
+                if (this.mode === 'development') {
+                    const timestamp = new Date().toLocaleTimeString('en-US', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        second: '2-digit',
+                    })
+                    this.webview?.postMessage({ type: 'debug', message: `(${timestamp}) ${msg}` })
+                }
+            })
         }
 
         const interaction = await recipe.getInteraction(

--- a/client/cody/tsconfig.json
+++ b/client/cody/tsconfig.json
@@ -15,6 +15,7 @@
     "package.json",
     ".eslintrc.js",
     "jest.config.js",
+    "../cody-shared/src/logger.ts",
   ],
   "exclude": ["scripts", "out", "dist"],
   "references": [{ "path": "../cody-shared" }],

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -15,9 +15,11 @@ import { UserHistory } from './UserHistory'
 import { ChatHistory, ChatMessage, View } from './utils/types'
 import { vscodeAPI } from './utils/VSCodeApi'
 
+const debugPlaceholder = 'No data yet'
+
 export function App(): React.ReactElement {
     const [devMode, setDevMode] = useState(false)
-    const [debugLog, setDebugLog] = useState(['No data yet'])
+    const [debugLog, setDebugLog] = useState([debugPlaceholder])
     const [view, setView] = useState<View | undefined>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
@@ -58,7 +60,13 @@ export function App(): React.ReactElement {
                     }
                     break
                 case 'debug':
-                    setDebugLog([...debugLog, message.data.message])
+                    if (debugLog.length === 1 && debugLog[0] === debugPlaceholder) {
+                        // Replace the placeholder message.
+                        setDebugLog([message.data.message])
+                    } else {
+                        // Add the new message to the top of the list.
+                        setDebugLog([message.data.message, ...debugLog])
+                    }
                     break
                 case 'history':
                     setInputHistory(message.data.messages.input)


### PR DESCRIPTION
This adds a singleton logger that allows us to easily log to the debug tab without much overhead in production mode.

Why can't we use vscodeAPI directly?
The logger needs access to acquireVsCodeAPI which is not available in `codebase-context/index.ts`. Hence we set the logging func in ChatViewProvider which has access to it.

As a first example, we log the context type and the context metadata (see debug tab in the screenshot)
![image](https://user-images.githubusercontent.com/26413131/228811578-652d0bd1-fde1-4781-9d0e-199b6dc6ae41.png)


## Test plan:
- Set debug=true in cody's vscode settings, reload the window
- Verify that the debug window appears
- Ask cody a question
- Check the debug tab for output


## App preview:

- [Web](https://sg-web-sh-cody-debug-logger.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

