### PR TITLE
chore: cleanup unused code from perms

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -768,9 +768,3 @@ func (t requestType) String() string {
 	}
 	return strconv.Itoa(int(t))
 }
-
-// higherPriorityThan returns true if the current request type has higher
-// priority than the other one.
-func (t requestType) higherPriorityThan(t2 requestType) bool {
-	return t > t2
-}

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -503,44 +503,6 @@ WHERE
 	return basestore.ScanInts(s.Query(ctx, q))
 }
 
-// upsertUserPermissionsQuery upserts single row of user permissions, it does the
-// same thing as upsertUserPermissionsBatchQuery but also updates "synced_at"
-// column to the value of p.SyncedAt field.
-func upsertUserPermissionsQuery(p *authz.UserPermissions) (*sqlf.Query, error) {
-	const format = `
-INSERT INTO user_permissions
-  (user_id, permission, object_type, object_ids_ints, updated_at, synced_at)
-VALUES
-  (%s, 'read', 'repos', %s, %s, %s)
-ON CONFLICT ON CONSTRAINT
-  user_permissions_perm_object_unique
-DO UPDATE SET
-  object_ids_ints = excluded.object_ids_ints,
-  updated_at = excluded.updated_at,
-  synced_at = excluded.synced_at,
-  migrated = TRUE
-`
-
-	if p.UpdatedAt.IsZero() {
-		return nil, ErrPermsUpdatedAtNotSet
-	} else if p.SyncedAt.IsZero() {
-		return nil, ErrPermsSyncedAtNotSet
-	}
-
-	idsArray := make([]int32, 0, len(p.IDs))
-
-	for id := range p.IDs {
-		idsArray = append(idsArray, id)
-	}
-	return sqlf.Sprintf(
-		format,
-		p.UserID,
-		pq.Array(idsArray),
-		p.UpdatedAt.UTC(),
-		p.SyncedAt.UTC(),
-	), nil
-}
-
 // upsertUserPermissionsBatchQuery composes a SQL query that does both addition (for `addedUserIDs`) and deletion (
 // for `removedUserIDs`) of `objectIDs` using upsert.
 func upsertUserPermissionsBatchQuery(addedUserIDs, removedUserIDs, objectIDs []int32, perm authz.Perms, permType authz.PermType, updatedAt time.Time) (*sqlf.Query, error) {
@@ -705,44 +667,6 @@ ON CONFLICT DO NOTHING;
 	}
 
 	return nil
-}
-
-// upsertRepoPermissionsQuery upserts single row of repository permissions.
-func upsertRepoPermissionsQuery(p *authz.RepoPermissions) (*sqlf.Query, error) {
-	const format = `
-INSERT INTO repo_permissions
-  (repo_id, permission, user_ids_ints, updated_at, synced_at, unrestricted)
-VALUES
-  (%s, %s, %s, %s, %s, %s)
-ON CONFLICT ON CONSTRAINT
-  repo_permissions_perm_unique
-DO UPDATE SET
-  user_ids_ints = excluded.user_ids_ints,
-  updated_at = excluded.updated_at,
-  synced_at = excluded.synced_at,
-  unrestricted = excluded.unrestricted
-`
-
-	if p.UpdatedAt.IsZero() {
-		return nil, ErrPermsUpdatedAtNotSet
-	} else if p.SyncedAt.IsZero() {
-		return nil, ErrPermsSyncedAtNotSet
-	}
-
-	userIDs := make([]int32, 0, len(p.UserIDs))
-	for id := range p.UserIDs {
-		userIDs = append(userIDs, id)
-	}
-
-	return sqlf.Sprintf(
-		format,
-		p.RepoID,
-		p.Perm.String(),
-		pq.Array(userIDs),
-		p.UpdatedAt.UTC(),
-		p.SyncedAt.UTC(),
-		p.Unrestricted,
-	), nil
 }
 
 // upsertRepoPendingPermissionsQuery
@@ -1407,89 +1331,6 @@ WHERE %s
 	return ScanPermissions(s.Query(ctx, query))
 }
 
