### PR TITLE
Update StatusMessagesNavItem info color to WCAG a11y contrast

### DIFF
--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -207,7 +207,7 @@ export const CloudInfoIconRefresh = React.forwardRef((props, reference) => (
         />
         <path
             d="M19.9649 9.49464C19.9649 11.7987 18.097 13.6665 15.793 13.6665C13.4889 13.6665 11.6211 11.7987 11.6211 9.49464C11.6211 7.19057 13.4889 5.32275 15.793 5.32275C18.097 5.32275 19.9649 7.19057 19.9649 9.49464Z"
-            fill="#72dbe8"
+            fill="#0B70DB"
         />
     </svg>
 )) as ForwardReferenceComponent<'svg', React.PropsWithChildren<IconProps>>

--- a/client/web/src/nav/StatusMessagesNavItem.module.scss
+++ b/client/web/src/nav/StatusMessagesNavItem.module.scss
@@ -30,7 +30,7 @@
     }
 
     &--border-info {
-        border-left: 2px solid var(--info);
+        border-left: 2px solid var(--primary);
     }
 
     &--border-progress {

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -103,7 +103,7 @@ function entryIcon(entryType: EntryType): JSX.Element {
             return (
                 <Icon
                     {...sharedProps}
-                    className={classNames('text-info', styles.icon)}
+                    className={classNames('text-primary', styles.icon)}
                     svgPath={mdiInformationOutline}
                     aria-label="Information"
                 />


### PR DESCRIPTION
Follow up to #[49809](https://github.com/sourcegraph/sourcegraph/pull/49809#issuecomment-1479924623)

Follow up design task: #50190.

![image](https://user-images.githubusercontent.com/59381432/228912984-45135f5c-a779-43bc-9f46-fccad0d46179.png)

## Test plan
- Ensure color passes webaim.org/resources/contrastchecker/
