### PR TITLE
References panel: Fetch search based definitions if no precise definitonis were found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - GitHub `repositoryQuery` searches now respect date ranges and use API requests more efficiently. #[49969](https://github.com/sourcegraph/sourcegraph/pull/49969)
+- Fixed an issue where search based references were not displayed in the references panel. [#50157](https://github.com/sourcegraph/sourcegraph/pull/50157)
 
 ### Removed
 

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -110,6 +110,7 @@ export const useCodeIntel = ({
         error: searchBasedError,
         fetch: fetchSearchBasedCodeIntel,
         fetchReferences: fetchSearchBasedReferences,
+        fetchDefinitions: fetchSearchBasedDefinitions,
     } = useSearchBasedCodeIntel({
         repo: variables.repository,
         commit: variables.commit,
@@ -145,6 +146,11 @@ export const useCodeIntel = ({
                     // If we've exhausted LSIF data and the flag is enabled, we add search-based data.
                     if (lsifData.references.endCursor === null && shouldMixPreciseAndSearchBasedReferences()) {
                         fetchSearchBasedReferences(deduplicateAndAddReferences)
+                    }
+
+                    // TODO: explain wth is going on here?
+                    if (lsifData.definitions.nodes.length === 0) {
+                        fetchSearchBasedDefinitions(setDefinitions)
                     }
                 } else {
                     fellBackToSearchBased.current = true

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -148,7 +148,8 @@ export const useCodeIntel = ({
                         fetchSearchBasedReferences(deduplicateAndAddReferences)
                     }
 
-                    // TODO: explain wth is going on here?
+                    // When no definitions are found, the hover tooltip falls back to a search based
+                    // search, regardless of the mixPreciseAndSearchBasedReferences setting.
                     if (lsifData.definitions.nodes.length === 0) {
                         fetchSearchBasedDefinitions(setDefinitions)
                     }

--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -37,6 +37,7 @@ type LocationHandler = (locations: Location[]) => void
 interface UseSearchBasedCodeIntelResult {
     fetch: (onReferences: LocationHandler, onDefinitions: LocationHandler) => void
     fetchReferences: (onReferences: LocationHandler) => void
+    fetchDefinitions: (onDefinitions: LocationHandler) => void
     loading: boolean
     error?: ErrorLike
 }
@@ -84,11 +85,10 @@ export const useSearchBasedCodeIntel = (options: UseSearchBasedCodeIntelOptions)
         [options]
     )
 
-    const fetch = useCallback(
-        (onReferences: LocationHandler, onDefinitions: LocationHandler) => {
-            fetchReferences(onReferences)
-
+    const fetchDefinitions = useCallback(
+        (onDefinitions: LocationHandler) => {
             setLoadingDefinitions(true)
+
             searchBasedDefinitions(options)
                 .then(definitions => {
                     onDefinitions(definitions)
@@ -99,13 +99,22 @@ export const useSearchBasedCodeIntel = (options: UseSearchBasedCodeIntelOptions)
                     setLoadingDefinitions(false)
                 })
         },
-        [options, fetchReferences]
+        [options]
+    )
+
+    const fetch = useCallback(
+        (onReferences: LocationHandler, onDefinitions: LocationHandler) => {
+            fetchReferences(onReferences)
+            fetchDefinitions(onDefinitions)
+        },
+        [fetchReferences, fetchDefinitions]
     )
 
     const errors = [definitionsError, referencesError].filter(isDefined)
     return {
         fetch,
         fetchReferences,
+        fetchDefinitions,
         loading: loadingReferences || loadingDefinitions,
         error: createAggregateError(errors),
     }


### PR DESCRIPTION
Workaround for https://github.com/sourcegraph/customer/issues/1995

This is a workaround to fix https://github.com/sourcegraph/customer/issues/1995 until we have time for a bigger scale fix up from all of our code intel APIs on the frontend (c.f. https://github.com/sourcegraph/sourcegraph/issues/49199). I’m OOO the next week and want to get a fix for the customer in though, hence this PR.

I did some investigations and this seems to match the behavior of the hover tooltip: If no precise definition is found, it seems to use the presence of a search based definition to render the buttons. It also seems to do this regardless of the `shouldMixPreciseAndSearchBasedReferences` flag.

## Test plan

(this is a bit more involved to reproduce so hear me out)

1. Enable npm package code intel feature flag
2. Add npm package to code host config
3. Add a precise index for the Sourcegraph repo 
4. Open a random tsx file (e.g. `SourcegraphWebApp.tsx`). It should show precise indexes and should show you that there are definitions on the hover tooltip.
5. Now click on the "Go to definition" button. Since there's no precise match, it will open the references panel.

Before the fix, the references panel would show no resources. After the fix, it will show search based definitions.

<img width="1153" alt="Screenshot 2023-03-30 at 13 08 36" src="https://user-images.githubusercontent.com/458591/228823934-8e72b79c-d22b-45e9-86d3-fbac0d770d9c.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-ref-panel-load-search-based.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

