### PR TITLE
[backport][embeddings][optimise] Encode RepoEmbeddingIndex in chunks (#50224)

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -74,7 +74,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	getRepoEmbeddingIndex, err := getCachedRepoEmbeddingIndex(repoStore, repoEmbeddingJobsStore, func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-		return embeddings.DownloadIndex[embeddings.RepoEmbeddingIndex](ctx, uploadStore, string(repoEmbeddingIndexName))
+		return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, string(repoEmbeddingIndexName))
 	})
 	if err != nil {
 		return err

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -65,6 +65,7 @@ func createEmptyEmbeddingIndex(columnDimension int) embeddings.EmbeddingIndex[em
 		Embeddings:      []float32{},
 		RowMetadata:     []embeddings.RepoEmbeddingRowMetadata{},
 		ColumnDimension: columnDimension,
+		Ranks:           []float32{},
 	}
 }
 
@@ -91,6 +92,7 @@ func embedFiles(
 		Embeddings:      make([]float32, 0, len(fileNames)*dimensions),
 		RowMetadata:     make([]embeddings.RepoEmbeddingRowMetadata, 0, len(fileNames)),
 		ColumnDimension: dimensions,
+		Ranks:           []float32{},
 	}
 
 	// addEmbeddableChunks batches embeddable chunks, gets embeddings for the batches, and appends them to the index above.

