### PR TITLE
embeddings: disable document ranks per default

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -130,7 +130,7 @@ func NewHandler(
 			return
 		}
 
-		res, err := searchRepoEmbeddingIndex(r.Context(), logger, args, readFile, getRepoEmbeddingIndex, getQueryEmbedding, args.Debug)
+		res, err := searchRepoEmbeddingIndex(r.Context(), logger, args, readFile, getRepoEmbeddingIndex, getQueryEmbedding)
 		if errcode.IsNotFound(err) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -35,7 +35,7 @@ func searchRepoEmbeddingIndex(
 		return nil, errors.Wrap(err, "getting query embedding")
 	}
 
-	opts := embeddings.SearchOpts{
+	opts := embeddings.SearchOptions{
 		Debug:            params.Debug,
 		UseDocumentRanks: params.UseDocumentRanks,
 	}
@@ -63,7 +63,7 @@ func searchEmbeddingIndex(
 	readFile readFileFn,
 	query []float32,
 	nResults int,
-	opts embeddings.SearchOpts,
+	opts embeddings.SearchOptions,
 ) []embeddings.EmbeddingSearchResult {
 	numWorkers := runtime.GOMAXPROCS(0)
 	rows := index.SimilaritySearch(query, nResults, embeddings.WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: SIMILARITY_SEARCH_MIN_ROWS_TO_SPLIT}, opts)

--- a/enterprise/internal/embeddings/client.go
+++ b/enterprise/internal/embeddings/client.go
@@ -51,6 +51,7 @@ type EmbeddingsSearchParameters struct {
 	CodeResultsCount int          `json:"codeResultsCount"`
 	TextResultsCount int          `json:"textResultsCount"`
 
+	UseDocumentRanks bool `json:"useDocumentRanks"`
 	// If set to "True", EmbeddingSearchResult.Debug will contain useful information about scoring.
 	Debug bool `json:"debug"`
 }

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -83,7 +83,7 @@ type WorkerOptions struct {
 
 // SimilaritySearch finds the `nResults` most similar rows to a query vector. It uses the cosine similarity metric.
 // IMPORTANT: The vectors in the embedding index have to be normalized for similarity search to work correctly.
-func (index *EmbeddingIndex) SimilaritySearch(query []float32, numResults int, workerOptions WorkerOptions, opts SearchOpts) []EmbeddingSearchResult {
+func (index *EmbeddingIndex) SimilaritySearch(query []float32, numResults int, workerOptions WorkerOptions, opts SearchOptions) []EmbeddingSearchResult {
 	if numResults == 0 {
 		return []EmbeddingSearchResult{}
 	}
@@ -136,7 +136,7 @@ func (index *EmbeddingIndex) SimilaritySearch(query []float32, numResults int, w
 	return results
 }
 
-func (index *EmbeddingIndex) partialSimilaritySearch(query []float32, numResults int, partialRows partialRows, opts SearchOpts) *nearestNeighborsHeap {
+func (index *EmbeddingIndex) partialSimilaritySearch(query []float32, numResults int, partialRows partialRows, opts SearchOptions) *nearestNeighborsHeap {
 	nRows := partialRows.end - partialRows.start
 	if nRows <= 0 {
 		return nil
@@ -167,7 +167,7 @@ const (
 	scoreSimilarityWeight float32 = 2.0 / 3.0
 )
 
-func (index *EmbeddingIndex) score(query []float32, i int, opts SearchOpts) (score float32, debugInfo string) {
+func (index *EmbeddingIndex) score(query []float32, i int, opts SearchOptions) (score float32, debugInfo string) {
 	addScore := func(what string, s float32) {
 		score += s
 		if opts.Debug {
@@ -224,7 +224,7 @@ func max(a, b int) int {
 	return b
 }
 
-type SearchOpts struct {
+type SearchOptions struct {
 	Debug            bool
 	UseDocumentRanks bool
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -70,7 +70,7 @@ func TestSimilaritySearch(t *testing.T) {
 			for q := 0; q < numQueries; q++ {
 				t.Run(fmt.Sprintf("find nearest neighbors query=%d numResults=%d numWorkers=%d", q, numResults, numWorkers), func(t *testing.T) {
 					query := queries[q*columnDimension : (q+1)*columnDimension]
-					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, SearchOpts{})
+					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, SearchOptions{})
 					expectedResults := getExpectedResults(ranks[q])
 					require.Equal(t, expectedResults[:min(numResults, len(expectedResults))], results)
 				})
@@ -153,7 +153,7 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 	for _, numWorkers := range []int{1, 2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("numWorkers=%d", numWorkers), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, SearchOpts{})
+				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, SearchOptions{})
 			}
 		})
 	}
@@ -173,7 +173,7 @@ func TestScore(t *testing.T) {
 	}
 	// embeddings[0] = 0.5061, 0.6595, 0.5558
 	// queries[0:3] = 0.4227, 0.4874, 0.7641
-	score, debugInfo := index.score(queries[0:columnDimension], 0, SearchOpts{Debug: true, UseDocumentRanks: true})
+	score, debugInfo := index.score(queries[0:columnDimension], 0, SearchOptions{Debug: true, UseDocumentRanks: true})
 
 	// Check that the score is correct
 	expectedScore := scoreSimilarityWeight*((0.5061*0.4227)+(0.6595*0.4874)+(0.5558*0.7641)) + scoreFileRankWeight*(1.0/32.0)

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -70,7 +70,7 @@ func TestSimilaritySearch(t *testing.T) {
 			for q := 0; q < numQueries; q++ {
 				t.Run(fmt.Sprintf("find nearest neighbors query=%d numResults=%d numWorkers=%d", q, numResults, numWorkers), func(t *testing.T) {
 					query := queries[q*columnDimension : (q+1)*columnDimension]
-					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, false)
+					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, SearchOpts{})
 					expectedResults := getExpectedResults(ranks[q])
 					require.Equal(t, expectedResults[:min(numResults, len(expectedResults))], results)
 				})
@@ -153,7 +153,7 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 	for _, numWorkers := range []int{1, 2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("numWorkers=%d", numWorkers), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, false)
+				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, SearchOpts{})
 			}
 		})
 	}
@@ -173,7 +173,7 @@ func TestScore(t *testing.T) {
 	}
 	// embeddings[0] = 0.5061, 0.6595, 0.5558
 	// queries[0:3] = 0.4227, 0.4874, 0.7641
-	score, debugInfo := index.score(queries[0:columnDimension], 0, true)
+	score, debugInfo := index.score(queries[0:columnDimension], 0, SearchOpts{Debug: true, UseDocumentRanks: true})
 
 	// Check that the score is correct
 	expectedScore := scoreSimilarityWeight*((0.5061*0.4227)+(0.6595*0.4874)+(0.5558*0.7641)) + scoreFileRankWeight*(1.0/32.0)


### PR DESCRIPTION
This PRs adds the boolean 'useDocumentRanks=FALSE' to the API of embeddings search.

We have seen confusing results for context fetching on s2 that can be explained by missing or broken document ranks. The background job to calculate path ranks is still in beta. Hence, for now, we disable the contribution of document ranks to the score.


## Test plan
1. `sg run embeddings`
2. Send post request and check whether the debug info contains contributions from document ranks.
```
curl --request POST \
  --url http://localhost:9991/search \
  --header 'Content-Type: application/json' \
  --data '{	
	"repoName": "github.com/hashicorp/go-multierror",
	"query": "func error",
	"codeResultsCount": 3,
	"textResultsCount": 1,
	"useDocumentRanks": true,
        "debug": true
}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
