### PR TITLE
Add queue rank to permissions sync jobs table

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -116,7 +116,7 @@ export const PermissionsSyncJobStatusBadge: React.FunctionComponent<PermissionsS
             tooltip={cancellationReason ?? failureMessage ?? warningMessage ?? undefined}
             variant={partialSuccess ? 'warning' : JOB_STATE_METADATA_MAPPING[state].badgeVariant}
         >
-            {partialSuccess ? 'PARTIAL' : state} {state === PermissionsSyncJobState.QUEUED ? `#${job.queueRank}` : ''}
+            {partialSuccess ? 'PARTIAL' : state} {job.placeInQueue ? `#${job.placeInQueue}` : ''}
         </Badge>
     )
 }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -116,7 +116,7 @@ export const PermissionsSyncJobStatusBadge: React.FunctionComponent<PermissionsS
             tooltip={cancellationReason ?? failureMessage ?? warningMessage ?? undefined}
             variant={partialSuccess ? 'warning' : JOB_STATE_METADATA_MAPPING[state].badgeVariant}
         >
-            {partialSuccess ? 'PARTIAL' : state}
+            {partialSuccess ? 'PARTIAL' : state} {state === PermissionsSyncJobState.QUEUED ? `#${job.queueRank}` : ''}
         </Badge>
     )
 }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -287,5 +287,6 @@ function createSyncJobMock(
               ]
             : [],
         partialSuccess: partial,
+        placeInQueue: 1,
     }
 }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -90,7 +90,7 @@ const DEFAULT_FILTERS = {
     query: '',
     partial: '',
 }
