### PR TITLE
Update to Go 1.19.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.6
+golang 1.19.7
 nodejs 16.18.1
 fd 8.6.0
 shfmt 3.5.0


### PR DESCRIPTION
Update to 1.19.7 because it fixes CVE-2023-24532

[_Created by Sourcegraph batch change `evict/update-to-go-1.19.7`._](https://sourcegraph.sourcegraph.com/users/evict/batch-changes/update-to-go-1.19.7)

## Test plan

CI tests will validate the changes.