### PR TITLE
bext: fix view on Sourcegraph links on GitHub (global navigation update feature enabled) 

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/github/codeHost.module.scss
@@ -30,9 +30,15 @@
 }
 
 .code-view-toolbar {
-    margin-right: 4px;
     margin-bottom: -4px;
     text-align: right;
+}
+
+/* "Old" GitHub (not logged in user or GHE) blob header */
+:global(.js-blob-header) {
+    .code-view-toolbar {
+        margin-right: 4px;
+    }
 }
 
 .code-view-toolbar-item {
@@ -50,6 +56,24 @@
 .hover-overlay-close-button {
     /* Align close button with large GitHub badges */
     top: 0.33rem !important; /* !important to override default close button `top` */
+}
+
+/* View repo on Sourcegraph link when global navigation update feature preview is enabled */
+:global(.AppHeader .open-on-sourcegraph),
+/* View file on Sourcegraph link in the blob header */
+:global(.sourcegraph-github-file-code-view-toolbar-mount .open-on-sourcegraph) {
+    /* Center link icon */
+    min-height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+/* New GitHub UI: View repo on Sourcegraph link when global navigation update feature preview is disabled */
+:global(.pagehead-actions .open-on-sourcegraph) {
+    .icon {
+        /* Center link icon */
+        margin-bottom: -1px;
+    }
 }
 
 /* Blob view

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -162,7 +162,7 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
     // new GitHub UI
     const container =
         codeViewElement.querySelector('#repos-sticky-header')?.childNodes[0]?.childNodes[0]?.childNodes[1]
-            ?.childNodes[1] // we have to use this level of nesting when selecting a target container because #repos-sticky-header children don't have specific classes or ids
+            ?.childNodes[2] // we have to use this level of nesting when selecting a target container because #repos-sticky-header children don't have specific classes or ids
     if (container instanceof HTMLElement) {
         container.prepend(mountElement)
         return mountElement
@@ -181,7 +181,6 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
 
 /**
  * Matches the modern single-file code view, or snippets embedded in comments.
- *
  */
 const fileLineContainerResolver: ViewResolver<CodeView> = {
     selector: getSelectorFor('blobContainer'),
@@ -299,7 +298,11 @@ export const checkIsGitHub = (): boolean => checkIsGitHubDotCom() || checkIsGitH
 const OPEN_ON_SOURCEGRAPH_ID = 'open-on-sourcegraph'
 
 export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLElement): HTMLElement | null => {
-    const pageheadActions = querySelectorOrSelf(container, '.pagehead-actions')
+    const isGlobalNavigationUpdateFeaturePreviewEnabled = !!querySelectorOrSelf(container, 'header.AppHeader')
+    const pageheadActions = querySelectorOrSelf(
+        container,
+        isGlobalNavigationUpdateFeaturePreviewEnabled ? '.AppHeader-globalBar-end' : '.pagehead-actions'
+    )
     // If ran on page that isn't under a repository namespace.
     if (!pageheadActions || pageheadActions.children.length === 0) {
         return null
@@ -310,7 +313,7 @@ export const createOpenOnSourcegraphIfNotExists: MountGetter = (container: HTMLE
         return mount
     }
     // Create new
-    mount = document.createElement('li')
+    mount = document.createElement(isGlobalNavigationUpdateFeaturePreviewEnabled ? 'div' : 'li')
     mount.id = OPEN_ON_SOURCEGRAPH_ID
     pageheadActions.prepend(mount)
     return mount


### PR DESCRIPTION
Renders view repo/file on Sourcegraph links on GitHub with [Global navigation update](https://github.blog/changelog/2023-04-05-redesigned-navigation-available-in-public-beta/) feature preview enabled.

## Test plan
- Run the browser extension locally
- Open any blob view on GitHub and ensure view repo/file on Sourcegraph links are rendered when the [New Code Search and Code View](https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view) and [Global navigation update](https://github.blog/changelog/2023-04-05-redesigned-navigation-available-in-public-beta/) features are enabled or disabled.

Tested locally (screenshots attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
