### PR TITLE
syntax-highlighter: load all tree-sitter highlight configurations at startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,5 +72,6 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cody.codebase": "github.com/sourcegraph/sourcegraph"
+  "cody.codebase": "github.com/sourcegraph/sourcegraph",
+  "rust-analyzer.linkedProjects": ["docker-images/syntax-highlighter/Cargo.toml"]
 }

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "rustyline",
  "scip",
  "scip-treesitter",
+ "scip-treesitter-languages",
  "serde",
  "serde_json",
  "sg-syntax",

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -20,7 +20,7 @@ rustyline = "9.1.2"
 
 sg-syntax = { path = "./crates/sg-syntax" }
 scip-treesitter = { path = "./crates/scip-treesitter" }
-
+scip-treesitter-languages = { path = "./crates/scip-treesitter-languages" }
 # March 20, 2023 - Pinned explicitly with features that match the features
 # required by rocket. Once bazel rules correctly roll up all the features,
 # we can remove this, but until then, this works just fine for building

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-languages/src/highlights.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-languages/src/highlights.rs
@@ -138,7 +138,7 @@ macro_rules! create_configurations {
 }
 
 lazy_static::lazy_static! {
-    static ref CONFIGURATIONS: HashMap<BundledParser, HighlightConfiguration> = {
+    pub static ref CONFIGURATIONS: HashMap<BundledParser, HighlightConfiguration> = {
         // NOTE: typescript/tsx crates are included, even though not listed below.
 
         // You can add any new crate::parsers::Parser variants here.

--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -50,6 +50,12 @@ fn not_found() -> JsonValue {
 
 #[launch]
 fn rocket() -> _ {
+    // load configurations on-startup instead of on-first-request.
+    // TODO: load individual languages lazily on-request instead, currently
+    // CONFIGURATIONS.get will load every configured configuration together.
+    scip_treesitter_languages::highlights::CONFIGURATIONS
+        .get(&scip_treesitter_languages::parsers::BundledParser::Go);
+
     // Only list features if QUIET != "true"
     match std::env::var("QUIET") {
         Ok(v) if v == "true" => {}


### PR DESCRIPTION
See comment in main.rs for more details

## Test plan

I LOOKED at the flamegraphs (x-axis is NOT time)

new: 
![image](https://user-images.githubusercontent.com/18282288/230134585-c139e88f-b0bf-49dc-9393-a64d0d99c84b.png)

old:
![image](https://user-images.githubusercontent.com/18282288/230144027-5e653cb7-73ba-4a5a-8036-f14e813a4e28.png)
