### PR TITLE
bazel: fix the web application bundle in Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -154,8 +154,6 @@ js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//:node_modules/@babel/plugin-transform-modules-commonjs",
-        "//:node_modules/@babel/plugin-transform-runtime",
         "//:node_modules/@babel/preset-env",
         "//:node_modules/@babel/runtime",
         "//:node_modules/signale",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -155,6 +155,8 @@ js_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/@babel/plugin-transform-modules-commonjs",
+        "//:node_modules/@babel/plugin-transform-runtime",
+        "//:node_modules/@babel/preset-env",
         "//:node_modules/@babel/runtime",
         "//:node_modules/signale",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -134,7 +134,7 @@ js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":babel_config_jest",
+        ":babel_config",
         "//:node_modules/@testing-library/jest-dom",
         "//:node_modules/abort-controller",
         "//:node_modules/babel-jest",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -169,10 +169,12 @@ js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//:node_modules/@babel/plugin-transform-runtime",
         "//:node_modules/@babel/plugin-transform-typescript",
         "//:node_modules/@babel/preset-env",
         "//:node_modules/@babel/preset-react",
         "//:node_modules/@babel/preset-typescript",
+        "//:node_modules/@babel/runtime",
         "//:node_modules/babel-plugin-lodash",
         "//:node_modules/babel-plugin-webpack-chunkname",
         "//:node_modules/semver",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -134,7 +134,7 @@ js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":babel_config",
+        ":babel_config_jest",
         "//:node_modules/@testing-library/jest-dom",
         "//:node_modules/abort-controller",
         "//:node_modules/babel-jest",
