### PR TITLE
codeintel-qa: pass $HOME / $USER through to src-cli

### DIFF
--- a/dev/codeintel-qa/cmd/upload/upload.go
+++ b/dev/codeintel-qa/cmd/upload/upload.go
@@ -129,10 +129,9 @@ func upload(ctx context.Context, repoName, commit, file string) (string, error) 
 
 	cmd := exec.CommandContext(ctx, "src", append([]string{"lsif", "upload", "-json"}, args...)...)
 	cmd.Dir = tempDir
-	cmd.Env = []string{
-		fmt.Sprintf("SRC_ENDPOINT=%s", internal.SourcegraphEndpoint),
-		fmt.Sprintf("SRC_ACCESS_TOKEN=%s", internal.SourcegraphAccessToken),
-	}
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SRC_ENDPOINT=%s", internal.SourcegraphEndpoint))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SRC_ACCESS_TOKEN=%s", internal.SourcegraphAccessToken))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
If using a binary release of src-cli, it is not possible to run the codeintel-qa test suite because `src` is not built with CGO and `$HOME` and `$USER` are not passed through in the environment, leading to a `user.Current` error.

This fixes the issue.

Helps #49865

## Test plan

Ran `go run ./cmd/upload`