### PR TITLE
ci: skip bazel build //... before bazel test //...

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -16,13 +16,13 @@ The default run type.
 
 - Pipeline for `Go` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Client` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
@@ -31,82 +31,82 @@ The default run type.
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: GraphQL lint
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - Upload build trace
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **DB backcompat tests**: Backcompat test (all), Backcompat test (all (gRPC)), Backcompat test (enterprise/internal/insights), Backcompat test (enterprise/internal/insights (gRPC)), Backcompat test (internal/repos), Backcompat test (internal/repos (gRPC)), Backcompat test (enterprise/internal/batches), Backcompat test (enterprise/internal/batches (gRPC)), Backcompat test (cmd/frontend), Backcompat test (cmd/frontend (gRPC)), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers), Backcompat test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Backcompat test (dev/sg), Backcompat test (dev/sg (gRPC)), Backcompat test (internal/database), Backcompat test (enterprise/internal/database)
   - Upload build trace
 
 - Pipeline for `Docs` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Dockerfiles` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `ExecutorVMImage` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - Upload build trace
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - Upload build trace
 
 - Pipeline for `CIScripts` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **CI script tests**: test-trace-command.sh
   - Upload build trace
 
 - Pipeline for `Terraform` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - Upload build trace
 
 - Pipeline for `SVG` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `Shell` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
 - Pipeline for `DockerImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Test builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build blobstore, Build blobstore2, Build node-exporter, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build prometheus-gcp, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build executor, Build executor-vm, Build batcheshelper, Build opentelemetry-collector, Build embeddings, Build dind, Build bundled-executor, Build server, Build sg
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan embeddings, Scan dind, Scan bundled-executor, Scan sg
   - Upload build trace
 
 - Pipeline for `WolfiPackages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - Upload build trace
 
 - Pipeline for `WolfiBaseImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - Upload build trace
 
 - Pipeline for `Protobuf` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Build && Test
+  - **Bazel**: Ensure buildfiles are up to date, Tests
   - **Linters and static analysis**: Run sg lint
   - Upload build trace
 
@@ -122,7 +122,7 @@ sg ci build bzl
 Base pipeline (more steps might be included based on branch changes):
 
 - **Metadata**: Pipeline metadata
-- **Bazel**: Ensure buildfiles are up to date, Build && Test
+- **Bazel**: Ensure buildfiles are up to date, Tests
 - Upload build trace
 
 ### Wolfi Exp Branch

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -13,7 +13,7 @@ const bazelRemoteCacheURL = "https://storage.googleapis.com/sourcegraph_bazel_ca
 func BazelOperations(optional bool) *operations.Set {
 	ops := operations.NewNamedSet("Bazel")
 	ops.Append(bazelConfigure(optional))
-	ops.Append(bazelBuildAndTest(optional, "//..."))
+	ops.Append(bazelTest(optional, "//..."))
 	return ops
 }
 
@@ -140,6 +140,7 @@ func bazelBuildAndTest(optional bool, targets ...string) func(*bk.Pipeline) {
 func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
+		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
 	}
 

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -144,7 +144,7 @@ func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 		bk.Agent("queue", "bazel"),
 	}
 
-	bazelRawCmd := bazelRawCmd("test %s", strings.Join(targets, " "))
+	bazelRawCmd := bazelRawCmd(fmt.Sprintf("test %s", strings.Join(targets, " ")))
 	cmds = append(cmds, bk.RawCmd(bazelRawCmd))
 
 	return func(pipeline *bk.Pipeline) {


### PR DESCRIPTION
It is safe to only run `bazel test //...` in CI instead of `bazel build //...` followed by `bazel test //...`. Bazel will implicitly build any targets needed for testing as part of the bazel test command. Running the explicit bazel build //... first does not provide any benefits and only adds build time to the CI cycle. 

Bazel builds have two phases:
1. The analysis phase, where Bazel determines which targets need to be built/rebuilt based on changes.
2. The execution phase, where the actual building and testing happens. When you run `bazel test //...`, Bazel will do a full analysis of the codebase and determine which tests need to be built and run based on what's changed. It will then build any dependencies of those tests on the fly during the execution phase, as needed to actually run the tests. So a full `bazel build //...` is not needed beforehand - Bazel is smart enough to figure out what needs to be built for the testing to be done. By only running `bazel test //...`, we save the time of rebuilding the entire codebase, and only build what's needed to run the tests that are affected by changes. Therefore, we simplify our CI builds to only a single `bazel test //...` step. 

This will make our CI builds faster and simpler, while still ensuring thorough test coverage of changes.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 