### PR TITLE
Reintroduce ordering of auth providers

### DIFF
--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -138,3 +138,15 @@ export const OnlyBuiltInAuthProvider: Story = () => (
         )}
     </WebStory>
 )
+
+export const PrefixCanBeChanged: Story = () => {
+    const providers = noBuiltInAuthProviders.map(provider => ({ ...provider, displayPrefix: 'Just login with' }))
+
+    return (
+        <WebStory>
+            {({ isLightTheme }) => (
+                <SignInPage context={{ ...context, authProviders: providers }} authenticatedUser={null} />
+            )}
+        </WebStory>
+    )
+}

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -199,4 +199,22 @@ describe('SignInPage', () => {
 
         expect(render('/sign-in', { authenticatedUser: mockUser }).asFragment()).toMatchSnapshot()
     })
+
+    it('renders different prefix on provider buttons', () => {
+        const providers = authProviders.map(provider => ({ ...provider, displayPrefix: 'Just login through' }))
+
+        const rendered = render('/sign-in', { authProviders: providers })
+        expect(
+            within(rendered.baseElement)
+                .queryByText(txt => txt.includes('Just login through GitHub'))
+                ?.closest('a')
+        ).toBeInTheDocument()
+        expect(
+            within(rendered.baseElement)
+                .queryByText(txt => txt.includes('Just login through GitLab'))
+                ?.closest('a')
+        ).toBeInTheDocument()
+
+        expect(rendered.asFragment()).toMatchSnapshot()
+    })
 })

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -144,7 +144,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                             {provider.serviceType === 'azuredevops' && (
                                 <Icon aria-hidden={true} svgPath={mdiMicrosoftAzureDevops} />
                             )}{' '}
