### PR TITLE
search input: Only insert type:symbol when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - GitHub `repositoryQuery` searches now respect date ranges and use API requests more efficiently. #[49969](https://github.com/sourcegraph/sourcegraph/pull/49969)
 - Fixed an issue where search based references were not displayed in the references panel. [#50157](https://github.com/sourcegraph/sourcegraph/pull/50157)
 - Fixed an issue where Slack code monitoring notifications failed when the message was too long. [#50083](https://github.com/sourcegraph/sourcegraph/pull/50083)
+- Symbol suggestions only insert `type:symbol` filters when necessary. [#50183](https://github.com/sourcegraph/sourcegraph/pull/50183)
 
 ### Removed
 


### PR DESCRIPTION
At the moment symbol suggestions will always insert 'type:symbol', which can produce incorrect queries if the current query already contains a 'type:' filter. This PR builds on top of #50554 and only inserts a 'type:' filter if the relevant branch of the query doesn't already contain one.


https://user-images.githubusercontent.com/179026/231516689-6c1b0a73-d25a-41cc-b032-e7a3d081ef5a.mp4



## Test plan

- Enter a query into the search input that triggers symbols suggestions and select a symbol suggestions -> the suggestion is inserted with `type:symbol`
- Like above but also include e.g. `type:diff` in the query -> only the symbol name (not `type:symbol`) is inserted into the input

## App preview:

- [Web](https://sg-web-fkling-search-input-symbol.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

