### PR TITLE
bzl: remove a left-over from e2e PR

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -141,7 +141,6 @@ func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	bazelRawCmd := bazelRawCmd(fmt.Sprintf("test %s", strings.Join(targets, " ")))
 	cmds = append(
 		cmds,
-		bk.RawCmd("dev/ci/integration/run-bazel-server.sh"),
 		bk.RawCmd(bazelRawCmd),
 	)
 


### PR DESCRIPTION
In the e2e PR, we had this temporarily in place to debug the e2e tests, but it shouldn't be running on normal tests. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 