### PR TITLE
dep: resolve CVE-2023-0464 in base image 1/2

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -36,5 +36,5 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1t-r0' 'libssl1.1>=1.1.1t-r0' \
+RUN apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1t-r2' 'libssl1.1>=1.1.1t-r2' \
     'libxml2>=2.9.14-r2'  # CVE-2022-40303 CVE-2022-40304


### PR DESCRIPTION
Resolve the SSL issue in the base image. This is part 1 of the fix. The next PR updates the image tag in all the other docker files.

## Test plan
Scanned a locally built image, no issues:

```
sha256:7ca42162d457704d422e1bacc1901a78cad0176e34cfc6175297d90f564ba44a (alpine 3.14.8)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
