### PR TITLE
Cody: Add "find code smells" recipe

### DIFF
--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -26,6 +26,7 @@ ts_project(
         "src/chat/recipes/chat-question.ts",
         "src/chat/recipes/explain-code-detailed.ts",
         "src/chat/recipes/explain-code-high-level.ts",
+        "src/chat/recipes/find-code-smells.ts",
         "src/chat/recipes/generate-docstring.ts",
         "src/chat/recipes/generate-test.ts",
         "src/chat/recipes/git-log.ts",

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -3,7 +3,7 @@ import { truncateText } from '../../prompt/truncation'
 import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
-import { getNormalizedLanguageName, } from './helpers'
+import { getNormalizedLanguageName } from './helpers'
 import { Recipe, RecipeContext } from './recipe'
 
 export class FindCodeSmells implements Recipe {
@@ -25,7 +25,8 @@ export class FindCodeSmells implements Recipe {
 If you have no ideas because the code looks fine, feel free to say that it already looks fine.`
 
         // Use the whole context window for the prompt because we're attaching no files
-        const maxTokenCount = MAX_AVAILABLE_PROMPT_LENGTH - (promptPrefix.length + promptSuffix.length) / CHARS_PER_TOKEN
+        const maxTokenCount =
+            MAX_AVAILABLE_PROMPT_LENGTH - (promptPrefix.length + promptSuffix.length) / CHARS_PER_TOKEN
         const truncatedSelectedText = truncateText(selection.selectedText, maxTokenCount)
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n\n${promptSuffix}`
 
@@ -40,7 +41,8 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
                 text: assistantResponsePrefix,
                 displayText: '',
                 timestamp,
-            }, new Promise(resolve => resolve([]))
+            },
+            new Promise(resolve => resolve([]))
         )
     }
 }

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -1,0 +1,46 @@
+import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
+import { truncateText } from '../../prompt/truncation'
+import { getShortTimestamp } from '../../timestamp'
+import { Interaction } from '../transcript/interaction'
+
+import { getNormalizedLanguageName, } from './helpers'
+import { Recipe, RecipeContext } from './recipe'
+
+export class FindCodeSmells implements Recipe {
+    public getID(): string {
+        return 'find-code-smells'
+    }
+
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const selection = context.editor.getActiveTextEditorSelection()
+        if (!selection) {
+            return Promise.resolve(null)
+        }
+
+        const timestamp = getShortTimestamp()
+
+        const languageName = getNormalizedLanguageName(selection.fileName)
+        const promptPrefix = `Find code smells, potential bugs, and unhandled errors in my ${languageName} code:`
+        const promptSuffix = `List maximum five of them as a list (if you have more in mind, mention that these are the top five), with a short context, reasoning, and suggestion on each.
+If you have no ideas because the code looks fine, feel free to say that it already looks fine.`
+
+        // Use the whole context window for the prompt because we're attaching no files
+        const maxTokenCount = MAX_AVAILABLE_PROMPT_LENGTH - (promptPrefix.length + promptSuffix.length) / CHARS_PER_TOKEN
+        const truncatedSelectedText = truncateText(selection.selectedText, maxTokenCount)
+        const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n\n${promptSuffix}`
+
+        const displayText = `Find code smells in the following code: \n\`\`\`\n${selection.selectedText}\n\`\`\``
+
+        const assistantResponsePrefix = ''
+        return new Interaction(
+            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            {
+                speaker: 'assistant',
+                prefix: assistantResponsePrefix,
+                text: assistantResponsePrefix,
+                displayText: '',
+                timestamp,
+            }, new Promise(resolve => resolve([]))
+        )
+    }
+}

--- a/client/cody-shared/src/chat/recipes/index.ts
+++ b/client/cody-shared/src/chat/recipes/index.ts
@@ -8,6 +8,7 @@ import { ImproveVariableNames } from './improve-variable-names'
 import { Recipe } from './recipe'
 import { Replace } from './replace'
 import { TranslateToLanguage } from './translate'
