### PR TITLE
VS Code extension: Fix main build

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -2,19 +2,15 @@
 
 The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release versions and major.ODD_NUMBER.patch (eg. 2.1.1) for pre-release versions.
 
-### Future Plans
-
-- Import Sourcegraph Access token automatically after completing authentication in the browser for Sourcegraph Cloud users [issues/28311](https://github.com/sourcegraph/sourcegraph/issues/28311)
-
 ## Unreleased
 
 ### Changes
 
 ### Fixes
 
-## 2.2.15
+- Various UI fixes for dark and light themes [pull/50598](https://github.com/sourcegraph/sourcegraph/pull/50598)
 
-### Changes
+## 2.2.15
 
 ### Fixes
 
@@ -26,8 +22,6 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 ### Changes
 
 - Implement proxy support in the process that has access to node APIs [issues/41181](https://github.com/sourcegraph/sourcegraph/issues/41181)
-
-### Fixes
 
 ## 2.2.13
 
@@ -44,8 +38,6 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ## 2.2.12
 
-### Changes
-
 ### Fixes
 
 - Vary search pattern type depending on Sourcegraph instance version: [issues/41236](https://github.com/sourcegraph/sourcegraph/issues/41236), [pull/42178](https://github.com/sourcegraph/sourcegraph/pull/42178)
@@ -61,8 +53,6 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 - Fix Sourcegraph blob link generation: [issues/42060](https://github.com/sourcegraph/sourcegraph/issues/42060), [pull/42065](https://github.com/sourcegraph/sourcegraph/pull/42065)
 
 ## 2.2.9
-
-### Changes
 
 ### Fixes
 

--- a/client/vscode/src/webview/search-panel/components/HomeFooter.module.scss
+++ b/client/vscode/src/webview/search-panel/components/HomeFooter.module.scss
@@ -51,8 +51,8 @@
         --hover-box-shadow: none;
 
         .search-example-icon {
-            color: var(--vscode-button-secondaryHoverBackground) !important;
-            background-color: var(--vscode-button-foreground) !important;
+            color: var(--vscode-button-foreground) !important;
+            background-color: var(--vscode-button-background) !important;
         }
     }
 }
@@ -66,8 +66,8 @@
     color: var(--vscode-button-foreground) !important;
 
     &:hover {
-        color: var(--vscode-button-secondaryHoverBackground) !important;
-        background-color: var(--vscode-button-foreground) !important;
+        color: var(--vscode-button-foreground) !important;
+        background-color: var(--vscode-button-background) !important;
     }
 }
 

--- a/client/vscode/src/webview/search-panel/index.module.scss
+++ b/client/vscode/src/webview/search-panel/index.module.scss
@@ -5,7 +5,7 @@
 }
 
 .search-box {
-    background-color: var(--vscode-editorWidget-background);
+    background-color: var(--vscode-editorWidget-background) !important;
 
     &:first-child {
         border-top-left-radius: 0;

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.module.scss
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.module.scss
@@ -28,18 +28,8 @@
 }
 
 .cta-title {
-    letter-spacing: 0.5px;
-    text-transform: uppercase;
-    font-weight: 600;
-    font-size: var(--vscode-editor-font-size) !important;
-    margin-top: 0;
-    margin-bottom: 0.25rem;
-    display: flex;
-    align-items: center;
-    text-align: left;
-    width: calc(100% + 0.5rem); // Take full width + account for negative margin
-    border: none;
-    padding-left: 0;
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.5rem !important;
 }
 
 .cta {
@@ -51,15 +41,14 @@
 }
 
 .cta-button {
-    background-color: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    border: 0;
+    justify-content: center;
     width: 100%;
-    font-size: var(--vscode-editor-font-size) !important;
+}
 
+.cta-link {
     &:hover {
-        color: var(--vscode-button-foreground);
-        background-color: var(--vscode-button-hoverBackground);
+        background: var(--button-primary-hover-background);
+        text-decoration: none !important;
     }
 }
 

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -154,9 +154,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
     const renderCommon = (content: JSX.Element): JSX.Element => (
         <div className={classNames(styles.ctaContainer)}>
             <Form onSubmit={validateAccessToken}>
-                <Button variant="secondary" outline={true} className={styles.ctaTitle}>
-                    <H5 className="flex-grow-1">Search your private code</H5>
-                </Button>
+                <H5 className={styles.ctaTitle}>Search your private code</H5>
                 {content}
             </Form>
         </div>
@@ -169,16 +167,21 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                     Create an account to search across your private repositories and access advanced features: search
                     multiple repositories & commit history, monitor code changes, save searches, and more.
                 </Text>
-                <Link to={signUpURL}>
-                    <Button
-                        as={VSCodeButton}
-                        onClick={onSignUpClick}
-                        className={classNames('my-1 p-0', styles.ctaButton, styles.ctaButtonWrapperWithContextBelow)}
-                        autofocus={false}
-                    >
-                        Create an account
-                    </Button>
-                </Link>
+                <div>
+                    <Link to={signUpURL} className={styles.ctaLink}>
+                        <VSCodeButton
+                            onClick={onSignUpClick}
+                            className={classNames(
+                                'my-1 p-0',
+                                styles.ctaButton,
+                                styles.ctaButtonWrapperWithContextBelow
+                            )}
+                            autofocus={false}
+                        >
+                            Create an account
+                        </VSCodeButton>
+                    </Link>
+                </div>
                 <VSCodeLink className="my-0" onClick={() => setHasAccount(true)}>
                     Have an account?
                 </VSCodeLink>
@@ -211,9 +214,8 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
             {/* ---------- UNRELEASED FEATURE ---------- */}
             {isSourcegraphDotCom && authenticatedUser?.displayName === 'sourcegraph' && (
                 <Text className={classNames(styles.ctaParagraph)}>
-                    <Link to={isSourcegraphDotCom}>
-                        <Button
-                            as={VSCodeButton}
+                    <Link to={isSourcegraphDotCom} className={styles.ctaLink}>
+                        <VSCodeButton
                             onClick={onSignUpClick}
                             className={classNames(
                                 'my-1 p-0',
@@ -223,7 +225,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                             autofocus={false}
                         >
                             Continue in browser
-                        </Button>
+                        </VSCodeButton>
                     </Link>
                 </Text>
             )}
@@ -264,14 +266,13 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                     />
                 </Text>
             )}
-            <Button
-                as={VSCodeButton}
+            <VSCodeButton
                 type="submit"
                 disabled={state === 'validating'}
                 className={classNames('my-1 p-0', styles.ctaButton, styles.ctaButtonWrapperWithContextBelow)}
             >
                 Authenticate account
-            </Button>
+            </VSCodeButton>
             {state === 'failure' && (
                 <Alert variant="danger" className={classNames(styles.ctaParagraph, 'my-1')}>
                     Unable to verify your access token for {hostname}. Please try again with a new access token or
@@ -300,9 +301,7 @@ export const AuthSidebarCta: React.FunctionComponent<React.PropsWithChildren<Aut
 
     return (
         <div>
-            <Button variant="secondary" outline={true} className={styles.ctaTitle}>
-                <H5 className="flex-grow-1">Welcome</H5>
-            </Button>
+            <H5 className={styles.ctaTitle}>Welcome</H5>
             <Text className={classNames(styles.ctaParagraph)}>
                 The Sourcegraph extension allows you to search millions of open source repositories without cloning them
                 to your local machine.

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { currentAuthStateQuery } from '@sourcegraph/shared/src/auth'
 import { CurrentAuthStateResult, CurrentAuthStateVariables } from '@sourcegraph/shared/src/graphql-operations'
-import { Alert, Text, Link, Input, H5, Button, Form } from '@sourcegraph/wildcard'
+import { Alert, Text, Link, Input, H5, Form } from '@sourcegraph/wildcard'
 
 import {
     VSCE_LINK_DOTCOM,

--- a/client/vscode/src/webview/sidebars/help/HelpSidebarView.module.scss
+++ b/client/vscode/src/webview/sidebars/help/HelpSidebarView.module.scss
@@ -17,6 +17,7 @@
 
 .sidebar-view-button {
     background-color: transparent;
+    color: inherit !important;
 
     &::part(control) {
         justify-content: flex-start;

--- a/client/vscode/src/webview/sidebars/search/index.tsx
+++ b/client/vscode/src/webview/sidebars/search/index.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useState } from 'react'
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import * as Comlink from 'comlink'
 import { createRoot } from 'react-dom/client'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
@@ -119,10 +120,20 @@ const Main: React.FC<React.PropsWithChildren<unknown>> = () => {
 
 const root = createRoot(document.querySelector('#root')!)
 
+const routes = [
+    {
+        path: '/*',
+        element: <Main />,
+    },
+]
+const router = createMemoryRouter(routes, {
+    initialEntries: ['/'],
+})
+
 root.render(
     <ShortcutProvider>
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
-            <Main />
+            <RouterProvider router={router} />
         </WildcardThemeContext.Provider>
     </ShortcutProvider>
 )


### PR DESCRIPTION
This PR fixes the VS Code extension on `main` which means we are now able to do release again from the `main` branch 🎉 

The UI is actually looking better now compared to the version we had before (see video below) which is why I'll likely do another patch release (I also want to fix the automation again).

The only behavioural change was the sidebar during the search which was not rendering because it was missing a top-level `<Router />`

## Test plan

https://www.loom.com/share/106de9206a8747f28fe583130437dab2

As mentioned in the video, the "Help and feedback" section for light themes was fixed afterwards:

<img width="449" alt="Screenshot 2023-04-13 at 16 53 08" src="https://user-images.githubusercontent.com/458591/231799814-9d6b0496-df23-4020-877b-8206d2009452.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-vsce-fix-main.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