-const PERMISSIONS_SYNC_JOBS_POLL_INTERVAL = 5000
+const PERMISSIONS_SYNC_JOBS_POLL_INTERVAL = 2000
 
 interface Props extends TelemetryProps {
     minimal?: boolean

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -56,7 +56,7 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         priority
         noPerms
         invalidateCaches
-        queueRank
+        placeInQueue
         codeHostStates {
             ...CodeHostState
         }

--- a/client/web/src/site-admin/permissions-center/backend.ts
+++ b/client/web/src/site-admin/permissions-center/backend.ts
@@ -56,6 +56,7 @@ export const PERMISSIONS_SYNC_JOBS_QUERY = gql`
         priority
         noPerms
         invalidateCaches
+        queueRank
         codeHostStates {
             ...CodeHostState
         }

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -756,9 +756,9 @@ type PermissionsSyncJob implements Node {
     """
     partialSuccess: Boolean!
     """
-    Rank of the permissions syncing job in processing queue. Rank if 0 if the job is not queued.
+    Rank of the permissions syncing job in processing queue.
     """
-    queueRank: Int!
+    placeInQueue: Int
 }
 
 """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -755,6 +755,10 @@ type PermissionsSyncJob implements Node {
     Show if the job has finished with a partially successful result.
     """
     partialSuccess: Boolean!
+    """
+    Rank of the permissions syncing job in processing queue. Rank if 0 if the job is not queued.
+    """
+    queueRank: Int!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -39,6 +39,7 @@ type PermissionsSyncJobResolver interface {
 	PermissionsFound() int32
 	CodeHostStates() []CodeHostStateResolver
 	PartialSuccess() bool
+	QueueRank() int32
 }
 
 type PermissionsSyncJobReasonResolver interface {

--- a/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
+++ b/cmd/frontend/graphqlbackend/permissions_sync_jobs.go
@@ -39,7 +39,7 @@ type PermissionsSyncJobResolver interface {
 	PermissionsFound() int32
 	CodeHostStates() []CodeHostStateResolver
 	PartialSuccess() bool
-	QueueRank() int32
+	PlaceInQueue() *int32
 }
 
 type PermissionsSyncJobReasonResolver interface {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -106,7 +106,7 @@ func (s *permissionsSyncJobConnectionStore) UnmarshalCursor(cursor string, _ dat
 }
 
 func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.PaginationArgs) database.ListPermissionSyncJobOpts {
-	opts := database.ListPermissionSyncJobOpts{WithQueueRank: true}
+	opts := database.ListPermissionSyncJobOpts{WithPlaceInQueue: true}
 	if pageArgs != nil {
 		opts.PaginationArgs = pageArgs
 	}
@@ -115,10 +115,6 @@ func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.Pagin
 	}
 	if s.args.State != nil {
 		opts.State = *s.args.State
-
-		if opts.State != "QUEUED" {
-			opts.WithQueueRank = false
-		}
 	}
 	if s.args.Partial != nil {
 		opts.PartialSuccess = *s.args.Partial
@@ -264,7 +260,7 @@ func (p *permissionsSyncJobResolver) PartialSuccess() bool {
 	return p.job.IsPartialSuccess
 }
 
-func (p *permissionsSyncJobResolver) QueueRank() int32 {
+func (p *permissionsSyncJobResolver) PlaceInQueue() *int32 {
 	return p.job.QueueRank
 }
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -106,7 +106,7 @@ func (s *permissionsSyncJobConnectionStore) UnmarshalCursor(cursor string, _ dat
 }
 
 func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.PaginationArgs) database.ListPermissionSyncJobOpts {
-	opts := database.ListPermissionSyncJobOpts{}
+	opts := database.ListPermissionSyncJobOpts{WithQueueRank: true}
 	if pageArgs != nil {
 		opts.PaginationArgs = pageArgs
 	}
@@ -115,6 +115,10 @@ func (s *permissionsSyncJobConnectionStore) getListArgs(pageArgs *database.Pagin
 	}
 	if s.args.State != nil {
 		opts.State = *s.args.State
+
+		if opts.State != "QUEUED" {
+			opts.WithQueueRank = false
+		}
 	}
 	if s.args.Partial != nil {
 		opts.PartialSuccess = *s.args.Partial
@@ -258,6 +262,10 @@ func (p *permissionsSyncJobResolver) CodeHostStates() []graphqlbackend.CodeHostS
 
 func (p *permissionsSyncJobResolver) PartialSuccess() bool {
 	return p.job.IsPartialSuccess
+}
+
+func (p *permissionsSyncJobResolver) QueueRank() int32 {
+	return p.job.QueueRank
 }
 
 type codeHostStateResolver struct {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -261,7 +261,7 @@ func (p *permissionsSyncJobResolver) PartialSuccess() bool {
 }
 
 func (p *permissionsSyncJobResolver) PlaceInQueue() *int32 {
-	return p.job.QueueRank
+	return p.job.PlaceInQueue
 }
 
 type codeHostStateResolver struct {

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -477,6 +477,7 @@ type ListPermissionSyncJobOpts struct {
 	NotNullProcessAfter bool
 	NotCanceled         bool
 	PartialSuccess      bool
+	WithQueueRank       bool
 
 	// SearchType and Query are related to text search for sync jobs.
 	SearchType PermissionsSyncSearchType
@@ -606,9 +607,22 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 		}
 	}
 
+	columns := sqlf.Join(PermissionSyncJobColumns, ", ")
+	if opts.WithQueueRank {
+		columns = sqlf.Sprintf("%s, CASE WHEN queue_ranks.rank IS NOT NULL THEN queue_ranks.rank ELSE 0 END AS queue_rank", columns)
+		joinClause = sqlf.Sprintf(`
+			%s
+			LEFT JOIN (
+				SELECT id, ROW_NUMBER() OVER (ORDER BY permission_sync_jobs.priority DESC, permission_sync_jobs.process_after ASC NULLS FIRST, permission_sync_jobs.id ASC) AS rank
+				FROM permission_sync_jobs
+				WHERE state = 'queued'
+			) AS queue_ranks ON queue_ranks.id = permission_sync_jobs.id
+		`, joinClause)
+	}
+
 	q := sqlf.Sprintf(
 		listPermissionSyncJobQueryFmtstr,
-		sqlf.Join(PermissionSyncJobColumns, ", "),
+		columns,
 		joinClause,
 		whereClause,
 	)
@@ -623,11 +637,18 @@ func (s *permissionSyncJobStore) List(ctx context.Context, opts ListPermissionSy
 
 	var syncJobs []*PermissionSyncJob
 	for rows.Next() {
-		job, err := ScanPermissionSyncJob(rows)
-		if err != nil {
-			return nil, err
+		var job PermissionSyncJob
+		if opts.WithQueueRank {
+			if err := scanPermissionSyncJobWithQueueRank(&job, rows); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := scanPermissionSyncJob(&job, rows); err != nil {
+				return nil, err
+			}
+
 		}
-		syncJobs = append(syncJobs, job)
+		syncJobs = append(syncJobs, &job)
 	}
 
 	return syncJobs, nil
@@ -754,6 +775,7 @@ type PermissionSyncJob struct {
 	PermissionsFound   int
 	CodeHostStates     []PermissionSyncCodeHostState
 	IsPartialSuccess   bool
+	QueueRank          int32
 }
 
 func (j *PermissionSyncJob) RecordID() int { return j.ID }
@@ -832,6 +854,51 @@ func scanPermissionSyncJob(job *PermissionSyncJob, s dbutil.Scanner) error {
 		&job.PermissionsFound,
 		pq.Array(&codeHostStates),
 		&job.IsPartialSuccess,
+	); err != nil {
+		return err
+	}
+
+	job.ExecutionLogs = append(job.ExecutionLogs, executionLogs...)
+	job.CodeHostStates = append(job.CodeHostStates, codeHostStates...)
+
+	return nil
+}
+
+func scanPermissionSyncJobWithQueueRank(job *PermissionSyncJob, s dbutil.Scanner) error {
+	var executionLogs []executor.ExecutionLogEntry
+	var codeHostStates []PermissionSyncCodeHostState
+
+	if err := s.Scan(
+		&job.ID,
+		&job.State,
+		&job.Reason,
+		&job.CancellationReason,
+		&dbutil.NullInt32{N: &job.TriggeredByUserID},
+		&job.FailureMessage,
+		&job.QueuedAt,
+		&dbutil.NullTime{Time: &job.StartedAt},
+		&dbutil.NullTime{Time: &job.FinishedAt},
+		&dbutil.NullTime{Time: &job.ProcessAfter},
+		&job.NumResets,
+		&job.NumFailures,
+		&dbutil.NullTime{Time: &job.LastHeartbeatAt},
+		pq.Array(&executionLogs),
+		&job.WorkerHostname,
+		&job.Cancel,
+
+		&dbutil.NullInt{N: &job.RepositoryID},
+		&dbutil.NullInt{N: &job.UserID},
+
+		&job.Priority,
+		&job.NoPerms,
+		&job.InvalidateCaches,
+
+		&job.PermissionsAdded,
+		&job.PermissionsRemoved,
+		&job.PermissionsFound,
+		pq.Array(&codeHostStates),
+		&job.IsPartialSuccess,
+		&job.QueueRank,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add queue rank to permission sync job items. This PR might be revered if it will not pass performance testing on production.

![image](https://user-images.githubusercontent.com/22571395/228932283-673d7792-1f29-45db-b54d-6686426c199f.png)


TODO
Test
- [ ] add unit tests

## Test plan
- unit tests need to be added