### PR TITLE
[embeddings][optimise] Encode RepoEmbeddingIndex in chunks

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -73,7 +73,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	getRepoEmbeddingIndex, err := getCachedRepoEmbeddingIndex(repoStore, repoEmbeddingJobsStore, func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-		return embeddings.DownloadIndex[embeddings.RepoEmbeddingIndex](ctx, uploadStore, string(repoEmbeddingIndexName))
+		return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, string(repoEmbeddingIndexName))
 	})
 	if err != nil {
 		return err

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -34,9 +34,11 @@ const MAX_FILE_SIZE = 1000000 // 1MB
 
 // The threshold to embed the entire file is slightly larger than the chunk threshold to
 // avoid splitting small files unnecessarily.
-const EMBED_ENTIRE_FILE_TOKENS_THRESHOLD = 384
-const EMBEDDING_CHUNK_TOKENS_THRESHOLD = 256
-const EMBEDDING_CHUNK_EARLY_SPLIT_TOKENS_THRESHOLD = EMBEDDING_CHUNK_TOKENS_THRESHOLD - 32
+const (
+	EMBED_ENTIRE_FILE_TOKENS_THRESHOLD           = 384
+	EMBEDDING_CHUNK_TOKENS_THRESHOLD             = 256
+	EMBEDDING_CHUNK_EARLY_SPLIT_TOKENS_THRESHOLD = EMBEDDING_CHUNK_TOKENS_THRESHOLD - 32
+)
 
 var splitOptions = split.SplitOptions{
 	NoSplitTokensThreshold:         EMBED_ENTIRE_FILE_TOKENS_THRESHOLD,
@@ -90,10 +92,9 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 		},
 		getDocumentRanks,
 	)
-
 	if err != nil {
 		return err
 	}
 
