### PR TITLE
site-admin: remove unnecessary `source: 'server'` from some site-admin sidebar items.

### DIFF
--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -44,7 +44,13 @@ export const SidebarNavItem: FC<PropsWithChildren<SidebarNavItemProps>> = ({
 
     if (source === 'server') {
         return (
-            <ButtonLink as={AnchorLink} to={to} className={classNames(buttonClassNames, className)} onClick={onClick}>
+            <ButtonLink
+                as={AnchorLink}
+                to={to}
+                variant={routeMatch ? 'primary' : undefined}
+                className={classNames(buttonClassNames, className)}
+                onClick={onClick}
+            >
                 {children}
             </ButtonLink>
         )

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -81,8 +81,6 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         telemetryService: props.telemetryService,
     }
 
-    console.log('$$$$$$$$$$$$$$$$$$$$$$$ re-render the site admin area $$$$$$$$$$$$$$$$$$$$$$$')
-
     return (
         <Page>
             <PageHeader>

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -81,6 +81,8 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         telemetryService: props.telemetryService,
     }
 
+    console.log('$$$$$$$$$$$$$$$$$$$$$$$ re-render the site admin area $$$$$$$$$$$$$$$$$$$$$$$')
+
     return (
         <Page>
             <PageHeader>

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -181,19 +181,16 @@ export const maintenanceGroup: SiteAdminSideBarGroup = {
         {
             label: 'Outbound requests',
             to: '/site-admin/outbound-requests',
-            source: 'server',
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Slow requests',
             to: '/site-admin/slow-requests',
-            source: 'server',
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Background jobs',
             to: '/site-admin/background-jobs',
-            source: 'server',
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
     ],


### PR DESCRIPTION
This commit removes this property from `Outbound requests`, `Slow requests` and `Background jobs` tabs, therefore fixing render time (there is no complete page reload anymore) and visibility into which tb is currently selected.

Test plan:
Local sg run and checks.

### Before (no current tab indication, long reloads)

https://user-images.githubusercontent.com/94846361/229808818-6b36bd16-922d-4e78-a720-a80c5ef98442.mp4

### After (yes current tab indication, no reloads)

https://user-images.githubusercontent.com/94846361/229808619-ce06ac10-9092-45bb-9856-54984a5c5c57.mp4


## App preview:

- [Web](https://sg-web-ao-ui-fix-sidebar-items-loading.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
