### PR TITLE
bazel: bundlesize check

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//:bundlesize2/package_json.bzl", bundlesize_bin = "bin")
 load("//client/shared/dev:generate_graphql_operations.bzl", "generate_graphql_operations")
 load("//client/shared/dev:tools.bzl", "module_style_typings")
 load("//dev:defs.bzl", "jest_test", "npm_package", "sass", "ts_project")
@@ -1978,6 +1979,7 @@ webpack_bundle(
     ],
     entry_points = {
         "src/enterprise/main.js": "app",
+        "src/enterprise/embed/main.js": "embed",
     },
     env = {
         "NODE_ENV": "production",
@@ -2043,4 +2045,20 @@ build_test(
         ":bundle",
         ":bundle-enterprise",
     ],
+)
+
+bundlesize_bin.bundlesize_test(
+    name = "bundlesize_test",
+    args = [
+        "--config",
+        "$(location bundlesize.config.js)",
+        "--enable-github-checks",
+    ],
+    data = [
+        "bundlesize.config.js",
+        ":bundle-enterprise",
+    ],
+    env = {
+        "WEB_BUNDLE_PATH": "$(rootpath //client/web:bundle-enterprise)",
+    },
 )

--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const STATIC_ASSETS_PATH = path.join(__dirname, '../../ui/assets')
+const STATIC_ASSETS_PATH = process.env.WEB_BUNDLE_PATH || path.join(__dirname, '../../ui/assets')
 
 const config = {
   files: [
@@ -8,7 +8,7 @@ const config = {
      * Our main entry JavaScript bundles, contains core logic that is loaded on every page.
      */
     {
-      path: path.join(STATIC_ASSETS_PATH, 'scripts/app.bundle.js.br'),
+      path: path.join(STATIC_ASSETS_PATH, 'scripts/app.*.bundle.js.br'),
       /**
        * Note: Temporary increase from 400kb.
        * Primary cause is due to multiple ongoing migrations that mean we are duplicating similar dependencies.
@@ -18,17 +18,17 @@ const config = {
       compression: 'none',
     },
     {
-      path: path.join(STATIC_ASSETS_PATH, 'scripts/embed.bundle.js.br'),
+      path: path.join(STATIC_ASSETS_PATH, 'scripts/embed.*.bundle.js.br'),
       maxSize: '155kb',
       compression: 'none',
     },
     {
-      path: path.join(STATIC_ASSETS_PATH, 'scripts/react.bundle.js.br'),
+      path: path.join(STATIC_ASSETS_PATH, 'scripts/react.*.bundle.js.br'),
       maxSize: '45kb',
       compression: 'none',
     },
     {
-      path: path.join(STATIC_ASSETS_PATH, 'scripts/opentelemetry.bundle.js.br'),
+      path: path.join(STATIC_ASSETS_PATH, 'scripts/opentelemetry.*.bundle.js.br'),
       maxSize: '40kb',
       compression: 'none',
     },

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -286,7 +286,7 @@ func addWebAppEnterpriseBuild(opts CoreTestOperationsOptions) operations.Operati
 			bk.Env("ENTERPRISE", "1"),
 			bk.Env("CHECK_BUNDLESIZE", "1"),
 			// To ensure the Bundlesize output can be diffed to the baseline on main
-			bk.Env("WEBPACK_USE_NAMED_CHUNKS", "true"),
+			// bk.Env("WEBPACK_USE_NAMED_CHUNKS", "true"),
 		}
 
 		if opts.CacheBundleSize {

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -285,8 +285,6 @@ func addWebAppEnterpriseBuild(opts CoreTestOperationsOptions) operations.Operati
 			bk.Env("NODE_ENV", "production"),
 			bk.Env("ENTERPRISE", "1"),
 			bk.Env("CHECK_BUNDLESIZE", "1"),
-			// To ensure the Bundlesize output can be diffed to the baseline on main
-			// bk.Env("WEBPACK_USE_NAMED_CHUNKS", "true"),
 		}
 
 		if opts.CacheBundleSize {


### PR DESCRIPTION
## Context

Enabled the bundlesize check in Bazel.

## Test plan

CI and see that the bundlesize check in GitHub actions.
