### PR TITLE
permissions-center: fix the story, so it is not broken.

### DIFF
--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -210,7 +210,7 @@ function generateResponse(
                 state: state ?? null,
                 searchType: null,
                 query: '',
-                partial: partial,
+                partial,
             },
         },
         result: {

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -4,6 +4,7 @@ import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import {
+    CodeHostStatus,
     ExternalServiceKind,
     PermissionsSyncJobPriority,
     PermissionsSyncJobReason,
@@ -38,7 +39,10 @@ const SG_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.reason.group === Perm
 const WEBHOOK_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.reason.group === PermissionsSyncJobReasonGroup.WEBHOOK)
 
 const CANCELED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.CANCELED)
-const COMPLETED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.COMPLETED)
+const COMPLETED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(
+    job => job.state === PermissionsSyncJobState.COMPLETED && !job.partialSuccess
+)
+const PARTIAL_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.partialSuccess)
 const ERRORED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.ERRORED)
 const FAILED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.FAILED)
 const PROCESSING_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.PROCESSING)
@@ -56,11 +60,12 @@ export const SixSyncJobsFound: Story = () => (
                         generateResponse(null, PermissionsSyncJobReasonGroup.SOURCEGRAPH, SG_JOBS_MOCK_DATA, 3),
                         generateResponse(null, PermissionsSyncJobReasonGroup.WEBHOOK, WEBHOOK_JOBS_MOCK_DATA, 8),
                         generateResponse(PermissionsSyncJobState.CANCELED, null, CANCELED_JOBS_MOCK_DATA, 4),
-                        generateResponse(PermissionsSyncJobState.COMPLETED, null, COMPLETED_JOBS_MOCK_DATA, 4),
+                        generateResponse(PermissionsSyncJobState.COMPLETED, null, COMPLETED_JOBS_MOCK_DATA, 2),
                         generateResponse(PermissionsSyncJobState.ERRORED, null, ERRORED_JOBS_MOCK_DATA, 3),
                         generateResponse(PermissionsSyncJobState.FAILED, null, FAILED_JOBS_MOCK_DATA, 3),
                         generateResponse(PermissionsSyncJobState.PROCESSING, null, PROCESSING_JOBS_MOCK_DATA, 3),
                         generateResponse(PermissionsSyncJobState.QUEUED, null, QUEUED_JOBS_MOCK_DATA, 3),
+                        generateResponse(null, null, PARTIAL_JOBS_MOCK_DATA, 2, true),
                     ])
                 }
             >
@@ -173,7 +178,15 @@ function getSyncJobs(): PermissionsSyncJob[] {
                       avatarURL: null,
                   }
 
-        jobs.push(createSyncJobMock(index.toString(), state, subject, reason))
+        jobs.push(
+            createSyncJobMock(
+                index.toString(),
+                state,
+                subject,
+                reason,
+                state === PermissionsSyncJobState.COMPLETED && index > 10
+            )
+        )
     }
     return jobs
 }
@@ -182,7 +195,8 @@ function generateResponse(
     state: PermissionsSyncJobState | null,
     reasonGroup: PermissionsSyncJobReasonGroup | null,
     jobs: PermissionsSyncJob[],
-    count: number
+    count: number,
+    partial: boolean = false
 ) {
     return {
         request: {
@@ -194,6 +208,9 @@ function generateResponse(
                 before: null,
                 reasonGroup: reasonGroup ?? null,
                 state: state ?? null,
+                searchType: null,
+                query: '',
+                partial: partial,
             },
         },
         result: {
@@ -218,7 +235,8 @@ function createSyncJobMock(
     id: string,
     state: PermissionsSyncJobState,
     subject: subject,
-    reason: reason
+    reason: reason,
+    partial: boolean = false
 ): PermissionsSyncJob {
     return {
         __typename: 'PermissionsSyncJob',
@@ -250,7 +268,24 @@ function createSyncJobMock(
         priority: PermissionsSyncJobPriority.LOW,
         noPerms: false,
         invalidateCaches: false,
-        codeHostStates: [],
-        partialSuccess: false,
+        codeHostStates: partial
+            ? [
+                  {
+                      __typename: 'CodeHostState',
+                      providerID: '1',
+                      providerType: 'github',
+                      status: CodeHostStatus.SUCCESS,
+                      message: 'success!',
+                  },
+                  {
+                      __typename: 'CodeHostState',
+                      providerID: '1',
+                      providerType: 'gitlab',
+                      status: CodeHostStatus.ERROR,
+                      message: 'error!',
+                  },
+              ]
+            : [],
+        partialSuccess: partial,
     }
 }


### PR DESCRIPTION
It can filter jobs by state or search, as before.

Test plan:
Storybook.

## App preview:

- [Web](https://sg-web-ao-ui-fix-perms-table-story.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
