### PR TITLE
Update to go 1.19.8

### DIFF
--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.19.8
 
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.6
+golang 1.19.8
 nodejs 16.18.1
 fd 8.6.0
 shfmt 3.5.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -211,7 +211,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.19.6",
+    version = "1.19.8",
 )
 
 linter_dependencies()

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -6,7 +6,7 @@ USER root
 COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
 RUN /ctags-install-alpine.sh
 
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS symbols-build
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS symbols-build
 # hadolint ignore=DL3002
 USER root
 

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -6,7 +6,7 @@ USER root
 COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
 RUN /ctags-install-alpine.sh
 
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS symbols-build
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS symbols-build
 # hadolint ignore=DL3002
 USER root
 

--- a/dev/build-tracker/Dockerfile
+++ b/dev/build-tracker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS build-tracker-build
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS build-tracker-build
 
 ENV GO111MODULE on
 ENV GOARCH amd64

--- a/dev/build-tracker/Dockerfile
+++ b/dev/build-tracker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS build-tracker-build
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS build-tracker-build
 
 ENV GO111MODULE on
 ENV GOARCH amd64

--- a/dev/ci/integration/code-intel/install-src.sh
+++ b/dev/ci/integration/code-intel/install-src.sh
@@ -8,8 +8,8 @@ set -eux
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 root_dir="$(pwd)"
 
-# By default, version of src-cli that builds with 1.19.6
-VERSION=${1:-'85115b1a8a2e1bc174075eefacbae6ad9d19af1f'}
+# By default, version of src-cli that builds with 1.19.8
+VERSION=${1:-'58b3f701691cbdbd10b54161d9bfca88b781480d'}
 
 TEMP=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -34,7 +34,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"pnpm":                  check.Combine(check.InPath("pnpm"), checkPnpmVersion(">= 7.28.0")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.19.6")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.19.8")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),

--- a/docker-images/opentelemetry-collector/Dockerfile
+++ b/docker-images/opentelemetry-collector/Dockerfile
@@ -1,5 +1,5 @@
 # Build custom collector binary
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS build
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS build
 
 ARG OTEL_COLLECTOR_VERSION
 ENV OTEL_COLLECTOR_VERSION=${OTEL_COLLECTOR_VERSION}

--- a/docker-images/opentelemetry-collector/Dockerfile
+++ b/docker-images/opentelemetry-collector/Dockerfile
@@ -1,5 +1,5 @@
 # Build custom collector binary
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS build
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS build
 
 ARG OTEL_COLLECTOR_VERSION
 ENV OTEL_COLLECTOR_VERSION=${OTEL_COLLECTOR_VERSION}

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS builder
 
 WORKDIR /go/src/app
 

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS builder
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
 
 WORKDIR /go/src/app
 

--- a/internal/cmd/progress-bot/Dockerfile
+++ b/internal/cmd/progress-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS builder
 
 WORKDIR /go/src/progress-bot
 

--- a/internal/cmd/progress-bot/Dockerfile
+++ b/internal/cmd/progress-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS builder
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
 
 WORKDIR /go/src/progress-bot
 

--- a/internal/cmd/search-blitz/Dockerfile
+++ b/internal/cmd/search-blitz/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS builder
 WORKDIR /build
 COPY go.sum go.mod ./
 COPY . .

--- a/internal/cmd/search-blitz/Dockerfile
+++ b/internal/cmd/search-blitz/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS builder
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
 WORKDIR /build
 COPY go.sum go.mod ./
 COPY . .

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine@sha256:f2e0acaf7c628cd819b73541d7c1ea8f888d51edb0a58935a3c46a084fa953fa AS builder
+FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY . .

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine@sha256:04065e607052705ede1ac6308ce56aec4715b0fafb1f0c2f4c2333aab9d84442 AS builder
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY . .


### PR DESCRIPTION
This will update our Go dependency to a newer version. Resolving CVE-2023-24532. 

## Test plan

Ran `sg ci build main-dry-run`, everything passed:

- https://buildkite.com/sourcegraph/sourcegraph/builds/212016#_


- [x] ci tests
- [x] review

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
