### PR TITLE
gRPC: commit search refinements

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -149,7 +149,11 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 	// Open connections for each address
 	after.grpcConns = make(map[string]connAndErr, len(after.Addresses))
 	for _, addr := range after.Addresses {
-		conn, err := defaults.Dial(addr)
+		conn, err := defaults.Dial(
+			addr,
+			// Allow large messages to accomodate large diffs
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(64*1024*1024)),
+		)
 		after.grpcConns[addr] = connAndErr{conn: conn, err: err}
 	}
 

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const maxMessageSizeBytes = 64 * 1024 * 1024 // 64MiB
+
 var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_gitserver_addr_for_repo_invoked",
 	Help: "Number of times gitserver.AddrForRepo was invoked",
@@ -152,7 +154,7 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 		conn, err := defaults.Dial(
 			addr,
 			// Allow large messages to accomodate large diffs
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(64*1024*1024)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSizeBytes)),
 		)
 		after.grpcConns[addr] = connAndErr{conn: conn, err: err}
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -676,7 +676,7 @@ func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 		client := proto.NewGitserverServiceClient(conn)
 		cs, err := client.Search(ctx, args.ToProto())
 		if err != nil {
-			return false, err
+			return false, convertGitserverError(err)
 		}
 
 		limitHit := false

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -673,9 +673,6 @@ func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 			return false, err
 		}
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
 		client := proto.NewGitserverServiceClient(conn)
 		cs, err := client.Search(ctx, args.ToProto())
 		if err != nil {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -177,7 +177,7 @@ func matchedStringFromProto(p *proto.CommitMatch_MatchedString) result.MatchedSt
 		ranges = append(ranges, rangeFromProto(rr))
 	}
 	return result.MatchedString{
-		Content:       p.Content,
+		Content:       p.GetContent(),
 		MatchedRanges: ranges,
 	}
 }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -202,8 +202,8 @@ func rangeToProto(r result.Range) *proto.CommitMatch_Range {
 
 func rangeFromProto(p *proto.CommitMatch_Range) result.Range {
 	return result.Range{
-		Start: locationFromProto(p.Start),
-		End:   locationFromProto(p.End),
+		Start: locationFromProto(p.GetStart()),
+		End:   locationFromProto(p.GetEnd()),
 	}
 }
 
@@ -217,9 +217,9 @@ func locationToProto(l result.Location) *proto.CommitMatch_Location {
 
 func locationFromProto(p *proto.CommitMatch_Location) result.Location {
 	return result.Location{
-		Offset: int(p.Offset),
-		Line:   int(p.Line),
-		Column: int(p.Column),
+		Offset: int(p.GetOffset()),
+		Line:   int(p.GetLine()),
+		Column: int(p.GetColumn()),
 	}
 }
 


### PR DESCRIPTION
This is a collection of small fixes to the gRPC implementation of commit search. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/50498

This is split into standalone commits:
1) Removes a defensive context cancellation that was added as part of our leak debugging efforts. This is now unnecessary and just adds noise.
2) Convert errors that are returned from `Search()`. Previously, we were only interpreting the errors that came from `Recv()`, so there were context errors that weren't being converted to Go's typed context errors (which we depend on further up in the stack).
3) Increase the max message side on the client. For large diffs, we can exceed the default 4MB limit for a single message. I increased this to 64MB. The best course of action here would be to limit on the server side, but that would require more investment since we depend on complete, parseable diffs in the client. This should be good enough for now. Ideally, we'll move away from passing around big, formatted diffs anyways. I think we do still want _some_ limit here to avoid reading massive messages into memory. Buffering really large files can cause instability. In the HTTP implementation, there is no limit, which I would consider a bug.
4) Use a getter on proto object so it doesn't panic on a malformed object.

## Test plan

1) Tested that the error displayed to the user is no longer the gross, unformatted RPC error.
2) Tested that we can send large messages (up to 16MB) without an error. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
