### PR TITLE
Print stack trace on panic in GraphQL tests

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -424,6 +424,7 @@ func NewSchema(
 	gitserverClient gitserver.Client,
 	enterpriseJobs jobutil.EnterpriseJobs,
 	optional OptionalResolver,
+	graphqlOpts ...graphql.SchemaOpt,
 ) (*graphql.Schema, error) {
 	resolver := newSchemaResolver(db, gitserverClient, enterpriseJobs)
 	schemas := []string{mainSchema, outboundWebhooksSchema}
@@ -570,9 +571,7 @@ func NewSchema(
 	}
 
 	logger := log.Scoped("GraphQL", "general GraphQL logging")
-	return graphql.ParseSchema(
-		strings.Join(schemas, "\n"),
-		resolver,
+	opts := []graphql.SchemaOpt{
 		graphql.Tracer(&requestTracer{
 			DB: db,
 			tracer: &otel.Tracer{
@@ -581,7 +580,12 @@ func NewSchema(
 			logger: logger,
 		}),
 		graphql.UseStringDescriptions(),
-	)
+	}
+	opts = append(opts, graphqlOpts...)
+	return graphql.ParseSchema(
+		strings.Join(schemas, "\n"),
+		resolver,
+		opts...)
 }
 
 // schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"testing"
@@ -25,7 +26,13 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, OptionalResolver{})
+	parsedSchema, parseSchemaErr := NewSchema(
+		db,
+		gitserverClient,
+		nil,
+		OptionalResolver{},
+		graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
+	)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}
@@ -132,4 +139,14 @@ func sortErrors(errs []*gqlerrors.QueryError) {
 	sort.Slice(errs, func(i, j int) bool {
 		return fmt.Sprintf("%s", errs[i].Path) < fmt.Sprintf("%s", errs[j].Path)
 	})
+}
+
+// printStackTrace wraps panic recovery from given Handler and prints the stack trace.
+type printStackTrace struct {
+	Handler gqlerrors.PanicHandler
+}
+
+func (t printStackTrace) MakePanicError(ctx context.Context, value interface{}) *gqlerrors.QueryError {
+	debug.PrintStack()
+	return t.Handler.MakePanicError(ctx, value)
 }


### PR DESCRIPTION
I am a sourcegraph developer writing a graphQL resolver test.

**before** my test fails with a panic, but gives no hint to where the panic occurs.

```
Running tool: /Users/cbart/.asdf/shims/go test -timeout 30s -run ^TestRepositoryMirrorInfoCloneProgressFetchedFromDatabase$ github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend

--- FAIL: TestRepositoryMirrorInfoCloneProgressFetchedFromDatabase (0.03s)
    /Users/cbart/sourcegraph/cmd/frontend/graphqlbackend/repository_mirror_test.go:321:   []*errors.QueryError(
        - 	nil,
        + 	{
        + 		e"graphql: panic occurred: runtime error: invalid memory address or nil pointer dereference",
        + 	},
          )
        
FAIL
FAIL	github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend	1.638s
FAIL
```

**after** this change the failure includes a stack trace:

