### PR TITLE
Conditionally render cody for repo sidebar web

### DIFF
--- a/client/web/src/repo/repoRevisionSidebar/cody/RepoRevisionSidebarCody.tsx
+++ b/client/web/src/repo/repoRevisionSidebar/cody/RepoRevisionSidebarCody.tsx
@@ -7,11 +7,14 @@ import { FileLinkProps } from '@sourcegraph/cody-ui/src/chat/ContextFiles'
 import { Terms } from '@sourcegraph/cody-ui/src/Terms'
 import { SubmitSvg } from '@sourcegraph/cody-ui/src/utils/icons'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
+import { useQuery } from '@sourcegraph/http-client'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { TextArea as WildcardTextArea } from '@sourcegraph/wildcard'
+import { Text, TextArea as WildcardTextArea, ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { Scalars } from '../../../graphql-operations'
+import { Scalars, RepoEmbeddingExistsQueryResult, RepoEmbeddingExistsQueryVariables } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
+
+import { REPO_EMBEDDING_EXISTS_QUERY } from './backend'
 
 import styles from './RepoRevisionSidebarCody.module.scss'
 
@@ -62,6 +65,27 @@ export const RepoRevisionSidebarCody: React.FunctionComponent<
         },
         [activePath, client, repoName]
     )
