### PR TITLE
bazel: add mocha retries

### DIFF
--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -57,6 +57,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, **kwargs)
             "$(location //:mocha_config)",
             "--parallel",
             "--jobs 16",
+            "--retries 4",
             "$(location :%s)/**/*.test.js" % bundle_name,
         ] + args,
         data = data + [


### PR DESCRIPTION
## Context

Automatically retry failed mocha tests in Bazel. [The CLI options doc](https://mochajs.org/#command-line-usage).

## Test plan

CI
