### PR TITLE
Cody: Add a button to copy code from Cody's responses

### DIFF
--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -8,9 +8,18 @@ import { registerHighlightContributions, renderMarkdown as renderMarkdownCommon 
  * DOM. We could use isomorphic-dompurify for that, but that adds needless complexity for now. If
  * that becomes necessary, we can add that.
  */
-export function renderMarkdown(markdown: string): string {
+export function renderMarkdown(markdown: string, options: { speaker: 'human' | 'assistant' }): string {
     registerHighlightContributions()
 
-    // Add Cody-specific Markdown rendering if needed.
-    return renderMarkdownCommon(markdown)
+    let html = renderMarkdownCommon(markdown)
+
+    // Add Cody-specific Markdown for code blocks
+    if (options.speaker === 'assistant') {
+        html = html.replaceAll(
+            '<pre><code',
+            '<pre><button class="copy-code-button" onclick="navigator.clipboard.writeText(event.target.nextSibling.textContent).then(() => event.target.textContent = \'Copied\')">Copy</button><code'
+        )
+    }
+
+    return html
 }

--- a/client/cody/webviews/Chat.css
+++ b/client/cody/webviews/Chat.css
@@ -209,12 +209,6 @@
     position: relative;
 }
 
-.chat-code-block-copy-btn {
-    position: absolute;
-    top: 0;
-    right: 0;
-}
-
 .link-button {
     background: none;
     border: none;
@@ -222,4 +216,27 @@
     cursor: pointer;
     font-size: inherit;
     text-decoration: underline;
+}
+
+pre {
+    position: relative;
+}
+
+.copy-code-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.2em;
+    font-family: var(--vscode-font-family);
+    font-size: inherit;
+    text-decoration: underline;
+    color: var(--vscode-textLink-foreground);
+    background: none;
+    border: none;
+    cursor: pointer;
+    visibility: hidden;
+}
+
+pre:hover > .copy-code-button {
+    visibility: visible;
 }

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -122,7 +122,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                                         {message.displayText && (
                                             <p
                                                 dangerouslySetInnerHTML={{
-                                                    __html: renderMarkdown(message.displayText),
+                                                    __html: renderMarkdown(message.displayText, {
+                                                        speaker: message.speaker,
+                                                    }),
                                                 }}
                                             />
                                         )}
@@ -146,7 +148,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                                         {messageInProgress.displayText ? (
                                             <p
                                                 dangerouslySetInnerHTML={{
-                                                    __html: renderMarkdown(messageInProgress.displayText),
+                                                    __html: renderMarkdown(messageInProgress.displayText, {
+                                                        speaker: messageInProgress.speaker,
+                                                    }),
                                                 }}
                                             />
                                         ) : (


### PR DESCRIPTION
It would be nicer if we injected a React component for the copy button, but for now this is a succinct way to add a simple "copy" button for Cody's generated code snippets.

## Test plan

Manual test:

- Run Cody extension w/ VScode, Run and Debug, Launch Cody Extension
- Ask Cody to write "Hello world" in a programming language
- A "Copy" button should appear on hover
- Clicking the button should change "Copy" to "Copied"
- Paste into the editor to verify the code is in the clipboard

![Screenshot 2023-03-31 at 0 15 20](https://user-images.githubusercontent.com/55120/228883773-e199dce2-0122-4902-a1fa-0835b26a35f9.png)
