### PR TITLE
context-aware completions

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -8,4 +8,5 @@ export interface Configuration {
     useContext: ConfigurationUseContext
     experimentalSuggest: boolean
     openaiKey: string | null
+    anthropicKey: string | null
 }

--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -7,6 +7,5 @@ export interface Configuration {
     debug: boolean
     useContext: ConfigurationUseContext
     experimentalSuggest: boolean
-    openaiKey: string | null
     anthropicKey: string | null
 }

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -230,13 +230,20 @@
         },
         "cody.experimental.keys.openai": {
           "type": "string"
+        },
+        "cody.experimental.keys.anthropic": {
+          "type": "string"
         }
       }
     }
   },
   "dependencies": {
-    "openai": "^3.2.1",
+    "@anthropic-ai/sdk": "^0.4.2",
     "@sourcegraph/cody-shared": "workspace:*",
-    "@sourcegraph/cody-ui": "workspace:*"
+    "openai": "^3.2.1",
+    "@sourcegraph/cody-ui": "workspace:*",
+    "wink-eng-lite-web-model": "^1.5.0",
+    "wink-nlp": "^1.13.1",
+    "wink-nlp-utils": "^2.1.0"
   }
 }

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -228,9 +228,6 @@
           "type": "boolean",
           "default": false
         },
-        "cody.experimental.keys.openai": {
-          "type": "string"
-        },
         "cody.experimental.keys.anthropic": {
           "type": "string"
         }

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -1,5 +1,4 @@
 import * as anthropic from '@anthropic-ai/sdk'
-import * as openai from 'openai'
 import * as vscode from 'vscode'
 
 import { ChatViewProvider } from '../chat/ChatViewProvider'
