### PR TITLE
Add completions to server

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
@@ -1,9 +1,13 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source'
 
 import { SourcegraphCompletionsClient } from './client'
-import type { Event, CompletionParameters, CompletionCallbacks } from './types'
+import type { Event, CompletionParameters, CompletionCallbacks, CodeCompletionResponse } from './types'
 
 export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
+    public complete(): Promise<CodeCompletionResponse> {
+        throw new Error('SourcegraphBrowserCompletionsClienet.complete not implemented')
+    }
+
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
         const abort = new AbortController()
         fetchEventSource(this.completionsEndpoint, {
@@ -15,7 +19,6 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             body: JSON.stringify(params),
             signal: abort.signal,
             onmessage: message => {
-                // console.log('[EventSource]', message)
                 const data: Event = { ...JSON.parse(message.data), type: message.event }
                 this.sendEvents([data], cb)
             },

--- a/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
@@ -5,7 +5,7 @@ import type { Event, CompletionParameters, CompletionCallbacks, CodeCompletionRe
 
 export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
     public complete(): Promise<CodeCompletionResponse> {
-        throw new Error('SourcegraphBrowserCompletionsClienet.complete not implemented')
+        throw new Error('SourcegraphBrowserCompletionsClient.complete not implemented')
     }
 
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {

--- a/client/cody-shared/src/sourcegraph-api/completions/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/client.ts
@@ -1,7 +1,14 @@
-import { Event, CompletionParameters, CompletionCallbacks } from './types'
+import {
+    Event,
+    CompletionParameters,
+    CompletionCallbacks,
+    CodeCompletionParameters,
+    CodeCompletionResponse,
+} from './types'
 
 export abstract class SourcegraphCompletionsClient {
     protected completionsEndpoint: string
+    protected codeCompletionsEndpoint: string
 
     constructor(
         instanceUrl: string,
@@ -9,6 +16,7 @@ export abstract class SourcegraphCompletionsClient {
         protected mode: 'development' | 'production'
     ) {
         this.completionsEndpoint = `${instanceUrl}/.api/completions/stream`
+        this.codeCompletionsEndpoint = `${instanceUrl}/.api/completions/code`
     }
 
     protected sendEvents(events: Event[], cb: CompletionCallbacks): void {
@@ -28,4 +36,5 @@ export abstract class SourcegraphCompletionsClient {
     }
 
     public abstract stream(params: CompletionParameters, cb: CompletionCallbacks): () => void
+    public abstract complete(params: CodeCompletionParameters): Promise<CodeCompletionResponse>
 }

--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -5,9 +5,58 @@ import { isError } from '../../utils'
 
 import { SourcegraphCompletionsClient } from './client'
 import { parseEvents } from './parse'
-import { CompletionParameters, CompletionCallbacks } from './types'
+import { CompletionParameters, CompletionCallbacks, CodeCompletionParameters, CodeCompletionResponse } from './types'
 
 export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClient {
+    public async complete(params: CodeCompletionParameters): Promise<CodeCompletionResponse> {
+        const requestFn = this.codeCompletionsEndpoint.startsWith('https://') ? https.request : http.request
+        const completion = await new Promise<CodeCompletionResponse>((resolve, reject) => {
+            const req = requestFn(
+                this.codeCompletionsEndpoint,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...(this.accessToken ? { Authorization: `token ${this.accessToken}` } : null),
+                    },
+                    // So we can send requests to the Sourcegraph local development instance, which has an incompatible cert.
+                    rejectUnauthorized: this.mode === 'production',
+                },
+                (res: http.IncomingMessage) => {
+                    let buffer = ''
+
+                    res.on('data', chunk => {
+                        if (!(chunk instanceof Buffer)) {
+                            throw new TypeError('expected chunk to be a Buffer')
+                        }
+                        buffer += chunk.toString()
+                    })
+                    res.on('end', () => {
+                        req.destroy()
+                        try {
+                            const resp = JSON.parse(buffer) as CodeCompletionResponse
+                            if (typeof resp.completion !== 'string' || typeof resp.stopReason !== 'string') {
+                                reject(`response ${resp} does not satisfiy CodeCompletionResponse`)
+                            } else {
+                                resolve(resp)
+                            }
+                        } catch (err) {
+                            reject(`error parsing response ${buffer} as CodeCompletionResponse: ${err}`)
+                        }
+                    })
+
+                    res.on('error', e => {
+                        req.destroy()
+                        reject(e)
+                    })
+                }
+            )
+            req.write(JSON.stringify(params))
+            req.end()
+        })
+        return completion
+    }
+
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
         const requestFn = this.completionsEndpoint.startsWith('https://') ? https.request : http.request
 

--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -36,7 +36,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         try {
                             const resp = JSON.parse(buffer) as CodeCompletionResponse
                             if (typeof resp.completion !== 'string' || typeof resp.stopReason !== 'string') {
-                                reject(`response ${resp} does not satisfiy CodeCompletionResponse`)
+                                reject(`response ${resp} does not satisfy CodeCompletionResponse`)
                             } else {
                                 resolve(resp)
                             }

--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -36,12 +36,16 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         try {
                             const resp = JSON.parse(buffer) as CodeCompletionResponse
                             if (typeof resp.completion !== 'string' || typeof resp.stopReason !== 'string') {
-                                reject(`response ${resp} does not satisfy CodeCompletionResponse`)
+                                reject(new Error(`response does not satisfy CodeCompletionResponse: ${buffer}`))
                             } else {
                                 resolve(resp)
                             }
-                        } catch (err) {
-                            reject(`error parsing response ${buffer} as CodeCompletionResponse: ${err}`)
+                        } catch (error) {
+                            reject(
+                                new Error(
+                                    `error parsing response CodeCompletionResponse: ${error}, response text: ${buffer}`
+                                )
+                            )
                         }
                     })
 

--- a/client/cody-shared/src/sourcegraph-api/completions/types.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/types.ts
@@ -19,6 +19,25 @@ export interface Message {
     text: string
 }
 
+export interface CodeCompletionResponse {
+    completion: string
+    stop: string | null
+    stopReason: string
+    truncated: boolean
+    exception: string | null
+    logID: string
+}
+
+export interface CodeCompletionParameters {
+    prompt: string
+    temperature: number
+    maxTokensToSample: number
+    stopSequences: string[]
+    topK: number
+    topP: number
+    model?: string
+}
+
 export interface CompletionParameters {
     messages: Message[]
     temperature: number

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -22,7 +22,6 @@ import { updateConfiguration } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { logEvent } from '../event-logger'
 import { configureExternalServices } from '../external-services'
-import { getRgPath } from '../rg'
 import { sanitizeServerEndpoint } from '../sanitize'
 import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, SecretStorage } from '../secret-storage'
 import { TestSupport } from '../test-support'
@@ -71,23 +70,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         codebase: string,
         serverEndpoint: string,
         contextType: 'embeddings' | 'keyword' | 'none' | 'blended',
-        debug: boolean,
         secretStorage: SecretStorage,
-        localStorage: LocalStorage
+        localStorage: LocalStorage,
+        editor: VSCodeEditor,
+        rgPath: string,
+        mode: 'development' | 'production',
+        intentDetector: IntentDetector,
+        codebaseContext: CodebaseContext,
+        chatClient: ChatClient
     ): Promise<ChatViewProvider> {
-        const mode = debug ? 'development' : 'production'
-        const rgPath = await getRgPath(extensionPath)
-        const editor = new VSCodeEditor()
-
-        const { intentDetector, codebaseContext, chatClient } = await configureExternalServices(
-            serverEndpoint,
-            codebase,
-            rgPath,
-            editor,
-            secretStorage,
-            contextType,
-            mode
-        )
         return new ChatViewProvider(
             extensionPath,
             codebase,
@@ -370,6 +361,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         return this.transcript.toChat()
     }
 
+    // TODO(beyang): maybe move this into CommandsProvider (should maybe change that to a top-level controller class)
     public async onConfigChange(change: string, codebase: string, serverEndpoint: string): Promise<void> {
         switch (change) {
             case 'token':

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -65,7 +65,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         this.createNewChatID()
     }
 
-    public static async create(
+    public static create(
         extensionPath: string,
         codebase: string,
         serverEndpoint: string,
@@ -78,7 +78,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         intentDetector: IntentDetector,
         codebaseContext: CodebaseContext,
         chatClient: ChatClient
-    ): Promise<ChatViewProvider> {
+    ): ChatViewProvider {
         return new ChatViewProvider(
             extensionPath,
             codebase,

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -1,4 +1,3 @@
-import * as anthropic from '@anthropic-ai/sdk'
 import * as vscode from 'vscode'
 
 import { ChatViewProvider } from '../chat/ChatViewProvider'
@@ -6,8 +5,11 @@ import { CodyCompletionItemProvider } from '../completions'
 import { CompletionsDocumentProvider } from '../completions/docprovider'
 import { History } from '../completions/history'
 import { getConfiguration } from '../configuration'
+import { VSCodeEditor } from '../editor/vscode-editor'
 import { logEvent, updateEventLogger } from '../event-logger'
 import { ExtensionApi } from '../extension-api'
+import { configureExternalServices } from '../external-services'
+import { getRgPath } from '../rg'
 import { sanitizeCodebase, sanitizeServerEndpoint } from '../sanitize'
 import { CODY_ACCESS_TOKEN_SECRET, InMemorySecretStorage, SecretStorage, VSCodeSecretStorage } from '../secret-storage'
 
@@ -28,15 +30,36 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
 
     await updateEventLogger(config, secretStorage, localStorage)
 
+    const editor = new VSCodeEditor()
+    const rgPath = await getRgPath(context.extensionPath)
+    const mode = config.debug ? 'development' : 'production'
+    const serverEndpoint = sanitizeServerEndpoint(config.serverEndpoint)
+    const codebase = sanitizeCodebase(config.codebase)
+
+    const { intentDetector, codebaseContext, chatClient, completionsClient } = await configureExternalServices(
+        serverEndpoint,
+        codebase,
+        rgPath,
+        editor,
+        secretStorage,
+        config.useContext,
+        mode
+    )
+
     // Create chat webview
     const chatProvider = await ChatViewProvider.create(
         context.extensionPath,
         sanitizeCodebase(config.codebase),
         sanitizeServerEndpoint(config.serverEndpoint),
         config.useContext,
-        config.debug,
         secretStorage,
-        localStorage
+        localStorage,
+        editor,
+        rgPath,
+        mode,
+        intentDetector,
+        codebaseContext,
+        chatClient
     )
 
     vscode.window.registerWebviewViewProvider('cody.chat', chatProvider, {
@@ -115,15 +138,11 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
     )
 
     if (config.experimentalSuggest) {
-        let claudeApi = null
-        if (config.anthropicKey) {
-            claudeApi = new anthropic.Client(config.anthropicKey)
-        }
         const docprovider = new CompletionsDocumentProvider()
         vscode.workspace.registerTextDocumentContentProvider('cody', docprovider)
 
         const history = new History()
-        const completionsProvider = new CodyCompletionItemProvider(claudeApi, docprovider, history)
+        const completionsProvider = new CodyCompletionItemProvider(completionsClient, docprovider, history)
         context.subscriptions.push(
             vscode.commands.registerCommand('cody.experimental.suggest', async () => {
                 await completionsProvider.fetchAndShowCompletions()

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -47,7 +47,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
     )
 
     // Create chat webview
-    const chatProvider = await ChatViewProvider.create(
+    const chatProvider = ChatViewProvider.create(
         context.extensionPath,
         sanitizeCodebase(config.codebase),
         sanitizeServerEndpoint(config.serverEndpoint),

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -103,15 +103,15 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     this.responseTokens,
                     prefix,
                     '',
-                    2
+                    2 // 2 tries
                 ),
                 new EndOfLineCompletionProvider(
                     this.completionsClient,
                     remainingChars,
                     this.responseTokens,
                     prefix,
-                    '\n',
-                    2
+                    '\n', // force a new line in the case we are at end of line
+                    2 // 2 tries
                 )
             )
         }
@@ -399,9 +399,9 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 stopSequences: [anthropic.HUMAN_PROMPT],
                 maxTokensToSample: this.responseTokens,
                 model: 'claude-instant-v1.0',
-                temperature: 1,
-                topK: -1,
-                topP: -1,
+                temperature: 1, // default value (source: https://console.anthropic.com/docs/api/reference)
+                topK: -1, // default value
+                topP: -1, // default value
             },
             n || this.defaultN
         )

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -2,6 +2,12 @@ import * as anthropic from '@anthropic-ai/sdk'
 import { ChatCompletionRequestMessage } from 'openai'
 import * as vscode from 'vscode'
 
+import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
+import {
+    CodeCompletionParameters,
+    CodeCompletionResponse,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
 import { ReferenceSnippet, getContext } from './context'
 import { CompletionsDocumentProvider } from './docprovider'
 import { History } from './history'
@@ -19,7 +25,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     private maxPrefixTokens: number
     private maxSuffixTokens: number
     constructor(
-        private claude: anthropic.Client | null,
+        private completionsClient: SourcegraphNodeCompletionsClient,
         private documentProvider: CompletionsDocumentProvider,
         private history: History,
         private contextWindowTokens = 2048, // 8001
@@ -57,11 +63,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         context: vscode.InlineCompletionContext,
         token: vscode.CancellationToken
     ): Promise<vscode.InlineCompletionItem[]> {
-        if (!this.claude) {
-            console.log('claude not activated')
-            return []
-        }
-
         const docContext = getCurrentDocContext(
             document,
             position,
@@ -80,7 +81,14 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             // Start of line: medium debounce
             waitMs = 1500
             completers.push(
-                new EndOfLineCompletionProvider(this.claude, remainingChars, this.responseTokens, prefix, '', 2)
+                new EndOfLineCompletionProvider(
+                    this.completionsClient,
+                    remainingChars,
+                    this.responseTokens,
+                    prefix,
+                    '',
+                    2
+                )
             )
         } else if (context.triggerKind === vscode.InlineCompletionTriggerKind.Invoke || precedingLine.endsWith('.')) {
             // Do nothing
@@ -89,8 +97,22 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             // End of line: long debounce, complete until newline
             waitMs = 3000
             completers.push(
-                new EndOfLineCompletionProvider(this.claude, remainingChars, this.responseTokens, prefix, '', 2),
-                new EndOfLineCompletionProvider(this.claude, remainingChars, this.responseTokens, prefix, '\n', 2)
+                new EndOfLineCompletionProvider(
+                    this.completionsClient,
+                    remainingChars,
+                    this.responseTokens,
+                    prefix,
+                    '',
+                    2
+                ),
+                new EndOfLineCompletionProvider(
+                    this.completionsClient,
+                    remainingChars,
+                    this.responseTokens,
+                    prefix,
+                    '\n',
+                    2
+                )
             )
         }
 
@@ -108,11 +130,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     }
 
     public async fetchAndShowCompletions(): Promise<void> {
-        if (!this.claude) {
-            console.log('claude not activated')
-            return
-        }
-
         const currentEditor = vscode.window.activeTextEditor
         if (!currentEditor || currentEditor?.document.uri.scheme === 'cody') {
             return
@@ -161,7 +178,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         const remainingChars = this.tokToChar(this.promptTokens)
 
         const completer = new MultilineCompletionProvider(
-            this.claude,
+            this.completionsClient,
             remainingChars,
             this.responseTokens,
             similarCode,
@@ -260,14 +277,14 @@ function getCurrentDocContext(
     }
 }
 
-async function batchClaude(
-    claude: anthropic.Client,
-    params: anthropic.SamplingParameters,
+async function batchCompletions(
+    client: SourcegraphNodeCompletionsClient,
+    params: CodeCompletionParameters,
     n: number
-): Promise<anthropic.CompletionResponse[]> {
-    const responses: Promise<anthropic.CompletionResponse>[] = []
+): Promise<CodeCompletionResponse[]> {
+    const responses: Promise<CodeCompletionResponse>[] = []
     for (let i = 0; i < n; i++) {
-        responses.push(claude.complete(params))
+        responses.push(client.complete(params))
     }
     return Promise.all(responses)
 }
@@ -284,7 +301,7 @@ interface CompletionProvider {
 
 export class MultilineCompletionProvider implements CompletionProvider {
     constructor(
-        private claude: anthropic.Client,
+        private completionsClient: SourcegraphNodeCompletionsClient,
         private promptChars: number,
         private responseTokens: number,
         private snippets: ReferenceSnippet[],
@@ -375,13 +392,16 @@ export class MultilineCompletionProvider implements CompletionProvider {
         }
 
         // Issue request
-        const responses = await batchClaude(
-            this.claude,
+        const responses = await batchCompletions(
+            this.completionsClient,
             {
                 prompt,
-                stop_sequences: [anthropic.HUMAN_PROMPT],
-                max_tokens_to_sample: this.responseTokens,
+                stopSequences: [anthropic.HUMAN_PROMPT],
+                maxTokensToSample: this.responseTokens,
                 model: 'claude-instant-v1.0',
+                temperature: 1,
+                topK: -1,
+                topP: -1,
             },
             n || this.defaultN
         )
@@ -389,14 +409,14 @@ export class MultilineCompletionProvider implements CompletionProvider {
         return responses.map(resp => ({
             prompt,
             content: this.postProcess(resp.completion),
-            stopReason: resp.stop_reason,
+            stopReason: resp.stopReason,
         }))
     }
 }
 
 export class EndOfLineCompletionProvider implements CompletionProvider {
     constructor(
-        private claude: anthropic.Client,
+        private completionsClient: SourcegraphNodeCompletionsClient,
         private promptChars: number,
         private responseTokens: number,
         private prefix: string,
@@ -449,7 +469,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
     }
 
     private postProcess(completion: string): string {
-        // Sometimes Claude omits an extra space
+        // Sometimes Claude emits an extra space
         if (
             completion.length > 0 &&
             completion.startsWith(' ') &&
@@ -478,13 +498,16 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         }
 
         // Issue request
-        const responses = await batchClaude(
-            this.claude,
+        const responses = await batchCompletions(
+            this.completionsClient,
             {
                 prompt,
-                stop_sequences: [anthropic.HUMAN_PROMPT, '\n'],
-                max_tokens_to_sample: this.responseTokens,
+                stopSequences: [anthropic.HUMAN_PROMPT, '\n'],
+                maxTokensToSample: this.responseTokens,
                 model: 'claude-instant-v1.0',
+                temperature: 1,
+                topK: -1,
+                topP: -1,
             },
             n || this.defaultN
         )
@@ -492,7 +515,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         return responses.map(resp => ({
             prompt,
             content: this.postProcess(resp.completion),
-            stopReason: resp.stop_reason,
+            stopReason: resp.stopReason,
         }))
     }
 }

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -15,6 +15,7 @@ interface ExternalServices {
     intentDetector: IntentDetector
     codebaseContext: CodebaseContext
     chatClient: ChatClient
+    completionsClient: SourcegraphNodeCompletionsClient
 }
 
 export async function configureExternalServices(
@@ -49,5 +50,6 @@ export async function configureExternalServices(
         intentDetector: new SourcegraphIntentDetectorClient(client),
         codebaseContext,
         chatClient: new ChatClient(completions),
+        completionsClient: completions,
     }
 }

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -44,6 +44,9 @@ type Services struct {
 	// Handler for completions stream.
 	NewCompletionsStreamHandler NewCompletionsStreamHandler
 
+	// Handler for code completions endpoint.
+	NewCodeCompletionsHandler NewCodeCompletionsHandler
+
 	PermissionsGitHubWebhook  webhooks.Registerer
 	NewCodeIntelUploadHandler NewCodeIntelUploadHandler
 	RankingService            RankingService
@@ -80,6 +83,9 @@ type NewComputeStreamHandler func() http.Handler
 // NewCompletionsStreamHandler creates a new handler for the completions streaming endpoint.
 type NewCompletionsStreamHandler func() http.Handler
 
+// NewCodeCompletionsHandler creates a new handler for the code completions endpoint.
+type NewCodeCompletionsHandler func() http.Handler
+
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
@@ -104,6 +110,7 @@ func DefaultServices() Services {
 		NewComputeStreamHandler:         func() http.Handler { return makeNotFoundHandler("compute streaming endpoint") },
 		CodeInsightsDataExportHandler:   makeNotFoundHandler("code insights data export handler"),
 		NewCompletionsStreamHandler:     func() http.Handler { return makeNotFoundHandler("completions streaming endpoint") },
+		NewCodeCompletionsHandler:       func() http.Handler { return makeNotFoundHandler("code completions streaming endpoint") },
 		EnterpriseSearchJobs:            jobutil.NewUnimplementedEnterpriseJobs(),
 	}
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -287,6 +287,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 			NewComputeStreamHandler:         enterprise.NewComputeStreamHandler,
 			CodeInsightsDataExportHandler:   enterprise.CodeInsightsDataExportHandler,
 			NewCompletionsStreamHandler:     enterprise.NewCompletionsStreamHandler,
+			NewCodeCompletionsHandler:       enterprise.NewCodeCompletionsHandler,
 		},
 		enterprise.NewExecutorProxyHandler,
 		enterprise.NewGitHubAppSetupHandler,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -49,6 +49,7 @@ func newTest(t *testing.T) *httptestutil.Client {
 			NewComputeStreamHandler:       enterpriseServices.NewComputeStreamHandler,
 			PermissionsGitHubWebhook:      enterpriseServices.PermissionsGitHubWebhook,
 			NewCompletionsStreamHandler:   enterpriseServices.NewCompletionsStreamHandler,
+			NewCodeCompletionsHandler:     enterpriseServices.NewCodeCompletionsHandler,
 		},
 	))
 }

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -75,6 +75,7 @@ type Handlers struct {
 
 	// Completions stream
 	NewCompletionsStreamHandler enterprise.NewCompletionsStreamHandler
+	NewCodeCompletionsHandler   enterprise.NewCodeCompletionsHandler
 }
 
 // NewHandler returns a new API handler that uses the provided API
@@ -151,6 +152,7 @@ func NewHandler(
 	m.Get(apirouter.SCIPUploadExists).Handler(trace.Route(noopHandler))
 	m.Get(apirouter.ComputeStream).Handler(trace.Route(handlers.NewComputeStreamHandler()))
 	m.Get(apirouter.CompletionsStream).Handler(trace.Route(handlers.NewCompletionsStreamHandler()))
+	m.Get(apirouter.CodeCompletions).Handler(trace.Route(handlers.NewCodeCompletionsHandler()))
 
 	m.Get(apirouter.CodeInsightsDataExport).Handler(trace.Route(handlers.CodeInsightsDataExportHandler))
 

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -18,6 +18,7 @@ const (
 	ComputeStream     = "compute.stream"
 	GitBlameStream    = "git.blame.stream"
 	CompletionsStream = "completions.stream"
+	CodeCompletions   = "completions.code"
 
 	SrcCli             = "src-cli"
 	SrcCliVersionCache = "src-cli.version-cache"
@@ -86,6 +87,7 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/src-cli/{rest:.*}").Methods("GET").Name(SrcCli)
 	base.Path("/insights/export/{id}").Methods("GET").Name(CodeInsightsDataExport)
 	base.Path("/completions/stream").Methods("POST").Name(CompletionsStream)
+	base.Path("/completions/code").Methods("POST").Name(CodeCompletions)
 
 	// repo contains routes that are NOT specific to a revision. In these routes, the URL may not contain a revspec after the repo (that is, no "github.com/foo/bar@myrevspec").
 	repoPath := `/repos/` + routevar.Repo

--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -25,6 +25,7 @@ func Init(
 ) error {
 	logger := log.Scoped("completions", "")
 	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger) }
+	enterpriseServices.NewCodeCompletionsHandler = func() http.Handler { return streaming.NewCodeCompletionsHandler(logger) }
 	enterpriseServices.CompletionsResolver = resolvers.NewCompletionsResolver()
 
 	return nil

--- a/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -15,6 +15,7 @@ import (
 
 var _ graphqlbackend.CompletionsResolver = &completionsResolver{}
 
+// completionsResolver provides chat completions
 type completionsResolver struct {
 }
 
@@ -35,13 +36,13 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 		return "", errors.New("completions are not configured or disabled")
 	}
 
-	client, err := streaming.GetCompletionStreamClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
+	client, err := streaming.GetCompletionClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
 	if err != nil {
 		return "", errors.Wrap(err, "GetCompletionStreamClient")
 	}
 
 	var last string
-	if err := client.Stream(ctx, convertParams(args), func(event types.CompletionEvent) error {
+	if err := client.Stream(ctx, convertParams(args), func(event types.ChatCompletionEvent) error {
 		// each completion is just a partial of the final result, since we're in a sync request anyway
 		// we will just wait for the final completion event
 		last = event.Completion
@@ -52,8 +53,8 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 	return last, nil
 }
 
-func convertParams(args graphqlbackend.CompletionsArgs) types.CompletionRequestParameters {
-	return types.CompletionRequestParameters{
+func convertParams(args graphqlbackend.CompletionsArgs) types.ChatCompletionRequestParameters {
+	return types.ChatCompletionRequestParameters{
 		Messages:          convertMessages(args.Input.Messages),
 		Temperature:       float32(args.Input.Temperature),
 		MaxTokensToSample: int(args.Input.MaxTokensToSample),

--- a/enterprise/cmd/frontend/internal/completions/streaming/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/streaming/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "streaming",
-    srcs = ["stream.go"],
+    srcs = [
+        "codecompletion.go",
+        "stream.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic.go
@@ -56,7 +56,7 @@ func (h *codeCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	// TODO(beyang): pass in model through params and default to completionsConfig
-	client := anthropic.NewAnthropicCompletionStreamClient(httpcli.ExternalDoer, completionsConfig.AccessToken, "claude-instant-v1.0")
+	client := anthropic.NewAnthropicClient(httpcli.ExternalDoer, completionsConfig.AccessToken, "claude-instant-v1.0")
 	completion, err := client.Complete(ctx, p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic.go
@@ -1,0 +1,71 @@
+// TODO(beyang): move this to separate package
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming/anthropic"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/cody"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+// NewCodeCompletionsHandler is an http handler which sends back code completion results
+func NewCodeCompletionsHandler(logger log.Logger) http.Handler {
+	return &codeCompletionHandler{logger: logger}
+}
+
+type codeCompletionHandler struct {
+	logger log.Logger
+}
+
+func (h *codeCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), maxRequestDuration)
+	defer cancel()
+
+	completionsConfig := conf.Get().Completions
+	if completionsConfig == nil || !completionsConfig.Enabled {
+		http.Error(w, "completions are not configured or disabled", http.StatusInternalServerError)
+		return
+	}
+
+	if envvar.SourcegraphDotComMode() {
+		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
+		if !isEnabled {
+			http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, fmt.Sprintf("unsupported method %s", r.Method), http.StatusBadRequest)
+		return
+	}
+
+	var p types.CodeCompletionRequestParameters
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// TODO(beyang): pass in model through params and default to completionsConfig
+	client := anthropic.NewAnthropicCompletionStreamClient(httpcli.ExternalDoer, completionsConfig.AccessToken, "claude-instant-v1.0")
+	completion, err := client.Complete(ctx, p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	completionBytes, err := json.Marshal(completion)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(completionBytes)
+}

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
@@ -30,21 +30,21 @@ type AnthropicCompletionsRequestParameters struct {
 	Stream            bool     `json:"stream"`
 }
 
-type anthropicCompletionStreamClient struct {
+type anthropicClient struct {
 	cli         httpcli.Doer
 	accessToken string
 	model       string
 }
 
-func NewAnthropicCompletionStreamClient(cli httpcli.Doer, accessToken string, model string) types.CompletionStreamClient {
-	return &anthropicCompletionStreamClient{
+func NewAnthropicClient(cli httpcli.Doer, accessToken string, model string) types.CompletionsClient {
+	return &anthropicClient{
 		cli:         cli,
 		accessToken: accessToken,
 		model:       model,
 	}
 }
 
-func (a *anthropicCompletionStreamClient) Complete(
+func (a *anthropicClient) Complete(
 	ctx context.Context,
 	requestParams types.CodeCompletionRequestParameters,
 ) (*types.CodeCompletionResponse, error) {
@@ -109,9 +109,9 @@ func (a *anthropicCompletionStreamClient) Complete(
 	}, nil
 }
 
-func (a *anthropicCompletionStreamClient) Stream(
+func (a *anthropicClient) Stream(
 	ctx context.Context,
-	requestParams types.CompletionRequestParameters,
+	requestParams types.ChatCompletionRequestParameters,
 	sendEvent types.SendCompletionEvent,
 ) error {
 	prompt, err := getPrompt(requestParams.Messages)
@@ -174,7 +174,7 @@ func (a *anthropicCompletionStreamClient) Stream(
 			continue
 		}
 
-		var event types.CompletionEvent
+		var event types.ChatCompletionEvent
 		if err := json.Unmarshal(data, &event); err != nil {
 			return errors.Errorf("failed to decode event payload: %w", err)
 		}

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
@@ -98,6 +98,9 @@ func (a *anthropicClient) Complete(
 
 	var response types.CodeCompletionResponse
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/types"
@@ -45,7 +44,7 @@ func NewAnthropicClient(cli httpcli.Doer, accessToken string, model string) type
 }
 
 var allowedClientSpecifiedModels = map[string]struct{}{
-	"claude-instant-v1.0": struct{}{},
+	"claude-instant-v1.0": {},
 }
 
 func (a *anthropicClient) Complete(
@@ -98,7 +97,7 @@ func (a *anthropicClient) Complete(
 	}
 
 	var response types.CodeCompletionResponse
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic.go
@@ -44,12 +44,16 @@ func NewAnthropicClient(cli httpcli.Doer, accessToken string, model string) type
 	}
 }
 
+var allowedClientSpecifiedModels = map[string]struct{}{
+	"claude-instant-v1.0": struct{}{},
+}
+
 func (a *anthropicClient) Complete(
 	ctx context.Context,
 	requestParams types.CodeCompletionRequestParameters,
 ) (*types.CodeCompletionResponse, error) {
 	var model string
-	if requestParams.Model != "" {
+	if _, isAllowed := allowedClientSpecifiedModels[requestParams.Model]; isAllowed {
 		model = requestParams.Model
 	} else {
 		model = a.model

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic_test.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/anthropic_test.go
@@ -31,8 +31,8 @@ func linesToResponse(lines []string) []byte {
 	return responseBytes
 }
 
-func getMockClient(responseBody []byte) types.CompletionStreamClient {
-	return NewAnthropicCompletionStreamClient(&mockDoer{
+func getMockClient(responseBody []byte) types.CompletionsClient {
+	return NewAnthropicClient(&mockDoer{
 		func(r *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(responseBody))}, nil
 		},
@@ -49,8 +49,8 @@ func TestValidAnthropicStream(t *testing.T) {
 	}
 
 	mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))
-	events := []types.CompletionEvent{}
-	err := mockClient.Stream(context.Background(), types.CompletionRequestParameters{}, func(event types.CompletionEvent) error {
+	events := []types.ChatCompletionEvent{}
+	err := mockClient.Stream(context.Background(), types.ChatCompletionRequestParameters{}, func(event types.ChatCompletionEvent) error {
 		events = append(events, event)
 		return nil
 	})
@@ -64,7 +64,7 @@ func TestInvalidAnthropicStream(t *testing.T) {
 	var mockAnthropicInvalidResponseLines = []string{`{]`}
 
 	mockClient := getMockClient(linesToResponse(mockAnthropicInvalidResponseLines))
-	err := mockClient.Stream(context.Background(), types.CompletionRequestParameters{}, func(event types.CompletionEvent) error { return nil })
+	err := mockClient.Stream(context.Background(), types.ChatCompletionRequestParameters{}, func(event types.ChatCompletionEvent) error { return nil })
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/enterprise/cmd/frontend/internal/completions/streaming/anthropic/testdata/TestValidAnthropicStream.golden
+++ b/enterprise/cmd/frontend/internal/completions/streaming/anthropic/testdata/TestValidAnthropicStream.golden
@@ -1,4 +1,4 @@
-[]types.CompletionEvent{
+[]types.ChatCompletionEvent{
 	{
 		Completion: "Sure!",
 	},

--- a/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
@@ -54,8 +54,7 @@ func (h *codeCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// TODO(beyang): pass in model through params and default to completionsConfig
-	client := anthropic.NewAnthropicClient(httpcli.ExternalDoer, completionsConfig.AccessToken, "claude-instant-v1.0")
+	client := anthropic.NewAnthropicClient(httpcli.ExternalDoer, completionsConfig.AccessToken, completionsConfig.CompletionModel)
 	completion, err := client.Complete(ctx, p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
@@ -1,4 +1,3 @@
-// TODO(beyang): move this to separate package
 package streaming
 
 import (

--- a/enterprise/cmd/frontend/internal/completions/streaming/openai/openai.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/openai/openai.go
@@ -43,7 +43,7 @@ type openAIChatCompletionStreamClient struct {
 	model       string
 }
 
-func NewOpenAIChatCompletionsStreamClient(cli httpcli.Doer, accessToken string, model string) types.CompletionStreamClient {
+func NewOpenAIClient(cli httpcli.Doer, accessToken string, model string) types.CompletionsClient {
 	return &openAIChatCompletionStreamClient{
 		cli:         cli,
 		accessToken: accessToken,
@@ -57,7 +57,7 @@ func (a *openAIChatCompletionStreamClient) Complete(ctx context.Context, request
 
 func (a *openAIChatCompletionStreamClient) Stream(
 	ctx context.Context,
-	requestParams types.CompletionRequestParameters,
+	requestParams types.ChatCompletionRequestParameters,
 	sendEvent types.SendCompletionEvent,
 ) error {
 	// TODO(sqs): make CompletionRequestParameters non-anthropic-specific
@@ -138,7 +138,7 @@ func (a *openAIChatCompletionStreamClient) Stream(
 
 		if len(event.Choices) > 0 && event.Choices[0].FinishReason == nil {
 			content = append(content, event.Choices[0].Delta.Content)
-			err = sendEvent(types.CompletionEvent{Completion: strings.Join(content, "")})
+			err = sendEvent(types.ChatCompletionEvent{Completion: strings.Join(content, "")})
 			if err != nil {
 				return err
 			}

--- a/enterprise/cmd/frontend/internal/completions/streaming/openai/openai.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/openai/openai.go
@@ -51,6 +51,10 @@ func NewOpenAIChatCompletionsStreamClient(cli httpcli.Doer, accessToken string, 
 	}
 }
 
+func (a *openAIChatCompletionStreamClient) Complete(ctx context.Context, requestParams types.CodeCompletionRequestParameters) (*types.CodeCompletionResponse, error) {
+	return nil, errors.New("openAIChatCompletionStreamClient.Complete: unimplemented")
+}
+
 func (a *openAIChatCompletionStreamClient) Stream(
 	ctx context.Context,
 	requestParams types.CompletionRequestParameters,

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -1,3 +1,4 @@
+// This package defines both streaming and non-streaming completion REST endpoints. Should probably be renamed "rest".
 package streaming
 
 import (

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -79,7 +79,11 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		tr.Finish()
 	}()
 
-	completionClient, err := GetCompletionClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
+	model := completionsConfig.ChatModel
+	if model == "" {
+		model = completionsConfig.Model
+	}
+	completionClient, err := GetCompletionClient(completionsConfig.Provider, completionsConfig.AccessToken, model)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -32,12 +32,12 @@ type streamHandler struct {
 	logger log.Logger
 }
 
-func GetCompletionStreamClient(provider string, accessToken string, model string) (types.CompletionStreamClient, error) {
+func GetCompletionClient(provider string, accessToken string, model string) (types.CompletionsClient, error) {
 	switch provider {
 	case "anthropic":
-		return anthropic.NewAnthropicCompletionStreamClient(httpcli.ExternalDoer, accessToken, model), nil
+		return anthropic.NewAnthropicClient(httpcli.ExternalDoer, accessToken, model), nil
 	case "openai":
-		return openai.NewOpenAIChatCompletionsStreamClient(httpcli.ExternalDoer, accessToken, model), nil
+		return openai.NewOpenAIClient(httpcli.ExternalDoer, accessToken, model), nil
 	default:
 		return nil, errors.Newf("unknown completion stream provider: %s", provider)
 	}
@@ -66,7 +66,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var requestParams types.CompletionRequestParameters
+	var requestParams types.ChatCompletionRequestParameters
 	if err := json.NewDecoder(r.Body).Decode(&requestParams); err != nil {
 		http.Error(w, "could not decode request body", http.StatusBadRequest)
 		return
@@ -79,7 +79,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		tr.Finish()
 	}()
 
-	completionStreamClient, err := GetCompletionStreamClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
+	completionClient, err := GetCompletionClient(completionsConfig.Provider, completionsConfig.AccessToken, completionsConfig.Model)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -94,7 +94,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Always send a final done event so clients know the stream is shutting down.
 	defer eventWriter.Event("done", map[string]any{})
 
-	err = completionStreamClient.Stream(ctx, requestParams, func(event types.CompletionEvent) error { return eventWriter.Event("completion", event) })
+	err = completionClient.Stream(ctx, requestParams, func(event types.ChatCompletionEvent) error { return eventWriter.Event("completion", event) })
 	if err != nil {
 		h.logger.Error("error while streaming completions", log.Error(err))
 		eventWriter.Event("error", map[string]string{"error": err.Error()})

--- a/enterprise/cmd/frontend/internal/completions/types/types.go
+++ b/enterprise/cmd/frontend/internal/completions/types/types.go
@@ -35,7 +35,7 @@ type CodeCompletionResponse struct {
 	LogID      string  `json:"logID"`
 }
 
-type CompletionRequestParameters struct {
+type ChatCompletionRequestParameters struct {
 	Messages          []Message `json:"messages"`
 	Temperature       float32   `json:"temperature"`
 	MaxTokensToSample int       `json:"maxTokensToSample"`
@@ -43,7 +43,7 @@ type CompletionRequestParameters struct {
 	TopP              float32   `json:"topP"`
 }
 
-type CompletionEvent struct {
+type ChatCompletionEvent struct {
 	Completion string `json:"completion"`
 }
 
@@ -65,9 +65,9 @@ func (m Message) GetPrompt(humanPromptPrefix, assistantPromptPrefix string) (str
 	return fmt.Sprintf("%s %s", prefix, m.Text), nil
 }
 
-type SendCompletionEvent func(event CompletionEvent) error
+type SendCompletionEvent func(event ChatCompletionEvent) error
 
-type CompletionStreamClient interface {
-	Stream(ctx context.Context, requestParams CompletionRequestParameters, sendEvent SendCompletionEvent) error
+type CompletionsClient interface {
+	Stream(ctx context.Context, requestParams ChatCompletionRequestParameters, sendEvent SendCompletionEvent) error
 	Complete(ctx context.Context, requestParams CodeCompletionRequestParameters) (*CodeCompletionResponse, error)
 }

--- a/enterprise/cmd/frontend/internal/completions/types/types.go
+++ b/enterprise/cmd/frontend/internal/completions/types/types.go
@@ -15,6 +15,26 @@ type Message struct {
 	Text    string `json:"text"`
 }
 
+type CodeCompletionRequestParameters struct {
+	Prompt            string            `json:"prompt"`
+	Temperature       float64           `json:"temperature,omitempty"`
+	MaxTokensToSample int               `json:"maxTokensToSample"`
+	StopSequences     []string          `json:"stopSequences"`
+	TopK              int               `json:"topK,omitempty"`
+	TopP              float64           `json:"topP,omitempty"`
+	Model             string            `json:"model"`
+	Tags              map[string]string `json:"tags,omitempty"`
+}
+
+type CodeCompletionResponse struct {
+	Completion string  `json:"completion"`
+	Stop       *string `json:"stop"`
+	StopReason string  `json:"stopReason"`
+	Truncated  bool    `json:"truncated"`
+	Exception  *string `json:"exception"`
+	LogID      string  `json:"logID"`
+}
+
 type CompletionRequestParameters struct {
 	Messages          []Message `json:"messages"`
 	Temperature       float32   `json:"temperature"`
@@ -49,4 +69,5 @@ type SendCompletionEvent func(event CompletionEvent) error
 
 type CompletionStreamClient interface {
 	Stream(ctx context.Context, requestParams CompletionRequestParameters, sendEvent SendCompletionEvent) error
+	Complete(ctx context.Context, requestParams CodeCompletionRequestParameters) (*CodeCompletionResponse, error)
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -561,9 +561,13 @@ type CloudKMSEncryptionKey struct {
 type Completions struct {
 	// AccessToken description: The access token used to authenticate with the external completions provider.
 	AccessToken string `json:"accessToken"`
+	// ChatModel description: The model used for chat completions.
+	ChatModel string `json:"chatModel,omitempty"`
+	// CompletionModel description: The model used for code completion.
+	CompletionModel string `json:"completionModel,omitempty"`
 	// Enabled description: Toggles whether completions are enabled.
 	Enabled bool `json:"enabled"`
-	// Model description: The model used for completions.
+	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model"`
 	// Provider description: The external completions provider.
 	Provider string `json:"provider"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2100,7 +2100,15 @@
           "default": false
         },
         "model": {
-          "description": "The model used for completions.",
+          "description": "DEPRECATED. Use chatModel instead.",
+          "type": "string"
+        },
+        "chatModel": {
+          "description": "The model used for chat completions.",
+          "type": "string"
+        },
+        "completionModel": {
+          "description": "The model used for code completion.",
           "type": "string"
         },
         "accessToken": {


### PR DESCRIPTION
Moves completions from extension -> Anthropic to extension -> Sourcegraph -> Anthropic, so we can use the Anthropic access token from the Sourcegraph instance.

* Adds the `.api/completions/code` endpoint (to accompany the existing `.api/completions/stream` endpoint for chat)
* Updates the VS Code extension to use this endpoint

## Test plan

Affects only Cody (experimental)