@@ -154,7 +154,8 @@ js_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//:node_modules/@babel/preset-env",
+        "//:node_modules/@babel/plugin-transform-modules-commonjs",
+        "//:node_modules/@babel/runtime",
         "//:node_modules/signale",
     ],
 )

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -33,6 +33,8 @@ module.exports = api => {
         '@babel/preset-env',
         {
           targets: {
+            // We only run jest tests in node. All the browser related transformations
+            // are already completed on the previous transpilation step.
             node: '16',
           },
         },

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -29,7 +29,14 @@ module.exports = api => {
     presets: [
       // Can't put this in plugins because it needs to run as the last plugin.
       ...(instrument ? [{ plugins: [['babel-plugin-istanbul', { cwd: path.resolve(__dirname) }]] }] : []),
+      [
+        '@babel/preset-env',
+        {
+          targets: {
+            node: '16',
+          },
+        },
+      ],
     ],
-    plugins: ['@babel/plugin-transform-modules-commonjs'],
   }
 }

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -29,7 +29,7 @@ module.exports = api => {
     presets: [
       // Can't put this in plugins because it needs to run as the last plugin.
       ...(instrument ? [{ plugins: [['babel-plugin-istanbul', { cwd: path.resolve(__dirname) }]] }] : []),
-      '@babel/preset-env',
     ],
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -63,6 +63,7 @@ module.exports = api => {
       ],
     ],
     plugins: [
+      '@babel/plugin-transform-runtime',
       ['@babel/plugin-transform-typescript', { isTSX: true }],
       'babel-plugin-lodash',
       [

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1991,7 +1991,6 @@ webpack_bundle(
 # because of the inlined source-maps.
 webpack_web_app(
     name = "app-enterprise",
-    testonly = True,
     srcs = ENTERPRISE_BUNDLE_DATA_DEPS + [
         "//:babel_config",
         "//:browserslist",

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1898,6 +1898,7 @@ jest_test(
 # webpack dev environment -------------------
 WEBPACK_CONFIG_DEPS = [
     ":node_modules/@sourcegraph/build-config",
+    "//:node_modules/@babel/runtime",
     "//:node_modules/@pmmmwh/react-refresh-webpack-plugin",
     "//:node_modules/@sentry/webpack-plugin",
     "//:node_modules/buffer",
@@ -1964,8 +1965,33 @@ ENTERPRISE_BUNDLE_DATA_DEPS = BUNDLE_DATA_DEPS + [
     ]
 ]
 
+webpack_bundle(
+    name = "bundle-enterprise",
+    srcs = ENTERPRISE_BUNDLE_DATA_DEPS + [
+        "//:babel_config",
+        "//:browserslist",
+        "//:package_json",
+    ],
+    entry_points = {
+        "src/enterprise/main.js": "app",
+    },
+    env = {
+        "NODE_ENV": "production",
+        "ENTERPRISE": "true",
+        "INTEGRATION_TESTS": "false",
+        "WEBPACK_BUNDLE_ANALYZER": "false",
+        "WEBPACK_USE_NAMED_CHUNKS": "false",
+    },
+    output_dir = True,
+    webpack_config = "webpack.bazel.config.js",
+    deps = WEBPACK_CONFIG_DEPS,
+)
+
+# Used for integartion tests and has bigger bundle size
+# because of the inlined source-maps.
 webpack_web_app(
     name = "app-enterprise",
+    testonly = True,
     srcs = ENTERPRISE_BUNDLE_DATA_DEPS + [
         "//:babel_config",
         "//:browserslist",
@@ -2012,6 +2038,6 @@ build_test(
     name = "webpack_test",
     targets = [
         ":bundle",
-        ":app-enterprise",
+        ":bundle-enterprise",
     ],
 )

--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -29,7 +29,7 @@ const config = {
     },
     {
       path: path.join(STATIC_ASSETS_PATH, 'scripts/opentelemetry.bundle.js.br'),
-      maxSize: '30kb',
+      maxSize: '40kb',
       compression: 'none',
     },
     /**

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -107,12 +107,12 @@ const config = {
     splitChunks: {
       cacheGroups: {
         [initialChunkNames.react]: {
-          test: /[/\\]node_modules.*[/\\](react|react-dom)[/\\]/,
+          test: /[/\\]node_modules[/\\](react|react-dom)[/\\]/,
           name: initialChunkNames.react,
           chunks: 'all',
         },
         [initialChunkNames.opentelemetry]: {
-          test: /[/\\]node_modules.*[/\\](@opentelemetry)[/\\]/,
+          test: /[/\\]node_modules[/\\](@opentelemetry|zone.js)[/\\]/,
           name: initialChunkNames.opentelemetry,
           chunks: 'all',
         },

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -110,7 +110,7 @@ const config = {
           chunks: 'all',
         },
         [initialChunkNames.opentelemetry]: {
-          test: /[/\\]node_modules[/\\](@opentelemetry)[/\\]/,
+          test: /[/\\]node_modules[/\\](@opentelemetry|zone.js)[/\\]/,
           name: initialChunkNames.opentelemetry,
           chunks: 'all',
         },

--- a/dev/babel.bzl
+++ b/dev/babel.bzl
@@ -79,6 +79,7 @@ def babel(name, srcs, module = None, usePresetEnv = True, **kwargs):
         srcs = ts_srcs + [
             "//:babel_config",
             "//:package_json",
+            "//:browserslist",
         ],
         outs = outs,
         args = args,

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -61,7 +61,7 @@ const config = {
       'babel-jest',
       {
         root: rootDir,
-        configFile: path.join(rootDir, 'babel.config.js'),
+        configFile: path.join(rootDir, IS_BAZEL ? 'babel.config.jest.js' : 'babel.config.js'),
       },
     ],
   },

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -61,7 +61,7 @@ const config = {
       'babel-jest',
       {
         root: rootDir,
-        configFile: path.join(rootDir, IS_BAZEL ? 'babel.config.jest.js' : 'babel.config.js'),
+        configFile: path.join(rootDir, 'babel.config.js'),
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.0-alpha.7",
+    "@babel/plugin-transform-modules-commonjs": "^7.21.2",
     "@codemirror/autocomplete": "^6.1.0",
     "@codemirror/commands": "^6.0.1",
     "@codemirror/lang-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -346,7 +346,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.0-alpha.7",
-    "@babel/plugin-transform-modules-commonjs": "^7.21.2",
     "@codemirror/autocomplete": "^6.1.0",
     "@codemirror/commands": "^6.0.1",
     "@codemirror/lang-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@axe-core/puppeteer": "^4.4.2",
     "@babel/cli": "^7.20.7",
     "@babel/core": "^7.20.5",
+    "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/plugin-transform-typescript": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ importers:
       '@axe-core/puppeteer': ^4.4.2
       '@babel/cli': ^7.20.7
       '@babel/core': ^7.20.5
-      '@babel/plugin-transform-modules-commonjs': ^7.21.2
       '@babel/plugin-transform-runtime': ^7.21.0
       '@babel/plugin-transform-typescript': ^7.20.2
       '@babel/preset-env': ^7.20.2
@@ -414,7 +413,6 @@ importers:
       zustand: ^3.6.9
     dependencies:
       '@apollo/client': 3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24
-      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
       '@codemirror/autocomplete': 6.1.0_42luzusa22g3gmuqmbrrjz6ypm
       '@codemirror/commands': 6.0.1
       '@codemirror/lang-json': 6.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       '@axe-core/puppeteer': ^4.4.2
       '@babel/cli': ^7.20.7
       '@babel/core': ^7.20.5
+      '@babel/plugin-transform-runtime': ^7.21.0
       '@babel/plugin-transform-typescript': ^7.20.2
       '@babel/preset-env': ^7.20.2
       '@babel/preset-react': ^7.18.6
@@ -565,6 +566,7 @@ importers:
       '@axe-core/puppeteer': 4.4.2_puppeteer@13.7.0
       '@babel/cli': 7.20.7_@babel+core@7.21.0
       '@babel/core': 7.21.0
+      '@babel/plugin-transform-runtime': 7.21.0_@babel+core@7.21.0
       '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.21.0
       '@babel/preset-env': 7.20.2_@babel+core@7.21.0
       '@babel/preset-react': 7.18.6_@babel+core@7.21.0
@@ -1281,7 +1283,7 @@ packages:
       '@babel/parser': 7.21.2
       '@babel/runtime': 7.20.6
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
       chalk: 4.1.2
       fb-watchman: 2.0.0
@@ -1374,7 +1376,6 @@ packages:
   /@babel/compat-data/7.21.0:
     resolution: {integrity: sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/core/7.12.9:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
@@ -1387,7 +1388,7 @@ packages:
       '@babel/parser': 7.21.2
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       convert-source-map: 1.7.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -1445,14 +1446,14 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -1534,26 +1535,26 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-function-name/7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-member-expression-to-functions/7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-member-expression-to-functions/7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
@@ -1566,7 +1567,7 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-module-transforms/7.21.2:
     resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
@@ -1587,7 +1588,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -1607,7 +1608,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1619,7 +1620,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1641,19 +1642,19 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -1674,7 +1675,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1701,7 +1702,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/parser/7.21.2:
@@ -2697,7 +2698,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -2979,7 +2979,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       debug: 4.3.4
       globals: 11.12.0
       lodash: 4.17.21
@@ -3045,7 +3045,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: false
 
   /@base2/pretty-print-object/1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -4304,7 +4303,7 @@ packages:
       '@babel/parser': 7.21.2
       '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.21.0
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@graphql-tools/utils': 9.1.3_graphql@15.4.0
       graphql: 15.4.0
       tslib: 2.1.0
@@ -8130,7 +8129,7 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.20.7_@babel+core@7.21.0
       '@babel/preset-env': 7.20.2_@babel+core@7.21.0
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/mdx1-csf': 0.0.1_@babel+core@7.21.0
       core-js: 3.22.8
@@ -8285,7 +8284,7 @@ packages:
       '@babel/generator': 7.21.1
       '@babel/parser': 7.21.2
       '@babel/preset-env': 7.20.2_@babel+core@7.21.0
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@mdx-js/mdx': 1.6.22
       '@types/lodash': 4.14.167
       js-string-escape: 1.0.1
@@ -8806,20 +8805,20 @@ packages:
   /@types/babel__generator/7.0.2:
     resolution: {integrity: sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__template/7.0.2:
     resolution: {integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==}
     dependencies:
       '@babel/parser': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__traverse/7.0.15:
     resolution: {integrity: sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/bloomfilter/0.0.0:
@@ -11332,7 +11331,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@types/babel__core': 7.1.20
       '@types/babel__traverse': 7.0.15
     dev: true
@@ -11364,7 +11363,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.5
+      '@babel/compat-data': 7.21.0
       '@babel/core': 7.21.0
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.21.0
       semver: 6.3.0
@@ -19270,7 +19269,7 @@ packages:
     resolution: {integrity: sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@jest/types': 26.6.2
       '@types/babel__traverse': 7.0.15
       '@types/prettier': 2.7.2
@@ -19298,7 +19297,7 @@ packages:
       '@babel/generator': 7.21.1
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.21.0
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@jest/expect-utils': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       '@axe-core/puppeteer': ^4.4.2
       '@babel/cli': ^7.20.7
       '@babel/core': ^7.20.5
+      '@babel/plugin-transform-modules-commonjs': ^7.21.2
       '@babel/plugin-transform-runtime': ^7.21.0
       '@babel/plugin-transform-typescript': ^7.20.2
       '@babel/preset-env': ^7.20.2
@@ -413,6 +414,7 @@ importers:
       zustand: ^3.6.9
     dependencies:
       '@apollo/client': 3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
       '@codemirror/autocomplete': 6.1.0_42luzusa22g3gmuqmbrrjz6ypm
       '@codemirror/commands': 6.0.1
       '@codemirror/lang-json': 6.0.0
@@ -2458,19 +2460,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-transform-modules-commonjs/7.19.6_@babel+core@7.21.0:
-    resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/plugin-transform-modules-commonjs/7.21.2_@babel+core@7.21.0:
     resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
     engines: {node: '>=6.9.0'}
@@ -2483,7 +2472,6 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/plugin-transform-modules-systemjs/7.19.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-fqGLBepcc3kErfR9R3DnVpURmckXP7gj7bAlrTQyBxrigFqszZCkFkcoxzCp2v32XmwXLvbw+8Yq9/b+QqksjQ==}
@@ -2846,7 +2834,7 @@ packages:
       '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.21.0
       '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.21.0
       '@babel/plugin-transform-modules-amd': 7.19.6_@babel+core@7.21.0
-      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
       '@babel/plugin-transform-modules-systemjs': 7.19.6_@babel+core@7.21.0
       '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.21.0
       '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.21.0
@@ -11462,7 +11450,7 @@ packages:
       '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.21.0
       '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.21.0
       '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-modules-commonjs': 7.19.6_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
       '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.21.0
       '@babel/plugin-transform-parameters': 7.20.5_@babel+core@7.21.0
       '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.21.0


### PR DESCRIPTION
## Context

Fixes issues with the web application bundle size:

1. Properly uses browserslist config with babel-cli.
2. Fixes the regex for split-chunks optimization in Bazel webpack config.
3. Uses @babel/plugin-transform-runtime to avoid duplicating babel helpers in every file.

TODO: in a follow-up PR, enable bundle size CI checks in Bazel.

## Test plan

CI and web application bundle comparison locally using Statoscope.

## App preview:

- [Web](https://sg-web-vb-bazel-web-bundle-size.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

