### PR TITLE
hot fix for resolving github auth failure in backend test

### DIFF
--- a/dev/ci/integration/backend/run.sh
+++ b/dev/ci/integration/backend/run.sh
@@ -9,5 +9,9 @@ set -ex
 echo "--- test.sh"
 
 # Backend integration tests requires a GitHub Enterprise Token
-GITHUB_TOKEN=$GHE_GITHUB_TOKEN
-GITHUB_TOKEN=$GITHUB_TOKEN ./dev/ci/integration/run-integration.sh "${root_dir}/dev/ci/integration/backend/test.sh"
+set +x
+# Hotfix (Owner: @mucles)
+GITHUB_TOKEN="$(gcloud secrets versions access latest --secret=QA_GITHUB_TOKEN --quiet --project=sourcegraph-ci)"
+export GITHUB_TOKEN
+set -x
+./dev/ci/integration/run-integration.sh "${root_dir}/dev/ci/integration/backend/test.sh"


### PR DESCRIPTION
CI has github authentication failures for our backend integration test. This fix should update the github token to the latest, resolve the auth failures we see, and prevent the main from blocking again.

relates to https://github.com/sourcegraph/sourcegraph/pull/41751
## Test plan
relates to https://github.com/sourcegraph/sourcegraph/pull/41751

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
