### PR TITLE
Code intel: don't show search-based results for non-interactive tokens

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/code-intel-tooltips.ts
@@ -222,10 +222,20 @@ async function hoverRequest(
                   .map(({ value }) => value)
                   .join('\n\n----\n\n')
                   .trimEnd()
+    const precise = isPrecise(hover)
+    if (!precise && markdownContents.length > 0 && !isInteractiveOccurrence(occurrence)) {
+        // Don't show search-based results for non-interactive tokens. For example, we don't
+        // want to show results for keyword tokens or string literals.
+        return {
+            isPrecise: false,
+            markdownContents: '',
+            hoverMerged: null,
+        }
+    }
     if (markdownContents === '' && isInteractiveOccurrence(occurrence)) {
         markdownContents = 'No hover information available'
     }
-    return { markdownContents, hoverMerged: hover, isPrecise: isPrecise(hover) }
+    return { markdownContents, hoverMerged: hover, isPrecise: precise }
 }
 
 function isPrecise(hover: HoverMerged | null | undefined): boolean {


### PR DESCRIPTION
Previously, we loaded the popover with search-based results for tokens like keywords and string literals where it doesn't make sense to display code intelligence. Now, we skip displaying search-based code intelligence for these tokens. Users can still explicitly trigger Goto definition with cmd-click.

Fixes https://github.com/sourcegraph/sourcegraph/issues/50094

## Test plan

- Start a local web-standalone server
- Hover over the line here https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/backend/user_emails.go?L325
- Observe that there's no popover
- Hover over the same line on sourcegraph.com and verify that it loads the popover

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-popover-non-interactive.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