```
Running tool: /Users/cbart/.asdf/shims/go test -timeout 30s -run ^TestRepositoryMirrorInfoCloneProgressFetchedFromDatabase$ github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend

goroutine 234 [running]:
runtime/debug.Stack()
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/runtime/debug/stack.go:24 +0x64
runtime/debug.PrintStack()
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/runtime/debug/stack.go:16 +0x1c
github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.printStackTrace.MakePanicError({{0x10732a000?, 0x1090cc018?}}, {0x107350000, 0x14003261bc0}, {0x106ea1120, 0x109021740})
	/Users/cbart/sourcegraph/cmd/frontend/graphqlbackend/testing.go:150 +0x3c
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2.1()
	/Users/cbart/.asdf/installs/golang/1.19.6/packages/pkg/mod/github.com/graph-gophers/graphql-go@v1.5.0/internal/exec/exec.go:188 +0xa4
panic({0x106ea1120, 0x109021740})
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/runtime/panic.go:884 +0x204
github.com/sourcegraph/sourcegraph/internal/featureflag.(*flagSetFetcher).fetchForActor(0x140024eee40, {0x107350000, 0x14003261bc0}, 0x2?)
	/Users/cbart/sourcegraph/internal/featureflag/middleware.go:84 +0x104
github.com/sourcegraph/sourcegraph/internal/featureflag.(*flagSetFetcher).fetch.func1()
	/Users/cbart/sourcegraph/internal/featureflag/middleware.go:54 +0x80
sync.(*Once).doSlow(0x1400290b4b8?, 0x1037ebd4c?)
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/sync/once.go:74 +0x104
sync.(*Once).Do(...)
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/sync/once.go:65
github.com/sourcegraph/sourcegraph/internal/featureflag.(*flagSetFetcher).fetch(0x140024eee40, {0x107350000, 0x14003261bc0})
	/Users/cbart/sourcegraph/internal/featureflag/middleware.go:52 +0x68
github.com/sourcegraph/sourcegraph/internal/featureflag.FromContext({0x107350000, 0x14003261bc0})
	/Users/cbart/sourcegraph/internal/featureflag/middleware.go:96 +0x60
github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*repositoryMirrorInfoResolver).CloneProgress(0x1400325f680, {0x107350000, 0x14003261bc0})
	/Users/cbart/sourcegraph/cmd/frontend/graphqlbackend/repository_mirror.go:130 +0x30
reflect.Value.call({0x1071ebd00?, 0x1400325f680?, 0x14000096c68?}, {0x104e183d0, 0x4}, {0x140017974d0, 0x1, 0x102d07824?})
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/reflect/value.go:584 +0x688
reflect.Value.Call({0x1071ebd00?, 0x1400325f680?, 0x140025e34f8?}, {0x140017974d0?, 0x50?, 0x107117860?})
	/Users/cbart/.asdf/installs/golang/1.19.6/go/src/reflect/value.go:368 +0x90
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection.func2(0x140025e3698?, {0x107350000?, 0x14003261bc0?}, 0x140017974b8, 0x140021b1ec0, 0x1400290beb0, {0x107350000?, 0x14003261bc0})
	/Users/cbart/.asdf/installs/golang/1.19.6/packages/pkg/mod/github.com/graph-gophers/graphql-go@v1.5.0/internal/exec/exec.go:211 +0x404
github.com/graph-gophers/graphql-go/internal/exec.execFieldSelection({0x107350000, 0x14003261bc0}, 0x1400325f580, 0x102b324d4?, 0x140021b1ec0, 0x102b3289c?, 0x1)
	/Users/cbart/.asdf/installs/golang/1.19.6/packages/pkg/mod/github.com/graph-gophers/graphql-go@v1.5.0/internal/exec/exec.go:231 +0x118
github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections.func1(0x140021b1ec0)
	/Users/cbart/.asdf/installs/golang/1.19.6/packages/pkg/mod/github.com/graph-gophers/graphql-go@v1.5.0/internal/exec/exec.go:81 +0x184
created by github.com/graph-gophers/graphql-go/internal/exec.(*Request).execSelections
	/Users/cbart/.asdf/installs/golang/1.19.6/packages/pkg/mod/github.com/graph-gophers/graphql-go@v1.5.0/internal/exec/exec.go:77 +0x134
--- FAIL: TestRepositoryMirrorInfoCloneProgressFetchedFromDatabase (0.03s)
    /Users/cbart/sourcegraph/cmd/frontend/graphqlbackend/repository_mirror_test.go:321:   []*errors.QueryError(
        - 	nil,
        + 	{
        + 		e"graphql: panic occurred: runtime error: invalid memory address or nil pointer dereference",
        + 	},
          )
        
FAIL
FAIL	github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend	1.459s
FAIL

```

## Test plan

Loom https://www.loom.com/share/4b04243970d04895b0db0be0f189c25c
