### PR TITLE
codeintel: Add stub context service

### DIFF
--- a/enterprise/internal/codeintel/BUILD.bazel
+++ b/enterprise/internal/codeintel/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/internal/codeintel/autoindexing",
         "//enterprise/internal/codeintel/codenav",
+        "//enterprise/internal/codeintel/context",
         "//enterprise/internal/codeintel/dependencies",
         "//enterprise/internal/codeintel/policies",
         "//enterprise/internal/codeintel/ranking",

--- a/enterprise/internal/codeintel/context/BUILD.bazel
+++ b/enterprise/internal/codeintel/context/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "context",
+    srcs = [
+        "config.go",
+        "iface.go",
+        "init.go",
+        "observability.go",
+        "service.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/context",
+    visibility = ["//enterprise:__subpackages__"],
+    deps = [
+        "//enterprise/internal/codeintel/context/internal/store",
+        "//internal/database",
+        "//internal/env",
+        "//internal/metrics",
+        "//internal/observation",
+    ],
+)
+
+go_test(
+    name = "context_test",
+    srcs = ["service_test.go"],
+    embed = [":context"],
+)

--- a/enterprise/internal/codeintel/context/config.go
+++ b/enterprise/internal/codeintel/context/config.go
@@ -1,0 +1,15 @@
+package context
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type config struct {
+	env.BaseConfig
+}
+
+var ConfigInst = &config{}
+
+func (c *config) Load() {
+	// TODO
+}

--- a/enterprise/internal/codeintel/context/iface.go
+++ b/enterprise/internal/codeintel/context/iface.go
@@ -1,0 +1,1 @@
+package context

--- a/enterprise/internal/codeintel/context/init.go
+++ b/enterprise/internal/codeintel/context/init.go
@@ -1,0 +1,23 @@
+package context
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/context/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func NewService(
+	observationCtx *observation.Context,
+	db database.DB,
+) *Service {
+	store := store.New(scopedContext("store", observationCtx), db)
+
+	return newService(
+		observationCtx,
+		store,
+	)
+}
+
+func scopedContext(component string, parent *observation.Context) *observation.Context {
+	return observation.ScopedContext("codeintel", "context", component, parent)
+}

--- a/enterprise/internal/codeintel/context/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/context/internal/store/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "store",
+    srcs = [
+        "observability.go",
+        "store.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/context/internal/store",
+    visibility = ["//enterprise:__subpackages__"],
+    deps = [
+        "//internal/database",
+        "//internal/database/basestore",
+        "//internal/metrics",
+        "//internal/observation",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "store_test",
+    srcs = ["store_test.go"],
+    embed = [":store"],
+)

--- a/enterprise/internal/codeintel/context/internal/store/observability.go
+++ b/enterprise/internal/codeintel/context/internal/store/observability.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	x *observation.Operation
+}
+
+var m = new(metrics.SingletonREDMetrics)
+
+func newOperations(observationCtx *observation.Context) *operations {
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationCtx.Registerer,
+			"codeintel_context_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
+
+	op := func(name string) *observation.Operation {
+		return observationCtx.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.context.store.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           m,
+		})
+	}
+
+	return &operations{
+		x: op("X"),
+	}
+}

--- a/enterprise/internal/codeintel/context/internal/store/store.go
+++ b/enterprise/internal/codeintel/context/internal/store/store.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	logger "github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Store interface {
+	// TODO
+}
+
+type store struct {
+	db         *basestore.Store
+	logger     logger.Logger
+	operations *operations
+}
+
+func New(observationCtx *observation.Context, db database.DB) Store {
+	return &store{
+		db:         basestore.NewWithHandle(db.Handle()),
+		logger:     logger.Scoped("context.store", ""),
+		operations: newOperations(observationCtx),
+	}
+}

--- a/enterprise/internal/codeintel/context/internal/store/store_test.go
+++ b/enterprise/internal/codeintel/context/internal/store/store_test.go
@@ -1,0 +1,3 @@
+package store
+
+// TODO

--- a/enterprise/internal/codeintel/context/observability.go
+++ b/enterprise/internal/codeintel/context/observability.go
@@ -1,0 +1,37 @@
+package context
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	x *observation.Operation
+}
+
+var m = new(metrics.SingletonREDMetrics)
+
+func newOperations(observationCtx *observation.Context) *operations {
+	redMetrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationCtx.Registerer,
+			"codeintel_context",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
+
+	op := func(name string) *observation.Operation {
+		return observationCtx.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.context.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           redMetrics,
+		})
+	}
+
+	return &operations{
+		x: op("X"),
+	}
+}

--- a/enterprise/internal/codeintel/context/service.go
+++ b/enterprise/internal/codeintel/context/service.go
@@ -1,0 +1,21 @@
+package context
+
+import (
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/context/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Service struct {
+	store      store.Store
+	operations *operations
+}
+
+func newService(
+	observationCtx *observation.Context,
+	store store.Store,
+) *Service {
+	return &Service{
+		store:      store,
+		operations: newOperations(observationCtx),
+	}
+}

--- a/enterprise/internal/codeintel/context/service_test.go
+++ b/enterprise/internal/codeintel/context/service_test.go
@@ -1,0 +1,3 @@
+package context
+
+// TODO

--- a/enterprise/internal/codeintel/services.go
+++ b/enterprise/internal/codeintel/services.go
@@ -3,6 +3,7 @@ package codeintel
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/context"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/ranking"
@@ -23,6 +24,7 @@ type Services struct {
 	RankingService      *ranking.Service
 	UploadsService      *uploads.Service
 	SentinelService     *sentinel.Service
+	ContextService      *context.Service
 	GitserverClient     gitserver.Client
 }
 
@@ -43,6 +45,7 @@ func NewServices(deps ServiceDependencies) (Services, error) {
 	codenavSvc := codenav.NewService(deps.ObservationCtx, db, codeIntelDB, uploadsSvc, gitserverClient)
 	rankingSvc := ranking.NewService(deps.ObservationCtx, db, codeIntelDB)
 	sentinelService := sentinel.NewService(deps.ObservationCtx, db)
+	contextService := context.NewService(deps.ObservationCtx, db)
 
 	return Services{
 		AutoIndexingService: autoIndexingSvc,
@@ -52,6 +55,7 @@ func NewServices(deps ServiceDependencies) (Services, error) {
 		RankingService:      rankingSvc,
 		UploadsService:      uploadsSvc,
 		SentinelService:     sentinelService,
+		ContextService:      contextService,
 		GitserverClient:     gitserverClient,
 	}, nil
 }


### PR DESCRIPTION
Adds a stub context package for [supplying precise context to Cody](https://docs.google.com/document/d/1b4nLWa8pc74xC3MmtZjVQhE1nXe_xWyWmwF-aoumeVw/edit).

## Test plan

N/A.