### PR TITLE
Cody: add patterns for queries that require context

### DIFF
--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -51,7 +51,10 @@ go_library(
 go_test(
     name = "shared_test",
     timeout = "short",
-    srcs = ["repo_embedding_index_cache_test.go"],
+    srcs = [
+        "context_detection_test.go",
+        "repo_embedding_index_cache_test.go",
+    ],
     embed = [":shared"],
     deps = [
         "//enterprise/internal/embeddings",

--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -12,7 +12,6 @@ import (
 type getContextDetectionEmbeddingIndexFn func(ctx context.Context) (*embeddings.ContextDetectionEmbeddingIndex, error)
 
 const MIN_NO_CONTEXT_SIMILARITY_DIFF = float32(0.02)
-const MIN_QUERY_WITH_CONTEXT_LENGTH = 16
 
 var NO_CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
 	lazyregexp.New(`(previous|above)\s+(message|code|text)`),
@@ -34,10 +33,6 @@ func isContextRequiredForChatQuery(
 	query string,
 ) (bool, error) {
 	queryTrimmed := strings.TrimSpace(query)
-	if len(queryTrimmed) < MIN_QUERY_WITH_CONTEXT_LENGTH {
-		return false, nil
-	}
-
 	queryLower := strings.ToLower(queryTrimmed)
 	for _, regexp := range NO_CONTEXT_MESSAGES_REGEXPS {
 		if submatches := regexp.FindStringSubmatch(queryLower); len(submatches) > 0 {

--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -14,7 +14,7 @@ type getContextDetectionEmbeddingIndexFn func(ctx context.Context) (*embeddings.
 const MIN_NO_CONTEXT_SIMILARITY_DIFF = float32(0.02)
 
 var CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
-	lazyregexp.New(`(what|where|how) (is|do|does)`),
+	lazyregexp.New(`(what|where|how) (are|do|does|is)`),
 	lazyregexp.New(`in (the|my) (code|codebase|repo|repository)`),
 }
 

--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -13,6 +13,11 @@ type getContextDetectionEmbeddingIndexFn func(ctx context.Context) (*embeddings.
 
 const MIN_NO_CONTEXT_SIMILARITY_DIFF = float32(0.02)
 
+var CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
+	lazyregexp.New(`(what|where|how) (is|do|does)`),
+	lazyregexp.New(`in (the|my) (code|codebase|repo|repository)`),
+}
+
 var NO_CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
 	lazyregexp.New(`(previous|above)\s+(message|code|text)`),
 	lazyregexp.New(
@@ -37,6 +42,12 @@ func isContextRequiredForChatQuery(
 	for _, regexp := range NO_CONTEXT_MESSAGES_REGEXPS {
 		if submatches := regexp.FindStringSubmatch(queryLower); len(submatches) > 0 {
 			return false, nil
+		}
+	}
+
+	for _, regexp := range CONTEXT_MESSAGES_REGEXPS {
+		if submatches := regexp.FindStringSubmatch(queryLower); len(submatches) > 0 {
+			return true, nil
 		}
 	}
 

--- a/enterprise/cmd/embeddings/shared/context_detection_test.go
+++ b/enterprise/cmd/embeddings/shared/context_detection_test.go
@@ -1,0 +1,77 @@
+package shared
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
+)
+
+func TestIsContextRequiredForChatQuery(t *testing.T) {
+	getContextDetectionEmbeddingIndex := func(ctx context.Context) (*embeddings.ContextDetectionEmbeddingIndex, error) {
+		return &embeddings.ContextDetectionEmbeddingIndex{
+			MessagesWithAdditionalContextMeanEmbedding:    []float32{0.0, 1.0},
+			MessagesWithoutAdditionalContextMeanEmbedding: []float32{1.0, 0.0},
+		}, nil
+	}
+
+	cases := []struct {
+		name         string
+		query        string
+		embedding    []float32
+		embeddingErr error
+		want         bool
+	}{
+		{
+			name:      "query matches no context regex",
+			query:     "that answer looks incorrect",
+			embedding: []float32{0.0, 0.0}, // unused
+			want:      false,
+		},
+		{
+			name:      "query matches context regex",
+			query:     "where is the cody plugin code?",
+			embedding: []float32{0.0, 0.0}, // unused
+			want:      true,
+		},
+		{
+			name:      "another query that matches context regex",
+			query:     "is the zoekt package used in my repo",
+			embedding: []float32{0.0, 0.0}, // unused
+			want:      true,
+		},
+		{
+			name:      "query similar to no context embeddings",
+			query:     "hello, testing this works!",
+			embedding: []float32{0.9, 0.1},
+			want:      false,
+		},
+		{
+			name:      "query not similar enough to no context embeddings",
+			query:     "hello, testing this works!",
+			embedding: []float32{0.5, 0.5},
+			want:      true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			getQueryEmbedding := func(query string) ([]float32, error) {
+				return tt.embedding, tt.embeddingErr
+			}
+
+			got, err := isContextRequiredForChatQuery(context.Background(),
+				getQueryEmbedding,
+				getContextDetectionEmbeddingIndex,
+				tt.query)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("expected context required to be %t but was %t", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds regex patterns for detecting when a query very likely needs file context. This is a natural extension since we already use regex patterns for the "no context" case.

## Test plan

Add new unit tests for detecting when context is required. Manually tested examples.