### PR TITLE
blobstore: fix multipart uploads

### DIFF
--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -134,7 +134,7 @@ func TestCompose(t *testing.T) {
 
 	// Compose the objects together.
 	resultLength, err := store.Compose(ctx, "foobar-result", "foobar1", "foobar2", "foobar3")
-	autogold.Expect([]interface{}{0, "<nil>"}).Equal(t, []any{resultLength, fmt.Sprint(err)})
+	autogold.Expect([]interface{}{26, "<nil>"}).Equal(t, []any{resultLength, fmt.Sprint(err)})
 
 	// Check the resulting object
 	reader, err := store.Get(ctx, "foobar-result")
@@ -145,7 +145,7 @@ func TestCompose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Expect("").Equal(t, string(data))
+	autogold.Expect("Hello 1! Hello 2! Hello 3!").Equal(t, string(data))
 
 	// Ensure the three objects we uploaded have been deleted.
 	assertObjectDoesNotExist(ctx, store, t, "foobar1")

--- a/cmd/blobstore/internal/blobstore/multipart.go
+++ b/cmd/blobstore/internal/blobstore/multipart.go
@@ -142,7 +142,7 @@ func (s *Service) completeUpload(ctx context.Context, bucketName, objectName, up
 	if err != nil {
 		return err
 	}
-	maxPartNumber, minPartNumber := upload.partNumberRange()
+	minPartNumber, maxPartNumber := upload.partNumberRange()
 
 	// Open the parts of the upload.
 	var partReaders []io.Reader
@@ -182,7 +182,7 @@ func (s *Service) completeUpload(ctx context.Context, bucketName, objectName, up
 		return errors.Wrap(err, "creating composed object")
 	}
 
-	s.Log.Debug("completeUpload", sglog.String("key", bucketName+"/"+objectName), sglog.String("uploadID", uploadID))
+	s.Log.Debug("completeUpload", sglog.String("key", bucketName+"/"+objectName), sglog.String("uploadID", uploadID), sglog.Int("parts", len(partReaders)))
 	return nil
 }
 
@@ -211,7 +211,7 @@ func (s *Service) abortUpload(ctx context.Context, bucketName, objectName, uploa
 	if err != nil {
 		return err
 	}
-	maxPartNumber, minPartNumber := upload.partNumberRange()
+	minPartNumber, maxPartNumber := upload.partNumberRange()
 
 	// Delete the upload
 	if err := s.deletePendingUpload(ctx, bucketName, objectName, uploadID, minPartNumber, maxPartNumber); err != nil {


### PR DESCRIPTION
Fixes a bug (and bad test) that prevented multipart uploads from working. Caught by codeintel-qa test suite.

## Test plan

Fixed test.