### PR TITLE
backport 50486 to 5.0

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -451,6 +451,9 @@ func (r *rootResolver) CodeIntelSummary(ctx context.Context) (_ resolverstubs.Co
 	return sharedresolvers.NewSummaryResolver(r.autoindexSvc, r.locationResolverFactory.Create()), nil
 }
 
+// For mocking in tests
+var autoIndexingEnabled = conf.CodeIntelAutoIndexingEnabled
+
 func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ resolverstubs.CodeIntelRepositorySummaryResolver, err error) {
 	ctx, errTracer, endObservation := r.operations.repositorySummary.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repoID", string(id)),
@@ -494,29 +497,32 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ 
 		blocklist[key] = struct{}{}
 	}
 
-	commit := "HEAD"
 	var limitErr error
-
-	indexJobs, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, repoID, commit, "", false)
-	if err != nil {
-		if !errors.As(err, &inference.LimitError{}) {
-			return nil, err
-		}
-
-		limitErr = errors.Append(limitErr, err)
-	}
-	// indexJobHints, err := r.autoindexSvc.InferIndexJobHintsFromRepositoryStructure(ctx, repoID, commit)
-	// if err != nil {
-	// 	if !errors.As(err, &inference.LimitError{}) {
-	// 		return nil, err
-	// 	}
-
-	// 	limitErr = errors.Append(limitErr, err)
-	// }
-
 	inferredAvailableIndexers := map[string]shared.AvailableIndexer{}
-	inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
-	// inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
+
+	if autoIndexingEnabled() {
+		commit := "HEAD"
+
+		indexJobs, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, repoID, commit, "", false)
+		if err != nil {
+			if !errors.As(err, &inference.LimitError{}) {
+				return nil, err
+			}
+
+			limitErr = errors.Append(limitErr, err)
+		}
+		// indexJobHints, err := r.autoindexSvc.InferIndexJobHintsFromRepositoryStructure(ctx, repoID, commit)
+		// if err != nil {
+		// 	if !errors.As(err, &inference.LimitError{}) {
+		// 		return nil, err
+		// 	}
+
+		// 	limitErr = errors.Append(limitErr, err)
+		// }
+
+		inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
+		// inferredAvailableIndexers = shared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
+	}
 
 	inferredAvailableIndexersResolver := make([]sharedresolvers.InferredAvailableIndexers, 0, len(inferredAvailableIndexers))
 	for _, indexer := range inferredAvailableIndexers {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver.go
@@ -451,9 +451,6 @@ func (r *rootResolver) CodeIntelSummary(ctx context.Context) (_ resolverstubs.Co
 	return sharedresolvers.NewSummaryResolver(r.autoindexSvc, r.locationResolverFactory.Create()), nil
 }
 
-// For mocking in tests
-var autoIndexingEnabled = conf.CodeIntelAutoIndexingEnabled
-
 func (r *rootResolver) RepositorySummary(ctx context.Context, id graphql.ID) (_ resolverstubs.CodeIntelRepositorySummaryResolver, err error) {
 	ctx, errTracer, endObservation := r.operations.repositorySummary.WithErrors(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repoID", string(id)),

--- a/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/internal/codeintel/uploads/shared",
         "//internal/api",
         "//internal/codeintel/resolvers",
+        "//internal/conf",
         "//internal/database",
         "//internal/gqlutil",
         "//internal/metrics",


### PR DESCRIPTION
Manual backport from https://github.com/sourcegraph/sourcegraph/pull/50486#issuecomment-1500662613.

## Test plan

Tested locally.