### PR TITLE
cody: Sketch `cody-api` pipelines

### DIFF
--- a/dev/cody-test-client/BUILD.bazel
+++ b/dev/cody-test-client/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "cody-test-client_lib",
+    srcs = [
+        "capabilities.go",
+        "config.go",
+        "main.go",
+        "pipeline.go",
+        "reader.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/cody-test-client",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//lib/errors",
+        "@org_golang_x_net//websocket",
+    ],
+)
+
+go_binary(
+    name = "cody-test-client",
+    embed = [":cody-test-client_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/dev/cody-test-client/capabilities.go
+++ b/dev/cody-test-client/capabilities.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type capability func(payload string) (string, bool, error)
+
+func newCapabilities(read readerFunc) map[string]capability {
+	return map[string]capability{
+		"respond": func(payload string) (string, bool, error) {
+			fmt.Printf("Response: %s\n", payload)
+			return "", false, nil
+		},
+		"error": func(payload string) (string, bool, error) {
+			return "", false, errors.New(payload)
+		},
+		"clarify": func(payload string) (string, bool, error) {
+			return read(fmt.Sprintf("%s: ", payload)), true, nil
+		},
+
+		//
+		"chat-input": func(payload string) (string, bool, error) {
+			return read(fmt.Sprintf("%s: ", payload)), true, nil
+		},
+	}
+}

--- a/dev/cody-test-client/config.go
+++ b/dev/cody-test-client/config.go
@@ -1,0 +1,9 @@
+package main
+
+import "golang.org/x/net/websocket"
+
+var (
+	origin = "http://localhost/"
+	addr   = "ws://localhost:4100/pipeline"
+	codec  = websocket.JSON
+)

--- a/dev/cody-test-client/main.go
+++ b/dev/cody-test-client/main.go
@@ -1,0 +1,21 @@
+package main
+
+import "fmt"
+
+func main() {
+	read := newStdinReader()
+	capabilities := newCapabilities(read)
+
+	for {
+		name := read("Select a pipeline: ")
+		if name == "" || name == "exit" || name == "quit" {
+			break
+		}
+
+		if err := runPipeline(name, capabilities); err != nil {
+			fmt.Printf("An error occurred: %s\n", err)
+		}
+
+		fmt.Printf("\n")
+	}
+}

--- a/dev/cody-test-client/pipeline.go
+++ b/dev/cody-test-client/pipeline.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"golang.org/x/net/websocket"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func runPipeline(name string, capabilities map[string]capability) error {
+	ws, err := websocket.Dial(addr, "", origin)
+	if err != nil {
+		return err
+	}
+	defer ws.Close()
+
+	if err := codec.Send(ws, name); err != nil {
+		return err
+	}
+
+	for {
+		var value struct {
+			Type    string `json:"type"`
+			Payload string `json:"payload"`
+		}
+		if err := codec.Receive(ws, &value); err != nil {
+			return err
+		}
+
+		capability, ok := capabilities[value.Type]
+		if !ok {
+			return errors.Newf("unknown capability %q", value.Type)
+		}
+
+		output, ok, err := capability(value.Payload)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			break
+		}
+
+		if err := codec.Send(ws, output); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/dev/cody-test-client/reader.go
+++ b/dev/cody-test-client/reader.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type readerFunc func(prompt string) string
+
+func newStdinReader() readerFunc {
+	reader := bufio.NewReader(os.Stdin)
+
+	return func(prompt string) string {
+		fmt.Print(prompt)
+		input, _ := reader.ReadString('\n')
+		return strings.TrimSpace(input)
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/BUILD.bazel
+++ b/enterprise/cmd/cody-api/internal/pipeline/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pipeline",
+    srcs = [
+        "handler.go",
+        "iface.go",
+        "libs.go",
+        "pipeline.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline",
+    visibility = ["//enterprise/cmd/cody-api:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/cody-api/internal/pipeline/libs",
+        "//enterprise/cmd/cody-api/internal/pipeline/lua",
+        "//internal/luasandbox",
+        "//internal/luasandbox/util",
+        "//internal/memo",
+        "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
+        "@com_github_yuin_gopher_lua//:gopher-lua",
+        "@org_golang_x_net//websocket",
+    ],
+)

--- a/enterprise/cmd/cody-api/internal/pipeline/handler.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/handler.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+	"golang.org/x/net/websocket"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// NewPipelineHandler is an http handler which streams back pipeline results.
+func NewPipelineHandler(logger log.Logger) http.Handler {
+	return websocket.Handler(func(ws *websocket.Conn) {
+		ctx, cancel := context.WithCancel(ws.Request().Context())
+		defer cancel()
+
+		if err := newPipelineHandler(ws).handle(ctx); err != nil {
+			logger.Error("failed to handle pipeline", log.Error(err))
+		}
+	})
+}
+
+type pipelineHandler struct {
+	ws    *websocket.Conn
+	codec websocket.Codec
+}
+
+func newPipelineHandler(ws *websocket.Conn) *pipelineHandler {
+	return &pipelineHandler{
+		ws:    ws,
+		codec: websocket.JSON,
+	}
+}
+
+func (h *pipelineHandler) handle(ctx context.Context) error {
+	var name string
+	if err := h.recv(&name); err != nil {
+		return err
+	}
+
+	output, err := newPipeline(name, h.performCapability).Run(ctx)
+	if err != nil {
+		return h.send("error", err.Error())
+	}
+
+	return h.send("respond", output)
+}
+
+func (h *pipelineHandler) performCapability(ctx context.Context, capability string, payload any) (output any, _ error) {
+	if err := h.send(capability, payload); err != nil {
+		return "", errors.Newf("failed to send %q request to client", capability)
+	}
+
+	err := h.recv(&output)
+	return output, err
+}
+
+func (h *pipelineHandler) recv(value any) error {
+	return h.codec.Receive(h.ws, &value)
+}
+
+func (h *pipelineHandler) send(responseType string, payload any) error {
+	return h.codec.Send(h.ws, struct {
+		Type    string `json:"type"`
+		Payload any    `json:"payload"`
+	}{
+		Type:    responseType,
+		Payload: payload,
+	})
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/iface.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/iface.go
@@ -1,0 +1,11 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
+)
+
+type SandboxService interface {
+	CreateSandbox(ctx context.Context, opts luasandbox.CreateOptions) (*luasandbox.Sandbox, error)
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs.go
@@ -1,0 +1,66 @@
+package pipeline
+
+import (
+	golua "github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline/libs"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+	"github.com/sourcegraph/sourcegraph/internal/memo"
+)
+
+var defaultAPIs = map[string]luasandbox.LuaLib{
+	"embeddings": libs.Embeddings,
+	"git":        libs.Git,
+	"keywords":   libs.Keywords,
+	"llm":        libs.LLM,
+	"log":        libs.Log,
+	"time":       libs.Time,
+}
+
+var defaultModules = memo.NewMemoizedConstructor(func() (map[string]lua.LGFunction, error) {
+	defaultModules, err := luasandbox.DefaultGoModules.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	modules := make(map[string]lua.LGFunction, len(defaultModules)+len(defaultAPIs))
+	for name, module := range defaultModules {
+		modules[name] = module
+	}
+	for name, api := range defaultAPIs {
+		modules[name] = util.CreateModule(api.LuaAPI())
+	}
+
+	return modules, nil
+})
+
+func makeModules(performCapability libs.CapabilityPerformer) (map[string]golua.LGFunction, error) {
+	defaultModules, err := defaultModules.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	requestModules := map[string]golua.LGFunction{
+		"user": util.CreateModule(libs.User.LuaAPI(performCapability)),
+	}
+
+	return combineMaps(defaultModules, requestModules), nil
+}
+
+func combineMaps[K comparable, V any](ms ...map[K]V) map[K]V {
+	n := 0
+	for _, m := range ms {
+		n += len(m)
+	}
+
+	m := make(map[K]V, n)
+	for _, s := range ms {
+		for k, v := range s {
+			m[k] = v
+		}
+	}
+
+	return m
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/BUILD.bazel
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "libs",
+    srcs = [
+        "embeddings.go",
+        "git.go",
+        "keywords.go",
+        "llm.go",
+        "log.go",
+        "time.go",
+        "user.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline/libs",
+    visibility = ["//enterprise/cmd/cody-api:__subpackages__"],
+    deps = [
+        "//internal/api",
+        "//internal/authz",
+        "//internal/gitserver",
+        "//internal/luasandbox/util",
+        "@com_github_yuin_gopher_lua//:gopher-lua",
+        "@com_layeh_gopher_luar//:gopher-luar",
+    ],
+)

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/embeddings.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/embeddings.go
@@ -1,0 +1,24 @@
+package libs
+
+import (
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var Embeddings = embeddingsAPI{}
+
+type embeddingsAPI struct{}
+
+func (embeddingsAPI) LuaAPI() map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"search": util.WrapLuaFunction(func(state *lua.LState) error {
+			if true {
+				panic("EMBEDDINGS SEARCH UNIMPL")
+			}
+
+			// TODO
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/git.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/git.go
@@ -1,0 +1,34 @@
+package libs
+
+import (
+	lua "github.com/yuin/gopher-lua"
+	luar "layeh.com/gopher-luar"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var Git = gitAPI{}
+
+type gitAPI struct{}
+
+func (gitAPI) LuaAPI() map[string]lua.LGFunction {
+	var (
+		client       = gitserver.NewClient()
+		authzChecker = authz.DefaultSubRepoPermsChecker
+	)
+
+	return map[string]lua.LGFunction{
+		"head": util.WrapLuaFunction(func(state *lua.LState) error {
+			head, _, err := client.Head(state.Context(), authzChecker, api.RepoName(state.CheckString(1)))
+			if err != nil {
+				return err
+			}
+
+			state.Push(luar.New(state, head))
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/keywords.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/keywords.go
@@ -1,0 +1,24 @@
+package libs
+
+import (
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var Keywords = keywordsAPI{}
+
+type keywordsAPI struct{}
+
+func (keywordsAPI) LuaAPI() map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"search": util.WrapLuaFunction(func(state *lua.LState) error {
+			if true {
+				panic("KEYWORD SEARCH UNIMPL")
+			}
+
+			// TODO
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/llm.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/llm.go
@@ -1,0 +1,26 @@
+package libs
+
+import (
+	lua "github.com/yuin/gopher-lua"
+	luar "layeh.com/gopher-luar"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var LLM = llmAPI{}
+
+type llmAPI struct{}
+
+func (llmAPI) LuaAPI() map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"run": util.WrapLuaFunction(func(state *lua.LState) error {
+			if false {
+				panic("RUN UNIMPL")
+			}
+
+			// TODO
+			state.Push(luar.New(state, "Henlo, yes this is Claob."))
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/log.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/log.go
@@ -1,0 +1,22 @@
+package libs
+
+import (
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var Log = logAPI{}
+
+type logAPI struct{}
+
+func (logAPI) LuaAPI() map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"log": util.WrapLuaFunction(func(state *lua.LState) error {
+			fmt.Printf("LOG: %v\n", state.CheckAny(1))
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/time.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/time.go
@@ -1,0 +1,25 @@
+package libs
+
+import (
+	"fmt"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+	luar "layeh.com/gopher-luar"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var Time = timeAPI{}
+
+type timeAPI struct{}
+
+func (timeAPI) LuaAPI() map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"shortTimestamp": util.WrapLuaFunction(func(state *lua.LState) error {
+			now := time.Now()
+			state.Push(luar.New(state, fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute())))
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/libs/user.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/libs/user.go
@@ -1,0 +1,32 @@
+package libs
+
+import (
+	"context"
+
+	lua "github.com/yuin/gopher-lua"
+	luar "layeh.com/gopher-luar"
+
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+var User = userAPI{}
+
+type userAPI struct{}
+
+type CapabilityPerformer func(ctx context.Context, capability string, data any) (any, error)
+
+func (userAPI) LuaAPI(performCapability CapabilityPerformer) map[string]lua.LGFunction {
+	return map[string]lua.LGFunction{
+		"perform": util.WrapLuaFunction(func(state *lua.LState) error {
+			ctx := state.Context()
+
+			resp, err := performCapability(ctx, state.CheckString(1), state.CheckString(2))
+			if err != nil {
+				return err
+			}
+
+			state.Push(luar.New(state, resp))
+			return nil
+		}),
+	}
+}

--- a/enterprise/cmd/cody-api/internal/pipeline/lua/BUILD.bazel
+++ b/enterprise/cmd/cody-api/internal/pipeline/lua/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "lua",
+    srcs = ["embed.go"],
+    embedsrcs = [
+        "embed.go",
+        "BUILD.bazel",
+        "context.lua",
+        "pipelines/chat.lua",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline/lua",
+    visibility = ["//enterprise/cmd/cody-api:__subpackages__"],
+)

--- a/enterprise/cmd/cody-api/internal/pipeline/lua/context.lua
+++ b/enterprise/cmd/cody-api/internal/pipeline/lua/context.lua
@@ -1,0 +1,30 @@
+-- TODO
+local llm = require("llm")
+local embeddings = require("embeddings")
+local keywords = require("keywords")
+
+local contextType = 'embeddings' -- 'keyword' 'none' 'blended'
+
+local M = {}
+
+local embeddingsContextMessages = function(query, numCodeResults, numTextResults)
+    -- TODO - group and map
+    return embeddings.search(query, numCodeResults, numTextResults)
+end
+
+local keywordContextMessages = function(query)
+    -- TODO - group and map
+    return keywords.search(query)
+end
+
+M.contextMessages = function(query)
+    if contextType == 'embeddings' or (contextType == 'blended' and embeddings.available()) then
+        return embeddingsContextMessages(query, 12, 3)
+    elseif contextType == 'keyword' or (contextType == 'blended' and not embeddings.available()) then
+        return keywordContextMessages(query)
+    else
+        return {}
+    end
+end
+
+return M

--- a/enterprise/cmd/cody-api/internal/pipeline/lua/embed.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/lua/embed.go
@@ -1,0 +1,6 @@
+package lua
+
+import "embed"
+
+//go:embed **
+var Scripts embed.FS

--- a/enterprise/cmd/cody-api/internal/pipeline/lua/pipelines/chat.lua
+++ b/enterprise/cmd/cody-api/internal/pipeline/lua/pipelines/chat.lua
@@ -1,0 +1,105 @@
+-- Go libs
+local log = require("log")
+local time = require("time")
+local user = require("user")
+local llm = require("llm")
+local embeddings = require("embeddings")
+
+-- Lua libs
+local context = require("sg.cody.context")
+
+local MAX_HUMAN_INPUT_TOKENS = 1000
+local MAX_CURRENT_FILE_TOKENS = 1000
+local CHARS_PER_TOKEN = 4
+
+local truncateText = function(text, numTokens)
+    return string.sub(text, 0, numTokens * CHARS_PER_TOKEN)
+end
+
+local editorContext = function()
+    -- TODO
+    if true then
+        return {}
+    end
+
+    local fileName = 'TODO'
+    local contents = "TODO"
+    local language = "TODO" -- path.extname(filePath).slice(1)
+
+    return {{
+        speaker = 'human',
+        text = "I have the `" .. filePath .. "` file opened in my editor. You are able to answer questions about `" ..
+            filePath .. "`. The following code snippet is from the currently open file in my editor `" .. filePath ..
+            "`:\n" .. "```" .. language .. "\n" .. contents .. "\n```",
+        fileName = filename
+    }, {
+        speaker = 'assistant',
+        text = "You currently have `" .. filePath ..
+            "` open in your editor, and I can answer questions about that file's contents."
+    }}
+end
+
+-- TODO
+local intent = {}
+intent.isCodebaseContextRequired = function(text)
+    return false
+end
+intent.isEditorContextRequired = function(text)
+    return false
+end
+
+local contextMessages = function(text)
+    local messages = {}
+
+    if intent.isCodebaseContextRequired(text) then
+        for _, value in context.contextMessages(text, {
+            numCodeResults = 12,
+            numTextResults = 3
+        }) do
+            table.insert(messages, value)
+        end
+    end
+
+    if intent.isCodebaseContextRequired(text) or intent.isEditorContextRequired(text) then
+        table.insert(messages, editorContext())
+    end
+
+    return messages
+end
+
+local M = {}
+
+M.capabilities = {"chat-input"}
+M.setup = function()
+    local timestamp = time.shortTimestamp()
+
+    -- "chat-input", "At " .. timestamp
+
+    return {
+        timestamp = timestamp
+    }
+end
+
+M.run = function(ctx)
+    -- TODO - get at input
+    local text = user.perform("chat-input", "At " .. ctx.timestamp)
+    local truncatedText = truncateText(text, MAX_HUMAN_INPUT_TOKENS)
+
+    local chatContext = {{
+        speaker = "human",
+        text = truncatedText,
+        timestamp = ctx.timestamp
+    }, {
+        speaker = "assistant",
+        text = "",
+        timestamp = ctx.timestamp
+    }}
+
+    for _, message in pairs(contextMessages(truncatedText)) do
+        table.insert(chatContext, message)
+    end
+
+    return llm.run(chatContext)
+end
+
+return M

--- a/enterprise/cmd/cody-api/internal/pipeline/pipeline.go
+++ b/enterprise/cmd/cody-api/internal/pipeline/pipeline.go
@@ -1,0 +1,120 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	golua "github.com/yuin/gopher-lua"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline/libs"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline/lua"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
+)
+
+type Pipeline struct {
+	name              string
+	performCapability libs.CapabilityPerformer
+	sandboxService    SandboxService
+}
+
+func newPipeline(name string, performCapability libs.CapabilityPerformer) *Pipeline {
+	return &Pipeline{
+		name:              name,
+		performCapability: performCapability,
+		sandboxService:    luasandbox.NewService(),
+	}
+}
+
+func (p *Pipeline) Run(ctx context.Context) (string, error) {
+	sandbox, err := p.createSandbox(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer sandbox.Close()
+
+	return p.runWithSandbox(ctx, sandbox, luasandbox.RunOptions{
+		Timeout: time.Minute,
+	})
+}
+
+func (p *Pipeline) createSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err error) {
+	modules, err := makeModules(p.performCapability)
+	if err != nil {
+		return nil, err
+	}
+	luaModules, err := luasandbox.LuaModulesFromFS(lua.Scripts, ".", "sg.cody")
+	if err != nil {
+		return nil, err
+	}
+	opts := luasandbox.CreateOptions{
+		GoModules:  modules,
+		LuaModules: luaModules,
+	}
+	sandbox, err := p.sandboxService.CreateSandbox(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return sandbox, nil
+}
+
+func (p *Pipeline) runWithSandbox(ctx context.Context, sandbox *luasandbox.Sandbox, opts luasandbox.RunOptions) (string, error) {
+	rawPipeline, err := sandbox.RunScriptNamed(ctx, opts, lua.Scripts, filepath.Join(
+		"pipelines",
+		fmt.Sprintf("%s.lua", p.name),
+	))
+	if err != nil {
+		return "", err
+	}
+	tablePipeline, ok := rawPipeline.(*golua.LTable)
+	if !ok {
+		return "", util.NewTypeError("table", rawPipeline)
+	}
+	pipeline, err := pipelineFromTable(tablePipeline)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO - capability negotiation
+	// fmt.Printf("LOOKING FOR CAPABILITIES %v\n", pipeline.capabilities)
+
+	rawContext, err := sandbox.Call(ctx, opts, pipeline.setup)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO - bulk-fill context
+
+	value, err := sandbox.Call(ctx, opts, pipeline.run, rawContext)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", value), nil
+}
+
+//
+//
+
+type luaPipeline struct {
+	capabilities []string
+	setup        *golua.LFunction
+	run          *golua.LFunction
+}
+
+func pipelineFromTable(table *golua.LTable) (*luaPipeline, error) {
+	pipeline := &luaPipeline{}
+
+	if err := util.DecodeTable(table, map[string]func(golua.LValue) error{
+		"capabilities": util.SetStrings(&pipeline.capabilities),
+		"setup":        util.SetLuaFunction(&pipeline.setup),
+		"run":          util.SetLuaFunction(&pipeline.run),
+	}); err != nil {
+		return nil, err
+	}
+
+	return pipeline, nil
+}

--- a/enterprise/cmd/cody-api/shared/BUILD.bazel
+++ b/enterprise/cmd/cody-api/shared/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/shared",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/cmd/cody-api/internal/pipeline",
         "//enterprise/cmd/cody-api/internal/streaming",
         "//internal/actor",
         "//internal/conf",

--- a/enterprise/cmd/cody-api/shared/server.go
+++ b/enterprise/cmd/cody-api/shared/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/pipeline"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-api/internal/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -53,6 +54,7 @@ func makeHandler(logger log.Logger) http.Handler {
 	mux.Handle("/healthz", handleHealthCheck(logger))
 	mux.Handle("/completions/final", streaming.NewCompletionsFinalHandler(logger))
 	mux.Handle("/completions/stream", streaming.NewCompletionsStreamHandler(logger))
+	mux.Handle("/pipeline", pipeline.NewPipelineHandler(logger))
 
 	return mux
 }


### PR DESCRIPTION
Implements [the cody-api service](https://docs.google.com/document/d/12MZE6j3EsBq0z1tR9MI2b7DN1PUbKkOKBNdz75YuZe8). Run a local instance via `sg start cody-api` and run `go run ./dev/cody-test-client` in another terminal to get a REPL-like PoC client. Enter the name of a pipeline to see a full completion flow.

Pipelines are implemented as Lua files in the `enterprise/cmd/cody-api/internal/pipeline/lua/pipelines` directory.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
