### PR TITLE
Cody: Fix IME composition, reply in the IDE/browser's language

### DIFF
--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -48,6 +48,7 @@ ts_project(
         "src/intent-detector/index.ts",
         "src/keyword-context/index.ts",
         "src/prompt/constants.ts",
+        "src/prompt/prompt-mixin.ts",
         "src/prompt/templates.ts",
         "src/prompt/truncation.ts",
         "src/sourcegraph-api/completions/browserClient.ts",

--- a/client/cody-shared/src/chat/transcript/interaction.ts
+++ b/client/cody-shared/src/chat/transcript/interaction.ts
@@ -1,6 +1,6 @@
 import { ContextMessage } from '../../codebase-context/messages'
 import { Message } from '../../sourcegraph-api'
-import { PromptMixin } from '../recipes/prompt-mixin'
+import { PromptMixin } from '../../prompt/prompt-mixin'
 
 import { ChatMessage, InteractionMessage } from './messages'
 
@@ -39,13 +39,7 @@ export class Interaction {
     }
 
     public async toPrompt(includeContext: boolean): Promise<Message[]> {
-        const messages: (ContextMessage | InteractionMessage)[] = [this.humanMessage, this.assistantMessage]
-        const mixins = PromptMixin.getAll()
-        if (mixins) {
-            // Stuff the prompt mixins at the start of the human text.
-            // Note we do not reflect them in displayText.
-            messages[0].text = `${mixins}\n\n${messages[0].text}`
-        }
+        const messages: (ContextMessage | InteractionMessage)[] = [PromptMixin.mixInto(this.humanMessage), this.assistantMessage]
         if (includeContext) {
             messages.unshift(...(await this.context))
         }

--- a/client/cody-shared/src/chat/transcript/interaction.ts
+++ b/client/cody-shared/src/chat/transcript/interaction.ts
@@ -1,6 +1,6 @@
 import { ContextMessage } from '../../codebase-context/messages'
-import { Message } from '../../sourcegraph-api'
 import { PromptMixin } from '../../prompt/prompt-mixin'
+import { Message } from '../../sourcegraph-api'
 
 import { ChatMessage, InteractionMessage } from './messages'
 
@@ -39,7 +39,10 @@ export class Interaction {
     }
 
     public async toPrompt(includeContext: boolean): Promise<Message[]> {
-        const messages: (ContextMessage | InteractionMessage)[] = [PromptMixin.mixInto(this.humanMessage), this.assistantMessage]
+        const messages: (ContextMessage | InteractionMessage)[] = [
+            PromptMixin.mixInto(this.humanMessage),
+            this.assistantMessage,
+        ]
         if (includeContext) {
             messages.unshift(...(await this.context))
         }

--- a/client/cody-shared/src/prompt/prompt-mixin.ts
+++ b/client/cody-shared/src/prompt/prompt-mixin.ts
@@ -1,0 +1,32 @@
+import { InteractionMessage } from '../chat/transcript/messages'
+
+// Prompt mixins elaborate every prompt presented to the LLM. Add a prompt mixin to prompt for cross-cutting concerns relevant to multiple recipes.
+export class PromptMixin {
+    private static mixins_: PromptMixin[] = []
+
+    // Adds a prompt mixin to the global set.
+    public static add(mixin: PromptMixin): void {
+        this.mixins_.push(mixin)
+    }
+
+    // Prepends all of the mixins to `humanMessage`. Modifies and returns `humanMessage`.
+    public static mixInto(humanMessage: InteractionMessage): InteractionMessage {
+	const mixins = this.mixins_.map(mixin => mixin.prompt).join('\n\n')
+        if (mixins) {
+            // Stuff the prompt mixins at the start of the human text.
+            // Note we do not reflect them in displayText.
+            humanMessage.text = `${mixins}\n\n${humanMessage.text}`
+        }
+	return humanMessage
+    }
+
+    // Creates a mixin with the given, fixed prompt to insert.
+    constructor(private readonly prompt: string) {}
+}
+
+// Creates a prompt mixin to get Cody to reply in the given language, for example "en-AU" for "Australian English".
+export function languagePromptMixin(languageCode: string): PromptMixin {
+    return new PromptMixin(
+        `Unless instructed otherwise, reply in the language with RFC5646/ISO language code "${languageCode}".`
+    )
+}

--- a/client/cody-shared/src/prompt/prompt-mixin.ts
+++ b/client/cody-shared/src/prompt/prompt-mixin.ts
@@ -11,13 +11,13 @@ export class PromptMixin {
 
     // Prepends all of the mixins to `humanMessage`. Modifies and returns `humanMessage`.
     public static mixInto(humanMessage: InteractionMessage): InteractionMessage {
-	const mixins = this.mixins_.map(mixin => mixin.prompt).join('\n\n')
+        const mixins = this.mixins_.map(mixin => mixin.prompt).join('\n\n')
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
             // Note we do not reflect them in displayText.
             humanMessage.text = `${mixins}\n\n${humanMessage.text}`
         }
-	return humanMessage
+        return humanMessage
     }
 
     // Creates a mixin with the given, fixed prompt to insert.

--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -115,7 +115,13 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
         (event: React.KeyboardEvent<HTMLDivElement>): void => {
             // Submit input on Enter press (without shift) and
             // trim the formInput to make sure input value is not empty.
-            if (event.key === 'Enter' && !event.shiftKey && formInput && formInput.trim()) {
+            if (
+                event.key === 'Enter' &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing &&
+                formInput &&
+                formInput.trim()
+            ) {
                 event.preventDefault()
                 event.stopPropagation()
                 onChatSubmit()

--- a/client/cody-web/src/index.tsx
+++ b/client/cody-web/src/index.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 
 import ReactDOM from 'react-dom/client'
 
+import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/chat/recipes/prompt-mixin'
 import { WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { App } from './App'
 
 import './index.css'
 
+PromptMixin.add(languagePromptMixin(navigator.language))
 ReactDOM.createRoot(document.querySelector('#root') as HTMLElement).render(
     <React.StrictMode>
         <WildcardThemeContext.Provider value={{ isBranded: true }}>

--- a/client/cody-web/src/index.tsx
+++ b/client/cody-web/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import ReactDOM from 'react-dom/client'
 
-import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/chat/recipes/prompt-mixin'
+import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import { WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { App } from './App'

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -1,10 +1,14 @@
 import * as vscode from 'vscode'
 
+import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/chat/recipes/prompt-mixin'
+
 import { CommandsProvider } from './command/CommandsProvider'
 import { ExtensionApi } from './extension-api'
 
 export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
     console.log('Cody extension activated')
+
+    PromptMixin.add(languagePromptMixin(vscode.env.language))
 
     // Register commands and webview
     return CommandsProvider(context)

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/chat/recipes/prompt-mixin'
+import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 
 import { CommandsProvider } from './command/CommandsProvider'
 import { ExtensionApi } from './extension-api'


### PR DESCRIPTION
Cody chat prematurely submits chat messages when composing with an input method editor. Wait for IME composition to be finished. Fixes #50445.

## Test plan

Manual test plan:

- Install Japanese as an input method
- VScode, Tool Palette & > Configure Display Language, Japanese, Tool Palette & > Reload Window
- Run vscode extension, open Cody chat
- Switch input method to Japanese (kana/あ)
- Type k-o-n-n-n-i-c-h-i-h-a, press space, press enter
- Verify Japanese text like こんにちは or 今日は (details depend on your IME) are inserted into the text area but the message is *not* sent to Cody
- Hit enter again, verify the message *is* sent to Cody
- Cody should respond in Japanese
- Switch the input method to English, type hello, hit enter, verify the message is sent to Cody after the first enter press

Automated testing of this change is involved, but TL;DR is it is blocked on Issue #50118. After that we need the integration test harness to [make the webviews debuggable,](https://github.com/microsoft/vscode/issues/101320#issue-647701245) connect to them with Puppeteer, and then dip into Chrome DevTools protocol to set `Input.setImeComposing` to generate authentic input events. Testing this with Puppeteer on cody-web would be easier but I'm unsure how to generate synthetic IME composition events with Firefox.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-dpc-multilingual-cody.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
