### PR TITLE
dev: use new Go blobstore implementation in dev env

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -621,27 +621,21 @@ commands:
       EXECUTOR_QUEUE_NAME: batches
 
   blobstore:
-    cmd: |
-      docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
-      docker run --rm \
-        --name=$CONTAINER \
-        --cpus=1 \
-        --memory=1g \
-        -p 0.0.0.0:9000:9000 \
-        -e 'S3PROXY_AUTHORIZATION=none' \
-        -v "$BLOBSTORE_DISK":/data \
-        $IMAGE >"$BLOBSTORE_LOG_FILE" 2>&1
+    cmd: .bin/blobstore
     install: |
-      mkdir -p $BLOBSTORE_LOGS
-      mkdir -p $BLOBSTORE_DISK
-      chmod u+rwx $BLOBSTORE_LOGS $BLOBSTORE_DISK
-      CACHE=true ./docker-images/blobstore/build.sh >$BLOBSTORE_LOG_FILE 2>&1
+      # Ensure the old blobstore Docker container is not running
+      docker rm -f blobstore
+      if [ -n "$DELVE" ]; then
+        export GCFLAGS='all=-N -l'
+      fi
+      go build -gcflags="$GCFLAGS" -o .bin/blobstore github.com/sourcegraph/sourcegraph/cmd/blobstore
+    checkBinary: .bin/blobstore
+    watch:
+      - lib
+      - internal
+      - cmd/blobstore
     env:
-      BLOBSTORE_DISK: $HOME/.sourcegraph-dev/data/blobstore
-      BLOBSTORE_LOGS: $HOME/.sourcegraph-dev/logs/blobstore
-      BLOBSTORE_LOG_FILE: $HOME/.sourcegraph-dev/logs/blobstore/blobstore.log
-      IMAGE: sourcegraph/blobstore
-      CONTAINER: blobstore
+      BLOBSTORE_DATA_DIR: $HOME/.sourcegraph-dev/data/blobstore-go
 
   redis-postgres:
     # Add the following overwrites to your sg.config.overwrite.yaml to use the docker-compose


### PR DESCRIPTION
Today, Sourcegraph [ships the Java service s3proxy](https://github.com/sourcegraph/sourcegraph/tree/main/docker-images/blobstore) as our S3-compatible blob storage provider out-of-the-box. I have been working on [a Go implementation](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/blobstore) which is generally nicer, reports errors in a more logical way, and just generally fits into Sourcegraph better.

We already ship the new Go implementation as part of the Sourcegraph app (it is easier to distribute) and now with this PR we will also use the new Go implementation in all our dev environments, too.

This is one step along the road to ultimately getting rid of s3proxy entirely: once we feel confident about running the new Go implementation in our dev environments, we can begin to ship the new implementation to all our enterprise customers as well. There are a few [small issues](https://github.com/sourcegraph/sourcegraph/issues/45594#issuecomment-1421935287) we should fix first.

Depends on #50211
Fixes #49865
Helps #45594

## Test plan

This commit can be easily reverted. If issues arise, please feel free to revert it.

To test this I ran the codeintel-qa test suite:

```
sg start enterprise-codeintel
export SOURCEGRAPH_SUDO_TOKEN=<redacted>
export SOURCEGRAPH_BASE_URL=http://localhost:3080
cd dev/codeintel-qa
go run ./cmd/download
go run ./cmd/upload
go run ./cmd/query
```
