### PR TITLE
Pjlast/cody extension llmsp

### DIFF
--- a/client/cody/.gitignore
+++ b/client/cody/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 out/
 .vscode-test/
 dist/
+scripts/llmsp/

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -74,6 +74,10 @@
         "title": "Cody: Toggle Enabled/Disabled"
       },
       {
+        "command": "cody.dostuff",
+        "title": "Cody: Do stuff"
+      },
+      {
         "command": "cody.recipe.explain-code",
         "title": "Ask Cody: Explain Code in Detail"
       },

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -264,8 +264,9 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.4.2",
     "@sourcegraph/cody-shared": "workspace:*",
-    "openai": "^3.2.1",
     "@sourcegraph/cody-ui": "workspace:*",
+    "openai": "^3.2.1",
+    "vscode-languageclient": "^8.1.0",
     "wink-eng-lite-web-model": "^1.5.0",
     "wink-nlp": "^1.13.1",
     "wink-nlp-utils": "^2.1.0"

--- a/client/cody/resources/.gitignore
+++ b/client/cody/resources/.gitignore
@@ -1,1 +1,2 @@
 bin/ripgrep*
+bin/llmsp*

--- a/client/cody/scripts/build-llmsp.sh
+++ b/client/cody/scripts/build-llmsp.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+VERSION="v1.0.0"
+
+run() {
+        LLMSP_DIR="$(dirname "$(readlink -f "$0")")/../resources/bin"
+        mkdir -p "${LLMSP_DIR}"
+	git clone "git@github.com:pjlast/llmsp" && cd llmsp && \
+    env GOOS=windows GOARCH=amd64 go build -o "${LLMSP_DIR}/llmsp-v1.0.0-amd64-windows.exe" && \
+    env GOOS=darwin GOARCH=amd64 go build -o "${LLMSP_DIR}/llmsp-v1.0.0-amd64-darwin" && \
+    env GOOS=darwin GOARCH=arm64 go build -o "${LLMSP_DIR}/llmsp-v1.0.0-arm64-darwin" && \
+    env GOOS=linux GOARCH=amd64 go build -o "${LLMSP_DIR}/llmsp-v1.0.0-amd64-linux" && \
+    env GOOS=linux GOARCH=arm64 go build -o "${LLMSP_DIR}/llmsp-v1.0.0-arm64-linux"
+
+  pushd "${LLMSP_DIR}" || return
+	trap 'popd' EXIT
+}
+
+run

--- a/client/cody/scripts/check-llmsp.sh
+++ b/client/cody/scripts/check-llmsp.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+run() {
+
+	pushd "$(dirname "$(readlink -f "$0")")/../resources/bin" &> /dev/null || return
+	trap 'popd > /dev/null' EXIT
+
+	# Get this list by copying output of `ls resources/bin/ripgrep*`
+	binaries=$(cat <<EOF
+llmsp-v1.0.0-amd64-darwin
+llmsp-v1.0.0-arm64-darwin
+llmsp-v1.0.0-amd64-linux
+llmsp-v1.0.0-arm64-linux
+llmsp-v1.0.0-amd64-windows.exe
+EOF
+			)
+
+	for binary in $binaries; do
+		if ls "$binary"; then
+			continue
+		fi
+		return 1
+	done
+}
+
+if run; then
+	exit 0
+else
+	echo "Need to build llmsp binaries. Try running 'scripts/build-llmsp.sh'? Afterward, update the list of binaries in 'scripts/check-llmsp.sh'"
+	exit 1
+fi

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -8,6 +8,7 @@ import { start } from './main'
 import { getConfiguration } from './configuration'
 import { ExtensionApi } from './extension-api'
 import { CODY_ACCESS_TOKEN_SECRET, VSCodeSecretStorage } from './secret-storage'
+import path from 'path'
 
 let client: LanguageClient
 
@@ -27,11 +28,11 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
 
     let serverOptions: ServerOptions = {
         run: {
-            command: '/home/pjlast/go/bin/llmsp',
+            command: path.join(context.extensionPath, "resources", "bin", "llmsp"),
             transport: TransportKind.stdio,
         },
         debug: {
-            command: '/home/pjlast/go/bin/llmsp',
+            command: path.join(context.extensionPath, "resources", "bin", "llmsp"),
             transport: TransportKind.stdio,
         },
     }

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -1,5 +1,7 @@
-import * as vscode from 'vscode'
 import * as os from 'os'
+import path from 'path'
+
+import * as vscode from 'vscode'
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node'
 
 import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
