### PR TITLE
Release JetBrains 2.1.3

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.1.3]
+
+### Added
+
 - Compatibility with IntelliJ 2023.1
 
 ### Fixed

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("java")
     // Dependencies are locked at this version to work with JDK 11 on CI.
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.intellij") version "1.11.0"
+    id("org.jetbrains.intellij") version "1.13.3"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 
@@ -25,6 +25,8 @@ intellij {
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+
+    updateSinceUntilBuild.set(false)
 }
 
 dependencies {
@@ -50,8 +52,6 @@ tasks {
 
     patchPluginXml {
         version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -51,6 +51,7 @@ tasks {
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -11,6 +11,7 @@ pluginVersion=2.1.3
 #  - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
 #    -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
 pluginSinceBuild=211.0
+pluginUntilBuild=*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2021.1

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,16 @@
     <name>Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
 
+    <!--
+        See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+        for insight into build numbers and IntelliJ Platform versions.
+        - 2020.2 was the first version to have JCEF enabled by default
+            -> https://plugins.jetbrains.com/docs/intellij/jcef.html
+        - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
+             -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
+    -->
+    <idea-version since-build="211.0" />
+
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-perforce.xml">PerforceDirectPlugin</depends>


### PR DESCRIPTION
It's out! This just updates the changelog.

## Test plan

Just a changelog change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-2-1-3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
