### PR TITLE
Prototype: own aggregation

### DIFF
--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -89,3 +89,30 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
         }
     }
 `
+
+export const FETCH_REPO_OWNERS = gql`
+    ${OWNER_FIELDS}
+
+    query FetchRepoOwners($repo: ID!, $revision: String!) {
+        node(id: $repo) {
+            ... on Repository {
+                commit(rev: $revision) {
+                    aggregatedOwners {
+                        totalCount
+                        nodes {
+                            totalFiles
+                            owner {
+                                ...OwnerFields
+                            }
+                            reasons {
+                                ... on CodeownersFileEntry {
+                                    title
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -51,6 +51,7 @@ import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { RepositoryFields } from '../../graphql-operations'
 import { OwnConfigProps } from '../../own/OwnConfigProps'
 import { basename } from '../../util/path'
+import { RepoHistoryAndOwnBar } from '../blob/own/HistoryAndOwnBar'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 import { isPackageServiceType } from '../packages/isPackageServiceType'
 
@@ -217,6 +218,7 @@ export const TreePage: FC<Props> = ({
 
     const RootHeaderSection = (): React.ReactElement => (
         <div className="d-flex flex-wrap justify-content-between px-0">
+            {ownFeatureFlagEnabled && repo?.id && <RepoHistoryAndOwnBar repoID={repo?.id} revision={commitID} />}
             <div className={styles.header}>
                 <PageHeader className="mb-3 test-tree-page-title">
                     <PageHeader.Heading as="h2" styleAs="h1">

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -19,11 +19,11 @@ import { Card, CardHeader, Link, Tooltip } from '@sourcegraph/wildcard'
 import { requestGraphQL } from '../../backend/graphql'
 import {
     ConnectionContainer,
+    ConnectionError,
     ConnectionList,
     ConnectionLoading,
     ConnectionSummary,
     SummaryContainer,
-    ConnectionError,
 } from '../../components/FilteredConnection/ui'
 import {
     CommitAtTimeResult,
@@ -32,12 +32,12 @@ import {
     DiffSinceVariables,
     GitCommitFields,
     RepositoryContributorNodeFields,
-    TreePageRepositoryContributorsResult,
-    TreePageRepositoryContributorsVariables,
     Scalars,
     TreeCommitsResult,
-    TreePageRepositoryFields,
     TreeCommitsVariables,
+    TreePageRepositoryContributorsResult,
+    TreePageRepositoryContributorsVariables,
+    TreePageRepositoryFields,
 } from '../../graphql-operations'
 import { PersonLink } from '../../person/PersonLink'
 import { quoteIfNeeded, searchQueryForRepoRevision } from '../../search'
@@ -214,6 +214,13 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                     <Card className={styles.commits}>
                         <CardHeader className={panelStyles.cardColHeaderWrapper}>Commits</CardHeader>
                         <Commits {...props} />
+                    </Card>
+                )}
+
+                {!isPackage && (
+                    <Card className={styles.contributors}>
+                        <CardHeader className={panelStyles.cardColHeaderWrapper}>Contributors</CardHeader>
+                        <Contributors {...props} />
                     </Card>
                 )}
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -417,3 +417,10 @@ func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 	repoUrl.Path += "@" + string(r.oid)
 	return &repoUrl
 }
+
+func (r *GitCommitResolver) AggregatedOwners(ctx context.Context, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error) {
+	if r.inputRev != nil {
+		args.Revision = *r.inputRev
+	}
+	return EnterpriseResolvers.ownResolver.AggregatedOwners(ctx, r.repoResolver, args)
+}

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -22,9 +22,16 @@ type AggregatedOwnersArgs struct {
 	After    *string
 }
 
+func (a AggregatedOwnersArgs) GetFirst() int32 {
+	if a.First != nil {
+		return *a.First
+	}
+	return 10
+}
+
 type OwnResolver interface {
 	GitBlobOwnership(ctx context.Context, blob *GitTreeEntryResolver, args ListOwnershipArgs) (OwnershipConnectionResolver, error)
-	AggregatedOwners(ctx context.Context, treeOrBlob *GitTreeEntryResolver, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error)
+	AggregatedOwners(ctx context.Context, repo *RepositoryResolver, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error)
 
 	PersonOwnerField(person *PersonResolver) string
 	UserOwnerField(user *UserResolver) string

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -16,8 +16,15 @@ type ListOwnershipArgs struct {
 	Reasons *[]string
 }
 
+type AggregatedOwnersArgs struct {
+	Revision string
+	First    *int32
+	After    *string
+}
+
 type OwnResolver interface {
 	GitBlobOwnership(ctx context.Context, blob *GitTreeEntryResolver, args ListOwnershipArgs) (OwnershipConnectionResolver, error)
+	AggregatedOwners(ctx context.Context, treeOrBlob *GitTreeEntryResolver, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error)
 
 	PersonOwnerField(person *PersonResolver) string
 	UserOwnerField(user *UserResolver) string
@@ -33,6 +40,19 @@ type OwnResolver interface {
 	AddCodeownersFile(context.Context, *CodeownersFileArgs) (CodeownersIngestedFileResolver, error)
 	UpdateCodeownersFile(context.Context, *CodeownersFileArgs) (CodeownersIngestedFileResolver, error)
 	DeleteCodeownersFiles(context.Context, *DeleteCodeownersFileArgs) (*EmptyResponse, error)
+}
+
+type AggregatedOwnershipConnectionResolver interface {
+	TotalCount(ctx context.Context) int32
+	PageInfo(ctx context.Context) *graphqlutil.PageInfo
+	Nodes(ctx context.Context) []AggregatedOwnershipResolver
+}
+
+type AggregatedOwnershipResolver interface {
+	Owner(ctx context.Context) (OwnerResolver, error)
+	TotalFiles(ctx context.Context) int32
+	//Samples(ctx context.Context) ([]*AggregatedOwnershipSampleResolver, error)
+	Reasons(ctx context.Context) ([]OwnershipReasonResolver, error)
 }
 
 type OwnershipConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -220,14 +220,13 @@ extend type Repository {
     A file containing manually ingested codeowners data, if any. Null if no data has been uploaded.
     """
     ingestedCodeowners: CodeownersIngestedFile
+}
+
+extend type GitCommit {
     """
     Owners of the repository
     """
     aggregatedOwners(
-        """
-        The Git revision range to compute contributors in.
-        """
-        revision: String!
         """
         Returns the first n ownership records from the list.
         """

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -220,4 +220,62 @@ extend type Repository {
     A file containing manually ingested codeowners data, if any. Null if no data has been uploaded.
     """
     ingestedCodeowners: CodeownersIngestedFile
+    """
+    Owners of the repository
+    """
+    aggregatedOwners(
+        """
+        The Git revision range to compute contributors in.
+        """
+        revision: String!
+        """
+        Returns the first n ownership records from the list.
+        """
+        first: Int
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): AggregatedOwnershipConnection!
+}
+
+type AggregatedOwnershipConnection {
+    """
+    The total count of items in the connection.
+    """
+    totalCount: Int!
+
+    """
+    The pagination info for the connection.
+    """
+    pageInfo: PageInfo!
+
+    """
+    Aggregated ownership
+    """
+    nodes: [AggregatedOwnership!]!
+}
+
+type AggregatedOwnership {
+    """
+    The owner this entry refers to. Can be a person or a team.
+    """
+    owner: Owner!
+
+    totalFiles: Int!
+
+    #samples: [AggregatedOwnershipSample!]!
+
+    """
+    The reasons why Sourcegraph determined this entity as an owner.
+    """
+    reasons: [OwnershipReason!]!
+}
+
+type AggregatedOwnershipSample {
+    file: String!
+    """
+    The reasons why Sourcegraph determined this entity as an owner.
+    """
+    reasons: [OwnershipReason!]!
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -700,7 +700,3 @@ func (r *schemaResolver) DeleteRepoKeyValuePair(ctx context.Context, args struct
 func (r *RepositoryResolver) IngestedCodeowners(ctx context.Context) (CodeownersIngestedFileResolver, error) {
 	return EnterpriseResolvers.ownResolver.RepoIngestedCodeowners(ctx, r.IDInt32())
 }
-
-func (r *RepositoryResolver) AggregatedOwners(ctx context.Context, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error) {
-	return EnterpriseResolvers.ownResolver.AggregatedOwners(ctx, r, args)
-}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -700,3 +700,7 @@ func (r *schemaResolver) DeleteRepoKeyValuePair(ctx context.Context, args struct
 func (r *RepositoryResolver) IngestedCodeowners(ctx context.Context) (CodeownersIngestedFileResolver, error) {
 	return EnterpriseResolvers.ownResolver.RepoIngestedCodeowners(ctx, r.IDInt32())
 }
+
+func (r *RepositoryResolver) AggregatedOwners(ctx context.Context, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error) {
+	return EnterpriseResolvers.ownResolver.AggregatedOwners(ctx, nil, args)
+}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -702,5 +702,5 @@ func (r *RepositoryResolver) IngestedCodeowners(ctx context.Context) (Codeowners
 }
 
 func (r *RepositoryResolver) AggregatedOwners(ctx context.Context, args AggregatedOwnersArgs) (AggregatedOwnershipConnectionResolver, error) {
-	return EnterpriseResolvers.ownResolver.AggregatedOwners(ctx, nil, args)
+	return EnterpriseResolvers.ownResolver.AggregatedOwners(ctx, r, args)
 }

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -292,3 +292,45 @@ func areOwnEndpointsAvailable(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (r *ownResolver) AggregatedOwners(ctx context.Context,
+	blob *graphqlbackend.GitTreeEntryResolver,
+	args graphqlbackend.AggregatedOwnersArgs,
+) (graphqlbackend.AggregatedOwnershipConnectionResolver, error) {
+	return &aggregatedOwnershipConnectionResolver{}, nil
+}
+
+type aggregatedOwnershipConnectionResolver struct {
+	owners []*aggregatedOwnershipResolver
+}
+
+func (r *aggregatedOwnershipConnectionResolver) TotalCount(ctx context.Context) int32 {
+	return int32(len(r.owners))
+}
+
+func (r *aggregatedOwnershipConnectionResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
+	return graphqlutil.HasNextPage(false)
+}
+
+func (r *aggregatedOwnershipConnectionResolver) Nodes(ctx context.Context) []graphqlbackend.AggregatedOwnershipResolver {
+	var rs []graphqlbackend.AggregatedOwnershipResolver
+	for _, o := range r.owners {
+		rs = append(rs, o)
+	}
+	return rs
+}
+
+type aggregatedOwnershipResolver struct {
+	owner      *ownerResolver
+	totalFiles int32
+}
+
+func (r *aggregatedOwnershipResolver) Owner(ctx context.Context) (graphqlbackend.OwnerResolver, error) {
+	return r.owner, nil
+}
+
+func (r *aggregatedOwnershipResolver) TotalFiles(ctx context.Context) int32 { return r.totalFiles }
+
+func (r *aggregatedOwnershipResolver) Reasons(ctx context.Context) ([]graphqlbackend.OwnershipReasonResolver, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This draft

- Adds graphql schema for querying ownership for repo
  - **TODO** This can easily be generalized to any file tree
- Computes aggregate ownership and returns sorted by # owned files DESC
- UI uses top own bar in a lousy manner (@limitedmage help!)

Goal: Extend this so it looks nice, expands, and has a flow to introduce override - that is if a person or team is determined by a signal of _knowership_ (new word), then we can promote them to _ownership_ of given repo or tree.

<img width="1251" alt="Screenshot 2023-04-03 at 10 35 02 PM" src="https://user-images.githubusercontent.com/153410/229680989-87eefad6-a1c1-42be-8baf-941611b34879.png">

Some UI considerations:

1. I've been thinking of adding a panel in repo view similar to contributors.
2. But this only works in repo view and not in tree view.
3. Plus I kindof want to use the extra space that the bottom panel gives me.

## Test plan

TBD
