### PR TITLE
hotfix: temporarily revert to curl 7.X

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -39,7 +39,11 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -43,7 +43,11 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,11 @@ RUN apk update && apk add --no-cache \
     'bind-tools>=9.16.33-r0' \
     busybox \
     ca-certificates \
-    'curl>=8.0.0-r0' --repository='https://dl-cdn.alpinelinux.org/alpine/edge/main' \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    # 'curl>=8.0.0-r0' --repository='https://dl-cdn.alpinelinux.org/alpine/edge/main' \
+    curl \
     mailcap \
     tini \
     wget

--- a/enterprise/cmd/batcheshelper/Dockerfile
+++ b/enterprise/cmd/batcheshelper/Dockerfile
@@ -17,6 +17,10 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
 
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/batcheshelper/Dockerfile
+++ b/enterprise/cmd/batcheshelper/Dockerfile
@@ -21,6 +21,6 @@ RUN apk add --no-cache \
     # TODO(DevX) for now, we disable this, because the latest release of curl on edge
     # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
     # DRI: @jhchabran
-    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
 
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/bundled-executor/Dockerfile
+++ b/enterprise/cmd/bundled-executor/Dockerfile
@@ -26,7 +26,11 @@ ENV EXECUTOR_NUM_TOTAL_JOBS=1
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     ca-certificates
 
 # Install src-cli.

--- a/enterprise/cmd/executor-kubernetes/Dockerfile
+++ b/enterprise/cmd/executor-kubernetes/Dockerfile
@@ -18,7 +18,11 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     ca-certificates
 
 USER sourcegraph

--- a/enterprise/cmd/executor/docker-image/Dockerfile
+++ b/enterprise/cmd/executor/docker-image/Dockerfile
@@ -21,7 +21,11 @@ ENV EXECUTOR_USE_FIRECRACKER=false
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     docker \
     ca-certificates
 

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -40,7 +40,11 @@ RUN apk add --no-cache \
     # backported fix for 3.14 https://security.alpinelinux.org/vuln/CVE-2023-22490
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # 'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # TODO(DevX) for now, we disable this, because the latest release of curl on edge
+    # segfaults on 3.14 and the latest git on edge depends on it. We'll be releasing a fix before the patch release.
+    # DRI: @jhchabran
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \


### PR DESCRIPTION
For now, we disable this, because the latest release of curl on edge segfaults on 3.14. We'll be releasing a fix before the patch release. DRI: @jhchabran

@evict We'll be ready with a safe curl version for the next patch release. For now this enables to unblock main and to deal with this not in hurry tomorrow. 

We rule this as safe, because this commit is not going to be released as is and by then it will be fixed. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

docker run + `wget` = no segfault. 