--- a/enterprise/internal/embeddings/index_storage.go
+++ b/enterprise/internal/embeddings/index_storage.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"io"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -31,4 +34,137 @@ func UploadIndex[T any](ctx context.Context, uploadStore uploadstore.Store, key 
 
 	_, err := uploadStore.Upload(ctx, key, buffer)
 	return err
+}
+
+func UploadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string, index *RepoEmbeddingIndex) error {
+	pr, pw := io.Pipe()
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		defer pw.Close()
+
+		enc := gob.NewEncoder(pw)
+		return encodeRepoEmbeddingIndex(enc, index, embeddingsChunkSize)
+	})
+
+	eg.Go(func() error {
+		defer pr.Close()
+
+		_, err := uploadStore.Upload(ctx, key, pr)
+		return err
+	})
+
+	return eg.Wait()
+}
+
+func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (*RepoEmbeddingIndex, error) {
+	file, err := uploadStore.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := gob.NewDecoder(file)
+
+	rei, err := decodeRepoEmbeddingIndex(dec)
+	// If decoding fails, assume it is an old index and decode with a generic decoder.
+	if err != nil {
+		// Close the existing file.
+		_ = file.Close()
+
+		return DownloadIndex[RepoEmbeddingIndex](ctx, uploadStore, key)
+	}
+
+	return rei, err
+}
+
+const embeddingsChunkSize = 10_000
+
+// encodeRepoEmbeddingIndex is a specialized encoder for repo embedding indexes. Instead of GOB-encoding
+// the entire RepoEmbeddingIndex, we encode each field separately, and we encode the embeddings array by chunks.
+// This way we avoid allocating a separate very large slice for the embeddings.
+func encodeRepoEmbeddingIndex(enc *gob.Encoder, rei *RepoEmbeddingIndex, chunkSize int) error {
+	if err := enc.Encode(rei.RepoName); err != nil {
+		return err
+	}
+
+	if err := enc.Encode(rei.Revision); err != nil {
+		return err
+	}
+
+	for _, ei := range []EmbeddingIndex{rei.CodeIndex, rei.TextIndex} {
+		if err := enc.Encode(ei.ColumnDimension); err != nil {
+			return err
+		}
+
+		if err := enc.Encode(ei.RowMetadata); err != nil {
+			return err
+		}
+
+		if err := enc.Encode(ei.Ranks); err != nil {
+			return err
+		}
+
+		numChunks := (len(ei.Embeddings) + chunkSize - 1) / chunkSize
+		if err := enc.Encode(numChunks); err != nil {
+			return err
+		}
+
+		for i := 0; i < numChunks; i++ {
+			start := i * chunkSize
+			end := start + chunkSize
+
+			if end > len(ei.Embeddings) {
+				end = len(ei.Embeddings)
+			}
+
+			if err := enc.Encode(ei.Embeddings[start:end]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func decodeRepoEmbeddingIndex(dec *gob.Decoder) (*RepoEmbeddingIndex, error) {
+	rei := &RepoEmbeddingIndex{}
+
+	if err := dec.Decode(&rei.RepoName); err != nil {
+		return nil, err
+	}
+
+	if err := dec.Decode(&rei.Revision); err != nil {
+		return nil, err
+	}
+
+	for _, ei := range []*EmbeddingIndex{&rei.CodeIndex, &rei.TextIndex} {
+		if err := dec.Decode(&ei.ColumnDimension); err != nil {
+			return nil, err
+		}
+
+		if err := dec.Decode(&ei.RowMetadata); err != nil {
+			return nil, err
+		}
+
+		if err := dec.Decode(&ei.Ranks); err != nil {
+			return nil, err
+		}
+
+		var numChunks int
+		if err := dec.Decode(&numChunks); err != nil {
+			return nil, err
+		}
+
+		ei.Embeddings = make([]float32, 0, numChunks*ei.ColumnDimension)
+		for i := 0; i < numChunks; i++ {
+			var embeddingSlice []float32
+			if err := dec.Decode(&embeddingSlice); err != nil {
+				return nil, err
+			}
+			ei.Embeddings = append(ei.Embeddings, embeddingSlice...)
+		}
+	}
+
+	return rei, nil
 }

--- a/enterprise/internal/embeddings/index_storage.go
+++ b/enterprise/internal/embeddings/index_storage.go
@@ -92,7 +92,7 @@ func encodeRepoEmbeddingIndex(enc *gob.Encoder, rei *RepoEmbeddingIndex, chunkSi
 		return err
 	}
 
-	for _, ei := range []EmbeddingIndex{rei.CodeIndex, rei.TextIndex} {
+	for _, ei := range []EmbeddingIndex[RepoEmbeddingRowMetadata]{rei.CodeIndex, rei.TextIndex} {
 		if err := enc.Encode(ei.ColumnDimension); err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func decodeRepoEmbeddingIndex(dec *gob.Decoder) (*RepoEmbeddingIndex, error) {
 		return nil, err
 	}
 
-	for _, ei := range []*EmbeddingIndex{&rei.CodeIndex, &rei.TextIndex} {
+	for _, ei := range []*EmbeddingIndex[RepoEmbeddingRowMetadata]{&rei.CodeIndex, &rei.TextIndex} {
 		if err := dec.Decode(&ei.ColumnDimension); err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/embeddings/index_storage_test.go
+++ b/enterprise/internal/embeddings/index_storage_test.go
@@ -132,12 +132,12 @@ func TestRepoEmbeddingVersionMismatch(t *testing.T) {
 	index := &RepoEmbeddingIndex{
 		RepoName: api.RepoName("repo"),
 		Revision: api.CommitID("commit"),
-		CodeIndex: EmbeddingIndex{
+		CodeIndex: EmbeddingIndex[RepoEmbeddingRowMetadata]{
 			Embeddings:      []float32{0.0, 0.1, 0.2},
 			ColumnDimension: 3,
 			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "a.go", StartLine: 0, EndLine: 1}},
 		},
-		TextIndex: EmbeddingIndex{
+		TextIndex: EmbeddingIndex[RepoEmbeddingRowMetadata]{
 			Embeddings:      []float32{1.0, 2.1, 3.2},
 			ColumnDimension: 3,
 			RowMetadata:     []RepoEmbeddingRowMetadata{{FileName: "b.py", StartLine: 0, EndLine: 1}},

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -6,6 +6,7 @@ type EmbeddingIndex[T any] struct {
 	Embeddings      []float32
 	ColumnDimension int
 	RowMetadata     []T
+	Ranks           []float32
 }
 
 type RepoEmbeddingRowMetadata struct {


### PR DESCRIPTION
Encode repo embeddings in chunks so as to minimise memory usage.

Before:

![Screenshot 2023-03-31 at 13 20
50](https://user-images.githubusercontent.com/6427795/229113103-079505fc-9734-43ba-bd6b-7c64eaa6f0d0.png)

After:

![Screenshot 2023-03-31 at 13 49
11](https://user-images.githubusercontent.com/6427795/229113127-5dad06d8-263b-4036-83bb-a6d4291b8be2.png)

Added test to assert that we are decoding the index correctly

<!-- All pull requests REQUIRE a test plan:
https://docs.sourcegraph.com/dev/background-information/testing_principles -->

---------

Co-authored-by: Rok Novosel <rok@sourcegraph.com>
(cherry picked from commit 0789320fe24976f23f9281b5cd227e5c348ee3b0)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
