### PR TITLE
Go to definition: push current location into browser history

### DIFF
--- a/client/client-api/src/contribution.ts
+++ b/client/client-api/src/contribution.ts
@@ -138,10 +138,15 @@ export interface ActionContributionClientCommandOpen extends ActionContribution 
     command: 'open'
 
     /**
-     * The arguments for the `open` client command. The first array element is a URL, which is opened by the client
-     * using the default URL handler.
+     * The arguments for the `open` client command, which can either have one or two elements.
+     *
+     * - The first array element is always a string with the destination URL,
+     *   which populates the `href` attribute of the link.
+     * - When defined, the second array element is an `(event: Event) => void`
+     *   handler that fires `onSelect`. The handler is responsible for triggering
+     *   `event.preventDefault()`, if necessary.
      */
-    commandArguments: [TemplateExpression]
+    commandArguments: [TemplateExpression] | [TemplateExpression, TemplateExpression]
 }
 
 /**

--- a/client/client-api/src/contribution.ts
+++ b/client/client-api/src/contribution.ts
@@ -141,10 +141,11 @@ export interface ActionContributionClientCommandOpen extends ActionContribution 
      * The arguments for the `open` client command, which can either have one or two elements.
      *
      * - The first array element is always a string with the destination URL,
-     *   which populates the `href` attribute of the link.
-     * - When defined, the second array element is an `(event: Event) => void`
-     *   handler that fires `onSelect`. The handler is responsible for triggering
-     *   `event.preventDefault()`, if necessary.
+     * which populates the `href` attribute of the link.
+     * - When defined, the second array element is an `(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMlElement>) => boolean`
+     * handler that fires `onSelect`. The handler is responsible for handling low-level details like whether
+     * the user is holding down modifier keys, or if `event.preventDefault()` should be triggered. The handler
+     * can return `false` to fallback to the default event handler.
      */
     commandArguments: [TemplateExpression] | [TemplateExpression, TemplateExpression]
 }

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -360,6 +360,11 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
             }
         }
 
+        const onSelect = onSelectCallbackForClientCommandOpen(action)
+        if (onSelect) {
+            onSelect(event)
+        }
+
         if (urlForClientCommandOpen(action, this.props.location.hash)) {
             if (event.currentTarget.tagName === 'A' && event.currentTarget.hasAttribute('href')) {
                 // Do not execute the command. The <LinkOrButton>'s default event handler will do what we want (which
@@ -398,6 +403,19 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
         ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
             this.state.actionOrError === LOADING) ||
         this.props.disabledWhen
+}
+
+type OnSelectHandler = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void
+export function onSelectCallbackForClientCommandOpen(
+    action: Pick<Evaluated<ActionContribution>, 'command' | 'commandArguments'>
+): OnSelectHandler | undefined {
+    if (action.command === 'open' && action.commandArguments && action.commandArguments.length > 1) {
+        const onSelect = action.commandArguments[1]
+        if (typeof onSelect === 'function') {
+            return onSelect as OnSelectHandler
+        }
+    }
+    return undefined
 }
 
 export function urlForClientCommandOpen(

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -361,8 +361,9 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
         }
 
         const onSelect = onSelectCallbackForClientCommandOpen(action)
-        if (onSelect) {
-            onSelect(event)
+        if (onSelect?.(event)) {
+            emitDidExecute()
+            return
         }
 
         if (urlForClientCommandOpen(action, this.props.location.hash)) {
@@ -405,7 +406,7 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
         this.props.disabledWhen
 }
 
-type OnSelectHandler = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void
+type OnSelectHandler = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => boolean
 export function onSelectCallbackForClientCommandOpen(
     action: Pick<Evaluated<ActionContribution>, 'command' | 'commandArguments'>
 ): OnSelectHandler | undefined {

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -98,7 +98,15 @@ export class CodeIntelTooltip implements Tooltip {
                     title: 'Go to definition',
                     disabledTitle: noDefinitionFound ? 'No definition found' : 'You are at the definition',
                     command: definition.url ? 'open' : 'invokeFunction-new',
-                    commandArguments: [definition.url ? definition.url : () => definition.asyncHandler()],
+                    commandArguments: definition.url
+                        ? [
+                              definition.url,
+                              (event: Event) => {
+                                  event.preventDefault()
+                                  definition.asyncHandler()
+                              },
+                          ]
+                        : [() => definition.asyncHandler()],
                 },
             },
             {

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -182,7 +182,10 @@ export class CodeIntelTooltip implements Tooltip {
 // Returns true if this event is "regular", meaning the user is not holding down
 // modifier keys or clicking with a non-main button.
 function isRegularEvent(event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>): boolean {
-    const mouseEvent = event as MouseEvent
-    const isMainButton = mouseEvent?.button === 0 || mouseEvent?.button === undefined
-    return isMainButton && !event.metaKey && !event.shiftKey && !event.ctrlKey
+    return (
+        ('button' in event ? event.button === MOUSE_MAIN_BUTTON : true) &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        !event.ctrlKey
+    )
 }

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -16,6 +16,7 @@ import { HovercardView, HoverData } from '../hovercard'
 import { rangeToCmSelection } from '../occurrence-utils'
 import { DefinitionResult, goToDefinitionAtOccurrence } from '../token-selection/definition'
 import { modifierClickDescription } from '../token-selection/modifier-click'
+import { MOUSE_MAIN_BUTTON } from '../utils'
 
 export interface HoverResult {
     markdownContents: string


### PR DESCRIPTION
Previously, the behavior was different whether you clicked on the "Go to definition" link in the popover or used cmd-click. When using the link, the current location didn't get pushed into the browser history making "Go back" jump to a surprising location. When using cmd-click to navigate to a definition, we pushed the current location into the browser history to replicate the experience of navigating code in the editor where you can easily go up/down the "jump stack", which is the list of locations you navigate from/to with "Go to definition".

Importantly, this PR preserves the HTML link in the popover so that users can still right-click "Open link in new tab".

## Test plan

Manually tested with 
```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

- Open URL https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/cmd/gitserver/server/server.go?L1080
- Load popover for `serverContext` on line 1093
- Click "Go to definition"
- "Go back" in the browser history and verify that you go back to line 1093 (not 1080!)
- Load the popover again for `serverContext`
- Use cmd-click (or ctrl-click on Linux/Windows) on the "Go to definition" *link* and verify that it opens the definition in a new browser tab. Do the same for shift-click to open the link in a new window.
- Load the popover again for `serverContext`
- Verify that you can right-click on the "Go to definition" *link* and use "Open Link in New Tab" to open the definition location in a new browser tab


Going back in history 
![CleanShot 2023-04-04 at 17 57 06](https://user-images.githubusercontent.com/1408093/229850120-1dc562c1-1a65-4b40-80ac-69fe75352a97.gif)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-definition-recover.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
