### PR TITLE
Add sitename to structured data

### DIFF
--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -56,13 +56,6 @@
 		window.pageError = {{.Error }}
 	</script>
 	{{.Injected.HeadBottom}}
-</head>
-
-<body>
-	{{ if .Context.SourcegraphDotComMode }}
-	<!-- Google Tag Manager (noscript) -->
-	<noscript><iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager (noscript) -->
 
 	<!-- Google Search Result SearchBox -->
 	<!-- See https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox -->
@@ -83,6 +76,13 @@
 		}
 	</script>
 	<!-- End Google Search Result SearchBox -->
+</head>
+
+<body>
+	{{ if .Context.SourcegraphDotComMode }}
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe ignore-csp src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
 
 	{{ end }}
 	{{.Injected.BodyTop}}


### PR DESCRIPTION
## Problem Description
Site name displays `Source graph` instead of `Sourcegraph`
![Screenshot 2023-03-29 at 12 39 01 PM](https://user-images.githubusercontent.com/45232708/228760353-d5d6a25d-b90f-41b8-85f3-ca0d8524d994.png).


## Description
Despite adding the `sitename` property to the structured data of the website, the incorrect `sitename` continues to be displayed on the Google search result page. The reason for this discrepancy is not yet clear. One possible hypothesis is that the structured data is currently placed in the body tag of the website instead of the recommended header tag, which may be affecting how Google interprets and displays the `sitename` in the search results. Further investigation and potential adjustments to the placement of the structured data in the header tag may be necessary to resolve this issue.

## Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6139)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6139)

## Test Plan
Test can be carried out on this change, after deployment and google re-index page.