### PR TITLE
batches: display note in dropdown if rollout windows are configured

### DIFF
--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { mdiChevronDown } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 
-import { BatchChangeRolloutWindow } from '@sourcegraph/shared/src/schema/site.schema'
 import {
     ProductStatusBadge,
     Button,
@@ -188,10 +187,13 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
                 )}
             </H4>
             <Text className="text-wrap text-muted mb-0">
-                {action.type === 'publish' && batchChangesRolloutWindows && batchChangesRolloutWindows.length > 0 ? (
+                {action.type === 'publish' ? (
                     <small>
-                        {action.dropdownDescription} Note: Rollout windows have been set up by the admin. This means
-                        that some of the selected changesets won't be processed until a time in the future.
+                        {action.dropdownDescription} <br></br>
+                        <b>
+                            Note: Rollout windows have been set up by the admin. This means that some of the selected
+                            changesets won't be processed until a time in the future.
+                        </b>{' '}
                     </small>
                 ) : (
                     <small>{action.dropdownDescription}</small>

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { mdiChevronDown } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 
+import { BatchChangeRolloutWindow } from '@sourcegraph/shared/src/schema/site.schema'
 import {
     ProductStatusBadge,
     Button,
@@ -172,6 +173,9 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
     const onSelect = useCallback(() => {
         setSelectedType(action.type)
     }, [setSelectedType, action.type])
+
+    const { batchChangesRolloutWindows } = window.context
+
     return (
         <MenuItem className={styles.menuListItem} onSelect={onSelect} disabled={action.disabled}>
             <H4 className="mb-1">
@@ -184,7 +188,14 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
                 )}
             </H4>
             <Text className="text-wrap text-muted mb-0">
-                <small>{action.dropdownDescription}</small>
+                {action.type === 'publish' && batchChangesRolloutWindows && batchChangesRolloutWindows.length > 0 ? (
+                    <small>
+                        {action.dropdownDescription} Note: Rollout windows have been set up by the admin. This means
+                        that some of the selected changesets won't be processed until a time in the future.
+                    </small>
+                ) : (
+                    <small>{action.dropdownDescription}</small>
+                )}
             </Text>
         </MenuItem>
     )

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -189,7 +189,7 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
             <Text className="text-wrap text-muted mb-0">
                 {action.type === 'publish' && batchChangesRolloutWindows && batchChangesRolloutWindows.length > 0 ? (
                     <small>
-                        {action.dropdownDescription} <br></br>
+                        {action.dropdownDescription} <br />
                         <b>
                             Note: Rollout windows have been set up by the admin. This means that some of the selected
                             changesets won't be processed until a time in the future.

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -187,7 +187,7 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
                 )}
             </H4>
             <Text className="text-wrap text-muted mb-0">
-                {action.type === 'publish' ? (
+                {action.type === 'publish' && batchChangesRolloutWindows && batchChangesRolloutWindows.length > 0 ? (
                     <small>
                         {action.dropdownDescription} <br></br>
                         <b>


### PR DESCRIPTION
closes #48217

checks if rollout windows are configured and displays a note about how changesets are processed if they are 

<img width="371" alt="CleanShot 2023-04-13 at 13 55 16@2x" src="https://user-images.githubusercontent.com/67931373/231843955-0f3e2907-56a2-4cc6-b9c1-5b4d6f3a1982.png">

## Test plan
Test with and without changesets to see the note

## App preview:

- [Web](https://sg-web-aa-rollout-notice.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
