### PR TITLE
Cody: Merge back CI changes

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -38,7 +38,6 @@
     "vscode:prepublish": "scripts/check-rg.sh",
     "vsce:package": "pnpm --silent build && vsce package --no-dependencies -o dist/cody.vsix",
     "vsce:prerelease": "pnpm --silent build && vsce package patch --pre-release --no-dependencies -o dist/cody.vsix",
-    "prerelease": "pnpm run download-rg && pnpm run vsce:package",
     "release": "ts-node ./scripts/release.ts",
     "watch": "concurrently \"pnpm watch:esbuild\" \"pnpm watch:webview\"",
     "watch:esbuild": "pnpm esbuild --sourcemap --watch",

--- a/client/cody/scripts/release.ts
+++ b/client/cody/scripts/release.ts
@@ -35,6 +35,7 @@ const commands = {
     openvsx_publish: 'pnpx ovsx publish dist/cody.vsix --pat $VSCODE_OPENVSX_TOKEN',
 }
 
+childProcess.execSync('pnpm run download-rg', { stdio: 'inherit' })
 childProcess.execSync('pnpm run vsce:package', { stdio: 'inherit' })
 
 const latestVersion = getPublishedVersion()


### PR DESCRIPTION
A few tweaks to get the CI build working that I pushed directly to `cody/release` to iterate faster. 

The next release will require a force-push though!

CI got further but its still using the old tokens. According to @burmudar this will take a bit to propagate fully

I’m considering doing this release locally one last time so we can have it out right now and we can test the CI script for 0.0.5 when the tokens are updated cc @novoselrok 

## Test plan

CI got further

<img width="814" alt="Screenshot 2023-03-31 at 17 00 02" src="https://user-images.githubusercontent.com/458591/229156848-545940e0-41d2-4fb9-bfa3-6e471e194c5c.png">





<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
