### PR TITLE
chore: remove unused metrics for perms syncer

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -4515,100 +4515,6 @@ Generated query for critical alert: `max((max(rate(src_repoupdater_sched_error[1
 
 <br />
 
-## repo-updater: perms_syncer_perms
-
-<p class="subtitle">time gap between least and most up to date permissions</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 259200s+ time gap between least and most up to date permissions for 5m0s
-
-**Next steps**
-
-- Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-perms-syncer-perms).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_perms_syncer_perms"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)) >= 259200)`
-
-</details>
-
-<br />
-
-## repo-updater: perms_syncer_stale_perms
-
-<p class="subtitle">number of entities with stale permissions</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 100+ number of entities with stale permissions for 5m0s
-
-**Next steps**
-
-- Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-perms-syncer-stale-perms).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_perms_syncer_stale_perms"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((max by (type) (src_repoupdater_perms_syncer_stale_perms)) >= 100)`
-
-</details>
-
-<br />
-
-## repo-updater: perms_syncer_no_perms
-
-<p class="subtitle">number of entities with no permissions</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 100+ number of entities with no permissions for 5m0s
-
-**Next steps**
-
-- **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
-- **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-perms-syncer-no-perms).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_perms_syncer_no_perms"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((max by (type) (src_repoupdater_perms_syncer_no_perms)) >= 100)`
-
-</details>
-
-<br />
-
 ## repo-updater: perms_syncer_outdated_perms
 
 <p class="subtitle">number of entities with outdated permissions</p>
