### PR TITLE
Patch: Render smart search preview only when ss is off

### DIFF
--- a/client/branded/src/search-ui/components/SmartSearchPreview.tsx
+++ b/client/branded/src/search-ui/components/SmartSearchPreview.tsx
@@ -71,7 +71,7 @@ export const SmartSearchPreview: React.FunctionComponent<SmartSearchPreviewProps
         return
     }, [results])
 
-    if (results?.state === 'complete' && !results?.alert?.proposedQueries) {
+    if (results?.state === 'complete' && (!results?.alert?.proposedQueries || resultNumber === 0)) {
         return null
     }
 

--- a/client/branded/src/search-ui/results/NoResultsPage.tsx
+++ b/client/branded/src/search-ui/results/NoResultsPage.tsx
@@ -50,6 +50,7 @@ interface NoResultsPageProps extends TelemetryProps, Pick<SearchContextProps, 's
     showSearchContext: boolean
     showQueryExamples?: boolean
     setQueryState?: (query: QueryState) => void
+    searchMode?: SearchMode
     setSearchMode?: (mode: SearchMode) => void
     submitSearch?: (parameters: SubmitSearchParameters) => void
     searchQueryFromURL?: string
@@ -65,6 +66,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
     showSearchContext,
     showQueryExamples,
     setQueryState,
+    searchMode,
     setSearchMode,
     submitSearch,
     caseSensitive,
@@ -89,14 +91,18 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
 
     return (
         <div className={styles.root}>
-            {setSearchMode && submitSearch && typeof caseSensitive === 'boolean' && searchQueryFromURL && (
-                <SmartSearchPreview
-                    setSearchMode={setSearchMode}
-                    submitSearch={submitSearch}
-                    caseSensitive={caseSensitive}
-                    searchQueryFromURL={searchQueryFromURL}
-                />
-            )}
+            {searchMode !== SearchMode.SmartSearch &&
+                setSearchMode &&
+                submitSearch &&
+                typeof caseSensitive === 'boolean' &&
+                searchQueryFromURL && (
+                    <SmartSearchPreview
+                        setSearchMode={setSearchMode}
+                        submitSearch={submitSearch}
+                        caseSensitive={caseSensitive}
+                        searchQueryFromURL={searchQueryFromURL}
+                    />
+                )}
 
             {showQueryExamples && setQueryState && (
                 <>

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -81,6 +81,7 @@ export interface StreamingSearchResultsListProps
     setQueryState?: (queryState: QueryState) => void
     buildSearchURLQueryFromQueryState?: (queryParameters: BuildSearchQueryURLParameters) => string
 
+    searchMode?: SearchMode
     setSearchMode?: (mode: SearchMode) => void
     submitSearch?: (parameters: SubmitSearchParameters) => void
     searchQueryFromURL?: string
@@ -119,6 +120,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     queryState,
     setQueryState,
     buildSearchURLQueryFromQueryState,
+    searchMode,
     setSearchMode,
     submitSearch,
     caseSensitive,
@@ -302,6 +304,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 showSearchContext={searchContextsEnabled}
                                 showQueryExamples={showQueryExamplesOnNoResultsPage}
                                 setQueryState={setQueryState}
+                                searchMode={searchMode}
                                 setSearchMode={setSearchMode}
                                 submitSearch={submitSearch}
                                 caseSensitive={caseSensitive}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -84,6 +84,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
 
         const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
+        const searchMode = useNavbarQueryState(state => state.searchMode)
         const submittedURLQuery = useNavbarQueryState(state => state.searchQueryFromURL)
 
         const onInputChange = useCallback(
@@ -209,6 +210,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 platformContext={props.platformContext}
                                 openMatchesInNewTab={true}
                                 executedQuery={executedQuery}
+                                searchMode={searchMode}
                                 setSearchMode={setSearchMode}
                                 submitSearch={submitSearch}
                                 caseSensitive={caseSensitive}

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -61,6 +61,7 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
     )
 
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
+    const searchMode = useNavbarQueryState(state => state.searchMode)
     const submittedURLQuery = useNavbarQueryState(state => state.searchQueryFromURL)
 
     const triggerSearch = useCallback(() => {
@@ -136,6 +137,7 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
                                 allExpanded={false}
                                 results={results}
                                 executedQuery={location.search}
+                                searchMode={searchMode}
                                 setSearchMode={setSearchMode}
                                 submitSearch={submitSearch}
                                 caseSensitive={caseSensitive}

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -535,6 +535,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                             queryState={queryState}
                             setQueryState={setQueryState}
                             buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                            searchMode={searchMode}
                             setSearchMode={setSearchMode}
                             submitSearch={submitSearch}
                             caseSensitive={caseSensitive}


### PR DESCRIPTION
Render smart search preview only when smart search mode is off. [Reported bug](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1681402996951779).

## Test plan
1. Run the following query: `context:global repo:^github\.com/sourcegraph/infrastructure$@29784a6 lang:Python requests.get(...)`
2. Ensure when Smart Search is enabled there is no Smart Search Preview on the No Results page
![image](https://user-images.githubusercontent.com/59381432/231839607-2dfb507d-9a90-4b29-8523-d42e4fd8c7f9.png)
3. Ensure toggling Smart Search to off still shows no Smart Search Preview since this case has `0` results
![image](https://user-images.githubusercontent.com/59381432/231840118-22ee4ccb-d5e8-47a6-93a2-a03a49bdafe4.png)
4. Run the following query: `sourcegraph javascript`
5. Ensure when Smart Search is enabled there is no Smart Search Preview in given results, just the regular Smart Search suggestions
![image](https://user-images.githubusercontent.com/59381432/231840577-bf67c048-5373-4cab-998b-4b4ef1808f30.png)
6. Ensure toggling Smart Search to off shows a Smart Search Preview since this case does have results
![image](https://user-images.githubusercontent.com/59381432/231839293-b3782a64-329d-4082-955c-56a192a76dc9.png)

## App preview:

- [Web](https://sg-web-becca-patch-smart-search-preview.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
