### PR TITLE
cmd/gitserver: Remove scrubRemoteURL cleanup job

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -165,13 +165,12 @@ const reposStatsName = "repos-stats.json"
 // 3. Remove stale lock files.
 // 4. Ensure correct git attributes
 // 5. Ensure gc.auto=0 or unset depending on gitGCMode
-// 6. Scrub remote URLs
-// 7. Perform garbage collection
-// 8. Re-clone repos after a while. (simulate git gc)
-// 9. Remove repos based on disk pressure.
-// 10. Perform sg-maintenance
-// 11. Git prune
-// 12. Set sizes of repos
+// 6. Perform garbage collection
+// 7. Re-clone repos after a while. (simulate git gc)
+// 8. Remove repos based on disk pressure.
+// 9. Perform sg-maintenance
+// 10. Git prune
+// 11. Set sizes of repos
 func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.GitserverAddresses) {
 	janitorRunning.Set(1)
 	janitorStart := time.Now()
@@ -292,14 +291,6 @@ func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.Gits
 
 	ensureAutoGC := func(dir GitDir) (done bool, err error) {
 		return false, gitSetAutoGC(dir)
-	}
-
-	scrubRemoteURL := func(dir GitDir) (done bool, err error) {
-		cmd := exec.Command("git", "remote", "remove", "origin")
-		dir.Set(cmd)
-		// ignore error since we fail if the remote has already been scrubbed.
-		_ = cmd.Run()
-		return false, nil
 	}
 
 	maybeReclone := func(dir GitDir) (done bool, err error) {
@@ -460,9 +451,6 @@ func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.Gits
 		{"remove stale locks", removeStaleLocks},
 		// We always want to have the same git attributes file at info/attributes.
 		{"ensure git attributes", ensureGitAttributes},
-		// 2021-03-01 (tomas,keegan) we used to store an authenticated remote URL on
-		// disk. We no longer need it so we can scrub it.
-		{"scrub remote URL", scrubRemoteURL},
 		// Enable or disable background garbage collection depending on
 		// gitGCMode. The purpose is to avoid repository corruption which can
 		// happen if several git-gc operations are running at the same time.

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -340,14 +340,12 @@ func TestCleanupExpired(t *testing.T) {
 	repoNonBare := path.Join(root, "repo-non-bare", ".git")
 	repoPerforce := path.Join(root, "repo-perforce", ".git")
 	repoPerforceGCOld := path.Join(root, "repo-perforce-gc-old", ".git")
-	repoRemoteURLScrub := path.Join(root, "repo-remote-url-scrub", ".git")
 	remote := path.Join(root, "remote", ".git")
 	for _, gitDirPath := range []string{
 		repoNew, repoOld,
 		repoGCNew, repoGCOld,
 		repoBoom, repoCorrupt,
 		repoPerforce, repoPerforceGCOld,
-		repoRemoteURLScrub,
 		remote,
 	} {
 		cmd := exec.Command("git", "--bare", "init", gitDirPath)
@@ -410,9 +408,6 @@ func TestCleanupExpired(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := setRepositoryType(GitDir(repoPerforceGCOld), "perforce"); err != nil {
-		t.Fatal(err)
-	}
-	if err := exec.Command("git", "-C", repoRemoteURLScrub, "remote", "add", "origin", "http://hello:world@boom.com/").Run(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -478,13 +473,6 @@ func TestCleanupExpired(t *testing.T) {
 	}
 	if !now.After(recloneTime(repoBoom)) {
 		t.Error("expected repoBoom reclone time to be updated to not now")
-	}
-
-	// we scrubbed remote URL
-	if out, err := exec.Command("git", "-C", repoRemoteURLScrub, "remote", "-v").Output(); len(out) > 0 {
-		t.Fatalf("expected no output from git remote after URL scrubbing, got: %s", out)
-	} else if err != nil {
-		t.Fatal(err)
 	}
 
 	if _, err := os.Stat(repoNonBare); err == nil {


### PR DESCRIPTION
This was added in https://github.com/sourcegraph/sourcegraph/pull/18535 to clean up remote URL that was being set on disk. A long time since then has passed and we don't set remote on disk any longer. This makes it a safe change to remove for both existing Sourcegraph instances (all existing repos would have been cleaned out since release v3.26 was rolled out) and for new Sourcegraph that were created after this change was implemented, this is a NOOP.



## Test plan

- Sourcegraph works locally
- Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
