### PR TITLE
clearer notif email

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -311,7 +311,7 @@ func (e *userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, c
 }
 
 var updateAccountEmailTemplate = txemail.MustValidate(txtypes.Templates{
-	Subject: `({{.Change}}) on your Sourcegraph account ({{.Host}})`,
+	Subject: `{{.Change}} on your Sourcegraph account ({{.Host}})`,
 	Text: `
 Hey there,
 

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -140,7 +140,7 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 		}
 
 		if conf.CanSendEmail() {
-			if err := e.SendUserEmailOnFieldUpdate(ctx, userID, "removed an email"); err != nil {
+			if err := e.SendUserEmailOnFieldUpdate(ctx, userID, "An email was removed"); err != nil {
 				logger.Warn("Failed to send email to inform user of email removal", log.Error(err))
 			}
 		}
@@ -176,7 +176,7 @@ func (e *userEmails) SetPrimaryEmail(ctx context.Context, userID int32, email st
 	}
 
 	if conf.CanSendEmail() {
-		if err := e.SendUserEmailOnFieldUpdate(ctx, userID, "changed primary email"); err != nil {
+		if err := e.SendUserEmailOnFieldUpdate(ctx, userID, "A primary email was changed"); err != nil {
 			logger.Warn("Failed to send email to inform user of primary address change", log.Error(err))
 		}
 	}
@@ -311,18 +311,28 @@ func (e *userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, c
 }
 
 var updateAccountEmailTemplate = txemail.MustValidate(txtypes.Templates{
-	Subject: `Update to your Sourcegraph account ({{.Host}})`,
+	Subject: `({{.Change}}) on your Sourcegraph account ({{.Host}})`,
 	Text: `
-Somebody (likely you) {{.Change}} for the user {{.Username}} on Sourcegraph ({{.Host}}).
+Hey there,
 
-If this was not you please change your password immediately.
+{{.Change}} for the user {{.Username}} on Sourcegraph ({{.Host}}).
+
+If this was you, then no action is required.
+
+If you did not take this action, please change your password immediately.
 `,
 	HTML: `
 <p>
-Somebody (likely you) <strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph ({{.Host}}).
+Hey there,
 </p>
 
-<p><strong>If this was not you please change your password immediately.</strong></p>
+<p>
+<strong>{{.Change}}</strong> for the user <strong>{{.Username}}</strong> on Sourcegraph ({{.Host}}).
+</p>
+
+<p>If this was you, then no action is required.</p>
+
+<p>If you <strong>did not</strong> take this action, please change your password immediately.</p>
 `,
 })
 

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -93,7 +93,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 		With(log.Int32("userID", uid))
 
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, userID, "an access token was created"); err != nil {
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, userID, "An access token was created"); err != nil {
 			logger.Warn("Failed to send email to inform user of access token creation", log.Error(err))
 		}
 	}

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -93,7 +93,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 		With(log.Int32("userID", uid))
 
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, userID, "created an access token"); err != nil {
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, userID, "an access token was created"); err != nil {
 			logger.Warn("Failed to send email to inform user of access token creation", log.Error(err))
 		}
 	}
@@ -161,7 +161,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		With(log.Int32("userID", subjectUserID))
 
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, subjectUserID, "deleted an access token"); err != nil {
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, subjectUserID, "an access token was deleted"); err != nil {
 			logger.Warn("Failed to send email to inform user of access token deletion", log.Error(err))
 		}
 	}

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -365,7 +365,7 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 		With(log.Int32("userID", user.ID))
 
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "updated the password"); err != nil {
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "the password was updated"); err != nil {
 			logger.Warn("Failed to send email to inform user of password update", log.Error(err))
 		}
 	}
@@ -393,7 +393,7 @@ func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 		With(log.Int32("userID", user.ID))
 
 	if conf.CanSendEmail() {
-		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "created a password"); err != nil {
+		if err := backend.NewUserEmailsService(r.db, logger).SendUserEmailOnFieldUpdate(ctx, user.ID, "a password was created"); err != nil {
 			logger.Warn("Failed to send email to inform user of password creation", log.Error(err))
 		}
 	}

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -116,7 +116,7 @@ func (r *schemaResolver) AddUserEmail(ctx context.Context, args *addUserEmailArg
 	}
 
 	if conf.CanSendEmail() {
-		if err := userEmails.SendUserEmailOnFieldUpdate(ctx, userID, "added an email"); err != nil {
+		if err := userEmails.SendUserEmailOnFieldUpdate(ctx, userID, "an email was added"); err != nil {
 			logger.Warn("Failed to send email to inform user of email addition", log.Error(err))
 		}
 	}

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -165,7 +165,7 @@ func HandleResetPasswordCode(logger log.Logger, db database.DB) http.HandlerFunc
 		}
 
 		if conf.CanSendEmail() {
-			if err := backend.NewUserEmailsService(db, logger).SendUserEmailOnFieldUpdate(ctx, params.UserID, "reset the password"); err != nil {
+			if err := backend.NewUserEmailsService(db, logger).SendUserEmailOnFieldUpdate(ctx, params.UserID, "the password was reset"); err != nil {
 				logger.Warn("Failed to send email to inform user of password reset", log.Error(err))
 			}
 		}


### PR DESCRIPTION
Responding to user feedback:

> Can I suggest using friendlier phrasing? I got a little heart jolt...
> The subject is vague and oooooo nobody likes vague subjects about their accounts.
> I read the bold text first, and right-to-left because it's underneath the blue link text. So the first thing I read was "please change your password immediately".
> Suggestion: put this in your normal Sourcegraph email branding, and both start & end with friendly phrases?
> "Hi friend! Just letting you know, ...
> If this was you, no worries - thanks for using the API!

## Test plan

Tested locally, wording change only