### PR TITLE
Cody: Download ripgrep on CI

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -38,7 +38,7 @@
     "vscode:prepublish": "scripts/check-rg.sh",
     "vsce:package": "pnpm --silent build && vsce package --no-dependencies -o dist/cody.vsix",
     "vsce:prerelease": "pnpm --silent build && vsce package patch --pre-release --no-dependencies -o dist/cody.vsix",
-    "prerelease": "pnpm run vsce:package",
+    "prerelease": "pnpm run download-rg && pnpm run vsce:package",
     "release": "ts-node ./scripts/release.ts",
     "watch": "concurrently \"pnpm watch:esbuild\" \"pnpm watch:webview\"",
     "watch:esbuild": "pnpm esbuild --sourcemap --watch",


### PR DESCRIPTION
Fixes this CI issue:

<img width="1222" alt="Screenshot 2023-03-31 at 14 46 41" src="https://user-images.githubusercontent.com/458591/229124063-8bb252a5-0663-4cf6-9e20-d78865dc5343.png">

## Test plan

- We'll have to test on CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-cody-rg-ci.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
