### PR TITLE
remove code host integration messaging setting

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -8,7 +8,7 @@ import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import ShieldHalfFullIcon from 'mdi-react/ShieldHalfFullIcon'
 import { RouteObject, useLocation } from 'react-router-dom'
 
-import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
+import { isMacPlatform } from '@sourcegraph/common'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
@@ -372,11 +372,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                 authenticatedUser={props.authenticatedUser}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                                 isSourcegraphApp={isSourcegraphApp}
-                                codeHostIntegrationMessaging={
-                                    (!isErrorLike(props.settingsCascade.final) &&
-                                        props.settingsCascade.final?.['alerts.codeHostIntegrationMessaging']) ||
-                                    'browser-extension'
-                                }
                                 showFeedbackModal={showFeedbackModal}
                             />
                         </NavAction>

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -27,10 +27,6 @@ const config: Meta = {
             control: { type: 'boolean' },
             defaultValue: true,
         },
-        codeHostIntegrationMessaging: {
-            control: { type: 'select', options: ['browser-extension', 'native-integration'] as const },
-            defaultValue: 'browser-extension',
-        },
     },
 }
 
@@ -69,7 +65,6 @@ const commonProps = (props: Args): UserNavItemProps => ({
     authenticatedUser,
     isSourcegraphDotCom: props.isSourcegraphDotCom,
     isSourcegraphApp: false,
-    codeHostIntegrationMessaging: props.codeHostIntegrationMessaging,
     showKeyboardShortcutsHelp: () => undefined,
     showFeedbackModal: () => undefined,
     telemetryService: NOOP_TELEMETRY_SERVICE,

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -58,7 +58,6 @@ describe('UserNavItem', () => {
                             authenticatedUser={USER}
                             isSourcegraphDotCom={true}
                             isSourcegraphApp={false}
-                            codeHostIntegrationMessaging="browser-extension"
                             showFeedbackModal={() => undefined}
                             telemetryService={NOOP_TELEMETRY_SERVICE}
                         />
@@ -76,7 +75,6 @@ describe('UserNavItem', () => {
                     authenticatedUser={USER}
                     isSourcegraphDotCom={true}
                     isSourcegraphApp={false}
-                    codeHostIntegrationMessaging="browser-extension"
                     showFeedbackModal={() => undefined}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                 />

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -45,7 +45,6 @@ export interface UserNavItemProps extends TelemetryProps {
     authenticatedUser: MinimalAuthenticatedUser
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
-    codeHostIntegrationMessaging: 'browser-extension' | 'native-integration'
     menuButtonRef?: React.Ref<HTMLButtonElement>
     showFeedbackModal: () => void
     showKeyboardShortcutsHelp: () => void
@@ -60,7 +59,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
         authenticatedUser,
         isSourcegraphDotCom,
         isSourcegraphApp,
-        codeHostIntegrationMessaging,
         menuButtonRef,
         showFeedbackModal,
         showKeyboardShortcutsHelp,
@@ -253,9 +251,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     Sign out
                                 </MenuLink>
                             )}
-                            {(isSourcegraphDotCom || codeHostIntegrationMessaging === 'browser-extension') && (
-                                <MenuDivider className={styles.dropdownDivider} />
-                            )}
+                            {isSourcegraphDotCom && <MenuDivider className={styles.dropdownDivider} />}
                             {isSourcegraphDotCom && (
                                 <MenuLink
                                     as={AnchorLink}
@@ -264,16 +260,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     rel="noopener"
                                 >
                                     About Sourcegraph <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
-                                </MenuLink>
-                            )}
-                            {codeHostIntegrationMessaging === 'browser-extension' && (
-                                <MenuLink
-                                    as={AnchorLink}
-                                    to="/help/integration/browser_extension"
-                                    target="_blank"
-                                    rel="noopener"
-                                >
-                                    Browser extension <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                                 </MenuLink>
                             )}
                         </MenuList>

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -29,10 +29,10 @@ func TestMergeSettings(t *testing.T) {
 		name: "empty left",
 		left: &schema.Settings{},
 		right: &schema.Settings{
-			AlertsCodeHostIntegrationMessaging: "test",
+			SearchDefaultMode: "test",
 		},
 		expected: &schema.Settings{
-			AlertsCodeHostIntegrationMessaging: "test",
+			SearchDefaultMode: "test",
 		},
 	}, {
 		name: "merge bool ptr",
@@ -40,11 +40,11 @@ func TestMergeSettings(t *testing.T) {
 			AlertsHideObservabilitySiteAlerts: boolPtr(true),
 		},
 		right: &schema.Settings{
-			AlertsCodeHostIntegrationMessaging: "test",
+			SearchDefaultMode: "test",
 		},
 		expected: &schema.Settings{
-			AlertsCodeHostIntegrationMessaging: "test",
-			AlertsHideObservabilitySiteAlerts:  boolPtr(true),
+			SearchDefaultMode:                 "test",
+			AlertsHideObservabilitySiteAlerts: boolPtr(true),
 		},
 	}, {
 		name: "merge bool",

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -175,16 +175,6 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 }
 ```
 
-The site admin should also set `alerts.codeHostIntegrationMessaging` in [global settings](../config/settings.md#editing-global-settings-for-site-admins) to ensure informational content for users in the Sourcegraph webapp references the native integration and not the browser extension.
-
-```json
-{
-  // ...
-  "alerts.codeHostIntegrationMessaging": "native-integration"
-  // ...
-}
-```
-
 ## Access token scopes
 
 Sourcegraph requires an access token with `api` permissions (and `sudo`, if you are using an `external` identity provider type). These permissions are required for the following reasons:

--- a/doc/admin/external_service/phabricator.md
+++ b/doc/admin/external_service/phabricator.md
@@ -64,16 +64,6 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 }
 ```
 
-The site admin should also set `alerts.codeHostIntegrationMessaging` in [global settings](../config/settings.md#editing-global-settings-for-site-admins) to ensure informational content for users in the Sourcegraph webapp references the native integration and not the browser extension.
-
-```json
-{
-  // ...
-  "alerts.codeHostIntegrationMessaging": "native-integration"
-  // ...
-}
-```
-
 ## Configuration
 
 <div markdown-func=jsonschemadoc jsonschemadoc:path="admin/external_service/phabricator.schema.json">[View page on docs.sourcegraph.com](https://docs.sourcegraph.com/admin/external_service/phabricator) to see rendered content.</div>

--- a/doc/integration/bitbucket_server.md
+++ b/doc/integration/bitbucket_server.md
@@ -42,16 +42,6 @@ For the Bitbucket Server plugin to then communicate with the Sourcegraph instanc
 }
 ```
 
-The site admin should also set `alerts.codeHostIntegrationMessaging` in [global settings](../admin/config/settings.md#editing-global-settings-for-site-admins) to ensure informational content for users in the Sourcegraph webapp references the native integration and not the browser extension.
-
-```json
-{
-  // ...
-  "alerts.codeHostIntegrationMessaging": "native-integration"
-  // ...
-}
-```
-
 #### I am seeing Content Security Policy violations, what should I do?
 
 If you have a Content Security Policy (CSP) setup in place and have encountered issues, you may need to adjust the CSP for our Bitbucket Server plugin.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1994,8 +1994,6 @@ type Sentry struct {
 
 // Settings description: Configuration settings for users and organizations on Sourcegraph.
 type Settings struct {
-	// AlertsCodeHostIntegrationMessaging description: What in-app messaging to use around availability of Sourcegraph's code intelligence on code hosts. If the native code host integration is installed, this should be set to "native-integration" and users won't need to install the Sourcegraph browser extension to get code intelligence on code hosts.
-	AlertsCodeHostIntegrationMessaging string `json:"alerts.codeHostIntegrationMessaging,omitempty"`
 	// AlertsHideObservabilitySiteAlerts description: Disables observability-related site alert banners.
 	AlertsHideObservabilitySiteAlerts *bool `json:"alerts.hideObservabilitySiteAlerts,omitempty"`
 	// AlertsShowMajorMinorUpdates description: Whether to show alerts for major and minor version updates. Alerts for patch version updates will be shown if `alerts.showPatchUpdates` is true.
@@ -2106,7 +2104,6 @@ func (v *Settings) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	delete(m, "alerts.codeHostIntegrationMessaging")
 	delete(m, "alerts.hideObservabilitySiteAlerts")
 	delete(m, "alerts.showMajorMinorUpdates")
 	delete(m, "alerts.showPatchUpdates")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -512,12 +512,6 @@
         "pointer": true
       }
     },
-    "alerts.codeHostIntegrationMessaging": {
-      "description": "What in-app messaging to use around availability of Sourcegraph's code intelligence on code hosts. If the native code host integration is installed, this should be set to \"native-integration\" and users won't need to install the Sourcegraph browser extension to get code intelligence on code hosts.",
-      "type": "string",
-      "enum": ["browser-extension", "native-integration"],
-      "default": "browser-extension"
-    },
     "search.hideSuggestions": {
       "description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
       "type": "boolean",


### PR DESCRIPTION
This was used to configure whether users should be informed of the browser extension or the native integration. However, it only affected the bottom-most nav item in the user menu, which is not very prominent. (Previously, it showed up in more prominent places, but those notices were annoying and were removed.)

Because this only affected a low-prominence thing in the UI, it is not worth keeping. Removing this also simplifies the user menu.




## Test plan

Automated tests will catch issues.