### PR TITLE
Add python to bundled executor

### DIFF
--- a/enterprise/cmd/bundled-executor/Dockerfile
+++ b/enterprise/cmd/bundled-executor/Dockerfile
@@ -41,7 +41,8 @@ RUN set -ex && \
 
 # Install additional common tools for running batch changes.
 RUN apk add --no-cache \
-    xmlstarlet
+    xmlstarlet \
+    python3 py3-pip
 
 # Install batcheshelper.
 COPY batcheshelper /usr/local/bin/


### PR DESCRIPTION
Adding this on customer request. Trivy seems not concerned about this, so this should be fine. It's a one-off solution still so doing customer specific things here should be alright. xmlstarlet was another of the things we have added here.



## Test plan

Verified trivy, built the image locally and checked that python works.