### PR TITLE
Fix broken link

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -83,7 +83,7 @@ Sourcegraph app is early-stages, if you run into any trouble or have ideas/feedb
 
 #### macOS (app .dmg installer)
 
-Navigate to your Applications directory using Finder, and delete the old version of Sourcegraph. Then [download and run the latest version](about.sourcegraph.com/app).
+Navigate to your Applications directory using Finder, and delete the old version of Sourcegraph. Then [download and run the latest version](https://about.sourcegraph.com/app).
 
 #### macOS (homebrew)
 


### PR DESCRIPTION
Current link doesn't point to the about page. It's current URL is https://docs.sourcegraph.com/app/about.sourcegraph.com/app



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
No test plan required. Doc update.