### PR TITLE
batches: surface batch change rollout window in JSContext

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -76,6 +76,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         embeddingsEnabled: false,
         primaryLoginProvidersCount: 5,
+        batchChangesRolloutWindows: null,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -58,4 +58,5 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     localFilePickerAvailable: false,
     srcServeGitUrl: 'http://127.0.0.1:3434',
     primaryLoginProvidersCount: 5,
+    batchChangesRolloutWindows: null,
 })

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -1,5 +1,5 @@
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
+import { SiteConfiguration, BatchChangeRolloutWindow } from '@sourcegraph/shared/src/schema/site.schema'
 
 import { TemporarySettingsResult } from './graphql-operations'
 
@@ -182,6 +182,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     batchChangesDisableWebhooksWarning: boolean
 
     batchChangesWebhookLogsEnabled: boolean
+
+    batchChangesRolloutWindows: BatchChangeRolloutWindow[] | null
 
     /** Whether executors are enabled on the site. */
     executorsEnabled: boolean

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -174,7 +174,7 @@ type JSContext struct {
 	BatchChangesEnabled                bool                                `json:"batchChangesEnabled"`
 	BatchChangesDisableWebhooksWarning bool                                `json:"batchChangesDisableWebhooksWarning"`
 	BatchChangesWebhookLogsEnabled     bool                                `json:"batchChangesWebhookLogsEnabled"`
-	BatchChangesRolloutWindows         *[]*schema.BatchChangeRolloutWindow `json:"batchChangesRolloutWindow"`
+	BatchChangesRolloutWindows         *[]*schema.BatchChangeRolloutWindow `json:"batchChangesRolloutWindows"`
 
 	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -171,9 +171,10 @@ type JSContext struct {
 
 	Branding *schema.Branding `json:"branding"`
 
-	BatchChangesEnabled                bool `json:"batchChangesEnabled"`
-	BatchChangesDisableWebhooksWarning bool `json:"batchChangesDisableWebhooksWarning"`
-	BatchChangesWebhookLogsEnabled     bool `json:"batchChangesWebhookLogsEnabled"`
+	BatchChangesEnabled                bool                                `json:"batchChangesEnabled"`
+	BatchChangesDisableWebhooksWarning bool                                `json:"batchChangesDisableWebhooksWarning"`
+	BatchChangesWebhookLogsEnabled     bool                                `json:"batchChangesWebhookLogsEnabled"`
+	BatchChangesRolloutWindows         *[]*schema.BatchChangeRolloutWindow `json:"batchChangesRolloutWindow"`
 
 	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
@@ -353,6 +354,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		BatchChangesEnabled:                enterprise.BatchChangesEnabledForUser(ctx, db) == nil,
 		BatchChangesDisableWebhooksWarning: conf.Get().BatchChangesDisableWebhooksWarning,
 		BatchChangesWebhookLogsEnabled:     webhooks.LoggingEnabled(conf.Get()),
+		BatchChangesRolloutWindows:         conf.Get().BatchChangesRolloutWindows,
 
 		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),


### PR DESCRIPTION
#48217 and #48963 require the `batchChangesRolloutWindows` configuration to be available in the frontend.
This PR surfaces the value via the `jscontext` object preloaded when the UI starts.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Start up a Sourcegraph instance with `sg start batches`
* If the rollout window is configured in the Site Config, then logging `window.context` should include the configured values in the `batchChangesRolloutWindows` field.
![CleanShot 2023-04-07 at 12 50 12@2x](https://user-images.githubusercontent.com/25608335/230604199-adecb401-29fe-4cd5-b94f-f4f5d7da157d.png)

* If not, the value of `batchChangesRolloutWindows` will be null.
![CleanShot 2023-04-07 at 12 49 46@2x](https://user-images.githubusercontent.com/25608335/230604227-c1013cf0-19a5-462f-81f9-20c5883e1f48.png)
