### PR TITLE
Replace deprecated links to signup.sourcegraph.com in docs

### DIFF
--- a/doc/admin/deploy/index.md
+++ b/doc/admin/deploy/index.md
@@ -22,14 +22,14 @@ Sourcegraph offers multiple deployment options to suit different needs. The appr
 
 Carefully consider your organization's needs and technical expertise when selecting a Sourcegraph deployment method. The method you choose cannot be changed for a running instance, so make an informed decision. The available methods have different capabilities, and the following sections provide recommendations to help you choose.
 
-### [Sourcegraph Cloud](https://signup.sourcegraph.com/)
+### [Sourcegraph Cloud](https://about.sourcegraph.com/get-started?t=enterprise/)
 
 **For Enterprises looking for a Cloud solution.**
 
 A cloud instance hosted and maintained by Sourcegraph
 
 <div>
-  <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
+  <a class="cloud-cta" href="https://about.sourcegraph.com/get-started?t=enterprise" target="_blank" rel="noopener noreferrer">
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>

--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -7,7 +7,7 @@ Sourcegraph provisions each instance in an isolated and secure cloud environment
 ## Start a Sourcegraph Cloud trial
 
 <div>
-  <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
+  <a class="cloud-cta" href="https://about.sourcegraph.com/get-started?t=enterprise" target="_blank" rel="noopener noreferrer">
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -19,7 +19,7 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
 ## Recommended
 
 <div>
-  <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
+  <a class="cloud-cta" href="https://about.sourcegraph.com/get-started?t=enterprise" target="_blank" rel="noopener noreferrer">
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>

--- a/doc/code_search/reference/queries.md
+++ b/doc/code_search/reference/queries.md
@@ -35,7 +35,7 @@ img.toggle {
 This page describes search pattern syntax and keywords available for code search. See the complementary [language reference](language.md) for a visual breakdown. A typical search pattern describes content or filenames to find across all repositories. At the most basic level, a search pattern can simply be a word like `hello`. See our [search patterns](#search-pattern-syntax) documentation for detailed usage. Queries can also include keywords. For example, a typical search query will include a `repo:` keyword that filters search results for a specific repository. See our [keywords](#keywords-all-searches) documentation for more examples.
 
 <div>
-  <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
+  <a class="cloud-cta" href="https://about.sourcegraph.com/get-started?t=enterprise" target="_blank" rel="noopener noreferrer">
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>

--- a/doc/getting-started/github-vs-sourcegraph.md
+++ b/doc/getting-started/github-vs-sourcegraph.md
@@ -729,4 +729,4 @@ Sourcegraph OSS is Apache 2 licensed and allows any developer to use, modify, an
 
 GitHub code search is currently available through a beta preview (you can sign up for their [waitlist](https://github.com/features/code-search-code-view/signup) to request access). The beta preview is not yet available for GitHub Enterprise. 
 
-Sourcegraph’s code intelligence platform is generally available, and you can sign up for a free trial for your team [here](https://signup.sourcegraph.com/).
+Sourcegraph’s code intelligence platform is generally available, and you can sign up for a free trial for your team [here](https://about.sourcegraph.com/get-started?t=enterprise/).

--- a/doc/getting-started/oss-enterprise.md
+++ b/doc/getting-started/oss-enterprise.md
@@ -29,7 +29,7 @@ Sourcegraph OSS is built as a single container which limits scalability.
 Check out our [handbook](https://handbook.sourcegraph.com/departments/engineering/product/process/gtm/licensing/) for additional details on Sourcegraph OSS. 
 
 ## Getting started
-Sourcegraph Enterprise can be run in a variety of environments, from cloud to self-hosted to your local machine. For most customers, we recommend [Sourcegraph Cloud](https://signup.sourcegraph.com/), managed entirely by Sourcegraph. Visit the [get started](https://docs.sourcegraph.com/#get-started) section of the docs for details on every deployment option.
+Sourcegraph Enterprise can be run in a variety of environments, from cloud to self-hosted to your local machine. For most customers, we recommend [Sourcegraph Cloud](https://about.sourcegraph.com/get-started?t=enterprise/), managed entirely by Sourcegraph. Visit the [get started](https://docs.sourcegraph.com/#get-started) section of the docs for details on every deployment option.
 
 Developers can use [Sourcegraph OSS](https://github.com/sourcegraph/sourcegraph) without agreeing to any enterprise licensing terms by building their own server image. If they do so, no code from our enterprise-licensed features will be included in their Sourcegraph deployment.
 

--- a/doc/integration/browser_extension/index.md
+++ b/doc/integration/browser_extension/index.md
@@ -80,7 +80,7 @@ Enterprise, GitLab, Phabricator, Bitbucket Server and Bitbucket Data Center.
 ## Recommended
 
 <div>
-  <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
+  <a class="cloud-cta" href="https://about.sourcegraph.com/get-started?t=enterprise" target="_blank" rel="noopener noreferrer">
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>


### PR DESCRIPTION
Replaces all remaining links that point to signup.sourcegraph.com with links to the "Request an  enterprise trial" page at https://about.sourcegraph.com/get-started?t=enterprise

## Test plan

- docs change