-	return embeddings.UploadIndex(ctx, h.uploadStore, string(embeddings.GetRepoEmbeddingIndexName(repo.Name)), repoEmbeddingIndex)
+	return embeddings.UploadRepoEmbeddingIndex(ctx, h.uploadStore, string(embeddings.GetRepoEmbeddingIndexName(repo.Name)), repoEmbeddingIndex)
 }

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -35,15 +35,15 @@ const MAX_FILE_SIZE = 1000000 // 1MB
 // The threshold to embed the entire file is slightly larger than the chunk threshold to
 // avoid splitting small files unnecessarily.
 const (
-	EMBED_ENTIRE_FILE_TOKENS_THRESHOLD           = 384
-	EMBEDDING_CHUNK_TOKENS_THRESHOLD             = 256
-	EMBEDDING_CHUNK_EARLY_SPLIT_TOKENS_THRESHOLD = EMBEDDING_CHUNK_TOKENS_THRESHOLD - 32
+	embedEntireFileTokensThreshold          = 384
+	embeddingChunkTokensThreshold           = 256
+	embeddingChunkEarlySplitTokensThreshold = embeddingChunkTokensThreshold - 32
 )
 
 var splitOptions = split.SplitOptions{
-	NoSplitTokensThreshold:         EMBED_ENTIRE_FILE_TOKENS_THRESHOLD,
-	ChunkTokensThreshold:           EMBEDDING_CHUNK_TOKENS_THRESHOLD,
-	ChunkEarlySplitTokensThreshold: EMBEDDING_CHUNK_EARLY_SPLIT_TOKENS_THRESHOLD,
+	NoSplitTokensThreshold:         embedEntireFileTokensThreshold,
+	ChunkTokensThreshold:           embeddingChunkTokensThreshold,
+	ChunkEarlySplitTokensThreshold: embeddingChunkEarlySplitTokensThreshold,
 }
 
 func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoembeddingsbg.RepoEmbeddingJob) error {

--- a/enterprise/internal/embeddings/index_storage.go
+++ b/enterprise/internal/embeddings/index_storage.go
@@ -150,7 +150,7 @@ func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Sto
 
 	dec := gob.NewDecoder(file)
 
-	rei := &RepoEmbeddingIndex{}
+	var rei *RepoEmbeddingIndex
 	// if decoding files, assume it is an old index and decode appropriately
 	if rei, err = decodeRepoEmbeddingIndex(dec); err != nil {
 		// close the existing file

--- a/enterprise/internal/embeddings/index_storage.go
+++ b/enterprise/internal/embeddings/index_storage.go
@@ -80,6 +80,9 @@ func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Sto
 
 const embeddingsChunkSize = 10_000
 
+// encodeRepoEmbeddingIndex is a specialized encoder for repo embedding indexes. Instead of GOB-encoding
+// the entire RepoEmbeddingIndex, we encode each field separately, and we encode the embeddings array by chunks.
+// This way we avoid allocating a separate very large slice for the embeddings.
 func encodeRepoEmbeddingIndex(enc *gob.Encoder, rei *RepoEmbeddingIndex, chunkSize int) error {
 	if err := enc.Encode(rei.RepoName); err != nil {
 		return err

--- a/enterprise/internal/embeddings/index_storage.go
+++ b/enterprise/internal/embeddings/index_storage.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"io"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -31,4 +34,124 @@ func UploadIndex[T any](ctx context.Context, uploadStore uploadstore.Store, key 
 
 	_, err := uploadStore.Upload(ctx, key, buffer)
 	return err
+}
+
+func encodeRepoEmbeddingIndex(pw io.Writer, rei *RepoEmbeddingIndex, chunkSize int) error {
+	enc := gob.NewEncoder(pw)
+
+	// Write RepoName field
+	if err := enc.Encode(rei.RepoName); err != nil {
+		return err
+	}
+
+	// Write Revision field
+	if err := enc.Encode(rei.Revision); err != nil {
+		return err
+	}
+
+	// Encode CodeIndex and TextIndex
+	for _, ei := range []EmbeddingIndex{rei.CodeIndex, rei.TextIndex} {
+		// Write Embeddings field
+		numChunks := (len(ei.Embeddings) + chunkSize - 1) / chunkSize
+		if err := enc.Encode(numChunks); err != nil {
+			return err
+		}
+		for i := 0; i < numChunks; i++ {
+			start := i * chunkSize
+			end := start + chunkSize
+
+			if end > len(ei.Embeddings) {
+				end = len(ei.Embeddings)
+			}
+
+			if err := enc.Encode(ei.Embeddings[start:end]); err != nil {
+				return err
+			}
+		}
+
+		if err := enc.Encode(ei.ColumnDimension); err != nil {
+			return err
+		}
+
+		if err := enc.Encode(ei.RowMetadata); err != nil {
+			return err
+		}
+
+		if err := enc.Encode(ei.Ranks); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func UploadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string, index *RepoEmbeddingIndex) error {
+	pr, pw := io.Pipe()
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		defer pw.Close()
+
+		return encodeRepoEmbeddingIndex(pw, index, 1000)
+	})
+
+	eg.Go(func() error {
+		defer pr.Close()
+
+		_, err := uploadStore.Upload(ctx, key, pr)
+		return err
+	})
+
+	return eg.Wait()
+}
+
+func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (*RepoEmbeddingIndex, error) {
+	file, err := uploadStore.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Append(err, file.Close()) }()
+
+	rei := &RepoEmbeddingIndex{}
+	dec := gob.NewDecoder(file)
+
+	if err := dec.Decode(&rei.RepoName); err != nil {
+		return nil, err
+	}
+
+	if err := dec.Decode(&rei.Revision); err != nil {
+		return nil, err
+	}
+
+	// Decode CodeIndex and TextIndex
+	for _, ei := range []*EmbeddingIndex{&rei.CodeIndex, &rei.TextIndex} {
+		// Write Embeddings field
+		var numChunks int
+		if err := dec.Decode(&numChunks); err != nil {
+			return nil, err
+		}
+
+		for i := 0; i < numChunks; i++ {
+			var embeddingSlice []float32
+			if err := dec.Decode(&embeddingSlice); err != nil {
+				return nil, err
+			}
+			ei.Embeddings = append(ei.Embeddings, embeddingSlice...)
+		}
+
+		if err := dec.Decode(&ei.ColumnDimension); err != nil {
+			return nil, err
+		}
+
+		if err := dec.Decode(&ei.RowMetadata); err != nil {
+			return nil, err
+		}
+
+		if err := dec.Decode(&ei.Ranks); err != nil {
+			return nil, err
+		}
+	}
+
+	return rei, nil
 }

--- a/enterprise/internal/embeddings/index_storage_test.go
+++ b/enterprise/internal/embeddings/index_storage_test.go
@@ -120,10 +120,38 @@ func TestEmbeddingIndexStorage(t *testing.T) {
 	ctx := context.Background()
 	uploadStore := newMockUploadStore()
 
+	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "index", index)
+	require.NoError(t, err)
+
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+	require.NoError(t, err)
+
+	require.Equal(t, index, downloadedIndex)
+}
+
+func TestEmbeddingVersionMismatch(t *testing.T) {
+	index := &RepoEmbeddingIndex{
+		RepoName: api.RepoName("repo"),
+		Revision: api.CommitID("commit"),
+		CodeIndex: EmbeddingIndex{
+			Embeddings:      []float32{0.0, 0.1, 0.2},
+			ColumnDimension: 3,
+			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "a.go", StartLine: 0, EndLine: 1}},
+		},
+		TextIndex: EmbeddingIndex{
+			Embeddings:      []float32{1.0, 2.1, 3.2},
+			ColumnDimension: 3,
+			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "b.py", StartLine: 0, EndLine: 1}},
+		},
+	}
+
+	ctx := context.Background()
+	uploadStore := newMockUploadStore()
+
 	err := UploadIndex(ctx, uploadStore, "index", index)
 	require.NoError(t, err)
 
-	downloadedIndex, err := DownloadIndex[RepoEmbeddingIndex](ctx, uploadStore, "index")
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
 	require.NoError(t, err)
 
 	require.Equal(t, index, downloadedIndex)


### PR DESCRIPTION
Encode repo embeddings in chunks so as to minimise memory usage.

Before:

![Screenshot 2023-03-31 at 13 20 50](https://user-images.githubusercontent.com/6427795/229113103-079505fc-9734-43ba-bd6b-7c64eaa6f0d0.png)


After:

![Screenshot 2023-03-31 at 13 49 11](https://user-images.githubusercontent.com/6427795/229113127-5dad06d8-263b-4036-83bb-a6d4291b8be2.png)


## Test plan

Added test to assert that we are decoding the index correctly

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
