### PR TITLE
Cody: fix bug where currently open file dominated context

### DIFF
--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -1,10 +1,9 @@
-import path from 'path'
-
 import { CodebaseContext } from '../../codebase-context'
 import { ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
 import { Editor } from '../../editor'
 import { IntentDetector } from '../../intent-detector'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
+import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
@@ -60,21 +59,8 @@ export class ChatQuestion implements Recipe {
         }
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
-            populateCurrentEditorCodeContextTemplate(truncatedContent, visibleContent.fileName),
-            visibleContent.fileName,
-            `You currently have \`${visibleContent.fileName}\` open in your editor, and I can answer questions about that file's contents.`
+            populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName),
+            visibleContent.fileName
         )
     }
-}
-
-const CURRENT_EDITOR_CODE_TEMPLATE = `I have the \`{filePath}\` file opened in my editor. You are able to answer questions about \`{filePath}\`. The following code snippet is from the currently open file in my editor \`{filePath}\`:
-\`\`\`{language}
-{text}
-\`\`\``
-
-function populateCurrentEditorCodeContextTemplate(code: string, filePath: string): string {
-    const language = path.extname(filePath).slice(1)
-    return CURRENT_EDITOR_CODE_TEMPLATE.replace(/{filePath}/g, filePath)
-        .replace('{language}', language)
-        .replace('{text}', code)
 }

--- a/client/cody-shared/src/chat/transcript/transcript.test.ts
+++ b/client/cody-shared/src/chat/transcript/transcript.test.ts
@@ -208,11 +208,11 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             {
                 speaker: 'human',
-                text: 'I have the `internal/lib.go` file opened in my editor. You are able to answer questions about `internal/lib.go`. The following code snippet is from the currently open file in my editor `internal/lib.go`:\n```go\npackage lib\n```',
+                text: 'I have the `internal/lib.go` file opened in my editor. Use following code snippet from file `internal/lib.go`:\n```go\npackage lib\n```',
             },
             {
                 speaker: 'assistant',
-                text: "You currently have `internal/lib.go` open in your editor, and I can answer questions about that file's contents.",
+                text: 'Ok.',
             },
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: '' },

--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import { EmbeddingsSearch } from '../embeddings'
 import { KeywordContextFetcher } from '../keyword-context'
-import { populateCodeContextTemplate, populateMarkdownContextTemplate } from '../prompt/templates'
+import { isMarkdownFile, populateCodeContextTemplate, populateMarkdownContextTemplate } from '../prompt/templates'
 import { Message } from '../sourcegraph-api'
 import { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 import { isError } from '../utils'
@@ -124,11 +124,4 @@ function mergeConsecutiveResults(results: EmbeddingsSearchResult[]): string[] {
     }
 
     return mergedResults
-}
-
-const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown'])
-
-function isMarkdownFile(filePath: string): boolean {
-    const extension = path.extname(filePath).slice(1)
-    return MARKDOWN_EXTENSIONS.has(extension)
 }

--- a/client/cody-shared/src/prompt/templates.ts
+++ b/client/cody-shared/src/prompt/templates.ts
@@ -15,3 +15,19 @@ const MARKDOWN_CONTEXT_TEMPLATE = 'Use the following text from file `{filePath}`
 export function populateMarkdownContextTemplate(markdown: string, filePath: string): string {
     return MARKDOWN_CONTEXT_TEMPLATE.replace('{filePath}', filePath).replace('{text}', markdown)
 }
+
+const CURRENT_EDITOR_CODE_TEMPLATE = 'I have the `{filePath}` file opened in my editor. '
+
+export function populateCurrentEditorContextTemplate(code: string, filePath: string): string {
+    const context = isMarkdownFile(filePath)
+        ? populateMarkdownContextTemplate(code, filePath)
+        : populateCodeContextTemplate(code, filePath)
+    return CURRENT_EDITOR_CODE_TEMPLATE.replace(/{filePath}/g, filePath) + context
+}
+
+const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown'])
+
+export function isMarkdownFile(filePath: string): boolean {
+    const extension = path.extname(filePath).slice(1)
+    return MARKDOWN_EXTENSIONS.has(extension)
+}


### PR DESCRIPTION
The change in #50101 caused a regression where Cody would refuse to answer questions about the codebase when there was a file open in the editor. This was because Cody thought the open file was the only context it was allowed to use. This PR adjusts the editor prompt so Cody will use all context files.

## Test plan

Adjusted unit test. Ran following tests against Sourcegraph repo to check they work:
* What repo do you have access to?
* Summarize the currently open file
* What does InternalDoer do?
* Where are the Cody “no context messages” defined
* are sub-repo permissions respected in the embeddings service?
