### PR TITLE
Fix timestamp window for event_logs queries to account for WAU edge cases

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -965,7 +965,7 @@ FROM (
     ` + makeDateTruncExpression("day", "%s::timestamp") + ` as current_day
   FROM event_logs
   LEFT OUTER JOIN users ON users.id = event_logs.user_id
-  WHERE (timestamp >= ` + makeDateTruncExpression("month", "%s::timestamp") + `) AND (%s) AND anonymous_user_id != 'backend'
+  WHERE (timestamp >= ` + makeDateTruncExpression("rolling_month", "%s::timestamp") + `) AND (%s) AND anonymous_user_id != 'backend'
 ) events
 
 GROUP BY current_rolling_month, rolling_month, current_month, current_week, current_day
@@ -1434,7 +1434,7 @@ WITH events AS (
     ` + makeDateTruncExpression("day", "%s::timestamp") + ` as current_day
   FROM event_logs
   WHERE
-    timestamp >= ` + makeDateTruncExpression("month", "%s::timestamp") + `
+    timestamp >= ` + makeDateTruncExpression("rolling_month", "%s::timestamp") + `
     AND name IN (` + strings.Join(searchLatencyEventNames, ", ") + `)
 )
 SELECT
@@ -1469,7 +1469,7 @@ WITH events AS (
   FROM event_logs
   CROSS JOIN LATERAL jsonb_each(argument->'code_search'->'query_data'->'query') json
   WHERE
-    timestamp >= ` + makeDateTruncExpression("month", "%s::timestamp") + `
+    timestamp >= ` + makeDateTruncExpression("rolling_month", "%s::timestamp") + `
     AND name = 'SearchResultsQueried'
 )
 SELECT


### PR DESCRIPTION
(cherry picked from commit 6b9e914ff96431ce30cc2f03270ef0a3d4be27ed)



## Test plan

n/a
Logical change to the filtering condition of the usage statistics SQL queries.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
