### PR TITLE
Cody: Implemented cody to open file in Sourcegraph view

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -160,11 +160,20 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                     try {
                         const doc = await vscode.workspace.openTextDocument(uri)
                         await vscode.window.showTextDocument(doc)
-                    } catch (error) {
-                        console.error(`Could not open file: ${error}`)
+                    } catch  {
+                        // Try to open the file in the sourcegraph view
+                        const sourcegraphInstanceUrl = 'https://sourcegraph.com'
+                        const sourcegraphWebUrl = `${sourcegraphInstanceUrl}/search?q=context:global+file:${message.filePath}`
+
+                        try {
+                            await vscode.env.openExternal(vscode.Uri.parse(sourcegraphWebUrl))
+                        }
+                        catch (error) {
+                            console.error(`Could not open the file: ${error}`)
+                        }
                     }
                 } else {
-                    console.error('Could not open file because rootPath is null')
+                   console.error('Could not open file because rootPath is null')
                 }
                 break
             }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -163,7 +163,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                     } catch  {
                         // Try to open the file in the sourcegraph view
                         const sourcegraphInstanceUrl = 'https://sourcegraph.com'
-                        const sourcegraphWebUrl = `${sourcegraphInstanceUrl}/search?q=context:global+file:${message.filePath}`
+                        const sourcegraphWebUrl = new URL(`/search?q=context:global+file:${message.filePath}`, sourcegraphInstanceUrl).href
 
                         try {
                             await vscode.env.openExternal(vscode.Uri.parse(sourcegraphWebUrl))

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -162,7 +162,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
                         await vscode.window.showTextDocument(doc)
                     } catch  {
                         // Try to open the file in the sourcegraph view
-                        const sourcegraphInstanceUrl = 'https://sourcegraph.com'
+                        const sourcegraphInstanceUrl = this.serverEndpoint
                         const sourcegraphWebUrl = new URL(`/search?q=context:global+file:${message.filePath}`, sourcegraphInstanceUrl).href
 
                         try {


### PR DESCRIPTION
**PR description**

This PR is for issue #50098 . The current implementation of Cody doesn't open the files anywhere if it's not in the project's local working directory. This PR implements the functionality to open the file in the Sourcegraph Code search view in the browser if it's not present in the local working directory.

**Test plan**

All the integration and unit tests have passed successfully.
Manual testing has been done with different projects to test the behaviour of the implemented functionality, and it works fine.

