### PR TITLE
[backport] embeddings: better logging and error wrapping (#50214)

### DIFF
--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type getContextDetectionEmbeddingIndexFn func(ctx context.Context) (*embeddings.ContextDetectionEmbeddingIndex, error)
@@ -60,12 +61,12 @@ func isQuerySimilarToNoContextMessages(
 ) (bool, error) {
 	contextDetectionEmbeddingIndex, err := getContextDetectionEmbeddingIndex(ctx)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "getting context detection embedding index")
 	}
 
 	queryEmbedding, err := getQueryEmbedding(query)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "getting query embedding")
 	}
 
 	messagesWithContextSimilarity := embeddings.CosineSimilarity(contextDetectionEmbeddingIndex.MessagesWithAdditionalContextMeanEmbedding, queryEmbedding)

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -88,7 +89,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	getContextDetectionEmbeddingIndex := getCachedContextDetectionEmbeddingIndex(uploadStore)
 
 	// Create HTTP server
-	handler := NewHandler(readFile, getRepoEmbeddingIndex, getQueryEmbedding, getContextDetectionEmbeddingIndex)
+	handler := NewHandler(logger, readFile, getRepoEmbeddingIndex, getQueryEmbedding, getContextDetectionEmbeddingIndex)
 	handler = handlePanic(logger, handler)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
 	handler = instrumentation.HTTPMiddleware("", handler)
@@ -108,6 +109,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 }
 
 func NewHandler(
+	logger log.Logger,
 	readFile readFileFn,
 	getRepoEmbeddingIndex getRepoEmbeddingIndexFn,
 	getQueryEmbedding getQueryEmbeddingFn,
@@ -128,9 +130,14 @@ func NewHandler(
 			return
 		}
 
-		res, err := searchRepoEmbeddingIndex(r.Context(), args, readFile, getRepoEmbeddingIndex, getQueryEmbedding)
+		res, err := searchRepoEmbeddingIndex(r.Context(), logger, args, readFile, getRepoEmbeddingIndex, getQueryEmbedding)
+		if errcode.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err != nil {
-			http.Error(w, "error searching embedding index", http.StatusInternalServerError)
+			logger.Error("error searching embedding index", log.Error(err))
+			http.Error(w, fmt.Sprintf("error searching embedding index: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
 
@@ -153,7 +160,8 @@ func NewHandler(
 
 		isRequired, err := isContextRequiredForChatQuery(r.Context(), getQueryEmbedding, getContextDetectionEmbeddingIndex, args.Query)
 		if err != nil {
-			http.Error(w, "error detecting if context is required for query", http.StatusInternalServerError)
+			logger.Error("error detecting if context is required for query", log.Error(err))
+			http.Error(w, fmt.Sprintf("error detecting if context is required for query: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
 

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -36,7 +36,7 @@ func getCachedRepoEmbeddingIndex(
 	getAndCacheIndex := func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
 		embeddingIndex, err := downloadRepoEmbeddingIndex(ctx, repoEmbeddingIndexName)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "downloading repo embedding index")
 		}
 		cache.Add(repoEmbeddingIndexName, repoEmbeddingIndexCacheEntry{index: embeddingIndex, finishedAt: *finishedAt})
 		return embeddingIndex, nil

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -2,11 +2,15 @@ package shared
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"strings"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type readFileFn func(ctx context.Context, repoName api.RepoName, revision api.CommitID, fileName string) ([]byte, error)
@@ -15,6 +19,7 @@ type getQueryEmbeddingFn func(query string) ([]float32, error)
 
 func searchRepoEmbeddingIndex(
 	ctx context.Context,
+	logger log.Logger,
 	params embeddings.EmbeddingsSearchParameters,
 	readFile readFileFn,
 	getRepoEmbeddingIndex getRepoEmbeddingIndexFn,
@@ -22,21 +27,21 @@ func searchRepoEmbeddingIndex(
 ) (*embeddings.EmbeddingSearchResults, error) {
 	embeddingIndex, err := getRepoEmbeddingIndex(ctx, params.RepoName)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getting repo embedding index")
 	}
 
 	embeddedQuery, err := getQueryEmbedding(params.Query)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getting query embedding")
 	}
 
 	var codeResults, textResults []embeddings.EmbeddingSearchResult
 	if params.CodeResultsCount > 0 && len(embeddingIndex.CodeIndex.Embeddings) > 0 {
-		codeResults = searchEmbeddingIndex(ctx, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.CodeIndex, readFile, embeddedQuery, params.CodeResultsCount)
+		codeResults = searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.CodeIndex, readFile, embeddedQuery, params.CodeResultsCount)
 	}
 
 	if params.TextResultsCount > 0 && len(embeddingIndex.TextIndex.Embeddings) > 0 {
-		textResults = searchEmbeddingIndex(ctx, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.TextIndex, readFile, embeddedQuery, params.TextResultsCount)
+		textResults = searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.TextIndex, readFile, embeddedQuery, params.TextResultsCount)
 	}
 
 	return &embeddings.EmbeddingSearchResults{CodeResults: codeResults, TextResults: textResults}, nil
@@ -46,6 +51,7 @@ const SIMILARITY_SEARCH_MIN_ROWS_TO_SPLIT = 1000
 
 func searchEmbeddingIndex(
 	ctx context.Context,
+	logger log.Logger,
 	repoName api.RepoName,
 	revision api.CommitID,
 	index *embeddings.EmbeddingIndex[embeddings.RepoEmbeddingRowMetadata],
@@ -60,6 +66,9 @@ func searchEmbeddingIndex(
 	for idx, row := range rows {
 		fileContent, err := readFile(ctx, repoName, revision, row.FileName)
 		if err != nil {
+			if !os.IsNotExist(err) {
+				logger.Error("error reading file", log.String("repoName", string(repoName)), log.String("revision", string(revision)), log.String("fileName", row.FileName), log.Error(err))
+			}
 			continue
 		}
 		lines := strings.Split(string(fileContent), "\n")

--- a/enterprise/cmd/worker/internal/embeddings/repo/worker.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/worker.go
@@ -69,8 +69,8 @@ func newRepoEmbeddingJobWorker(
 	handler := &handler{db, uploadStore, gitserverClient}
 	return dbworker.NewWorker[*repoembeddingsbg.RepoEmbeddingJob](ctx, workerStore, handler, workerutil.WorkerOptions{
 		Name:              "repo_embedding_job_worker",
-		Interval:          time.Minute, // Poll for a job once per minute
-		NumHandlers:       1,           // Process only one job at a time (per instance)
+		Interval:          10 * time.Second, // Poll for a job once every 10 seconds
+		NumHandlers:       1,                // Process only one job at a time (per instance)
 		HeartbeatInterval: 10 * time.Second,
 		Metrics:           workerutil.NewMetrics(observationCtx, "repo_embedding_job_worker"),
 	})


### PR DESCRIPTION
Add better logging and error wrapping for embeddings searcher service. Return 400 if the repo embedding job is not found. Reduce the wait time for workers to pick up new embedding jobs.

* Tried searching for a non-existent repo embedding job, got 400 response
* Deleted an embedding index from the bucket, got 500, and an error got logged

(cherry picked from commit 92cfe5a151aca9cb721727a3c9cd339229a0104e)

