### PR TITLE
Code graph: provide server-side HTML title for settings page

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -39,6 +39,7 @@ const (
 	routeRepo                    = "repo"
 	routeRepoSettings            = "repo-settings"
 	routeRepoCodeIntelligence    = "repo-code-intelligence"
+	routeRepoCodeGraph           = "repo-code-intelligence"
 	routeRepoCommit              = "repo-commit"
 	routeRepoBranches            = "repo-branches"
 	routeRepoBatchChanges        = "repo-batch-changes"
@@ -219,6 +220,7 @@ func newRouter() *mux.Router {
 	repo := r.PathPrefix(repoRevPath + "/" + routevar.RepoPathDelim).Subrouter()
 	repo.PathPrefix("/settings").Methods("GET").Name(routeRepoSettings)
 	repo.PathPrefix("/code-intelligence").Methods("GET").Name(routeRepoCodeIntelligence)
+	repo.PathPrefix("/code-graph").Methods("GET").Name(routeRepoCodeGraph)
 	repo.PathPrefix("/commit").Methods("GET").Name(routeRepoCommit)
 	repo.PathPrefix("/branches").Methods("GET").Name(routeRepoBranches)
 	repo.PathPrefix("/batch-changes").Methods("GET").Name(routeRepoBatchChanges)
@@ -274,6 +276,7 @@ func initRouter(db database.DB, enterpriseJobs jobutil.EnterpriseJobs, router *m
 	router.Get(routeAPIConsole).Handler(brandedIndex("API console"))
 	router.Get(routeRepoSettings).Handler(brandedNoIndex("Repository settings"))
 	router.Get(routeRepoCodeIntelligence).Handler(brandedNoIndex("Code intelligence"))
+	router.Get(routeRepoCodeGraph).Handler(brandedNoIndex("Code graph"))
 	router.Get(routeRepoCommit).Handler(brandedNoIndex("Commit"))
 	router.Get(routeRepoBranches).Handler(brandedNoIndex("Branches"))
 	router.Get(routeRepoBatchChanges).Handler(brandedIndex("Batch Changes"))


### PR DESCRIPTION
Previously, opening a URL like
https://sourcegraph.com/github.com/llvm/llvm-project/-/code-graph/indexes/UHJlY2lzZUluZGV4OiJVOjU3MjE0ODAi had a 404 page title until the SPA loaded. This PR fixes the issue by using the title "Code graph" for all SPA pages that have `/code-graph` in the prefix. The more detailed sub-page title gets displayed once the SPA finishes loading.

## Test plan

- Run `sg start`
- Open URL https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/code-graph/indexes?filters-indexer=all&visible=1
- Hard refresh page and verify that the title of the tab is "Code graph" for a brief second until it gets updated to "Precise indexes".

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
