### PR TITLE
repositories list: change label from "View Permissions" to "Permissions"

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -218,7 +218,7 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                     className="p-2"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiSecurity} className="mr-1" />
-                                    View Permissions
+                                    Permissions
                                 </MenuItem>
                                 <MenuItem
                                     as={Button}


### PR DESCRIPTION
The other labels are also called "Settings" and "Code graph data" and not "View settings" or "View code graph data".

I think this is more consistent.

## Test plan

- N/A

## App preview:

- [Web](https://sg-web-mrn-change-permissions-label.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
