### PR TITLE
Fix empty symbolInfo returned from gRPC causing non-nil value in API

### DIFF
--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -428,8 +428,7 @@ func (c *Client) symbolInfoGRPC(ctx context.Context, args types.RepoCommitPathPo
 		return nil, err
 	}
 
-	response := protoResponse.ToInternal()
-	return &response, nil
+	return protoResponse.ToInternal(), nil
 }
 
 func (c *Client) symbolInfoJSON(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {

--- a/internal/symbols/v1/conversion.go
+++ b/internal/symbols/v1/conversion.go
@@ -137,10 +137,10 @@ func (x *SymbolInfoResponse) FromInternal(s *types.SymbolInfo) {
 	}
 }
 
-func (x *SymbolInfoResponse) ToInternal() types.SymbolInfo {
+func (x *SymbolInfoResponse) ToInternal() *types.SymbolInfo {
 	maybeResult := x.GetResult()
 	if maybeResult == nil {
-		return types.SymbolInfo{}
+		return nil
 	}
 
 	var definition types.RepoCommitPathMaybeRange
@@ -153,7 +153,7 @@ func (x *SymbolInfoResponse) ToInternal() types.SymbolInfo {
 		definition.Range = &defRange
 	}
 
-	return types.SymbolInfo{
+	return &types.SymbolInfo{
 		Definition: definition,
 		Hover:      maybeResult.Hover, // don't use GetHover() because it returns a string, not a pointer to a string
 	}

--- a/internal/symbols/v1/conversion_test.go
+++ b/internal/symbols/v1/conversion_test.go
@@ -91,14 +91,16 @@ func Test_Result_Symbol_ProtoRoundTrip(t *testing.T) {
 func Test_Internal_Types_SymbolInfo_ProtoRoundTrip(t *testing.T) {
 	var diff string
 
-	f := func(original types.SymbolInfo) bool {
-		defRange := original.Definition.Range
-		if defRange != nil && !rangeWithinInt32(*defRange) {
-			return true // skip
+	f := func(original *types.SymbolInfo) bool {
+		if original != nil {
+			defRange := original.Definition.Range
+			if defRange != nil && !rangeWithinInt32(*defRange) {
+				return true // skip
+			}
 		}
 
 		var originalProto SymbolInfoResponse
-		originalProto.FromInternal(&original)
+		originalProto.FromInternal(original)
 
 		converted := originalProto.ToInternal()
 
@@ -110,6 +112,18 @@ func Test_Internal_Types_SymbolInfo_ProtoRoundTrip(t *testing.T) {
 	}
 
 	if err := quick.Check(f, nil); err != nil {
+		t.Errorf("SymbolInfo diff (-want +got):\n%s", diff)
+	}
+}
+
+func Test_Internal_Types_SymbolInfo_ProtoRoundTripNil(t *testing.T) {
+	// Make sure a nil SymbolInfo is returned as nil.
+	var originalProto SymbolInfoResponse
+	originalProto.FromInternal(nil)
+	converted := originalProto.ToInternal()
+
+	var expect *types.SymbolInfo
+	if diff := cmp.Diff(expect, converted, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("SymbolInfo diff (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/CHXHX7XAS/p1680614144141909 this PR should fix it.



## Test plan

Added a nullability test, could you verify this fixes the issue you're seeing, too? 