### PR TITLE
standardize on cody-experimental feature flag name (not cody)

### DIFF
--- a/client/web/src/enterprise/cody/search/CodySearchPage.tsx
+++ b/client/web/src/enterprise/cody/search/CodySearchPage.tsx
@@ -18,7 +18,7 @@ import styles from './CodySearchPage.module.scss'
 export const CodySearchPage: React.FunctionComponent<{}> = () => {
     const navigate = useNavigate()
 
-    const [codyEnabled] = useFeatureFlag('cody', false)
+    const [codyEnabled] = useFeatureFlag('cody-experimental', false)
 
     /** The value entered by the user in the query input */
     const [input, setInput] = useState('')

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -19,7 +19,6 @@ export type FeatureFlagName =
     | 'accessible-symbol-tree'
     | 'accessible-file-tree-always-load-ancestors'
     | 'search-ownership'
-    | 'cody'
     | 'search-ranking'
     | 'blob-page-switch-areas-shortcuts'
     | 'app-connect-dotcom'

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -171,7 +171,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     // isCodeInsightsEnabled selector controls appearance based on user settings flags
     const codeInsights = codeInsightsEnabled && isCodeInsightsEnabled(props.settingsCascade)
 
-    const [codyEnabled] = useFeatureFlag('cody')
+    const [codyEnabled] = useFeatureFlag('cody-experimental')
 
     const searchNavBarItems = useMemo(() => {
         const items: (NavDropdownItem | false)[] = [


### PR DESCRIPTION
The /search/cody page previously used the `cody` feature flag, but now it uses the `cody-experimental` feature flag (same as for everything else Cody).




## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-std-cody-ff.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
