### PR TITLE
Revert "ci: temporarily disable chromatic (#50160)"

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -451,7 +451,6 @@ func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		stepOpts := []bk.StepOpt{
 			withPnpmCache(),
-			bk.Skip("disabled, ongoing issue on their side"),
 			bk.AutomaticRetry(3),
 			bk.Cmd("./dev/ci/pnpm-install-with-retry.sh"),
 			bk.Cmd("pnpm gulp generate"),


### PR DESCRIPTION
This reverts commit 24d14e6d8e02a7ee629dd8f647206705420e5efc.

Chromatic says it is fixed:
* I tested it seperately
* Also doing a main dry run

## Test plan
main-dry-run
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