+
+    const { data, loading, error } = useQuery<RepoEmbeddingExistsQueryResult, RepoEmbeddingExistsQueryVariables>(
+        REPO_EMBEDDING_EXISTS_QUERY,
+        { variables: { repoName } }
+    )
+
+    if (!client || loading) {
+        return <LoadingSpinner />
+    }
+
+    if (error) {
+        return <ErrorAlert error={error} />
+    }
+
+    if (isErrorLike(client)) {
+        return <ErrorAlert error={client} />
+    }
+
+    if (!data?.repository?.embeddingExists) {
+        return <Text>Repo embeddings not generated.</Text>
+    }
 
     return (
         <Chat

--- a/client/web/src/repo/repoRevisionSidebar/cody/backend.tsx
+++ b/client/web/src/repo/repoRevisionSidebar/cody/backend.tsx
@@ -1,0 +1,10 @@
+import { gql } from '@sourcegraph/http-client'
+
+export const REPO_EMBEDDING_EXISTS_QUERY = gql`
+    query RepoEmbeddingExistsQuery($repoName: String!) {
+        repository(name: $repoName) {
+            id
+            embeddingExists
+        }
+    }
+`

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
@@ -85,6 +86,14 @@ func (r *RepositoryResolver) ID() graphql.ID {
 
 func (r *RepositoryResolver) IDInt32() api.RepoID {
 	return r.RepoMatch.ID
+}
+
+func (r *RepositoryResolver) EmbeddingExists(ctx context.Context) (bool, error) {
+	if !conf.EmbeddingsEnabled() {
+		return false, nil
+	}
+
+	return r.db.Repos().RepoEmbeddingExists(ctx, r.IDInt32())
 }
 
 func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3649,6 +3649,11 @@ type Repository implements Node & GenericSearchResultInterface {
     The size of repo when cloned on disk
     """
     diskSizeBytes: BigInt
+
+    """
+    Returns true if embeddings for the repo are generated.
+    """
+    embeddingExists: Boolean!
 }
 
 """

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -41718,6 +41718,9 @@ type MockRepoStore struct {
 	// QueryFunc is an instance of a mock function object controlling the
 	// behavior of the method Query.
 	QueryFunc *RepoStoreQueryFunc
+	// RepoEmbeddingExistsFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoEmbeddingExists.
+	RepoEmbeddingExistsFunc *RepoStoreRepoEmbeddingExistsFunc
 	// StreamMinimalReposFunc is an instance of a mock function object
 	// controlling the behavior of the method StreamMinimalRepos.
 	StreamMinimalReposFunc *RepoStoreStreamMinimalReposFunc
@@ -41820,6 +41823,11 @@ func NewMockRepoStore() *MockRepoStore {
 		},
 		QueryFunc: &RepoStoreQueryFunc{
 			defaultHook: func(context.Context, *sqlf.Query) (r0 *sql.Rows, r1 error) {
+				return
+			},
+		},
+		RepoEmbeddingExistsFunc: &RepoStoreRepoEmbeddingExistsFunc{
+			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -41935,6 +41943,11 @@ func NewStrictMockRepoStore() *MockRepoStore {
 				panic("unexpected invocation of MockRepoStore.Query")
 			},
 		},
+		RepoEmbeddingExistsFunc: &RepoStoreRepoEmbeddingExistsFunc{
+			defaultHook: func(context.Context, api.RepoID) (bool, error) {
+				panic("unexpected invocation of MockRepoStore.RepoEmbeddingExists")
+			},
+		},
 		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
 			defaultHook: func(context.Context, ReposListOptions, func(*types.MinimalRepo)) error {
 				panic("unexpected invocation of MockRepoStore.StreamMinimalRepos")
@@ -42010,6 +42023,9 @@ func NewMockRepoStoreFrom(i RepoStore) *MockRepoStore {
 		},
 		QueryFunc: &RepoStoreQueryFunc{
 			defaultHook: i.Query,
+		},
+		RepoEmbeddingExistsFunc: &RepoStoreRepoEmbeddingExistsFunc{
+			defaultHook: i.RepoEmbeddingExists,
 		},
 		StreamMinimalReposFunc: &RepoStoreStreamMinimalReposFunc{
 			defaultHook: i.StreamMinimalRepos,
@@ -43988,6 +44004,115 @@ func (c RepoStoreQueryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RepoStoreQueryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// RepoStoreRepoEmbeddingExistsFunc describes the behavior when the
+// RepoEmbeddingExists method of the parent MockRepoStore instance is
+// invoked.
+type RepoStoreRepoEmbeddingExistsFunc struct {
+	defaultHook func(context.Context, api.RepoID) (bool, error)
+	hooks       []func(context.Context, api.RepoID) (bool, error)
+	history     []RepoStoreRepoEmbeddingExistsFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoEmbeddingExists delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockRepoStore) RepoEmbeddingExists(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.RepoEmbeddingExistsFunc.nextHook()(v0, v1)
+	m.RepoEmbeddingExistsFunc.appendCall(RepoStoreRepoEmbeddingExistsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RepoEmbeddingExists
+// method of the parent MockRepoStore instance is invoked and the hook queue
+// is empty.
+func (f *RepoStoreRepoEmbeddingExistsFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoEmbeddingExists method of the parent MockRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *RepoStoreRepoEmbeddingExistsFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoStoreRepoEmbeddingExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoStoreRepoEmbeddingExistsFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *RepoStoreRepoEmbeddingExistsFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoStoreRepoEmbeddingExistsFunc) appendCall(r0 RepoStoreRepoEmbeddingExistsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RepoStoreRepoEmbeddingExistsFuncCall
+// objects describing the invocations of this function.
+func (f *RepoStoreRepoEmbeddingExistsFunc) History() []RepoStoreRepoEmbeddingExistsFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoStoreRepoEmbeddingExistsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoStoreRepoEmbeddingExistsFuncCall is an object that describes an
+// invocation of method RepoEmbeddingExists on an instance of MockRepoStore.
+type RepoStoreRepoEmbeddingExistsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoStoreRepoEmbeddingExistsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoStoreRepoEmbeddingExistsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
Partially closes: https://sourcegraph.slack.com/archives/C04MZPE4JKD/p1680629686220919?thread_ts=1680629557.802319&cid=C04MZPE4JKD

This PR adds a graphql resolver for `repo.embeddingExists`. 

It also adds a message in the repo sidebar Cody section stating the repo has not embeddings based on the resolver.

The messaging can be improved separately in a following PR. 

<img width="557" alt="image" src="https://user-images.githubusercontent.com/22571395/230563603-1c967dcc-638a-4b95-89e2-972fe599e7c9.png">


## Test plan

added unit tests