### PR TITLE
insights: allow repo iterators to be created over zero repos

### DIFF
--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -86,10 +86,6 @@ func New(ctx context.Context, store *basestore.Store, repos []int32) (*Persisten
 
 // NewWithClock returns a new (durable) repo iterator starting from cursor position 0 and optionally overrides the internal clock. Useful for tests.
 func NewWithClock(ctx context.Context, store *basestore.Store, clock glock.Clock, repos []int32) (*PersistentRepoIterator, error) {
-	if len(repos) == 0 {
-		return nil, errors.New("unable to construct a repo iterator for an empty set")
-	}
-
 	q := "INSERT INTO repo_iterator(repos, total_count, created_at) VALUES (%S, %S, %S) RETURNING Id"
 	id, err := basestore.ScanInt(store.QueryRow(ctx, sqlf.Sprintf(q, pq.Int32Array(repos), len(repos), clock.Now())))
 	if err != nil {


### PR DESCRIPTION
Currently insights that have resolve to matching no repos will fail the backfill because a repo iterator isn't allowed to be created for 0 repos.  I don't see a reason why we need to disallow empty iterators.  This removes that restriction.
## Test plan
Unit test added
Created an insight over 0 repos using repo search `repo:notarepo` - verified insight completed backfilling with zero data. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
