### PR TITLE
Update SG instructions to add local admins with sg

### DIFF
--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -60,7 +60,7 @@ sg db reset-pg -db=all
 sg db reset-redis
 
 # Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
-sg db add-user -name=foo
+sg db add-user -username=foo
 `,
 		Category: CategoryDev,
 		Subcommands: []*cli.Command{

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -552,7 +552,7 @@ $ sg db reset-pg -db=all
 $ sg db reset-redis
 
 # Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
-$ sg db add-user -name=foo
+$ sg db add-user -username foo
 ```
 
 ### sg db delete-test-dbs

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -552,7 +552,7 @@ $ sg db reset-pg -db=all
 $ sg db reset-redis
 
 # Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
-$ sg db add-user -username foo
+$ sg db add-user -username=foo
 ```
 
 ### sg db delete-test-dbs


### PR DESCRIPTION
The actual command is: 

`sg db add-user -username`

and not 

`sg db add-user name=`

![Screenshot 2023-03-30 at 15 30 08](https://user-images.githubusercontent.com/7814431/228870578-5e0eea69-f672-4e13-9192-85bf2471b825.png)



## Test plan

Just encountered this and created a user with the guidance provided in the CLI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