-// legacyLoadUserPermissions is a method that scans three values from one user_permissions table row:
-// []int32 (ids), time.Time (updatedAt) and nullable time.Time (syncedAt).
-func (s *permsStore) legacyLoadUserPermissions(ctx context.Context, userID int32, lock string) ([]int32, error) {
-	var err error
-	const format = `
-SELECT object_ids_ints
-FROM user_permissions
-WHERE user_id = %s
-AND permission = 'read'
-AND object_type = 'repos'
-`
-	q := sqlf.Sprintf(format+lock, userID)
-	ctx, save := s.observe(ctx, "load", "")
-	defer func() {
-		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
-		)
-	}()
-
-	ids, ok, err := basestore.ScanFirstInt32Array(s.Query(ctx, q))
-	if err != nil {
-		return nil, err
-	}
-
-	if !ok {
-		// One item is expected, return ErrPermsNotFound if no other errors occurred.
-		err = authz.ErrPermsNotFound
-		return nil, err
-	}
-
-	return ids, nil
-}
-
-type legacyRepoPermissionsResult struct {
-	ids          []int32
-	unrestricted bool
-}
-
-var scanLegacyRepoPermissions = basestore.NewFirstScanner(func(s dbutil.Scanner) (legacyRepoPermissionsResult, error) {
-	var r legacyRepoPermissionsResult
-	err := s.Scan(
-		pq.Array(&r.ids),
-		&r.unrestricted,
-	)
-	return r, err
-})
-
-// legacyLoadRepoPermissions is a method that scans three values from one repo_permissions table row:
-// []int32 (ids), time.Time (updatedAt) and nullable time.Time (syncedAt).
-func (s *permsStore) legacyLoadRepoPermissions(ctx context.Context, repoID int32, lock string) ([]int32, bool, error) {
-	var err error
-	const format = `
-SELECT user_ids_ints, unrestricted
-FROM repo_permissions
-WHERE repo_id = %s
-AND permission = 'read'
-`
-
-	q := sqlf.Sprintf(format+lock, repoID)
-
-	ctx, save := s.observe(ctx, "load", "")
-	defer func() {
-		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
-		)
-	}()
-
-	r, ok, err := scanLegacyRepoPermissions(s.Query(ctx, q))
-	if err != nil {
-		return nil, false, err
-	}
-
-	if !ok {
-		// One item is expected, return ErrPermsNotFound if no other errors occurred.
-		err = authz.ErrPermsNotFound
-		return nil, false, err
-	}
-
-	return r.ids, r.unrestricted, nil
-}
-
 // loadUserPendingPermissions is a method that scans three values from one user_pending_permissions table row:
 // int64 (id), []int32 (ids), time.Time (updatedAt).
 func (s *permsStore) loadUserPendingPermissions(ctx context.Context, p *authz.UserPendingPermissions, lock string) (id int64, ids []int32, updatedAt time.Time, err error) {
@@ -1706,22 +1547,12 @@ func (s *permsStore) CountReposWithOldestPerms(ctx context.Context, age time.Dur
 	return basestore.ScanInt(s.QueryRow(ctx, q))
 }
 
-const legacyUsersWithNoPermsQuery = `
-SELECT users.id
-FROM users
-LEFT OUTER JOIN user_permissions AS rp ON rp.user_id = users.id
-WHERE
-	users.deleted_at IS NULL
-AND %s
-AND rp.user_id IS NULL
-`
-
-const unifiedUsersWithNoPermsQuery = `
+const usersWithNoPermsQuery = `
 WITH rp AS (
 	-- Filter out users with permissions
 	SELECT DISTINCT user_id FROM user_repo_permissions
 	UNION
-	-- Filter out users with completed sync jobs
+	-- Filter out users with sync jobs
 	SELECT DISTINCT user_id FROM permission_sync_jobs WHERE user_id IS NOT NULL
 )
 SELECT users.id
@@ -1741,27 +1572,13 @@ func (s *permsStore) UserIDsWithNoPerms(ctx context.Context) ([]int32, error) {
 		filterSiteAdmins = sqlf.Sprintf("TRUE")
 	}
 
-	query := unifiedUsersWithNoPermsQuery
+	query := usersWithNoPermsQuery
 
 	q := sqlf.Sprintf(query, filterSiteAdmins)
 	return basestore.ScanInt32s(s.Query(ctx, q))
 }
 
-const legacyRepoIDsWithNoPermsQuery = `
-WITH rp AS (
-	SELECT perms.repo_id FROM repo_permissions AS perms
-	UNION
-	SELECT pending.repo_id FROM repo_pending_permissions AS pending
-)
-SELECT r.id
-FROM repo AS r
-LEFT OUTER JOIN rp ON rp.repo_id = r.id
-WHERE r.deleted_at IS NULL
-AND r.private = TRUE
-AND rp.repo_id IS NULL
-`
-
-const unifiedRepoIDsWithNoPermsQuery = `
+const repoIDsWithNoPermsQuery = `
 WITH rp AS (
 	-- Filter out repos with permissions
 	SELECT DISTINCT perms.repo_id FROM user_repo_permissions AS perms
@@ -1779,7 +1596,7 @@ AND rp.repo_id IS NULL
 `
 
 func (s *permsStore) RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, error) {
-	return scanRepoIDs(s.Query(ctx, sqlf.Sprintf(unifiedRepoIDsWithNoPermsQuery)))
+	return scanRepoIDs(s.Query(ctx, sqlf.Sprintf(repoIDsWithNoPermsQuery)))
 }
 
 func (s *permsStore) getCutoffClause(age time.Duration) *sqlf.Query {


### PR DESCRIPTION
## Description

Getting rid of unused code, which in turn removes lint warnings like:
```
   enterprise/internal/database/perms_store.go:711:6: func `upsertRepoPermissionsQuery` is unused (unused)
   func upsertRepoPermissionsQuery(p *authz.RepoPermissions) (*sqlf.Query, error) {
        ^
```

## Test plan
unit tests cover this
