### PR TITLE
feat: control how many auth providers we show on login screen

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -75,6 +75,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
             endpoint: ENVIRONMENT_CONFIG.CLIENT_OTEL_EXPORTER_OTLP_ENDPOINT,
         },
         embeddingsEnabled: false,
+        primaryLoginProvidersCount: 5,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -1,0 +1,143 @@
+import React, { ReactNode } from 'react'
+
+import { Meta, Story } from '@storybook/react'
+import { InitialEntry } from 'history'
+
+import { WebStory, WebStoryProps } from '../components/WebStory'
+import { SourcegraphContext } from '../jscontext'
+
+import { SignInPage, SignInPageProps } from './SignInPage'
+
+const config: Meta = {
+    title: 'web/auth/SignInPage',
+}
+
+export default config
+
+const authProviders: SourcegraphContext['authProviders'] = [
+    {
+        displayName: 'Builtin username-password authentication',
+        isBuiltin: true,
+        serviceType: 'builtin',
+        authenticationURL: '',
+        serviceID: '',
+    },
+    {
+        serviceType: 'github',
+        displayName: 'GitHub',
+        isBuiltin: false,
+        authenticationURL: '/.auth/github/login?pc=f00bar',
+        serviceID: 'https://github.com',
+    },
+    {
+        serviceType: 'gitlab',
+        displayName: 'GitLab',
+        isBuiltin: false,
+        authenticationURL: '/.auth/gitlab/login?pc=f00bar',
+        serviceID: 'https://gitlab.com',
+    },
+]
+
+const noBuiltInAuthProviders = authProviders.filter(p => !p.isBuiltin)
+const onlyBuiltInAuthProvider = authProviders.filter(p => p.isBuiltin)
+
+const context: SignInPageProps['context'] = {
+    allowSignup: true,
+    authProviders,
+    sourcegraphDotComMode: false,
+    primaryLoginProvidersCount: 5,
+    authAccessRequest: { enabled: true },
+    xhrHeaders: {},
+    resetPasswordEnabled: true,
+}
+
+export const Default: Story = () => (
+    <WebStory>{({ isLightTheme }) => <SignInPage context={context} authenticatedUser={null} />}</WebStory>
+)
+
+export const NoBuiltIn: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, authProviders: noBuiltInAuthProviders }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)
+
+export const NoResetPassword: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, resetPasswordEnabled: false }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)
+
+export const NoSignUp: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => <SignInPage context={{ ...context, allowSignup: false }} authenticatedUser={null} />}
+    </WebStory>
+)
+
+export const NoAccessRequest: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage
+                context={{ ...context, allowSignup: false, authAccessRequest: { enabled: false } }}
+                authenticatedUser={null}
+            />
+        )}
+    </WebStory>
+)
+
+export const DotComSignUp: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, sourcegraphDotComMode: true }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)
+
+export const OnlyOnePrimaryProvider: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)
+
+export const OnlyOnePrimaryProviderWithoutBuiltIn: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage
+                context={{ ...context, primaryLoginProvidersCount: 1, authProviders: noBuiltInAuthProviders }}
+                authenticatedUser={null}
+            />
+        )}
+    </WebStory>
+)
+
+export const ShowMoreProviders: Story = () => (
+    <WebStory initialEntries={['/sign-in?showMore']}>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)
+
+export const ShowMoreProvidersWithoutBuiltIn: Story = () => (
+    <WebStory initialEntries={['/sign-in?showMore']}>
+        {({ isLightTheme }) => (
+            <SignInPage
+                context={{ ...context, authProviders: noBuiltInAuthProviders, primaryLoginProvidersCount: 1 }}
+                authenticatedUser={null}
+            />
+        )}
+    </WebStory>
+)
+
+export const OnlyBuiltInAuthProvider: Story = () => (
+    <WebStory>
+        {({ isLightTheme }) => (
+            <SignInPage context={{ ...context, authProviders: onlyBuiltInAuthProvider }} authenticatedUser={null} />
+        )}
+    </WebStory>
+)

--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -35,8 +35,8 @@ const authProviders: SourcegraphContext['authProviders'] = [
     },
 ]
 
-const noBuiltInAuthProviders = authProviders.filter(p => !p.isBuiltin)
-const onlyBuiltInAuthProvider = authProviders.filter(p => p.isBuiltin)
+const noBuiltInAuthProviders = authProviders.filter(provider => !provider.isBuiltin)
+const onlyBuiltInAuthProvider = authProviders.filter(provider => provider.isBuiltin)
 
 const context: SignInPageProps['context'] = {
     allowSignup: true,

--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -1,9 +1,6 @@
-import React, { ReactNode } from 'react'
-
 import { Meta, Story } from '@storybook/react'
-import { InitialEntry } from 'history'
 
-import { WebStory, WebStoryProps } from '../components/WebStory'
+import { WebStory } from '../components/WebStory'
 import { SourcegraphContext } from '../jscontext'
 
 import { SignInPage, SignInPageProps } from './SignInPage'

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -1,11 +1,10 @@
 import { within } from '@testing-library/dom'
 import { Route, Routes } from 'react-router-dom'
 
-import { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { AuthenticatedUser } from '../auth'
-import { AuthProvider, SourcegraphContext } from '../jscontext'
+import { SourcegraphContext } from '../jscontext'
 
 import { SignInPage } from './SignInPage'
 
@@ -57,7 +56,6 @@ describe('SignInPage', () => {
                                 authProviders: props.authProviders ?? authProviders,
                                 resetPasswordEnabled: true,
                                 xhrHeaders: {},
-                                experimentalFeatures: props.experimentalFeatures ?? {},
                                 primaryLoginProvidersCount: props.primaryLoginProvidersCount ?? 5,
                             }}
                         />
@@ -186,7 +184,7 @@ describe('SignInPage', () => {
         })
     })
 
