### PR TITLE
admin-analytics: make `ValueLegendList` accept/render 2 numbers.

### DIFF
--- a/client/web/src/site-admin/analytics/components/ValueLegendList.story.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.story.tsx
@@ -1,0 +1,108 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { Container, LoadingSpinner } from '@sourcegraph/wildcard'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { ValueLegendItem, ValueLegendList, ValueLegendListProps } from './ValueLegendList'
+
+const decorator: DecoratorFn = Story => <Story />
+
+const config: Meta = {
+    title: 'web/src/site-admin/analytics/components/ValueLegendList',
+    decorators: [decorator],
+}
+
+export default config
+
+export const SingleValueLegendItem: Story = () => (
+    <WebStory>
+        {() => (
+            <Container>
+                <ValueLegendItem value={12345} description="Single item" tooltip="Here is a tooltip" />
+            </Container>
+        )}
+    </WebStory>
+)
+
+SingleValueLegendItem.storyName = 'Single value legend item'
+
+export const ValueLegendListStory: Story = () => {
+    const items: ValueLegendListProps['items'] = [
+        {
+            value: 12345,
+            description: 'Single item',
+            tooltip: 'Here is a tooltip',
+            color: 'var(--orange)',
+        },
+        {
+            value: '101',
+            description: 'String value',
+            tooltip: 'Here is a tooltip',
+            color: 'var(--orange)',
+        },
+        {
+            value: '101',
+            secondValue: 1000,
+            description: 'Right string double value',
+            position: 'right',
+            tooltip: 'Here is a tooltip',
+            color: 'var(--cyan)',
+        },
+        {
+            value: 42,
+            description: 'Right side single',
+            tooltip: 'Here is a tooltip',
+            position: 'right',
+            color: 'var(--cyan)',
+        },
+        {
+            value: 12,
+            secondValue: 55555,
+            description: 'Double item',
+            tooltip: 'Here is a tooltip',
+            color: 'var(--orange)',
+        },
+        {
+            value: 13,
+            secondValue: 37,
+            description: 'Right side',
+            tooltip: 'Here is a tooltip',
+            position: 'right',
+            color: 'var(--cyan)',
+        },
+        {
+            value: <LoadingSpinner />,
+            secondValue: 37,
+            description: 'Latency-2 :(',
+            tooltip: 'Still waiting for your "scalable" backend to respond',
+            position: 'right',
+            color: 'var(--cyan)',
+        },
+        {
+            value: <LoadingSpinner />,
+            description: 'Latency :(',
+            tooltip: 'Still waiting for your "scalable" backend to respond',
+            color: 'var(--orange)',
+        },
+        {
+            value: 1337,
+            secondValue: 3705,
+            description: 'Double item with tooltip',
+            tooltip: 'Here is a tooltip',
+            color: 'var(--orange)',
+        },
+    ]
+
+    return (
+        <WebStory>
+            {() => (
+                <Container>
+                    <ValueLegendList items={items} />
+                </Container>
+            )}
+        </WebStory>
+    )
+}
+
+ValueLegendListStory.storyName = 'Value legend list with items'

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -12,8 +12,10 @@ import styles from './index.module.scss'
 interface ValueLegendItemProps {
     color?: string
     description: string
-    // Value is a number or LoadingSpinner
+    // Value is a number or LoadingSpinner.
     value: number | string | ReactNode
+    // secondValue is used for items showing a relative number (i.e. 13/37 -- 13 out of 37).
+    secondValue?: number
     tooltip?: string
     className?: string
     filter?: { name: string; value: string }
@@ -22,6 +24,7 @@ interface ValueLegendItemProps {
 
 export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     value,
+    secondValue,
     color = 'var(--body-color)',
     description,
     tooltip,
@@ -31,6 +34,8 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
 }) => {
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
+    const formattedSecondNumber = useMemo(() => (secondValue ? formatNumber(secondValue) : secondValue), [secondValue])
+    const unformattedSecondNumber = `${secondValue}`
     const location = useLocation()
 
     const searchParams = useMemo(() => {
@@ -41,12 +46,25 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
         return search
     }, [filter, location.search])
 
-    const tooltipOnNumber =
-        formattedNumber !== unformattedNumber && typeof value !== 'object'
-            ? isNaN(parseFloat(unformattedNumber))
-                ? unformattedNumber
-                : Intl.NumberFormat('en').format(parseFloat(unformattedNumber))
-            : undefined
+    let tooltipOnNumber
+    if (secondValue) {
+        tooltipOnNumber =
+            typeof value !== 'object' &&
+            (formattedNumber !== unformattedNumber || formattedSecondNumber !== unformattedSecondNumber)
+                ? isNaN(parseFloat(unformattedNumber))
+                    ? unformattedNumber
+                    : `${Intl.NumberFormat('en').format(parseFloat(unformattedNumber))} out of ${Intl.NumberFormat(
+                          'en'
+                      ).format(parseFloat(unformattedSecondNumber))}`
+                : undefined
+    } else {
+        tooltipOnNumber =
+            formattedNumber !== unformattedNumber && typeof value !== 'object'
+                ? isNaN(parseFloat(unformattedNumber))
+                    ? unformattedNumber
+                    : Intl.NumberFormat('en').format(parseFloat(unformattedNumber))
+                : undefined
+    }
     return (
         <div className={classNames(styles.legendItem, className)}>
             <Tooltip content={tooltipOnNumber}>
@@ -62,7 +80,9 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
                         className={classNames(styles.count, 'cursor-pointer')}
                         onClick={onClick}
                     >
-                        {formattedNumber}
+                        {secondValue && !isNaN(parseFloat(unformattedNumber))
+                            ? `${formattedNumber} / ${formattedSecondNumber}`
+                            : formattedNumber}
                     </Text>
                 )}
             </Tooltip>


### PR DESCRIPTION
This is used for items of "1 out of 5" format, which are rendered like so: `1/5`.

Test plan:
Storybook added.

## App preview:

- [Web](https://sg-web-ao-ui-extend-value-legend-list.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
