### PR TITLE
codeintel: Disable inference when autoindexing is not enabled

### DIFF
--- a/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//internal/api",
         "//internal/auth",
         "//internal/codeintel/resolvers",
+        "//internal/conf",
         "//internal/database",
         "//internal/executor",
         "//internal/gitserver",


### PR DESCRIPTION
The `RepositorySummary` GraphQL request does not respect the auto indexing site config flag. This may be why some customers are seeing increased gitserver traffic after a recent upgrade.

## Test plan

Tested locally.