### PR TITLE
cody: increase chat question context from 10 files to 16 files

### DIFF
--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -45,7 +45,7 @@ export class ChatQuestion implements Recipe {
         const isCodebaseContextRequired = await intentDetector.isCodebaseContextRequired(text)
         if (isCodebaseContextRequired) {
             // Request 16 context files in total. That amounts to roughly 16 * 256 = 4096 tokens used for context.
-            // That leaves us ~3000 tokens to include the chat history.
+            // That leaves us ~3000 tokens to include the chat history and editor context.
             const codebaseContextMessages = await codebaseContext.getContextMessages(text, {
                 numCodeResults: 13,
                 numTextResults: 3,

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -44,9 +44,11 @@ export class ChatQuestion implements Recipe {
 
         const isCodebaseContextRequired = await intentDetector.isCodebaseContextRequired(text)
         if (isCodebaseContextRequired) {
+            // Request 16 context files in total. That amounts to roughly 16 * 256 = 4096 tokens used for context.
+            // That leaves us ~3000 tokens to include the chat history.
             const codebaseContextMessages = await codebaseContext.getContextMessages(text, {
-                numCodeResults: 8,
-                numTextResults: 2,
+                numCodeResults: 13,
+                numTextResults: 3,
             })
             contextMessages.push(...codebaseContextMessages)
         }

--- a/client/cody/webviews/Chat.css
+++ b/client/cody/webviews/Chat.css
@@ -232,4 +232,5 @@
     cursor: pointer;
     font-size: inherit;
     text-decoration: underline;
+    text-align: left;
 }


### PR DESCRIPTION
The idea is that Cody can provide better answers with a larger context. Now we included 10 file chunks (~256 tokens, ~1000 characters) as context. I propose we bump that up to 16 file chunks, which is still a good balance between context messages and chat history.

## Test plan

* Tried asking some questions: using a larger context Cody was able to find more relevant files which made it more confident. Hard to evaluate the exact numeric improvement. 

## App preview:

- [Web](https://sg-web-rn-increase-cody-chat-question.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