-                            Continue with {provider.displayName}
+                            {provider.displayPrefix ?? 'Continue with'} {provider.displayName}
                         </Button>
                     </div>
                 ))}

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -111,6 +111,140 @@ exports[`SignInPage renders "Other login methods" if primary provider count is l
 </DocumentFragment>
 `;
 
+exports[`SignInPage renders different prefix on provider buttons 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Just login through GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnPrimary btnBlock"
+              href="/.auth/gitlab/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M21.94 13.11L20.89 9.89C20.89 9.86 20.88 9.83 20.87 9.8L18.76 3.32C18.65 3 18.33 2.75 17.96 2.75C17.6 2.75 17.28 3 17.17 3.33L15.17 9.5H8.84L6.83 3.33C6.72 3 6.4 2.75 6.04 2.75H6.04C5.67 2.75 5.35 3 5.24 3.33L3.13 9.82C3.13 9.82 3.13 9.83 3.13 9.83L2.06 13.11C1.9 13.61 2.07 14.15 2.5 14.45L11.72 21.16C11.89 21.28 12.11 21.28 12.28 21.15L21.5 14.45C21.93 14.15 22.1 13.61 21.94 13.11M8.15 10.45L10.72 18.36L4.55 10.45M13.28 18.37L15.75 10.78L15.85 10.45H19.46L13.87 17.61M17.97 3.94L19.78 9.5H16.16M14.86 10.45L13.07 15.96L12 19.24L9.14 10.45M6.03 3.94L7.84 9.5H4.23M3.05 13.69C2.96 13.62 2.92 13.5 2.96 13.4L3.75 10.97L9.57 18.42M20.95 13.69L14.44 18.42L14.46 18.39L20.25 10.97L21.04 13.4C21.08 13.5 21.04 13.62 20.95 13.69"
+                />
+              </svg>
+               Just login through GitLab
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <button
+              class="btn btnSecondary btnBlock"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z"
+                />
+              </svg>
+               Other login methods
+            </button>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up.
+          </a>
+           
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SignInPage renders non-primary auth provider if primary provider count is low enough and showMore is in the query 1`] = `
 <DocumentFragment>
   <div

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -22,6 +22,7 @@ export interface AuthProvider {
         | 'gerrit'
         | 'azuredevops'
     displayName: string
+    displayPrefix?: string
     isBuiltin: boolean
     authenticationURL: string
     serviceID: string

--- a/cmd/frontend/auth/providers/BUILD.bazel
+++ b/cmd/frontend/auth/providers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "providers",
@@ -9,5 +9,16 @@ go_library(
         "//internal/extsvc",
         "//schema",
         "@com_github_inconshreveable_log15//:log15",
+    ],
+)
+
+go_test(
+    name = "providers_test",
+    srcs = ["providers_test.go"],
+    embed = [":providers"],
+    deps = [
+        "//internal/extsvc",
+        "//schema",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -198,9 +198,9 @@ func GetAuthProviderCommon(p Provider) schema.AuthProviderCommon {
 		if !field.IsNil() {
 			// the field struct incorporates all the fields from schema.AuthProviderCommon
 			e := field.Elem()
-			common.Hidden = e.FieldByName("Hidden").Bool()
-			common.Order = int(e.FieldByName("Order").Int())
-			common.DisplayName = e.FieldByName("DisplayName").String()
+			common.Hidden = e.FieldByName("Hidden").Interface().(bool)
+			common.Order = e.FieldByName("Order").Interface().(int)
+			common.DisplayName = e.FieldByName("DisplayName").Interface().(string)
 
 			dP := e.FieldByName("DisplayPrefix")
 			if !dP.IsNil() {

--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -197,13 +197,22 @@ func GetAuthProviderCommon(p Provider) schema.AuthProviderCommon {
 		field := v.FieldByName(f.Name)
 		if !field.IsNil() {
 			// the field struct incorporates all the fields from schema.AuthProviderCommon
+			// except for builtin and http-header auth providers
 			e := field.Elem()
-			common.Hidden = e.FieldByName("Hidden").Interface().(bool)
-			common.Order = e.FieldByName("Order").Interface().(int)
-			common.DisplayName = e.FieldByName("DisplayName").Interface().(string)
-
+			hidden := e.FieldByName("Hidden")
+			if hidden.IsValid() {
+				common.Hidden = hidden.Bool()
+			}
+			order := e.FieldByName("Order")
+			if order.IsValid() {
+				common.Order = order.Interface().(int)
+			}
+			dN := e.FieldByName("DisplayName")
+			if dN.IsValid() {
+				common.DisplayName = dN.Interface().(string)
+			}
 			dP := e.FieldByName("DisplayPrefix")
-			if !dP.IsNil() {
+			if dP.IsValid() && !dP.IsNil() {
 				s := dP.Elem().String()
 				common.DisplayPrefix = &s
 			}

--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"sort"
 	"sync"
 
@@ -118,8 +119,9 @@ func Update(pkgName string, providers []Provider) {
 	curProviders[pkgName] = newPkgProviders
 }
 
-// Providers returns the set of currently registered authentication providers. When no providers are
+// Providers returns the list of currently registered authentication providers. When no providers are
 // registered, returns nil (and sign-in is effectively disabled).
+// The list is not sorted in any way.
 func Providers() []Provider {
 	if MockProviders != nil {
 		return MockProviders
@@ -143,10 +145,72 @@ func Providers() []Provider {
 		}
 	}
 
-	// Sort the providers to ensure a stable ordering (this is for the UI display order).
-	sort.Sort(sortProviders(providers))
-
 	return providers
+}
+
+// SortedProviders returns sorted provider slice.
+// Sort the providers to ensure a stable ordering (this is for the UI display order).
+// Puts the builtin provider first and sorts the others based on order.
+// If order field is not specified, puts the rest at the end alphabetically by type and then ID.
+func SortedProviders() []Provider {
+	p := Providers()
+	sort.Slice(p, func(i, j int) bool {
+		// natural ordering based on order int
+		// if order == 0, it means it was not specified, in which case all 0 should go to the end
+		cI := GetAuthProviderCommon(p[i])
+		cJ := GetAuthProviderCommon(p[j])
+		orderI := cI.Order
+		orderJ := cJ.Order
+		// if both have order specified, sort based on order
+		if orderI != 0 && orderJ != 0 {
+			return orderI < orderJ
+		}
+		// if just one has order specified, put the one with 0 last
+		if orderI != 0 || orderJ != 0 {
+			return orderJ == 0
+		}
+
+		if p[i].ConfigID().Type == "builtin" && p[j].ConfigID().Type != "builtin" {
+			return true
+		}
+		if p[j].ConfigID().Type == "builtin" && p[i].ConfigID().Type != "builtin" {
+			return false
+		}
+		if p[i].ConfigID().Type != p[j].ConfigID().Type {
+			return p[i].ConfigID().Type < p[j].ConfigID().Type
+		}
+		return p[i].ConfigID().ID < p[j].ConfigID().ID
+	})
+
+	return p
+}
+
+// GetAuthProviderCommon returns the common fields from a Provider's config struct.
+//
+// p (Provider): The authentication provider to extract common fields from.
+// Returns schema.AuthProviderCommon: The common fields from the provider's config struct.
+func GetAuthProviderCommon(p Provider) schema.AuthProviderCommon {
+	common := schema.AuthProviderCommon{}
+
+	v := reflect.ValueOf(p.Config())
+	for _, f := range reflect.VisibleFields(v.Type()) {
+		field := v.FieldByName(f.Name)
+		if !field.IsNil() {
+			// the field struct incorporates all the fields from schema.AuthProviderCommon
+			e := field.Elem()
+			common.Hidden = e.FieldByName("Hidden").Bool()
+			common.Order = int(e.FieldByName("Order").Int())
+			common.DisplayName = e.FieldByName("DisplayName").String()
+
+			dP := e.FieldByName("DisplayPrefix")
+			if !dP.IsNil() {
+				s := dP.Elem().String()
+				common.DisplayPrefix = &s
+			}
+		}
+	}
+
+	return common
 }
 
 func BuiltinAuthEnabled() bool {
@@ -156,30 +220,6 @@ func BuiltinAuthEnabled() bool {
 		}
 	}
 	return false
-}
-
-type sortProviders []Provider
-
-func (p sortProviders) Len() int {
-	return len(p)
-}
-
-// Less puts the builtin provider first and sorts the others alphabetically by type and then ID.
-func (p sortProviders) Less(i, j int) bool {
-	if p[i].ConfigID().Type == "builtin" && p[j].ConfigID().Type != "builtin" {
-		return true
-	}
-	if p[j].ConfigID().Type == "builtin" && p[i].ConfigID().Type != "builtin" {
-		return false
-	}
-	if p[i].ConfigID().Type != p[j].ConfigID().Type {
-		return p[i].ConfigID().Type < p[j].ConfigID().Type
-	}
-	return p[i].ConfigID().ID < p[j].ConfigID().ID
-}
-
-func (p sortProviders) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
 }
 
 func GetProviderByConfigID(id ConfigID) Provider {

--- a/cmd/frontend/auth/providers/providers_test.go
+++ b/cmd/frontend/auth/providers/providers_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 type mockAuthProvider struct {
-	configID ConfigID
-	config   schema.AuthProviderCommon
+	configID            ConfigID
+	config              schema.AuthProviderCommon
+	authProvidersConfig *schema.AuthProviders
 }
 
 func (m mockAuthProvider) ConfigID() ConfigID {
@@ -21,6 +22,10 @@ func (m mockAuthProvider) ConfigID() ConfigID {
 }
 
 func (m mockAuthProvider) Config() schema.AuthProviders {
+	if m.authProvidersConfig != nil {
+		return *m.authProvidersConfig
+	}
+
 	return schema.AuthProviders{
 		Github: &schema.GitHubAuthProvider{
 			Type:          m.configID.Type,
@@ -120,6 +125,48 @@ func TestGetAuthProviderCommon(t *testing.T) {
 			name: "All parameters are zero value",
 			provider: mockAuthProvider{
 				config: schema.AuthProviderCommon{},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         0,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name:     "Works without a config",
+			provider: mockAuthProvider{},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         0,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name: "Works with BuiltinAuthProvider",
+			provider: mockAuthProvider{
+				authProvidersConfig: &schema.AuthProviders{
+					Builtin: &schema.BuiltinAuthProvider{
+						Type: "builtin",
+					},
+				},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         0,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name: "Works with HttpHeaderAuthProvider",
+			provider: mockAuthProvider{
+				authProvidersConfig: &schema.AuthProviders{
+					HttpHeader: &schema.HTTPHeaderAuthProvider{
+						Type: "http-header",
+					},
+				},
 			},
 			want: schema.AuthProviderCommon{
 				Hidden:        false,

--- a/cmd/frontend/auth/providers/providers_test.go
+++ b/cmd/frontend/auth/providers/providers_test.go
@@ -1,0 +1,81 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type mockAuthProvider struct {
+	configID ConfigID
+	config   schema.AuthProviderCommon
+}
+
+func (m mockAuthProvider) ConfigID() ConfigID {
+	return m.configID
+}
+
+func (m mockAuthProvider) Config() schema.AuthProviders {
+	return schema.AuthProviders{
+		Github: &schema.GitHubAuthProvider{
+			Type: m.configID.Type,
+		},
+	}
+}
+
+func (m mockAuthProvider) CachedInfo() *Info {
+	panic("should not be called")
+}
+
+func (m mockAuthProvider) Refresh(ctx context.Context) error {
+	panic("should not be called")
+}
+
+func (m mockAuthProvider) ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error) {
+	panic("should not be called")
+}
+
+func TestSortedProviders(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []Provider
+		expectedOrder []int
+	}{
+		{
+			name: "sort works as expected",
+			input: []Provider{
+				mockAuthProvider{configID: ConfigID{Type: "a", ID: "1"}, config: schema.AuthProviderCommon{Order: 2}},
+				mockAuthProvider{configID: ConfigID{Type: "b", ID: "2"}},
+				mockAuthProvider{configID: ConfigID{Type: "builtin", ID: "3"}},
+				mockAuthProvider{configID: ConfigID{Type: "c", ID: "4"}, config: schema.AuthProviderCommon{Order: 1}},
+				mockAuthProvider{configID: ConfigID{Type: "d", ID: "5"}, config: schema.AuthProviderCommon{Order: 1}},
+				mockAuthProvider{configID: ConfigID{Type: "b", ID: "6"}, config: schema.AuthProviderCommon{Order: 1}},
+			},
+			expectedOrder: []int{3, 0, 2, 1, 5, 4},
+		},
+		{
+			name:          "Behaves well for empty slice",
+			input:         []Provider{},
+			expectedOrder: []int{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			MockProviders = test.input
+			t.Cleanup(func() {
+				MockProviders = nil
+			})
+
+			sorted := SortedProviders()
+			expected := make([]Provider, len(sorted))
+			for i, order := range test.expectedOrder {
+				expected[i] = test.input[order]
+			}
+			require.ElementsMatch(t, expected, sorted)
+		})
+	}
+}

--- a/cmd/frontend/auth/providers/providers_test.go
+++ b/cmd/frontend/auth/providers/providers_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,11 @@ func (m mockAuthProvider) ConfigID() ConfigID {
 func (m mockAuthProvider) Config() schema.AuthProviders {
 	return schema.AuthProviders{
 		Github: &schema.GitHubAuthProvider{
-			Type: m.configID.Type,
+			Type:          m.configID.Type,
+			DisplayName:   m.config.DisplayName,
+			DisplayPrefix: m.config.DisplayPrefix,
+			Hidden:        m.config.Hidden,
+			Order:         m.config.Order,
 		},
 	}
 }
@@ -37,6 +42,102 @@ func (m mockAuthProvider) Refresh(ctx context.Context) error {
 
 func (m mockAuthProvider) ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error) {
 	panic("should not be called")
+}
+
+func stringPointer(s string) *string {
+	return &s
+}
+
+func TestGetAuthProviderCommon(t *testing.T) {
+	testCases := []struct {
+		name     string
+		provider Provider
+		want     schema.AuthProviderCommon
+	}{
+		{
+			name: "all config fields are defined",
+			provider: mockAuthProvider{
+				config: schema.AuthProviderCommon{
+					Hidden:        true,
+					Order:         1,
+					DisplayName:   "Mock Provider",
+					DisplayPrefix: stringPointer("Mock"),
+				},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        true,
+				Order:         1,
+				DisplayName:   "Mock Provider",
+				DisplayPrefix: stringPointer("Mock"),
+			},
+		},
+		{
+			name: "DisplayPrefix is zero value",
+			provider: mockAuthProvider{
+				config: schema.AuthProviderCommon{
+					Hidden:      false,
+					Order:       2,
+					DisplayName: "Another Mock",
+				},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         2,
+				DisplayName:   "Another Mock",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name: "DisplayName is zero value",
+			provider: mockAuthProvider{
+				config: schema.AuthProviderCommon{
+					Hidden: false,
+					Order:  2,
+				},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         2,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name: "Hidden is zero value",
+			provider: mockAuthProvider{
+				config: schema.AuthProviderCommon{
+					Order: 2,
+				},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         2,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+		{
+			name: "All parameters are zero value",
+			provider: mockAuthProvider{
+				config: schema.AuthProviderCommon{},
+			},
+			want: schema.AuthProviderCommon{
+				Hidden:        false,
+				Order:         0,
+				DisplayName:   "",
+				DisplayPrefix: nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			have := GetAuthProviderCommon(tc.provider)
+			if !reflect.DeepEqual(have, tc.want) {
+				t.Errorf("have %+v, want %+v", have, tc.want)
+			}
+		})
+	}
 }
 
 func TestSortedProviders(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/auth_providers.go
+++ b/cmd/frontend/graphqlbackend/auth_providers.go
@@ -9,7 +9,7 @@ import (
 
 func (r *siteResolver) AuthProviders(ctx context.Context) (*authProviderConnectionResolver, error) {
 	return &authProviderConnectionResolver{
-		authProviders: providers.Providers(),
+		authProviders: providers.SortedProviders(),
 	}, nil
 }
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -39,11 +39,12 @@ import (
 var BillingPublishableKey string
 
 type authProviderInfo struct {
-	IsBuiltin         bool   `json:"isBuiltin"`
-	DisplayName       string `json:"displayName"`
-	ServiceType       string `json:"serviceType"`
-	AuthenticationURL string `json:"authenticationURL"`
-	ServiceID         string `json:"serviceID"`
+	IsBuiltin         bool    `json:"isBuiltin"`
+	DisplayName       string  `json:"displayName"`
+	DisplayPrefix     *string `json:"displayPrefix"`
+	ServiceType       string  `json:"serviceType"`
+	AuthenticationURL string  `json:"authenticationURL"`
+	ServiceID         string  `json:"serviceID"`
 }
 
 // GenericPasswordPolicy a generic password policy that holds password requirements
@@ -234,15 +235,17 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 	// Auth providers
 	var authProviders []authProviderInfo
-	for _, p := range providers.Providers() {
-		if p.Config().Github != nil && p.Config().Github.Hidden {
+	for _, p := range providers.SortedProviders() {
+		commonConfig := providers.GetAuthProviderCommon(p)
+		if commonConfig.Hidden {
 			continue
 		}
 		info := p.CachedInfo()
 		if info != nil {
 			authProviders = append(authProviders, authProviderInfo{
 				IsBuiltin:         p.Config().Builtin != nil,
-				DisplayName:       info.DisplayName,
+				DisplayName:       commonConfig.DisplayName,
+				DisplayPrefix:     commonConfig.DisplayPrefix,
 				ServiceType:       p.ConfigID().Type,
 				AuthenticationURL: info.AuthenticationURL,
 				ServiceID:         info.ServiceID,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -950,9 +950,11 @@ type FusionClient struct {
 
 // GerritAuthProvider description: Gerrit auth provider
 type GerritAuthProvider struct {
-	Hidden bool   `json:"hidden,omitempty"`
-	Order  int    `json:"order,omitempty"`
-	Type   string `json:"type"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
+	Order         int     `json:"order,omitempty"`
+	Type          string  `json:"type"`
 	// Url description: URL of the Gerrit instance, such as https://gerrit-review.googlesource.com or https://gerrit.example.com.
 	Url string `json:"url"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -132,6 +132,12 @@ type AuthPasswordPolicy struct {
 type AuthProviderCommon struct {
 	// DisplayName description: The name to use when displaying this authentication provider in the UI. Defaults to an auto-generated name with the type of authentication provider and other relevant identifiers (such as a hostname).
 	DisplayName string `json:"displayName,omitempty"`
+	// DisplayPrefix description: Defines the prefix of the auth provider button on the login screen. By default we show `Continue with <displayName>`. This propery allows you to change the `Continue with ` part to something else. Useful in cases where the displayName is not compatible with the prefix.
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	// Hidden description: Hides the configured auth provider from regular use through our web interface by omitting it from the JSContext, useful for experimental auth setups.
+	Hidden bool `json:"hidden,omitempty"`
+	// Order description: Determines order of auth providers on the login screen. Ordered as numbers, for example 1, 2, 3.
+	Order int `json:"order,omitempty"`
 }
 type AuthProviders struct {
 	AzureDevOps    *AzureDevOpsAuthProvider
@@ -216,9 +222,12 @@ type AzureDevOpsAuthProvider struct {
 	// ClientID description: The app ID of the Azure OAuth app.
 	ClientID string `json:"clientID"`
 	// ClientSecret description: The client Secret of the Azure OAuth app.
-	ClientSecret string `json:"clientSecret"`
-	DisplayName  string `json:"displayName,omitempty"`
-	Type         string `json:"type"`
+	ClientSecret  string  `json:"clientSecret"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
+	Order         int     `json:"order,omitempty"`
+	Type          string  `json:"type"`
 }
 
 // AzureDevOpsConnection description: Configuration for a connection to Azure DevOps.
