### PR TITLE
codeintel: Higher-level store cleanup

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/iface.go
@@ -51,7 +51,7 @@ type RepoUpdaterClient interface {
 }
 
 type AutoIndexingService interface {
-	GetRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) (_ []int, err error)
+	GetRepositoriesForIndexScan(ctx context.Context, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) (_ []int, err error)
 }
 
 type UploadService interface {

--- a/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/mocks_test.go
@@ -2355,9 +2355,6 @@ func (c PackageReferenceScannerNextFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store)
 // used for unit testing.
 type MockStore struct {
-	// DoneFunc is an instance of a mock function object controlling the
-	// behavior of the method Done.
-	DoneFunc *StoreDoneFunc
 	// GetIndexConfigurationByRepositoryIDFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// GetIndexConfigurationByRepositoryID.
@@ -2409,9 +2406,6 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// TopRepositoriesToConfigure.
 	TopRepositoriesToConfigureFunc *StoreTopRepositoriesToConfigureFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *StoreTransactFunc
 	// TruncateConfigurationSummaryFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// TruncateConfigurationSummary.
@@ -2420,17 +2414,15 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// UpdateIndexConfigurationByRepositoryID.
 	UpdateIndexConfigurationByRepositoryIDFunc *StoreUpdateIndexConfigurationByRepositoryIDFunc
+	// WithTransactionFunc is an instance of a mock function object
+	// controlling the behavior of the method WithTransaction.
+	WithTransactionFunc *StoreWithTransactionFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
 // return zero values for all results, unless overwritten.
 func NewMockStore() *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) (r0 error) {
-				return
-			},
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: func(context.Context, int) (r0 shared3.IndexConfiguration, r1 bool, r2 error) {
 				return
@@ -2452,7 +2444,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetRepositoriesForIndexScanFunc: &StoreGetRepositoriesForIndexScanFunc{
-			defaultHook: func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) (r0 []int, r1 error) {
+			defaultHook: func(context.Context, time.Duration, bool, *int, int, time.Time) (r0 []int, r1 error) {
 				return
 			},
 		},
@@ -2506,11 +2498,6 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (r0 store.Store, r1 error) {
-				return
-			},
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: func(context.Context, int) (r0 error) {
 				return
@@ -2521,6 +2508,11 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(tx store.Store) error) (r0 error) {
+				return
+			},
+		},
 	}
 }
 
@@ -2528,11 +2520,6 @@ func NewMockStore() *MockStore {
 // panic on invocation, unless overwritten.
 func NewStrictMockStore() *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) error {
-				panic("unexpected invocation of MockStore.Done")
-			},
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: func(context.Context, int) (shared3.IndexConfiguration, bool, error) {
 				panic("unexpected invocation of MockStore.GetIndexConfigurationByRepositoryID")
@@ -2554,7 +2541,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		GetRepositoriesForIndexScanFunc: &StoreGetRepositoriesForIndexScanFunc{
-			defaultHook: func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+			defaultHook: func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 				panic("unexpected invocation of MockStore.GetRepositoriesForIndexScan")
 			},
 		},
@@ -2608,11 +2595,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.TopRepositoriesToConfigure")
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (store.Store, error) {
-				panic("unexpected invocation of MockStore.Transact")
-			},
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: func(context.Context, int) error {
 				panic("unexpected invocation of MockStore.TruncateConfigurationSummary")
@@ -2623,6 +2605,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateIndexConfigurationByRepositoryID")
 			},
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(tx store.Store) error) error {
+				panic("unexpected invocation of MockStore.WithTransaction")
+			},
+		},
 	}
 }
 
@@ -2630,9 +2617,6 @@ func NewStrictMockStore() *MockStore {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockStoreFrom(i store.Store) *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: i.Done,
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.GetIndexConfigurationByRepositoryID,
 		},
@@ -2678,117 +2662,16 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		TopRepositoriesToConfigureFunc: &StoreTopRepositoriesToConfigureFunc{
 			defaultHook: i.TopRepositoriesToConfigure,
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: i.TruncateConfigurationSummary,
 		},
 		UpdateIndexConfigurationByRepositoryIDFunc: &StoreUpdateIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.UpdateIndexConfigurationByRepositoryID,
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: i.WithTransaction,
+		},
 	}
-}
-
-// StoreDoneFunc describes the behavior when the Done method of the parent
-// MockStore instance is invoked.
-type StoreDoneFunc struct {
-	defaultHook func(error) error
-	hooks       []func(error) error
-	history     []StoreDoneFuncCall
-	mutex       sync.Mutex
-}
-
-// Done delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Done(v0 error) error {
-	r0 := m.DoneFunc.nextHook()(v0)
-	m.DoneFunc.appendCall(StoreDoneFuncCall{v0, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Done method of the
-// parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDoneFunc) SetDefaultHook(hook func(error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Done method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreDoneFunc) PushHook(hook func(error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreDoneFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDoneFunc) PushReturn(r0 error) {
-	f.PushHook(func(error) error {
-		return r0
-	})
-}
-
-func (f *StoreDoneFunc) nextHook() func(error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreDoneFunc) appendCall(r0 StoreDoneFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreDoneFuncCall objects describing the
-// invocations of this function.
-func (f *StoreDoneFunc) History() []StoreDoneFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreDoneFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreDoneFuncCall is an object that describes an invocation of method
-// Done on an instance of MockStore.
-type StoreDoneFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreGetIndexConfigurationByRepositoryIDFunc describes the behavior when
@@ -3235,24 +3118,24 @@ func (c StoreGetQueuedRepoRevFuncCall) Results() []interface{} {
 // GetRepositoriesForIndexScan method of the parent MockStore instance is
 // invoked.
 type StoreGetRepositoriesForIndexScanFunc struct {
-	defaultHook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)
-	hooks       []func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)
+	defaultHook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)
+	hooks       []func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)
 	history     []StoreGetRepositoriesForIndexScanFuncCall
 	mutex       sync.Mutex
 }
 
 // GetRepositoriesForIndexScan delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetRepositoriesForIndexScan(v0 context.Context, v1 string, v2 string, v3 time.Duration, v4 bool, v5 *int, v6 int, v7 time.Time) ([]int, error) {
-	r0, r1 := m.GetRepositoriesForIndexScanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
-	m.GetRepositoriesForIndexScanFunc.appendCall(StoreGetRepositoriesForIndexScanFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0, r1})
+func (m *MockStore) GetRepositoriesForIndexScan(v0 context.Context, v1 time.Duration, v2 bool, v3 *int, v4 int, v5 time.Time) ([]int, error) {
+	r0, r1 := m.GetRepositoriesForIndexScanFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.GetRepositoriesForIndexScanFunc.appendCall(StoreGetRepositoriesForIndexScanFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // GetRepositoriesForIndexScan method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
+func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
 	f.defaultHook = hook
 }
 
@@ -3261,7 +3144,7 @@ func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
+func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3270,19 +3153,19 @@ func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultReturn(r0 []int, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+	f.SetDefaultHook(func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreGetRepositoriesForIndexScanFunc) PushReturn(r0 []int, r1 error) {
-	f.PushHook(func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+	f.PushHook(func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetRepositoriesForIndexScanFunc) nextHook() func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+func (f *StoreGetRepositoriesForIndexScanFunc) nextHook() func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3321,25 +3204,19 @@ type StoreGetRepositoriesForIndexScanFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 time.Duration
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 bool
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 time.Duration
+	Arg3 *int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 bool
+	Arg4 int
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 *int
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 int
-	// Arg7 is the value of the 8th argument passed to this method
-	// invocation.
-	Arg7 time.Time
+	Arg5 time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []int
@@ -3351,7 +3228,7 @@ type StoreGetRepositoriesForIndexScanFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreGetRepositoriesForIndexScanFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
@@ -4469,110 +4346,6 @@ func (c StoreTopRepositoriesToConfigureFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreTransactFunc describes the behavior when the Transact method of the
-// parent MockStore instance is invoked.
-type StoreTransactFunc struct {
-	defaultHook func(context.Context) (store.Store, error)
-	hooks       []func(context.Context) (store.Store, error)
-	history     []StoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Transact(v0 context.Context) (store.Store, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(StoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreTransactFunc) SetDefaultHook(hook func(context.Context) (store.Store, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreTransactFunc) PushHook(hook func(context.Context) (store.Store, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreTransactFunc) SetDefaultReturn(r0 store.Store, r1 error) {
-	f.SetDefaultHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreTransactFunc) PushReturn(r0 store.Store, r1 error) {
-	f.PushHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreTransactFunc) nextHook() func(context.Context) (store.Store, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreTransactFunc) appendCall(r0 StoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreTransactFuncCall objects describing
-// the invocations of this function.
-func (f *StoreTransactFunc) History() []StoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreTransactFuncCall is an object that describes an invocation of method
-// Transact on an instance of MockStore.
-type StoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 store.Store
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // StoreTruncateConfigurationSummaryFunc describes the behavior when the
 // TruncateConfigurationSummary method of the parent MockStore instance is
 // invoked.
@@ -4791,6 +4564,111 @@ func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interface{
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreWithTransactionFunc describes the behavior when the WithTransaction
+// method of the parent MockStore instance is invoked.
+type StoreWithTransactionFunc struct {
+	defaultHook func(context.Context, func(tx store.Store) error) error
+	hooks       []func(context.Context, func(tx store.Store) error) error
+	history     []StoreWithTransactionFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransaction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) WithTransaction(v0 context.Context, v1 func(tx store.Store) error) error {
+	r0 := m.WithTransactionFunc.nextHook()(v0, v1)
+	m.WithTransactionFunc.appendCall(StoreWithTransactionFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransaction
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreWithTransactionFunc) SetDefaultHook(hook func(context.Context, func(tx store.Store) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransaction method of the parent MockStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreWithTransactionFunc) PushHook(hook func(context.Context, func(tx store.Store) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreWithTransactionFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(tx store.Store) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreWithTransactionFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(tx store.Store) error) error {
+		return r0
+	})
+}
+
+func (f *StoreWithTransactionFunc) nextHook() func(context.Context, func(tx store.Store) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreWithTransactionFunc) appendCall(r0 StoreWithTransactionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreWithTransactionFuncCall objects
+// describing the invocations of this function.
+func (f *StoreWithTransactionFunc) History() []StoreWithTransactionFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreWithTransactionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreWithTransactionFuncCall is an object that describes an invocation of
+// method WithTransaction on an instance of MockStore.
+type StoreWithTransactionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(tx store.Store) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/autoindexing/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "observability.go",
         "scheduler.go",
         "store.go",
+        "util.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store",
     visibility = ["//enterprise:__subpackages__"],

--- a/enterprise/internal/codeintel/autoindexing/internal/store/scheduler_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/scheduler_test.go
@@ -53,28 +53,28 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	}
 
 	// Can return null last_index_scan
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 2, now); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 2, now); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{50, 51}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 20 minutes later, first two repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*20)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*20)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 30 minutes later, all repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*30)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*30)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 90 minutes later, all repositories are visible
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*90)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*90)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{50, 51, 52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
@@ -84,7 +84,7 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	insertRepo(t, db, 54, "r4")
 
 	// 95 minutes later, new repository is not yet visible
-	if repositoryIDs, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*95)); err != nil {
+	if repositoryIDs, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*95)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int(nil), repositoryIDs); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
@@ -96,14 +96,14 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	}
 
 	// 100 minutes later, only new repository is visible
-	if repositoryIDs, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*100)); err != nil {
+	if repositoryIDs, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*100)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{54}, repositoryIDs); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 110 minutes later, nothing is ready to go (too close to last index scan)
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*110)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*110)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
@@ -116,7 +116,7 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	}
 
 	// 110 minutes later, updated repositories are ready for re-indexing
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*110)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*110)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{50}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
@@ -157,7 +157,7 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 	}
 
 	// Returns nothing when disabled
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, false, nil, 100, now); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, false, nil, 100, now); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
@@ -167,107 +167,28 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 	limit := 2
 
 	// Can return null last_index_scan
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, &limit, 100, now); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, &limit, 100, now); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{50, 51}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 20 minutes later, first two repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*20)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*20)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 30 minutes later, all repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*30)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*30)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
 	}
 
 	// 90 minutes later, all repositories are visible
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), "lsif_last_index_scan", "last_index_scan_at", time.Hour, true, nil, 100, now.Add(time.Minute*90)); err != nil {
-		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
-	} else if diff := cmp.Diff([]int{50, 51, 52, 53}, repositories); diff != "" {
-		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
-	}
-}
-
-func TestSelectRepositoriesForIndexScanInDifferentTable(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	store := testStoreWithoutConfigurationPolicies(t, db)
-
-	now := timeutil.Now()
-	insertRepo(t, db, 50, "r0")
-	insertRepo(t, db, 51, "r1")
-	insertRepo(t, db, 52, "r2")
-	insertRepo(t, db, 53, "r3")
-	updateGitserverUpdatedAt(t, db, now)
-
-	query := `
-		INSERT INTO lsif_configuration_policies (
-			id,
-			repository_id,
-			name,
-			type,
-			pattern,
-			repository_patterns,
-			retention_enabled,
-			retention_duration_hours,
-			retain_intermediate_commits,
-			indexing_enabled,
-			index_commit_max_age_hours,
-			index_intermediate_commits
-		) VALUES
-			(101, NULL, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true, 0, false)
-	`
-	if _, err := db.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
-	}
-
-	// Create a new table
-	query = `
-		CREATE TABLE last_incredible_testing_scan (
-			repository_id integer NOT NULL PRIMARY KEY,
-			last_incredible_testing_scan_at timestamp with time zone NOT NULL
-		)
-	`
-
-	if _, err := db.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
-	}
-
-	tableName := "last_incredible_testing_scan"
-	columnName := "last_incredible_testing_scan_at"
-
-	// Returns at most configured limit
-	limit := 2
-
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), tableName, columnName, time.Hour, true, &limit, 100, now); err != nil {
-		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
-	} else if diff := cmp.Diff([]int{50, 51}, repositories); diff != "" {
-		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
-	}
-
-	// 20 minutes later, first two repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), tableName, columnName, time.Hour, true, nil, 100, now.Add(time.Minute*20)); err != nil {
-		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
-	} else if diff := cmp.Diff([]int{52, 53}, repositories); diff != "" {
-		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
-	}
-
-	// 30 minutes later, all repositories are still on cooldown
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), tableName, columnName, time.Hour, true, nil, 100, now.Add(time.Minute*30)); err != nil {
-		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
-	} else if diff := cmp.Diff([]int(nil), repositories); diff != "" {
-		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)
-	}
-
-	// 90 minutes later, all repositories are visible
-	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), tableName, columnName, time.Hour, true, nil, 100, now.Add(time.Minute*90)); err != nil {
+	if repositories, err := store.GetRepositoriesForIndexScan(context.Background(), time.Hour, true, nil, 100, now.Add(time.Minute*90)); err != nil {
 		t.Fatalf("unexpected error fetching repositories for index scan: %s", err)
 	} else if diff := cmp.Diff([]int{50, 51, 52, 53}, repositories); diff != "" {
 		t.Fatalf("unexpected repository list (-want +got):\n%s", diff)

--- a/enterprise/internal/codeintel/autoindexing/internal/store/store.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store.go
@@ -14,8 +14,7 @@ import (
 )
 
 type Store interface {
-	Transact(ctx context.Context) (Store, error)
-	Done(err error) error
+	WithTransaction(ctx context.Context, f func(tx Store) error) error
 
 	// Inference configuration
 	GetInferenceScript(ctx context.Context) (string, error)
@@ -33,7 +32,7 @@ type Store interface {
 	TruncateConfigurationSummary(ctx context.Context, numRecordsToRetain int) error
 
 	// Scheduler
-	GetRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) ([]int, error)
+	GetRepositoriesForIndexScan(ctx context.Context, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) ([]int, error)
 	GetQueuedRepoRev(ctx context.Context, batchSize int) ([]RepoRev, error)
 	MarkRepoRevsAsProcessed(ctx context.Context, ids []int) error
 
@@ -67,11 +66,15 @@ func New(observationCtx *observation.Context, db database.DB) Store {
 	}
 }
 
-func (s *store) Transact(ctx context.Context) (Store, error) {
-	return s.transact(ctx)
+func (s *store) WithTransaction(ctx context.Context, f func(s Store) error) error {
+	return s.withTransaction(ctx, func(s *store) error { return f(s) })
 }
 
-func (s *store) transact(ctx context.Context) (*store, error) {
+func (s *store) withTransaction(ctx context.Context, f func(s *store) error) error {
+	return basestore.InTransaction[*store](ctx, s, f)
+}
+
+func (s *store) Transact(ctx context.Context) (*store, error) {
 	tx, err := s.db.Transact(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codeintel/autoindexing/internal/store/util.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/util.go
@@ -1,0 +1,11 @@
+package store
+
+import "github.com/keegancsmith/sqlf"
+
+func optionalLimit(limit *int) *sqlf.Query {
+	if limit != nil {
+		return sqlf.Sprintf("LIMIT %d", *limit)
+	}
+
+	return sqlf.Sprintf("")
+}

--- a/enterprise/internal/codeintel/autoindexing/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/mocks_test.go
@@ -24,9 +24,6 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store)
 // used for unit testing.
 type MockStore struct {
-	// DoneFunc is an instance of a mock function object controlling the
-	// behavior of the method Done.
-	DoneFunc *StoreDoneFunc
 	// GetIndexConfigurationByRepositoryIDFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// GetIndexConfigurationByRepositoryID.
@@ -78,9 +75,6 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// TopRepositoriesToConfigure.
 	TopRepositoriesToConfigureFunc *StoreTopRepositoriesToConfigureFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *StoreTransactFunc
 	// TruncateConfigurationSummaryFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// TruncateConfigurationSummary.
@@ -89,17 +83,15 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// UpdateIndexConfigurationByRepositoryID.
 	UpdateIndexConfigurationByRepositoryIDFunc *StoreUpdateIndexConfigurationByRepositoryIDFunc
+	// WithTransactionFunc is an instance of a mock function object
+	// controlling the behavior of the method WithTransaction.
+	WithTransactionFunc *StoreWithTransactionFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
 // return zero values for all results, unless overwritten.
 func NewMockStore() *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) (r0 error) {
-				return
-			},
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: func(context.Context, int) (r0 shared.IndexConfiguration, r1 bool, r2 error) {
 				return
@@ -121,7 +113,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetRepositoriesForIndexScanFunc: &StoreGetRepositoriesForIndexScanFunc{
-			defaultHook: func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) (r0 []int, r1 error) {
+			defaultHook: func(context.Context, time.Duration, bool, *int, int, time.Time) (r0 []int, r1 error) {
 				return
 			},
 		},
@@ -175,11 +167,6 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (r0 store.Store, r1 error) {
-				return
-			},
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: func(context.Context, int) (r0 error) {
 				return
@@ -190,6 +177,11 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(tx store.Store) error) (r0 error) {
+				return
+			},
+		},
 	}
 }
 
@@ -197,11 +189,6 @@ func NewMockStore() *MockStore {
 // panic on invocation, unless overwritten.
 func NewStrictMockStore() *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) error {
-				panic("unexpected invocation of MockStore.Done")
-			},
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: func(context.Context, int) (shared.IndexConfiguration, bool, error) {
 				panic("unexpected invocation of MockStore.GetIndexConfigurationByRepositoryID")
@@ -223,7 +210,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		GetRepositoriesForIndexScanFunc: &StoreGetRepositoriesForIndexScanFunc{
-			defaultHook: func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+			defaultHook: func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 				panic("unexpected invocation of MockStore.GetRepositoriesForIndexScan")
 			},
 		},
@@ -277,11 +264,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.TopRepositoriesToConfigure")
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (store.Store, error) {
-				panic("unexpected invocation of MockStore.Transact")
-			},
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: func(context.Context, int) error {
 				panic("unexpected invocation of MockStore.TruncateConfigurationSummary")
@@ -292,6 +274,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateIndexConfigurationByRepositoryID")
 			},
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(tx store.Store) error) error {
+				panic("unexpected invocation of MockStore.WithTransaction")
+			},
+		},
 	}
 }
 
