### PR TITLE
docs: add documentation for permission mechanisms in parallel

### DIFF
--- a/doc/admin/config/authorization_and_authentication.md
+++ b/doc/admin/config/authorization_and_authentication.md
@@ -21,16 +21,9 @@ For users using any of the other authentication mechanisms, removing `builtin` a
 
 > NOTE: If Sourcegraph is running on a free license all users will be created as site admins. Learn more about license settings on our [pricing page](https://about.sourcegraph.com/pricing).
 
-## Authorization in Sourcegraph
+## Repository permissions in Sourcegraph
 
-If you use GitHub, GitLab, Bitbucket Server / Bitbucket Data Center or Azure DevOps Services you can sync access permissions directly from the code host:
-
-- [GitHub](#github-enterprise-or-github-cloud-authentication-and-authorization)
-- [GitLab](#gitlab-enterprise-or-gilab-cloud-authentication-and-authorization)
-- [Bitbucket Server / Bitbucket Data Center](#bitbucket-server-authorization)
-- [Azure DevOps Services](#azure-devops-services)
-
-If you do not use one of those listed code hosts, you will need to control access using our [explicit permissions API](#explicit-permissions-api-authorization).
+See [repository permissions documentation](../permissions/index.md).
 
 ## Username normalization
 

--- a/doc/admin/permissions/api.md
+++ b/doc/admin/permissions/api.md
@@ -4,10 +4,16 @@ Sourcegraph's GraphQL API allows users to explicitly set repository permissions.
 
 <span class="virtual-br"></span>
 
-**If the permissions API is enabled, all the other repository permissions mechanisms are disabled.**
+## Permission mechanisms in parallel
 
-> NOTE: If you're using Sourcegraph with multiple code hosts, it's not possible to use the explicit permissions API for one code host and use other mechanisms for getting permissions for others.
+<span class="badge badge-note">Up to Sourcegraph 5.0</span>
 
+> NOTE: Up to version 5.0, if the permissions API is enabled, all the other repository permissions mechanisms are disabled. If you're using Sourcegraph with multiple code hosts, it's not possible to use the explicit permissions API for one code host and use other mechanisms for getting permissions for others.
+
+<span class="badge badge-experimental">Experimental</span>
+<span class="badge badge-note">Sourcegraph 5.0+</span>
+
+If you want to use explicit permissions API alongside synced permissions, read section [permission mechanisms in parallel here](index.md#permission-mechanisms-in-parallel). 
 ## Recommendations
 
 We only recommend to use explicit permissions API in cases, where the other methods are not possible or effective. 

--- a/doc/admin/permissions/api.md
+++ b/doc/admin/permissions/api.md
@@ -4,16 +4,16 @@ Sourcegraph's GraphQL API allows users to explicitly set repository permissions.
 
 <span class="virtual-br"></span>
 
-## Permission mechanisms in parallel
+## Permissions mechanisms in parallel
 
 <span class="badge badge-note">Up to Sourcegraph 5.0</span>
 
-> NOTE: Up to version 5.0, if the permissions API is enabled, all the other repository permissions mechanisms are disabled. If you're using Sourcegraph with multiple code hosts, it's not possible to use the explicit permissions API for one code host and use other mechanisms for getting permissions for others.
+> NOTE: Up to version 5.0, if the Explicit permissions API is enabled, all the other repository permissions mechanisms are disabled. If you're using Sourcegraph with multiple code hosts, it's not possible to use the explicit permissions API for one code host and use other mechanisms for getting permissions for others.
 
 <span class="badge badge-experimental">Experimental</span>
 <span class="badge badge-note">Sourcegraph 5.0+</span>
 
-If you want to use explicit permissions API alongside synced permissions, read section [permission mechanisms in parallel here](index.md#permission-mechanisms-in-parallel). 
+If you want to use explicit permissions API alongside synced permissions, read section [permission mechanisms in parallel here](index.md#permissions-mechanisms-in-parallel). 
 ## Recommendations
 
 We only recommend to use explicit permissions API in cases, where the other methods are not possible or effective. 

--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -90,7 +90,7 @@ option `authz.enforceForSiteAdmins` to `true`.
 E.g. trying to figure out if a specific repository is syncing source code to Sourcegraph correctly 
 might become an impossible task if the site admin cannot access that repository.
 
-## Permission mechanisms in parallel
+## Permissions mechanisms in parallel
 
 <span class="badge badge-experimental">Experimental</span>
 <span class="badge badge-note">Sourcegraph 5.0+</span>
@@ -127,9 +127,9 @@ what was previously impossible.
 
 ### Permission updates
 
-Each permission mechanism is going to update only it's own data. This means, that permission syncing is not 
+Each permission mechanism is going to update only its own data. This means, that permission syncing is not 
 going to touch permissions created by explicit permissions API and vice versa. We consider webhooks permissions 
-as part of the permission syncing mechanism as well, since it's using the same underlying database operations. 
+as part of the permission syncing mechanism as well, since it is using the same underlying database operations. 
 
 What the above paragraph means is, that when an updated set of accessible repositories for a user is given via 
 permission sync, it will replace the existing set of synced permissions for that user, but not the explicit permissions.

--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -85,7 +85,62 @@ By default, site-admins bypass all of the permissions checks. Which means, all s
 view all the repositories by default. The default can be changed by setting the site config 
 option `authz.enforceForSiteAdmins` to `true`.
 
-> NOTE: However, we recommend to be cautious with this option, as it might make some operations for site admins more complicated or impossible.
+> NOTE: However, we recommend to be cautious with this option, as it might make some operations for site admins more complicated or impossible. 
 
 E.g. trying to figure out if a specific repository is syncing source code to Sourcegraph correctly 
 might become an impossible task if the site admin cannot access that repository.
+
+## Permission mechanisms in parallel
+
+<span class="badge badge-experimental">Experimental</span>
+<span class="badge badge-note">Sourcegraph 5.0+</span>
+
+Up to version 5.0 it was not possible to use explicit permissions API alongside permission syncing. 
+Meaning, if explicit permissions API was turned ON, synced permissions were turned OFF. Which also meant it was 
+impossible to use explicit permissions for one code host and synced permissions for another one on the same Sourcegraph instance. 
+
+**Example**:
+
+User `alice` has existing synced permissions to repositories `horsegraph/global` and `horsegraph/hay-v1`. 
+Alice also has explicit API permissions to repository `horsegraph/hay-dev`. So the overall repository permissions 
+of `alice` are the following union set: [`horsegraph/global`, `horsegraph/hay-v1`, `horsegraph/hay-dev`]
+
+### Configuration
+
+**Prerequisites:** 
+1. Sourcegraph version 5.0+
+1. Go to **Site Admin > Migrations** page. There is a migration called `Migrate data from user_permissions table to unified user_repo_permissions.`. 
+Make sure that it finished migrating all the data (it reports as 100%). Contact support if the migration does not seem to complete for a long time (multiple days). 
+
+1. Enable the experimental feature in the [site configuration](../config/site_config.md):
+```json
+{
+  "experimentalFeatures": {
+    "unifiedPermissions": "enabled"
+  }
+  // ...
+}
+```
+1. Continue [configuring the explicit permissions API](api.md#configuration) as you would before. 
+Both mechanisms work at the same time, thanks to a new behind the scenes data model that allows 
+what was previously impossible. 
+
+### Permission updates
+
+Each permission mechanism is going to update only it's own data. This means, that permission syncing is not 
+going to touch permissions created by explicit permissions API and vice versa. We consider webhooks permissions 
+as part of the permission syncing mechanism as well, since it's using the same underlying database operations. 
+
+What the above paragraph means is, that when an updated set of accessible repositories for a user is given via 
+permission sync, it will replace the existing set of synced permissions for that user, but not the explicit permissions.
+
+**Example**:
+
+Let's follow the example from above, `alice` has existing synced permissions to repositories `horsegraph/global` and `horsegraph/hay-v1` 
+and explicit permissions to `horsegraph/hay-dev`, meaning a unioned set of effective permissions of [`horsegraph/global`, `horsegraph-hay-v1`, `horsegraph/hay-dev`]. 
+
+An update comes in from permission sync, now returning `alice` permissions as [`horsegraph/global`, `horsegraph/hay-v2`]. Notice 
+the removal of `horsegraph-v1` from the set.
+
+After the update, the synced permissions of `alice` will be [`horsegraph/global`, `horsegraph/hay-v2`], but explicit permissions 
+were not touched, leading to effective permissions of [`horsegraph/global`, `horsegraph-hay-v2`, `horsegraph/hay-dev`]


### PR DESCRIPTION
## Description

Adding documentation for the experimental permission mechanisms in parallel.

## Test plan

Checked the docs locally.

[The new docs can be viewed here](https://docs.sourcegraph.com/@milan_docs_parallel_perms/admin/permissions#permission-mechanisms-in-parallel)