### PR TITLE
bazel: bazel_operations.go cleanup

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -86,51 +86,6 @@ func bazelConfigure(optional bool) func(*bk.Pipeline) {
 	}
 }
 
-// bazelBuildAndTest will perform a build and test on the same agent, which is the preferred method
-// over running them in two separate jobs, so we don't build the same code twice.
-func bazelBuildAndTest(optional bool, targets ...string) func(*bk.Pipeline) {
-	cmds := []bk.StepOpt{
-		bk.DependsOn("bazel-configure"),
-		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
-		bk.Agent("queue", "bazel"),
-	}
-
-	ts := strings.Join(targets, " ")
-	bazelBuildCmd := bazelRawCmd(fmt.Sprintf("build %s", ts))
-	bazelTestCmd := bazelRawCmd(
-		fmt.Sprintf("test %s", ts),
-		"--remote_cache=$$CI_BAZEL_REMOTE_CACHE",
-		"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
-	)
-
-	cmds = append(
-		cmds,
-		// TODO(JH): run server image for end-to-end tests on SOURCEGRAPH_BASE_URL similar to run-bazel-server.sh.
-		bk.RawCmd(bazelBuildCmd),
-		bk.RawCmd(bazelTestCmd),
-	)
-
-	return func(pipeline *bk.Pipeline) {
-		if optional {
-			cmds = append(cmds, bk.SoftFail())
-		}
-
-		// TODO(JH) Broken we don't have go on the bazel agents
-		// cmds = append(cmds, bk.SlackStepNotify(&bk.SlackStepNotifyConfigPayload{
-		// 	Message:     ":alert: :bazel: test failed",
-		// 	ChannelName: "dev-experience-alerts",
-		// 	Conditions: bk.SlackStepNotifyPayloadConditions{
-		// 		Failed:   true,
-		// 		Branches: []string{"main"},
-		// 	},
-		// }))
-
-		pipeline.AddStep(":bazel: Build && Test",
-			cmds...,
-		)
-	}
-}
-
 func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
@@ -141,6 +96,7 @@ func bazelTest(optional bool, targets ...string) func(*bk.Pipeline) {
 	bazelRawCmd := bazelRawCmd(fmt.Sprintf("test %s", strings.Join(targets, " ")))
 	cmds = append(
 		cmds,
+		// TODO(JH): run server image for end-to-end tests on SOURCEGRAPH_BASE_URL similar to run-bazel-server.sh.
 		bk.RawCmd(bazelRawCmd),
 	)
 


### PR DESCRIPTION
## Context

When I was cleaning up my E2E tests PR, I updated the wrong function that's not used anymore. (which lead to https://github.com/sourcegraph/sourcegraph/pull/50593)
This PR removes the redundant func and moves TODO to an appropriate place.

## Test plan

CI
