### PR TITLE
batches: add settings for org level batch changes admin

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2022,6 +2022,8 @@ type Settings struct {
 	Notices []*Notice `json:"notices,omitempty"`
 	// OpenInEditor description: Group of settings related to opening files in an editor.
 	OpenInEditor *SettingsOpenInEditor `json:"openInEditor,omitempty"`
+	// OrgsAllMembersBatchChangesAdmin description: Enables/Disables org-level admin access for Batch Changes to all members of an org
+	OrgsAllMembersBatchChangesAdmin *bool `json:"orgs.allMembersBatchChangesAdmin,omitempty"`
 	// PerforceCodeHostToSwarmMap description: Key-value pairs of code host URLs to Swarm URLs. Keys should have no prefix and should not end with a slash, like "perforce.company.com:1666". Values should look like "https://swarm.company.com/", with a slash at the end.
 	PerforceCodeHostToSwarmMap map[string]string `json:"perforce.codeHostToSwarmMap,omitempty"`
 	// Quicklinks description: DEPRECATED: This setting will be removed in a future version of Sourcegraph.
@@ -2098,6 +2100,7 @@ func (v *Settings) UnmarshalJSON(data []byte) error {
 	delete(m, "motd")
 	delete(m, "notices")
 	delete(m, "openInEditor")
+	delete(m, "orgs.allMembersBatchChangesAdmin")
 	delete(m, "perforce.codeHostToSwarmMap")
 	delete(m, "quicklinks")
 	delete(m, "search.contextLines")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -508,6 +508,14 @@
         "type": "string"
       },
       "default": {}
+    },
+    "orgs.allMembersBatchChangesAdmin": {
+      "description": "Enables/Disables org-level admin access for Batch Changes to all members of an org",
+      "type": "boolean",
+      "default": false,
+      "!go": {
+        "pointer": true
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
Part 1 #50447

This PR adds a new settings field for org admins to specify if all members of the Org are Batch Changes admin. With this, org-members who are not site administrators can execute/apply/run batch changes in the org namespace.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Just a settings field addition. A quick test is to open the settings editor and enter `orgs.allMembersBatchChangesAdmin` in the editor, it should be a valid field.

<img width="1187" alt="CleanShot 2023-04-13 at 17 57 18@2x" src="https://user-images.githubusercontent.com/25608335/231831401-1a6ba031-1f10-4aea-9879-5906749f2c96.png">
