### PR TITLE
ci: temporarily disable chromatic

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -451,6 +451,7 @@ func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		stepOpts := []bk.StepOpt{
 			withPnpmCache(),
+			bk.Skip("disabled, ongoing issue on their side"),
 			bk.AutomaticRetry(3),
 			bk.Cmd("./dev/ci/pnpm-install-with-retry.sh"),
 			bk.Cmd("pnpm gulp generate"),


### PR DESCRIPTION
We're waiting on their support to answer back. I'm disabling it because it's blocking the CI pipeline. 

See: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1680168645487459 and https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1680162412260729

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + `sg preview` 