-    it('renders sign in page (cloud)', () => {
+    it('renders sign in page (dotcom)', () => {
         expect(render('/sign-in', { sourcegraphDotComMode: true }).asFragment()).toMatchSnapshot()
     })
 

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -25,6 +25,13 @@ describe('SignInPage', () => {
             authenticationURL: '/.auth/github/login?pc=f00bar',
             serviceID: 'https://github.com',
         },
+        {
+            serviceType: 'gitlab',
+            displayName: 'GitLab',
+            isBuiltin: false,
+            authenticationURL: '/.auth/gitlab/login?pc=f00bar',
+            serviceID: 'https://gitlab.com',
+        },
     ]
 
     const render = (
@@ -35,6 +42,7 @@ describe('SignInPage', () => {
             sourcegraphDotComMode?: boolean
             experimentalFeatures?: SiteConfiguration['experimentalFeatures']
             allowSignup?: boolean
+            primaryLoginProvidersCount?: Number
         }
     ) =>
         renderWithBrandedContext(
@@ -51,6 +59,7 @@ describe('SignInPage', () => {
                                 resetPasswordEnabled: true,
                                 xhrHeaders: {},
                                 experimentalFeatures: props.experimentalFeatures ?? {},
+                                primaryLoginProvidersCount: props.primaryLoginProvidersCount ?? 5,
                             }}
                             isSourcegraphDotCom={false}
                         />
@@ -64,9 +73,9 @@ describe('SignInPage', () => {
         const rendered = render('/sign-in', {})
         expect(
             within(rendered.baseElement)
-                .queryByText(txt => txt.includes('Continue with Email'))
+                .queryByText(txt => txt.includes('More ways to login'))
                 ?.closest('a')
-        ).toHaveAttribute('href', '/sign-in?email=1&')
+        ).toBeVisible()
         expect(
             within(rendered.baseElement)
                 .queryByText(txt => txt.includes('Sign up'))
@@ -77,7 +86,7 @@ describe('SignInPage', () => {
     })
 
     it('renders sign in page (server) with email form expanded', () => {
-        const rendered = render('/sign-in?email=1', {})
+        const rendered = render('/sign-in?showMore', {})
         expect(
             within(rendered.baseElement).queryByText(txt => txt.includes('Continue with Email'))
         ).not.toBeInTheDocument()
@@ -100,7 +109,7 @@ describe('SignInPage', () => {
             authProviders: authProviders.filter(authProvider => authProvider.serviceType === 'builtin'),
         })
         expect(
-            within(rendered.baseElement).queryByText(txt => txt.includes('Continue with Email'))
+            within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))
         ).not.toBeInTheDocument()
 
         expect(rendered.asFragment()).toMatchSnapshot()

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -37,12 +37,11 @@ describe('SignInPage', () => {
     const render = (
         route: string,
         props: {
-            authProviders?: AuthProvider[]
+            authProviders?: SourcegraphContext['authProviders']
             authenticatedUser?: AuthenticatedUser
-            sourcegraphDotComMode?: boolean
-            experimentalFeatures?: SiteConfiguration['experimentalFeatures']
-            allowSignup?: boolean
-            primaryLoginProvidersCount?: Number
+            sourcegraphDotComMode?: SourcegraphContext['sourcegraphDotComMode']
+            allowSignup?: SourcegraphContext['allowSignup']
+            primaryLoginProvidersCount?: SourcegraphContext['primaryLoginProvidersCount']
         }
     ) =>
         renderWithBrandedContext(
@@ -61,7 +60,6 @@ describe('SignInPage', () => {
                                 experimentalFeatures: props.experimentalFeatures ?? {},
                                 primaryLoginProvidersCount: props.primaryLoginProvidersCount ?? 5,
                             }}
-                            isSourcegraphDotCom={false}
                         />
                     }
                 />

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -69,7 +69,7 @@ describe('SignInPage', () => {
         const rendered = render('/sign-in', {})
         expect(
             within(rendered.baseElement)
-                .queryByText(txt => txt.includes('More ways to login'))
+                .queryByText(txt => txt.includes('Other login methods'))
                 ?.closest('a')
         ).toBeInTheDocument()
         expect(
@@ -105,18 +105,18 @@ describe('SignInPage', () => {
             authProviders: authProviders.filter(authProvider => authProvider.serviceType === 'builtin'),
         })
         expect(
-            within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))
+            within(rendered.baseElement).queryByText(txt => txt.includes('Other login methods'))
         ).not.toBeInTheDocument()
 
         expect(rendered.asFragment()).toMatchSnapshot()
     })
 
-    it('renders "More ways to login" if primary provider count is low enough', () => {
+    it('renders "Other login methods" if primary provider count is low enough', () => {
         const rendered = render('/sign-in', {
             authProviders: authProviders.filter(authProvider => authProvider.serviceType !== 'builtin'),
             primaryLoginProvidersCount: 1,
         })
-        expect(within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))).toBeInTheDocument()
+        expect(within(rendered.baseElement).queryByText(txt => txt.includes('Other login methods'))).toBeInTheDocument()
 
         expect(rendered.asFragment()).toMatchSnapshot()
     })
@@ -127,7 +127,7 @@ describe('SignInPage', () => {
             primaryLoginProvidersCount: 1,
         })
         expect(
-            within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))
+            within(rendered.baseElement).queryByText(txt => txt.includes('Other login methods'))
         ).not.toBeInTheDocument()
 
         expect(

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -75,7 +75,7 @@ describe('SignInPage', () => {
             within(rendered.baseElement)
                 .queryByText(txt => txt.includes('More ways to login'))
                 ?.closest('a')
-        ).toBeVisible()
+        ).toBeInTheDocument()
         expect(
             within(rendered.baseElement)
                 .queryByText(txt => txt.includes('Sign up'))
@@ -111,6 +111,32 @@ describe('SignInPage', () => {
         expect(
             within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))
         ).not.toBeInTheDocument()
+
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
+
+    it('renders "More ways to login" if primary provider count is low enough', () => {
+        const rendered = render('/sign-in', {
+            authProviders: authProviders.filter(authProvider => authProvider.serviceType !== 'builtin'),
+            primaryLoginProvidersCount: 1,
+        })
+        expect(within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))).toBeInTheDocument()
+
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
+
+    it('renders non-primary auth provider if primary provider count is low enough and showMore is in the query', () => {
+        const rendered = render('/sign-in?showMore', {
+            authProviders: authProviders.filter(authProvider => authProvider.serviceType !== 'builtin'),
+            primaryLoginProvidersCount: 1,
+        })
+        expect(
+            within(rendered.baseElement).queryByText(txt => txt.includes('More ways to login'))
+        ).not.toBeInTheDocument()
+
+        expect(
+            within(rendered.baseElement).queryByText(txt => txt.includes('Continue with GitLab'))
+        ).toBeInTheDocument()
 
         expect(rendered.asFragment()).toMatchSnapshot()
     })

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -70,7 +70,7 @@ describe('SignInPage', () => {
         expect(
             within(rendered.baseElement)
                 .queryByText(txt => txt.includes('Other login methods'))
-                ?.closest('a')
+                ?.closest('button')
         ).toBeInTheDocument()
         expect(
             within(rendered.baseElement)

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -68,10 +68,10 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
         return true
     }
 
-    const unsetShowMore = (e: React.MouseEvent) => {
+    const unsetShowMore = (event: React.MouseEvent): void => {
         searchParams.delete('showMore')
         setSearchParams(searchParams)
-        e.preventDefault()
+        event.preventDefault()
     }
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -21,24 +21,24 @@ import { UsernamePasswordSignInForm } from './UsernamePasswordSignInForm'
 
 import signInSignUpCommonStyles from './SignInSignUpCommon.module.scss'
 
-interface SignInPageProps {
+export interface SignInPageProps {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
         | 'allowSignup'
         | 'authProviders'
         | 'sourcegraphDotComMode'
+        | 'primaryLoginProvidersCount'
+        // needed for checkRequestAccessAllowed
+        | 'authAccessRequest'
+        // needed for UsernamePasswordSignInForm
         | 'xhrHeaders'
         | 'resetPasswordEnabled'
-        | 'experimentalFeatures'
-        | 'authAccessRequest'
-        | 'primaryLoginProvidersCount'
     >
-    isSourcegraphDotCom: boolean
 }
 
 export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInPageProps>> = props => {
-    const { isSourcegraphDotCom, context, authenticatedUser } = props
+    const { context, authenticatedUser } = props
     useEffect(() => eventLogger.logViewEvent('SignIn', null, false))
 
     const location = useLocation()
@@ -70,7 +70,6 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const unsetShowMore = (e: React.MouseEvent) => {
         searchParams.delete('showMore')
-        console.log('S', searchParams)
         setSearchParams(searchParams)
         e.preventDefault()
     }
@@ -156,7 +155,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
             {context.allowSignup ? (
                 <Text>
                     New to Sourcegraph? <Link to="/sign-up">Sign up.</Link>{' '}
-                    {isSourcegraphDotCom && (
+                    {context.sourcegraphDotComMode && (
                         <>
                             To use Sourcegraph on private repositories,{' '}
                             <Link

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -68,10 +68,14 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
         return true
     }
 
-    const unsetShowMore = (event: React.MouseEvent): void => {
-        searchParams.delete('showMore')
+    const toggleMoreProviders = (showMore: boolean): void => {
+        const param = 'showMore'
+        if (showMore) {
+            searchParams.set(param, '')
+        } else {
+            searchParams.delete(param)
+        }
         setSearchParams(searchParams)
-        event.preventDefault()
     }
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
@@ -101,9 +105,14 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
             >
                 {showMoreProviders && (
                     <div className="mb-3 text-left">
-                        <Link to="" onClick={unsetShowMore}>
-                            <Icon aria-hidden={true} svgPath={mdiChevronLeft} /> Back
-                        </Link>
+                        <Button
+                            variant="link"
+                            className="p-0 border-0 font-weight-normal"
+                            onClick={() => toggleMoreProviders(false)}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiChevronLeft} />
+                            Back
+                        </Button>
                     </div>
                 )}
                 {builtInAuthProvider && (showMoreProviders || thirdPartyAuthProviders.length === 0) && (
@@ -141,12 +150,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 ))}
                 {showMoreWaysToLogin && (
                     <div className="mb-2">
-                        <Button
-                            to={`${location.pathname}?showMore&${searchParams.toString()}`}
-                            display="block"
-                            variant="secondary"
-                            as={Link}
-                        >
+                        <Button display="block" variant="secondary" onClick={() => toggleMoreProviders(true)}>
                             <Icon aria-hidden={true} svgPath={mdiKeyVariant} /> Other login methods
                         </Button>
                     </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -81,6 +81,8 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const showMoreProviders = searchParams.has('showMore') && (builtInAuthProvider || moreProviders.length > 0)
     const hasProviders = builtInAuthProvider || thirdPartyAuthProviders.length > 0
+    const showMoreWaysToLogin =
+        !showMoreProviders && (moreProviders.length > 0 || (primaryProviders.length > 0 && builtInAuthProvider))
 
     const providers = showMoreProviders ? moreProviders : primaryProviders
 
@@ -138,7 +140,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                         </Button>
                     </div>
                 ))}
-                {!showMoreProviders && moreProviders.length > 0 && (
+                {showMoreWaysToLogin && (
                     <div className="mb-2">
                         <Button
                             to={`${location.pathname}?showMore&${searchParams.toString()}`}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -147,7 +147,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                             variant="secondary"
                             as={Link}
                         >
-                            <Icon aria-hidden={true} svgPath={mdiKeyVariant} /> More ways to login
+                            <Icon aria-hidden={true} svgPath={mdiKeyVariant} /> Other login methods
                         </Button>
                     </div>
                 )}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { mdiBitbucket, mdiGithub, mdiGitlab, mdiEmail, mdiMicrosoftAzureDevops } from '@mdi/js'
+import { mdiBitbucket, mdiChevronLeft, mdiGithub, mdiGitlab, mdiKeyVariant, mdiMicrosoftAzureDevops } from '@mdi/js'
 import classNames from 'classnames'
 import { partition } from 'lodash'
 import { Navigate, useLocation, useSearchParams } from 'react-router-dom'
@@ -32,6 +32,7 @@ interface SignInPageProps {
         | 'resetPasswordEnabled'
         | 'experimentalFeatures'
         | 'authAccessRequest'
+        | 'primaryLoginProvidersCount'
     >
     isSourcegraphDotCom: boolean
 }
@@ -42,7 +43,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)
-    const [searchParams] = useSearchParams()
+    const [searchParams, setSearchParams] = useSearchParams()
     const isRequestAccessAllowed = checkRequestAccessAllowed(props.context)
 
     if (authenticatedUser) {
@@ -67,105 +68,121 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
         return true
     }
 
+    const unsetShowMore = (e: React.MouseEvent) => {
+        searchParams.delete('showMore')
+        console.log('S', searchParams)
+        setSearchParams(searchParams)
+        e.preventDefault()
+    }
+
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
+    const primaryProviders = thirdPartyAuthProviders.slice(0, context.primaryLoginProvidersCount)
+    const moreProviders = thirdPartyAuthProviders.slice(context.primaryLoginProvidersCount)
 
-    const showBuiltInAuthForm = searchParams.has('email') || thirdPartyAuthProviders.length === 0
+    const showMoreProviders = searchParams.has('showMore') && (builtInAuthProvider || moreProviders.length > 0)
+    const hasProviders = builtInAuthProvider || thirdPartyAuthProviders.length > 0
 
-    const body =
-        !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (
-            <Alert className="mt-3" variant="info">
-                No authentication providers are available. Contact a site administrator for help.
-            </Alert>
-        ) : (
-            <div className={classNames('mb-4 pb-5', signInSignUpCommonStyles.signinPageContainer)}>
-                {error && <ErrorAlert className="mt-4 mb-0 text-left" error={error} />}
-                <div
-                    className={classNames(
-                        'test-signin-form rounded p-4 my-3',
-                        signInSignUpCommonStyles.signinSignupForm,
-                        error ? 'mt-3' : 'mt-4'
-                    )}
-                >
-                    {builtInAuthProvider && showBuiltInAuthForm && (
-                        <UsernamePasswordSignInForm
-                            {...props}
-                            onAuthError={setError}
-                            className={classNames({ 'mb-3': thirdPartyAuthProviders.length > 0 })}
-                        />
-                    )}
-                    {builtInAuthProvider && showBuiltInAuthForm && thirdPartyAuthProviders.length > 0 && (
-                        <OrDivider className="mb-3 py-1" />
-                    )}
-                    {thirdPartyAuthProviders.map((provider, index) => (
-                        // Use index as key because display name may not be unique. This is OK
-                        // here because this list will not be updated during this component's lifetime.
-                        /* eslint-disable react/no-array-index-key */
-                        <div className="mb-2" key={index}>
-                            <Button
-                                to={provider.authenticationURL}
-                                display="block"
-                                variant={showBuiltInAuthForm ? 'secondary' : 'primary'}
-                                as={AnchorLink}
-                            >
-                                {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
-                                {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
-                                {provider.serviceType === 'bitbucketCloud' && (
-                                    <Icon aria-hidden={true} svgPath={mdiBitbucket} />
-                                )}
-                                {provider.serviceType === 'azuredevops' && (
-                                    <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
-                                )}{' '}
-                                Continue with {provider.displayName}
-                            </Button>
-                        </div>
-                    ))}
-                    {builtInAuthProvider && !showBuiltInAuthForm && (
-                        <div className="mb-2">
-                            <Button
-                                to={`${location.pathname}?email=1&${searchParams.toString()}`}
-                                display="block"
-                                variant="secondary"
-                                as={Link}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiEmail} /> Continue with Email
-                            </Button>
-                        </div>
-                    )}
-                </div>
-                {context.allowSignup ? (
-                    <Text>
-                        New to Sourcegraph? <Link to="/sign-up">Sign up.</Link>{' '}
-                        {isSourcegraphDotCom && (
-                            <>
-                                To use Sourcegraph on private repositories,{' '}
-                                <Link
-                                    to="https://about.sourcegraph.com/app"
-                                    onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
-                                >
-                                    download Sourcegraph app
-                                </Link>{' '}
-                                or{' '}
-                                <Link
-                                    to="https://sourcegraph.com/get-started?t=enterprise"
-                                    onClick={() =>
-                                        eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })
-                                    }
-                                >
-                                    get Sourcegraph Enterprise
-                                </Link>
-                                .
-                            </>
-                        )}
-                    </Text>
-                ) : isRequestAccessAllowed ? (
-                    <Text className="text-muted">
-                        Need an account? <Link to="/request-access">Request access</Link> or contact your site admin.
-                    </Text>
-                ) : (
-                    <Text className="text-muted">Need an account? Contact your site admin.</Text>
+    const providers = showMoreProviders ? moreProviders : primaryProviders
+
+    const body = !hasProviders ? (
+        <Alert className="mt-3" variant="info">
+            No authentication providers are available. Contact a site administrator for help.
+        </Alert>
+    ) : (
+        <div className={classNames('mb-4 pb-5', signInSignUpCommonStyles.signinPageContainer)}>
+            {error && <ErrorAlert className="mt-4 mb-0 text-left" error={error} />}
+            <div
+                className={classNames(
+                    'test-signin-form rounded p-4 my-3',
+                    signInSignUpCommonStyles.signinSignupForm,
+                    error ? 'mt-3' : 'mt-4'
+                )}
+            >
+                {showMoreProviders && (
+                    <div className="mb-3 text-left">
+                        <Link to="" onClick={unsetShowMore}>
+                            <Icon aria-hidden={true} svgPath={mdiChevronLeft} /> Back
+                        </Link>
+                    </div>
+                )}
+                {builtInAuthProvider && (showMoreProviders || thirdPartyAuthProviders.length === 0) && (
+                    <UsernamePasswordSignInForm
+                        {...props}
+                        onAuthError={setError}
+                        className={classNames({ 'mb-3': providers.length > 0 })}
+                    />
+                )}
+                {builtInAuthProvider && showMoreProviders && providers.length > 0 && (
+                    <OrDivider className="mb-3 py-1" />
+                )}
+                {providers.map((provider, index) => (
+                    // Use index as key because display name may not be unique. This is OK
+                    // here because this list will not be updated during this component's lifetime.
+                    /* eslint-disable react/no-array-index-key */
+                    <div className="mb-2" key={index}>
+                        <Button
+                            to={provider.authenticationURL}
+                            display="block"
+                            variant={showMoreProviders ? 'secondary' : 'primary'}
+                            as={AnchorLink}
+                        >
+                            {provider.serviceType === 'github' && <Icon aria-hidden={true} svgPath={mdiGithub} />}
+                            {provider.serviceType === 'gitlab' && <Icon aria-hidden={true} svgPath={mdiGitlab} />}
+                            {provider.serviceType === 'bitbucketCloud' && (
+                                <Icon aria-hidden={true} svgPath={mdiBitbucket} />
+                            )}
+                            {provider.serviceType === 'azuredevops' && (
+                                <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
+                            )}{' '}
+                            Continue with {provider.displayName}
+                        </Button>
+                    </div>
+                ))}
+                {!showMoreProviders && moreProviders.length > 0 && (
+                    <div className="mb-2">
+                        <Button
+                            to={`${location.pathname}?showMore&${searchParams.toString()}`}
+                            display="block"
+                            variant="secondary"
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiKeyVariant} /> More ways to login
+                        </Button>
+                    </div>
                 )}
             </div>
-        )
+            {context.allowSignup ? (
+                <Text>
+                    New to Sourcegraph? <Link to="/sign-up">Sign up.</Link>{' '}
+                    {isSourcegraphDotCom && (
+                        <>
+                            To use Sourcegraph on private repositories,{' '}
+                            <Link
+                                to="https://about.sourcegraph.com/app"
+                                onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
+                            >
+                                download Sourcegraph app
+                            </Link>{' '}
+                            or{' '}
+                            <Link
+                                to="https://sourcegraph.com/get-started?t=enterprise"
+                                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
+                            >
+                                get Sourcegraph Enterprise
+                            </Link>
+                            .
+                        </>
+                    )}
+                </Text>
+            ) : isRequestAccessAllowed ? (
+                <Text className="text-muted">
+                    Need an account? <Link to="/request-access">Request access</Link> or contact your site admin.
+                </Text>
+            ) : (
+                <Text className="text-muted">Need an account? Contact your site admin.</Text>
+            )}
+        </div>
+    )
 
     return (
         <div className={signInSignUpCommonStyles.signinSignupPage}>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -72,9 +72,9 @@ exports[`SignInPage renders "Other login methods" if primary provider count is l
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -90,7 +90,7 @@ exports[`SignInPage renders "Other login methods" if primary provider count is l
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -160,9 +160,9 @@ exports[`SignInPage renders non-primary auth provider if primary provider count 
           <div
             class="mb-3 text-left"
           >
-            <a
-              class="anchorLink"
-              href=""
+            <button
+              class="btn btnLink p-0 border-0 font-weight-normal"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -177,8 +177,8 @@ exports[`SignInPage renders non-primary auth provider if primary provider count 
                   d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
                 />
               </svg>
-               Back
-            </a>
+              Back
+            </button>
           </div>
           <div
             class="mb-2"
@@ -325,9 +325,9 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -343,7 +343,7 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -473,9 +473,9 @@ exports[`SignInPage renders sign in page (server) 1`] = `
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -491,7 +491,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -561,9 +561,9 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
           <div
             class="mb-3 text-left"
           >
-            <a
-              class="anchorLink"
-              href=""
+            <button
+              class="btn btnLink p-0 border-0 font-weight-normal"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -578,8 +578,8 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
                   d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
                 />
               </svg>
-               Back
-            </a>
+              Back
+            </button>
           </div>
           <form
             class=""
@@ -910,9 +910,9 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -928,7 +928,7 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -1044,9 +1044,9 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -1062,7 +1062,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -1178,9 +1178,9 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&"
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -1196,7 +1196,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p
@@ -1322,9 +1322,9 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
           <div
             class="mb-2"
           >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?showMore&sourcegraph-operator="
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -1340,7 +1340,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
                 />
               </svg>
                Other login methods
-            </a>
+            </button>
           </div>
         </div>
         <p

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SignInPage renders "More ways to login" if primary provider count is low enough 1`] = `
+exports[`SignInPage renders "Other login methods" if primary provider count is low enough 1`] = `
 <DocumentFragment>
   <div
     class="signinSignupPage"
@@ -89,7 +89,7 @@ exports[`SignInPage renders "More ways to login" if primary provider count is lo
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -342,7 +342,7 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -490,7 +490,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -927,7 +927,7 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -1061,7 +1061,7 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -1195,7 +1195,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>
@@ -1339,7 +1339,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
                   d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
                 />
               </svg>
-               More ways to login
+               Other login methods
             </a>
           </div>
         </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`SignInPage renders non-primary auth provider if primary provider count 
 
 exports[`SignInPage renders redirect when user is authenticated 1`] = `<DocumentFragment />`;
 
-exports[`SignInPage renders sign in page (cloud) 1`] = `
+exports[`SignInPage renders sign in page (dotcom) 1`] = `
 <DocumentFragment>
   <div
     class="signinSignupPage"
@@ -356,7 +356,21 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
           >
             Sign up.
           </a>
-           
+           To use Sourcegraph on private repositories, 
+          <a
+            class="anchorLink"
+            href="https://about.sourcegraph.com/app"
+          >
+            download Sourcegraph app
+          </a>
+           or 
+          <a
+            class="anchorLink"
+            href="https://sourcegraph.com/get-started?t=enterprise"
+          >
+            get Sourcegraph Enterprise
+          </a>
+          .
         </p>
       </div>
     </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -81,8 +81,8 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&"
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -94,10 +94,10 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
             </a>
           </div>
         </div>
@@ -276,8 +276,31 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
         <div
           class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
         >
+          <div
+            class="mb-3 text-left"
+          >
+            <a
+              class="anchorLink"
+              href=""
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+                />
+              </svg>
+               Back
+            </a>
+          </div>
           <form
-            class="mb-3"
+            class=""
           >
             <label
               class="label label form-group"
@@ -351,44 +374,6 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
               </button>
             </div>
           </form>
-          <div
-            class="mb-3 py-1 d-flex align-items-center"
-          >
-            <div
-              class="w-100 border"
-            />
-            <small
-              class="px-2 text-muted "
-            >
-              OR
-            </small>
-            <div
-              class="w-100 border"
-            />
-          </div>
-          <div
-            class="mb-2"
-          >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/.auth/github/login?pc=f00bar"
-            >
-              <svg
-                aria-hidden="true"
-                class="mdi-icon iconInline"
-                fill="currentColor"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-              >
-                <path
-                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
-                />
-              </svg>
-               Continue with GitHub
-            </a>
-          </div>
         </div>
         <p
           class=""
@@ -621,8 +606,8 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&"
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -634,10 +619,10 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
             </a>
           </div>
         </div>
@@ -732,8 +717,8 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&"
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -745,10 +730,10 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
             </a>
           </div>
         </div>
@@ -843,8 +828,8 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&"
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -856,10 +841,10 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
             </a>
           </div>
         </div>
@@ -955,17 +940,7 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
           >
             <a
               class="anchorLink btn btnPrimary btnBlock"
-              href=""
-            >
-               Continue with Sourcegraph Operators
-            </a>
-          </div>
-          <div
-            class="mb-2"
-          >
-            <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&sourcegraph-operator="
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -977,10 +952,20 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnPrimary btnBlock"
+              href=""
+            >
+               Continue with Sourcegraph Operators
             </a>
           </div>
         </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -1,5 +1,227 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SignInPage renders "More ways to login" if primary provider count is low enough 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up.
+          </a>
+           
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SignInPage renders non-primary auth provider if primary provider count is low enough and showMore is in the query 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <div
+            class="mb-3 text-left"
+          >
+            <a
+              class="anchorLink"
+              href=""
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+                />
+              </svg>
+               Back
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
+                />
+              </svg>
+               Continue with GitLab
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up.
+          </a>
+           
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SignInPage renders redirect when user is authenticated 1`] = `<DocumentFragment />`;
 
 exports[`SignInPage renders sign in page (cloud) 1`] = `
@@ -100,6 +322,29 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                Continue with GitLab
             </a>
           </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
+            </a>
+          </div>
         </div>
         <p
           class=""
@@ -192,8 +437,8 @@ exports[`SignInPage renders sign in page (server) 1`] = `
             class="mb-2"
           >
             <a
-              class="anchorLink btn btnSecondary btnBlock"
-              href="/sign-in?email=1&"
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -205,10 +450,33 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                 width="24"
               >
                 <path
-                  d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
                 />
               </svg>
-               Continue with Email
+               Continue with GitLab
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
             </a>
           </div>
         </div>
@@ -625,6 +893,29 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
                Continue with GitLab
             </a>
           </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
+            </a>
+          </div>
         </div>
         <p
           class="text-muted"
@@ -736,6 +1027,29 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
                Continue with GitLab
             </a>
           </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
+            </a>
+          </div>
         </div>
         <p
           class=""
@@ -845,6 +1159,29 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
                 />
               </svg>
                Continue with GitLab
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
             </a>
           </div>
         </div>
@@ -966,6 +1303,29 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
               href=""
             >
                Continue with Sourcegraph Operators
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/sign-in?showMore&sourcegraph-operator="
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               More ways to login
             </a>
           </div>
         </div>

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -57,4 +57,5 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     runningOnMacOS: true,
     localFilePickerAvailable: false,
     srcServeGitUrl: 'http://127.0.0.1:3434',
+    primaryLoginProvidersCount: 5,
 })

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -210,6 +210,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Authentication provider instances in site config. */
     authProviders: AuthProvider[]
 
+    /** primaryLoginProvidersCount sets the max number of primary login providers on signin page */
+    primaryLoginProvidersCount: number
+
     /** What the minimum length for a password should be. */
     authMinPasswordLength: number
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -164,7 +164,8 @@ type JSContext struct {
 	AuthMinPasswordLength int                `json:"authMinPasswordLength"`
 	AuthPasswordPolicy    authPasswordPolicy `json:"authPasswordPolicy"`
 
-	AuthProviders []authProviderInfo `json:"authProviders"`
+	AuthProviders                  []authProviderInfo `json:"authProviders"`
+	AuthPrimaryLoginProvidersCount int                `json:"primaryLoginProvidersCount"`
 
 	AuthAccessRequest *schema.AuthAccessRequest `json:"authAccessRequest"`
 
@@ -342,7 +343,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		AuthMinPasswordLength: conf.AuthMinPasswordLength(),
 		AuthPasswordPolicy:    authPasswordPolicy,
 
-		AuthProviders: authProviders,
+		AuthProviders:                  authProviders,
+		AuthPrimaryLoginProvidersCount: conf.AuthPrimaryLoginProvidersCount(),
 
 		AuthAccessRequest: conf.Get().AuthAccessRequest,
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -334,6 +334,17 @@ func IsAccessRequestEnabled() bool {
 	return authAccessRequest == nil || authAccessRequest.Enabled == nil || *authAccessRequest.Enabled
 }
 
+// AuthPrimaryLoginProvidersCount returns the number of primary login providers
+// configured, or 3 (the default) if not explicitly configured.
+// This is only used for the UI
+func AuthPrimaryLoginProvidersCount() int {
+	c := Get().AuthPrimaryLoginProvidersCount
+	if c == 0 {
+		return 3 // default to 3
+	}
+	return c
+}
+
 // SearchSymbolsParallelism returns 20, or the site config
 // "debug.search.symbolsParallelism" value if configured.
 func SearchSymbolsParallelism() int {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2353,6 +2353,8 @@ type SiteConfiguration struct {
 	AuthUnlockAccountLinkSigningKey string `json:"auth.unlockAccountLinkSigningKey,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`
+	// AuthPrimaryLoginProvidersCount description: The number of primary login providers configured. These are shown by default to the user on login screen. Other providers are shown under `More ways to login` section.
+	AuthPrimaryLoginProvidersCount int `json:"auth.primaryLoginProvidersCount,omitempty"`
 	// AuthzEnforceForSiteAdmins description: When true, site admins will only be able to see private code they have access to via our authz system.
 	AuthzEnforceForSiteAdmins bool `json:"authz.enforceForSiteAdmins,omitempty"`
 	// AuthzRefreshInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2329,6 +2329,8 @@ type SiteConfiguration struct {
 	AuthPasswordPolicy *AuthPasswordPolicy `json:"auth.passwordPolicy,omitempty"`
 	// AuthPasswordResetLinkExpiry description: The duration (in seconds) that a password reset link is considered valid.
 	AuthPasswordResetLinkExpiry int `json:"auth.passwordResetLinkExpiry,omitempty"`
+	// AuthPrimaryLoginProvidersCount description: The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `More ways to login` section.
+	AuthPrimaryLoginProvidersCount int `json:"auth.primaryLoginProvidersCount,omitempty"`
 	// AuthProviders description: The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
 	AuthProviders []AuthProviders `json:"auth.providers,omitempty"`
 	// AuthPublic description: WARNING: This option has been removed as of 3.8.
@@ -2353,8 +2355,6 @@ type SiteConfiguration struct {
 	AuthUnlockAccountLinkSigningKey string `json:"auth.unlockAccountLinkSigningKey,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`
-	// AuthPrimaryLoginProvidersCount description: The number of primary login providers configured. These are shown by default to the user on login screen. Other providers are shown under `More ways to login` section.
-	AuthPrimaryLoginProvidersCount int `json:"auth.primaryLoginProvidersCount,omitempty"`
 	// AuthzEnforceForSiteAdmins description: When true, site admins will only be able to see private code they have access to via our authz system.
 	AuthzEnforceForSiteAdmins bool `json:"authz.enforceForSiteAdmins,omitempty"`
 	// AuthzRefreshInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
@@ -2609,6 +2609,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "auth.minPasswordLength")
 	delete(m, "auth.passwordPolicy")
 	delete(m, "auth.passwordResetLinkExpiry")
+	delete(m, "auth.primaryLoginProvidersCount")
 	delete(m, "auth.providers")
 	delete(m, "auth.public")
 	delete(m, "auth.sessionExpiry")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2329,7 +2329,7 @@ type SiteConfiguration struct {
 	AuthPasswordPolicy *AuthPasswordPolicy `json:"auth.passwordPolicy,omitempty"`
 	// AuthPasswordResetLinkExpiry description: The duration (in seconds) that a password reset link is considered valid.
 	AuthPasswordResetLinkExpiry int `json:"auth.passwordResetLinkExpiry,omitempty"`
-	// AuthPrimaryLoginProvidersCount description: The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `More ways to login` section.
+	// AuthPrimaryLoginProvidersCount description: The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `Other login methods` section.
 	AuthPrimaryLoginProvidersCount int `json:"auth.primaryLoginProvidersCount,omitempty"`
 	// AuthProviders description: The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
 	AuthProviders []AuthProviders `json:"auth.providers,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1889,6 +1889,12 @@
         }
       }
     },
+    "auth.primaryLoginProvidersCount": {
+      "description": "The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `More ways to login` section.",
+      "type": "integer",
+      "group": "Authentication",
+      "default": 3
+    },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
       "type": ["string"],

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1890,7 +1890,7 @@
       }
     },
     "auth.primaryLoginProvidersCount": {
-      "description": "The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `More ways to login` section.",
+      "description": "The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `Other login methods` section.",
       "type": "integer",
       "group": "Authentication",
       "default": 3


### PR DESCRIPTION
## Description

We only show primary auth providers by default. The rest of the auth providers can be accessed by clicking the "Other login methods" button.

## Screenshots

### When limit < count of all providers
<img width="348" alt="Screenshot 2023-04-05 at 14 38 50" src="https://user-images.githubusercontent.com/9974711/230083091-21e3e943-f9ba-4422-8db7-c7f42a07747d.png">

### With builtin auth provider
<img width="357" alt="Screenshot 2023-04-05 at 14 39 25" src="https://user-images.githubusercontent.com/9974711/230083088-ef31397a-cd84-4d7a-a12b-cc679765a1eb.png">

### Without builtin auth provider
<img width="355" alt="Screenshot 2023-04-05 at 14 39 41" src="https://user-images.githubusercontent.com/9974711/230083085-61656f27-bf60-41bc-aa5d-fd461f123deb.png">

### When limit >= count of all providers
<img width="350" alt="Screenshot 2023-04-05 at 14 39 58" src="https://user-images.githubusercontent.com/9974711/230083080-f4e277bf-5042-46b9-a30d-f60f7e9cb59a.png">


## Related

- https://github.com/sourcegraph/sourcegraph/issues/49831

## Test plan

tested manually
### TODO

- [x] fix the unit test that is failing
- [x] add/fix storybook
