### PR TITLE
chore: load user only once from the database in `UserResolver`.

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -142,7 +142,7 @@ type PermissionsInfoRepositoriesArgs struct {
 
 type PermissionsInfoUserResolver interface {
 	ID() graphql.ID
-	User() *UserResolver
+	User(context.Context) *UserResolver
 	Reason() string
 	UpdatedAt() *gqlutil.DateTime
 }

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -23,14 +23,14 @@ func marshalDefaultSettingsGQLID(defaultSettingsID string) graphql.ID {
 
 func (r *defaultSettingsResolver) ID() graphql.ID { return marshalDefaultSettingsGQLID(r.gqlID) }
 
-func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
+func (r *defaultSettingsResolver) LatestSettings(_ context.Context) (*settingsResolver, error) {
 	settings := &api.Settings{Subject: api.SettingsSubject{Default: true}, Contents: `{"experimentalFeatures": {}}`}
 	return &settingsResolver{r.db, &settingsSubject{defaultSettings: r}, settings, nil}, nil
 }
 
 func (r *defaultSettingsResolver) SettingsURL() *string { return nil }
 
-func (r *defaultSettingsResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+func (r *defaultSettingsResolver) ViewerCanAdminister(_ context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/cmd/frontend/graphqlbackend/event_logs_test.go
+++ b/cmd/frontend/graphqlbackend/event_logs_test.go
@@ -58,7 +58,7 @@ func TestUser_EventLogs(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := NewUserResolver(db, &types.User{ID: 1}).EventLogs(test.ctx, nil)
+				_, err := NewUserResolver(test.ctx, db, &types.User{ID: 1}).EventLogs(test.ctx, nil)
 				got := fmt.Sprintf("%v", err)
 				want := "must be authenticated as user with id 1"
 				assert.Equal(t, want, got)

--- a/cmd/frontend/graphqlbackend/executor_secret_access_log.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_log.go
@@ -74,7 +74,7 @@ func (r *executorSecretAccessLogResolver) User(ctx context.Context) (*UserResolv
 		if r.preloadedUser == nil {
 			return nil, nil
 		}
-		return NewUserResolver(r.db, r.preloadedUser), nil
+		return NewUserResolver(ctx, r.db, r.preloadedUser), nil
 	}
 
 	if r.log.UserID == nil {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -189,7 +189,7 @@ func (s *membersConnectionStore) ComputeNodes(ctx context.Context, args *databas
 
 	var userResolvers []*UserResolver
 	for _, user := range users {
-		userResolvers = append(userResolvers, NewUserResolver(s.db, user))
+		userResolvers = append(userResolvers, NewUserResolver(ctx, s.db, user))
 	}
 
 	return userResolvers, nil

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -98,7 +98,7 @@ func (r *PersonResolver) User(ctx context.Context) (*UserResolver, error) {
 	if user == nil || err != nil {
 		return nil, err
 	}
-	return NewUserResolver(r.db, user), nil
+	return NewUserResolver(ctx, r.db, user), nil
 }
 
 func (r *PersonResolver) OwnerField() string {

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -52,7 +52,7 @@ func (o *settingsResolver) Author(ctx context.Context) (*UserResolver, error) {
 			return nil, err
 		}
 	}
-	return NewUserResolver(o.db, o.user), nil
+	return NewUserResolver(ctx, o.db, o.user), nil
 }
 
 var globalSettingsAllowEdits, _ = strconv.ParseBool(env.Get("GLOBAL_SETTINGS_ALLOW_EDITS", "false", "When GLOBAL_SETTINGS_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -144,7 +144,7 @@ func (s *settingsSubject) ViewerCanAdminister(ctx context.Context) (bool, error)
 	case s.org != nil:
 		return s.org.ViewerCanAdminister(ctx)
 	case s.user != nil:
-		return s.user.ViewerCanAdminister(ctx)
+		return s.user.ViewerCanAdminister()
 	default:
 		return false, errUnknownSettingsSubject
 	}

--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -209,7 +209,7 @@ func (r *TeamResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	return canModifyTeam(ctx, r.db, r.team)
 }
 
-func (r *TeamResolver) Members(ctx context.Context, args *ListTeamMembersArgs) (*teamMemberConnection, error) {
+func (r *TeamResolver) Members(_ context.Context, args *ListTeamMembersArgs) (*teamMemberConnection, error) {
 	c := &teamMemberConnection{
 		db:     r.db,
 		teamID: r.team.ID,
@@ -220,7 +220,7 @@ func (r *TeamResolver) Members(ctx context.Context, args *ListTeamMembersArgs) (
 	return c, nil
 }
 
-func (r *TeamResolver) ChildTeams(ctx context.Context, args *ListTeamsArgs) (*teamConnectionResolver, error) {
+func (r *TeamResolver) ChildTeams(_ context.Context, args *ListTeamsArgs) (*teamConnectionResolver, error) {
 	c := &teamConnectionResolver{
 		db:       r.db,
 		parentID: r.team.ID,
@@ -356,7 +356,7 @@ func (r *teamMemberConnection) Nodes(ctx context.Context) ([]*UserResolver, erro
 		if err != nil {
 			return nil, err
 		}
-		rs = append(rs, NewUserResolver(r.db, user))
+		rs = append(rs, NewUserResolver(ctx, r.db, user))
 	}
 	return rs, nil
 }

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 
 	"github.com/sourcegraph/log"
 
@@ -57,7 +57,7 @@ func (r *schemaResolver) User(
 		}
 		return nil, err
 	}
-	return NewUserResolver(r.db, user), nil
+	return NewUserResolver(ctx, r.db, user), nil
 }
 
 // UserResolver implements the GraphQL User type.
@@ -65,14 +65,29 @@ type UserResolver struct {
 	logger log.Logger
 	db     database.DB
 	user   *types.User
+	// actor containing current user (derived from request context), which lets us
+	// skip fetching actor from context in every resolver function and save DB calls,
+	// because user is fetched in actor only once.
+	actor *actor.Actor
 }
 
 // NewUserResolver returns a new UserResolver with given user object.
-func NewUserResolver(db database.DB, user *types.User) *UserResolver {
+func NewUserResolver(ctx context.Context, db database.DB, user *types.User) *UserResolver {
 	return &UserResolver{
 		db:     db,
 		user:   user,
 		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
+		actor:  actor.FromContext(ctx),
+	}
+}
+
+// newUserResolverFromActor returns a new UserResolver with given user object.
+func newUserResolverFromActor(a *actor.Actor, db database.DB, user *types.User) *UserResolver {
+	return &UserResolver{
+		db:     db,
+		user:   user,
+		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
+		actor:  a,
 	}
 }
 
@@ -93,7 +108,7 @@ func UserByIDInt32(ctx context.Context, db database.DB, id int32) (*UserResolver
 	if err != nil {
 		return nil, err
 	}
-	return NewUserResolver(db, user), nil
+	return NewUserResolver(ctx, db, user), nil
 }
 
 func (r *UserResolver) ID() graphql.ID { return MarshalUserID(r.user.ID) }
@@ -112,7 +127,7 @@ func (r *UserResolver) DatabaseID() int32 { return r.user.ID }
 // Deprecated: use Emails instead.
 func (r *UserResolver) Email(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the email address.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
 		return "", err
 	}
 
@@ -166,13 +181,13 @@ func (r *UserResolver) LatestSettings(ctx context.Context) (*settingsResolver, e
 	// 🚨 SECURITY: Only the authenticated user can view their settings on
 	// Sourcegraph.com.
 	if envvar.SourcegraphDotComMode() {
-		if err := auth.CheckSameUser(ctx, r.user.ID); err != nil {
+		if err := auth.CheckSameUserFromActor(r.actor, r.user.ID); err != nil {
 			return nil, err
 		}
 	} else {
 		// 🚨 SECURITY: Only the user and admins are allowed to access the user's
 		// settings, because they may contain secrets or other sensitive data.
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
 			return nil, err
 		}
 	}
@@ -193,9 +208,9 @@ func (r *UserResolver) SettingsCascade() *settingsCascade {
 
 func (r *UserResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }
 
-func (r *UserResolver) SiteAdmin(ctx context.Context) (bool, error) {
+func (r *UserResolver) SiteAdmin() (bool, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to determine if the user is a site admin.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
 		return false, err
 	}
 
@@ -259,8 +274,15 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 		DisplayName: args.DisplayName,
 		AvatarURL:   args.AvatarURL,
 	}
-	if args.Username != nil && viewerIsChangingUsername(ctx, r.db, userID, *args.Username) {
-		if !viewerCanChangeUsername(ctx, r.db, userID) {
+	user, err := r.db.Users().GetByID(ctx, userID)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting user from the database")
+	}
+
+	// If user is changing their username, we need to verify if this action can be
+	// done.
+	if args.Username != nil && user.Username != *args.Username {
+		if !viewerCanChangeUsername(actor.FromActualUser(user), r.db, userID) {
 			return nil, errors.Errorf("unable to change username because auth.enableUsernameChanges is false in site configuration")
 		}
 		update.Username = *args.Username
@@ -281,13 +303,13 @@ func CurrentUser(ctx context.Context, db database.DB) (*UserResolver, error) {
 		}
 		return nil, err
 	}
-	return NewUserResolver(db, user), nil
+	return newUserResolverFromActor(actor.FromActualUser(user), db, user), nil
 }
 
 func (r *UserResolver) Organizations(ctx context.Context) (*orgConnectionStaticResolver, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the user's
 	// organisations.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 	orgs, err := r.db.Orgs().GetByUserID(ctx, r.user.ID)
@@ -303,7 +325,7 @@ func (r *UserResolver) Organizations(ctx context.Context) (*orgConnectionStaticR
 
 func (r *UserResolver) SurveyResponses(ctx context.Context) ([]*surveyResponseResolver, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to access the user's survey responses.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 
@@ -311,21 +333,21 @@ func (r *UserResolver) SurveyResponses(ctx context.Context) ([]*surveyResponseRe
 	if err != nil {
 		return nil, err
 	}
-	surveyResponseResolvers := []*surveyResponseResolver{}
+	surveyResponseResolvers := make([]*surveyResponseResolver, 0, len(responses))
 	for _, response := range responses {
 		surveyResponseResolvers = append(surveyResponseResolvers, &surveyResponseResolver{r.db, response})
 	}
 	return surveyResponseResolvers, nil
 }
 
-func (r *UserResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+func (r *UserResolver) ViewerCanAdminister() (bool, error) {
 	// 🚨 SECURITY: Only the authenticated user can administrate themselves on
 	// Sourcegraph.com.
 	var err error
 	if envvar.SourcegraphDotComMode() {
-		err = auth.CheckSameUser(ctx, r.user.ID)
+		err = auth.CheckSameUserFromActor(r.actor, r.user.ID)
 	} else {
-		err = auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID)
+		err = auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID)
 	}
 	if errcode.IsUnauthorized(err) {
 		return false, nil
@@ -408,18 +430,22 @@ func (r *schemaResolver) SetTosAccepted(ctx context.Context, args *struct{ UserI
 		if err != nil {
 			return nil, err
 		}
+
+		// 🚨 SECURITY: Only the user and admins are allowed to set the Terms of Service accepted flag.
+		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, affectedUserID); err != nil {
+			return nil, err
+		}
 	} else {
 		user, err := r.db.Users().GetByCurrentAuthUser(ctx)
 		if err != nil {
 			return nil, err
 		}
-
 		affectedUserID = user.ID
-	}
 
-	// 🚨 SECURITY: Only the user and admins are allowed to set the Terms of Service accepted flag.
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, affectedUserID); err != nil {
-		return nil, err
+		// 🚨 SECURITY: Only the user and admins are allowed to set the Terms of Service accepted flag.
+		if err := auth.CheckSiteAdminOrSameUserFromActor(actor.FromActualUser(user), r.db, affectedUserID); err != nil {
+			return nil, err
+		}
 	}
 
 	tosAccepted := true
@@ -456,8 +482,8 @@ func (r *schemaResolver) SetSearchable(ctx context.Context, args *struct{ Search
 }
 
 // ViewerCanChangeUsername returns if the current user can change the username of the user.
-func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
-	return viewerCanChangeUsername(ctx, r.db, r.user.ID)
+func (r *UserResolver) ViewerCanChangeUsername() bool {
+	return viewerCanChangeUsername(r.actor, r.db, r.user.ID)
 }
 
 func (r *UserResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
@@ -489,9 +515,9 @@ func (r *UserResolver) Roles(_ context.Context, args *ListRoleArgs) (*graphqluti
 	)
 }
 
-func (r *UserResolver) Permissions(ctx context.Context) (*graphqlutil.ConnectionResolver[PermissionResolver], error) {
+func (r *UserResolver) Permissions() (*graphqlutil.ConnectionResolver[PermissionResolver], error) {
 	userID := r.user.ID
-	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, userID); err != nil {
 		return nil, err
 	}
 	connectionStore := &permisionConnectionStore{
@@ -507,36 +533,19 @@ func (r *UserResolver) Permissions(ctx context.Context) (*graphqlutil.Connection
 	)
 }
 
-func viewerCanChangeUsername(ctx context.Context, db database.DB, userID int32) bool {
-	if err := auth.CheckSiteAdminOrSameUser(ctx, db, userID); err != nil {
+func viewerCanChangeUsername(a *actor.Actor, db database.DB, userID int32) bool {
+	if err := auth.CheckSiteAdminOrSameUserFromActor(a, db, userID); err != nil {
 		return false
 	}
 	if conf.Get().AuthEnableUsernameChanges {
 		return true
 	}
 	// 🚨 SECURITY: Only site admins are allowed to change a user's username when auth.enableUsernameChanges == false.
-	return auth.CheckCurrentUserIsSiteAdmin(ctx, db) == nil
-}
-
-// Users may be trying to change their own username, or someone else's.
-//
-// The subjectUserID value represents the decoded user ID from the incoming
-// update request, and the proposedUsername is the value that would be applied
-// to that subject's record if all security checks pass.
-//
-// If that subject's username is different from the proposed one, then a
-// change is being attempted and may be rejected by viewerCanChangeUsername.
-func viewerIsChangingUsername(ctx context.Context, db database.DB, subjectUserID int32, proposedUsername string) bool {
-	subject, err := db.Users().GetByID(ctx, subjectUserID)
-	if err != nil {
-		log15.Warn("viewerIsChangingUsername", "error", err)
-		return true
-	}
-	return subject.Username != proposedUsername
+	return auth.CheckCurrentActorIsSiteAdmin(a, db) == nil
 }
 
 func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
-	if err := auth.CheckSameUser(ctx, r.user.ID); err != nil {
+	if err := auth.CheckSameUserFromActor(r.actor, r.user.ID); err != nil {
 		return nil, err
 	}
 	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.user.ID, args)

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -544,13 +544,17 @@ func TestUpdateUser(t *testing.T) {
 
 	t.Run("success with an empty avatarURL", func(t *testing.T) {
 		users := database.NewMockUserStore()
+		siteAdminUser := &types.User{SiteAdmin: true}
 		users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+			if id == 0 {
+				return siteAdminUser, nil
+			}
 			return &types.User{
 				ID:       id,
 				Username: strconv.Itoa(int(id)),
 			}, nil
 		})
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(siteAdminUser, nil)
 		users.UpdateFunc.SetDefaultReturn(nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
@@ -582,7 +586,11 @@ func TestUpdateUser(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		users := database.NewMockUserStore()
+		siteAdminUser := &types.User{SiteAdmin: true}
 		users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
+			if id == 0 {
+				return siteAdminUser, nil
+			}
 			return &types.User{
 				ID:       id,
 				Username: strconv.Itoa(int(id)),

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -141,26 +141,10 @@ func TestUser(t *testing.T) {
 
 func TestUser_Email(t *testing.T) {
 	db := database.NewMockDB()
-	t.Run("only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
-		orig := envvar.SourcegraphDotComMode()
-		envvar.MockSourcegraphDotComMode(true)
-		defer envvar.MockSourcegraphDotComMode(orig)
+	user := &types.User{ID: 1}
+	ctx := actor.WithActor(context.Background(), actor.FromActualUser(user))
 
-		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, database.ErrNoCurrentUser)
-		db.UsersFunc.SetDefaultReturn(users)
-
-		_, err := NewUserResolver(db, &types.User{ID: 1}).Email(context.Background())
-		got := fmt.Sprintf("%v", err)
-		want := "must be authenticated as the authorized user or site admin"
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("allowed by authenticated site admin user on Sourcegraph.com", func(t *testing.T) {
-		orig := envvar.SourcegraphDotComMode()
-		envvar.MockSourcegraphDotComMode(true)
-		defer envvar.MockSourcegraphDotComMode(orig)
-
+	t.Run("allowed by authenticated site admin user", func(t *testing.T) {
 		users := database.NewMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, SiteAdmin: true}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
@@ -169,26 +153,22 @@ func TestUser_Email(t *testing.T) {
 		userEmails.GetPrimaryEmailFunc.SetDefaultReturn("john@doe.com", true, nil)
 		db.UserEmailsFunc.SetDefaultReturn(userEmails)
 
-		email, _ := NewUserResolver(db, &types.User{ID: 1}).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 2}))
+		email, _ := NewUserResolver(ctx, db, user).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 2}))
 		got := fmt.Sprintf("%v", email)
 		want := "john@doe.com"
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
-		orig := envvar.SourcegraphDotComMode()
-		envvar.MockSourcegraphDotComMode(true)
-		defer envvar.MockSourcegraphDotComMode(orig)
-
+	t.Run("allowed by authenticated user", func(t *testing.T) {
 		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(user, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
 		userEmails := database.NewMockUserEmailsStore()
 		userEmails.GetPrimaryEmailFunc.SetDefaultReturn("john@doe.com", true, nil)
 		db.UserEmailsFunc.SetDefaultReturn(userEmails)
 
-		email, _ := NewUserResolver(db, &types.User{ID: 1}).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 1}))
+		email, _ := NewUserResolver(ctx, db, user).Email(actor.WithActor(context.Background(), &actor.Actor{UID: 1}))
 		got := fmt.Sprintf("%v", email)
 		want := "john@doe.com"
 		assert.Equal(t, want, got)
@@ -240,7 +220,7 @@ func TestUser_LatestSettings(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := NewUserResolver(db, &types.User{ID: 1}).LatestSettings(test.ctx)
+				_, err := NewUserResolver(test.ctx, db, &types.User{ID: 1}).LatestSettings(test.ctx)
 				got := fmt.Sprintf("%v", err)
 				want := "must be authenticated as user with id 1"
 				assert.Equal(t, want, got)
@@ -257,45 +237,60 @@ func TestUser_ViewerCanAdminister(t *testing.T) {
 
 		orig := envvar.SourcegraphDotComMode()
 		envvar.MockSourcegraphDotComMode(true)
-		defer envvar.MockSourcegraphDotComMode(orig)
+		t.Cleanup(func() {
+			envvar.MockSourcegraphDotComMode(orig)
+		})
 
 		tests := []struct {
-			name  string
-			ctx   context.Context
-			setup func()
+			name string
+			ctx  context.Context
 		}{
-			{
-				name: "unauthenticated",
-				ctx:  context.Background(),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
-				},
-			},
 			{
 				name: "another user",
 				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
-						return &types.User{ID: id}, nil
-					})
-				},
 			},
 			{
 				name: "site admin",
 				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				setup: func() {
-					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
-						return &types.User{ID: id, SiteAdmin: true}, nil
-					})
-				},
 			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				test.setup()
-
-				ok, _ := NewUserResolver(db, &types.User{ID: 1}).ViewerCanAdminister(test.ctx)
+				ok, _ := NewUserResolver(test.ctx, db, &types.User{ID: 1}).ViewerCanAdminister()
 				assert.False(t, ok, "ViewerCanAdminister")
+			})
+		}
+	})
+
+	t.Run("allowed by same user or site admin not on Sourcegraph.com", func(t *testing.T) {
+		users := database.NewMockUserStore()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		tests := []struct {
+			name string
+			ctx  context.Context
+			want bool
+		}{
+			{
+				name: "same user",
+				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
+				want: true,
+			},
+			{
+				name: "another user",
+				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				want: false,
+			},
+			{
+				name: "another user, but site admin",
+				ctx:  actor.WithActor(context.Background(), actor.FromActualUser(&types.User{ID: 2, SiteAdmin: true})),
+				want: true,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ok, _ := NewUserResolver(test.ctx, db, &types.User{ID: 1}).ViewerCanAdminister()
+				assert.Equal(t, test.want, ok, "ViewerCanAdminister")
 			})
 		}
 	})

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -32,12 +32,12 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 	}
 
 	// 🚨 SECURITY: Do not assume user email is verified on creation if email delivery is
-	// enabled and we are allowed to reset passwords (which will become the primary
+	// enabled, and we are allowed to reset passwords (which will become the primary
 	// mechanism for verifying this newly created email).
 	needsEmailVerification := email != "" &&
 		conf.CanSendEmail() &&
 		userpasswd.ResetPasswordEnabled()
-	// For backwards-compatibility, allow this behaviour to be confiugred based
+	// For backwards-compatibility, allow this behaviour to be configured based
 	// on the VerifiedEmail argument. If not provided, or set to true, we
 	// forcibly mark the email as not needing verification.
 	if args.VerifiedEmail == nil || *args.VerifiedEmail {
@@ -107,7 +107,9 @@ type createUserResult struct {
 	emailVerified bool
 }
 
-func (r *createUserResult) User() *UserResolver { return NewUserResolver(r.db, r.user) }
+func (r *createUserResult) User(ctx context.Context) *UserResolver {
+	return NewUserResolver(ctx, r.db, r.user)
+}
 
 // ResetPasswordURL modifies the DB when it generates reset URLs, which is somewhat
 // counterintuitive for a "value" type from an implementation POV. Its behavior is

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -390,13 +390,13 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		return nil
 	}
 
-	userResolver := graphqlbackend.NewUserResolver(db, user)
+	userResolver := graphqlbackend.NewUserResolver(ctx, db, user)
 
-	siteAdmin, err := userResolver.SiteAdmin(ctx)
+	siteAdmin, err := userResolver.SiteAdmin()
 	if err != nil {
 		return nil
 	}
-	canAdminister, err := userResolver.ViewerCanAdminister(ctx)
+	canAdminister, err := userResolver.ViewerCanAdminister()
 	if err != nil {
 		return nil
 	}
@@ -440,7 +440,7 @@ func resolveUserPermissions(ctx context.Context, userResolver *graphqlbackend.Us
 		Nodes:           []Permission{},
 	}
 
-	permissionResolver, err := userResolver.Permissions(ctx)
+	permissionResolver, err := userResolver.Permissions()
 	if err != nil {
 		return connection
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -45,7 +45,7 @@ func (r *permissionsInfoResolver) UpdatedAt() *gqlutil.DateTime {
 	return gqlutil.FromTime(r.updatedAt)
 }
 
-func (r *permissionsInfoResolver) Unrestricted(ctx context.Context) bool {
+func (r *permissionsInfoResolver) Unrestricted(_ context.Context) bool {
 	return r.unrestricted
 }
 
@@ -149,7 +149,7 @@ var permissionsInfoUserConnectionOptions = &graphqlutil.ConnectionResolverOption
 	MaxPageSize: &permissionsInfoUserConnectionMaxPageSize,
 }
 
-func (r *permissionsInfoResolver) Users(_ context.Context, args graphqlbackend.PermissionsInfoUsersArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsInfoUserResolver], error) {
+func (r *permissionsInfoResolver) Users(ctx context.Context, args graphqlbackend.PermissionsInfoUsersArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.PermissionsInfoUserResolver], error) {
 	if r.repoID == 0 {
 		return nil, nil
 	}
@@ -160,6 +160,7 @@ func (r *permissionsInfoResolver) Users(_ context.Context, args graphqlbackend.P
 	}
 
 	connectionStore := &permissionsInfoUsersStore{
+		ctx:    ctx,
 		repoID: r.repoID,
 		db:     r.db,
 		ossDB:  r.ossDB,
@@ -170,6 +171,7 @@ func (r *permissionsInfoResolver) Users(_ context.Context, args graphqlbackend.P
 }
 
 type permissionsInfoUsersStore struct {
+	ctx    context.Context
 	repoID api.RepoID
 	db     edb.EnterpriseDB
 	ossDB  database.DB
@@ -177,7 +179,7 @@ type permissionsInfoUsersStore struct {
 }
 
 func (s *permissionsInfoUsersStore) MarshalCursor(node graphqlbackend.PermissionsInfoUserResolver, _ database.OrderBy) (*string, error) {
-	cursor := node.User().Username()
+	cursor := node.User(s.ctx).Username()
 
 	return &cursor, nil
 }
@@ -216,8 +218,8 @@ func (r permissionsInfoUserResolver) ID() graphql.ID {
 	return graphqlbackend.MarshalUserID(r.perm.User.ID)
 }
 
-func (r permissionsInfoUserResolver) User() *graphqlbackend.UserResolver {
-	return graphqlbackend.NewUserResolver(r.db, r.perm.User)
+func (r permissionsInfoUserResolver) User(ctx context.Context) *graphqlbackend.UserResolver {
+	return graphqlbackend.NewUserResolver(ctx, r.db, r.perm.User)
 }
 
 func (r permissionsInfoUserResolver) Reason() string {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -77,7 +77,7 @@ func (s *permissionsSyncJobConnectionStore) resolveSubject(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		userResolver = graphqlbackend.NewUserResolver(s.db, user)
+		userResolver = graphqlbackend.NewUserResolver(ctx, s.db, user)
 	} else {
 		repo, err := s.db.Repos().Get(ctx, api.RepoID(job.RepositoryID))
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -104,7 +104,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.U
 	}
 	resolvers := make([]*graphqlbackend.UserResolver, len(users))
 	for i := range users {
-		resolvers[i] = graphqlbackend.NewUserResolver(r.db, users[i])
+		resolvers[i] = graphqlbackend.NewUserResolver(ctx, r.db, users[i])
 	}
 	return resolvers, nil
 }

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -56,6 +56,13 @@ type Actor struct {
 // FromUser returns an actor corresponding to the user with the given ID
 func FromUser(uid int32) *Actor { return &Actor{UID: uid} }
 
+// FromActualUser returns an actor corresponding to the user with the given ID
+func FromActualUser(user *types.User) *Actor {
+	a := &Actor{UID: user.ID, user: user, userErr: nil}
+	a.userOnce.Do(func() {})
+	return a
+}
+
 // FromAnonymousUser returns an actor corresponding to an unauthenticated user with the given anonymous ID
 func FromAnonymousUser(anonymousUID string) *Actor { return &Actor{AnonymousUID: anonymousUID} }
 

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -101,3 +101,51 @@ func CurrentUser(ctx context.Context, db database.DB) (*types.User, error) {
 	}
 	return user, nil
 }
+
+// CheckCurrentActorIsSiteAdmin returns an error if the current user derived from
+// actor is NOT a site admin.
+func CheckCurrentActorIsSiteAdmin(a *actor.Actor, db database.DB) error {
+	if a.IsInternal() {
+		return nil
+	}
+	// If actor already contains a user, then no DB query will be made. Background
+	// context here is fine, because it is used only for a DB query.
+	user, err := a.User(context.Background(), db.Users())
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return ErrNotAuthenticated
+	}
+	if !user.SiteAdmin {
+		return ErrMustBeSiteAdmin
+	}
+	return nil
+}
+
+// CheckSiteAdminOrSameUserFromActor returns an error if the user derived from actor is
+// NEITHER (1) a site admin NOR (2) the user specified by subjectUserID.
+//
+// It is used when an action on a user can be performed by site admins and the
+// user themselves, but nobody else.
+//
+// Returns an error without the name of the given user.
+func CheckSiteAdminOrSameUserFromActor(a *actor.Actor, db database.DB, subjectUserID int32) error {
+	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
+		return nil
+	}
+	isSiteAdminErr := CheckCurrentActorIsSiteAdmin(a, db)
+	if isSiteAdminErr == nil {
+		return nil
+	}
+	return ErrMustBeSiteAdminOrSameUser
+}
+
+// CheckSameUserFromActor returns an error if the user derived from actor is not the user
+// specified by subjectUserID.
+func CheckSameUserFromActor(a *actor.Actor, subjectUserID int32) error {
+	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
+		return nil
+	}
+	return &InsufficientAuthorizationError{Message: fmt.Sprintf("must be authenticated as user with id %d", subjectUserID)}
+}

--- a/internal/database/survey_responses.go
+++ b/internal/database/survey_responses.go
@@ -26,11 +26,6 @@ func SurveyResponses(db DB) *SurveyResponseStore {
 	return &SurveyResponseStore{Store: basestore.NewWithHandle(db.Handle())}
 }
 
-// NewSurveyResponseStoreWithDB instantiates and returns a new SurveyResponseStore using the other store handle.
-func SurveyResponsesWith(other basestore.ShareableStore) *SurveyResponseStore {
-	return &SurveyResponseStore{Store: basestore.NewWithHandle(other.Handle())}
-}
-
 func (s *SurveyResponseStore) With(other basestore.ShareableStore) *SurveyResponseStore {
 	return &SurveyResponseStore{Store: s.Store.With(other)}
 }
@@ -98,7 +93,7 @@ func (s *SurveyResponseStore) Last30DaysAverageScore(ctx context.Context) (float
 	return avg.Float64, err
 }
 
-// Last30DaysNPS returns the net promoter score for all surveys submitted in the last 30 days.
+// Last30DaysNetPromoterScore returns the net promoter score for all surveys submitted in the last 30 days.
 // This is calculated as 100*((% of responses that are >= 9) - (% of responses that are <= 6))
 func (s *SurveyResponseStore) Last30DaysNetPromoterScore(ctx context.Context) (int, error) {
 	since := thirtyDaysAgo()
@@ -123,7 +118,7 @@ func (s *SurveyResponseStore) Last30DaysNetPromoterScore(ctx context.Context) (i
 	return int(promoterPercent - detractorPercent), err
 }
 
-// Last30Count returns the count of surveys submitted in the last 30 days.
+// Last30DaysCount returns the count of surveys submitted in the last 30 days.
 func (s *SurveyResponseStore) Last30DaysCount(ctx context.Context) (int, error) {
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM survey_responses WHERE created_at>%s", thirtyDaysAgo())
 


### PR DESCRIPTION
By saving an actor with precomputed (or lazily fetched only once) user we can save up to 8 duplicated DB calls (if all user properties requiring auth checks are queried in one GraphQL request).

Test plan:
Existing unit tests updated.
Local sg run and GraphQL API querying.

Closes https://github.com/sourcegraph/sourcegraph/issues/48014