### PR TITLE
Don't run old puppeteer jobs if bazel is enabled

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -24,7 +24,7 @@ The default run type.
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Build && Test
   - **Linters and static analysis**: Run sg lint
-  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
   - Client PR preview
   - Upload build trace
@@ -33,7 +33,7 @@ The default run type.
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Build && Test
   - **Linters and static analysis**: GraphQL lint
-  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Puppeteer tests chunk #11, Puppeteer tests chunk #12, Puppeteer tests chunk #13, Puppeteer tests chunk #14, Puppeteer tests chunk #15, Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - Upload build trace
 
 - Pipeline for `DatabaseSchema` changes:

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -69,7 +69,8 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 		if opts.ForceBazel {
 			// If there are any Graphql changes, they are impacting the client as well.
 			clientChecks = operations.NewNamedSet("Client checks",
-				clientIntegrationTests,
+				// clientIntegrationTests is now covered by Bazel
+				// clientIntegrationTests,
 				clientChromaticTests(opts),
 				// frontendTests is now covered by Bazel
 				// frontendTests,                // ~4.5m


### PR DESCRIPTION
This PR removes puppeteer tests from PRs who're running with Bazel enabled (so all of them, unless you're passing `[no-bazel]` in the commit description. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 