### PR TITLE
bazel: rename arg to follow convention

### DIFF
--- a/client/shared/src/testing/BUILD.bazel
+++ b/client/shared/src/testing/BUILD.bazel
@@ -58,7 +58,7 @@ ts_project(
         "utils.ts",
     ],
     tsconfig = "//client/shared:tsconfig",
-    usePresetEnv = False,
+    use_preset_env = False,
     deps = [
         "//:node_modules/@apollo/client",
         "//:node_modules/@axe-core/puppeteer",

--- a/client/web/src/end-to-end/BUILD.bazel
+++ b/client/web/src/end-to-end/BUILD.bazel
@@ -25,7 +25,7 @@ ts_project(
         "utils/initEndToEndTest.ts",
     ],
     tsconfig = ":tsconfig",
-    usePresetEnv = False,
+    use_preset_env = False,
     deps = [
         "//:node_modules/@types/mockdate",
         "//:node_modules/mockdate",
@@ -42,7 +42,7 @@ ts_project(
         "frontend-platform/theme-switcher.test.ts",
     ],
     tsconfig = ":tsconfig",
-    usePresetEnv = False,
+    use_preset_env = False,
     deps = [
         ":end-to-end",
         "//:node_modules/@types/lodash",

--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -84,7 +84,7 @@ ts_project(
         "sign-in.test.ts",
     ],
     tsconfig = ":tsconfig",
-    usePresetEnv = False,
+    use_preset_env = False,
     deps = [
         ":integration",
         "//:node_modules/@types/lodash",

--- a/dev/babel.bzl
+++ b/dev/babel.bzl
@@ -3,7 +3,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:@babel/cli/package_json.bzl", "bin")
 
-def babel(name, srcs, module = None, usePresetEnv = True, **kwargs):
+def babel(name, srcs, module = None, use_preset_env = True, **kwargs):
     """A wrapper around Babel CLI
 
     Args:
@@ -13,7 +13,7 @@ def babel(name, srcs, module = None, usePresetEnv = True, **kwargs):
 
         module: If specified, sets BABEL_MODULE environment variable to this value
 
-        usePresetEnv: Controls if we transpile TS sources with babel-preset-env.
+        use_preset_env: Controls if we transpile TS sources with babel-preset-env.
         If set to False, sets the DISABLE_PRESET_ENV environment variable to "true".
 
         **kwargs: Additional arguments to pass to the rule
@@ -70,7 +70,7 @@ def babel(name, srcs, module = None, usePresetEnv = True, **kwargs):
     if module != None:
         env["BABEL_MODULE"] = module
 
-    if usePresetEnv == False:
+    if use_preset_env == False:
         env["DISABLE_PRESET_ENV"] = "true"
 
     bin.babel(

--- a/dev/defs.bzl
+++ b/dev/defs.bzl
@@ -10,7 +10,7 @@ load(":babel.bzl", _babel = "babel")
 
 sass = _sass
 
-def ts_project(name, deps = [], usePresetEnv = True, **kwargs):
+def ts_project(name, deps = [], use_preset_env = True, **kwargs):
     """A wrapper around ts_project
 
     Args:
@@ -18,7 +18,7 @@ def ts_project(name, deps = [], usePresetEnv = True, **kwargs):
 
         deps: A list of dependencies
 
-        usePresetEnv: Controls if we transpile TS sources with babel-preset-env
+        use_preset_env: Controls if we transpile TS sources with babel-preset-env
 
         **kwargs: Additional arguments to pass to ts_project
     """
@@ -54,7 +54,7 @@ def ts_project(name, deps = [], usePresetEnv = True, **kwargs):
         # use babel as the transpiler
         transpiler = partial.make(
             _babel,
-            usePresetEnv = usePresetEnv,
+            use_preset_env = use_preset_env,
             module = kwargs.pop("module", None),
             tags = kwargs.get("tags", []),
             visibility = visibility,


### PR DESCRIPTION
## Context

Use snake_case for the argument to be consistent with other rules.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-rename-arg.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