@@ -4667,38 +4573,6 @@ Generated query for warning alert: `max((max by (type) (src_repoupdater_perms_sy
 <summary>Technical details</summary>
 
 Generated query for warning alert: `max((histogram_quantile(0.95, max by (le, type) (rate(src_repoupdater_perms_syncer_sync_duration_seconds_bucket[1m])))) >= 30)`
-
-</details>
-
-<br />
-
-## repo-updater: perms_syncer_queue_size
-
-<p class="subtitle">permissions sync queued items</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 100+ permissions sync queued items for 5m0s
-
-**Next steps**
-
-- **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
-- **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-perms-syncer-queue-size).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_perms_syncer_queue_size"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((max(src_repoupdater_perms_syncer_queue_size)) >= 100)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12644,48 +12644,6 @@ Query: `max(rate(src_repoupdater_sched_error[1m]))`
 
 ### Repo Updater: Permissions
 
-#### repo-updater: permissions_syncs_scheduled_reason
-
-<p class="subtitle">Number of users/repos scheduled for permissions sync grouped by reason</p>
-
-Indicates the number of users/repos scheduled for permissions sync grouped by reason.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100100` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (type) (src_repoupdater_perms_syncer_items_sync_scheduled)`
-
-</details>
-
-<br />
-
-#### repo-updater: permissions_syncs_scheduled_priority
-
-<p class="subtitle">Number of users/repos scheduled for permissions sync grouped by priority</p>
-
-Indicates the number of users/repos scheduled for permissions sync grouped by priority.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100101` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (priority) (src_repoupdater_perms_syncer_items_sync_scheduled)`
-
-</details>
-
-<br />
-
 #### repo-updater: user_success_syncs_total
 
 <p class="subtitle">Total number of user permissions syncs</p>
@@ -12694,7 +12652,7 @@ Indicates the total number of user permissions sync completed.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100110` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100100` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12715,7 +12673,7 @@ Indicates the number of users permissions syncs completed.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100111` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100101` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12736,7 +12694,7 @@ Indicates the number of permissions syncs done for the first time for the user.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100112` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100102` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12744,27 +12702,6 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <summary>Technical details</summary>
 
 Query: `sum(increase(src_repoupdater_perms_syncer_initial_syncs{type="user"}[5m]))`
-
-</details>
-
-<br />
-
-#### repo-updater: user_failed_syncs
-
-<p class="subtitle">Number of user permissions failed syncs [5m]</p>
-
-Indicates the number of users permissions syncs failed.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100120` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_repoupdater_perms_syncer_failed_syncs{type="user"}[5m]))`
 
 </details>
 
@@ -12778,7 +12715,7 @@ Indicates the total number of repo permissions sync completed.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100130` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100110` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12799,7 +12736,7 @@ Indicates the number of repos permissions syncs completed.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100131` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100111` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12820,7 +12757,7 @@ Indicates the number of permissions syncs done for the first time for the repo.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100132` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100112` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12828,27 +12765,6 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <summary>Technical details</summary>
 
 Query: `sum(increase(src_repoupdater_perms_syncer_initial_syncs{type="repo"}[5m]))`
-
-</details>
-
-<br />
-
-#### repo-updater: repo_failed_syncs
-
-<p class="subtitle">Number of repo permissions failed syncs over 5m</p>
-
-Indicates the number of repos permissions syncs failed in last 5 minute.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100140` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_repoupdater_perms_syncer_failed_syncs{type="repo"}[5m]))`
 
 </details>
 
@@ -12862,7 +12778,7 @@ Indicates the max delay between two consecutive permissions sync for a user duri
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100150` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100120` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12883,7 +12799,7 @@ Indicates the max delay between two consecutive permissions sync for a repo duri
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100151` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100121` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12904,7 +12820,7 @@ Indicates the max delay between user creation and their permissions sync
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100160` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100130` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12925,7 +12841,7 @@ Indicates the max delay between repo creation and their permissions sync
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100161` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100131` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12946,7 +12862,7 @@ Indicates the number permissions found during users/repos permissions sync.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100170` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100140` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12967,7 +12883,7 @@ Indicates the average number permissions found during permissions sync per user/
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100171` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100141` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -12980,70 +12896,13 @@ Query: `avg by (type) (src_repoupdater_perms_syncer_perms_found)`
 
 <br />
 
-#### repo-updater: perms_syncer_perms
-
-<p class="subtitle">Time gap between least and most up to date permissions</p>
-
-Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-perms) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100180` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)`
-
-</details>
-
-<br />
-
-#### repo-updater: perms_syncer_stale_perms
-
-<p class="subtitle">Number of entities with stale permissions</p>
-
-Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-stale-perms) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100181` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max by (type) (src_repoupdater_perms_syncer_stale_perms)`
-
-</details>
-
-<br />
-
-#### repo-updater: perms_syncer_no_perms
-
-<p class="subtitle">Number of entities with no permissions</p>
-
-Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-no-perms) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100190` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max by (type) (src_repoupdater_perms_syncer_no_perms)`
-
-</details>
-
-<br />
-
 #### repo-updater: perms_syncer_outdated_perms
 
 <p class="subtitle">Number of entities with outdated permissions</p>
 
 Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-outdated-perms) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100191` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100150` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -13062,7 +12921,7 @@ Query: `max by (type) (src_repoupdater_perms_syncer_outdated_perms)`
 
 Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-sync-duration) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100160` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -13075,32 +12934,13 @@ Query: `histogram_quantile(0.95, max by (le, type) (rate(src_repoupdater_perms_s
 
 <br />
 
-#### repo-updater: perms_syncer_queue_size
-
-<p class="subtitle">Permissions sync queued items</p>
-
-Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-queue-size) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100201` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max(src_repoupdater_perms_syncer_queue_size)`
-
-</details>
-
-<br />
-
 #### repo-updater: perms_syncer_sync_errors
 
 <p class="subtitle">Permissions sync error rate</p>
 
 Refer to the [alerts reference](./alerts.md#repo-updater-perms-syncer-sync-errors) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100210` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100170` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 
@@ -13122,7 +12962,7 @@ More about repository permissions synchronization [here](https://docs.sourcegrap
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100211` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100171` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Identity and Access Management team](https://handbook.sourcegraph.com/departments/engineering/teams/iam).*</sub>
 

--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -11,18 +11,6 @@ var (
 		Name: "src_repoupdater_perms_syncer_no_perms",
 		Help: "The number of records that do not have any permissions",
 	}, []string{"type"})
-	metricsStalePerms = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_stale_perms",
-		Help: "The number of records that have stale permissions",
-	}, []string{"type"})
-	metricsStrictStalePerms = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_strict_stale_perms",
-		Help: "The number of records that have permissions older than 1h",
-	}, []string{"type"})
-	metricsPermsGap = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_perms_gap_seconds",
-		Help: "The time gap between least and most up to date permissions",
-	}, []string{"type"})
 	metricsSyncDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_repoupdater_perms_syncer_sync_duration_seconds",
 		Help:    "Time spent on syncing permissions",
@@ -31,14 +19,6 @@ var (
 	metricsSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_perms_syncer_sync_errors_total",
 		Help: "Total number of permissions sync errors",
-	}, []string{"type"})
-	metricsQueueSize = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_queue_size",
-		Help: "The size of the sync request queue",
-	})
-	metricsConcurrentSyncs = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_concurrent_syncs",
-		Help: "The number of concurrent permissions syncs",
 	}, []string{"type"})
 	metricsSuccessPermsSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_perms_syncer_success_syncs",
@@ -60,8 +40,4 @@ var (
 		Name: "src_repoupdater_perms_syncer_perms_first_sync_delay",
 		Help: "The duration in seconds it took for first user/repo complete perms sync after creation",
 	}, []string{"type"})
-	metricsItemsSyncScheduled = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_items_sync_scheduled",
-		Help: "The number of users/repos scheduled for sync",
-	}, []string{"type", "priority"})
 )

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -241,26 +241,6 @@ func RepoUpdater() *monitoring.Dashboard {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:           "permissions_syncs_scheduled_reason",
-							Description:    "number of users/repos scheduled for permissions sync grouped by reason",
-							Query:          `sum by (type) (src_repoupdater_perms_syncer_items_sync_scheduled)`,
-							Panel:          monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Number),
-							Owner:          monitoring.ObservableOwnerIAM,
-							NoAlert:        true,
-							Interpretation: "Indicates the number of users/repos scheduled for permissions sync grouped by reason.",
-						},
-						{
-							Name:           "permissions_syncs_scheduled_priority",
-							Description:    "number of users/repos scheduled for permissions sync grouped by priority",
-							Query:          `sum by (priority) (src_repoupdater_perms_syncer_items_sync_scheduled)`,
-							Panel:          monitoring.Panel().LegendFormat("{{priority}}").Unit(monitoring.Number),
-							Owner:          monitoring.ObservableOwnerIAM,
-							NoAlert:        true,
-							Interpretation: "Indicates the number of users/repos scheduled for permissions sync grouped by priority.",
-						},
-					},
-					{
-						{
 							Name:           "user_success_syncs_total",
 							Description:    "total number of user permissions syncs",
 							Query:          `sum(src_repoupdater_perms_syncer_success_syncs{type="user"})`,
@@ -286,17 +266,6 @@ func RepoUpdater() *monitoring.Dashboard {
 							Owner:          monitoring.ObservableOwnerIAM,
 							NoAlert:        true,
 							Interpretation: "Indicates the number of permissions syncs done for the first time for the user.",
-						},
-					},
-					{
-						{
-							Name:           "user_failed_syncs",
-							Description:    "number of user permissions failed syncs [5m]",
-							Query:          `sum(increase(src_repoupdater_perms_syncer_failed_syncs{type="user"}[5m]))`,
-							Panel:          monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Number),
-							Owner:          monitoring.ObservableOwnerIAM,
-							NoAlert:        true,
-							Interpretation: "Indicates the number of users permissions syncs failed.",
 						},
 					},
 					{
@@ -327,17 +296,6 @@ func RepoUpdater() *monitoring.Dashboard {
 							Owner:          monitoring.ObservableOwnerIAM,
 							NoAlert:        true,
 							Interpretation: "Indicates the number of permissions syncs done for the first time for the repo.",
-						},
-					},
-					{
-						{
-							Name:           "repo_failed_syncs",
-							Description:    "number of repo permissions failed syncs over 5m",
-							Query:          `sum(increase(src_repoupdater_perms_syncer_failed_syncs{type="repo"}[5m]))`,
-							Panel:          monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Number),
-							Owner:          monitoring.ObservableOwnerIAM,
-							NoAlert:        true,
-							Interpretation: "Indicates the number of repos permissions syncs failed in last 5 minute.",
 						},
 					},
 					{
@@ -402,40 +360,6 @@ func RepoUpdater() *monitoring.Dashboard {
 					},
 					{
 						{
-							Name:        "perms_syncer_perms",
-							Description: "time gap between least and most up to date permissions",
-							Query:       `max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
-							Warning:     monitoring.Alert().GreaterOrEqual((3 * 24 * time.Hour).Seconds()).For(5 * time.Minute), // 3 days
-							Panel:       monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Seconds),
-							Owner:       monitoring.ObservableOwnerIAM,
-							NextSteps:   "Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).",
-
-							MultiInstance: true,
-						},
-						{
-							Name:        "perms_syncer_stale_perms",
-							Description: "number of entities with stale permissions",
-							Query:       `max by (type) (src_repoupdater_perms_syncer_stale_perms)`,
-							Warning:     monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Number),
-							Owner:       monitoring.ObservableOwnerIAM,
-							NextSteps:   "Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).",
-						},
-					},
-					{
-						{
-							Name:        "perms_syncer_no_perms",
-							Description: "number of entities with no permissions",
-							Query:       `max by (type) (src_repoupdater_perms_syncer_no_perms)`,
-							Warning:     monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Number),
-							Owner:       monitoring.ObservableOwnerIAM,
-							NextSteps: `
-								- **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
-								- **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-							`,
-						},
-						{
 							Name:        "perms_syncer_outdated_perms",
 							Description: "number of entities with outdated permissions",
 							Query:       `max by (type) (src_repoupdater_perms_syncer_outdated_perms)`,
@@ -457,18 +381,6 @@ func RepoUpdater() *monitoring.Dashboard {
 							Panel:       monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerIAM,
 							NextSteps:   "Check the network latency is reasonable (<50ms) between the Sourcegraph and the code host.",
-						},
-						{
-							Name:        "perms_syncer_queue_size",
-							Description: "permissions sync queued items",
-							Query:       `max(src_repoupdater_perms_syncer_queue_size)`,
-							Warning:     monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
-							Panel:       monitoring.Panel().Unit(monitoring.Number),
-							Owner:       monitoring.ObservableOwnerIAM,
-							NextSteps: `
-								- **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
-								- **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
-							`,
 						},
 					},
 					{

--- a/monitoring/monitoring/internal/promql/promql_test.go
+++ b/monitoring/monitoring/internal/promql/promql_test.go
@@ -187,20 +187,6 @@ func TestInjectGroupings(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:       "with existing by()",
-			expression: `max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
-			groupings:  []string{"project_id"},
-			want:       `max by (type, project_id) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
-			wantErr:    false,
-		},
-		{
-			name:       "without existing by()",
-			expression: `max(src_repoupdater_perms_syncer_perms_gap_seconds)`,
-			groupings:  []string{"project_id"},
-			want:       `max by (project_id) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
-			wantErr:    false,
-		},
-		{
 			name:       "repeated and without existing by()",
 			expression: `max((max(src_codeintel_commit_graph_queued_duration_seconds_total)) >= 3600)`,
 			groupings:  []string{"project_id"},


### PR DESCRIPTION
## Description

These are no longer published from anywhere in the code, so it's useles to keep the definitions.

Actually got here by seeing linter complaining about unused functions.

## Test plan

not really much to test, mostly removal of code
