### PR TITLE
Update Grafana Wolfi base image to patch CVE-2023-0464

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -13,7 +13,7 @@ RUN ls '/generated/grafana'
 # See https://docs.google.com/document/d/1nSmz1ChL_rBvX8FAKTB-CNzgcff083sUlIpoXEz6FHE/edit#heading=h.69clsrno4211
 # We use a Grafana base image built by Chainguard
 # TODO(@willdollman): This image was manually uploaded to our registry 2023-03-08
-FROM us.gcr.io/sourcegraph-dev/wolfi-grafana@sha256:47c8c8eaf8d2829f0c34d2e3616e96c04a3fbf6d3ea7e8a420ff910e5916a528 as production
+FROM us.gcr.io/sourcegraph-dev/wolfi-grafana@sha256:6f0734b54847925c92f716d613864561c1d98920e80875d40c7288559acfddf6 as production
 LABEL com.sourcegraph.grafana.version=7.5.17
 
 ARG COMMIT_SHA="unknown"


### PR DESCRIPTION
This patches [CVE-2023-0464](https://github.com/wolfi-dev/os/blob/main/openssl/CVE-2023-0464.patch) (HIGH) but not CVE-2023-0465 (MEDIUM).

Chainguard have patches for both, but the grafana image hasn't been rebuilt on their end since the CVE-2023-0465 patch was made available. It's medium severity so not a big problem but I'll ping them about it to understand when they issue images.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Manually tested image locally