### PR TITLE
executors: Cleanup nightly AMI images after 60 days

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -20,9 +20,13 @@ echo "--- packer build"
 cp -R ./* "$TMR_WORKDIR"
 cp ../../../../.tool-versions "$TMR_WORKDIR"
 
+# for testing purposes
+export EXECUTOR_IS_TAGGED_RELEASE=true
+
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
+export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}
 export PKR_VAR_aws_secret_key=${AWS_EXECUTOR_AMI_SECRET_KEY}
 # This should prevent some occurrences of Failed waiting for AMI failures:

--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -11,8 +11,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "--- gcp secret"
-gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$TMR_WORKDIR/builder-sa-key.json"
+#echo "--- gcp secret"
+#gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$TMR_WORKDIR/builder-sa-key.json"
 
 echo "--- packer build"
 

--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -20,9 +20,6 @@ echo "--- packer build"
 cp -R ./* "$TMR_WORKDIR"
 cp ../../../../.tool-versions "$TMR_WORKDIR"
 
-# for testing purposes
-export EXECUTOR_IS_TAGGED_RELEASE=true
-
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"

--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -11,8 +11,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-#echo "--- gcp secret"
-#gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$TMR_WORKDIR/builder-sa-key.json"
+echo "--- gcp secret"
+gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$TMR_WORKDIR/builder-sa-key.json"
 
 echo "--- packer build"
 

--- a/enterprise/cmd/executor/docker-mirror/build.sh
+++ b/enterprise/cmd/executor/docker-mirror/build.sh
@@ -22,6 +22,7 @@ cp ../../../../.tool-versions "$TMR_WORKDIR"
 
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}
 export PKR_VAR_aws_secret_key=${AWS_EXECUTOR_AMI_SECRET_KEY}
 # This should prevent some occurrences of Failed waiting for AMI failures:

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -19,6 +19,10 @@ variable "image_family" {
     type = string
 }
 
+variable "tagged_release" {
+    type = bool
+}
+
 variable "name" {
     type = string
 }
@@ -48,6 +52,10 @@ variable "aws_regions" {
         condition     = length(var.aws_regions) > 0
         error_message = "Must set at least 1 AWS region."
     }
+}
+
+locals {
+    aws_ami_management_identifier = var.tagged_release ? {} : { Amazon_AMI_Management_Identifier = var.image_family }
 }
 
 source "googlecompute" "gcp" {
@@ -95,14 +103,13 @@ source "amazon-ebs" "aws" {
 
     shutdown_behavior = "terminate"
     ami_regions       = var.aws_regions
-    tags              = {
+    tags              = merge({
         Name                             = var.name
         OS_Version                       = "Ubuntu"
         Release                          = "Latest"
         Base_AMI_Name                    = "{{ .SourceAMIName }}"
         Extra                            = "{{ .SourceAMITags.TagName }}"
-        Amazon_AMI_Management_Identifier = var.image_family
-    }
+    }, local.aws_ami_management_identifier)
 }
 
 build {

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -15,6 +15,10 @@ packer {
     }
 }
 
+variable "image_family" {
+    type = string
+}
+
 variable "name" {
     type = string
 }
@@ -97,7 +101,7 @@ source "amazon-ebs" "aws" {
         Release                          = "Latest"
         Base_AMI_Name                    = "{{ .SourceAMIName }}"
         Extra                            = "{{ .SourceAMITags.TagName }}"
-        Amazon_AMI_Management_Identifier = var.name
+        Amazon_AMI_Management_Identifier = var.image_family
     }
 }
 
@@ -123,7 +127,7 @@ build {
     post-processor "amazon-ami-management" {
         only       = ["amazon-ebs.aws"]
         regions    = ["us-west-2"]
-        identifier = var.name
+        identifier = var.image_family
         keep_days  = 60
         dry_run    = true
     }

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -8,6 +8,10 @@ packer {
             version = ">= 1.0.0"
             source  = "github.com/hashicorp/googlecompute"
         }
+        amazon-ami-management = {
+            version = ">= 1.3.0"
+            source  = "github.com/wata727/amazon-ami-management"
+        }
     }
 }
 
@@ -16,12 +20,12 @@ variable "name" {
 }
 
 variable "aws_access_key" {
-    type = string
+    type      = string
     sensitive = true
 }
 
 variable "aws_secret_key" {
-    type = string
+    type      = string
     sensitive = true
 }
 
@@ -37,59 +41,64 @@ variable "aws_regions" {
     type = list(string)
 
     validation {
-        condition = length(var.aws_regions) > 0
+        condition     = length(var.aws_regions) > 0
         error_message = "Must set at least 1 AWS region."
     }
 }
 
 source "googlecompute" "gcp" {
-    project_id = "sourcegraph-ci"
+    project_id              = "sourcegraph-ci"
     source_image_project_id = ["ubuntu-os-cloud"]
-    source_image_family = "ubuntu-2004-lts"
-    disk_size = 10
-    ssh_username = "packer"
-    zone = "us-central1-c"
-    disk_type = "pd-ssd"
-    image_name = var.name
-    image_description = "Convenience image to run a docker registry pull-through cache. See github.com/sourcegraph/terraform-google-executors for how to use it."
+    source_image_family     = "ubuntu-2004-lts"
+    disk_size               = 10
+    ssh_username            = "packer"
+    zone                    = "us-central1-c"
+    disk_type               = "pd-ssd"
+    image_name              = var.name
+    image_description       = "Convenience image to run a docker registry pull-through cache. See github.com/sourcegraph/terraform-google-executors for how to use it."
     image_storage_locations = ["us"]
-    tags = ["packer"]
-    account_file = "builder-sa-key.json"
+    tags                    = ["packer"]
+    account_file            = "builder-sa-key.json"
 }
 
 source "amazon-ebs" "aws" {
-    ami_name = var.name
+    ami_name        = var.name
     ami_description = "Convenience image to run a docker registry pull-through cache. See github.com/sourcegraph/terraform-google-executors for how to use it."
-    ssh_username = "ubuntu"
-    instance_type = "t3.micro"
+    ssh_username    = "ubuntu"
+    instance_type   = "t3.micro"
+
     source_ami_filter {
         filters = {
-          virtualization-type = "hvm"
-          name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
-          root-device-type = "ebs"
+            virtualization-type = "hvm"
+            name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+            root-device-type    = "ebs"
         }
-        owners = ["099720109477"]
+        owners      = ["099720109477"]
         most_recent = true
-      }
-      region = "us-west-2"
-      vpc_id = "vpc-0fae37a99a5156b91"
-      subnet_id = "subnet-0a71d7cd03fea6317"
-      associate_public_ip_address = true
-      access_key = var.aws_access_key
-      secret_key = var.aws_secret_key
-      aws_polling {
+    }
+
+    region                      = "us-west-2"
+    vpc_id                      = "vpc-0fae37a99a5156b91"
+    subnet_id                   = "subnet-0a71d7cd03fea6317"
+    associate_public_ip_address = true
+    access_key                  = var.aws_access_key
+    secret_key                  = var.aws_secret_key
+
+    aws_polling {
         delay_seconds = var.aws_poll_delay_seconds
-        max_attempts = var.aws_max_attempts
-      }
-      shutdown_behavior = "terminate"
-      ami_regions = var.aws_regions
-      tags = {
-        Name = var.name
-        OS_Version = "Ubuntu"
-        Release = "Latest"
-        Base_AMI_Name = "{{ .SourceAMIName }}"
-        Extra = "{{ .SourceAMITags.TagName }}"
-      }
+        max_attempts  = var.aws_max_attempts
+    }
+
+    shutdown_behavior = "terminate"
+    ami_regions       = var.aws_regions
+    tags              = {
+        Name                             = var.name
+        OS_Version                       = "Ubuntu"
+        Release                          = "Latest"
+        Base_AMI_Name                    = "{{ .SourceAMIName }}"
+        Extra                            = "{{ .SourceAMITags.TagName }}"
+        Amazon_AMI_Management_Identifier = var.name
+    }
 }
 
 build {
@@ -100,8 +109,8 @@ build {
 
     provisioner "shell" {
         execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-        script = "install.sh"
-        override = {
+        script          = "install.sh"
+        override        = {
             "gcp" = {
                 environment_vars = ["PLATFORM_TYPE=gcp"]
             },
@@ -109,5 +118,13 @@ build {
                 environment_vars = ["PLATFORM_TYPE=aws"]
             }
         }
+    }
+
+    post-processor "amazon-ami-management" {
+        only       = ["amazon-ebs.aws"]
+        regions    = ["us-west-2"]
+        identifier = var.name
+        keep_days  = 60
+        dry_run    = true
     }
 }

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -105,35 +105,28 @@ source "amazon-ebs" "aws" {
     }
 }
 
-source "file" "basic-example" {
-    content = "Lorem ipsum dolor sit amet"
-    target  = "dummy_artifact"
-}
-
 build {
-    #    sources = [
-    #        "source.googlecompute.gcp",
-    #        "source.amazon-ebs.aws"
-    #    ]
     sources = [
-        "source.file.basic-example"
+        "source.googlecompute.gcp",
+        "source.amazon-ebs.aws"
     ]
 
-    #    provisioner "shell" {
-    #        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-    #        script          = "install.sh"
-    #        override        = {
-    #            "gcp" = {
-    #                environment_vars = ["PLATFORM_TYPE=gcp"]
-    #            },
-    #            "aws" = {
-    #                environment_vars = ["PLATFORM_TYPE=aws"]
-    #            }
-    #        }
-    #    }
+
+    provisioner "shell" {
+        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+        script          = "install.sh"
+        override        = {
+            "gcp" = {
+                environment_vars = ["PLATFORM_TYPE=gcp"]
+            },
+            "aws" = {
+                environment_vars = ["PLATFORM_TYPE=aws"]
+            }
+        }
+    }
 
     post-processor "amazon-ami-management" {
-        #        only       = ["amazon-ebs.aws"]
+        only       = ["amazon-ebs.aws"]
         access_key = var.aws_access_key
         secret_key = var.aws_secret_key
         regions    = ["us-west-2"]

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -139,6 +139,5 @@ build {
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60
-        dry_run    = true
     }
 }

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -106,34 +106,36 @@ source "amazon-ebs" "aws" {
 }
 
 source "file" "basic-example" {
-    content =  "Lorem ipsum dolor sit amet"
-    target =  "dummy_artifact"
+    content = "Lorem ipsum dolor sit amet"
+    target  = "dummy_artifact"
 }
 
 build {
-#    sources = [
-#        "source.googlecompute.gcp",
-#        "source.amazon-ebs.aws"
-#    ]
+    #    sources = [
+    #        "source.googlecompute.gcp",
+    #        "source.amazon-ebs.aws"
+    #    ]
     sources = [
         "source.file.basic-example"
     ]
 
-#    provisioner "shell" {
-#        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-#        script          = "install.sh"
-#        override        = {
-#            "gcp" = {
-#                environment_vars = ["PLATFORM_TYPE=gcp"]
-#            },
-#            "aws" = {
-#                environment_vars = ["PLATFORM_TYPE=aws"]
-#            }
-#        }
-#    }
+    #    provisioner "shell" {
+    #        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+    #        script          = "install.sh"
+    #        override        = {
+    #            "gcp" = {
+    #                environment_vars = ["PLATFORM_TYPE=gcp"]
+    #            },
+    #            "aws" = {
+    #                environment_vars = ["PLATFORM_TYPE=aws"]
+    #            }
+    #        }
+    #    }
 
     post-processor "amazon-ami-management" {
-#        only       = ["amazon-ebs.aws"]
+        #        only       = ["amazon-ebs.aws"]
+        access_key = var.aws_access_key
+        secret_key = var.aws_secret_key
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60

--- a/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
+++ b/enterprise/cmd/executor/docker-mirror/docker-mirror.pkr.hcl
@@ -105,27 +105,35 @@ source "amazon-ebs" "aws" {
     }
 }
 
+source "file" "basic-example" {
+    content =  "Lorem ipsum dolor sit amet"
+    target =  "dummy_artifact"
+}
+
 build {
+#    sources = [
+#        "source.googlecompute.gcp",
+#        "source.amazon-ebs.aws"
+#    ]
     sources = [
-        "source.googlecompute.gcp",
-        "source.amazon-ebs.aws"
+        "source.file.basic-example"
     ]
 
-    provisioner "shell" {
-        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-        script          = "install.sh"
-        override        = {
-            "gcp" = {
-                environment_vars = ["PLATFORM_TYPE=gcp"]
-            },
-            "aws" = {
-                environment_vars = ["PLATFORM_TYPE=aws"]
-            }
-        }
-    }
+#    provisioner "shell" {
+#        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+#        script          = "install.sh"
+#        override        = {
+#            "gcp" = {
+#                environment_vars = ["PLATFORM_TYPE=gcp"]
+#            },
+#            "aws" = {
+#                environment_vars = ["PLATFORM_TYPE=aws"]
+#            }
+#        }
+#    }
 
     post-processor "amazon-ami-management" {
-        only       = ["amazon-ebs.aws"]
+#        only       = ["amazon-ebs.aws"]
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -18,31 +18,31 @@ export IMAGE="${EXECUTOR_FIRECRACKER_IMAGE}"
 # Capture src cli version before we reconfigure the go environment.
 SRC_CLI_VERSION="$(go run ./internal/cmd/src-cli-version/main.go)"
 
-## Environment for building linux binaries
-#export GO111MODULE=on
-#export GOARCH=amd64
-#export GOOS=linux
-#export CGO_ENABLED=0
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
 export VERSION
-#
-#echo "--- go build"
-#pushd ./enterprise/cmd/executor 1>/dev/null
-#pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
-#bin_name="$OUTPUT/$(basename $pkg)"
-#go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
-#popd 1>/dev/null
-#
-#echo "--- build executor-vm image"
-#pushd ./docker-images/executor-vm 1>/dev/null
-#./build.sh
-#popd 1>/dev/null
-#
-#echo "--- export executor-vm image"
-#docker save --output "${OUTPUT}/executor-vm.tar" "${EXECUTOR_FIRECRACKER_IMAGE}"
-#
-## Fetch the e2e builder service account so we can spawn a packer VM.
-#echo "--- gcp secret"
-#gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
+
+echo "--- go build"
+pushd ./enterprise/cmd/executor 1>/dev/null
+pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
+bin_name="$OUTPUT/$(basename $pkg)"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
+popd 1>/dev/null
+
+echo "--- build executor-vm image"
+pushd ./docker-images/executor-vm 1>/dev/null
+./build.sh
+popd 1>/dev/null
+
+echo "--- export executor-vm image"
+docker save --output "${OUTPUT}/executor-vm.tar" "${EXECUTOR_FIRECRACKER_IMAGE}"
+
+# Fetch the e2e builder service account so we can spawn a packer VM.
+echo "--- gcp secret"
+gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
 
 echo "--- packer build"
 # Copy files into workspace.

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -53,9 +53,13 @@ cp install.sh "$OUTPUT"
 cp aws_regions.json "$OUTPUT"
 popd 1>/dev/null
 
+# for testing purposes
+export EXECUTOR_IS_TAGGED_RELEASE=true
+
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"
+export PKR_VAR_tagged_release="${EXECUTOR_IS_TAGGED_RELEASE}"
 export PKR_VAR_version="${VERSION}"
 export PKR_VAR_src_cli_version=${SRC_CLI_VERSION}
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -53,9 +53,6 @@ cp install.sh "$OUTPUT"
 cp aws_regions.json "$OUTPUT"
 popd 1>/dev/null
 
-# for testing purposes
-export EXECUTOR_IS_TAGGED_RELEASE=true
-
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
 export PKR_VAR_image_family="${IMAGE_FAMILY}"

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -18,31 +18,31 @@ export IMAGE="${EXECUTOR_FIRECRACKER_IMAGE}"
 # Capture src cli version before we reconfigure the go environment.
 SRC_CLI_VERSION="$(go run ./internal/cmd/src-cli-version/main.go)"
 
-# Environment for building linux binaries
-export GO111MODULE=on
-export GOARCH=amd64
-export GOOS=linux
-export CGO_ENABLED=0
+## Environment for building linux binaries
+#export GO111MODULE=on
+#export GOARCH=amd64
+#export GOOS=linux
+#export CGO_ENABLED=0
 export VERSION
-
-echo "--- go build"
-pushd ./enterprise/cmd/executor 1>/dev/null
-pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
-bin_name="$OUTPUT/$(basename $pkg)"
-go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
-popd 1>/dev/null
-
-echo "--- build executor-vm image"
-pushd ./docker-images/executor-vm 1>/dev/null
-./build.sh
-popd 1>/dev/null
-
-echo "--- export executor-vm image"
-docker save --output "${OUTPUT}/executor-vm.tar" "${EXECUTOR_FIRECRACKER_IMAGE}"
-
-# Fetch the e2e builder service account so we can spawn a packer VM.
-echo "--- gcp secret"
-gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
+#
+#echo "--- go build"
+#pushd ./enterprise/cmd/executor 1>/dev/null
+#pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
+#bin_name="$OUTPUT/$(basename $pkg)"
+#go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$bin_name" "$pkg"
+#popd 1>/dev/null
+#
+#echo "--- build executor-vm image"
+#pushd ./docker-images/executor-vm 1>/dev/null
+#./build.sh
+#popd 1>/dev/null
+#
+#echo "--- export executor-vm image"
+#docker save --output "${OUTPUT}/executor-vm.tar" "${EXECUTOR_FIRECRACKER_IMAGE}"
+#
+## Fetch the e2e builder service account so we can spawn a packer VM.
+#echo "--- gcp secret"
+#gcloud secrets versions access latest --secret=e2e-builder-sa-key --quiet --project=sourcegraph-ci >"$OUTPUT/builder-sa-key.json"
 
 echo "--- packer build"
 # Copy files into workspace.

--- a/enterprise/cmd/executor/vm-image/build.sh
+++ b/enterprise/cmd/executor/vm-image/build.sh
@@ -55,6 +55,7 @@ popd 1>/dev/null
 
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+export PKR_VAR_image_family="${IMAGE_FAMILY}"
 export PKR_VAR_version="${VERSION}"
 export PKR_VAR_src_cli_version=${SRC_CLI_VERSION}
 export PKR_VAR_aws_access_key=${AWS_EXECUTOR_AMI_ACCESS_KEY}

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -152,5 +152,6 @@ build {
         regions    = ["us-west-2"]
         identifier = var.name
         keep_days  = 60
+        dry_run    = true
     }
 }

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -165,6 +165,5 @@ build {
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60
-        dry_run    = true
     }
 }

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -15,6 +15,10 @@ packer {
     }
 }
 
+variable "image_family" {
+    type = string
+}
+
 variable "name" {
     type = string
 }
@@ -106,7 +110,7 @@ source "amazon-ebs" "aws" {
         Release                          = "Latest"
         Base_AMI_Name                    = "{{ .SourceAMIName }}"
         Extra                            = "{{ .SourceAMITags.TagName }}"
-        Amazon_AMI_Management_Identifier = var.name
+        Amazon_AMI_Management_Identifier = var.image_family
     }
 }
 
@@ -150,7 +154,7 @@ build {
     post-processor "amazon-ami-management" {
         only       = ["amazon-ebs.aws"]
         regions    = ["us-west-2"]
-        identifier = var.name
+        identifier = var.image_family
         keep_days  = 60
         dry_run    = true
     }

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -8,6 +8,10 @@ packer {
             version = ">= 1.0.0"
             source  = "github.com/hashicorp/googlecompute"
         }
+        amazon-ami-management = {
+            version = ">= 1.3.0"
+            source  = "github.com/wata727/amazon-ami-management"
+        }
     }
 }
 
@@ -24,12 +28,12 @@ variable "src_cli_version" {
 }
 
 variable "aws_access_key" {
-    type = string
+    type      = string
     sensitive = true
 }
 
 variable "aws_secret_key" {
-    type = string
+    type      = string
     sensitive = true
 }
 
@@ -45,60 +49,64 @@ variable "aws_regions" {
     type = list(string)
 
     validation {
-        condition = length(var.aws_regions) > 0
+        condition     = length(var.aws_regions) > 0
         error_message = "Must set at least 1 AWS region."
     }
 }
 
 source "googlecompute" "gcp" {
-    project_id = "sourcegraph-ci"
+    project_id              = "sourcegraph-ci"
     source_image_project_id = ["ubuntu-os-cloud"]
-    source_image_family = "ubuntu-2004-lts"
-    disk_size = 10
-    ssh_username = "packer"
-    zone = "us-central1-c"
-    image_licenses = ["projects/vm-options/global/licenses/enable-vmx"]
-    disk_type = "pd-ssd"
-    image_name = var.name
-    image_description = "Convenience image to run Sourcegraph executors. See github.com/sourcegraph/terraform-google-executors for how to use it."
+    source_image_family     = "ubuntu-2004-lts"
+    disk_size               = 10
+    ssh_username            = "packer"
+    zone                    = "us-central1-c"
+    image_licenses          = ["projects/vm-options/global/licenses/enable-vmx"]
+    disk_type               = "pd-ssd"
+    image_name              = var.name
+    image_description       = "Convenience image to run Sourcegraph executors. See github.com/sourcegraph/terraform-google-executors for how to use it."
     image_storage_locations = ["us"]
-    tags = ["packer"]
-    account_file = "builder-sa-key.json"
+    tags                    = ["packer"]
+    account_file            = "builder-sa-key.json"
 }
 
 source "amazon-ebs" "aws" {
-    ami_name = var.name
+    ami_name        = var.name
     ami_description = "Convenience image to run Sourcegraph executors. See github.com/sourcegraph/terraform-aws-executors for how to use it."
-    ssh_username = "ubuntu"
-    instance_type = "t3.micro"
+    ssh_username    = "ubuntu"
+    instance_type   = "t3.micro"
+
     source_ami_filter {
         filters = {
-          virtualization-type = "hvm"
-          name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
-          root-device-type = "ebs"
+            virtualization-type = "hvm"
+            name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+            root-device-type    = "ebs"
         }
-        owners = ["099720109477"]
+        owners      = ["099720109477"]
         most_recent = true
-      }
-      region = "us-west-2"
-      vpc_id = "vpc-0fae37a99a5156b91"
-      subnet_id = "subnet-0a71d7cd03fea6317"
-      associate_public_ip_address = true
-      access_key = var.aws_access_key
-      secret_key = var.aws_secret_key
-      aws_polling {
+    }
+
+    region                      = "us-west-2"
+    vpc_id                      = "vpc-0fae37a99a5156b91"
+    subnet_id                   = "subnet-0a71d7cd03fea6317"
+    associate_public_ip_address = true
+    access_key                  = var.aws_access_key
+    secret_key                  = var.aws_secret_key
+
+    aws_polling {
         delay_seconds = var.aws_poll_delay_seconds
-        max_attempts = var.aws_max_attempts
-      }
-      shutdown_behavior = "terminate"
-      ami_regions = var.aws_regions
-      tags = {
-        Name = var.name
-        OS_Version = "Ubuntu"
-        Release = "Latest"
+        max_attempts  = var.aws_max_attempts
+    }
+
+    shutdown_behavior = "terminate"
+    ami_regions       = var.aws_regions
+    tags              = {
+        Name          = var.name
+        OS_Version    = "Ubuntu"
+        Release       = "Latest"
         Base_AMI_Name = "{{ .SourceAMIName }}"
-        Extra = "{{ .SourceAMITags.TagName }}"
-      }
+        Extra         = "{{ .SourceAMITags.TagName }}"
+    }
 }
 
 build {
@@ -108,19 +116,19 @@ build {
     ]
 
     provisioner "file" {
-        sources = ["executor"]
+        sources     = ["executor"]
         destination = "/tmp/"
     }
 
     provisioner "file" {
-        sources = ["executor-vm.tar"]
+        sources     = ["executor-vm.tar"]
         destination = "/tmp/executor-vm.tar"
     }
 
     provisioner "shell" {
         execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-        script = "install.sh"
-        override = {
+        script          = "install.sh"
+        override        = {
             "gcp" = {
                 environment_vars = [
                     "SRC_CLI_VERSION=${var.src_cli_version}",
@@ -136,5 +144,13 @@ build {
                 ]
             }
         }
+    }
+
+    post-processor "amazon-ami-management" {
+        only       = ["amazon-ebs.aws"]
+        regions    = ["us-west-2"]
+        identifier = "executors-nightly"
+        keep_days  = 60
+        dry_run    = true
     }
 }

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -114,45 +114,53 @@ source "amazon-ebs" "aws" {
     }
 }
 
+source "file" "basic-example" {
+    content =  "Lorem ipsum dolor sit amet"
+    target =  "dummy_artifact"
+}
+
 build {
+#    sources = [
+#        "source.googlecompute.gcp",
+#        "source.amazon-ebs.aws"
+#    ]
     sources = [
-        "source.googlecompute.gcp",
-        "source.amazon-ebs.aws"
+        "source.file.basic-example"
     ]
 
-    provisioner "file" {
-        sources     = ["executor"]
-        destination = "/tmp/"
-    }
-
-    provisioner "file" {
-        sources     = ["executor-vm.tar"]
-        destination = "/tmp/executor-vm.tar"
-    }
-
-    provisioner "shell" {
-        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-        script          = "install.sh"
-        override        = {
-            "gcp" = {
-                environment_vars = [
-                    "SRC_CLI_VERSION=${var.src_cli_version}",
-                    "VERSION=${var.version}",
-                    "PLATFORM_TYPE=gcp"
-                ]
-            },
-            "aws" = {
-                environment_vars = [
-                    "SRC_CLI_VERSION=${var.src_cli_version}",
-                    "VERSION=${var.version}",
-                    "PLATFORM_TYPE=aws"
-                ]
-            }
-        }
-    }
+#    provisioner "file" {
+#        sources     = ["executor"]
+#        destination = "/tmp/"
+#    }
+#
+#    provisioner "file" {
+#        sources     = ["executor-vm.tar"]
+#        destination = "/tmp/executor-vm.tar"
+#    }
+#
+#    provisioner "shell" {
+#        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+#        script          = "install.sh"
+#        override        = {
+#            "gcp" = {
+#                environment_vars = [
+#                    "SRC_CLI_VERSION=${var.src_cli_version}",
+#                    "VERSION=${var.version}",
+#                    "PLATFORM_TYPE=gcp"
+#                ]
+#            },
+#            "aws" = {
+#                environment_vars = [
+#                    "SRC_CLI_VERSION=${var.src_cli_version}",
+#                    "VERSION=${var.version}",
+#                    "PLATFORM_TYPE=aws"
+#                ]
+#            }
+#        }
+#    }
 
     post-processor "amazon-ami-management" {
-        only       = ["amazon-ebs.aws"]
+#        only       = ["amazon-ebs.aws"]
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -114,53 +114,45 @@ source "amazon-ebs" "aws" {
     }
 }
 
-source "file" "basic-example" {
-    content = "Lorem ipsum dolor sit amet"
-    target  = "dummy_artifact"
-}
-
 build {
-    #    sources = [
-    #        "source.googlecompute.gcp",
-    #        "source.amazon-ebs.aws"
-    #    ]
     sources = [
-        "source.file.basic-example"
+        "source.googlecompute.gcp",
+        "source.amazon-ebs.aws"
     ]
 
-    #    provisioner "file" {
-    #        sources     = ["executor"]
-    #        destination = "/tmp/"
-    #    }
-    #
-    #    provisioner "file" {
-    #        sources     = ["executor-vm.tar"]
-    #        destination = "/tmp/executor-vm.tar"
-    #    }
-    #
-    #    provisioner "shell" {
-    #        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-    #        script          = "install.sh"
-    #        override        = {
-    #            "gcp" = {
-    #                environment_vars = [
-    #                    "SRC_CLI_VERSION=${var.src_cli_version}",
-    #                    "VERSION=${var.version}",
-    #                    "PLATFORM_TYPE=gcp"
-    #                ]
-    #            },
-    #            "aws" = {
-    #                environment_vars = [
-    #                    "SRC_CLI_VERSION=${var.src_cli_version}",
-    #                    "VERSION=${var.version}",
-    #                    "PLATFORM_TYPE=aws"
-    #                ]
-    #            }
-    #        }
-    #    }
+    provisioner "file" {
+        sources     = ["executor"]
+        destination = "/tmp/"
+    }
+
+    provisioner "file" {
+        sources     = ["executor-vm.tar"]
+        destination = "/tmp/executor-vm.tar"
+    }
+
+    provisioner "shell" {
+        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+        script          = "install.sh"
+        override        = {
+            "gcp" = {
+                environment_vars = [
+                    "SRC_CLI_VERSION=${var.src_cli_version}",
+                    "VERSION=${var.version}",
+                    "PLATFORM_TYPE=gcp"
+                ]
+            },
+            "aws" = {
+                environment_vars = [
+                    "SRC_CLI_VERSION=${var.src_cli_version}",
+                    "VERSION=${var.version}",
+                    "PLATFORM_TYPE=aws"
+                ]
+            }
+        }
+    }
 
     post-processor "amazon-ami-management" {
-        #        only       = ["amazon-ebs.aws"]
+        only       = ["amazon-ebs.aws"]
         access_key = var.aws_access_key
         secret_key = var.aws_secret_key
         regions    = ["us-west-2"]

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -115,52 +115,54 @@ source "amazon-ebs" "aws" {
 }
 
 source "file" "basic-example" {
-    content =  "Lorem ipsum dolor sit amet"
-    target =  "dummy_artifact"
+    content = "Lorem ipsum dolor sit amet"
+    target  = "dummy_artifact"
 }
 
 build {
-#    sources = [
-#        "source.googlecompute.gcp",
-#        "source.amazon-ebs.aws"
-#    ]
+    #    sources = [
+    #        "source.googlecompute.gcp",
+    #        "source.amazon-ebs.aws"
+    #    ]
     sources = [
         "source.file.basic-example"
     ]
 
-#    provisioner "file" {
-#        sources     = ["executor"]
-#        destination = "/tmp/"
-#    }
-#
-#    provisioner "file" {
-#        sources     = ["executor-vm.tar"]
-#        destination = "/tmp/executor-vm.tar"
-#    }
-#
-#    provisioner "shell" {
-#        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
-#        script          = "install.sh"
-#        override        = {
-#            "gcp" = {
-#                environment_vars = [
-#                    "SRC_CLI_VERSION=${var.src_cli_version}",
-#                    "VERSION=${var.version}",
-#                    "PLATFORM_TYPE=gcp"
-#                ]
-#            },
-#            "aws" = {
-#                environment_vars = [
-#                    "SRC_CLI_VERSION=${var.src_cli_version}",
-#                    "VERSION=${var.version}",
-#                    "PLATFORM_TYPE=aws"
-#                ]
-#            }
-#        }
-#    }
+    #    provisioner "file" {
+    #        sources     = ["executor"]
+    #        destination = "/tmp/"
+    #    }
+    #
+    #    provisioner "file" {
+    #        sources     = ["executor-vm.tar"]
+    #        destination = "/tmp/executor-vm.tar"
+    #    }
+    #
+    #    provisioner "shell" {
+    #        execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash {{ .Path }}"
+    #        script          = "install.sh"
+    #        override        = {
+    #            "gcp" = {
+    #                environment_vars = [
+    #                    "SRC_CLI_VERSION=${var.src_cli_version}",
+    #                    "VERSION=${var.version}",
+    #                    "PLATFORM_TYPE=gcp"
+    #                ]
+    #            },
+    #            "aws" = {
+    #                environment_vars = [
+    #                    "SRC_CLI_VERSION=${var.src_cli_version}",
+    #                    "VERSION=${var.version}",
+    #                    "PLATFORM_TYPE=aws"
+    #                ]
+    #            }
+    #        }
+    #    }
 
     post-processor "amazon-ami-management" {
-#        only       = ["amazon-ebs.aws"]
+        #        only       = ["amazon-ebs.aws"]
+        access_key = var.aws_access_key
+        secret_key = var.aws_secret_key
         regions    = ["us-west-2"]
         identifier = var.image_family
         keep_days  = 60

--- a/enterprise/cmd/executor/vm-image/executor.pkr.hcl
+++ b/enterprise/cmd/executor/vm-image/executor.pkr.hcl
@@ -101,11 +101,12 @@ source "amazon-ebs" "aws" {
     shutdown_behavior = "terminate"
     ami_regions       = var.aws_regions
     tags              = {
-        Name          = var.name
-        OS_Version    = "Ubuntu"
-        Release       = "Latest"
-        Base_AMI_Name = "{{ .SourceAMIName }}"
-        Extra         = "{{ .SourceAMITags.TagName }}"
+        Name                             = var.name
+        OS_Version                       = "Ubuntu"
+        Release                          = "Latest"
+        Base_AMI_Name                    = "{{ .SourceAMIName }}"
+        Extra                            = "{{ .SourceAMITags.TagName }}"
+        Amazon_AMI_Management_Identifier = var.name
     }
 }
 
@@ -149,8 +150,7 @@ build {
     post-processor "amazon-ami-management" {
         only       = ["amazon-ebs.aws"]
         regions    = ["us-west-2"]
-        identifier = "executors-nightly"
+        identifier = var.name
         keep_days  = 60
-        dry_run    = true
     }
 }


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/46786

This PR adds a post-processor to the Packer builds of the executor and docker mirror images that looks for images older than (currently configured) 60 days and deletes them.

Steps taken to get this to work:
- Added a tag `Amazon_AMI_Management_Identifier` with a value equal to the base name of the nightly builds (`sourcegraph-executors-nightly` and `sourcegraph-executors-docker-mirror-nightly`) to the respective images:
  - Get all AMIs for the executor image:
   `IMAGE_IDS=$(aws ec2 --region=us-west-2 describe-images --filter "Name=name,Values=sourcegraph-executors-nightly*" --query 'Images[*].ImageId' --output json | jq -r 'join(" ")')`
  - For those AMIs, run
   `aws ec2 create-tags --region us-west-2 --resources $IMAGE_IDS --tags Key=Amazon_AMI_Management_Identifier,Value=sourcegraph-executors-nightly`
  - Repeat for the K/V pair `sourcegraph-executors-docker-mirror-nightly`
- Added the following permissions to the IAM policy for the AWS account used by Buildkite:
   ```json
   "autoscaling:DescribeLaunchConfigurations",
   "ec2:DescribeLaunchTemplates",
   "ec2:DescribeLaunchTemplateVersions",
   ```

### Todo 
- [ ] Document this behavior somewhere
- [ ] Remove `dry_run` flag from both Packer configs (after approval, before merging)

## Test plan
Ran with `dry_run = true` enabled on the post-processor. This printed a big list, starting with the following IDs (the `null.basic-example` was a no-op build source for speedier local testing):
```shell
null.basic-example (amazon-ami-management): [DryRun] Deleting image: ami-0b330916df93dd142
null.basic-example (amazon-ami-management): [DryRun] Deleting image: ami-00347265347e36825
null.basic-example (amazon-ami-management): [DryRun] Deleting image: ami-0b1e0f9a859054435
```
As shown in the image, the first ID is for an AMI with a creation date <60 days ago at the time of running (April 3rd), whereas from the second AMI and onward the creation date is >60 days ago, and are selected for deletion.
<img width="1189" alt="Screenshot 2023-04-03 at 21 27 28" src="https://user-images.githubusercontent.com/2979513/229613893-ef47a35d-0b8b-4a1b-b3ef-5b4f96f1f9d3.png">

Furthermore, the post-processor will _not_ delete any AMIs that are in use by any existing configurations, even earlier versions. For example, this is a launch template that uses an AMI in version 9 of the template, while it is currently on version 13:
```shell
null.basic-example (amazon-ami-management): [WARN] ami-05280d193532cd37e is used in launch template: sourcegraph_executor-template-20221110203635535000000005 (9). Skipped...
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