@@ -295,9 +304,12 @@ type BitbucketCloudAuthProvider struct {
 	// ClientKey description: The Key of the Bitbucket OAuth app.
 	ClientKey string `json:"clientKey"`
 	// ClientSecret description: The Client Secret of the Bitbucket OAuth app.
-	ClientSecret string `json:"clientSecret"`
-	DisplayName  string `json:"displayName,omitempty"`
-	Type         string `json:"type"`
+	ClientSecret  string  `json:"clientSecret"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
+	Order         int     `json:"order,omitempty"`
+	Type          string  `json:"type"`
 	// Url description: URL of the Bitbucket Cloud instance.
 	Url string `json:"url,omitempty"`
 }
@@ -938,7 +950,9 @@ type FusionClient struct {
 
 // GerritAuthProvider description: Gerrit auth provider
 type GerritAuthProvider struct {
-	Type string `json:"type"`
+	Hidden bool   `json:"hidden,omitempty"`
+	Order  int    `json:"order,omitempty"`
+	Type   string `json:"type"`
 	// Url description: URL of the Gerrit instance, such as https://gerrit-review.googlesource.com or https://gerrit.example.com.
 	Url string `json:"url"`
 }
@@ -1012,11 +1026,12 @@ type GitHubAuthProvider struct {
 	// ClientID description: The Client ID of the GitHub OAuth app, accessible from https://github.com/settings/developers (or the same path on GitHub Enterprise).
 	ClientID string `json:"clientID"`
 	// ClientSecret description: The Client Secret of the GitHub OAuth app, accessible from https://github.com/settings/developers (or the same path on GitHub Enterprise).
-	ClientSecret string `json:"clientSecret"`
-	DisplayName  string `json:"displayName,omitempty"`
-	// Hidden description: Hides the configured auth provider from regular use through our web interface by omitting it from the JSContext, useful for experimental auth setups.
-	Hidden bool   `json:"hidden,omitempty"`
-	Type   string `json:"type"`
+	ClientSecret  string  `json:"clientSecret"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
+	Order         int     `json:"order,omitempty"`
+	Type          string  `json:"type"`
 	// Url description: URL of the GitHub instance, such as https://github.com or https://github-enterprise.example.com.
 	Url string `json:"url,omitempty"`
 }
