### PR TITLE
feat(licensing): add 'mau' tag to MiscTags list

### DIFF
--- a/enterprise/internal/licensing/tags.go
+++ b/enterprise/internal/licensing/tags.go
@@ -73,4 +73,5 @@ var MiscTags = []string{
 	"dev",
 	TrueUpUserCountTag,
 	"starter",
+	"mau",
 }


### PR DESCRIPTION
This PR:
- adds `mau` to the MiscTags to make it valid on the license generation UI

See [slack thread](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1680116761152899)

## Test plan
- `sg start dotcom`
- Go to site admin / subscriptions / generate new license
- Add `mau` to the tags and make sure it is not highlighted as invalid

## Screenshots
| Before | After |
| --: | :-- |
| <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230151990-6dee71a5-9cce-4c8f-b308-3991365fa887.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/230151896-885522f9-6ccc-4df0-bef0-cc7246814dfe.png"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