@@ -9,7 +11,6 @@ import { start } from './main'
 import { getConfiguration } from './configuration'
 import { ExtensionApi } from './extension-api'
 import { CODY_ACCESS_TOKEN_SECRET, VSCodeSecretStorage } from './secret-storage'
-import path from 'path'
 
 let client: LanguageClient
 
@@ -28,35 +29,35 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
     console.log('Cody extension activated')
 
     const arch = process.env.npm_config_path || os.arch()
-    let binaryName = "llmsp-v1.0.0"
-    switch (os.platform()) {
-        case 'darwin':
-            binaryName += "-darwin"
+    let binaryName = 'llmsp-v1.0.0'
+    switch (arch) {
+        case 'arm64':
+            binaryName += '-arm64'
             break
-        case 'win32':
-            binaryName += "-windows"
-            break
-        case 'linux':
-            binaryName += "-linux"
+        case 'amd64':
+            binaryName += '-amd64'
             break
     }
 
-    switch (arch) {
-        case 'arm64':
-            binaryName += "-arm64"
+    switch (os.platform()) {
+        case 'darwin':
+            binaryName += '-darwin'
             break
-        case 'amd64':
-            binaryName += "-amd64"
+        case 'win32':
+            binaryName += '-windows'
+            break
+        case 'linux':
+            binaryName += '-linux'
             break
     }
 
     let serverOptions: ServerOptions = {
         run: {
-            command: path.join(context.extensionPath, "resources", "bin", binaryName),
+            command: path.join(context.extensionPath, 'resources', 'bin', binaryName),
             transport: TransportKind.stdio,
         },
         debug: {
-            command: path.join(context.extensionPath, "resources", "bin", binaryName),
+            command: path.join(context.extensionPath, 'resources', 'bin', binaryName),
             transport: TransportKind.stdio,
         },
     }
@@ -94,7 +95,7 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
     })
 
     const config = getConfiguration(vscode.workspace.getConfiguration())
