### PR TITLE
bzl: enable our internal remote-cache server

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -2,6 +2,7 @@
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
 # Docs: https://bazel.build/reference/command-line-reference#flag--repository_cache
 build --repository_cache=/home/buildkite/repocache-sourcegraph
+build --remote_cache=grpc://ci-bazel-remote-cache:9092
 
 # Use Disk caching for building and testing.
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -8,8 +8,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
-const bazelRemoteCacheURL = "https://storage.googleapis.com/sourcegraph_bazel_cache"
-
 func BazelOperations(optional bool) *operations.Set {
 	ops := operations.NewNamedSet("Bazel")
 	ops.Append(bazelConfigure(optional))
@@ -24,13 +22,7 @@ func bazelRawCmd(args ...string) string {
 		"--bazelrc=.aspect/bazelrc/ci.bazelrc",
 		"--bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc",
 	}
-
-	post := []string{
-		"--remote_cache=grpc://ci-bazel-remote-cache:9092",
-	}
-
 	rawCmd := append(pre, args...)
-	rawCmd = append(rawCmd, post...)
 	return strings.Join(rawCmd, " ")
 }
 
@@ -46,7 +38,6 @@ func bazelAnalysisPhase(optional bool) func(*bk.Pipeline) {
 
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-analysis"),
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 		bk.RawCmd(cmd),
 	}
@@ -65,7 +56,6 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-configure"),
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 		bk.AnnotatedCmd("dev/ci/bazel-configure.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{
@@ -87,7 +77,6 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 
 func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
 	}
@@ -111,7 +100,6 @@ func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 
 func bazelTestWithDepends(optional bool, dependsOn string, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 	}
 
@@ -131,7 +119,6 @@ func bazelTestWithDepends(optional bool, dependsOn string, targets ...string) fu
 
 func bazelBuild(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
 		bk.Agent("queue", "bazel"),
 	}
 	bazelRawCmd := bazelRawCmd(fmt.Sprintf("build %s", strings.Join(targets, " ")))

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -26,8 +26,7 @@ func bazelRawCmd(args ...string) string {
 	}
 
 	post := []string{
-		"--remote_cache=$$CI_BAZEL_REMOTE_CACHE",
-		"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
+		"--remote_cache=grpc://ci-bazel-remote-cache:9092",
 	}
 
 	rawCmd := append(pre, args...)


### PR DESCRIPTION
This uses our own remote-cache server, see https://github.com/sourcegraph/infrastructure/pull/4806

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 