### PR TITLE
codeintel: Large-chunk reorganize sentinel store

### DIFF
--- a/enterprise/internal/codeintel/sentinel/internal/store/matches.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/matches.go
@@ -128,7 +128,7 @@ var flattenMatches = func(ms []shared.VulnerabilityMatch) []shared.Vulnerability
 }
 
 func (s *store) GetVulnerabilityMatchesSummaryCount(ctx context.Context) (counts shared.GetVulnerabilityMatchesSummaryCounts, err error) {
-	ctx, _, endObservation := s.operations.getVulnerabilityMatchesSummaryCounts.With(ctx, &err, observation.Args{})
+	ctx, _, endObservation := s.operations.getVulnerabilityMatchesSummaryCount.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	row := s.db.QueryRow(ctx, sqlf.Sprintf(getVulnerabilityMatchesSummaryCounts))

--- a/enterprise/internal/codeintel/sentinel/internal/store/observability.go
+++ b/enterprise/internal/codeintel/sentinel/internal/store/observability.go
@@ -11,11 +11,11 @@ type operations struct {
 	vulnerabilityByID                        *observation.Operation
 	getVulnerabilitiesByIDs                  *observation.Operation
 	getVulnerabilities                       *observation.Operation
-	getVulnerabilityMatchesCountByRepository *observation.Operation
-	getVulnerabilityMatchesSummaryCounts     *observation.Operation
 	insertVulnerabilities                    *observation.Operation
 	vulnerabilityMatchByID                   *observation.Operation
 	getVulnerabilityMatches                  *observation.Operation
+	getVulnerabilityMatchesSummaryCount      *observation.Operation
+	getVulnerabilityMatchesCountByRepository *observation.Operation
 	scanMatches                              *observation.Operation
 }
 
@@ -43,11 +43,11 @@ func newOperations(observationCtx *observation.Context) *operations {
 		vulnerabilityByID:                        op("VulnerabilityByID"),
 		getVulnerabilitiesByIDs:                  op("GetVulnerabilitiesByIDs"),
 		getVulnerabilities:                       op("GetVulnerabilities"),
-		getVulnerabilityMatchesSummaryCounts:     op("GetVulnerabilityMatchesSummaryCounts"),
-		getVulnerabilityMatchesCountByRepository: op("GetVulnerabilityMatchesCountByRepository"),
 		insertVulnerabilities:                    op("InsertVulnerabilities"),
 		vulnerabilityMatchByID:                   op("VulnerabilityMatchByID"),
 		getVulnerabilityMatches:                  op("GetVulnerabilityMatches"),
+		getVulnerabilityMatchesSummaryCount:      op("GetVulnerabilityMatchesSummaryCount"),
+		getVulnerabilityMatchesCountByRepository: op("GetVulnerabilityMatchesCountByRepository"),
 		scanMatches:                              op("ScanMatches"),
 	}
 }


### PR DESCRIPTION
Reorganize chunks of code to follow the broad organization in the interface definition.

## Test plan

CI.