### PR TITLE
cody: fix extension styling

### DIFF
--- a/client/cody-ui/src/Chat.module.css
+++ b/client/cody-ui/src/Chat.module.css
@@ -10,7 +10,6 @@
 
 .transcript-container {
     flex: 1;
-    overflow: auto;
 }
 
 .bubble-container {

--- a/client/cody-ui/src/Chat.module.css
+++ b/client/cody-ui/src/Chat.module.css
@@ -8,8 +8,9 @@
     height: 100%;
 }
 
-.transcript-container, .non-transcript-container {
+.transcript-container {
     flex: 1;
+    overflow: auto;
 }
 
 .bubble-container {

--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -30,6 +30,7 @@ interface ChatProps extends ChatClassNames {
 }
 
 interface ChatClassNames {
+    transcriptContainerClassName?: string
     bubbleContentClassName?: string
     humanBubbleContentClassName?: string
     botBubbleContentClassName?: string
@@ -69,6 +70,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     tipsRecommendations,
     afterTips,
     className,
+    transcriptContainerClassName,
     bubbleContentClassName,
     humanBubbleContentClassName,
     botBubbleContentClassName,
@@ -152,7 +154,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
         <div className={classNames(className, styles.innerContainer)}>
             <div
                 ref={transcriptContainerRef}
-                className={transcript.length >= 1 ? styles.transcriptContainer : styles.nonTranscriptContainer}
+                className={classNames(styles.transcriptContainer, transcriptContainerClassName)}
             >
                 {/* Show Tips view if no conversation has happened */}
                 {transcript.length === 0 && !messageInProgress && (

--- a/client/cody-ui/src/chat/ContextFiles.module.css
+++ b/client/cody-ui/src/chat/ContextFiles.module.css
@@ -32,7 +32,6 @@
 .context-files-collapsed .context-files-toggle-icon {
     display: flex;
     align-items: flex-start;
-    padding-top: 0.2rem;
 }
 
 .context-files-collapsed-text {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -128,6 +128,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                 const isValid = await isValidLogin(message.serverEndpoint, message.accessToken)
                 if (isValid) {
                     await updateConfiguration('serverEndpoint', message.serverEndpoint)
+                    await this.secretStorage.store(CODY_ACCESS_TOKEN_SECRET, message.accessToken)
                     logEvent(
                         'CodyVSCodeExtension:login:clicked',
                         { serverEndpoint: this.serverEndpoint },

--- a/client/cody/webviews/App.css
+++ b/client/cody/webviews/App.css
@@ -25,10 +25,3 @@ button {
     overflow: auto;
     flex: 1;
 }
-
-.transcript-container {
-    display: flex;
-    flex-direction: column-reverse;
-    overflow: auto;
-    flex: 1;
-}

--- a/client/cody/webviews/Chat.module.css
+++ b/client/cody/webviews/Chat.module.css
@@ -46,3 +46,14 @@
     color: var(--vscode-input-foreground);
     background-color: var(--vscode-input-background);
 }
+
+.transcript-container {
+    display: flex;
+    flex-direction: column-reverse;
+    flex: 1;
+}
+
+.inner-container {
+    height: 100%;
+    overflow: auto;
+}

--- a/client/cody/webviews/Chat.module.css
+++ b/client/cody/webviews/Chat.module.css
@@ -51,6 +51,11 @@
     display: flex;
     flex-direction: column-reverse;
     flex: 1;
+    overflow: auto;
+}
+
+.empty-transcript-container {
+    overflow: auto;
 }
 
 .inner-container {

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -54,6 +54,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             submitButtonComponent={SubmitButton}
             fileLinkComponent={FileLink}
             tipsRecommendations={TIPS_RECOMMENDATIONS}
+            className={styles.innerContainer}
+            transcriptContainerClassName={transcript.length > 0 ? styles.transcriptContainer : undefined}
             bubbleContentClassName={styles.bubbleContent}
             humanBubbleContentClassName={styles.humanBubbleContent}
             botBubbleContentClassName={styles.botBubbleContent}

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -55,7 +55,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             fileLinkComponent={FileLink}
             tipsRecommendations={TIPS_RECOMMENDATIONS}
             className={styles.innerContainer}
-            transcriptContainerClassName={transcript.length > 0 ? styles.transcriptContainer : undefined}
+            transcriptContainerClassName={
+                transcript.length > 0 ? styles.transcriptContainer : styles.emptyTranscriptContainer
+            }
             bubbleContentClassName={styles.bubbleContent}
             humanBubbleContentClassName={styles.humanBubbleContent}
             botBubbleContentClassName={styles.botBubbleContent}

--- a/client/cody/webviews/FileLink.module.css
+++ b/client/cody/webviews/FileLink.module.css
@@ -8,4 +8,5 @@
     display: inline;
     padding: 0;
     margin: 0;
+    text-align: left;
 }


### PR DESCRIPTION
Moving the styles around broke the extension UI. The logging PR introduced a bug where the user is logged out each time they open the extension.

Style fixes:

* Chat bubbles should stick to the bottom in the extension.
* Only the chat transcript should be scrollable.
* Context files should be left aligned.

## Test plan

* Manual testing.

## App preview:

- [Web](https://sg-web-rn-cody-style-and-bug-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
