### PR TITLE
Cody: Replace Recipe.getInteraction arguments with parameter object.

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -95,12 +95,11 @@ export async function createClient({
 
     return {
         submitMessage: async (text: string) => {
-            const interaction = await chatQuestionRecipe.getInteraction(
-                text,
-                fakeEditor,
+            const interaction = await chatQuestionRecipe.getInteraction(text, {
+                editor: fakeEditor,
                 intentDetector,
-                codebaseContext
-            )
+                codebaseContext,
+            })
             if (!interaction) {
                 throw new Error('No interaction')
             }

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -9,19 +9,14 @@ import { truncateText } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class ChatQuestion implements Recipe {
     public getID(): string {
         return 'chat-question'
     }
 
-    public async getInteraction(
-        humanChatInput: string,
-        editor: Editor,
-        intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
+    public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const timestamp = getShortTimestamp()
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
@@ -29,7 +24,7 @@ export class ChatQuestion implements Recipe {
             new Interaction(
                 { speaker: 'human', text: truncatedText, displayText: humanChatInput, timestamp },
                 { speaker: 'assistant', text: '', displayText: '', timestamp },
-                this.getContextMessages(truncatedText, editor, intentDetector, codebaseContext)
+                this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext)
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -1,26 +1,18 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class ExplainCodeDetailed implements Recipe {
     public getID(): string {
         return 'explain-code-detailed'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return Promise.resolve(null)
         }
@@ -42,7 +34,7 @@ export class ExplainCodeDetailed implements Recipe {
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection.fileName,
-                codebaseContext
+                context.codebaseContext
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,26 +1,18 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class ExplainCodeHighLevel implements Recipe {
     public getID(): string {
         return 'explain-code-high-level'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return Promise.resolve(null)
         }
@@ -42,7 +34,7 @@ export class ExplainCodeHighLevel implements Recipe {
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection.fileName,
-                codebaseContext
+                context.codebaseContext
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -1,6 +1,3 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
@@ -12,20 +9,15 @@ import {
     getContextMessagesFromSelection,
     getFileExtension,
 } from './helpers'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class GenerateDocstring implements Recipe {
     public getID(): string {
         return 'generate-docstring'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return Promise.resolve(null)
         }
@@ -72,7 +64,7 @@ export class GenerateDocstring implements Recipe {
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection.fileName,
-                codebaseContext
+                context.codebaseContext
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -1,6 +1,3 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
@@ -12,20 +9,15 @@ import {
     getFileExtension,
     getContextMessagesFromSelection,
 } from './helpers'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class GenerateTest implements Recipe {
     public getID(): string {
         return 'generate-unit-test'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return Promise.resolve(null)
         }
@@ -56,7 +48,7 @@ export class GenerateTest implements Recipe {
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection.fileName,
-                codebaseContext
+                context.codebaseContext
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -1,27 +1,19 @@
 import { spawnSync } from 'child_process'
 
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class GitHistory implements Recipe {
     public getID(): string {
         return 'git-history'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        _codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const dirPath = editor.getWorkspaceRootPath()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const dirPath = context.editor.getWorkspaceRootPath()
         if (!dirPath) {
             return null
         }
@@ -44,7 +36,7 @@ export class GitHistory implements Recipe {
                 rawDisplayText: 'What changed in my codebase in the last week?',
             },
         ]
-        const selectedLabel = await editor.showQuickPick(items.map(e => e.label))
+        const selectedLabel = await context.editor.showQuickPick(items.map(e => e.label))
         if (!selectedLabel) {
             return null
         }

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -1,6 +1,3 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
@@ -12,20 +9,15 @@ import {
     getContextMessagesFromSelection,
     getFileExtension,
 } from './helpers'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class ImproveVariableNames implements Recipe {
     public getID(): string {
         return 'improve-variable-names'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return Promise.resolve(null)
         }
@@ -56,7 +48,7 @@ export class ImproveVariableNames implements Recipe {
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection.fileName,
-                codebaseContext
+                context.codebaseContext
             )
         )
     }

--- a/client/cody-shared/src/chat/recipes/recipe.ts
+++ b/client/cody-shared/src/chat/recipes/recipe.ts
@@ -3,12 +3,14 @@ import { Editor } from '../../editor'
 import { IntentDetector } from '../../intent-detector'
 import { Interaction } from '../transcript/interaction'
 
+/** Tools and context recipes can use at the point they are invoked. */
+export interface RecipeContext {
+    editor: Editor
+    intentDetector: IntentDetector
+    codebaseContext: CodebaseContext
+}
+
 export interface Recipe {
     getID(): string
-    getInteraction(
-        humanChatInput: string,
-        editor: Editor,
-        intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
-    ): Promise<Interaction | null>
+    getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null>
 }

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -1,31 +1,23 @@
-import { CodebaseContext } from '../../codebase-context'
-import { Editor } from '../../editor'
-import { IntentDetector } from '../../intent-detector'
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
-import { Recipe } from './recipe'
+import { Recipe, RecipeContext } from './recipe'
 
 export class TranslateToLanguage implements Recipe {
     public getID(): string {
         return 'translate-to-language'
     }
 
-    public async getInteraction(
-        _humanChatInput: string,
-        editor: Editor,
-        _intentDetector: IntentDetector,
-        _codebaseContext: CodebaseContext
-    ): Promise<Interaction | null> {
-        const selection = editor.getActiveTextEditorSelection()
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
         if (!selection) {
             return null
         }
 
-        const toLanguage = await editor.showQuickPick(languageNames)
+        const toLanguage = await context.editor.showQuickPick(languageNames)
         if (!toLanguage) {
             // TODO: Show the warning within the Chat UI.
             // editor.showWarningMessage('Must pick a language to translate to.')

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -1,3 +1,5 @@
+import { RecipeContext } from '../chat/recipes/recipe'
+import { CodebaseContext } from '../codebase-context'
 import { ActiveTextEditor, ActiveTextEditorSelection, ActiveTextEditorVisibleContent, Editor } from '../editor'
 import { EmbeddingsSearch } from '../embeddings'
 import { IntentDetector } from '../intent-detector'
@@ -74,3 +76,13 @@ export const defaultIntentDetector = new MockIntentDetector()
 export const defaultKeywordContextFetcher = new MockKeywordContextFetcher()
 
 export const defaultEditor = new MockEditor()
+
+export function newRecipeContext(args?: Partial<RecipeContext>): RecipeContext {
+    args = args || {}
+    return {
+        editor: args.editor || defaultEditor,
+        intentDetector: args.intentDetector || defaultIntentDetector,
+        codebaseContext:
+            args.codebaseContext || new CodebaseContext('none', defaultEmbeddingsClient, defaultKeywordContextFetcher),
+    }
+}

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -230,12 +230,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             return
         }
 
-        const interaction = await recipe.getInteraction(
-            humanChatInput,
-            this.editor,
-            this.intentDetector,
-            this.codebaseContext
-        )
+        const interaction = await recipe.getInteraction(humanChatInput, {
+            editor: this.editor,
+            intentDetector: this.intentDetector,
+            codebaseContext: this.codebaseContext,
+        })
         if (!interaction) {
             return
         }


### PR DESCRIPTION
Makes recipes more succinct and eliminates toil in providing more context to recipes.

## Test plan

```
cd client/cody-shared
pnpm test
```

Manually test a recipe works in the VScode plugin.

## App preview:

- [Web](https://sg-web-dpc-recipe-context.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