@@ -116,14 +115,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
     )
 
     if (config.experimentalSuggest) {
-        let openaiApi = null
         let claudeApi = null
-        if (config.openaiKey) {
-            const configuration = new openai.Configuration({
-                apiKey: config.openaiKey,
-            })
-            openaiApi = new openai.OpenAIApi(configuration)
-        }
         if (config.anthropicKey) {
             claudeApi = new anthropic.Client(config.anthropicKey)
         }

--- a/client/cody/src/completions/context.test.ts
+++ b/client/cody/src/completions/context.test.ts
@@ -1,0 +1,101 @@
+import { bestJaccardMatch, jaccardScore, getWords } from './context'
+
+describe('getWords', () => {
+    it('', () => {
+        expect(getWords('foo bar baz')).toEqual(
+            new Map<string, number>([
+                ['foo', 1],
+                ['bar', 1],
+                ['baz', 1],
+            ])
+        )
+        expect(getWords('running rocks slipped over')).toEqual(
+            new Map<string, number>([
+                ['run', 1],
+                ['rock', 1],
+                ['slip', 1],
+            ])
+        )
+    })
+})
+
+describe('jaccardScore', () => {
+    it('perfect overlap', () => {
+        const targetWords = new Map<string, number>([
+            ['foo', 1],
+            ['bar', 1],
+            ['baz', 1],
+        ])
+        const matchWords = new Map<string, number>([
+            ['foo', 1],
+            ['bar', 1],
+            ['baz', 1],
+        ])
+        expect(jaccardScore(targetWords, matchWords)).toEqual(1)
+    })
+    it('no overlap', () => {
+        const targetWords = new Map<string, number>([
+            ['foo', 1],
+            ['bar', 1],
+            ['baz', 1],
+        ])
+        const matchWords = new Map<string, number>([
+            ['qux', 1],
+            ['quux', 1],
+            ['quuz', 1],
+        ])
+        expect(jaccardScore(targetWords, matchWords)).toEqual(0)
+    })
+    it('50% overlap', () => {
+        const targetWords = new Map<string, number>([
+            ['bar', 1],
+            ['baz', 1],
+        ])
+        const matchWords = new Map<string, number>([
+            ['foo', 1],
+            ['bar', 1],
+            ['baz', 1],
+            ['qux', 1],
+        ])
+        expect(jaccardScore(targetWords, matchWords)).toEqual(0.5)
+    })
+})
+
+describe('bestJaccardMatch', () => {
+    it('should return the best match', () => {
+        const matchText = [
+            'foo',
+            'bar',
+            'baz',
+            'qux',
+            'quux',
+            'quuz',
+            'corge',
+            'grault',
+            'garply',
+            'waldo',
+            'fred',
+            'plugh',
+            'xyzzy',
+            'thud',
+        ].join('\n')
+        expect(bestJaccardMatch('foo\nbar\nbaz', matchText, 3)).toEqual({
+            score: 1,
+            text: 'foo\nbar\nbaz',
+        })
+        expect(bestJaccardMatch('bar\nquux', matchText, 4)).toEqual({
+            score: 0.5,
+            text: 'bar\nbaz\nqux\nquux',
+        })
+        expect(
+            bestJaccardMatch(
+                ['grault', 'notexist', 'garply', 'notexist', 'waldo', 'notexist', 'notexist'].join('\n'),
+                matchText,
+                6
+            )
+        ).toEqual({
+            score: 0.3,
+            text: ['quux', 'quuz', 'corge', 'grault', 'garply', 'waldo'].join('\n'),
+        })
+    })
+})

--- a/client/cody/src/completions/context.test.ts
+++ b/client/cody/src/completions/context.test.ts
@@ -1,4 +1,4 @@
-import { bestJaccardMatch, jaccardScore, getWords } from './context'
+import { bestJaccardMatch, getWords } from './context'
 
 describe('getWords', () => {
     it('', () => {
@@ -16,48 +16,6 @@ describe('getWords', () => {
                 ['slip', 1],
             ])
         )
-    })
-})
-
-describe('jaccardScore', () => {
-    it('perfect overlap', () => {
-        const targetWords = new Map<string, number>([
-            ['foo', 1],
-            ['bar', 1],
-            ['baz', 1],
-        ])
-        const matchWords = new Map<string, number>([
-            ['foo', 1],
-            ['bar', 1],
-            ['baz', 1],
-        ])
-        expect(jaccardScore(targetWords, matchWords)).toEqual(1)
-    })
-    it('no overlap', () => {
-        const targetWords = new Map<string, number>([
-            ['foo', 1],
-            ['bar', 1],
-            ['baz', 1],
-        ])
-        const matchWords = new Map<string, number>([
-            ['qux', 1],
-            ['quux', 1],
-            ['quuz', 1],
-        ])
-        expect(jaccardScore(targetWords, matchWords)).toEqual(0)
-    })
-    it('50% overlap', () => {
-        const targetWords = new Map<string, number>([
-            ['bar', 1],
-            ['baz', 1],
-        ])
-        const matchWords = new Map<string, number>([
-            ['foo', 1],
-            ['bar', 1],
-            ['baz', 1],
-            ['qux', 1],
-        ])
-        expect(jaccardScore(targetWords, matchWords)).toEqual(0.5)
     })
 })
 

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -13,7 +13,7 @@ export async function getContext(
     history: History,
     targetText: string,
     windowSize: number,
-    maxBytes: number
+    maxChars: number
 ): Promise<ReferenceSnippet[]> {
     const files = await getFiles(currentEditor, history)
     const matches: ReferenceSnippet[] = []
@@ -28,13 +28,13 @@ export async function getContext(
     matches.sort((a, b) => b.score - a.score)
 
     const context: ReferenceSnippet[] = []
-    let totalBytes = 0
+    let totalChars = 0
     for (const match of matches) {
-        if (totalBytes + match.text.length > maxBytes) {
+        if (totalChars + match.text.length > maxChars) {
             break
         }
         context.push(match)
-        totalBytes += match.text.length
+        totalChars += match.text.length
     }
 
     return context

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -1,0 +1,172 @@
+import * as vscode from 'vscode'
+
+import { History } from './history'
+
+const winkUtils = require('wink-nlp-utils')
+
+export interface ReferenceSnippet extends JaccardMatch {
+    filename: string
+}
+
+export async function getContext(
+    currentEditor: vscode.TextEditor,
+    history: History,
+    targetText: string,
+    windowSize: number,
+    maxBytes: number
+): Promise<ReferenceSnippet[]> {
+    const files = await getFiles(currentEditor, history)
+    const matches: ReferenceSnippet[] = []
+    for (const { uri, contents } of files) {
+        const match = bestJaccardMatch(targetText, contents, windowSize)
+        if (!match) {
+            continue
+        }
+        matches.push({ filename: uri.fsPath, ...match })
+    }
+
+    matches.sort((a, b) => b.score - a.score)
+
+    const context: ReferenceSnippet[] = []
+    let totalBytes = 0
+    for (const match of matches) {
+        if (totalBytes + match.text.length > maxBytes) {
+            break
+        }
+        context.push(match)
+        totalBytes += match.text.length
+    }
+
+    return context
+}
+
+interface FileContents {
+    uri: vscode.Uri
+    contents: string
+}
+
+async function getFiles(currentEditor: vscode.TextEditor, history: History): Promise<FileContents[]> {
+    const files: FileContents[] = []
+    const editorTabs = vscode.window.visibleTextEditors
+    const curLang = currentEditor.document.languageId
+    if (!curLang) {
+        return []
+    }
+    for (const tab of editorTabs) {
+        if (tab.document.uri === currentEditor.document.uri) {
+            // omit current file
+            continue
+        }
+        if (tab.document.languageId !== curLang) {
+            // omit files of other languages
+            continue
+        }
+        files.push({
+            uri: tab.document.uri,
+            contents: tab.document.getText(),
+        })
+    }
+    const historyFiles = await Promise.all(
+        history.lastN(10, curLang, [currentEditor.document.uri, ...files.map(f => f.uri)]).map(async item => {
+            const contents = (await vscode.workspace.openTextDocument(item.document.uri)).getText()
+            return {
+                uri: item.document.uri,
+                contents,
+            }
+        })
+    )
+    files.push(...historyFiles)
+    return files
+}
+
+export interface JaccardMatch {
+    score: number
+    text: string
+}
+
+export function jaccardScore(targetWords: Map<string, number>, matchWords: Map<string, number>): number {
+    const intersection = [...targetWords.keys()].reduce((acc, word) => {
+        return acc + Math.min(targetWords.get(word) || 0, matchWords.get(word) || 0)
+    }, 0)
+    const unionSet = new Set([...targetWords.keys(), ...matchWords.keys()])
+
+    const union = [...unionSet].reduce((acc, word) => {
+        return acc + Math.max(targetWords.get(word) || 0, matchWords.get(word) || 0)
+    }, 0)
+    if (intersection === 0) {
+        return 0
+    }
+    return intersection / union
+}
+
+export function bestJaccardMatch(targetText: string, matchText: string, windowSize: number): JaccardMatch | null {
+    const targetWords = getWords(targetText)
+    const lines = matchText.split('\n')
+    const wordsForEachLine = lines.map(line => getWords(line))
+
+    const windowWords = new Map<string, number>()
+    for (let i = 0; i < Math.min(windowSize, lines.length); i++) {
+        for (const wordInThisLine of wordsForEachLine[i].keys()) {
+            windowWords.set(
+                wordInThisLine,
+                (windowWords.get(wordInThisLine) || 0) + (wordsForEachLine[i].get(wordInThisLine) || 0)
+            )
+        }
+    }
+    const bothWords = new Map<string, number>()
+    for (const word of targetWords.keys()) {
+        bothWords.set(word, Math.min(targetWords.get(word) || 0, windowWords.get(word) || 0))
+    }
+
+    let bestScore = jaccardScore(targetWords, windowWords)
+    let bestWindow = [0, Math.min(windowSize, lines.length)]
+    for (let i = 0; i < wordsForEachLine.length - windowSize; i++) {
+        for (const word of wordsForEachLine[i].keys()) {
+            windowWords.set(word, (windowWords.get(word) || 0) - (wordsForEachLine[i].get(word) || 0))
+            if (windowWords.get(word)! < 0) {
+                windowWords.set(word, 0)
+            }
+            bothWords.set(word, (bothWords.get(word) || 0) - (wordsForEachLine[i].get(word) || 0))
+            if (bothWords.get(word)! < 0) {
+                bothWords.set(word, 0)
+            }
+        }
+        for (const word of wordsForEachLine[i + windowSize].keys()) {
+            if (windowWords.get(word) === undefined) {
+                windowWords.set(word, 0)
+            }
+            windowWords.set(word, (windowWords.get(word) || 0) + (wordsForEachLine[i + windowSize].get(word) || 0))
+            if (targetWords.get(word)! > 0) {
+                bothWords.set(
+                    word,
+                    Math.min(
+                        (bothWords.get(word) || 0) + (wordsForEachLine[i + windowSize].get(word) || 0),
+                        targetWords.get(word) || 0
+                    )
+                )
+            }
+        }
+        const score = jaccardScore(targetWords, windowWords)
+        if (score > bestScore) {
+            bestScore = score
+            bestWindow = [i + 1, i + windowSize + 1]
+        }
+    }
+
+    return {
+        score: bestScore,
+        text: lines.slice(bestWindow[0], bestWindow[1]).join('\n'),
+    }
+}
+
+export function getWords(s: string): Map<string, number> {
+    let frequencyCounter = new Map<string, number>()
+    const words = winkUtils.string.tokenize0(s)
+
+    const filteredWords = winkUtils.tokens.removeWords(words)
+    const stems = winkUtils.tokens.stem(filteredWords)
+    for (const stem of stems) {
+        frequencyCounter.set(stem, (frequencyCounter.get(stem) || 0) + 1)
+    }
+    return frequencyCounter
+}

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -85,15 +85,10 @@ export interface JaccardMatch {
     text: string
 }
 
-export function jaccardScore(targetWords: Map<string, number>, matchWords: Map<string, number>): number {
-    let intersection = 0
-    for (const [targetWord, count] of targetWords.entries()) {
-        intersection += Math.min(count, matchWords.get(targetWord) || 0)
-    }
-    const unionSet = new Set([...targetWords.keys(), ...matchWords.keys()])
-    let union = 0
-    for (const word of unionSet) {
-        union += Math.max(targetWords.get(word) || 0, matchWords.get(word) || 0)
+export function jaccardDistance(left: number, right: number, intersection: number): number {
+    const union = left + right - intersection
+    if (union < 0) {
+        throw new Error("intersection can't be greater than the sum of left and right")
     }
     if (union === 0) {
         return 0
@@ -101,51 +96,104 @@ export function jaccardScore(targetWords: Map<string, number>, matchWords: Map<s
     return intersection / union
 }
 
+/**
+ * Finds the window from matchText with the lowest Jaccard distance from targetText.
+ * The Jaccard distance is the ratio of intersection over union, using a bag-of-words-with-count as
+ * the representation for text snippet.
+ *
+ * @param targetText is the text that serves as the target we are trying to find a match for
+ * @param matchText is the text we are sliding our window through to find the best match
+ * @param windowSize is the size of the match window in number of lines
+ * @returns
+ */
 export function bestJaccardMatch(targetText: string, matchText: string, windowSize: number): JaccardMatch | null {
+    const wordCount = (words: Map<string, number>) => {
+        let count = 0
+        for (const v of words.values()) {
+            count += v
+        }
+        return count
+    }
+    // subract the subtrahend bag of words from minuend and return the net change in word count
+    const subtract = (minuend: Map<string, number>, subtrahend: Map<string, number>): number => {
+        let decrease = 0 // will be non-positive
+        for (const [word, count] of subtrahend) {
+            const currentCount = minuend.get(word) || 0
+            const newCount = Math.max(0, currentCount - count)
+            minuend.set(word, newCount)
+            decrease += newCount - currentCount
+        }
+        return decrease
+    }
+    // add incorporates a new line into window and intersection, updating each, and returns the
+    // net increase in size for each
+    const add = (
+        target: Map<string, number>,
+        window: Map<string, number>,
+        intersection: Map<string, number>,
+        newLine: Map<string, number>
+    ): { windowIncrease: number; intersectionIncrease: number } => {
+        let windowIncrease = 0
+        let intersectionIncrease = 0
+        for (const [word, count] of newLine) {
+            windowIncrease += count
+            window.set(word, (window.get(word) || 0) + count)
+
+            const targetCount = target.get(word) || 0
+            if (targetCount > 0) {
+                const intersectionCount = intersection.get(word) || 0
+                const newIntersectionCount = Math.min(count + intersectionCount, targetCount)
+                intersection.set(word, newIntersectionCount)
+                intersectionIncrease += newIntersectionCount - intersectionCount
+            }
+        }
+        return { windowIncrease, intersectionIncrease }
+    }
+
+    // get the bag-of-words-count dictionary for the target text
     const targetWords = getWords(targetText)
+    const targetCount = wordCount(targetWords)
+
+    // split the matchText into lines
     const lines = matchText.split('\n')
     const wordsForEachLine = lines.map(line => getWords(line))
 
+    // initialize the bag of words for the topmost window
     const windowWords = new Map<string, number>()
     for (let i = 0; i < Math.min(windowSize, lines.length); i++) {
         for (const [wordInThisLine, wordInThisLineCount] of wordsForEachLine[i].entries()) {
             windowWords.set(wordInThisLine, (windowWords.get(wordInThisLine) || 0) + wordInThisLineCount)
         }
     }
+
+    let windowCount = wordCount(windowWords)
+    // initialize the bag of words for the intersection of the match window and targetText
     const bothWords = new Map<string, number>()
     for (const [word, wordCount] of targetWords.entries()) {
         bothWords.set(word, Math.min(wordCount, windowWords.get(word) || 0))
     }
+    let bothCount = wordCount(bothWords)
 
-    let bestScore = jaccardScore(targetWords, windowWords)
+    // slide our window through matchText, keeping track of the best score and window so far
+    let bestScore = jaccardDistance(targetCount, windowCount, bothCount)
     let bestWindow = [0, Math.min(windowSize, lines.length)]
     for (let i = 0; i < wordsForEachLine.length - windowSize; i++) {
-        for (const [word, wordCount] of wordsForEachLine[i].entries()) {
-            windowWords.set(word, (windowWords.get(word) || 0) - wordCount)
-            if (windowWords.get(word)! < 0) {
-                windowWords.set(word, 0)
-            }
-            bothWords.set(word, (bothWords.get(word) || 0) - wordCount)
-            if (bothWords.get(word)! < 0) {
-                bothWords.set(word, 0)
-            }
-        }
-        for (const [word, wordCount] of wordsForEachLine[i + windowSize].entries()) {
-            if (windowWords.get(word) === undefined) {
-                windowWords.set(word, 0)
-            }
-            windowWords.set(word, (windowWords.get(word) || 0) + wordCount)
-            if (targetWords.get(word)! > 0) {
-                bothWords.set(
-                    word,
-                    Math.min(
-                        (bothWords.get(word) || 0) + (wordsForEachLine[i + windowSize].get(word) || 0),
-                        targetWords.get(word) || 0
-                    )
-                )
-            }
-        }
-        const score = jaccardScore(targetWords, windowWords)
+        // subtract the words from the line we are scrolling past
+        windowCount += subtract(windowWords, wordsForEachLine[i])
+        bothCount += subtract(bothWords, wordsForEachLine[i])
+
+        // add the words from the new line our window just slid over
+        const { windowIncrease, intersectionIncrease } = add(
+            targetWords,
+            windowWords,
+            bothWords,
+            wordsForEachLine[i + windowSize]
+        )
+        windowCount += windowIncrease
+        bothCount += intersectionIncrease
+
+        // compute the jaccard distance between our target text and window
+        const score = jaccardDistance(targetCount, windowCount, bothCount)
         if (score > bestScore) {
             bestScore = score
             bestWindow = [i + 1, i + windowSize + 1]

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode'
+import winkUtils from 'wink-nlp-utils'
 
 import { History } from './history'
-
-const winkUtils = require('wink-nlp-utils')
 
 export interface ReferenceSnippet extends JaccardMatch {
     filename: string
@@ -107,7 +106,7 @@ export function jaccardDistance(left: number, right: number, intersection: numbe
  * @returns
  */
 export function bestJaccardMatch(targetText: string, matchText: string, windowSize: number): JaccardMatch | null {
-    const wordCount = (words: Map<string, number>) => {
+    const wordCount = (words: Map<string, number>): number => {
         let count = 0
         for (const v of words.values()) {
             count += v
@@ -207,7 +206,7 @@ export function bestJaccardMatch(targetText: string, matchText: string, windowSi
 }
 
 export function getWords(s: string): Map<string, number> {
-    let frequencyCounter = new Map<string, number>()
+    const frequencyCounter = new Map<string, number>()
     const words = winkUtils.string.tokenize0(s)
 
     const filteredWords = winkUtils.tokens.removeWords(words)

--- a/client/cody/src/completions/docprovider.ts
+++ b/client/cody/src/completions/docprovider.ts
@@ -62,7 +62,7 @@ export class CompletionsDocumentProvider implements vscode.TextDocumentContentPr
                     .map(({ prompt, content, stopReason: finishReason }, index) => {
                         let completionText = `\`\`\`${lang}\n$${content}\n\`\`\``
                         if (this.isDebug() && meta) {
-                            completionText = '===== PROMPT:\n' + prompt + '\n' + '===== Result:\n' + content + '\n'
+                            completionText = '===== PROMPT:\n' + prompt + '\n===== Result:\n' + content + '\n'
                         }
                         const headerComponents = [`${index + 1} / ${completions.length}`]
                         if (finishReason) {

--- a/client/cody/src/completions/docprovider.ts
+++ b/client/cody/src/completions/docprovider.ts
@@ -1,5 +1,6 @@
-import * as openai from 'openai'
 import * as vscode from 'vscode'
+
+import { Completion } from '.'
 
 // FIXME: When OpenAI's logit_bias uses a more precise type than 'object',
 // specify JSON-able objects as { [prop: string]: JSONSerialiable | undefined }
@@ -7,15 +8,13 @@ export type JSONSerializable = null | string | number | boolean | object | JSONS
 
 interface Meta {
     elapsedMillis: number
-    prompt: string
     suffix: string
     llmOptions: JSONSerializable
 }
 
 export interface CompletionGroup {
     lang: string
-    prefixText: string
-    completions: openai.CreateChatCompletionResponse
+    completions: Completion[]
     meta?: Meta
 }
 
@@ -35,20 +34,13 @@ export class CompletionsDocumentProvider implements vscode.TextDocumentContentPr
         this.fireDocumentChanged(uri)
     }
 
-    public addCompletions(
-        uri: vscode.Uri,
-        lang: string,
-        prefixText: string,
-        completions: openai.CreateChatCompletionResponse,
-        debug?: Meta
-    ): void {
+    public addCompletions(uri: vscode.Uri, lang: string, completions: Completion[], debug?: Meta): void {
         if (!this.completionsByUri[uri.toString()]) {
             this.completionsByUri[uri.toString()] = []
         }
 
         this.completionsByUri[uri.toString()].push({
             lang,
-            prefixText,
             completions,
             meta: debug,
         })
@@ -65,25 +57,16 @@ export class CompletionsDocumentProvider implements vscode.TextDocumentContentPr
         }
 
         return completionGroups
-            .map(({ completions, lang, prefixText, meta }) =>
-                completions.choices
-                    .map(({ message, finish_reason }, index) => {
-                        if (!message?.content) {
-                            return undefined
-                        }
-
-                        let completionText = `\`\`\`${lang}\n${prefixText}${message.content}\n\`\`\``
+            .map(({ completions, lang, meta }) =>
+                completions
+                    .map(({ prompt, content, stopReason: finishReason }, index) => {
+                        let completionText = `\`\`\`${lang}\n$${content}\n\`\`\``
                         if (this.isDebug() && meta) {
-                            completionText =
-                                `\`\`\`\n${meta.prompt}\n\`\`\`` +
-                                '\n' +
-                                completionText +
-                                '\n' +
-                                `\`\`\`\n${meta.suffix}\n\`\`\``
+                            completionText = '===== PROMPT:\n' + prompt + '\n' + '===== Result:\n' + content + '\n'
                         }
-                        const headerComponents = [`${index + 1} / ${completions.choices.length}`]
-                        if (finish_reason) {
-                            headerComponents.push(`finish_reason:${finish_reason}`)
+                        const headerComponents = [`${index + 1} / ${completions.length}`]
+                        if (finishReason) {
+                            headerComponents.push(`finish_reason:${finishReason}`)
                         }
                         return headerize(headerComponents.join(', '), 80) + '\n' + completionText
                     })

--- a/client/cody/src/completions/history.ts
+++ b/client/cody/src/completions/history.ts
@@ -13,7 +13,8 @@ export class History implements vscode.Disposable {
     private subscriptions: vscode.Disposable[] = []
 
     constructor(
-        register: () => vscode.Disposable | null = () => vscode.window.onDidChangeActiveTextEditor(event => {
+        register: () => vscode.Disposable | null = () =>
+            vscode.window.onDidChangeActiveTextEditor(event => {
                 if (!event?.document.uri) {
                     return
                 }

--- a/client/cody/src/completions/history.ts
+++ b/client/cody/src/completions/history.ts
@@ -1,0 +1,71 @@
+import * as vscode from 'vscode'
+
+export interface HistoryItem {
+    document: Pick<vscode.TextDocument, 'uri' | 'languageId'>
+}
+
+export class History implements vscode.Disposable {
+    private window = 50
+    private history: HistoryItem[]
+    private subscriptions: vscode.Disposable[] = []
+
+    constructor(
+        register: () => vscode.Disposable | null = () => {
+            return vscode.window.onDidChangeActiveTextEditor(event => {
+                if (!event?.document.uri) {
+                    return
+                }
+                this.addItem({
+                    document: event.document,
+                })
+            })
+        }
+    ) {
+        this.history = []
+        if (register) {
+            const d = register()
+            if (d) {
+                this.subscriptions.push(d)
+            }
+        }
+    }
+
+    public dispose(): void {
+        vscode.Disposable.from(...this.subscriptions).dispose()
+    }
+
+    public addItem(newItem: HistoryItem): void {
+        if (newItem.document.uri.scheme === 'codegen') {
+            return
+        }
+        const foundIndex = this.history.findIndex(
+            item => item.document.uri.toString() === newItem.document.uri.toString()
+        )
+        if (foundIndex >= 0) {
+            this.history = [...this.history.slice(0, foundIndex), ...this.history.slice(foundIndex + 1)]
+        }
+        this.history.push(newItem)
+        if (this.history.length > this.window) {
+            this.history = this.lastN(this.window).reverse()
+        }
+    }
+
+    public lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): HistoryItem[] {
+        const ret: HistoryItem[] = []
+        const ignoreSet = new Set(ignoreUris || [])
+        for (let i = this.history.length - 1; i >= 0; i--) {
+            const item = this.history[i]
+            if (ret.length > n) {
+                break
+            }
+            if (ignoreSet.has(item.document.uri)) {
+                continue
+            }
+            if (languageId && languageId !== item.document.languageId) {
+                continue
+            }
+            ret.push(item)
+        }
+        return ret
+    }
+}

--- a/client/cody/src/completions/history.ts
+++ b/client/cody/src/completions/history.ts
@@ -6,7 +6,10 @@ export interface HistoryItem {
 
 export class History implements vscode.Disposable {
     private window = 50
+
+    // tracks history in chronological order (latest at the end of the array)
     private history: HistoryItem[]
+
     private subscriptions: vscode.Disposable[] = []
 
     constructor(
@@ -23,9 +26,9 @@ export class History implements vscode.Disposable {
     ) {
         this.history = []
         if (register) {
-            const d = register()
-            if (d) {
-                this.subscriptions.push(d)
+            const disposable = register()
+            if (disposable) {
+                this.subscriptions.push(disposable)
             }
         }
     }
@@ -46,10 +49,13 @@ export class History implements vscode.Disposable {
         }
         this.history.push(newItem)
         if (this.history.length > this.window) {
-            this.history = this.lastN(this.window).reverse()
+            this.history.shift()
         }
     }
 
+    /**
+     * Returns the last n items of history in reverse chronological order (latest item at the front)
+     */
     public lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): HistoryItem[] {
         const ret: HistoryItem[] = []
         const ignoreSet = new Set(ignoreUris || [])

--- a/client/cody/src/completions/history.ts
+++ b/client/cody/src/completions/history.ts
@@ -13,8 +13,7 @@ export class History implements vscode.Disposable {
     private subscriptions: vscode.Disposable[] = []
 
     constructor(
-        register: () => vscode.Disposable | null = () => {
-            return vscode.window.onDidChangeActiveTextEditor(event => {
+        register: () => vscode.Disposable | null = () => vscode.window.onDidChangeActiveTextEditor(event => {
                 if (!event?.document.uri) {
                     return
                 }
@@ -22,7 +21,6 @@ export class History implements vscode.Disposable {
                     document: event.document,
                 })
             })
-        }
     ) {
         this.history = []
         if (register) {

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -69,7 +69,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        const { prefix, suffix, prevLine: precedingLine } = docContext
+        const { prefix, prevLine: precedingLine } = docContext
         let waitMs: number
         // let completionPrefix = '' // text to require as the first part of the completion
         const remainingBytes = this.tokToByte(this.promptTokens)
@@ -79,7 +79,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             // TODO(beyang): allow multiple lines
             waitMs = 1000
             completers.push(
-                new EndOfLineCompletionProvider(this.claude, remainingBytes, this.responseTokens, prefix, suffix, '', 2)
+                new EndOfLineCompletionProvider(this.claude, remainingBytes, this.responseTokens, prefix, '', 2)
             )
         } else if (context.triggerKind === vscode.InlineCompletionTriggerKind.Invoke || precedingLine.endsWith('.')) {
             // Do nothing
@@ -87,24 +87,8 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             // End of line: long debounce, complete until newline
             waitMs = 2000
             completers.push(
-                new EndOfLineCompletionProvider(
-                    this.claude,
-                    remainingBytes,
-                    this.responseTokens,
-                    prefix,
-                    suffix,
-                    '',
-                    2
-                ),
-                new EndOfLineCompletionProvider(
-                    this.claude,
-                    remainingBytes,
-                    this.responseTokens,
-                    prefix,
-                    suffix,
-                    '\n',
-                    2
-                )
+                new EndOfLineCompletionProvider(this.claude, remainingBytes, this.responseTokens, prefix, '', 2),
+                new EndOfLineCompletionProvider(this.claude, remainingBytes, this.responseTokens, prefix, '\n', 2)
             )
         }
 
@@ -416,7 +400,6 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         private responseTokens: number,
         private prefix: string,
         // eslint-disable-next-line
-        private suffix: string, // TODO(beyang): make use of
         private injectPrefix: string,
         private defaultN: number = 1
     ) {}

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -39,7 +39,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         try {
             return await this.provideInlineCompletionItemsInner(document, position, context, token)
         } catch (error) {
-            vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
+            await vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
             return []
         }
     }
@@ -171,7 +171,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 llmOptions: null,
             })
         } catch (error) {
-            vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
+            await vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
         }
     }
 }
@@ -311,8 +311,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 },
                 {
                     role: 'ai',
-                    text:
-                        'Here is the completion of the file:\n' + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                    text: `Here is the completion of the file:\n\`\`\`\n${prefixLines.slice(endLine).join('\n')}`,
                 },
             ]
         } else {
@@ -323,7 +322,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 },
                 {
                     role: 'ai',
-                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
+                    text: `Here is some code:\n\`\`\`\n${prefix}`,
                 },
             ]
         }
@@ -355,7 +354,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
 
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])
     }
-    private postProcess(completion: string) {
+    private postProcess(completion: string): string {
         const endBlockIndex = completion.indexOf('```')
         if (endBlockIndex !== -1) {
             return completion.slice(0, endBlockIndex).trimEnd()
@@ -363,7 +362,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
         return completion.trimEnd()
     }
 
-    async generateCompletions(n?: number): Promise<Completion[]> {
+    public async generateCompletions(n?: number): Promise<Completion[]> {
         // Create prompt
         const prompt = this.makePrompt()
         if (prompt.length > this.promptChars) {
@@ -436,7 +435,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
                 },
                 {
                     role: 'ai',
-                    text: 'Here is some code:\n' + '```' + `\n${this.prefix}${this.injectPrefix}`,
+                    text: `Here is some code:\n\`\`\`\n${this.prefix}${this.injectPrefix}`,
                 },
             ]
         }
@@ -444,7 +443,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])
     }
 
-    private postProcess(completion: string) {
+    private postProcess(completion: string): string {
         // Sometimes Claude omits an extra space
         if (
             completion.length > 0 &&
@@ -466,7 +465,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         return completion.trimEnd()
     }
 
-    async generateCompletions(n?: number): Promise<Completion[]> {
+    public async generateCompletions(n?: number): Promise<Completion[]> {
         // Create prompt
         const prompt = this.makePrompt()
         if (prompt.length > this.promptChars) {

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -97,7 +97,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         const waiter = new Promise<void>(resolve => setTimeout(() => resolve(), waitMs))
 
-        const results = (await Promise.all(completers.map(c => c.generateCompletions()))).flatMap(c => c)
+        const results = (await Promise.all(completers.map(c => c.generateCompletions()))).flat()
         await waiter
         return results.map(r => new vscode.InlineCompletionItem(r.content))
     }
@@ -264,7 +264,7 @@ async function batchClaude(
     for (let i = 0; i < n; i++) {
         responses.push(claude.complete(params))
     }
-    return await Promise.all(responses)
+    return Promise.all(responses)
 }
 
 export interface Completion {
@@ -304,7 +304,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 {
                     role: 'human',
                     text:
-                        `Complete the following file:\n` +
+                        'Complete the following file:\n' +
                         '```' +
                         `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
                         '```',
@@ -312,7 +312,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                        'Here is the completion of the file:\n' + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
                 },
             ]
         } else {
@@ -323,7 +323,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 },
                 {
                     role: 'ai',
-                    text: `Here is some code:\n` + '```' + `\n${prefix}`,
+                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
                 },
             ]
         }
@@ -396,7 +396,6 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         private promptChars: number,
         private responseTokens: number,
         private prefix: string,
-        // eslint-disable-next-line
         private injectPrefix: string,
         private defaultN: number = 1
     ) {}
@@ -416,7 +415,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
                 {
                     role: 'human',
                     text:
-                        `Complete the following file:\n` +
+                        'Complete the following file:\n' +
                         '```' +
                         `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
                         '```',
@@ -424,7 +423,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` +
+                        'Here is the completion of the file:\n' +
                         '```' +
                         `\n${prefixLines.slice(endLine).join('\n')}${this.injectPrefix}`,
                 },
@@ -437,7 +436,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
                 },
                 {
                     role: 'ai',
-                    text: `Here is some code:\n` + '```' + `\n${this.prefix}${this.injectPrefix}`,
+                    text: 'Here is some code:\n' + '```' + `\n${this.prefix}${this.injectPrefix}`,
                 },
             ]
         }
@@ -449,9 +448,9 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         // Sometimes Claude omits an extra space
         if (
             completion.length > 0 &&
-            completion[0] === ' ' &&
+            completion.startsWith(' ') &&
             this.prefix.length > 0 &&
-            this.prefix[this.prefix.length - 1] === ' '
+            this.prefix.endsWith(' ')
         ) {
             completion = completion.slice(1)
         }

--- a/client/cody/src/completions/prompts.ts
+++ b/client/cody/src/completions/prompts.ts
@@ -24,7 +24,7 @@ export interface PromptTemplate {
 }
 
 export class SingleLinePromptTemplate implements PromptTemplate {
-    make(charsBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string {
+    public make(charsBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string {
         // TODO(beyang): escape 'Human:' and 'Assistant:'
         // console.log(`>>>${prefix}<<<`)
 
@@ -62,14 +62,14 @@ export class SingleLinePromptTemplate implements PromptTemplate {
                 },
                 {
                     role: 'ai',
-                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
+                    text: `Here is some code:\n\`\`\`\n${prefix}`,
                 },
             ]
         }
 
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])
     }
-    postProcess(completion: string, prefix: string): string {
+    public postProcess(completion: string, prefix: string): string {
         if (completion.length > 0 && completion.startsWith(' ') && prefix.length > 0 && prefix.endsWith(' ')) {
             completion = completion.slice(1)
         }
@@ -82,7 +82,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
 }
 
 export class KnowledgeBasePromptTemplate implements PromptTemplate {
-    make(
+    public make(
         charsBudget: number,
         prefix: string,
         suffix: string, // TODO(beyang)
@@ -125,7 +125,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
                 },
                 {
                     role: 'ai',
-                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
+                    text: `Here is some code:\n\`\`\`\n${prefix}`,
                 },
             ]
         }
@@ -158,7 +158,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])
     }
 
-    postProcess(completion: string): string {
+    public postProcess(completion: string): string {
         const endBlockIndex = completion.indexOf('```')
         if (endBlockIndex !== -1) {
             return completion.slice(0, endBlockIndex).trimEnd()

--- a/client/cody/src/completions/prompts.ts
+++ b/client/cody/src/completions/prompts.ts
@@ -19,12 +19,12 @@ export function messagesToText(messages: Message[]): string {
 }
 
 export interface PromptTemplate {
-    make(bytesBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string
+    make(charsBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string
     postProcess(completion: string, prefix: string): string
 }
 
 export class SingleLinePromptTemplate implements PromptTemplate {
-    make(bytesBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string {
+    make(charsBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string {
         // TODO(beyang): escape 'Human:' and 'Assistant:'
         // console.log(`>>>${prefix}<<<`)
 
@@ -81,7 +81,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
 
 export class KnowledgeBasePromptTemplate implements PromptTemplate {
     make(
-        bytesBudget: number,
+        charsBudget: number,
         prefix: string,
         suffix: string, // TODO(beyang)
         snippets: ReferenceSnippet[]
@@ -127,7 +127,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
         }
 
         const promptNoSnippets = messagesToText([...referenceSnippetMessages, ...prefixMessages])
-        let remainingBytes = bytesBudget - promptNoSnippets.length - 10 // extra 10 bytes of buffer cuz who knows
+        let remainingChars = charsBudget - promptNoSnippets.length - 10 // extra 10 chars of buffer cuz who knows
         for (const snippet of snippets) {
             const snippetMessages: Message[] = [
                 {
@@ -143,13 +143,12 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
                     text: 'Okay, I have added it to my knowledge base.',
                 },
             ]
-            const numSnippetBytes = messagesToText(snippetMessages).length + 1
-            console.log(`# numSnippetBytes: ${numSnippetBytes}, remainingBytes: ${remainingBytes}`)
-            if (numSnippetBytes > remainingBytes) {
+            const numSnippetChars = messagesToText(snippetMessages).length + 1
+            if (numSnippetChars > remainingChars) {
                 break
             }
             referenceSnippetMessages.push(...snippetMessages)
-            remainingBytes -= numSnippetBytes
+            remainingChars -= numSnippetChars
         }
 
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])

--- a/client/cody/src/completions/prompts.ts
+++ b/client/cody/src/completions/prompts.ts
@@ -36,20 +36,22 @@ export class SingleLinePromptTemplate implements PromptTemplate {
         const referenceSnippetMessages: Message[] = []
         let prefixMessages: Message[]
         if (prefixLines.length > 2) {
-            const endLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
+            const lastHumanLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
             prefixMessages = [
                 {
                     role: 'human',
                     text:
                         `Complete the following file:\n` +
                         '```' +
-                        `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
+                        `\n${prefixLines.slice(0, lastHumanLine).join('\n')}\n` +
                         '```',
                 },
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                        `Here is the completion of the file:\n` +
+                        '```' +
+                        `\n${prefixLines.slice(lastHumanLine).join('\n')}`,
                 },
             ]
         } else {
@@ -97,20 +99,22 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
         const referenceSnippetMessages: Message[] = []
         let prefixMessages: Message[]
         if (prefixLines.length > 2) {
-            const endLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
+            const lastHumanLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
             prefixMessages = [
                 {
                     role: 'human',
                     text:
                         `Complete the following file:\n` +
                         '```' +
-                        `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
+                        `\n${prefixLines.slice(0, lastHumanLine).join('\n')}\n` +
                         '```',
                 },
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                        `Here is the completion of the file:\n` +
+                        '```' +
+                        `\n${prefixLines.slice(lastHumanLine).join('\n')}`,
                 },
             ]
         } else {

--- a/client/cody/src/completions/prompts.ts
+++ b/client/cody/src/completions/prompts.ts
@@ -1,0 +1,165 @@
+import * as anthropic from '@anthropic-ai/sdk'
+
+import { ReferenceSnippet } from './context'
+
+export interface Message {
+    role: 'human' | 'ai'
+    text: string | null
+}
+
+export function messagesToText(messages: Message[]): string {
+    return messages
+        .map(
+            message =>
+                `${message.role === 'human' ? anthropic.HUMAN_PROMPT : anthropic.AI_PROMPT}${
+                    message.text === null ? '' : ' ' + message.text
+                }`
+        )
+        .join('')
+}
+
+export interface PromptTemplate {
+    make(bytesBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string
+    postProcess(completion: string, prefix: string): string
+}
+
+export class SingleLinePromptTemplate implements PromptTemplate {
+    make(bytesBudget: number, prefix: string, suffix: string, snippets: ReferenceSnippet[]): string {
+        // TODO(beyang): escape 'Human:' and 'Assistant:'
+        // console.log(`>>>${prefix}<<<`)
+
+        const prefixLines = prefix.split('\n')
+        if (prefixLines.length === 0) {
+            throw new Error('no prefix lines')
+        }
+
+        const referenceSnippetMessages: Message[] = []
+        let prefixMessages: Message[]
+        if (prefixLines.length > 2) {
+            const endLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
+            prefixMessages = [
+                {
+                    role: 'human',
+                    text:
+                        `Complete the following file:\n` +
+                        '```' +
+                        `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
+                        '```',
+                },
+                {
+                    role: 'ai',
+                    text:
+                        `Here is the completion of the file:\n` + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                },
+            ]
+        } else {
+            prefixMessages = [
+                {
+                    role: 'human',
+                    text: 'Write some code',
+                },
+                {
+                    role: 'ai',
+                    text: `Here is some code:\n` + '```' + `\n${prefix}`,
+                },
+            ]
+        }
+
+        return messagesToText([...referenceSnippetMessages, ...prefixMessages])
+    }
+    postProcess(completion: string, prefix: string): string {
+        if (completion.length > 0 && completion[0] === ' ' && prefix.length > 0 && prefix[prefix.length - 1] === ' ') {
+            completion = completion.slice(1)
+        }
+        const endBlockIndex = completion.indexOf('```')
+        if (endBlockIndex !== -1) {
+            return completion.slice(0, endBlockIndex).trimEnd()
+        }
+        return completion.trimEnd()
+    }
+}
+
+export class KnowledgeBasePromptTemplate implements PromptTemplate {
+    make(
+        bytesBudget: number,
+        prefix: string,
+        suffix: string, // TODO(beyang)
+        snippets: ReferenceSnippet[]
+    ): string {
+        // TODO(beyang): escape 'Human:' and 'Assistant:'
+        prefix = prefix.trim()
+
+        const prefixLines = prefix.split('\n')
+        if (prefixLines.length === 0) {
+            throw new Error('no prefix lines')
+        }
+
+        const referenceSnippetMessages: Message[] = []
+        let prefixMessages: Message[]
+        if (prefixLines.length > 2) {
+            const endLine = Math.max(Math.floor(prefixLines.length / 2), prefixLines.length - 5)
+            prefixMessages = [
+                {
+                    role: 'human',
+                    text:
+                        `Complete the following file:\n` +
+                        '```' +
+                        `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
+                        '```',
+                },
+                {
+                    role: 'ai',
+                    text:
+                        `Here is the completion of the file:\n` + '```' + `\n${prefixLines.slice(endLine).join('\n')}`,
+                },
+            ]
+        } else {
+            prefixMessages = [
+                {
+                    role: 'human',
+                    text: 'Write some code',
+                },
+                {
+                    role: 'ai',
+                    text: `Here is some code:\n` + '```' + `\n${prefix}`,
+                },
+            ]
+        }
+
+        const promptNoSnippets = messagesToText([...referenceSnippetMessages, ...prefixMessages])
+        let remainingBytes = bytesBudget - promptNoSnippets.length - 10 // extra 10 bytes of buffer cuz who knows
+        for (const snippet of snippets) {
+            const snippetMessages: Message[] = [
+                {
+                    role: 'human',
+                    text:
+                        `Add the following code snippet (from file ${snippet.filename}) to your knowledge base:\n` +
+                        '```' +
+                        `\n${snippet.text}\n` +
+                        '```',
+                },
+                {
+                    role: 'ai',
+                    text: 'Okay, I have added it to my knowledge base.',
+                },
+            ]
+            const numSnippetBytes = messagesToText(snippetMessages).length + 1
+            console.log(`# numSnippetBytes: ${numSnippetBytes}, remainingBytes: ${remainingBytes}`)
+            if (numSnippetBytes > remainingBytes) {
+                break
+            }
+            referenceSnippetMessages.push(...snippetMessages)
+            remainingBytes -= numSnippetBytes
+        }
+
+        return messagesToText([...referenceSnippetMessages, ...prefixMessages])
+    }
+
+    postProcess(completion: string): string {
+        const endBlockIndex = completion.indexOf('```')
+        if (endBlockIndex !== -1) {
+            return completion.slice(0, endBlockIndex).trimEnd()
+        }
+        return completion.trimEnd()
+    }
+}

--- a/client/cody/src/completions/prompts.ts
+++ b/client/cody/src/completions/prompts.ts
@@ -41,7 +41,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
                 {
                     role: 'human',
                     text:
-                        `Complete the following file:\n` +
+                        'Complete the following file:\n' +
                         '```' +
                         `\n${prefixLines.slice(0, lastHumanLine).join('\n')}\n` +
                         '```',
@@ -49,7 +49,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` +
+                        'Here is the completion of the file:\n' +
                         '```' +
                         `\n${prefixLines.slice(lastHumanLine).join('\n')}`,
                 },
@@ -62,7 +62,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
                 },
                 {
                     role: 'ai',
-                    text: `Here is some code:\n` + '```' + `\n${prefix}`,
+                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
                 },
             ]
         }
@@ -70,7 +70,7 @@ export class SingleLinePromptTemplate implements PromptTemplate {
         return messagesToText([...referenceSnippetMessages, ...prefixMessages])
     }
     postProcess(completion: string, prefix: string): string {
-        if (completion.length > 0 && completion[0] === ' ' && prefix.length > 0 && prefix[prefix.length - 1] === ' ') {
+        if (completion.length > 0 && completion.startsWith(' ') && prefix.length > 0 && prefix.endsWith(' ')) {
             completion = completion.slice(1)
         }
         const endBlockIndex = completion.indexOf('```')
@@ -104,7 +104,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
                 {
                     role: 'human',
                     text:
-                        `Complete the following file:\n` +
+                        'Complete the following file:\n' +
                         '```' +
                         `\n${prefixLines.slice(0, lastHumanLine).join('\n')}\n` +
                         '```',
@@ -112,7 +112,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
                 {
                     role: 'ai',
                     text:
-                        `Here is the completion of the file:\n` +
+                        'Here is the completion of the file:\n' +
                         '```' +
                         `\n${prefixLines.slice(lastHumanLine).join('\n')}`,
                 },
@@ -125,7 +125,7 @@ export class KnowledgeBasePromptTemplate implements PromptTemplate {
                 },
                 {
                     role: 'ai',
-                    text: `Here is some code:\n` + '```' + `\n${prefix}`,
+                    text: 'Here is some code:\n' + '```' + `\n${prefix}`,
                 },
             ]
         }

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -14,7 +14,6 @@ describe('getConfiguration', () => {
             debug: false,
             useContext: 'embeddings',
             experimentalSuggest: false,
-            openaiKey: null,
             anthropicKey: null,
         })
     })
@@ -35,8 +34,6 @@ describe('getConfiguration', () => {
                         return 'keyword'
                     case 'cody.experimental.suggestions':
                         return true
-                    case 'cody.experimental.keys.openai':
-                        return 'sk-XXX'
                     case 'cody.experimental.keys.anthropic':
                         return 'sk-YYY'
                     default:
@@ -51,7 +48,6 @@ describe('getConfiguration', () => {
             debug: true,
             useContext: 'keyword',
             experimentalSuggest: true,
-            openaiKey: 'sk-XXX',
             anthropicKey: 'sk-YYY',
         })
     })

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -15,6 +15,7 @@ describe('getConfiguration', () => {
             useContext: 'embeddings',
             experimentalSuggest: false,
             openaiKey: null,
+            anthropicKey: null,
         })
     })
 
@@ -36,6 +37,8 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.keys.openai':
                         return 'sk-XXX'
+                    case 'cody.experimental.keys.anthropic':
+                        return 'sk-YYY'
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -49,6 +52,7 @@ describe('getConfiguration', () => {
             useContext: 'keyword',
             experimentalSuggest: true,
             openaiKey: 'sk-XXX',
+            anthropicKey: 'sk-YYY',
         })
     })
 })

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -11,6 +11,7 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         useContext: config.get<ConfigurationUseContext>('cody.useContext') || 'embeddings',
         experimentalSuggest: config.get('cody.experimental.suggestions', false),
         openaiKey: config.get('cody.experimental.keys.openai', null),
+        anthropicKey: config.get('cody.experimental.keys.anthropic', null),
     }
 }
 

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -10,7 +10,6 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         debug: config.get('cody.debug', false),
         useContext: config.get<ConfigurationUseContext>('cody.useContext') || 'embeddings',
         experimentalSuggest: config.get('cody.experimental.suggestions', false),
-        openaiKey: config.get('cody.experimental.keys.openai', null),
         anthropicKey: config.get('cody.experimental.keys.anthropic', null),
     }
 }

--- a/client/cody/src/integration-test/extension.test.ts
+++ b/client/cody/src/integration-test/extension.test.ts
@@ -97,7 +97,7 @@ suite('End-to-end', () => {
         await ensureExecuteCommand('cody.delete-access-token')
     })
 
-    test('History', async () => {
+    test('History', () => {
         const h = new History(() => null)
         h.addItem({
             document: {

--- a/client/cody/src/integration-test/extension.test.ts
+++ b/client/cody/src/integration-test/extension.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
+import { History } from '../completions/history'
 import { ExtensionApi } from '../extension-api'
 
 import * as mockServer from './mock-server'
@@ -94,5 +95,31 @@ suite('End-to-end', () => {
 
         // Clean up.
         await ensureExecuteCommand('cody.delete-access-token')
+    })
+
+    test('History', async () => {
+        const h = new History(() => null)
+        h.addItem({
+            document: {
+                uri: vscode.Uri.file('foo.ts'),
+                languageId: 'ts',
+            },
+        })
+        h.addItem({
+            document: {
+                uri: vscode.Uri.file('bar.ts'),
+                languageId: 'ts',
+            },
+        })
+        h.addItem({
+            document: {
+                uri: vscode.Uri.file('foo.ts'),
+                languageId: 'ts',
+            },
+        })
+        assert.deepStrictEqual(
+            h.lastN(20).map(h => h.document.uri.fsPath),
+            ['/foo.ts', '/bar.ts']
+        )
     })
 })

--- a/client/cody/src/wink-nlp-utils.d.ts
+++ b/client/cody/src/wink-nlp-utils.d.ts
@@ -1,0 +1,1 @@
+declare module 'wink-nlp-utils'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -921,13 +921,21 @@ importers:
 
   client/cody:
     specifiers:
+      '@anthropic-ai/sdk': ^0.4.2
       '@sourcegraph/cody-shared': workspace:*
       '@sourcegraph/cody-ui': workspace:*
       openai: ^3.2.1
+      wink-eng-lite-web-model: ^1.5.0
+      wink-nlp: ^1.13.1
+      wink-nlp-utils: ^2.1.0
     dependencies:
+      '@anthropic-ai/sdk': 0.4.2
       '@sourcegraph/cody-shared': link:../cody-shared
       '@sourcegraph/cody-ui': link:../cody-ui
       openai: 3.2.1
+      wink-eng-lite-web-model: 1.5.0_wink-nlp@1.13.1
+      wink-nlp: 1.13.1
+      wink-nlp-utils: 2.1.0
 
   client/cody-shared:
     specifiers:
@@ -1202,6 +1210,15 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
+
+  /@anthropic-ai/sdk/0.4.2:
+    resolution: {integrity: sha512-L/uhXDxPNWKIUV3V2v+97XyVVjY2P6vhxpdNFqmZEKUKy6FqVwcfPPHcckH6ixyQ5+j/Zq4A6eybc7ewc2+WjQ==}
+    dependencies:
+      '@fortaine/fetch-event-source': 3.0.6
+      cross-fetch: 3.1.5
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@apidevtools/json-schema-ref-parser/9.0.6:
     resolution: {integrity: sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==}
@@ -3814,6 +3831,11 @@ packages:
       '@figspec/components': 1.0.0
       react: 18.1.0
     dev: true
+
+  /@fortaine/fetch-event-source/3.0.6:
+    resolution: {integrity: sha512-621GAuLMvKtyZQ3IA6nlDWhV1V/7PGOTNIGLUifxt0KzM+dZIweJ6F3XvQF3QnqeNfS1N7WQ0Kil1Di/lhChEw==}
+    engines: {node: '>=16.15'}
+    dev: false
 
   /@gql2ts/from-query/1.9.0_graphql@14.7.0:
     resolution: {integrity: sha512-hfH2Oq3ikHu+zKE4b9kdGbzEqFiX+VxIg0nhgpY5iUgl975cAtTFhAdwfzr/jKdZhC9Ad5dE1CPrjEA+G7hzMg==}
@@ -13100,7 +13122,6 @@ packages:
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /cross-spawn/5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -14640,7 +14661,6 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /emojis-list/3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -29027,6 +29047,55 @@ packages:
     dependencies:
       execa: 1.0.0
     dev: true
+
+  /wink-distance/2.0.2:
+    resolution: {integrity: sha512-pyEhUB/OKFYcgOC4J6E+c+gwVA/8qg2s5n49mIcUsJZM5iDSa17uOxRQXR4rvfp+gbj55K/I08FwjFBwb6fq3g==}
+    dependencies:
+      wink-helpers: 2.0.0
+      wink-jaro-distance: 2.0.0
+    dev: false
+
+  /wink-eng-lite-web-model/1.5.0_wink-nlp@1.13.1:
+    resolution: {integrity: sha512-5t27uqKRpQVyjb+ztIabmD2m76ct+5NP9e3TVxla4GBQzgPJnAHCynPw4KQa42BNn5xxi7b7E9P3akSFiYWHbg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      wink-nlp: '>1.8.1'
+    dependencies:
+      wink-nlp: 1.13.1
+    dev: false
+
+  /wink-helpers/2.0.0:
+    resolution: {integrity: sha512-I/ZzXrHcNRXuoeFJmp2vMVqDI6UCK02Tds1WP4kSGAmx520gjL1BObVzF7d2ps24tyHIly9ngdB2jwhlFUjPvg==}
+    dev: false
+
+  /wink-jaro-distance/2.0.0:
+    resolution: {integrity: sha512-9bcUaXCi9N8iYpGWbFkf83OsBkg17r4hEyxusEzl+nnReLRPqxhB9YNeRn3g54SYnVRNXP029lY3HDsbdxTAuA==}
+    dev: false
+
+  /wink-nlp-utils/2.1.0:
+    resolution: {integrity: sha512-b7PcRhEBNxQmsmht70jLOkwYUyie3da4/cgEXL+CumYO5b/nwV+W7fuMXToh5BtGq1RABznmc2TGTp1Qf/JUXg==}
+    dependencies:
+      wink-distance: 2.0.2
+      wink-eng-lite-web-model: 1.5.0_wink-nlp@1.13.1
+      wink-helpers: 2.0.0
+      wink-nlp: 1.13.1
+      wink-porter2-stemmer: 2.0.1
+      wink-tokenizer: 5.3.0
+    dev: false
+
+  /wink-nlp/1.13.1:
+    resolution: {integrity: sha512-JhZpPhGxUhGhqSykManCHkRRUU07LgqiAnG14HT7ZS4p3rKnanKJwl1NSwenEmUIwr4aEik3BWLoEF49xkrsyQ==}
+    dev: false
+
+  /wink-porter2-stemmer/2.0.1:
+    resolution: {integrity: sha512-0g+RkkqhRXFmSpJQStVXW5N/WsshWpJXsoDRW7DwVkGI2uDT6IBCoq3xdH5p6IHLaC6ygk7RWUsUx4alKxoagQ==}
+    dev: false
+
+  /wink-tokenizer/5.3.0:
+    resolution: {integrity: sha512-O/yAw0g3FmSgeeQuYAJJfP7fVPB4A6ay0018qASh79aWmIOyPYy4j4r9EQT8xBjicja6lCLvgRVAybmEBaATQA==}
+    dependencies:
+      emoji-regex: 9.2.2
+    dev: false
 
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}


### PR DESCRIPTION
Ports completion backend to claude-instant (Codex is now sunsetted). This requires an anthropic key to be set locally for now.

### Inline completions
Restricted to single-line only for now. Does not fetch context (only looks at file contents preceding cursor):
![image](https://user-images.githubusercontent.com/1646931/229954628-ad9e087a-a842-4799-8f02-931f02ed4397.png)

### Completions window
Fetches context from recent history, retrieves at most one 20-line snippet from each file, ranked via Jaccard distance:
![image](https://user-images.githubusercontent.com/1646931/229954690-9e49476c-af84-4b5d-917b-6458b526b0ca.png)

### Here is the actual code written for reference (ground truth)
![image](https://user-images.githubusercontent.com/1646931/229954720-00969d76-0905-4570-868e-eb0c578c8178.png)


## Test plan

Cody-only. This feature is experimental. Tested locally.

## App preview:

- [Web](https://sg-web-bl-completions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