@@ -1117,8 +1132,11 @@ type GitLabAuthProvider struct {
 	// ClientID description: The Client ID of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).
 	ClientID string `json:"clientID"`
 	// ClientSecret description: The Client Secret of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).
-	ClientSecret string `json:"clientSecret"`
-	DisplayName  string `json:"displayName,omitempty"`
+	ClientSecret  string  `json:"clientSecret"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
+	Order         int     `json:"order,omitempty"`
 	// TokenRefreshWindowMinutes description: Time in minutes before token expiry when we should attempt to refresh it
 	TokenRefreshWindowMinutes int    `json:"tokenRefreshWindowMinutes,omitempty"`
 	Type                      string `json:"type"`
@@ -1602,12 +1620,15 @@ type OpenIDConnectAuthProvider struct {
 	// For Google Apps: obtain this value from the API console (https://console.developers.google.com), as described at https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials
 	ClientSecret string `json:"clientSecret"`
 	// ConfigID description: An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.
-	ConfigID    string `json:"configID,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
+	ConfigID      string  `json:"configID,omitempty"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
+	Hidden        bool    `json:"hidden,omitempty"`
 	// Issuer description: The URL of the OpenID Connect issuer.
 	//
 	// For Google Apps: https://accounts.google.com
 	Issuer string `json:"issuer"`
+	Order  int    `json:"order,omitempty"`
 	// RequireEmailDomain description: Only allow users to authenticate if their email domain is equal to this value (example: mycompany.com). Do not include a leading "@". If not set, all users on this OpenID Connect provider can authenticate to Sourcegraph.
 	RequireEmailDomain string `json:"requireEmailDomain,omitempty"`
 	Type               string `json:"type"`
@@ -1894,10 +1915,12 @@ type SAMLAuthProvider struct {
 	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
 	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// ConfigID description: An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.
-	ConfigID    string `json:"configID,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
+	ConfigID      string  `json:"configID,omitempty"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	DisplayPrefix *string `json:"displayPrefix,omitempty"`
 	// GroupsAttributeName description: Name of the SAML assertion attribute that holds group membership for allowGroups setting
 	GroupsAttributeName string `json:"groupsAttributeName,omitempty"`
+	Hidden              bool   `json:"hidden,omitempty"`
 	// IdentityProviderMetadata description: The SAML Identity Provider metadata XML contents (for static configuration of the SAML Service Provider). The value of this field should be an XML document whose root element is `<EntityDescriptor>` or `<EntityDescriptors>`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	IdentityProviderMetadata string `json:"identityProviderMetadata,omitempty"`
 	// IdentityProviderMetadataURL description: The SAML Identity Provider metadata URL (for dynamic configuration of the SAML Service Provider).
@@ -1906,6 +1929,7 @@ type SAMLAuthProvider struct {
 	InsecureSkipAssertionSignatureValidation bool `json:"insecureSkipAssertionSignatureValidation,omitempty"`
 	// NameIDFormat description: The SAML NameID format to use when performing user authentication.
 	NameIDFormat string `json:"nameIDFormat,omitempty"`
+	Order        int    `json:"order,omitempty"`
 	// ServiceProviderCertificate description: The SAML Service Provider certificate in X.509 encoding (begins with "-----BEGIN CERTIFICATE-----"). This certificate is used by the Identity Provider to validate the Service Provider's AuthnRequests and LogoutRequests. It corresponds to the Service Provider's private key (`serviceProviderPrivateKey`). To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	ServiceProviderCertificate string `json:"serviceProviderCertificate,omitempty"`
 	// ServiceProviderIssuer description: The SAML Service Provider name, used to identify this Service Provider. This is required if the "externalURL" field is not set (as the SAML metadata endpoint is computed as "<externalURL>.auth/saml/metadata"), or when using multiple SAML authentication providers.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2162,6 +2162,18 @@
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
         },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
+        },
         "configID": {
           "description": "An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.",
           "type": "string"
@@ -2217,6 +2229,18 @@
         },
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+        },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
         },
         "serviceProviderIssuer": {
           "description": "The SAML Service Provider name, used to identify this Service Provider. This is required if the \"externalURL\" field is not set (as the SAML metadata endpoint is computed as \"<externalURL>.auth/saml/metadata\"), or when using multiple SAML authentication providers.",
@@ -2352,6 +2376,18 @@
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
         },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
+        },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitHub authentication. If false, users signing in via GitHub must have an existing Sourcegraph account, which will be linked to their GitHub identity after sign-in.",
           "default": false,
@@ -2387,11 +2423,6 @@
           "description": "Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://docs.sourcegraph.com/admin/external_service/github#teams-and-organizations-permissions-caching).",
           "default": false,
           "type": "boolean"
-        },
-        "hidden": {
-          "description": "Hides the configured auth provider from regular use through our web interface by omitting it from the JSContext, useful for experimental auth setups.",
-          "default": false,
-          "type": "boolean"
         }
       }
     },
@@ -2420,6 +2451,18 @@
         },
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+        },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
         },
         "apiScope": {
           "type": "string",
@@ -2478,6 +2521,18 @@
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
         },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
+        },
         "apiScope": {
           "type": "string",
           "description": "The OAuth API scope that should be used",
@@ -2505,6 +2560,12 @@
           "type": "string",
           "description": "URL of the Gerrit instance, such as https://gerrit-review.googlesource.com or https://gerrit.example.com.",
           "default": "https://gerrit-review.googlesource.com/"
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
         }
       }
     },
@@ -2528,6 +2589,18 @@
         },
         "displayName": {
           "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+        },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
+        "hidden": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+        },
+        "order": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/order"
         },
         "apiScope": {
           "type": "string",
@@ -2558,9 +2631,27 @@
       "description": "Common properties for authentication providers.",
       "type": "object",
       "properties": {
+        "hidden": {
+          "description": "Hides the configured auth provider from regular use through our web interface by omitting it from the JSContext, useful for experimental auth setups.",
+          "type": "boolean",
+          "default": false
+        },
+        "order": {
+          "description": "Determines order of auth providers on the login screen. Ordered as numbers, for example 1, 2, 3.",
+          "type": "integer",
+          "minimum": 1
+        },
         "displayName": {
           "description": "The name to use when displaying this authentication provider in the UI. Defaults to an auto-generated name with the type of authentication provider and other relevant identifiers (such as a hostname).",
           "type": "string"
+        },
+        "displayPrefix": {
+          "description": "Defines the prefix of the auth provider button on the login screen. By default we show `Continue with <displayName>`. This propery allows you to change the `Continue with ` part to something else. Useful in cases where the displayName is not compatible with the prefix.",
+          "type": "string",
+          "default": "Continue with ",
+          "!go": {
+            "pointer": true
+          }
         }
       }
     },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2561,6 +2561,15 @@
           "description": "URL of the Gerrit instance, such as https://gerrit-review.googlesource.com or https://gerrit.example.com.",
           "default": "https://gerrit-review.googlesource.com/"
         },
+        "displayName": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+        },
+        "displayPrefix": {
+          "$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix",
+          "!go": {
+            "pointer": true
+          }
+        },
         "hidden": {
           "$ref": "#/definitions/AuthProviderCommon/properties/hidden"
         },


### PR DESCRIPTION
## Description

This PR reintroduces the changes that were reverted in 
- #50450

Also fixes a problem where I did not handle correctly the case when certain fields have zero value.

## Test plan

- [x] New unit test added for the fixed changes.
- [x] [main-dry-run can be seen here](https://buildkite.com/sourcegraph/sourcegraph/builds/213015)
