### PR TITLE
[WIP] [feat] Add soft deleted user recovery restriction duration

### DIFF
--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -265,6 +265,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     /** Whether the feedback survey is enabled. */
     disableFeedbackSurvey?: boolean
+
+    /** Duration in seconds during which deleted users cannot be recovered */
+    userRecoveryRestrictedDurationInSeconds: number
 }
 
 export interface BrandAssets {

--- a/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useCallback } from 'react'
 
+import { formatDuration } from 'date-fns'
+
 import { logger } from '@sourcegraph/common'
 import { useMutation } from '@sourcegraph/http-client'
 import { Text } from '@sourcegraph/wildcard'
@@ -72,7 +74,23 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
 
     const handleDeleteUsers = useCallback(
         (users: SiteUser[]) => {
-            if (confirm('Are you sure you want to delete the selected user(s)?')) {
+            const duration = window.context.userRecoveryRestrictedDurationInSeconds
+            const seconds = duration % 60
+            const minutes = Math.floor(duration / 60) % 60
+            const hours = Math.floor(duration / 60 / 60) % 24
+            const days = Math.floor(duration / 60 / 60 / 24)
+
+            const formattedDuration = formatDuration({
+                days,
+                hours,
+                minutes,
+                seconds,
+            })
+            if (
+                confirm(
+                    `Are you sure you want to delete the selected user(s)?\nYou won't be able to recover again within ${formattedDuration}.`
+                )
+            ) {
                 deleteUsers({ variables: { userIDs: users.map(user => user.id) } })
                     .then(
                         createOnSuccess(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -251,7 +251,8 @@ type Mutation {
     """
     deleteUsers(users: [ID!]!, hard: Boolean): EmptyResponse
     """
-    Bulk "recoverUser" action.
+    Restores previously soft deleted users
+    Returns error if any of the users's deletions time is within recovery restriction duration
     """
     recoverUsers(userIDs: [ID!]!): EmptyResponse
     """

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -205,6 +205,8 @@ type JSContext struct {
 	LocalFilePickerAvailable bool `json:"localFilePickerAvailable"`
 
 	SrcServeGitUrl string `json:"srcServeGitUrl"`
+
+	UserRecoveryRestrictedDurationInSeconds int `json:"userRecoveryRestrictedDurationInSeconds"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -381,6 +383,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		LocalFilePickerAvailable: deploy.IsApp() && filepicker.Available(),
 
 		SrcServeGitUrl: srcServeGitUrl,
+
+		UserRecoveryRestrictedDurationInSeconds: int(database.UserRecoveryRestrictedDuration / time.Second),
 	}
 }
 

--- a/internal/timeutil/duration.go
+++ b/internal/timeutil/duration.go
@@ -1,0 +1,30 @@
+package timeutil
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+func FormatDuration(duration time.Duration) string {
+	totalSeconds := int(duration.Seconds())
+	seconds := totalSeconds % 60
+	minutes := totalSeconds / 60 % 60
+	hours := totalSeconds / 60 / 60 % 24
+	days := totalSeconds / 60 / 60 / 24
+
+	formatted := ""
+	if days > 0 {
+		formatted += strconv.Itoa(int(days)) + "d "
+	}
+	if hours > 0 {
+		formatted += strconv.Itoa(int(hours)) + "h "
+	}
+	if minutes > 0 {
+		formatted += strconv.Itoa(int(minutes)) + "m "
+	}
+	if seconds > 0 {
+		formatted += strconv.Itoa(int(seconds)) + "s "
+	}
+	return strings.Trim(formatted, " ")
+}

--- a/internal/timeutil/duration_test.go
+++ b/internal/timeutil/duration_test.go
@@ -1,0 +1,27 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestDuration_FormatDuration(t *testing.T) {
+	testCases := []struct {
+		duration time.Duration
+		want     string
+	}{
+		{duration: 24 * time.Hour, want: "1d"},
+		{duration: 24*time.Hour + 13*time.Hour, want: "1d 13h"},
+		{duration: 24*time.Hour + 13*time.Hour + 55*time.Minute, want: "1d 13h 55m"},
+		{duration: 24*time.Hour + 13*time.Hour + 55*time.Minute + 7*time.Minute, want: "1d 14h 2m"},
+		{duration: 24*time.Hour + 13*time.Hour + 55*time.Minute + 45*time.Second, want: "1d 13h 55m 45s"},
+		{duration: 24*time.Hour + 13*time.Hour + 55*time.Minute + 45*time.Second + 45*time.Second, want: "1d 13h 56m 30s"},
+		{duration: 45 * time.Second, want: "45s"},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.want, FormatDuration(tc.duration), tc.duration)
+	}
+}


### PR DESCRIPTION
This PR adds a restriction for recovering soft deleted users within 7 days. See [PRFAQ: Improved Licensing and Gating](https://docs.google.com/document/d/1Ft1EcyNnwy_VnWfZXygPBwzf6uRpVcoPUOLQ4ya-mFQ/edit#bookmark=id.b9m3rhsq0818)

> It restricts on the database store level, so API calls can't pass either.

## Test plan


## Screenshots
| Before | After |
| --: | :-- |
| <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230065707-aae657f5-b81f-4d5a-96cb-120d997e3ea8.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230065431-641fecb2-3b85-421b-82be-4c12af8f42ca.png">|
| <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230065759-91545af1-27a3-4c14-a240-2a3052d4ef0d.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230065522-23cee517-9327-4aa3-adb5-5cd3f7f4142b.png"> | 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
