### PR TITLE
codeintel: Remove concurrent writes within a single txn

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/store/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 


### PR DESCRIPTION
Do not write to the same transaction, which @camdencheek graciously checks for and blathers into the logs (a symptom which has been ignored basically out of principal up until this point :laff:). Watch this just fix **everything**.

## Test plan

Tested locally.