### PR TITLE
permission sync jobs: don't highlight if 0 added/0 removed

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -242,11 +242,17 @@ export const PermissionsSyncJobNumbers: React.FunctionComponent<{ job: Permissio
     added,
 }) =>
     added ? (
-        <div className="text-success text-right">
-            +<b>{job.permissionsAdded}</b>
-        </div>
-    ) : (
+        job.permissionsAdded > 0 ? (
+            <div className="text-success text-right">
+                +<b>{job.permissionsAdded}</b>
+            </div>
+        ) : (
+            <div className="text-right">{job.permissionsAdded}</div>
+        )
+    ) : job.permissionsRemoved > 0 ? (
         <div className="text-danger text-right">
             -<b>{job.permissionsRemoved}</b>
         </div>
+    ) : (
+        <div className="text-right">{job.permissionsRemoved}</div>
     )

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobNode.tsx
@@ -242,17 +242,13 @@ export const PermissionsSyncJobNumbers: React.FunctionComponent<{ job: Permissio
     added,
 }) =>
     added ? (
-        job.permissionsAdded > 0 ? (
-            <div className="text-success text-right">
-                +<b>{job.permissionsAdded}</b>
-            </div>
-        ) : (
-            <div className="text-right">{job.permissionsAdded}</div>
-        )
-    ) : job.permissionsRemoved > 0 ? (
-        <div className="text-danger text-right">
-            -<b>{job.permissionsRemoved}</b>
+        <div className={classNames('text-right', job.permissionsAdded > 0 ? 'text-success' : styles.textSuccessMuted)}>
+            {job.permissionsAdded > 0 && '+'}
+            <b>{job.permissionsAdded}</b>
         </div>
     ) : (
-        <div className="text-right">{job.permissionsRemoved}</div>
+        <div className={classNames('text-right', job.permissionsRemoved > 0 ? 'text-danger' : styles.textDangerMuted)}>
+            {job.permissionsRemoved > 0 && '-'}
+            <b>{job.permissionsRemoved}</b>
+        </div>
     )

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -185,8 +185,8 @@ function getSyncJobs(): PermissionsSyncJob[] {
                 subject,
                 reason,
                 state === PermissionsSyncJobState.COMPLETED && index > 10,
-                index % 2 == 0 ? index + 10 : 0,
-                index % 2 == 0 ? index + 5 : 0
+                index % 4 === 0 ? 0 : index + 10,
+                index % 4 === 0 ? 0 : index + 5
             )
         )
     }

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -184,7 +184,9 @@ function getSyncJobs(): PermissionsSyncJob[] {
                 state,
                 subject,
                 reason,
-                state === PermissionsSyncJobState.COMPLETED && index > 10
+                state === PermissionsSyncJobState.COMPLETED && index > 10,
+                index % 2 == 0 ? index + 10 : 0,
+                index % 2 == 0 ? index + 5 : 0
             )
         )
     }
@@ -236,7 +238,9 @@ function createSyncJobMock(
     state: PermissionsSyncJobState,
     subject: subject,
     reason: reason,
-    partial: boolean = false
+    partial: boolean = false,
+    permissionsAdded: number = 1337,
+    permissionsRemoved: number = 42
 ): PermissionsSyncJob {
     return {
         __typename: 'PermissionsSyncJob',
@@ -254,9 +258,9 @@ function createSyncJobMock(
                 ? formatRFC3339(addMinutes(TIMESTAMP_MOCK, 2))
                 : null,
         processAfter: null,
-        permissionsAdded: 1337,
-        permissionsRemoved: 42,
-        permissionsFound: 1337 + 42,
+        permissionsAdded,
+        permissionsRemoved,
+        permissionsFound: permissionsAdded + permissionsRemoved,
         failureMessage: null,
         cancellationReason: null,
         ranForMs: null,

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -440,7 +440,7 @@ const TableColumns: IColumn<PermissionsSyncJob>[] = [
         header: { label: 'Total', align: 'right' },
         align: 'right',
         render: ({ permissionsFound }: PermissionsSyncJob) => (
-            <div className={classNames('text-right', permissionsFound == 0 ? styles.textTotalNumber : 'text-muted')}>
+            <div className={classNames('text-right', permissionsFound === 0 ? styles.textTotalNumber : 'text-muted')}>
                 <b>{permissionsFound}</b>
             </div>
         ),

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -440,7 +440,7 @@ const TableColumns: IColumn<PermissionsSyncJob>[] = [
         header: { label: 'Total', align: 'right' },
         align: 'right',
         render: ({ permissionsFound }: PermissionsSyncJob) => (
-            <div className="text-muted text-right">
+            <div className={classNames('text-right', permissionsFound == 0 ? styles.textTotalNumber : 'text-muted')}>
                 <b>{permissionsFound}</b>
             </div>
         ),

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -90,3 +90,6 @@
 .text-danger-muted {
     color: var(--danger-2);
 }
+.text-total-number {
+    color: var(--icon-muted);
+}

--- a/client/web/src/site-admin/permissions-center/styles.module.scss
+++ b/client/web/src/site-admin/permissions-center/styles.module.scss
@@ -83,3 +83,10 @@
     max-width: 1.5rem;
     max-height: 1.5rem;
 }
+
+.text-success-muted {
+    color: var(--success-2);
+}
+.text-danger-muted {
+    color: var(--danger-2);
+}


### PR DESCRIPTION
I don't really like this: I think when nothing was changed it can just be plain and boring.

<img width="901" alt="screenshot_2023-03-31_12 26 06@2x" src="https://user-images.githubusercontent.com/1185253/229095677-89532c31-4e10-40ff-bfc4-cd0fa6436a34.png">

## After

<img width="925" alt="screenshot_2023-03-31_14 21 38@2x" src="https://user-images.githubusercontent.com/1185253/229118675-1f2a8c26-3109-4ccb-844e-13646855b323.png">

## Test plan

- Existing tests

## App preview:

- [Web](https://sg-web-mrn-fix-0-sync-jobs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
