### PR TITLE
dep: Update Grafana alpine base image

### DIFF
--- a/docker-images/alpine-3.14/update-all-dockerfiles.sh
+++ b/docker-images/alpine-3.14/update-all-dockerfiles.sh
@@ -63,7 +63,7 @@ TAG="${TAG:-${NEW_TAG:?"$MISSING_MESSAGE"}}"
 
 NEW_TAG_AND_DIGEST="$(get_new_tag_and_digest "$NEW_IMAGE" "$TAG")"
 
-for file in $(fd --glob Dockerfile .); do
+for file in $(fd --glob Dockerfile\* .); do
   update_image_reference "$OLD_IMAGE" "$NEW_IMAGE" "$NEW_TAG_AND_DIGEST" "$file"
   echo "$file"
 done

--- a/docker-images/grafana/Dockerfile.alpine
+++ b/docker-images/grafana/Dockerfile.alpine
@@ -1,7 +1,7 @@
 # sourcegraph/grafana - learn more about this image in https://docs.sourcegraph.com/dev/background-information/observability/grafana
 
 # Build monitoring definitions
-FROM sourcegraph/alpine-3.14:201280_2023-02-23_4.5-1071f8b97a60@sha256:c4970b21169db155c1b497740e622adb23007ac11a87ec571d9ecef8aba0adc5 AS monitoring_builder
+FROM sourcegraph/alpine-3.14:211375_2023-04-02_5.0-05ccd1762636@sha256:cd5089e0b0f7e5a5cd18996f5acd23cfa2bde33f6b7ffb9ace47f552941f0be2 AS monitoring_builder
 RUN mkdir -p '/generated/grafana'
 COPY ./.bin/monitoring-generator /bin/monitoring-generator
 RUN GRAFANA_DIR='/generated/grafana' PROMETHEUS_DIR='' DOCS_DIR='' NO_PRUNE=true /bin/monitoring-generator


### PR DESCRIPTION
The Grafana Alpine docker base image did not get updated last time. This is due to the naming of the Dockerfile. I've manually updated the base-image and updated the glob in the `update-all-dockerfiles.sh` script.

## Test plan
Ran a build locally, the CVE does not occur in this image. Tested the glob, by running the script and confirmed that the alpine Dockerfile was included.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
