### PR TITLE
bazel: ensure all analyzers respect nolint

### DIFF
--- a/dev/linters/bodyclose/BUILD.bazel
+++ b/dev/linters/bodyclose/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["bodyclose.go"],
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/bodyclose",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_timakin_bodyclose//passes/bodyclose:go_default_library"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_timakin_bodyclose//passes/bodyclose:go_default_library",
+    ],
 )

--- a/dev/linters/bodyclose/bodyclose.go
+++ b/dev/linters/bodyclose/bodyclose.go
@@ -2,6 +2,8 @@ package bodyclose
 
 import (
 	"github.com/timakin/bodyclose/passes/bodyclose"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
-var Analyzer = bodyclose.Analyzer
+var Analyzer = nolint.Wrap(bodyclose.Analyzer)

--- a/dev/linters/exportloopref/BUILD.bazel
+++ b/dev/linters/exportloopref/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["exportloopref.go"],
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/exportloopref",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_kyoh86_exportloopref//:go_default_library"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_kyoh86_exportloopref//:go_default_library",
+    ],
 )

--- a/dev/linters/exportloopref/exportloopref.go
+++ b/dev/linters/exportloopref/exportloopref.go
@@ -2,6 +2,7 @@ package exportloopref
 
 import (
 	"github.com/kyoh86/exportloopref"
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
-var Analyzer = exportloopref.Analyzer
+var Analyzer = nolint.Wrap(exportloopref.Analyzer)

--- a/dev/linters/forbidigo/BUILD.bazel
+++ b/dev/linters/forbidigo/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/forbidigo",
     visibility = ["//visibility:public"],
     deps = [
+        "//dev/linters/nolint",
         "@com_github_ashanbrown_forbidigo//forbidigo:go_default_library",  #keep
         "@com_github_ashanbrown_forbidigo//pkg/analyzer:go_default_library",  #keep
         "@org_golang_x_tools//go/analysis",

--- a/dev/linters/forbidigo/forbidigo.go
+++ b/dev/linters/forbidigo/forbidigo.go
@@ -6,10 +6,12 @@ import (
 	"github.com/ashanbrown/forbidigo/forbidigo"
 	"github.com/ashanbrown/forbidigo/pkg/analyzer"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
 // Analyzer is the analyzer nogo should use
-var Analyzer = analyzer.NewAnalyzer()
+var Analyzer = nolint.Wrap(analyzer.NewAnalyzer())
 
 // defaultPatterns the patterns forbigigo should ban if they match
 var defaultPatterns = []string{

--- a/dev/linters/gocritic/BUILD.bazel
+++ b/dev/linters/gocritic/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/gocritic",
     visibility = ["//visibility:public"],
     deps = [
+        "//dev/linters/nolint",
         "@com_github_go_critic_go_critic//framework/linter:go_default_library",  #keep
         "@org_golang_x_tools//go/analysis",
     ],

--- a/dev/linters/gocritic/gocritic.go
+++ b/dev/linters/gocritic/gocritic.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-critic/go-critic/framework/linter"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
 var Analyzer *analysis.Analyzer = createAnalyzer()
@@ -24,11 +26,11 @@ var DisabledLinters = []string{
 func createAnalyzer() *analysis.Analyzer {
 	linters := GetEnabledLinters(DisabledLinters...)
 
-	return &analysis.Analyzer{
+	return nolint.Wrap(&analysis.Analyzer{
 		Name: "gocritic",
 		Doc:  "linter from go-critic/go-critic, modified to be runnable in nogo",
 		Run:  runWithLinters(linters),
-	}
+	})
 }
 
 // runWithLinters is copied from https://sourcegraph.com/github.com/go-critic/go-critic@3f8d719ce34bb78eacfdb8fef52228aff8cbdb10/-/blob/checkers/analyzer/run.go?L27

--- a/dev/linters/ineffassign/BUILD.bazel
+++ b/dev/linters/ineffassign/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["ineffassign.go"],
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/ineffassign",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gordonklaus_ineffassign//pkg/ineffassign"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_gordonklaus_ineffassign//pkg/ineffassign",
+    ],
 )

--- a/dev/linters/ineffassign/ineffassign.go
+++ b/dev/linters/ineffassign/ineffassign.go
@@ -2,6 +2,8 @@ package ineffassign
 
 import (
 	"github.com/gordonklaus/ineffassign/pkg/ineffassign"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
-var Analyzer = ineffassign.Analyzer
+var Analyzer = nolint.Wrap(ineffassign.Analyzer)

--- a/dev/linters/nolint/BUILD.bazel
+++ b/dev/linters/nolint/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "directive",
-    srcs = ["directive.go"],
-    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/directive",
+    name = "nolint",
+    srcs = ["nolint.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/nolint",
     visibility = ["//visibility:public"],
     deps = [
         "@co_honnef_go_tools//analysis/report",

--- a/dev/linters/nolint/nolint.go
+++ b/dev/linters/nolint/nolint.go
@@ -121,7 +121,7 @@ func Wrap(analyzer *analysis.Analyzer) *analysis.Analyzer {
 	return analyzer
 }
 
-// respectNolintDirectives updates an analyzer from `staticcheck` and `golangci-linter` to make it work on nogo.
+// respectNolintDirectives updates an analyzer to make it work on nogo.
 // They have "lint:ignore" or "nolint" to make the analyzer ignore the code.
 func respectNolintDirectives(analyzer *analysis.Analyzer) {
 	analyzer.Requires = append(analyzer.Requires, Directives)

--- a/dev/linters/staticcheck/BUILD.bazel
+++ b/dev/linters/staticcheck/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -27,7 +27,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -41,7 +41,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1002"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -55,7 +55,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -69,7 +69,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1004"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -83,7 +83,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1005"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -97,7 +97,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1006"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -111,7 +111,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1007"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -125,7 +125,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1008"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -139,7 +139,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1010"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -153,7 +153,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1011"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -167,7 +167,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1012"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -181,7 +181,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1013"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -195,7 +195,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1014"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -209,7 +209,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1015"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -223,7 +223,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1016"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -237,7 +237,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1017"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -251,7 +251,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1018"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -265,7 +265,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1019"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -279,7 +279,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1020"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -293,7 +293,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1021"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -307,7 +307,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1023"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -321,7 +321,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1024"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -335,7 +335,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1025"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -349,7 +349,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1026"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -363,7 +363,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1027"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -377,7 +377,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1028"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -391,7 +391,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1029"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -405,7 +405,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA1030"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -419,7 +419,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA2000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -433,7 +433,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA2001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -447,7 +447,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA2002"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -461,7 +461,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA2003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -475,7 +475,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA3000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -489,7 +489,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA3001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -503,7 +503,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -517,7 +517,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -531,7 +531,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -545,7 +545,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4004"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -559,7 +559,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4005"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -573,7 +573,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4006"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -587,7 +587,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4008"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -601,7 +601,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4009"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -615,7 +615,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4010"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -629,7 +629,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4011"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -643,7 +643,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4012"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -657,7 +657,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4013"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -671,7 +671,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4014"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -685,7 +685,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4015"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -699,7 +699,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4016"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -713,7 +713,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4017"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -727,7 +727,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4018"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -741,7 +741,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4019"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -755,7 +755,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4020"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -769,7 +769,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4021"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -783,7 +783,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4022"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -797,7 +797,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4023"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -811,7 +811,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4024"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -825,7 +825,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4025"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -839,7 +839,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4026"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -853,7 +853,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4027"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -867,7 +867,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4028"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -881,7 +881,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4029"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -895,7 +895,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4030"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -909,7 +909,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA4031"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -923,7 +923,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -937,7 +937,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -951,7 +951,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5002"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -965,7 +965,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -979,7 +979,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5004"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -993,7 +993,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5005"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1007,7 +1007,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5007"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1021,7 +1021,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5008"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1035,7 +1035,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5009"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1049,7 +1049,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5010"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1063,7 +1063,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5011"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1077,7 +1077,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA5012"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1091,7 +1091,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA6000"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1105,7 +1105,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA6001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1119,7 +1119,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA6002"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1133,7 +1133,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA6003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1147,7 +1147,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA6005"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1161,7 +1161,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9001"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1175,7 +1175,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9002"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1189,7 +1189,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9003"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1203,7 +1203,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9004"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1217,7 +1217,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9005"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1231,7 +1231,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9006"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1245,7 +1245,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9007"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1259,7 +1259,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "SA9008"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -1272,7 +1272,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/staticcheck",
     visibility = ["//visibility:public"],
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",

--- a/dev/linters/staticcheck/cmd/gen.go
+++ b/dev/linters/staticcheck/cmd/gen.go
@@ -31,7 +31,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"AnalyzerName": "{{.Analyzer.Name}}"},
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",
@@ -44,7 +44,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/staticcheck",
     visibility = ["//visibility:public"],
     deps = [
-        "//dev/linters/directive",
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//analysis/lint",
         "@co_honnef_go_tools//staticcheck",
         "@org_golang_x_tools//go/analysis",

--- a/dev/linters/staticcheck/staticcheck.go
+++ b/dev/linters/staticcheck/staticcheck.go
@@ -6,7 +6,7 @@ import (
 	"honnef.co/go/tools/analysis/lint"
 	"honnef.co/go/tools/staticcheck"
 
-	"github.com/sourcegraph/sourcegraph/dev/linters/directive"
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 )
 
 var StaticCheckAnalyzers []*lint.Analyzer = staticcheck.Analyzers
@@ -16,9 +16,7 @@ var Analyzer *analysis.Analyzer = GetAnalyzerByName(AnalyzerName)
 func GetAnalyzerByName(name string) *analysis.Analyzer {
 	for _, a := range StaticCheckAnalyzers {
 		if a.Analyzer.Name == name {
-			//Wrap the analyzer so that it respects nolint directives
-			directive.RespectDirectives(a.Analyzer)
-			return a.Analyzer
+			return nolint.Wrap(a.Analyzer)
 		}
 	}
 	return nil


### PR DESCRIPTION
* Rename `directive` package to nolint
* Wrap all analyzers with `nolint.Wrap`
## Test plan
green ci
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