@@ -299,9 +286,6 @@ func NewStrictMockStore() *MockStore {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockStoreFrom(i store.Store) *MockStore {
 	return &MockStore{
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: i.Done,
-		},
 		GetIndexConfigurationByRepositoryIDFunc: &StoreGetIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.GetIndexConfigurationByRepositoryID,
 		},
@@ -347,117 +331,16 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		TopRepositoriesToConfigureFunc: &StoreTopRepositoriesToConfigureFunc{
 			defaultHook: i.TopRepositoriesToConfigure,
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		TruncateConfigurationSummaryFunc: &StoreTruncateConfigurationSummaryFunc{
 			defaultHook: i.TruncateConfigurationSummary,
 		},
 		UpdateIndexConfigurationByRepositoryIDFunc: &StoreUpdateIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.UpdateIndexConfigurationByRepositoryID,
 		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: i.WithTransaction,
+		},
 	}
-}
-
-// StoreDoneFunc describes the behavior when the Done method of the parent
-// MockStore instance is invoked.
-type StoreDoneFunc struct {
-	defaultHook func(error) error
-	hooks       []func(error) error
-	history     []StoreDoneFuncCall
-	mutex       sync.Mutex
-}
-
-// Done delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Done(v0 error) error {
-	r0 := m.DoneFunc.nextHook()(v0)
-	m.DoneFunc.appendCall(StoreDoneFuncCall{v0, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Done method of the
-// parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDoneFunc) SetDefaultHook(hook func(error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Done method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreDoneFunc) PushHook(hook func(error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreDoneFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDoneFunc) PushReturn(r0 error) {
-	f.PushHook(func(error) error {
-		return r0
-	})
-}
-
-func (f *StoreDoneFunc) nextHook() func(error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreDoneFunc) appendCall(r0 StoreDoneFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreDoneFuncCall objects describing the
-// invocations of this function.
-func (f *StoreDoneFunc) History() []StoreDoneFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreDoneFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreDoneFuncCall is an object that describes an invocation of method
-// Done on an instance of MockStore.
-type StoreDoneFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreGetIndexConfigurationByRepositoryIDFunc describes the behavior when
@@ -904,24 +787,24 @@ func (c StoreGetQueuedRepoRevFuncCall) Results() []interface{} {
 // GetRepositoriesForIndexScan method of the parent MockStore instance is
 // invoked.
 type StoreGetRepositoriesForIndexScanFunc struct {
-	defaultHook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)
-	hooks       []func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)
+	defaultHook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)
+	hooks       []func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)
 	history     []StoreGetRepositoriesForIndexScanFuncCall
 	mutex       sync.Mutex
 }
 
 // GetRepositoriesForIndexScan delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetRepositoriesForIndexScan(v0 context.Context, v1 string, v2 string, v3 time.Duration, v4 bool, v5 *int, v6 int, v7 time.Time) ([]int, error) {
