### PR TITLE
Chore: Cleanup previous ValueLegendListItem fix

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { Container, Input, LoadingSpinner, ErrorAlert, PageSwitcher } from '@sourcegraph/wildcard'
+import { Container, Input, ErrorAlert, PageSwitcher } from '@sourcegraph/wildcard'
 
 import { EXTERNAL_SERVICE_IDS_AND_NAMES } from '../components/externalServices/backend'
 import {
@@ -366,7 +366,7 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent = () => {
         }
         if (loading && !error) {
             items.splice(0, 1, {
-                value: <LoadingSpinner />,
+                value: 'loading',
                 description: 'Repositories',
             })
         }

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, ReactNode } from 'react'
+import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
-import { Link, Text, Tooltip } from '@sourcegraph/wildcard'
+import { Link, LoadingSpinner, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { formatNumber } from '../utils'
 
@@ -12,8 +12,7 @@ import styles from './index.module.scss'
 interface ValueLegendItemProps {
     color?: string
     description: string
-    // Value is a number or LoadingSpinner
-    value: number | string | ReactNode
+    value: number | string
     tooltip?: string
     className?: string
     filter?: { name: string; value: string }
@@ -29,6 +28,10 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     filter,
     onClick,
 }) => {
+    if (value === 'loading') {
+        return <LoadingSpinner className={classNames(styles.count, 'my-auto')} />
+    }
+
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
     const location = useLocation()
@@ -42,11 +45,12 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     }, [filter, location.search])
 
     const tooltipOnNumber =
-        formattedNumber !== unformattedNumber && typeof value !== 'object'
+        formattedNumber !== unformattedNumber
             ? isNaN(parseFloat(unformattedNumber))
                 ? unformattedNumber
                 : Intl.NumberFormat('en').format(parseFloat(unformattedNumber))
             : undefined
+
     return (
         <div className={classNames(styles.legendItem, className)}>
             <Tooltip content={tooltipOnNumber}>

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -28,10 +28,6 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     filter,
     onClick,
 }) => {
-    if (value === 'loading') {
-        return <LoadingSpinner className={classNames(styles.count, 'my-auto')} />
-    }
-
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
     const location = useLocation()
@@ -105,9 +101,17 @@ export const ValueLegendList: React.FunctionComponent<ValueLegendListProps> = ({
         <div className={styles.legendLeftPanel}>
             {items
                 .filter(item => item.position !== 'right')
-                .map(item => (
-                    <ValueLegendItem key={item.description} {...item} />
-                ))}
+                .map((item, index) => {
+                    if (item.value === 'loading') {
+                        return (
+                            <div key={`loading-${index}`} className={classNames(styles.count, 'my-auto')}>
+                                <LoadingSpinner />
+                            </div>
+                        )
+                    } else {
+                        return <ValueLegendItem key={item.description} {...item} />
+                    }
+                })}
         </div>
         <div className={styles.legendRightPanel}>
             {items

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -108,9 +108,8 @@ export const ValueLegendList: React.FunctionComponent<ValueLegendListProps> = ({
                                 <LoadingSpinner />
                             </div>
                         )
-                    } else {
-                        return <ValueLegendItem key={item.description} {...item} />
                     }
+                    return <ValueLegendItem key={item.description} {...item} />
                 })}
         </div>
         <div className={styles.legendRightPanel}>


### PR DESCRIPTION
Follow up chore to #48284. Cleans up loading icon render to be more clean. ([Comment](https://github.com/sourcegraph/sourcegraph/pull/48284/files#r1119022616))

### Fix recap
**BEFORE**
![image](https://user-images.githubusercontent.com/59381432/221622667-1c575eac-80ae-40ee-b383-6e0a645340a8.png)

**AFTER**
![Screenshot 2023-02-27 at 9 30 58 AM](https://user-images.githubusercontent.com/59381432/221622686-a325b311-da41-400c-a1de-2cebbe6e82fb.png)

## Test plan
- Ensure no breaking changes to repo table loading state
- To force loading state on `/site-admin/repositories` view, change [this line](https://github.com/sourcegraph/sourcegraph/pull/50196/files#diff-5b98a3dd19e2db56d6107f263efe0288f72f3fc0eb1c3debb0799807bdb089c4L367) to `if (!loading && !error) {...`

## App preview:

- [Web](https://sg-web-becca-chore-value-legend-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

