### PR TITLE
Update GitLab docs to recommend read_api scope

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -248,7 +248,7 @@ When combined with `"allowSignup": false` or unset, an admin should first create
 Sourcegraph instance:
 
 - Authorization callback URL: `https://sourcegraph.example.com/.auth/gitlab/callback`
-- Scopes: `api`, `read_user`
+- Scopes: `read_api`, `read_user`
 
 Then add the following lines to your site configuration:
 
@@ -262,6 +262,7 @@ Then add the following lines to your site configuration:
         "clientID": "replace-with-the-oauth-application-id",
         "clientSecret": "replace-with-the-oauth-secret",
         "url": "https://gitlab.example.com",
+        "apiScope": "read_api", // If not set, it defaults to "api" and the OAuth application will have to be adjusted accordingly.
         "allowSignup": false, // If not set, it defaults to true allowing any GitLab user with access to your instance to sign up.
         "allowGroups": ["group", "group/subgroup", "group/subgroup/subgroup"], // Restrict logins and sign-ups to members of groups or subgroups based on the full-path provided.
       }

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -248,7 +248,7 @@ When combined with `"allowSignup": false` or unset, an admin should first create
 Sourcegraph instance:
 
 - Authorization callback URL: `https://sourcegraph.example.com/.auth/gitlab/callback`
-- Scopes: `read_api`, `read_user`
+- Scopes: `read_user`, `read_api` (be sure to set `"apiScope": "read_api"` in the `auth.providers` config, as indicated below)
 
 Then add the following lines to your site configuration:
 

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -129,7 +129,8 @@ func TestParseConfig(t *testing.T) {
 						ClientSecret: "my-client-secret",
 						DisplayName:  "GitLab",
 						Type:         extsvc.TypeGitLab,
-						Url:          "https://gitlab.com"},
+						Url:          "https://gitlab.com",
+					},
 				}},
 			}}},
 			wantProviders: []Provider{
@@ -149,7 +150,7 @@ func TestParseConfig(t *testing.T) {
 							AuthURL:  "https://gitlab.com/oauth/authorize",
 							TokenURL: "https://gitlab.com/oauth/token",
 						},
-						Scopes: []string{"read_user", "read_api"},
+						Scopes: []string{"read_user", "api"},
 					}),
 				},
 			},

--- a/internal/extsvc/gitlab/auth.go
+++ b/internal/extsvc/gitlab/auth.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
@@ -48,19 +47,12 @@ func (pat *SudoableToken) Hash() string {
 // RequestedOAuthScopes returns the list of OAuth scopes given the default API
 // scope and any extra scopes.
 func RequestedOAuthScopes(defaultAPIScope string) []string {
-	scopes := []string{"read_user"}
-	if defaultAPIScope == "" {
-		defaultAPIScope = "api"
-	}
-	if envvar.SourcegraphDotComMode() {
-		// By default, request `read_api`. User's who are allowed to add private code
-		// will request full `api` access via extraScopes.
-		scopes = append(scopes, "read_api")
-	} else {
-		// For customer instances we default to api scope so that they can clone private
-		// repos but in they can optionally override this in config.
-		scopes = append(scopes, defaultAPIScope)
-	}
+  scopes := []string{"read_user"}
+  if defaultAPIScope == "api" || defaultAPIScope == "read_api" {
+    scopes = append(scopes, defaultAPIScope)
+  } else {
+    scopes = append(scopes, "api")
+  }
 
-	return scopes
+  return scopes
 }

--- a/internal/extsvc/gitlab/auth.go
+++ b/internal/extsvc/gitlab/auth.go
@@ -47,12 +47,12 @@ func (pat *SudoableToken) Hash() string {
 // RequestedOAuthScopes returns the list of OAuth scopes given the default API
 // scope and any extra scopes.
 func RequestedOAuthScopes(defaultAPIScope string) []string {
-  scopes := []string{"read_user"}
-  if defaultAPIScope == "api" || defaultAPIScope == "read_api" {
-    scopes = append(scopes, defaultAPIScope)
-  } else {
-    scopes = append(scopes, "api")
-  }
+	scopes := []string{"read_user"}
+	if defaultAPIScope == "" {
+		defaultAPIScope = "api"
+	} else {
+		scopes = append(scopes, defaultAPIScope)
+	}
 
-  return scopes
+	return scopes
 }

--- a/internal/extsvc/gitlab/auth.go
+++ b/internal/extsvc/gitlab/auth.go
@@ -49,7 +49,7 @@ func (pat *SudoableToken) Hash() string {
 func RequestedOAuthScopes(defaultAPIScope string) []string {
 	scopes := []string{"read_user"}
 	if defaultAPIScope == "" {
-		defaultAPIScope = "api"
+		scopes = append(scopes, "api")
 	} else {
 		scopes = append(scopes, defaultAPIScope)
 	}


### PR DESCRIPTION
We have had several user concerns over GitLab OAuth requesting read/write access to the API instead of just read access.

This PR updates the docs to recommend the `read_api` scope instead of the `api` scope and adds the necessary `apiScope` entry to the example config.

I would love to make this the default behaviour, but it would break existing setups and everyone would have to add `"apiScope": "api"` to their site config to fix it.

## Test plan

Verified manually that sign in and user permissions syncing, the things we use OAuth tokens for, still work.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