+import { FindCodeSmells } from './find-code-smells'
 
 const registeredRecipes: { [id: string]: Recipe } = {}
 
@@ -34,6 +35,7 @@ function init(): void {
         new ImproveVariableNames(),
         new Replace(),
         new TranslateToLanguage(),
+        new FindCodeSmells(),
     ]
 
     for (const recipe of recipes) {

--- a/client/cody-shared/src/chat/recipes/index.ts
+++ b/client/cody-shared/src/chat/recipes/index.ts
@@ -1,6 +1,7 @@
 import { ChatQuestion } from './chat-question'
 import { ExplainCodeDetailed } from './explain-code-detailed'
 import { ExplainCodeHighLevel } from './explain-code-high-level'
+import { FindCodeSmells } from './find-code-smells'
 import { GenerateDocstring } from './generate-docstring'
 import { GenerateTest } from './generate-test'
 import { GitHistory } from './git-log'
@@ -8,7 +9,6 @@ import { ImproveVariableNames } from './improve-variable-names'
 import { Recipe } from './recipe'
 import { Replace } from './replace'
 import { TranslateToLanguage } from './translate'
-import { FindCodeSmells } from './find-code-smells'
 
 const registeredRecipes: { [id: string]: Recipe } = {}
 

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -137,6 +137,9 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
         vscode.commands.registerCommand('cody.recipe.git-history', async () => executeRecipe('git-history')),
         vscode.commands.registerCommand('cody.recipe.improve-variable-names', async () =>
             executeRecipe('improve-variable-names')
+        ),
+        vscode.commands.registerCommand('cody.recipe.find-code-smells', async () =>
+            executeRecipe('find-code-smells')
         )
     )
 

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -138,9 +138,7 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
         vscode.commands.registerCommand('cody.recipe.improve-variable-names', async () =>
             executeRecipe('improve-variable-names')
         ),
-        vscode.commands.registerCommand('cody.recipe.find-code-smells', async () =>
-            executeRecipe('find-code-smells')
-        )
+        vscode.commands.registerCommand('cody.recipe.find-code-smells', async () => executeRecipe('find-code-smells'))
     )
 
     if (config.experimentalSuggest) {

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -12,6 +12,7 @@ export const recipesList = {
     'improve-variable-names': 'Improve variable names',
     'translate-to-language': 'Translate to different language',
     'git-history': 'Summarize recent code changes',
+    'find-code-smells': 'Find code smells',
 }
 
 export function Recipes(): React.ReactElement {

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -12,7 +12,7 @@ export const recipesList = {
     'improve-variable-names': 'Improve variable names',
     'translate-to-language': 'Translate to different language',
     'git-history': 'Summarize recent code changes',
-    'find-code-smells': 'Find code smells',
+    'find-code-smells': 'Smell code',
 }
 
 export function Recipes(): React.ReactElement {


### PR DESCRIPTION
Added new button:

<img src="https://user-images.githubusercontent.com/2552265/232011080-709cb35a-f9de-4789-8287-2e55630b1636.png" width="200" alt="New button screenshot" />

[30-sec Loom demo](https://www.loom.com/share/cd24253e46de4027b316483b0677767e)

Another response to a file that looked good to it:

<img width="575" alt="Looks good" src="https://user-images.githubusercontent.com/2552265/232013016-64b5ca68-14eb-488e-9e75-1d3f17dcb6a4.png">

And one where tip no. 2 is wrong, but it's still cool:

<img width="1330" alt="CleanShot 2023-04-14 at 12 03 00@2x" src="https://user-images.githubusercontent.com/2552265/232014956-29cb771f-3e3a-420f-a0dc-baccf9eb1802.png">

## Test plan

Tested it with a few selections.

## App preview:

- [Web](https://sg-web-dv-cody-find-code-smells-recipe.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