-    const repos = config.codebase != undefined && config.codebase != "" ? [config.codebase] : null;
+    const repos = config.codebase != undefined && config.codebase != '' ? [config.codebase] : null
 
     secretStorage.get(CODY_ACCESS_TOKEN_SECRET).then(res => {
         client.sendNotification('workspace/didChangeConfiguration', {

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -1,11 +1,88 @@
 import * as vscode from 'vscode'
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node'
 
 import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 
-import { ExtensionApi } from './extension-api'
 import { start } from './main'
 
+import { getConfiguration } from './configuration'
+import { ExtensionApi } from './extension-api'
+import { CODY_ACCESS_TOKEN_SECRET, VSCodeSecretStorage } from './secret-storage'
+
+let client: LanguageClient
+
+function sendCommandRequest(command: string, args: any[] | undefined): void {
+    client
+        .sendRequest('workspace/executeCommand', {
+            command,
+            arguments: args,
+        })
+        .catch(e => {
+            console.error(e)
+        })
+}
+
 export function activate(context: vscode.ExtensionContext): ExtensionApi {
+    console.log('Cody extension activated')
+
+    let serverOptions: ServerOptions = {
+        run: {
+            command: '/home/pjlast/go/bin/llmsp',
+            transport: TransportKind.stdio,
+        },
+        debug: {
+            command: '/home/pjlast/go/bin/llmsp',
+            transport: TransportKind.stdio,
+        },
+    }
+
+    PromptMixin.add(languagePromptMixin(vscode.env.language))
+
+    vscode.commands.registerCommand
+
+    // Options to control the language client
+    let clientOptions: LanguageClientOptions = {
+        // Register the server for plain text documents
+        documentSelector: [{ scheme: 'file', language: 'go' }],
+        synchronize: {
+            // Notify the server about file changes to '.clientrc files contained in the workspace
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.go'),
+        },
+        middleware: {
+            resolveCodeAction: async (item, token, next): Promise<vscode.CodeAction | undefined> => {
+                const action = await next(item, token)
+                if (action != null && action != undefined && action.command != undefined) {
+                    sendCommandRequest(action.command.command, action.command.arguments)
+                }
+                return undefined
+            },
+        },
+    }
+
+    // Create the language client and start the client.
+    client = new LanguageClient('llmsp', 'LLM-powered LSP', serverOptions, clientOptions)
+    const secretStorage = new VSCodeSecretStorage(context.secrets)
+
+    // Start the client. This will also launch the server
+    client.start().catch(e => {
+        console.error("LSP failed to start: ", e)
+    })
+
+    const config = getConfiguration(vscode.workspace.getConfiguration())
+
+    secretStorage.get(CODY_ACCESS_TOKEN_SECRET).then(res => {
+        client.sendNotification('workspace/didChangeConfiguration', {
+            settings: {
+                llmsp: {
+                    sourcegraph: {
+                        url: config.serverEndpoint,
+                        accessToken: res ?? '',
+                    },
+                },
+            },
+        })
+    })
+
     PromptMixin.add(languagePromptMixin(vscode.env.language))
 
     if (process.env.CODY_FOCUS_ON_STARTUP) {

--- a/package.json
+++ b/package.json
@@ -487,6 +487,7 @@
     "util": "^0.12.5",
     "utility-types": "^3.10.0",
     "uuid": "^8.3.0",
+    "vscode-languageclient": "^8.1.0",
     "vscode-uri": "^3.0.7",
     "webext-domain-permission-toggle": "^1.0.1",
     "webextension-polyfill": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,7 @@ importers:
       uuid: ^8.3.0
       vite: ^4.1.4
       vsce: ^2.7.0
+      vscode-languageclient: ^8.1.0
       vscode-uri: ^3.0.7
       webext-domain-permission-toggle: ^1.0.1
       webextension-polyfill: ^0.6.0
@@ -553,6 +554,7 @@ importers:
       util: 0.12.5
       utility-types: 3.10.0
       uuid: 8.3.2
+      vscode-languageclient: 8.1.0
       vscode-uri: 3.0.7
       webext-domain-permission-toggle: 1.0.1
       webextension-polyfill: 0.6.0
@@ -923,6 +925,7 @@ importers:
       '@sourcegraph/cody-shared': workspace:*
       '@sourcegraph/cody-ui': workspace:*
       openai: ^3.2.1
+      vscode-languageclient: ^8.1.0
       wink-eng-lite-web-model: ^1.5.0
       wink-nlp: ^1.13.1
       wink-nlp-utils: ^2.1.0
@@ -931,6 +934,7 @@ importers:
       '@sourcegraph/cody-shared': link:../cody-shared
       '@sourcegraph/cody-ui': link:../cody-ui
       openai: 3.2.1
+      vscode-languageclient: 8.1.0
       wink-eng-lite-web-model: 1.5.0_wink-nlp@1.13.1
       wink-nlp: 1.13.1
       wink-nlp-utils: 2.1.0
@@ -11254,6 +11258,12 @@ packages:
       balanced-match: 1.0.0
       concat-map: 0.0.1
 
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.0
+    dev: false
+
   /braces/2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
     engines: {node: '>=0.10.0'}
@@ -16498,7 +16508,7 @@ packages:
     dependencies:
       graphql: 15.4.0
       nullthrows: 1.1.1
-      vscode-languageserver-types: 3.17.2
+      vscode-languageserver-types: 3.17.3
     dev: false
 
   /graphql-request/5.0.0_graphql@15.4.0:
@@ -20823,6 +20833,13 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
     dev: true
+
+  /minimatch/5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist-options/4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -27844,12 +27861,37 @@ packages:
       yazl: 2.5.1
     dev: true
 
+  /vscode-jsonrpc/8.1.0:
+    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /vscode-languageclient/8.1.0:
+    resolution: {integrity: sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==}
+    engines: {vscode: ^1.67.0}
+    dependencies:
+      minimatch: 5.1.6
+      semver: 7.3.8
+      vscode-languageserver-protocol: 3.17.3
+    dev: false
+
+  /vscode-languageserver-protocol/3.17.3:
+    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+    dependencies:
+      vscode-jsonrpc: 8.1.0
+      vscode-languageserver-types: 3.17.3
+    dev: false
+
   /vscode-languageserver-textdocument/1.0.2:
     resolution: {integrity: sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==}
     dev: false
 
   /vscode-languageserver-types/3.17.2:
     resolution: {integrity: sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==}
+    dev: false
+
+  /vscode-languageserver-types/3.17.3:
+    resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
     dev: false
 
   /vscode-uri/3.0.7:


### PR DESCRIPTION
This PR is a proof of concept to use an LSP to interact with Cody in the VS Code extension.

To test it you will need to:

1. `cd` to `client/cody` and run `pnpm install`
2. `cd` into `scripts` and run `./build-llmsp.sh`
3. Rebuild the extension with `pnpm vsce:package` and install the extension from the resulting .vsix file

This is a bare minimal example. The prompts used come from the github.com/pjlast/llmsp repository and aren't particularly refined.

Autocompletion is enabled by default.

See [this Google doc](https://docs.google.com/document/d/1Tcm5GxDCHhbhttEyqSioA7fh_uj8MZdpUnrtRFt2sjc/edit#heading=h.3h14em4e1glt) for further thoughts.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-cody-extension-llmsp.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

