### PR TITLE
bazel: build `cody-ui` and `cody-shared`

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -7,10 +7,9 @@ client/build-config/node_modules
 client/client-api/node_modules
 client/codeintellify/node_modules
 client/cody/node_modules
-client/cody/common/node_modules
-client/cody/server/node_modules
 client/cody-shared/node_modules
-client/cody/vscode-codegen/node_modules
+client/cody-ui/node_modules
+client/cody-web/node_modules
 client/common/node_modules
 client/eslint-plugin-wildcard/node_modules
 client/extension-api/node_modules
@@ -48,4 +47,3 @@ cmd/sitemap
 
 internal/cmd/progress-bot
 client/cody
-client/cody-shared

--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -1,0 +1,94 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//dev:defs.bzl", "jest_test", "npm_package", "ts_project")
+
+npm_link_all_packages(name = "node_modules")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//:tsconfig",
+        "//client/common:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "cody-shared_lib",
+    srcs = [
+        "src/chat/chat.ts",
+        "src/chat/client.ts",
+        "src/chat/markdown.ts",
+        "src/chat/preamble.ts",
+        "src/chat/recipes/chat-question.ts",
+        "src/chat/recipes/explain-code-detailed.ts",
+        "src/chat/recipes/explain-code-high-level.ts",
+        "src/chat/recipes/generate-docstring.ts",
+        "src/chat/recipes/generate-test.ts",
+        "src/chat/recipes/git-log.ts",
+        "src/chat/recipes/helpers.ts",
+        "src/chat/recipes/improve-variable-names.ts",
+        "src/chat/recipes/index.ts",
+        "src/chat/recipes/langs.ts",
+        "src/chat/recipes/recipe.ts",
+        "src/chat/recipes/translate.ts",
+        "src/chat/transcript/index.ts",
+        "src/chat/transcript/interaction.ts",
+        "src/chat/transcript/messages.ts",
+        "src/chat/viewHelpers.ts",
+        "src/codebase-context/index.ts",
+        "src/codebase-context/messages.ts",
+        "src/configuration.ts",
+        "src/editor/index.ts",
+        "src/embeddings/client.ts",
+        "src/embeddings/index.ts",
+        "src/intent-detector/client.ts",
+        "src/intent-detector/index.ts",
+        "src/keyword-context/index.ts",
+        "src/prompt/constants.ts",
+        "src/prompt/templates.ts",
+        "src/prompt/truncation.ts",
+        "src/sourcegraph-api/completions/browserClient.ts",
+        "src/sourcegraph-api/completions/client.ts",
+        "src/sourcegraph-api/completions/nodeClient.ts",
+        "src/sourcegraph-api/completions/parse.ts",
+        "src/sourcegraph-api/completions/types.ts",
+        "src/sourcegraph-api/graphql/client.ts",
+        "src/sourcegraph-api/graphql/index.ts",
+        "src/sourcegraph-api/graphql/queries.ts",
+        "src/sourcegraph-api/index.ts",
+        "src/timestamp.ts",
+        "src/utils.ts",
+    ],
+    tsconfig = ":tsconfig",
+    # TODO(bazel): "#keep"s required for type-only imports
+    deps = [
+        ":node_modules/@sourcegraph/common",
+        "//:node_modules/@microsoft/fetch-event-source",
+        "//:node_modules/@types/isomorphic-fetch",
+        "//:node_modules/@types/node",
+        "//:node_modules/isomorphic-fetch",
+    ],
+)
+
+npm_package(
+    name = "cody-shared_pkg",
+    srcs = [
+        "package.json",
+        ":cody-shared_lib",
+    ],
+)
+
+ts_project(
+    name = "cody-shared_tests",
+    testonly = True,
+    srcs = [
+        "src/chat/transcript/transcript.test.ts",
+        "src/test/mocks.ts",
+    ],
+    deps = [
+        ":cody-shared_lib",
+        "//:node_modules/@types/node",
+    ],
+)

--- a/client/cody-ui/BUILD.bazel
+++ b/client/cody-ui/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//dev:defs.bzl", "jest_test", "npm_package", "ts_project")
+
+# gazelle:js_ignore_imports **/*.css
+
+npm_link_all_packages(name = "node_modules")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//:tsconfig",
+        "//client/cody-shared:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "cody-ui_lib",
+    srcs = [
+        "src/Chat.tsx",
+        "src/Terms.tsx",
+        "src/Tips.tsx",
+        "src/chat/CodeBlocks.tsx",
+        "src/chat/ContextFiles.tsx",
+        "src/index.ts",
+        "src/utils/icons.tsx",
+    ],
+	data = [
+		"src/Tips.css"
+	],
+    tsconfig = ":tsconfig",
+    # TODO(bazel): "#keep"s required for type-only imports
+    deps = [
+        ":node_modules/@sourcegraph/cody-shared",
+        "//:node_modules/@types/classnames",
+        "//:node_modules/@types/react",
+        "//:node_modules/classnames",
+        "//:node_modules/react",
+    ],
+)
+
+npm_package(
+    name = "cody-ui_pkg",
+    srcs = [
+        "package.json",
+        ":cody-ui_lib",
+    ],
+)

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1243,6 +1243,7 @@ ts_project(
         "src/repo/repoContainerRoutes.tsx",
         "src/repo/repoHeaderActionButtons.tsx",
         "src/repo/repoRevisionContainerRoutes.tsx",
+        "src/repo/repoRevisionSidebar/cody/RepoRevisionSidebarCody.tsx",
         "src/repo/settings/RepoSettingsArea.tsx",
         "src/repo/settings/RepoSettingsIndexPage.tsx",
         "src/repo/settings/RepoSettingsMirrorPage.tsx",
@@ -1592,6 +1593,8 @@ ts_project(
         ":node_modules/@sourcegraph/branded",
         ":node_modules/@sourcegraph/client-api",  #keep
         ":node_modules/@sourcegraph/codeintellify",
+        ":node_modules/@sourcegraph/cody-shared",
+        ":node_modules/@sourcegraph/cody-ui",
         ":node_modules/@sourcegraph/common",
         ":node_modules/@sourcegraph/extension-api-types",  #keep
         ":node_modules/@sourcegraph/http-client",
@@ -1816,6 +1819,7 @@ ts_project(
         "src/user/index.test.ts",
         "src/user/settings/profile/UserSettingsProfilePage.test.tsx",
         "src/user/settings/research/ProductResearch.test.tsx",
+        "src/util/checkRequestAccessAllowed.test.ts",
         "src/util/codeStatsUtils.test.ts",
         "src/util/getReactElements.test.tsx",
         "src/util/prettyBytesBigint.test.ts",


### PR DESCRIPTION
## Context

Build `cody-ui` and `cody-shared` packages with Bazel.

## Test plan

bazel build locally.
