### PR TITLE
Don't hard require Sentry.onLoad

### DIFF
--- a/client/web/src/monitoring/sentry/initSentry.ts
+++ b/client/web/src/monitoring/sentry/initSentry.ts
@@ -24,7 +24,7 @@ export function initSentry(): void {
         const { sentryDSN, version } = window.context
 
         try {
-            const initSentry = () => {
+            const initSentry = (): void => {
                 Sentry.init({
                     dsn: sentryDSN,
                     // TODO frontend platform team, follow-up to https://github.com/sourcegraph/sourcegraph/pull/38411

--- a/client/web/src/monitoring/sentry/initSentry.ts
+++ b/client/web/src/monitoring/sentry/initSentry.ts
@@ -1,6 +1,8 @@
 // Import only types to avoid adding `@sentry/browser` to our bundle.
 import type { Hub, init, onLoad } from '@sentry/browser'
 
+import { logger } from '@sourcegraph/common'
+
 import { authenticatedUser } from '../../auth'
 import { shouldErrorBeReported } from '../shouldErrorBeReported'
 
@@ -21,33 +23,45 @@ export function initSentry(): void {
     ) {
         const { sentryDSN, version } = window.context
 
-        // Wait for Sentry to lazy-load from the script tag defined in the `app.html`.
-        // https://sentry-docs-git-patch-1.sentry.dev/platforms/javascript/guides/react/install/lazy-load-sentry/
-        Sentry.onLoad(() => {
-            Sentry.init({
-                dsn: sentryDSN,
-                // TODO frontend platform team, follow-up to https://github.com/sourcegraph/sourcegraph/pull/38411
-                // tunnel: '/-/debug/sentry_tunnel',
-                release: 'frontend@' + version,
-                beforeSend(event, hint) {
-                    // Use `originalException` to check if we want to ignore the error.
-                    if (!hint || shouldErrorBeReported(hint.originalException)) {
-                        return event
-                    }
+        try {
+            const initSentry = () => {
+                Sentry.init({
+                    dsn: sentryDSN,
+                    // TODO frontend platform team, follow-up to https://github.com/sourcegraph/sourcegraph/pull/38411
+                    // tunnel: '/-/debug/sentry_tunnel',
+                    release: 'frontend@' + version,
+                    beforeSend(event, hint) {
+                        // Use `originalException` to check if we want to ignore the error.
+                        if (!hint || shouldErrorBeReported(hint.originalException)) {
+                            return event
+                        }
 
-                    return null
-                },
-            })
-
-            // Sentry is never un-initialized.
-            // eslint-disable-next-line rxjs/no-ignored-subscription
-            authenticatedUser.subscribe(user => {
-                Sentry.configureScope(scope => {
-                    if (user) {
-                        scope.setUser({ id: user.id })
-                    }
+                        return null
+                    },
                 })
-            })
-        })
+
+                // Sentry is never un-initialized.
+                // eslint-disable-next-line rxjs/no-ignored-subscription
+                authenticatedUser.subscribe(user => {
+                    Sentry.configureScope(scope => {
+                        if (user) {
+                            scope.setUser({ id: user.id })
+                        }
+                    })
+                })
+            }
+
+            // Wait for Sentry to lazy-load from the script tag defined in the `app.html` if it
+            // hasn't already.
+            //
+            // https://sentry-docs-git-patch-1.sentry.dev/platforms/javascript/guides/react/install/lazy-load-sentry/
+            if (typeof Sentry.init === 'function') {
+                initSentry()
+            } else {
+                Sentry.onLoad(initSentry)
+            }
+        } catch (error) {
+            logger.error('Error initializing Sentry', error)
+        }
     }
 }


### PR DESCRIPTION
We're currently having an incident where sourcegraph.com is not available because something in the Sentry setup have changed (which could be related to the third-party Sentry code but it could also be that sentry already initialized somehow).

When debugging in prod I noticed that the `Sentry` global object is loaded with the `init` function but no `onLoad` function, so this I updated the script to:

- Use `Sentry.init` if available
- Otherwise do what we do now
- Wrap everything with a catch block


## Test plan

👀 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-dont-hard-require-sentry.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
