### PR TITLE
Bugfix: always return when an error is returned

### DIFF
--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -66,6 +66,10 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
 		requestedPath := mux.Vars(r)["Path"]
 		streamWriter, err := streamhttp.NewWriter(w)


### PR DESCRIPTION
Previously, we would ignore any errors that weren't one of the well-known error types. This would cause a panic down the line when we tried to use repo.

Two commits: first fixes the panic by returning a 503 on any other type of errors, second refactors the error handling to make it more clear that every code path returns with a status.

Fixes panic [here](https://console.cloud.google.com/errors/detail/CNWRiJr2952ZhwE;time=P30D?project=sourcegraph-dev&utm_source=error-reporting-notification&utm_medium=email&utm_content=resolved-error)

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
