### PR TITLE
[backport] embeddings: configurable repo embedding index cache size (#50146)

### DIFF
--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -60,7 +60,7 @@ Embeddings are a semantic representation of text. Embeddings are usually floatin
 
 To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. **If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker-compose or Kubernetes, set the environment variables on the `frontend`, `embeddings`, and `worker` containers.**
 
-### Using S3
+#### Using S3
 
 To target an S3 bucket you've already provisioned, set the following environment variables. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optional session token), or via the EC2 metadata API.
 
@@ -80,7 +80,7 @@ To target an S3 bucket you've already provisioned, set the following environment
 > NOTE: You don't need to set the `EMBEDDINGS_UPLOAD_AWS_ACCESS_KEY_ID` environment variable when using `EMBEDDINGS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` because role credentials will be automatically resolved. 
 
 
-### Using GCS
+#### Using GCS
 
 To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
 
@@ -90,8 +90,12 @@ To target a GCS bucket you've already provisioned, set the following environment
 - `EMBEDDINGS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE=</path/to/file>`
 - `EMBEDDINGS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT=<{"my": "content"}>`
 
-### Provisioning buckets
+#### Provisioning buckets
 
 If you would like to allow your Sourcegraph instance to control the creation and lifecycle configuration management of the target buckets, set the following environment variables:
 
 - `EMBEDDINGS_UPLOAD_MANAGE_BUCKET=true`
+
+### Environment variables for the `embeddings` service
+
+- `EMBEDDINGS_REPO_INDEX_CACHE_SIZE`: Number of repository embedding indexes to cache in memory (the default cache size is 5). Increasing the cache size will improve the search performance but require more memory resources.

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -12,9 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-const REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES = 5
+var cacheSize = env.MustGetInt("EMBEDDINGS_REPO_INDEX_CACHE_SIZE", 5, "Number of repository embedding indexes to cache in memory.")
 
 type downloadRepoEmbeddingIndexFn func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error)
 
@@ -28,7 +29,7 @@ func getCachedRepoEmbeddingIndex(
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn,
 ) (getRepoEmbeddingIndexFn, error) {
-	cache, err := lru.New(REPO_EMBEDDING_INDEX_CACHE_MAX_ENTRIES)
+	cache, err := lru.New(cacheSize)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating repo embedding index cache")
 	}


### PR DESCRIPTION
* Set the `EMBEDDINGS_REPO_INDEX_CACHE_SIZE` in my shell and ran the embeddings service, and checked if it picked up the variable.

(cherry picked from commit bbd157b41f85fa34a92bc2e424114eccd9a1e4ce)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
