### PR TITLE
bazel: fail script if configure fails

### DIFF
--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
+set -eu
+
 # We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
 echo "--- Running bazel configure"
 bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc configure
+
+# We disable exit on error here, since we want to catch the exit code and interpret it
+set +e
 
 echo "--- Checking if BUILD.bazel files were updated"
 git diff --exit-code


### PR DESCRIPTION
The bazel configure script didnt' fail if the bazel command failed - this fixes.
## Test plan
1. removed `set -eu`
2. made bazel command fail
3. `git diff` still got executed
4. added `set -eu` back
5. scripted exited after bazel command failure
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
