### PR TITLE
cody-slack: fix Bazel build issue

### DIFF
--- a/client/cody-slack/src/services/openai-completions-client.ts
+++ b/client/cody-slack/src/services/openai-completions-client.ts
@@ -4,6 +4,7 @@ import { Configuration, OpenAIApi } from 'openai'
 
 import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 import {
+    CodeCompletionResponse,
     CompletionCallbacks,
     CompletionParameters,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
@@ -81,5 +82,9 @@ export class OpenAICompletionsClient extends SourcegraphCompletionsClient {
             .catch(console.error)
 
         return () => {}
+    }
+
+    public complete(): Promise<CodeCompletionResponse> {
+        throw new Error('SourcegraphBrowserCompletionsClient.complete not implemented')
     }
 }


### PR DESCRIPTION
## Context

Fixes the TS error in the new `cody-slack` package caused by recent changes on main, which were not caught in the PR.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-cody-slack-bazel-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

