### PR TITLE
Fix ExternalService storybook stories

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -13,7 +13,10 @@ import { ExternalServiceEditPage } from './ExternalServiceEditPage'
 
 const decorator: DecoratorFn = story => (
     <div className="p-3 container">
-        <WebStory path="/:externalServiceID" initialEntries={['service123']}>
+        <WebStory
+            path="/site-admin/external-services/:externalServiceID/edit"
+            initialEntries={['/site-admin/external-services/service123/edit']}
+        >
             {story}
         </WebStory>
     </div>

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -15,7 +15,10 @@ import { ExternalServicePage } from './ExternalServicePage'
 
 const decorator: DecoratorFn = story => (
     <div className="p-3 container">
-        <WebStory path="/:externalServiceID" initialEntries={['service123']}>
+        <WebStory
+            path="/site-admin/external-services/:externalServiceID"
+            initialEntries={['/site-admin/external-services/service123']}
+        >
             {story}
         </WebStory>
     </div>


### PR DESCRIPTION
Something in the migration to the new React router broke those -- I think. Now they work again.

## Test plan

- N/A