-	r0, r1 := m.GetRepositoriesForIndexScanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
-	m.GetRepositoriesForIndexScanFunc.appendCall(StoreGetRepositoriesForIndexScanFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0, r1})
+func (m *MockStore) GetRepositoriesForIndexScan(v0 context.Context, v1 time.Duration, v2 bool, v3 *int, v4 int, v5 time.Time) ([]int, error) {
+	r0, r1 := m.GetRepositoriesForIndexScanFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.GetRepositoriesForIndexScanFunc.appendCall(StoreGetRepositoriesForIndexScanFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // GetRepositoriesForIndexScan method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
+func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
 	f.defaultHook = hook
 }
 
@@ -930,7 +813,7 @@ func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
+func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -939,19 +822,19 @@ func (f *StoreGetRepositoriesForIndexScanFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreGetRepositoriesForIndexScanFunc) SetDefaultReturn(r0 []int, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+	f.SetDefaultHook(func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreGetRepositoriesForIndexScanFunc) PushReturn(r0 []int, r1 error) {
-	f.PushHook(func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+	f.PushHook(func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetRepositoriesForIndexScanFunc) nextHook() func(context.Context, string, string, time.Duration, bool, *int, int, time.Time) ([]int, error) {
+func (f *StoreGetRepositoriesForIndexScanFunc) nextHook() func(context.Context, time.Duration, bool, *int, int, time.Time) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -990,25 +873,19 @@ type StoreGetRepositoriesForIndexScanFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 time.Duration
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 bool
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 time.Duration
+	Arg3 *int
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 bool
+	Arg4 int
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 *int
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 int
-	// Arg7 is the value of the 8th argument passed to this method
-	// invocation.
-	Arg7 time.Time
+	Arg5 time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []int
@@ -1020,7 +897,7 @@ type StoreGetRepositoriesForIndexScanFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreGetRepositoriesForIndexScanFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
@@ -2138,110 +2015,6 @@ func (c StoreTopRepositoriesToConfigureFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreTransactFunc describes the behavior when the Transact method of the
-// parent MockStore instance is invoked.
-type StoreTransactFunc struct {
-	defaultHook func(context.Context) (store.Store, error)
-	hooks       []func(context.Context) (store.Store, error)
-	history     []StoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Transact(v0 context.Context) (store.Store, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(StoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreTransactFunc) SetDefaultHook(hook func(context.Context) (store.Store, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreTransactFunc) PushHook(hook func(context.Context) (store.Store, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreTransactFunc) SetDefaultReturn(r0 store.Store, r1 error) {
-	f.SetDefaultHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreTransactFunc) PushReturn(r0 store.Store, r1 error) {
-	f.PushHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreTransactFunc) nextHook() func(context.Context) (store.Store, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreTransactFunc) appendCall(r0 StoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreTransactFuncCall objects describing
-// the invocations of this function.
-func (f *StoreTransactFunc) History() []StoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreTransactFuncCall is an object that describes an invocation of method
-// Transact on an instance of MockStore.
-type StoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 store.Store
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // StoreTruncateConfigurationSummaryFunc describes the behavior when the
 // TruncateConfigurationSummary method of the parent MockStore instance is
 // invoked.
@@ -2460,6 +2233,111 @@ func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interface{
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// StoreWithTransactionFunc describes the behavior when the WithTransaction
+// method of the parent MockStore instance is invoked.
+type StoreWithTransactionFunc struct {
+	defaultHook func(context.Context, func(tx store.Store) error) error
+	hooks       []func(context.Context, func(tx store.Store) error) error
+	history     []StoreWithTransactionFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransaction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) WithTransaction(v0 context.Context, v1 func(tx store.Store) error) error {
+	r0 := m.WithTransactionFunc.nextHook()(v0, v1)
+	m.WithTransactionFunc.appendCall(StoreWithTransactionFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransaction
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreWithTransactionFunc) SetDefaultHook(hook func(context.Context, func(tx store.Store) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransaction method of the parent MockStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreWithTransactionFunc) PushHook(hook func(context.Context, func(tx store.Store) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreWithTransactionFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(tx store.Store) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreWithTransactionFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(tx store.Store) error) error {
+		return r0
+	})
+}
+
+func (f *StoreWithTransactionFunc) nextHook() func(context.Context, func(tx store.Store) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreWithTransactionFunc) appendCall(r0 StoreWithTransactionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreWithTransactionFuncCall objects
+// describing the invocations of this function.
+func (f *StoreWithTransactionFunc) History() []StoreWithTransactionFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreWithTransactionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreWithTransactionFuncCall is an object that describes an invocation of
+// method WithTransaction on an instance of MockStore.
+type StoreWithTransactionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(tx store.Store) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/autoindexing/service.go
+++ b/enterprise/internal/codeintel/autoindexing/service.go
@@ -167,8 +167,8 @@ func IsLimitError(err error) bool {
 	return errors.As(err, &inference.LimitError{})
 }
 
-func (s *Service) GetRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) ([]int, error) {
-	return s.store.GetRepositoriesForIndexScan(ctx, table, column, processDelay, allowGlobalPolicies, repositoryMatchLimit, limit, now)
+func (s *Service) GetRepositoriesForIndexScan(ctx context.Context, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) ([]int, error) {
+	return s.store.GetRepositoriesForIndexScan(ctx, processDelay, allowGlobalPolicies, repositoryMatchLimit, limit, now)
 }
 
 func (s *Service) RepositoryIDsWithConfiguration(ctx context.Context, offset, limit int) ([]uploadsshared.RepositoryWithAvailableIndexers, int, error) {

--- a/enterprise/internal/codeintel/policies/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/policies/internal/store/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "observability.go",
         "repository_matches.go",
         "store.go",
+        "util.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store",
     visibility = ["//enterprise:__subpackages__"],

--- a/enterprise/internal/codeintel/policies/internal/store/store.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store.go
@@ -35,7 +35,6 @@ type store struct {
 	operations *operations
 }
 
-// New returns a new policies store.
 func New(observationCtx *observation.Context, db database.DB) Store {
 	return &store{
 		db:         basestore.NewWithHandle(db.Handle()),

--- a/enterprise/internal/codeintel/policies/internal/store/util.go
+++ b/enterprise/internal/codeintel/policies/internal/store/util.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"strings"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+)
+
+func makePatternCondition(patterns []string, defaultValue bool) *sqlf.Query {
+	if len(patterns) == 0 {
+		if defaultValue {
+			return sqlf.Sprintf("TRUE")
+		}
+
+		return sqlf.Sprintf("FALSE")
+	}
+
+	conds := make([]*sqlf.Query, 0, len(patterns))
+	for _, pattern := range patterns {
+		conds = append(conds, sqlf.Sprintf("lower(name) LIKE %s", strings.ToLower(strings.ReplaceAll(pattern, "*", "%"))))
+	}
+
+	return sqlf.Join(conds, "OR")
+}
+
+func optionalLimit(limit *int) *sqlf.Query {
+	if limit != nil {
+		return sqlf.Sprintf("LIMIT %d", *limit)
+	}
+
+	return sqlf.Sprintf("")
+}
+
+func optionalArray[T any](values *[]T) any {
+	if values != nil {
+		return pq.Array(*values)
+	}
+
+	return nil
+}
+
+func optionalNumHours(duration *time.Duration) *int {
+	if duration != nil {
+		v := int(*duration / time.Hour)
+		return &v
+	}
+
+	return nil
+}
+
+func optionalDuration(numHours *int) *time.Duration {
+	if numHours != nil {
+		v := time.Duration(*numHours) * time.Hour
+		return &v
+	}
+
+	return nil
+}
+
+func optionalSlice[T any](s []T) *[]T {
+	if len(s) != 0 {
+		return &s
+	}
+
+	return nil
+}

--- a/enterprise/internal/codeintel/ranking/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/job_graph_exporter.go
@@ -16,7 +16,7 @@ const recordTypeName = "path count inputs"
 func NewSymbolExporter(
 	observationCtx *observation.Context,
 	store store.Store,
-	lsifstore lsifstore.LsifStore,
+	lsifstore lsifstore.Store,
 	interval time.Duration,
 	readBatchSize int,
 	writeBatchSize int,

--- a/enterprise/internal/codeintel/ranking/internal/background/ranking.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/ranking.go
@@ -20,7 +20,7 @@ import (
 func exportRankingGraph(
 	ctx context.Context,
 	store store.Store,
-	lsifstore lsifstore.LsifStore,
+	lsifstore lsifstore.Store,
 	logger log.Logger,
 	readBatchSize int,
 	writeBatchSize int,

--- a/enterprise/internal/codeintel/ranking/internal/lsifstore/BUILD.bazel
+++ b/enterprise/internal/codeintel/ranking/internal/lsifstore/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "lsifstore",
     srcs = [
-        "lsifstore.go",
         "observability.go",
+        "store.go",
         "stream.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/ranking/internal/lsifstore",

--- a/enterprise/internal/codeintel/ranking/internal/store/reducer.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/reducer.go
@@ -17,13 +17,9 @@ func (s *store) InsertPathRanks(
 	derivativeGraphKey string,
 	batchSize int,
 ) (numPathRanksInserted int, numInputsProcessed int, err error) {
-	ctx, _, endObservation := s.operations.insertPathRanks.With(
-		ctx,
-		&err,
-		observation.Args{LogFields: []otlog.Field{
-			otlog.String("derivativeGraphKey", derivativeGraphKey),
-		}},
-	)
+	ctx, _, endObservation := s.operations.insertPathRanks.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.String("derivativeGraphKey", derivativeGraphKey),
+	}})
 	defer endObservation(1, observation.Args{})
 
 	_, ok := rankingshared.GraphKeyFromDerivativeGraphKey(derivativeGraphKey)

--- a/enterprise/internal/codeintel/ranking/internal/store/util.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/util.go
@@ -1,5 +1,13 @@
 package store
 
+import "time"
+
+// TODO - configure these via envvar
+const (
+	vacuumBatchSize = 100
+	threshold       = time.Duration(1) * time.Hour
+)
+
 func batchChannel[T any](ch <-chan T, batchSize int) <-chan []T {
 	batches := make(chan []T)
 	go func() {

--- a/enterprise/internal/codeintel/ranking/service.go
+++ b/enterprise/internal/codeintel/ranking/service.go
@@ -18,7 +18,7 @@ import (
 
 type Service struct {
 	store      store.Store
-	lsifstore  lsifstore.LsifStore
+	lsifstore  lsifstore.Store
 	getConf    conftypes.SiteConfigQuerier
 	operations *operations
 	logger     log.Logger
@@ -27,7 +27,7 @@ type Service struct {
 func newService(
 	observationCtx *observation.Context,
 	store store.Store,
-	lsifStore lsifstore.LsifStore,
+	lsifStore lsifstore.Store,
 	getConf conftypes.SiteConfigQuerier,
 ) *Service {
 	return &Service{

--- a/enterprise/internal/codeintel/sentinel/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/sentinel/internal/store/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_hashicorp_go_version//:go-version",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_opentracing_opentracing_go//log",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/internal/codeintel/uploads/internal/background/job_backfill_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_backfill_test.go
@@ -24,8 +24,7 @@ func TestBackfillCommittedAtBatch(t *testing.T) {
 	}
 
 	// Return self for txn
-	store.TransactFunc.SetDefaultReturn(store, nil)
-	store.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	store.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(s shared.Store) error) error { return f(store) })
 
 	n := 50
 	t0 := time.Unix(1587396557, 0).UTC()
@@ -99,8 +98,7 @@ func TestBackfillCommittedAtBatchUnknownCommits(t *testing.T) {
 	}
 
 	// Return self for txn
-	store.TransactFunc.SetDefaultReturn(store, nil)
-	store.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	store.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(s shared.Store) error) error { return f(store) })
 
 	n := 50
 	t0 := time.Unix(1587396557, 0).UTC()

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
@@ -162,7 +162,7 @@ func NewExpiredUploadTraversalJanitor(
 
 func NewHardDeleter(
 	store store.Store,
-	lsifStore lsifstore.LsifStore,
+	lsifStore lsifstore.Store,
 	interval time.Duration,
 	observationCtx *observation.Context,
 ) goroutine.BackgroundRoutine {
@@ -249,7 +249,7 @@ func NewAuditLogJanitor(
 //
 
 func NewSCIPExpirationTask(
-	lsifStore lsifstore.LsifStore,
+	lsifStore lsifstore.Store,
 	interval time.Duration,
 	unreferencedDocumentBatchSize int,
 	unreferencedDocumentMaxAge time.Duration,

--- a/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
@@ -13,7 +13,7 @@ import (
 
 func NewFrontendDBReconciler(
 	store store.Store,
-	lsifstore lsifstore.LsifStore,
+	lsifstore lsifstore.Store,
 	interval time.Duration,
 	batchSize int,
 	observationCtx *observation.Context,
@@ -32,7 +32,7 @@ func NewFrontendDBReconciler(
 
 func NewCodeIntelDBReconciler(
 	store store.Store,
-	lsifstore lsifstore.LsifStore,
+	lsifstore lsifstore.Store,
 	interval time.Duration,
 	batchSize int,
 	observationCtx *observation.Context,
@@ -143,7 +143,7 @@ func (s *storeWrapper) FilterExists(ctx context.Context, candidateIDs []int) ([]
 }
 
 type lsifStoreWrapper struct {
-	lsifstore lsifstore.LsifStore
+	lsifstore lsifstore.Store
 }
 
 func (s *lsifStoreWrapper) Candidates(ctx context.Context, batchSize int) ([]int, error) {

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -403,9 +403,6 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// DeleteUploadsWithoutRepository.
 	DeleteUploadsWithoutRepositoryFunc *StoreDeleteUploadsWithoutRepositoryFunc
-	// DoneFunc is an instance of a mock function object controlling the
-	// behavior of the method Done.
-	DoneFunc *StoreDoneFunc
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
@@ -558,9 +555,6 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// SourcedCommitsWithoutCommittedAt.
 	SourcedCommitsWithoutCommittedAtFunc *StoreSourcedCommitsWithoutCommittedAtFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *StoreTransactFunc
 	// UpdateCommittedAtFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateCommittedAt.
 	UpdateCommittedAtFunc *StoreUpdateCommittedAtFunc
@@ -577,6 +571,9 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// UpdateUploadsVisibleToCommits.
 	UpdateUploadsVisibleToCommitsFunc *StoreUpdateUploadsVisibleToCommitsFunc
+	// WithTransactionFunc is an instance of a mock function object
+	// controlling the behavior of the method WithTransaction.
+	WithTransactionFunc *StoreWithTransactionFunc
 	// WorkerutilStoreFunc is an instance of a mock function object
 	// controlling the behavior of the method WorkerutilStore.
 	WorkerutilStoreFunc *StoreWorkerutilStoreFunc
@@ -633,11 +630,6 @@ func NewMockStore() *MockStore {
 		},
 		DeleteUploadsWithoutRepositoryFunc: &StoreDeleteUploadsWithoutRepositoryFunc{
 			defaultHook: func(context.Context, time.Time) (r0 int, r1 int, r2 error) {
-				return
-			},
-		},
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) (r0 error) {
 				return
 			},
 		},
@@ -871,11 +863,6 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (r0 store.Store, r1 error) {
-				return
-			},
-		},
 		UpdateCommittedAtFunc: &StoreUpdateCommittedAtFunc{
 			defaultHook: func(context.Context, int, string, string) (r0 error) {
 				return
@@ -898,6 +885,11 @@ func NewMockStore() *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: func(context.Context, int, *gitdomain.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) (r0 error) {
+				return
+			},
+		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(s store.Store) error) (r0 error) {
 				return
 			},
 		},
@@ -961,11 +953,6 @@ func NewStrictMockStore() *MockStore {
 		DeleteUploadsWithoutRepositoryFunc: &StoreDeleteUploadsWithoutRepositoryFunc{
 			defaultHook: func(context.Context, time.Time) (int, int, error) {
 				panic("unexpected invocation of MockStore.DeleteUploadsWithoutRepository")
-			},
-		},
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: func(error) error {
-				panic("unexpected invocation of MockStore.Done")
 			},
 		},
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
@@ -1198,11 +1185,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.SourcedCommitsWithoutCommittedAt")
 			},
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: func(context.Context) (store.Store, error) {
-				panic("unexpected invocation of MockStore.Transact")
-			},
-		},
 		UpdateCommittedAtFunc: &StoreUpdateCommittedAtFunc{
 			defaultHook: func(context.Context, int, string, string) error {
 				panic("unexpected invocation of MockStore.UpdateCommittedAt")
@@ -1226,6 +1208,11 @@ func NewStrictMockStore() *MockStore {
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: func(context.Context, int, *gitdomain.CommitGraph, map[string][]gitdomain.RefDescription, time.Duration, time.Duration, int, time.Time) error {
 				panic("unexpected invocation of MockStore.UpdateUploadsVisibleToCommits")
+			},
+		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(s store.Store) error) error {
+				panic("unexpected invocation of MockStore.WithTransaction")
 			},
 		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
@@ -1269,9 +1256,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		DeleteUploadsWithoutRepositoryFunc: &StoreDeleteUploadsWithoutRepositoryFunc{
 			defaultHook: i.DeleteUploadsWithoutRepository,
-		},
-		DoneFunc: &StoreDoneFunc{
-			defaultHook: i.Done,
 		},
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
@@ -1411,9 +1395,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		SourcedCommitsWithoutCommittedAtFunc: &StoreSourcedCommitsWithoutCommittedAtFunc{
 			defaultHook: i.SourcedCommitsWithoutCommittedAt,
 		},
-		TransactFunc: &StoreTransactFunc{
-			defaultHook: i.Transact,
-		},
 		UpdateCommittedAtFunc: &StoreUpdateCommittedAtFunc{
 			defaultHook: i.UpdateCommittedAt,
 		},
@@ -1428,6 +1409,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		UpdateUploadsVisibleToCommitsFunc: &StoreUpdateUploadsVisibleToCommitsFunc{
 			defaultHook: i.UpdateUploadsVisibleToCommits,
+		},
+		WithTransactionFunc: &StoreWithTransactionFunc{
+			defaultHook: i.WithTransaction,
 		},
 		WorkerutilStoreFunc: &StoreWorkerutilStoreFunc{
 			defaultHook: i.WorkerutilStore,
@@ -2535,107 +2519,6 @@ func (c StoreDeleteUploadsWithoutRepositoryFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreDeleteUploadsWithoutRepositoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreDoneFunc describes the behavior when the Done method of the parent
-// MockStore instance is invoked.
-type StoreDoneFunc struct {
-	defaultHook func(error) error
-	hooks       []func(error) error
-	history     []StoreDoneFuncCall
-	mutex       sync.Mutex
-}
-
-// Done delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Done(v0 error) error {
-	r0 := m.DoneFunc.nextHook()(v0)
-	m.DoneFunc.appendCall(StoreDoneFuncCall{v0, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Done method of the
-// parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDoneFunc) SetDefaultHook(hook func(error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Done method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreDoneFunc) PushHook(hook func(error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreDoneFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDoneFunc) PushReturn(r0 error) {
-	f.PushHook(func(error) error {
-		return r0
-	})
-}
-
-func (f *StoreDoneFunc) nextHook() func(error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreDoneFunc) appendCall(r0 StoreDoneFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreDoneFuncCall objects describing the
-// invocations of this function.
-func (f *StoreDoneFunc) History() []StoreDoneFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreDoneFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreDoneFuncCall is an object that describes an invocation of method
-// Done on an instance of MockStore.
-type StoreDoneFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // StoreExpireFailedRecordsFunc describes the behavior when the
@@ -7802,110 +7685,6 @@ func (c StoreSourcedCommitsWithoutCommittedAtFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreTransactFunc describes the behavior when the Transact method of the
-// parent MockStore instance is invoked.
-type StoreTransactFunc struct {
-	defaultHook func(context.Context) (store.Store, error)
-	hooks       []func(context.Context) (store.Store, error)
-	history     []StoreTransactFuncCall
-	mutex       sync.Mutex
-}
-
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) Transact(v0 context.Context) (store.Store, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(StoreTransactFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreTransactFunc) SetDefaultHook(hook func(context.Context) (store.Store, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreTransactFunc) PushHook(hook func(context.Context) (store.Store, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreTransactFunc) SetDefaultReturn(r0 store.Store, r1 error) {
-	f.SetDefaultHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreTransactFunc) PushReturn(r0 store.Store, r1 error) {
-	f.PushHook(func(context.Context) (store.Store, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreTransactFunc) nextHook() func(context.Context) (store.Store, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreTransactFunc) appendCall(r0 StoreTransactFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreTransactFuncCall objects describing
-// the invocations of this function.
-func (f *StoreTransactFunc) History() []StoreTransactFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreTransactFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreTransactFuncCall is an object that describes an invocation of method
-// Transact on an instance of MockStore.
-type StoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 store.Store
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // StoreUpdateCommittedAtFunc describes the behavior when the
 // UpdateCommittedAt method of the parent MockStore instance is invoked.
 type StoreUpdateCommittedAtFunc struct {
@@ -8468,6 +8247,111 @@ func (c StoreUpdateUploadsVisibleToCommitsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// StoreWithTransactionFunc describes the behavior when the WithTransaction
+// method of the parent MockStore instance is invoked.
+type StoreWithTransactionFunc struct {
+	defaultHook func(context.Context, func(s store.Store) error) error
+	hooks       []func(context.Context, func(s store.Store) error) error
+	history     []StoreWithTransactionFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransaction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) WithTransaction(v0 context.Context, v1 func(s store.Store) error) error {
+	r0 := m.WithTransactionFunc.nextHook()(v0, v1)
+	m.WithTransactionFunc.appendCall(StoreWithTransactionFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransaction
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreWithTransactionFunc) SetDefaultHook(hook func(context.Context, func(s store.Store) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransaction method of the parent MockStore instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreWithTransactionFunc) PushHook(hook func(context.Context, func(s store.Store) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreWithTransactionFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(s store.Store) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreWithTransactionFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(s store.Store) error) error {
+		return r0
+	})
+}
+
+func (f *StoreWithTransactionFunc) nextHook() func(context.Context, func(s store.Store) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreWithTransactionFunc) appendCall(r0 StoreWithTransactionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreWithTransactionFuncCall objects
+// describing the invocations of this function.
+func (f *StoreWithTransactionFunc) History() []StoreWithTransactionFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreWithTransactionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreWithTransactionFuncCall is an object that describes an invocation of
+// method WithTransaction on an instance of MockStore.
+type StoreWithTransactionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(s store.Store) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreWithTransactionFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
 // StoreWorkerutilStoreFunc describes the behavior when the WorkerutilStore
 // method of the parent MockStore instance is invoked.
 type StoreWorkerutilStoreFunc struct {
@@ -8721,212 +8605,96 @@ func (c RepoStoreGetFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// MockLsifStore is a mock implementation of the LsifStore interface (from
-// the package
+// MockLSIFSCIPWriter is a mock implementation of the SCIPWriter interface
+// (from the package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore)
 // used for unit testing.
-type MockLsifStore struct {
-	// DeleteLsifDataByUploadIdsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// DeleteLsifDataByUploadIds.
-	DeleteLsifDataByUploadIdsFunc *LsifStoreDeleteLsifDataByUploadIdsFunc
-	// DeleteUnreferencedDocumentsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// DeleteUnreferencedDocuments.
-	DeleteUnreferencedDocumentsFunc *LsifStoreDeleteUnreferencedDocumentsFunc
-	// DoneFunc is an instance of a mock function object controlling the
-	// behavior of the method Done.
-	DoneFunc *LsifStoreDoneFunc
-	// IDsWithMetaFunc is an instance of a mock function object controlling
-	// the behavior of the method IDsWithMeta.
-	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
-	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// InsertDefinitionsAndReferencesForDocument.
-	InsertDefinitionsAndReferencesForDocumentFunc *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc
-	// InsertMetadataFunc is an instance of a mock function object
-	// controlling the behavior of the method InsertMetadata.
-	InsertMetadataFunc *LsifStoreInsertMetadataFunc
-	// NewSCIPWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSCIPWriter.
-	NewSCIPWriterFunc *LsifStoreNewSCIPWriterFunc
-	// ReconcileCandidatesFunc is an instance of a mock function object
-	// controlling the behavior of the method ReconcileCandidates.
-	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *LsifStoreTransactFunc
+type MockLSIFSCIPWriter struct {
+	// FlushFunc is an instance of a mock function object controlling the
+	// behavior of the method Flush.
+	FlushFunc *LSIFSCIPWriterFlushFunc
+	// InsertDocumentFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertDocument.
+	InsertDocumentFunc *LSIFSCIPWriterInsertDocumentFunc
 }
 
-// NewMockLsifStore creates a new mock of the LsifStore interface. All
+// NewMockLSIFSCIPWriter creates a new mock of the SCIPWriter interface. All
 // methods return zero values for all results, unless overwritten.
-func NewMockLsifStore() *MockLsifStore {
-	return &MockLsifStore{
-		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
-			defaultHook: func(context.Context, ...int) (r0 error) {
+func NewMockLSIFSCIPWriter() *MockLSIFSCIPWriter {
+	return &MockLSIFSCIPWriter{
+		FlushFunc: &LSIFSCIPWriterFlushFunc{
+			defaultHook: func(context.Context) (r0 uint32, r1 error) {
 				return
 			},
 		},
-		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
-			defaultHook: func(context.Context, int, time.Duration, time.Time) (r0 int, r1 int, r2 error) {
-				return
-			},
-		},
-		DoneFunc: &LsifStoreDoneFunc{
-			defaultHook: func(error) (r0 error) {
-				return
-			},
-		},
-		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
-			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
-				return
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
-				return
-			},
-		},
-		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
-			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) (r0 error) {
-				return
-			},
-		},
-		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
-				return
-			},
-		},
-		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
-			defaultHook: func(context.Context, int) (r0 []int, r1 error) {
-				return
-			},
-		},
-		TransactFunc: &LsifStoreTransactFunc{
-			defaultHook: func(context.Context) (r0 lsifstore.LsifStore, r1 error) {
+		InsertDocumentFunc: &LSIFSCIPWriterInsertDocumentFunc{
+			defaultHook: func(context.Context, string, *scip.Document) (r0 error) {
 				return
 			},
 		},
 	}
 }
 
-// NewStrictMockLsifStore creates a new mock of the LsifStore interface. All
-// methods panic on invocation, unless overwritten.
-func NewStrictMockLsifStore() *MockLsifStore {
-	return &MockLsifStore{
-		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
-			defaultHook: func(context.Context, ...int) error {
-				panic("unexpected invocation of MockLsifStore.DeleteLsifDataByUploadIds")
+// NewStrictMockLSIFSCIPWriter creates a new mock of the SCIPWriter
+// interface. All methods panic on invocation, unless overwritten.
+func NewStrictMockLSIFSCIPWriter() *MockLSIFSCIPWriter {
+	return &MockLSIFSCIPWriter{
+		FlushFunc: &LSIFSCIPWriterFlushFunc{
+			defaultHook: func(context.Context) (uint32, error) {
+				panic("unexpected invocation of MockLSIFSCIPWriter.Flush")
 			},
 		},
-		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
-			defaultHook: func(context.Context, int, time.Duration, time.Time) (int, int, error) {
-				panic("unexpected invocation of MockLsifStore.DeleteUnreferencedDocuments")
-			},
-		},
-		DoneFunc: &LsifStoreDoneFunc{
-			defaultHook: func(error) error {
-				panic("unexpected invocation of MockLsifStore.Done")
-			},
-		},
-		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
-			defaultHook: func(context.Context, []int) ([]int, error) {
-				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
-			},
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
-				panic("unexpected invocation of MockLsifStore.InsertDefinitionsAndReferencesForDocument")
-			},
-		},
-		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
-			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
-				panic("unexpected invocation of MockLsifStore.InsertMetadata")
-			},
-		},
-		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
-				panic("unexpected invocation of MockLsifStore.NewSCIPWriter")
-			},
-		},
-		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
-			defaultHook: func(context.Context, int) ([]int, error) {
-				panic("unexpected invocation of MockLsifStore.ReconcileCandidates")
-			},
-		},
-		TransactFunc: &LsifStoreTransactFunc{
-			defaultHook: func(context.Context) (lsifstore.LsifStore, error) {
-				panic("unexpected invocation of MockLsifStore.Transact")
+		InsertDocumentFunc: &LSIFSCIPWriterInsertDocumentFunc{
+			defaultHook: func(context.Context, string, *scip.Document) error {
+				panic("unexpected invocation of MockLSIFSCIPWriter.InsertDocument")
 			},
 		},
 	}
 }
 
-// NewMockLsifStoreFrom creates a new mock of the MockLsifStore interface.
-// All methods delegate to the given implementation, unless overwritten.
-func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
-	return &MockLsifStore{
-		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
-			defaultHook: i.DeleteLsifDataByUploadIds,
+// NewMockLSIFSCIPWriterFrom creates a new mock of the MockLSIFSCIPWriter
+// interface. All methods delegate to the given implementation, unless
+// overwritten.
+func NewMockLSIFSCIPWriterFrom(i lsifstore.SCIPWriter) *MockLSIFSCIPWriter {
+	return &MockLSIFSCIPWriter{
+		FlushFunc: &LSIFSCIPWriterFlushFunc{
+			defaultHook: i.Flush,
 		},
-		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
-			defaultHook: i.DeleteUnreferencedDocuments,
-		},
-		DoneFunc: &LsifStoreDoneFunc{
-			defaultHook: i.Done,
-		},
-		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
-			defaultHook: i.IDsWithMeta,
-		},
-		InsertDefinitionsAndReferencesForDocumentFunc: &LsifStoreInsertDefinitionsAndReferencesForDocumentFunc{
-			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
-		},
-		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
-			defaultHook: i.InsertMetadata,
-		},
-		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
-			defaultHook: i.NewSCIPWriter,
-		},
-		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
-			defaultHook: i.ReconcileCandidates,
-		},
-		TransactFunc: &LsifStoreTransactFunc{
-			defaultHook: i.Transact,
+		InsertDocumentFunc: &LSIFSCIPWriterInsertDocumentFunc{
+			defaultHook: i.InsertDocument,
 		},
 	}
 }
 
-// LsifStoreDeleteLsifDataByUploadIdsFunc describes the behavior when the
-// DeleteLsifDataByUploadIds method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreDeleteLsifDataByUploadIdsFunc struct {
-	defaultHook func(context.Context, ...int) error
-	hooks       []func(context.Context, ...int) error
-	history     []LsifStoreDeleteLsifDataByUploadIdsFuncCall
+// LSIFSCIPWriterFlushFunc describes the behavior when the Flush method of
+// the parent MockLSIFSCIPWriter instance is invoked.
+type LSIFSCIPWriterFlushFunc struct {
+	defaultHook func(context.Context) (uint32, error)
+	hooks       []func(context.Context) (uint32, error)
+	history     []LSIFSCIPWriterFlushFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteLsifDataByUploadIds delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) DeleteLsifDataByUploadIds(v0 context.Context, v1 ...int) error {
-	r0 := m.DeleteLsifDataByUploadIdsFunc.nextHook()(v0, v1...)
-	m.DeleteLsifDataByUploadIdsFunc.appendCall(LsifStoreDeleteLsifDataByUploadIdsFuncCall{v0, v1, r0})
-	return r0
+// Flush delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockLSIFSCIPWriter) Flush(v0 context.Context) (uint32, error) {
+	r0, r1 := m.FlushFunc.nextHook()(v0)
+	m.FlushFunc.appendCall(LSIFSCIPWriterFlushFuncCall{v0, r0, r1})
+	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the
-// DeleteLsifDataByUploadIds method of the parent MockLsifStore instance is
-// invoked and the hook queue is empty.
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) SetDefaultHook(hook func(context.Context, ...int) error) {
+// SetDefaultHook sets function that is called when the Flush method of the
+// parent MockLSIFSCIPWriter instance is invoked and the hook queue is
+// empty.
+func (f *LSIFSCIPWriterFlushFunc) SetDefaultHook(hook func(context.Context) (uint32, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteLsifDataByUploadIds method of the parent MockLsifStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) PushHook(hook func(context.Context, ...int) error) {
+// Flush method of the parent MockLSIFSCIPWriter instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *LSIFSCIPWriterFlushFunc) PushHook(hook func(context.Context) (uint32, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8934,20 +8702,20 @@ func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) PushHook(hook func(context.Cont
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, ...int) error {
-		return r0
+func (f *LSIFSCIPWriterFlushFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context) (uint32, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, ...int) error {
-		return r0
+func (f *LSIFSCIPWriterFlushFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context) (uint32, error) {
+		return r0, r1
 	})
 }
 
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) nextHook() func(context.Context, ...int) error {
+func (f *LSIFSCIPWriterFlushFunc) nextHook() func(context.Context) (uint32, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8960,27 +8728,419 @@ func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) nextHook() func(context.Context
 	return hook
 }
 
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) appendCall(r0 LsifStoreDeleteLsifDataByUploadIdsFuncCall) {
+func (f *LSIFSCIPWriterFlushFunc) appendCall(r0 LSIFSCIPWriterFlushFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreDeleteLsifDataByUploadIdsFuncCall
-// objects describing the invocations of this function.
-func (f *LsifStoreDeleteLsifDataByUploadIdsFunc) History() []LsifStoreDeleteLsifDataByUploadIdsFuncCall {
+// History returns a sequence of LSIFSCIPWriterFlushFuncCall objects
+// describing the invocations of this function.
+func (f *LSIFSCIPWriterFlushFunc) History() []LSIFSCIPWriterFlushFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreDeleteLsifDataByUploadIdsFuncCall, len(f.history))
+	history := make([]LSIFSCIPWriterFlushFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreDeleteLsifDataByUploadIdsFuncCall is an object that describes an
+// LSIFSCIPWriterFlushFuncCall is an object that describes an invocation of
+// method Flush on an instance of MockLSIFSCIPWriter.
+type LSIFSCIPWriterFlushFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFSCIPWriterFlushFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFSCIPWriterFlushFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFSCIPWriterInsertDocumentFunc describes the behavior when the
+// InsertDocument method of the parent MockLSIFSCIPWriter instance is
+// invoked.
+type LSIFSCIPWriterInsertDocumentFunc struct {
+	defaultHook func(context.Context, string, *scip.Document) error
+	hooks       []func(context.Context, string, *scip.Document) error
+	history     []LSIFSCIPWriterInsertDocumentFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertDocument delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLSIFSCIPWriter) InsertDocument(v0 context.Context, v1 string, v2 *scip.Document) error {
+	r0 := m.InsertDocumentFunc.nextHook()(v0, v1, v2)
+	m.InsertDocumentFunc.appendCall(LSIFSCIPWriterInsertDocumentFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the InsertDocument
+// method of the parent MockLSIFSCIPWriter instance is invoked and the hook
+// queue is empty.
+func (f *LSIFSCIPWriterInsertDocumentFunc) SetDefaultHook(hook func(context.Context, string, *scip.Document) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertDocument method of the parent MockLSIFSCIPWriter instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LSIFSCIPWriterInsertDocumentFunc) PushHook(hook func(context.Context, string, *scip.Document) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFSCIPWriterInsertDocumentFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, *scip.Document) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFSCIPWriterInsertDocumentFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, *scip.Document) error {
+		return r0
+	})
+}
+
+func (f *LSIFSCIPWriterInsertDocumentFunc) nextHook() func(context.Context, string, *scip.Document) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFSCIPWriterInsertDocumentFunc) appendCall(r0 LSIFSCIPWriterInsertDocumentFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFSCIPWriterInsertDocumentFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFSCIPWriterInsertDocumentFunc) History() []LSIFSCIPWriterInsertDocumentFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFSCIPWriterInsertDocumentFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFSCIPWriterInsertDocumentFuncCall is an object that describes an
+// invocation of method InsertDocument on an instance of MockLSIFSCIPWriter.
+type LSIFSCIPWriterInsertDocumentFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *scip.Document
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFSCIPWriterInsertDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFSCIPWriterInsertDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// MockLSIFStore is a mock implementation of the Store interface (from the
+// package
+// github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore)
+// used for unit testing.
+type MockLSIFStore struct {
+	// DeleteLsifDataByUploadIdsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteLsifDataByUploadIds.
+	DeleteLsifDataByUploadIdsFunc *LSIFStoreDeleteLsifDataByUploadIdsFunc
+	// DeleteUnreferencedDocumentsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteUnreferencedDocuments.
+	DeleteUnreferencedDocumentsFunc *LSIFStoreDeleteUnreferencedDocumentsFunc
+	// IDsWithMetaFunc is an instance of a mock function object controlling
+	// the behavior of the method IDsWithMeta.
+	IDsWithMetaFunc *LSIFStoreIDsWithMetaFunc
+	// InsertDefinitionsAndReferencesForDocumentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// InsertDefinitionsAndReferencesForDocument.
+	InsertDefinitionsAndReferencesForDocumentFunc *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc
+	// InsertMetadataFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertMetadata.
+	InsertMetadataFunc *LSIFStoreInsertMetadataFunc
+	// NewSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSCIPWriter.
+	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// ReconcileCandidatesFunc is an instance of a mock function object
+	// controlling the behavior of the method ReconcileCandidates.
+	ReconcileCandidatesFunc *LSIFStoreReconcileCandidatesFunc
+	// ReconcileCandidatesWithTimeFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ReconcileCandidatesWithTime.
+	ReconcileCandidatesWithTimeFunc *LSIFStoreReconcileCandidatesWithTimeFunc
+	// WithTransactionFunc is an instance of a mock function object
+	// controlling the behavior of the method WithTransaction.
+	WithTransactionFunc *LSIFStoreWithTransactionFunc
+}
+
+// NewMockLSIFStore creates a new mock of the Store interface. All methods
+// return zero values for all results, unless overwritten.
+func NewMockLSIFStore() *MockLSIFStore {
+	return &MockLSIFStore{
+		DeleteLsifDataByUploadIdsFunc: &LSIFStoreDeleteLsifDataByUploadIdsFunc{
+			defaultHook: func(context.Context, ...int) (r0 error) {
+				return
+			},
+		},
+		DeleteUnreferencedDocumentsFunc: &LSIFStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (r0 int, r1 int, r2 error) {
+				return
+			},
+		},
+		IDsWithMetaFunc: &LSIFStoreIDsWithMetaFunc{
+			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) (r0 error) {
+				return
+			},
+		},
+		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) (r0 error) {
+				return
+			},
+		},
+		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+				return
+			},
+		},
+		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
+			defaultHook: func(context.Context, int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		ReconcileCandidatesWithTimeFunc: &LSIFStoreReconcileCandidatesWithTimeFunc{
+			defaultHook: func(context.Context, int, time.Time) (r0 []int, r1 error) {
+				return
+			},
+		},
+		WithTransactionFunc: &LSIFStoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(s lsifstore.Store) error) (r0 error) {
+				return
+			},
+		},
+	}
+}
+
+// NewStrictMockLSIFStore creates a new mock of the Store interface. All
+// methods panic on invocation, unless overwritten.
+func NewStrictMockLSIFStore() *MockLSIFStore {
+	return &MockLSIFStore{
+		DeleteLsifDataByUploadIdsFunc: &LSIFStoreDeleteLsifDataByUploadIdsFunc{
+			defaultHook: func(context.Context, ...int) error {
+				panic("unexpected invocation of MockLSIFStore.DeleteLsifDataByUploadIds")
+			},
+		},
+		DeleteUnreferencedDocumentsFunc: &LSIFStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (int, int, error) {
+				panic("unexpected invocation of MockLSIFStore.DeleteUnreferencedDocuments")
+			},
+		},
+		IDsWithMetaFunc: &LSIFStoreIDsWithMetaFunc{
+			defaultHook: func(context.Context, []int) ([]int, error) {
+				panic("unexpected invocation of MockLSIFStore.IDsWithMeta")
+			},
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+				panic("unexpected invocation of MockLSIFStore.InsertDefinitionsAndReferencesForDocument")
+			},
+		},
+		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
+				panic("unexpected invocation of MockLSIFStore.InsertMetadata")
+			},
+		},
+		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
+			},
+		},
+		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
+			defaultHook: func(context.Context, int) ([]int, error) {
+				panic("unexpected invocation of MockLSIFStore.ReconcileCandidates")
+			},
+		},
+		ReconcileCandidatesWithTimeFunc: &LSIFStoreReconcileCandidatesWithTimeFunc{
+			defaultHook: func(context.Context, int, time.Time) ([]int, error) {
+				panic("unexpected invocation of MockLSIFStore.ReconcileCandidatesWithTime")
+			},
+		},
+		WithTransactionFunc: &LSIFStoreWithTransactionFunc{
+			defaultHook: func(context.Context, func(s lsifstore.Store) error) error {
+				panic("unexpected invocation of MockLSIFStore.WithTransaction")
+			},
+		},
+	}
+}
+
+// NewMockLSIFStoreFrom creates a new mock of the MockLSIFStore interface.
+// All methods delegate to the given implementation, unless overwritten.
+func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
+	return &MockLSIFStore{
+		DeleteLsifDataByUploadIdsFunc: &LSIFStoreDeleteLsifDataByUploadIdsFunc{
+			defaultHook: i.DeleteLsifDataByUploadIds,
+		},
+		DeleteUnreferencedDocumentsFunc: &LSIFStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: i.DeleteUnreferencedDocuments,
+		},
+		IDsWithMetaFunc: &LSIFStoreIDsWithMetaFunc{
+			defaultHook: i.IDsWithMeta,
+		},
+		InsertDefinitionsAndReferencesForDocumentFunc: &LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc{
+			defaultHook: i.InsertDefinitionsAndReferencesForDocument,
+		},
+		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
+			defaultHook: i.InsertMetadata,
+		},
+		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: i.NewSCIPWriter,
+		},
+		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
+			defaultHook: i.ReconcileCandidates,
+		},
+		ReconcileCandidatesWithTimeFunc: &LSIFStoreReconcileCandidatesWithTimeFunc{
+			defaultHook: i.ReconcileCandidatesWithTime,
+		},
+		WithTransactionFunc: &LSIFStoreWithTransactionFunc{
+			defaultHook: i.WithTransaction,
+		},
+	}
+}
+
+// LSIFStoreDeleteLsifDataByUploadIdsFunc describes the behavior when the
+// DeleteLsifDataByUploadIds method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreDeleteLsifDataByUploadIdsFunc struct {
+	defaultHook func(context.Context, ...int) error
+	hooks       []func(context.Context, ...int) error
+	history     []LSIFStoreDeleteLsifDataByUploadIdsFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteLsifDataByUploadIds delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) DeleteLsifDataByUploadIds(v0 context.Context, v1 ...int) error {
+	r0 := m.DeleteLsifDataByUploadIdsFunc.nextHook()(v0, v1...)
+	m.DeleteLsifDataByUploadIdsFunc.appendCall(LSIFStoreDeleteLsifDataByUploadIdsFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// DeleteLsifDataByUploadIds method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) SetDefaultHook(hook func(context.Context, ...int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteLsifDataByUploadIds method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) PushHook(hook func(context.Context, ...int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, ...int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, ...int) error {
+		return r0
+	})
+}
+
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) nextHook() func(context.Context, ...int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) appendCall(r0 LSIFStoreDeleteLsifDataByUploadIdsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreDeleteLsifDataByUploadIdsFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreDeleteLsifDataByUploadIdsFunc) History() []LSIFStoreDeleteLsifDataByUploadIdsFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreDeleteLsifDataByUploadIdsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreDeleteLsifDataByUploadIdsFuncCall is an object that describes an
 // invocation of method DeleteLsifDataByUploadIds on an instance of
-// MockLsifStore.
-type LsifStoreDeleteLsifDataByUploadIdsFuncCall struct {
+// MockLSIFStore.
+type LSIFStoreDeleteLsifDataByUploadIdsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -8996,7 +9156,7 @@ type LsifStoreDeleteLsifDataByUploadIdsFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Args() []interface{} {
+func (c LSIFStoreDeleteLsifDataByUploadIdsFuncCall) Args() []interface{} {
 	trailing := []interface{}{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
@@ -9007,41 +9167,41 @@ func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Args() []interface{} {
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Results() []interface{} {
+func (c LSIFStoreDeleteLsifDataByUploadIdsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LsifStoreDeleteUnreferencedDocumentsFunc describes the behavior when the
-// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// LSIFStoreDeleteUnreferencedDocumentsFunc describes the behavior when the
+// DeleteUnreferencedDocuments method of the parent MockLSIFStore instance
 // is invoked.
-type LsifStoreDeleteUnreferencedDocumentsFunc struct {
+type LSIFStoreDeleteUnreferencedDocumentsFunc struct {
 	defaultHook func(context.Context, int, time.Duration, time.Time) (int, int, error)
 	hooks       []func(context.Context, int, time.Duration, time.Time) (int, int, error)
-	history     []LsifStoreDeleteUnreferencedDocumentsFuncCall
+	history     []LSIFStoreDeleteUnreferencedDocumentsFuncCall
 	mutex       sync.Mutex
 }
 
 // DeleteUnreferencedDocuments delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) DeleteUnreferencedDocuments(v0 context.Context, v1 int, v2 time.Duration, v3 time.Time) (int, int, error) {
+func (m *MockLSIFStore) DeleteUnreferencedDocuments(v0 context.Context, v1 int, v2 time.Duration, v3 time.Time) (int, int, error) {
 	r0, r1, r2 := m.DeleteUnreferencedDocumentsFunc.nextHook()(v0, v1, v2, v3)
-	m.DeleteUnreferencedDocumentsFunc.appendCall(LsifStoreDeleteUnreferencedDocumentsFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	m.DeleteUnreferencedDocumentsFunc.appendCall(LSIFStoreDeleteUnreferencedDocumentsFuncCall{v0, v1, v2, v3, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// DeleteUnreferencedDocuments method of the parent MockLSIFStore instance
 // is invoked and the hook queue is empty.
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration, time.Time) (int, int, error)) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration, time.Time) (int, int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// DeleteUnreferencedDocuments method of the parent MockLSIFStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushHook(hook func(context.Context, int, time.Duration, time.Time) (int, int, error)) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) PushHook(hook func(context.Context, int, time.Duration, time.Time) (int, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9049,20 +9209,20 @@ func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushHook(hook func(context.Co
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) SetDefaultReturn(r0 int, r1 int, r2 error) {
 	f.SetDefaultHook(func(context.Context, int, time.Duration, time.Time) (int, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushReturn(r0 int, r1 int, r2 error) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) PushReturn(r0 int, r1 int, r2 error) {
 	f.PushHook(func(context.Context, int, time.Duration, time.Time) (int, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) nextHook() func(context.Context, int, time.Duration, time.Time) (int, int, error) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) nextHook() func(context.Context, int, time.Duration, time.Time) (int, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9075,28 +9235,28 @@ func (f *LsifStoreDeleteUnreferencedDocumentsFunc) nextHook() func(context.Conte
 	return hook
 }
 
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) appendCall(r0 LsifStoreDeleteUnreferencedDocumentsFuncCall) {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) appendCall(r0 LSIFStoreDeleteUnreferencedDocumentsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// LsifStoreDeleteUnreferencedDocumentsFuncCall objects describing the
+// LSIFStoreDeleteUnreferencedDocumentsFuncCall objects describing the
 // invocations of this function.
-func (f *LsifStoreDeleteUnreferencedDocumentsFunc) History() []LsifStoreDeleteUnreferencedDocumentsFuncCall {
+func (f *LSIFStoreDeleteUnreferencedDocumentsFunc) History() []LSIFStoreDeleteUnreferencedDocumentsFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreDeleteUnreferencedDocumentsFuncCall, len(f.history))
+	history := make([]LSIFStoreDeleteUnreferencedDocumentsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreDeleteUnreferencedDocumentsFuncCall is an object that describes
+// LSIFStoreDeleteUnreferencedDocumentsFuncCall is an object that describes
 // an invocation of method DeleteUnreferencedDocuments on an instance of
-// MockLsifStore.
-type LsifStoreDeleteUnreferencedDocumentsFuncCall struct {
+// MockLSIFStore.
+type LSIFStoreDeleteUnreferencedDocumentsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9122,146 +9282,45 @@ type LsifStoreDeleteUnreferencedDocumentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Args() []interface{} {
+func (c LSIFStoreDeleteUnreferencedDocumentsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Results() []interface{} {
+func (c LSIFStoreDeleteUnreferencedDocumentsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// LsifStoreDoneFunc describes the behavior when the Done method of the
-// parent MockLsifStore instance is invoked.
-type LsifStoreDoneFunc struct {
-	defaultHook func(error) error
-	hooks       []func(error) error
-	history     []LsifStoreDoneFuncCall
-	mutex       sync.Mutex
-}
-
-// Done delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockLsifStore) Done(v0 error) error {
-	r0 := m.DoneFunc.nextHook()(v0)
-	m.DoneFunc.appendCall(LsifStoreDoneFuncCall{v0, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Done method of the
-// parent MockLsifStore instance is invoked and the hook queue is empty.
-func (f *LsifStoreDoneFunc) SetDefaultHook(hook func(error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Done method of the parent MockLsifStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *LsifStoreDoneFunc) PushHook(hook func(error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreDoneFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreDoneFunc) PushReturn(r0 error) {
-	f.PushHook(func(error) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreDoneFunc) nextHook() func(error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreDoneFunc) appendCall(r0 LsifStoreDoneFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreDoneFuncCall objects describing
-// the invocations of this function.
-func (f *LsifStoreDoneFunc) History() []LsifStoreDoneFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreDoneFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreDoneFuncCall is an object that describes an invocation of method
-// Done on an instance of MockLsifStore.
-type LsifStoreDoneFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreIDsWithMetaFunc describes the behavior when the IDsWithMeta
-// method of the parent MockLsifStore instance is invoked.
-type LsifStoreIDsWithMetaFunc struct {
+// LSIFStoreIDsWithMetaFunc describes the behavior when the IDsWithMeta
+// method of the parent MockLSIFStore instance is invoked.
+type LSIFStoreIDsWithMetaFunc struct {
 	defaultHook func(context.Context, []int) ([]int, error)
 	hooks       []func(context.Context, []int) ([]int, error)
-	history     []LsifStoreIDsWithMetaFuncCall
+	history     []LSIFStoreIDsWithMetaFuncCall
 	mutex       sync.Mutex
 }
 
 // IDsWithMeta delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLsifStore) IDsWithMeta(v0 context.Context, v1 []int) ([]int, error) {
+func (m *MockLSIFStore) IDsWithMeta(v0 context.Context, v1 []int) ([]int, error) {
 	r0, r1 := m.IDsWithMetaFunc.nextHook()(v0, v1)
-	m.IDsWithMetaFunc.appendCall(LsifStoreIDsWithMetaFuncCall{v0, v1, r0, r1})
+	m.IDsWithMetaFunc.appendCall(LSIFStoreIDsWithMetaFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the IDsWithMeta method
-// of the parent MockLsifStore instance is invoked and the hook queue is
+// of the parent MockLSIFStore instance is invoked and the hook queue is
 // empty.
-func (f *LsifStoreIDsWithMetaFunc) SetDefaultHook(hook func(context.Context, []int) ([]int, error)) {
+func (f *LSIFStoreIDsWithMetaFunc) SetDefaultHook(hook func(context.Context, []int) ([]int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// IDsWithMeta method of the parent MockLsifStore instance invokes the hook
+// IDsWithMeta method of the parent MockLSIFStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *LsifStoreIDsWithMetaFunc) PushHook(hook func(context.Context, []int) ([]int, error)) {
+func (f *LSIFStoreIDsWithMetaFunc) PushHook(hook func(context.Context, []int) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9269,20 +9328,20 @@ func (f *LsifStoreIDsWithMetaFunc) PushHook(hook func(context.Context, []int) ([
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreIDsWithMetaFunc) SetDefaultReturn(r0 []int, r1 error) {
+func (f *LSIFStoreIDsWithMetaFunc) SetDefaultReturn(r0 []int, r1 error) {
 	f.SetDefaultHook(func(context.Context, []int) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreIDsWithMetaFunc) PushReturn(r0 []int, r1 error) {
+func (f *LSIFStoreIDsWithMetaFunc) PushReturn(r0 []int, r1 error) {
 	f.PushHook(func(context.Context, []int) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreIDsWithMetaFunc) nextHook() func(context.Context, []int) ([]int, error) {
+func (f *LSIFStoreIDsWithMetaFunc) nextHook() func(context.Context, []int) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9295,26 +9354,26 @@ func (f *LsifStoreIDsWithMetaFunc) nextHook() func(context.Context, []int) ([]in
 	return hook
 }
 
-func (f *LsifStoreIDsWithMetaFunc) appendCall(r0 LsifStoreIDsWithMetaFuncCall) {
+func (f *LSIFStoreIDsWithMetaFunc) appendCall(r0 LSIFStoreIDsWithMetaFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreIDsWithMetaFuncCall objects
+// History returns a sequence of LSIFStoreIDsWithMetaFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreIDsWithMetaFunc) History() []LsifStoreIDsWithMetaFuncCall {
+func (f *LSIFStoreIDsWithMetaFunc) History() []LSIFStoreIDsWithMetaFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreIDsWithMetaFuncCall, len(f.history))
+	history := make([]LSIFStoreIDsWithMetaFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreIDsWithMetaFuncCall is an object that describes an invocation of
-// method IDsWithMeta on an instance of MockLsifStore.
-type LsifStoreIDsWithMetaFuncCall struct {
+// LSIFStoreIDsWithMetaFuncCall is an object that describes an invocation of
+// method IDsWithMeta on an instance of MockLSIFStore.
+type LSIFStoreIDsWithMetaFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9331,48 +9390,48 @@ type LsifStoreIDsWithMetaFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
+func (c LSIFStoreIDsWithMetaFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
+func (c LSIFStoreIDsWithMetaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreInsertDefinitionsAndReferencesForDocumentFunc describes the
+// LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc describes the
 // behavior when the InsertDefinitionsAndReferencesForDocument method of the
-// parent MockLsifStore instance is invoked.
-type LsifStoreInsertDefinitionsAndReferencesForDocumentFunc struct {
+// parent MockLSIFStore instance is invoked.
+type LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc struct {
 	defaultHook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
 	hooks       []func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error
-	history     []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall
+	history     []LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertDefinitionsAndReferencesForDocument delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockLsifStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 shared1.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+func (m *MockLSIFStore) InsertDefinitionsAndReferencesForDocument(v0 context.Context, v1 shared1.ExportedUpload, v2 string, v3 int, v4 func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
 	r0 := m.InsertDefinitionsAndReferencesForDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
+	m.InsertDefinitionsAndReferencesForDocumentFunc.appendCall(LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // InsertDefinitionsAndReferencesForDocument method of the parent
-// MockLsifStore instance is invoked and the hook queue is empty.
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+// MockLSIFStore instance is invoked and the hook queue is empty.
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
 // InsertDefinitionsAndReferencesForDocument method of the parent
-// MockLsifStore instance invokes the hook at the front of the queue and
+// MockLSIFStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9380,20 +9439,20 @@ func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func(context.Context, shared1.ExportedUpload, string, int, func(ctx context.Context, upload shared1.ExportedUpload, rankingBatchSize int, rankingGraphKey string, path string, document *scip.Document) error) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9406,29 +9465,29 @@ func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) nextHook() func
 	return hook
 }
 
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) appendCall(r0 LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall objects
+// LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreInsertDefinitionsAndReferencesForDocumentFunc) History() []LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall {
+func (f *LSIFStoreInsertDefinitionsAndReferencesForDocumentFunc) History() []LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
+	history := make([]LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object
+// LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall is an object
 // that describes an invocation of method
 // InsertDefinitionsAndReferencesForDocument on an instance of
-// MockLsifStore.
-type LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
+// MockLSIFStore.
+type LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9451,45 +9510,45 @@ type LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
+func (c LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
+func (c LSIFStoreInsertDefinitionsAndReferencesForDocumentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LsifStoreInsertMetadataFunc describes the behavior when the
-// InsertMetadata method of the parent MockLsifStore instance is invoked.
-type LsifStoreInsertMetadataFunc struct {
+// LSIFStoreInsertMetadataFunc describes the behavior when the
+// InsertMetadata method of the parent MockLSIFStore instance is invoked.
+type LSIFStoreInsertMetadataFunc struct {
 	defaultHook func(context.Context, int, lsifstore.ProcessedMetadata) error
 	hooks       []func(context.Context, int, lsifstore.ProcessedMetadata) error
-	history     []LsifStoreInsertMetadataFuncCall
+	history     []LSIFStoreInsertMetadataFuncCall
 	mutex       sync.Mutex
 }
 
 // InsertMetadata delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockLsifStore) InsertMetadata(v0 context.Context, v1 int, v2 lsifstore.ProcessedMetadata) error {
+func (m *MockLSIFStore) InsertMetadata(v0 context.Context, v1 int, v2 lsifstore.ProcessedMetadata) error {
 	r0 := m.InsertMetadataFunc.nextHook()(v0, v1, v2)
-	m.InsertMetadataFunc.appendCall(LsifStoreInsertMetadataFuncCall{v0, v1, v2, r0})
+	m.InsertMetadataFunc.appendCall(LSIFStoreInsertMetadataFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the InsertMetadata
-// method of the parent MockLsifStore instance is invoked and the hook queue
+// method of the parent MockLSIFStore instance is invoked and the hook queue
 // is empty.
-func (f *LsifStoreInsertMetadataFunc) SetDefaultHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+func (f *LSIFStoreInsertMetadataFunc) SetDefaultHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertMetadata method of the parent MockLsifStore instance invokes the
+// InsertMetadata method of the parent MockLSIFStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreInsertMetadataFunc) PushHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+func (f *LSIFStoreInsertMetadataFunc) PushHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9497,20 +9556,20 @@ func (f *LsifStoreInsertMetadataFunc) PushHook(hook func(context.Context, int, l
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreInsertMetadataFunc) SetDefaultReturn(r0 error) {
+func (f *LSIFStoreInsertMetadataFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreInsertMetadataFunc) PushReturn(r0 error) {
+func (f *LSIFStoreInsertMetadataFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
 		return r0
 	})
 }
 
-func (f *LsifStoreInsertMetadataFunc) nextHook() func(context.Context, int, lsifstore.ProcessedMetadata) error {
+func (f *LSIFStoreInsertMetadataFunc) nextHook() func(context.Context, int, lsifstore.ProcessedMetadata) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9523,26 +9582,26 @@ func (f *LsifStoreInsertMetadataFunc) nextHook() func(context.Context, int, lsif
 	return hook
 }
 
-func (f *LsifStoreInsertMetadataFunc) appendCall(r0 LsifStoreInsertMetadataFuncCall) {
+func (f *LSIFStoreInsertMetadataFunc) appendCall(r0 LSIFStoreInsertMetadataFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreInsertMetadataFuncCall objects
+// History returns a sequence of LSIFStoreInsertMetadataFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreInsertMetadataFunc) History() []LsifStoreInsertMetadataFuncCall {
+func (f *LSIFStoreInsertMetadataFunc) History() []LSIFStoreInsertMetadataFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreInsertMetadataFuncCall, len(f.history))
+	history := make([]LSIFStoreInsertMetadataFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreInsertMetadataFuncCall is an object that describes an invocation
-// of method InsertMetadata on an instance of MockLsifStore.
-type LsifStoreInsertMetadataFuncCall struct {
+// LSIFStoreInsertMetadataFuncCall is an object that describes an invocation
+// of method InsertMetadata on an instance of MockLSIFStore.
+type LSIFStoreInsertMetadataFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9559,45 +9618,45 @@ type LsifStoreInsertMetadataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreInsertMetadataFuncCall) Args() []interface{} {
+func (c LSIFStoreInsertMetadataFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreInsertMetadataFuncCall) Results() []interface{} {
+func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LsifStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
-// method of the parent MockLsifStore instance is invoked.
-type LsifStoreNewSCIPWriterFunc struct {
+// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// method of the parent MockLSIFStore instance is invoked.
+type LSIFStoreNewSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
 	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
-	history     []LsifStoreNewSCIPWriterFuncCall
+	history     []LSIFStoreNewSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
 // NewSCIPWriter delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLsifStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+func (m *MockLSIFStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
 	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSCIPWriterFunc.appendCall(LsifStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
+	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the NewSCIPWriter method
-// of the parent MockLsifStore instance is invoked and the hook queue is
+// of the parent MockLSIFStore instance is invoked and the hook queue is
 // empty.
-func (f *LsifStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSCIPWriter method of the parent MockLsifStore instance invokes the
+// NewSCIPWriter method of the parent MockLSIFStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9605,20 +9664,20 @@ func (f *LsifStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (l
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9631,26 +9690,26 @@ func (f *LsifStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsif
 	return hook
 }
 
-func (f *LsifStoreNewSCIPWriterFunc) appendCall(r0 LsifStoreNewSCIPWriterFuncCall) {
+func (f *LSIFStoreNewSCIPWriterFunc) appendCall(r0 LSIFStoreNewSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreNewSCIPWriterFuncCall objects
+// History returns a sequence of LSIFStoreNewSCIPWriterFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreNewSCIPWriterFunc) History() []LsifStoreNewSCIPWriterFuncCall {
+func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreNewSCIPWriterFuncCall, len(f.history))
+	history := make([]LSIFStoreNewSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewSCIPWriter on an instance of MockLsifStore.
-type LsifStoreNewSCIPWriterFuncCall struct {
+// LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
+// of method NewSCIPWriter on an instance of MockLSIFStore.
+type LSIFStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9667,46 +9726,46 @@ type LsifStoreNewSCIPWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreNewSCIPWriterFuncCall) Args() []interface{} {
+func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreNewSCIPWriterFuncCall) Results() []interface{} {
+func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreReconcileCandidatesFunc describes the behavior when the
-// ReconcileCandidates method of the parent MockLsifStore instance is
+// LSIFStoreReconcileCandidatesFunc describes the behavior when the
+// ReconcileCandidates method of the parent MockLSIFStore instance is
 // invoked.
-type LsifStoreReconcileCandidatesFunc struct {
+type LSIFStoreReconcileCandidatesFunc struct {
 	defaultHook func(context.Context, int) ([]int, error)
 	hooks       []func(context.Context, int) ([]int, error)
-	history     []LsifStoreReconcileCandidatesFuncCall
+	history     []LSIFStoreReconcileCandidatesFuncCall
 	mutex       sync.Mutex
 }
 
 // ReconcileCandidates delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockLsifStore) ReconcileCandidates(v0 context.Context, v1 int) ([]int, error) {
+func (m *MockLSIFStore) ReconcileCandidates(v0 context.Context, v1 int) ([]int, error) {
 	r0, r1 := m.ReconcileCandidatesFunc.nextHook()(v0, v1)
-	m.ReconcileCandidatesFunc.appendCall(LsifStoreReconcileCandidatesFuncCall{v0, v1, r0, r1})
+	m.ReconcileCandidatesFunc.appendCall(LSIFStoreReconcileCandidatesFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the ReconcileCandidates
-// method of the parent MockLsifStore instance is invoked and the hook queue
+// method of the parent MockLSIFStore instance is invoked and the hook queue
 // is empty.
-func (f *LsifStoreReconcileCandidatesFunc) SetDefaultHook(hook func(context.Context, int) ([]int, error)) {
+func (f *LSIFStoreReconcileCandidatesFunc) SetDefaultHook(hook func(context.Context, int) ([]int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ReconcileCandidates method of the parent MockLsifStore instance invokes
+// ReconcileCandidates method of the parent MockLSIFStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *LsifStoreReconcileCandidatesFunc) PushHook(hook func(context.Context, int) ([]int, error)) {
+func (f *LSIFStoreReconcileCandidatesFunc) PushHook(hook func(context.Context, int) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9714,20 +9773,20 @@ func (f *LsifStoreReconcileCandidatesFunc) PushHook(hook func(context.Context, i
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreReconcileCandidatesFunc) SetDefaultReturn(r0 []int, r1 error) {
+func (f *LSIFStoreReconcileCandidatesFunc) SetDefaultReturn(r0 []int, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreReconcileCandidatesFunc) PushReturn(r0 []int, r1 error) {
+func (f *LSIFStoreReconcileCandidatesFunc) PushReturn(r0 []int, r1 error) {
 	f.PushHook(func(context.Context, int) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreReconcileCandidatesFunc) nextHook() func(context.Context, int) ([]int, error) {
+func (f *LSIFStoreReconcileCandidatesFunc) nextHook() func(context.Context, int) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9740,26 +9799,26 @@ func (f *LsifStoreReconcileCandidatesFunc) nextHook() func(context.Context, int)
 	return hook
 }
 
-func (f *LsifStoreReconcileCandidatesFunc) appendCall(r0 LsifStoreReconcileCandidatesFuncCall) {
+func (f *LSIFStoreReconcileCandidatesFunc) appendCall(r0 LSIFStoreReconcileCandidatesFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreReconcileCandidatesFuncCall
+// History returns a sequence of LSIFStoreReconcileCandidatesFuncCall
 // objects describing the invocations of this function.
-func (f *LsifStoreReconcileCandidatesFunc) History() []LsifStoreReconcileCandidatesFuncCall {
+func (f *LSIFStoreReconcileCandidatesFunc) History() []LSIFStoreReconcileCandidatesFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreReconcileCandidatesFuncCall, len(f.history))
+	history := make([]LSIFStoreReconcileCandidatesFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreReconcileCandidatesFuncCall is an object that describes an
-// invocation of method ReconcileCandidates on an instance of MockLsifStore.
-type LsifStoreReconcileCandidatesFuncCall struct {
+// LSIFStoreReconcileCandidatesFuncCall is an object that describes an
+// invocation of method ReconcileCandidates on an instance of MockLSIFStore.
+type LSIFStoreReconcileCandidatesFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9776,44 +9835,47 @@ type LsifStoreReconcileCandidatesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreReconcileCandidatesFuncCall) Args() []interface{} {
+func (c LSIFStoreReconcileCandidatesFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreReconcileCandidatesFuncCall) Results() []interface{} {
+func (c LSIFStoreReconcileCandidatesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreTransactFunc describes the behavior when the Transact method of
-// the parent MockLsifStore instance is invoked.
-type LsifStoreTransactFunc struct {
-	defaultHook func(context.Context) (lsifstore.LsifStore, error)
-	hooks       []func(context.Context) (lsifstore.LsifStore, error)
-	history     []LsifStoreTransactFuncCall
+// LSIFStoreReconcileCandidatesWithTimeFunc describes the behavior when the
+// ReconcileCandidatesWithTime method of the parent MockLSIFStore instance
+// is invoked.
+type LSIFStoreReconcileCandidatesWithTimeFunc struct {
+	defaultHook func(context.Context, int, time.Time) ([]int, error)
+	hooks       []func(context.Context, int, time.Time) ([]int, error)
+	history     []LSIFStoreReconcileCandidatesWithTimeFuncCall
 	mutex       sync.Mutex
 }
 
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockLsifStore) Transact(v0 context.Context) (lsifstore.LsifStore, error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(LsifStoreTransactFuncCall{v0, r0, r1})
+// ReconcileCandidatesWithTime delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) ReconcileCandidatesWithTime(v0 context.Context, v1 int, v2 time.Time) ([]int, error) {
+	r0, r1 := m.ReconcileCandidatesWithTimeFunc.nextHook()(v0, v1, v2)
+	m.ReconcileCandidatesWithTimeFunc.appendCall(LSIFStoreReconcileCandidatesWithTimeFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockLsifStore instance is invoked and the hook queue is empty.
-func (f *LsifStoreTransactFunc) SetDefaultHook(hook func(context.Context) (lsifstore.LsifStore, error)) {
+// SetDefaultHook sets function that is called when the
+// ReconcileCandidatesWithTime method of the parent MockLSIFStore instance
+// is invoked and the hook queue is empty.
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) SetDefaultHook(hook func(context.Context, int, time.Time) ([]int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockLsifStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *LsifStoreTransactFunc) PushHook(hook func(context.Context) (lsifstore.LsifStore, error)) {
+// ReconcileCandidatesWithTime method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) PushHook(hook func(context.Context, int, time.Time) ([]int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9821,20 +9883,20 @@ func (f *LsifStoreTransactFunc) PushHook(hook func(context.Context) (lsifstore.L
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreTransactFunc) SetDefaultReturn(r0 lsifstore.LsifStore, r1 error) {
-	f.SetDefaultHook(func(context.Context) (lsifstore.LsifStore, error) {
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) SetDefaultReturn(r0 []int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreTransactFunc) PushReturn(r0 lsifstore.LsifStore, r1 error) {
-	f.PushHook(func(context.Context) (lsifstore.LsifStore, error) {
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) PushReturn(r0 []int, r1 error) {
+	f.PushHook(func(context.Context, int, time.Time) ([]int, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreTransactFunc) nextHook() func(context.Context) (lsifstore.LsifStore, error) {
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) nextHook() func(context.Context, int, time.Time) ([]int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9847,304 +9909,145 @@ func (f *LsifStoreTransactFunc) nextHook() func(context.Context) (lsifstore.Lsif
 	return hook
 }
 
-func (f *LsifStoreTransactFunc) appendCall(r0 LsifStoreTransactFuncCall) {
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) appendCall(r0 LSIFStoreReconcileCandidatesWithTimeFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreTransactFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreTransactFunc) History() []LsifStoreTransactFuncCall {
+// History returns a sequence of
+// LSIFStoreReconcileCandidatesWithTimeFuncCall objects describing the
+// invocations of this function.
+func (f *LSIFStoreReconcileCandidatesWithTimeFunc) History() []LSIFStoreReconcileCandidatesWithTimeFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreTransactFuncCall, len(f.history))
+	history := make([]LSIFStoreReconcileCandidatesWithTimeFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreTransactFuncCall is an object that describes an invocation of
-// method Transact on an instance of MockLsifStore.
-type LsifStoreTransactFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 lsifstore.LsifStore
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// MockSCIPWriter is a mock implementation of the SCIPWriter interface (from
-// the package
-// github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore)
-// used for unit testing.
-type MockSCIPWriter struct {
-	// FlushFunc is an instance of a mock function object controlling the
-	// behavior of the method Flush.
-	FlushFunc *SCIPWriterFlushFunc
-	// InsertDocumentFunc is an instance of a mock function object
-	// controlling the behavior of the method InsertDocument.
-	InsertDocumentFunc *SCIPWriterInsertDocumentFunc
-}
-
-// NewMockSCIPWriter creates a new mock of the SCIPWriter interface. All
-// methods return zero values for all results, unless overwritten.
-func NewMockSCIPWriter() *MockSCIPWriter {
-	return &MockSCIPWriter{
-		FlushFunc: &SCIPWriterFlushFunc{
-			defaultHook: func(context.Context) (r0 uint32, r1 error) {
-				return
-			},
-		},
-		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
-			defaultHook: func(context.Context, string, *scip.Document) (r0 error) {
-				return
-			},
-		},
-	}
-}
-
-// NewStrictMockSCIPWriter creates a new mock of the SCIPWriter interface.
-// All methods panic on invocation, unless overwritten.
-func NewStrictMockSCIPWriter() *MockSCIPWriter {
-	return &MockSCIPWriter{
-		FlushFunc: &SCIPWriterFlushFunc{
-			defaultHook: func(context.Context) (uint32, error) {
-				panic("unexpected invocation of MockSCIPWriter.Flush")
-			},
-		},
-		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
-			defaultHook: func(context.Context, string, *scip.Document) error {
-				panic("unexpected invocation of MockSCIPWriter.InsertDocument")
-			},
-		},
-	}
-}
-
-// NewMockSCIPWriterFrom creates a new mock of the MockSCIPWriter interface.
-// All methods delegate to the given implementation, unless overwritten.
-func NewMockSCIPWriterFrom(i lsifstore.SCIPWriter) *MockSCIPWriter {
-	return &MockSCIPWriter{
-		FlushFunc: &SCIPWriterFlushFunc{
-			defaultHook: i.Flush,
-		},
-		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
-			defaultHook: i.InsertDocument,
-		},
-	}
-}
-
-// SCIPWriterFlushFunc describes the behavior when the Flush method of the
-// parent MockSCIPWriter instance is invoked.
-type SCIPWriterFlushFunc struct {
-	defaultHook func(context.Context) (uint32, error)
-	hooks       []func(context.Context) (uint32, error)
-	history     []SCIPWriterFlushFuncCall
-	mutex       sync.Mutex
-}
-
-// Flush delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockSCIPWriter) Flush(v0 context.Context) (uint32, error) {
-	r0, r1 := m.FlushFunc.nextHook()(v0)
-	m.FlushFunc.appendCall(SCIPWriterFlushFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the Flush method of the
-// parent MockSCIPWriter instance is invoked and the hook queue is empty.
-func (f *SCIPWriterFlushFunc) SetDefaultHook(hook func(context.Context) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Flush method of the parent MockSCIPWriter instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *SCIPWriterFlushFunc) PushHook(hook func(context.Context) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SCIPWriterFlushFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SCIPWriterFlushFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *SCIPWriterFlushFunc) nextHook() func(context.Context) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SCIPWriterFlushFunc) appendCall(r0 SCIPWriterFlushFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of SCIPWriterFlushFuncCall objects describing
-// the invocations of this function.
-func (f *SCIPWriterFlushFunc) History() []SCIPWriterFlushFuncCall {
-	f.mutex.Lock()
-	history := make([]SCIPWriterFlushFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SCIPWriterFlushFuncCall is an object that describes an invocation of
-// method Flush on an instance of MockSCIPWriter.
-type SCIPWriterFlushFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c SCIPWriterFlushFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c SCIPWriterFlushFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// SCIPWriterInsertDocumentFunc describes the behavior when the
-// InsertDocument method of the parent MockSCIPWriter instance is invoked.
-type SCIPWriterInsertDocumentFunc struct {
-	defaultHook func(context.Context, string, *scip.Document) error
-	hooks       []func(context.Context, string, *scip.Document) error
-	history     []SCIPWriterInsertDocumentFuncCall
-	mutex       sync.Mutex
-}
-
-// InsertDocument delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockSCIPWriter) InsertDocument(v0 context.Context, v1 string, v2 *scip.Document) error {
-	r0 := m.InsertDocumentFunc.nextHook()(v0, v1, v2)
-	m.InsertDocumentFunc.appendCall(SCIPWriterInsertDocumentFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the InsertDocument
-// method of the parent MockSCIPWriter instance is invoked and the hook
-// queue is empty.
-func (f *SCIPWriterInsertDocumentFunc) SetDefaultHook(hook func(context.Context, string, *scip.Document) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertDocument method of the parent MockSCIPWriter instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *SCIPWriterInsertDocumentFunc) PushHook(hook func(context.Context, string, *scip.Document) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *SCIPWriterInsertDocumentFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, string, *scip.Document) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *SCIPWriterInsertDocumentFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, string, *scip.Document) error {
-		return r0
-	})
-}
-
-func (f *SCIPWriterInsertDocumentFunc) nextHook() func(context.Context, string, *scip.Document) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *SCIPWriterInsertDocumentFunc) appendCall(r0 SCIPWriterInsertDocumentFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of SCIPWriterInsertDocumentFuncCall objects
-// describing the invocations of this function.
-func (f *SCIPWriterInsertDocumentFunc) History() []SCIPWriterInsertDocumentFuncCall {
-	f.mutex.Lock()
-	history := make([]SCIPWriterInsertDocumentFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// SCIPWriterInsertDocumentFuncCall is an object that describes an
-// invocation of method InsertDocument on an instance of MockSCIPWriter.
-type SCIPWriterInsertDocumentFuncCall struct {
+// LSIFStoreReconcileCandidatesWithTimeFuncCall is an object that describes
+// an invocation of method ReconcileCandidatesWithTime on an instance of
+// MockLSIFStore.
+type LSIFStoreReconcileCandidatesWithTimeFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 int
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 *scip.Document
+	Arg2 time.Time
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreReconcileCandidatesWithTimeFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreReconcileCandidatesWithTimeFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreWithTransactionFunc describes the behavior when the
+// WithTransaction method of the parent MockLSIFStore instance is invoked.
+type LSIFStoreWithTransactionFunc struct {
+	defaultHook func(context.Context, func(s lsifstore.Store) error) error
+	hooks       []func(context.Context, func(s lsifstore.Store) error) error
+	history     []LSIFStoreWithTransactionFuncCall
+	mutex       sync.Mutex
+}
+
+// WithTransaction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) WithTransaction(v0 context.Context, v1 func(s lsifstore.Store) error) error {
+	r0 := m.WithTransactionFunc.nextHook()(v0, v1)
+	m.WithTransactionFunc.appendCall(LSIFStoreWithTransactionFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WithTransaction
+// method of the parent MockLSIFStore instance is invoked and the hook queue
+// is empty.
+func (f *LSIFStoreWithTransactionFunc) SetDefaultHook(hook func(context.Context, func(s lsifstore.Store) error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WithTransaction method of the parent MockLSIFStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LSIFStoreWithTransactionFunc) PushHook(hook func(context.Context, func(s lsifstore.Store) error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFStoreWithTransactionFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(s lsifstore.Store) error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFStoreWithTransactionFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(s lsifstore.Store) error) error {
+		return r0
+	})
+}
+
+func (f *LSIFStoreWithTransactionFunc) nextHook() func(context.Context, func(s lsifstore.Store) error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreWithTransactionFunc) appendCall(r0 LSIFStoreWithTransactionFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreWithTransactionFuncCall objects
+// describing the invocations of this function.
+func (f *LSIFStoreWithTransactionFunc) History() []LSIFStoreWithTransactionFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreWithTransactionFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreWithTransactionFuncCall is an object that describes an
+// invocation of method WithTransaction on an instance of MockLSIFStore.
+type LSIFStoreWithTransactionFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(s lsifstore.Store) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -10152,13 +10055,13 @@ type SCIPWriterInsertDocumentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SCIPWriterInsertDocumentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWithTransactionFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SCIPWriterInsertDocumentFuncCall) Results() []interface{} {
+func (c LSIFStoreWithTransactionFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/store.go
@@ -12,9 +12,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-type LsifStore interface {
-	Transact(ctx context.Context) (LsifStore, error)
-	Done(err error) error
+type Store interface {
+	WithTransaction(ctx context.Context, f func(s Store) error) error
 
 	// Insert
 	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
@@ -23,6 +22,7 @@ type LsifStore interface {
 	// Reconciliation and cleanup
 	IDsWithMeta(ctx context.Context, ids []int) ([]int, error)
 	ReconcileCandidates(ctx context.Context, batchSize int) ([]int, error)
+	ReconcileCandidatesWithTime(ctx context.Context, batchSize int, now time.Time) (_ []int, err error)
 	DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error)
 	DeleteUnreferencedDocuments(ctx context.Context, batchSize int, maxAge time.Duration, now time.Time) (numScanned, numDeleted int, err error)
 
@@ -40,18 +40,26 @@ type store struct {
 	operations *operations
 }
 
-func New(observationCtx *observation.Context, db codeintelshared.CodeIntelDB) LsifStore {
-	return newStore(observationCtx, db)
+func New(observationCtx *observation.Context, db codeintelshared.CodeIntelDB) Store {
+	return newInternal(observationCtx, db)
 }
 
-func newStore(observationCtx *observation.Context, db codeintelshared.CodeIntelDB) *store {
+func newInternal(observationCtx *observation.Context, db codeintelshared.CodeIntelDB) *store {
 	return &store{
 		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationCtx),
 	}
 }
 
-func (s *store) Transact(ctx context.Context) (LsifStore, error) {
+func (s *store) WithTransaction(ctx context.Context, f func(s Store) error) error {
+	return s.withTransaction(ctx, func(s *store) error { return f(s) })
+}
+
+func (s *store) withTransaction(ctx context.Context, f func(s *store) error) error {
+	return basestore.InTransaction[*store](ctx, s, f)
+}
+
+func (s *store) Transact(ctx context.Context) (*store, error) {
 	tx, err := s.db.Transact(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codeintel/uploads/internal/store/summary.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/summary.go
@@ -281,7 +281,7 @@ ORDER BY u.root, u.indexer
 `
 
 func (s *store) RepositoryIDsWithErrors(ctx context.Context, offset, limit int) (_ []uploadsshared.RepositoryWithCount, totalCount int, err error) {
-	ctx, _, endObservation := s.operations.repositoryIDsWithErrors.With(ctx, &err, observation.Args{LogFields: []log.Field{}})
+	ctx, _, endObservation := s.operations.repositoryIDsWithErrors.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	return scanRepositoryWithCounts(s.db.Query(ctx, sqlf.Sprintf(repositoriesWithErrorsQuery, limit, offset)))
@@ -358,7 +358,7 @@ OFFSET %s
 `
 
 func (s *store) NumRepositoriesWithCodeIntelligence(ctx context.Context) (_ int, err error) {
-	ctx, _, endObservation := s.operations.numRepositoriesWithCodeIntelligence.With(ctx, &err, observation.Args{LogFields: []log.Field{}})
+	ctx, _, endObservation := s.operations.numRepositoriesWithCodeIntelligence.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	numRepositoriesWithCodeIntelligence, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(countRepositoriesQuery)))

--- a/enterprise/internal/codeintel/uploads/service.go
+++ b/enterprise/internal/codeintel/uploads/service.go
@@ -25,7 +25,7 @@ type Service struct {
 	store           store.Store
 	repoStore       RepoStore
 	workerutilStore dbworkerstore.Store[shared.Upload]
-	lsifstore       lsifstore.LsifStore
+	lsifstore       lsifstore.Store
 	gitserverClient gitserver.Client
 	rankingBucket   *storage.BucketHandle
 	policySvc       PolicyService
@@ -40,7 +40,7 @@ func newService(
 	observationCtx *observation.Context,
 	store store.Store,
 	repoStore RepoStore,
-	lsifstore lsifstore.LsifStore,
+	lsifstore lsifstore.Store,
 	gsc gitserver.Client,
 	rankingBucket *storage.BucketHandle,
 	policySvc PolicyService,

--- a/enterprise/internal/codeintel/uploads/transport/graphql/util_identifiers.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/util_identifiers.go
@@ -13,7 +13,7 @@ import (
 func unmarshalPreciseIndexGQLID(id graphql.ID) (uploadID, indexID int, err error) {
 	uploadID, indexID, err = unmarshalRawPreciseIndexGQLID(id)
 	if err == nil && uploadID == 0 && indexID == 0 {
-		err = errors.New("no payload")
+		err = errors.Newf("invalid precise index id %q", id)
 	}
 
 	return uploadID, indexID, errors.Wrap(err, "unexpected precise index ID")

--- a/enterprise/internal/codeintel/uploads/transport/http/handler_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/handler_test.go
@@ -46,8 +46,9 @@ func TestHandleEnqueueAuth(t *testing.T) {
 	})
 	t.Cleanup(func() { conf.Mock(nil) })
 
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx uploadhandler.DBStore[uploads.UploadMetadata]) error) error {
+		return f(mockDBStore)
+	})
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")

--- a/enterprise/internal/codeintel/uploads/transport/http/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/mocks_test.go
@@ -20,9 +20,6 @@ type MockDBStore[T interface{}] struct {
 	// AddUploadPartFunc is an instance of a mock function object
 	// controlling the behavior of the method AddUploadPart.
 	AddUploadPartFunc *DBStoreAddUploadPartFunc[T]
-	// DoneFunc is an instance of a mock function object controlling the
-	// behavior of the method Done.
-	DoneFunc *DBStoreDoneFunc[T]
 	// GetUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadByID.
 	GetUploadByIDFunc *DBStoreGetUploadByIDFunc[T]
@@ -35,9 +32,9 @@ type MockDBStore[T interface{}] struct {
 	// MarkQueuedFunc is an instance of a mock function object controlling
 	// the behavior of the method MarkQueued.
 	MarkQueuedFunc *DBStoreMarkQueuedFunc[T]
-	// TransactFunc is an instance of a mock function object controlling the
-	// behavior of the method Transact.
-	TransactFunc *DBStoreTransactFunc[T]
+	// WithTransactionFunc is an instance of a mock function object
+	// controlling the behavior of the method WithTransaction.
+	WithTransactionFunc *DBStoreWithTransactionFunc[T]
 }
 
 // NewMockDBStore creates a new mock of the DBStore interface. All methods
@@ -46,11 +43,6 @@ func NewMockDBStore[T interface{}]() *MockDBStore[T] {
 	return &MockDBStore[T]{
 		AddUploadPartFunc: &DBStoreAddUploadPartFunc[T]{
 			defaultHook: func(context.Context, int, int) (r0 error) {
-				return
-			},
-		},
-		DoneFunc: &DBStoreDoneFunc[T]{
-			defaultHook: func(error) (r0 error) {
 				return
 			},
 		},
@@ -74,8 +66,8 @@ func NewMockDBStore[T interface{}]() *MockDBStore[T] {
 				return
 			},
 		},
-		TransactFunc: &DBStoreTransactFunc[T]{
-			defaultHook: func(context.Context) (r0 uploadhandler.DBStore[T], r1 error) {
+		WithTransactionFunc: &DBStoreWithTransactionFunc[T]{
+			defaultHook: func(context.Context, func(tx uploadhandler.DBStore[T]) error) (r0 error) {
 				return
 			},
 		},
@@ -89,11 +81,6 @@ func NewStrictMockDBStore[T interface{}]() *MockDBStore[T] {
 		AddUploadPartFunc: &DBStoreAddUploadPartFunc[T]{
 			defaultHook: func(context.Context, int, int) error {
 				panic("unexpected invocation of MockDBStore.AddUploadPart")
-			},
-		},
-		DoneFunc: &DBStoreDoneFunc[T]{
-			defaultHook: func(error) error {
-				panic("unexpected invocation of MockDBStore.Done")
 			},
 		},
 		GetUploadByIDFunc: &DBStoreGetUploadByIDFunc[T]{
@@ -116,9 +103,9 @@ func NewStrictMockDBStore[T interface{}]() *MockDBStore[T] {
 				panic("unexpected invocation of MockDBStore.MarkQueued")
 			},
 		},
-		TransactFunc: &DBStoreTransactFunc[T]{
-			defaultHook: func(context.Context) (uploadhandler.DBStore[T], error) {
-				panic("unexpected invocation of MockDBStore.Transact")
+		WithTransactionFunc: &DBStoreWithTransactionFunc[T]{
+			defaultHook: func(context.Context, func(tx uploadhandler.DBStore[T]) error) error {
+				panic("unexpected invocation of MockDBStore.WithTransaction")
 			},
 		},
 	}
@@ -130,9 +117,6 @@ func NewMockDBStoreFrom[T interface{}](i uploadhandler.DBStore[T]) *MockDBStore[
 	return &MockDBStore[T]{
 		AddUploadPartFunc: &DBStoreAddUploadPartFunc[T]{
 			defaultHook: i.AddUploadPart,
-		},
-		DoneFunc: &DBStoreDoneFunc[T]{
-			defaultHook: i.Done,
 		},
 		GetUploadByIDFunc: &DBStoreGetUploadByIDFunc[T]{
 			defaultHook: i.GetUploadByID,
@@ -146,8 +130,8 @@ func NewMockDBStoreFrom[T interface{}](i uploadhandler.DBStore[T]) *MockDBStore[
 		MarkQueuedFunc: &DBStoreMarkQueuedFunc[T]{
 			defaultHook: i.MarkQueued,
 		},
-		TransactFunc: &DBStoreTransactFunc[T]{
-			defaultHook: i.Transact,
+		WithTransactionFunc: &DBStoreWithTransactionFunc[T]{
+			defaultHook: i.WithTransaction,
 		},
 	}
 }
@@ -257,107 +241,6 @@ func (c DBStoreAddUploadPartFuncCall[T]) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBStoreAddUploadPartFuncCall[T]) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// DBStoreDoneFunc describes the behavior when the Done method of the parent
-// MockDBStore instance is invoked.
-type DBStoreDoneFunc[T interface{}] struct {
-	defaultHook func(error) error
-	hooks       []func(error) error
-	history     []DBStoreDoneFuncCall[T]
-	mutex       sync.Mutex
-}
-
-// Done delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockDBStore[T]) Done(v0 error) error {
-	r0 := m.DoneFunc.nextHook()(v0)
-	m.DoneFunc.appendCall(DBStoreDoneFuncCall[T]{v0, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Done method of the
-// parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreDoneFunc[T]) SetDefaultHook(hook func(error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Done method of the parent MockDBStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *DBStoreDoneFunc[T]) PushHook(hook func(error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *DBStoreDoneFunc[T]) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreDoneFunc[T]) PushReturn(r0 error) {
-	f.PushHook(func(error) error {
-		return r0
-	})
-}
-
-func (f *DBStoreDoneFunc[T]) nextHook() func(error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *DBStoreDoneFunc[T]) appendCall(r0 DBStoreDoneFuncCall[T]) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of DBStoreDoneFuncCall objects describing the
-// invocations of this function.
-func (f *DBStoreDoneFunc[T]) History() []DBStoreDoneFuncCall[T] {
-	f.mutex.Lock()
-	history := make([]DBStoreDoneFuncCall[T], len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// DBStoreDoneFuncCall is an object that describes an invocation of method
-// Done on an instance of MockDBStore.
-type DBStoreDoneFuncCall[T interface{}] struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c DBStoreDoneFuncCall[T]) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c DBStoreDoneFuncCall[T]) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -794,34 +677,35 @@ func (c DBStoreMarkQueuedFuncCall[T]) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// DBStoreTransactFunc describes the behavior when the Transact method of
-// the parent MockDBStore instance is invoked.
-type DBStoreTransactFunc[T interface{}] struct {
-	defaultHook func(context.Context) (uploadhandler.DBStore[T], error)
-	hooks       []func(context.Context) (uploadhandler.DBStore[T], error)
-	history     []DBStoreTransactFuncCall[T]
+// DBStoreWithTransactionFunc describes the behavior when the
+// WithTransaction method of the parent MockDBStore instance is invoked.
+type DBStoreWithTransactionFunc[T interface{}] struct {
+	defaultHook func(context.Context, func(tx uploadhandler.DBStore[T]) error) error
+	hooks       []func(context.Context, func(tx uploadhandler.DBStore[T]) error) error
+	history     []DBStoreWithTransactionFuncCall[T]
 	mutex       sync.Mutex
 }
 
-// Transact delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockDBStore[T]) Transact(v0 context.Context) (uploadhandler.DBStore[T], error) {
-	r0, r1 := m.TransactFunc.nextHook()(v0)
-	m.TransactFunc.appendCall(DBStoreTransactFuncCall[T]{v0, r0, r1})
-	return r0, r1
+// WithTransaction delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDBStore[T]) WithTransaction(v0 context.Context, v1 func(tx uploadhandler.DBStore[T]) error) error {
+	r0 := m.WithTransactionFunc.nextHook()(v0, v1)
+	m.WithTransactionFunc.appendCall(DBStoreWithTransactionFuncCall[T]{v0, v1, r0})
+	return r0
 }
 
-// SetDefaultHook sets function that is called when the Transact method of
-// the parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreTransactFunc[T]) SetDefaultHook(hook func(context.Context) (uploadhandler.DBStore[T], error)) {
+// SetDefaultHook sets function that is called when the WithTransaction
+// method of the parent MockDBStore instance is invoked and the hook queue
+// is empty.
+func (f *DBStoreWithTransactionFunc[T]) SetDefaultHook(hook func(context.Context, func(tx uploadhandler.DBStore[T]) error) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// Transact method of the parent MockDBStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *DBStoreTransactFunc[T]) PushHook(hook func(context.Context) (uploadhandler.DBStore[T], error)) {
+// WithTransaction method of the parent MockDBStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBStoreWithTransactionFunc[T]) PushHook(hook func(context.Context, func(tx uploadhandler.DBStore[T]) error) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -829,20 +713,20 @@ func (f *DBStoreTransactFunc[T]) PushHook(hook func(context.Context) (uploadhand
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreTransactFunc[T]) SetDefaultReturn(r0 uploadhandler.DBStore[T], r1 error) {
-	f.SetDefaultHook(func(context.Context) (uploadhandler.DBStore[T], error) {
-		return r0, r1
+func (f *DBStoreWithTransactionFunc[T]) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, func(tx uploadhandler.DBStore[T]) error) error {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreTransactFunc[T]) PushReturn(r0 uploadhandler.DBStore[T], r1 error) {
-	f.PushHook(func(context.Context) (uploadhandler.DBStore[T], error) {
-		return r0, r1
+func (f *DBStoreWithTransactionFunc[T]) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, func(tx uploadhandler.DBStore[T]) error) error {
+		return r0
 	})
 }
 
-func (f *DBStoreTransactFunc[T]) nextHook() func(context.Context) (uploadhandler.DBStore[T], error) {
+func (f *DBStoreWithTransactionFunc[T]) nextHook() func(context.Context, func(tx uploadhandler.DBStore[T]) error) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -855,45 +739,45 @@ func (f *DBStoreTransactFunc[T]) nextHook() func(context.Context) (uploadhandler
 	return hook
 }
 
-func (f *DBStoreTransactFunc[T]) appendCall(r0 DBStoreTransactFuncCall[T]) {
+func (f *DBStoreWithTransactionFunc[T]) appendCall(r0 DBStoreWithTransactionFuncCall[T]) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of DBStoreTransactFuncCall objects describing
-// the invocations of this function.
-func (f *DBStoreTransactFunc[T]) History() []DBStoreTransactFuncCall[T] {
+// History returns a sequence of DBStoreWithTransactionFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreWithTransactionFunc[T]) History() []DBStoreWithTransactionFuncCall[T] {
 	f.mutex.Lock()
-	history := make([]DBStoreTransactFuncCall[T], len(f.history))
+	history := make([]DBStoreWithTransactionFuncCall[T], len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// DBStoreTransactFuncCall is an object that describes an invocation of
-// method Transact on an instance of MockDBStore.
-type DBStoreTransactFuncCall[T interface{}] struct {
+// DBStoreWithTransactionFuncCall is an object that describes an invocation
+// of method WithTransaction on an instance of MockDBStore.
+type DBStoreWithTransactionFuncCall[T interface{}] struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 func(tx uploadhandler.DBStore[T]) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 uploadhandler.DBStore[T]
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
+	Result0 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreTransactFuncCall[T]) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreWithTransactionFuncCall[T]) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreTransactFuncCall[T]) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreWithTransactionFuncCall[T]) Results() []interface{} {
+	return []interface{}{c.Result0}
 }

--- a/enterprise/internal/codeintel/uploads/upload_handler.go
+++ b/enterprise/internal/codeintel/uploads/upload_handler.go
@@ -27,7 +27,7 @@ func (s *Service) UploadHandlerStore() uploadhandler.DBStore[UploadMetadata] {
 }
 
 func (s *uploadHandlerShim) WithTransaction(ctx context.Context, f func(tx uploadhandler.DBStore[UploadMetadata]) error) error {
-	return nil
+	return s.Store.WithTransaction(ctx, func(tx store.Store) error { return f(&uploadHandlerShim{tx}) })
 }
 
 func (s *uploadHandlerShim) InsertUpload(ctx context.Context, upload uploadhandler.Upload[UploadMetadata]) (int, error) {

--- a/enterprise/internal/codeintel/uploads/upload_handler.go
+++ b/enterprise/internal/codeintel/uploads/upload_handler.go
@@ -26,13 +26,8 @@ func (s *Service) UploadHandlerStore() uploadhandler.DBStore[UploadMetadata] {
 	return &uploadHandlerShim{s.store}
 }
 
-func (s *uploadHandlerShim) Transact(ctx context.Context) (uploadhandler.DBStore[UploadMetadata], error) {
-	tx, err := s.Store.Transact(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &uploadHandlerShim{tx}, nil
+func (s *uploadHandlerShim) WithTransaction(ctx context.Context, f func(tx uploadhandler.DBStore[UploadMetadata]) error) error {
+	return nil
 }
 
 func (s *uploadHandlerShim) InsertUpload(ctx context.Context, upload uploadhandler.Upload[UploadMetadata]) (int, error) {

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -37,6 +37,18 @@ type TransactableHandle interface {
 	Done(error) error
 }
 
+// Transactable marks an interface that returns a type that returns a transactable
+// store that is polymorphic on a generic type. The type `TransactableHandle` is a
+// related type, but is stricter in that returns a hard-coded interface type, not
+// the type of the implementor.
+//
+// Many stores return their *self* as the return for Transaction.
+// See the `InTransaction` function for a concrete use-case.
+type Transactable[T any] interface {
+	Transact(context.Context) (T, error)
+	Done(error) error
+}
+
 var (
 	_ TransactableHandle = (*dbHandle)(nil)
 	_ TransactableHandle = (*txHandle)(nil)

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -139,13 +139,13 @@ var ErrPanicDuringTransaction = errors.New("encountered panic during transaction
 
 // WithTransact executes the callback using a transaction on the store. If the callback
 // returns an error or panics, the transaction will be rolled back.
-func (s *Store) WithTransact(ctx context.Context, f func(tx *Store) error) (err error) {
+func (s *Store) WithTransact(ctx context.Context, f func(tx *Store) error) error {
 	return InTransaction[*Store](ctx, s, f)
 }
 
 // InTransaction executes the callback using a transaction on the given transactable store. If
 // the callback returns an error or panics, the transaction will be rolled back.
-func InTransaction[T Transactable[T]](ctx context.Context, t Transactable[T], f func(tx T) error) error {
+func InTransaction[T Transactable[T]](ctx context.Context, t Transactable[T], f func(tx T) error) (err error) {
 	tx, err := t.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -140,7 +140,13 @@ var ErrPanicDuringTransaction = errors.New("encountered panic during transaction
 // WithTransact executes the callback using a transaction on the store. If the callback
 // returns an error or panics, the transaction will be rolled back.
 func (s *Store) WithTransact(ctx context.Context, f func(tx *Store) error) (err error) {
-	tx, err := s.Transact(ctx)
+	return InTransaction[*Store](ctx, s, f)
+}
+
+// InTransaction executes the callback using a transaction on the given transactable store. If
+// the callback returns an error or panics, the transaction will be rolled back.
+func InTransaction[T Transactable[T]](ctx context.Context, t Transactable[T], f func(tx T) error) error {
+	tx, err := t.Transact(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/uploadhandler/iface.go
+++ b/internal/uploadhandler/iface.go
@@ -15,8 +15,7 @@ type Upload[T any] struct {
 }
 
 type DBStore[T any] interface {
-	Transact(ctx context.Context) (DBStore[T], error)
-	Done(err error) error
+	WithTransaction(ctx context.Context, f func(tx DBStore[T]) error) error
 
 	GetUploadByID(ctx context.Context, uploadID int) (Upload[T], bool, error)
 	InsertUpload(ctx context.Context, upload Upload[T]) (int, error)

--- a/internal/uploadhandler/upload_handler_test.go
+++ b/internal/uploadhandler/upload_handler_test.go
@@ -41,8 +41,7 @@ func TestHandleEnqueueSinglePayload(t *testing.T) {
 	mockDBStore := NewMockDBStore[testUploadMetadata]()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx DBStore[testUploadMetadata]) error) error { return f(mockDBStore) })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")
@@ -123,8 +122,7 @@ func TestHandleEnqueueSinglePayloadNoIndexerName(t *testing.T) {
 	mockDBStore := NewMockDBStore[testUploadMetadata]()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx DBStore[testUploadMetadata]) error) error { return f(mockDBStore) })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")
@@ -186,8 +184,7 @@ func TestHandleEnqueueMultipartSetup(t *testing.T) {
 	mockDBStore := NewMockDBStore[testUploadMetadata]()
 	mockUploadStore := uploadstoremocks.NewMockStore()
 
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx DBStore[testUploadMetadata]) error) error { return f(mockDBStore) })
 	mockDBStore.InsertUploadFunc.SetDefaultReturn(42, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")
@@ -253,8 +250,7 @@ func TestHandleEnqueueMultipartUpload(t *testing.T) {
 		UploadedParts: []int{0, 1, 2, 3, 4},
 	}
 
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx DBStore[testUploadMetadata]) error) error { return f(mockDBStore) })
 	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(upload, true, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")
@@ -325,8 +321,7 @@ func TestHandleEnqueueMultipartFinalize(t *testing.T) {
 		NumParts:      5,
 		UploadedParts: []int{0, 1, 2, 3, 4},
 	}
-	mockDBStore.TransactFunc.SetDefaultReturn(mockDBStore, nil)
-	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
+	mockDBStore.WithTransactionFunc.SetDefaultHook(func(ctx context.Context, f func(tx DBStore[testUploadMetadata]) error) error { return f(mockDBStore) })
 	mockDBStore.GetUploadByIDFunc.SetDefaultReturn(upload, true, nil)
 
 	testURL, err := url.Parse("http://test.com/upload")

--- a/mockgen.test.yaml
+++ b/mockgen.test.yaml
@@ -195,7 +195,8 @@
         - RepoStore
     - path: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore
       interfaces:
-        - LSIFStore
+        - Store
+      prefix: LSIF
     - path: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads
       interfaces:
         - PolicyService
@@ -218,8 +219,9 @@
         - RepoStore
     - path: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore
       interfaces:
-        - LSIFStore
+        - Store
         - SCIPWriter
+      prefix: LSIF
     - path: github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store
       interfaces:
         - Store


### PR DESCRIPTION
This is a clean-up pass of the code intel stores (over all domains). This is a "higher-level" clean-up as opposed to optimizing specific queries.

No behaviors should change and no code should change ownership here. Some additional utilities have been added in basestore to help simplify the transaction story. Notes have been left in-comments as follow-up ideas for a lower-level cleanup pass.

Notable changes:
- Rearranged some blocks
- Reformatted some queries
- Reworked transaction machinery (see basestore first)
- Ensured things are consistently observed

## Test plan

Existing tests and pipelines.