### PR TITLE
Cody: Fix Windows file path error

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -289,7 +289,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     ): Promise<void> {
         this.webview = webviewView.webview
 
-        const extensionPath = vscode.Uri.parse(this.extensionPath)
+        const extensionPath = vscode.Uri.file(this.extensionPath)
         const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist')
 
         webviewView.webview.options = {


### PR DESCRIPTION
It looks like `vscode.Uri.parse()` leads to a malfunctioning Uri object on Windows systems. This PR changes  `vscode.Uri.parse()` to `vscode.Uri.file()`, which converts a file system path to a Uri object.

More context [here](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1680058607541409)

Windows Error:
```
log.ts:404   ERR Unable to resolve filesystem provider with relative file path 'c:\Users\user\.vscode\extensions\sourcegraph.cody-ai-0.0.3/dist/index.html'
```
![image (51)](https://user-images.githubusercontent.com/69164745/228989701-d19ea57b-553d-4015-b236-252fba0c5ece.png)

## Test plan
Tested on Windows 10

![cody](https://user-images.githubusercontent.com/69164745/228973540-3c6384de-6173-4487-bdae-671c61ec9ee1.JPG)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-gabe-cody-relative-path.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
