### PR TITLE
dep: fix openssl vuln dind

### DIFF
--- a/docker-images/dind/Dockerfile
+++ b/docker-images/dind/Dockerfile
@@ -3,7 +3,7 @@ FROM docker:23.0.1-dind@sha256:ed6220b0de0f309f0844cf8cf1a6b861e981fb7f5c28bec6a
 RUN rm -f /usr/libexec/docker/cli-plugins/docker-compose && \
     rm -f /usr/libexec/docker/cli-plugins/docker-buildx
 
-RUN apk update && apk add --no-cache 'e2fsprogs>=1.46.6-r0' 'libcom_err>=1.46.6-r0' 'e2fsprogs-libs>=1.46.6-r0' 'libcrypto3>=3.0.8-r0' 'libssl3>=3.0.8-r0'
+RUN apk update && apk add --no-cache 'e2fsprogs>=1.46.6-r0' 'libcom_err>=1.46.6-r0' 'e2fsprogs-libs>=1.46.6-r0' 'libcrypto3>=3.0.8-r3' 'libssl3>=3.0.8-r3' 'openssl>=3.0.8-r3'
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
DIND had some OpenSSL issues, this will resolve them.

## Test plan
Ran build locally, scanned and confirmed no vulnerabilities. 

```

sha256:1907b55084b7abe7ed2c53f538ac30e80f89ca9decb3fe53ca278babc28ecf16 (alpine 3.17.2)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
