### PR TITLE
Force line break before cloning progress

### DIFF
--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -35,7 +35,7 @@ export const RepoMirrorInfo: React.FunctionComponent<
                                 </Tooltip>
                             </>
                         )}
-                        {mirrorInfo.cloneInProgress ? (
+                        {mirrorInfo.cloneInProgress && (mirrorInfo.cloneProgress ?? '').trim() !== '' ? (
                             <>
                                 <br />
                                 <Code>{mirrorInfo.cloneProgress}</Code>

--- a/client/web/src/site-admin/components/RepoMirrorInfo.tsx
+++ b/client/web/src/site-admin/components/RepoMirrorInfo.tsx
@@ -37,7 +37,7 @@ export const RepoMirrorInfo: React.FunctionComponent<
                         )}
                         {mirrorInfo.cloneInProgress ? (
                             <>
-                                {' '}
+                                <br />
                                 <Code>{mirrorInfo.cloneProgress}</Code>
                             </>
                         ) : (


### PR DESCRIPTION
Part of #39327

This small fix makes sure that the cloning progress appears on a separate line than the rest of the repo status.

## Test plan

Visual assessment.

## App preview:

- [Web](https://sg-web-cb-force-linebreak-before-cloning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
