### PR TITLE
Fix sidebar Cody gating typo

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -88,7 +88,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
     const [fileTreeFocusKey, setFileTreeFocusKey] = useState('')
     const [symbolsFocusKey, setSymbolsFocusKey] = useState('')
 
-    const codyEnabled = useFeatureFlag('cody-experimental')
+    const [codyEnabled] = useFeatureFlag('cody-experimental')
     const focusCodyShortcut = useKeyboardShortcut('focusCody')
     const [codyFocusKey, setCodyFocusKey] = useState('')
 


### PR DESCRIPTION
Noticed this while reviewing #50618. This didn't error because `useFeatureFlag` returns a tuple and an array is always truthy. 🙃 

## Test plan

Cody be gone (especially from the 5.1 release for customers that don't want it 😐)

<img width="304" alt="Screenshot 2023-04-14 at 12 41 57" src="https://user-images.githubusercontent.com/458591/232023390-df421ebf-1e19-4388-910c-aa5733212475.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-cody-gating.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
