### PR TITLE
cody: fix summarize history recipe

### DIFF
--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -58,6 +58,7 @@ export class GitHistory implements Recipe {
         const gitLogOutput = gitLogCommand.stdout.toString().trim()
 
         if (!gitLogOutput) {
+            // TODO: Show the warning within the Chat UI.
             console.error(
                 'No git history found for the selected option.',
                 gitLogCommand.stderr.toString(),
@@ -68,6 +69,7 @@ export class GitHistory implements Recipe {
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
         if (truncatedGitLogOutput.length < gitLogOutput.length) {
+            // TODO: Show the warning within the Chat UI.
             console.warn('Truncated extra long git log output, so summary may be incomplete.')
         }
 

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from 'child_process'
-import * as path from 'path'
 
 import { CodebaseContext } from '../../codebase-context'
 import { Editor } from '../../editor'
@@ -22,11 +21,10 @@ export class GitHistory implements Recipe {
         _intentDetector: IntentDetector,
         _codebaseContext: CodebaseContext
     ): Promise<Interaction | null> {
-        const activeEditor = editor.getActiveTextEditor()
-        if (!activeEditor) {
+        const dirPath = editor.getWorkspaceRootPath()
+        if (!dirPath) {
             return null
         }
-        const dirPath = path.dirname(activeEditor.filePath)
 
         const logFormat = '--pretty="Commit author: %an%nCommit message: %s%nChange description:%b%n"'
         const items = [
@@ -60,15 +58,17 @@ export class GitHistory implements Recipe {
         const gitLogOutput = gitLogCommand.stdout.toString().trim()
 
         if (!gitLogOutput) {
-            // TODO: Show the warning within the Chat UI.
-            // editor.showWarningMessage('No git history found for the selected option.')
+            console.error(
+                'No git history found for the selected option.',
+                gitLogCommand.stderr.toString(),
+                gitLogCommand.error?.message
+            )
             return null
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
         if (truncatedGitLogOutput.length < gitLogOutput.length) {
-            // TODO: Show the warning within the Chat UI.
-            // editor.showWarningMessage('Truncated extra long git log output, so summary may be incomplete.')
+            console.warn('Truncated extra long git log output, so summary may be incomplete.')
         }
 
         const timestamp = getShortTimestamp()

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -16,6 +16,7 @@ export interface ActiveTextEditorVisibleContent {
 }
 
 export interface Editor {
+    getWorkspaceRootPath(): string | null
     getActiveTextEditor(): ActiveTextEditor | null
     getActiveTextEditorSelection(): ActiveTextEditorSelection | null
     getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -42,6 +42,10 @@ export class MockKeywordContextFetcher implements KeywordContextFetcher {
 export class MockEditor implements Editor {
     constructor(private mocks: Partial<Editor> = {}) {}
 
+    public getWorkspaceRootPath(): string | null {
+        return this.mocks.getWorkspaceRootPath?.() ?? null
+    }
+
     public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {
         return this.mocks.getActiveTextEditorSelection?.() ?? null
     }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -22,7 +22,6 @@ import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, SecretStorage } from '../comm
 import { updateConfiguration } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { configureExternalServices } from '../external-services'
-import { getRootPath } from '../keyword-context/local-keyword-context-fetcher'
 import { getRgPath } from '../rg'
 import { TestSupport } from '../test-support'
 
@@ -103,7 +102,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     private async onDidReceiveMessage(message: any): Promise<void> {
-        const rootPath = getRootPath()
         switch (message.command) {
             case 'initialized':
                 await this.sendToken()
@@ -141,7 +139,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             case 'links':
                 await vscode.env.openExternal(vscode.Uri.parse(message.value))
                 break
-            case 'openFile':
+            case 'openFile': {
+                const rootPath = this.editor.getWorkspaceRootPath()
                 if (rootPath !== null) {
                     const uri = vscode.Uri.file(path.join(rootPath, message.filePath))
                     // This opens the file in the active column.
@@ -155,6 +154,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                     console.error('Could not open file because rootPath is null')
                 }
                 break
+            }
             default:
                 console.error('Invalid request type from Webview')
         }

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -11,18 +11,14 @@ const SURROUNDING_LINES = 50
 
 export class VSCodeEditor implements Editor {
     public getWorkspaceRootPath(): string | null {
-        const uri = vscode.window.activeTextEditor?.document.uri
+        const uri = vscode.window.activeTextEditor?.document?.uri
         if (uri) {
             const wsFolder = vscode.workspace.getWorkspaceFolder(uri)
             if (wsFolder) {
                 return wsFolder.uri.fsPath
             }
         }
-
-        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length >= 1) {
-            return vscode.workspace.workspaceFolders[0].uri.fsPath
-        }
-        return null
+        return vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath ?? null
     }
 
     public getActiveTextEditor(): ActiveTextEditor | null {

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -10,6 +10,21 @@ import {
 const SURROUNDING_LINES = 50
 
 export class VSCodeEditor implements Editor {
+    public getWorkspaceRootPath(): string | null {
+        const uri = vscode.window.activeTextEditor?.document.uri
+        if (uri) {
+            const wsFolder = vscode.workspace.getWorkspaceFolder(uri)
+            if (wsFolder) {
+                return wsFolder.uri.fsPath
+            }
+        }
+
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length >= 1) {
+            return vscode.workspace.workspaceFolders[0].uri.fsPath
+        }
+        return null
+    }
+
     public getActiveTextEditor(): ActiveTextEditor | null {
         const activeEditor = vscode.window.activeTextEditor
         if (!activeEditor || activeEditor.document.uri.scheme !== 'file') {

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -39,7 +39,11 @@ export async function configureExternalServices(
     }
     const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
 
-    const codebaseContext = new CodebaseContext(contextType, embeddingsSearch, new LocalKeywordContextFetcher(rgPath))
+    const codebaseContext = new CodebaseContext(
+        contextType,
+        embeddingsSearch,
+        new LocalKeywordContextFetcher(rgPath, editor)
+    )
 
     return {
         intentDetector: new SourcegraphIntentDetectorClient(client),

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
@@ -5,16 +5,17 @@ import { removeStopwords } from 'stopword'
 import StreamValues from 'stream-json/streamers/StreamValues'
 import * as vscode from 'vscode'
 
+import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { KeywordContextFetcher, KeywordContextFetcherResult } from '@sourcegraph/cody-shared/src/keyword-context'
 
 const fileExtRipgrepParams = ['-Tmarkdown', '-Tyaml', '-Tjson', '-g', '!*.lock']
 
 export class LocalKeywordContextFetcher implements KeywordContextFetcher {
-    constructor(private rgPath: string) {}
+    constructor(private rgPath: string, private editor: Editor) {}
 
     public async getContext(query: string, numResults: number): Promise<KeywordContextFetcherResult[]> {
         console.log('fetching keyword matches')
-        const rootPath = getRootPath()
+        const rootPath = this.editor.getWorkspaceRootPath()
         if (!rootPath) {
             return []
         }
@@ -209,21 +210,6 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
 
         return filenamesWithScores
     }
-}
-
-export function getRootPath(): string | null {
-    const uri = vscode.window.activeTextEditor?.document.uri
-    if (uri) {
-        const wsFolder = vscode.workspace.getWorkspaceFolder(uri)
-        if (wsFolder) {
-            return wsFolder.uri.fsPath
-        }
-    }
-
-    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length >= 1) {
-        return vscode.workspace.workspaceFolders[0].uri.fsPath
-    }
-    return null
 }
 
 async function fetchFileStats(


### PR DESCRIPTION
If there's no file opened, the summarize history recipe does not work. Use workspace root instead as the current working directory for git commands.

## Test plan

* Run Cody in dev mode
* Open a repo in VSCode, but don't open any files
* Run the summarize history command
* You should get a summary of Git history in the chat panel

## App preview:

- [Web](https://sg-web-rn-cody-fix-summarize-history.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
