### PR TITLE
own: offer a valid `has.owner` query when possible.

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -13,7 +13,12 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { Alert, Button, ErrorAlert, H3, H4, Icon, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
-import { FetchOwnershipResult, FetchOwnershipVariables, SearchPatternType } from '../../../graphql-operations'
+import {
+    FetchOwnershipResult,
+    FetchOwnershipVariables,
+    OwnerFields,
+    SearchPatternType,
+} from '../../../graphql-operations'
 
 import { FileOwnershipEntry } from './FileOwnershipEntry'
 import { FETCH_OWNERS } from './grapqlQueries'
@@ -64,7 +69,7 @@ export const FileOwnershipPanel: React.FunctionComponent<
     ) {
         return (
             <div className={styles.contents}>
-                <OwnExplanation />
+                <OwnExplanation owners={data.node.commit.blob.ownership.nodes.map(ownership => ownership.owner)} />
                 <Accordion
                     as="table"
                     collapsible={true}
@@ -102,7 +107,11 @@ export const FileOwnershipPanel: React.FunctionComponent<
     )
 }
 
-const OwnExplanation: React.FunctionComponent<{}> = () => {
+interface OwnExplanationProps {
+    owners?: Array<OwnerFields>
+}
+
+const OwnExplanation: React.FunctionComponent<OwnExplanationProps> = ({ owners }) => {
     const [dismissed, setDismissed] = useTemporarySetting('own.panelExplanationHidden')
 
     const onDismiss = React.useCallback(() => {
@@ -112,6 +121,8 @@ const OwnExplanation: React.FunctionComponent<{}> = () => {
     if (dismissed) {
         return null
     }
+
+    const ownerSearchPredicate = resolveOwnerSearchPredicate(owners)
 
     return (
         <MarketingBlock contentClassName={styles.ownExplanationContainer} wrapperClassName="mb-3">
@@ -133,11 +144,11 @@ const OwnExplanation: React.FunctionComponent<{}> = () => {
                         size="sm"
                         outline={true}
                         as={Link}
-                        to="/search?q=file:has.owner(johndoe)"
+                        to={`/search?q=file:has.owner(${ownerSearchPredicate})`}
                         className="mr-2"
                     >
                         <SyntaxHighlightedSearchQuery
-                            query="file:has.owner(johndoe)"
+                            query={`file:has.owner(${ownerSearchPredicate})`}
                             searchPatternType={SearchPatternType.standard}
                         />
                     </Button>
@@ -154,4 +165,15 @@ const OwnExplanation: React.FunctionComponent<{}> = () => {
             </div>
         </MarketingBlock>
     )
+}
+
+const resolveOwnerSearchPredicate = (owners?: Array<OwnerFields>): string => {
+    if (owners) {
+        for (const owner of owners) {
+            if (owner.__typename === 'Person' && owner.user?.username) {
+                return `@${owner.user.username}`
+            }
+        }
+    }
+    return 'johndoe'
 }

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -108,7 +108,7 @@ export const FileOwnershipPanel: React.FunctionComponent<
 }
 
 interface OwnExplanationProps {
-    owners?: Array<OwnerFields>
+    owners?: OwnerFields[]
 }
 
 const OwnExplanation: React.FunctionComponent<OwnExplanationProps> = ({ owners }) => {
@@ -167,7 +167,7 @@ const OwnExplanation: React.FunctionComponent<OwnExplanationProps> = ({ owners }
     )
 }
 
-const resolveOwnerSearchPredicate = (owners?: Array<OwnerFields>): string => {
+const resolveOwnerSearchPredicate = (owners?: OwnerFields[]): string => {
     if (owners) {
         for (const owner of owners) {
             if (owner.__typename === 'Person' && owner.user?.username) {

--- a/enterprise/cmd/frontend/internal/own/init.go
+++ b/enterprise/cmd/frontend/internal/own/init.go
@@ -15,7 +15,7 @@ import (
 // Init initializes the given enterpriseServices to include the required
 // resolvers for Sourcegraph Own.
 func Init(
-	ctx context.Context,
+	_ context.Context,
 	observationCtx *observation.Context,
 	db database.DB,
 	_ codeintel.Services,

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -1,5 +1,3 @@
-// Ownership resolvers are currently just returning fake data to support development.
-// The actual resolver implementation is landing with #46592.
 package resolvers
 
 import (
@@ -143,15 +141,15 @@ func (r *ownResolver) GitBlobOwnership(
 	}, nil
 }
 
-func (r *ownResolver) PersonOwnerField(person *graphqlbackend.PersonResolver) string {
+func (r *ownResolver) PersonOwnerField(_ *graphqlbackend.PersonResolver) string {
 	return "owner"
 }
 
-func (r *ownResolver) UserOwnerField(user *graphqlbackend.UserResolver) string {
+func (r *ownResolver) UserOwnerField(_ *graphqlbackend.UserResolver) string {
 	return "owner"
 }
 
-func (r *ownResolver) TeamOwnerField(team *graphqlbackend.TeamResolver) string {
+func (r *ownResolver) TeamOwnerField(_ *graphqlbackend.TeamResolver) string {
 	return "owner"
 }
 

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -87,7 +87,7 @@ func (s *selectOwnersJob) Name() string {
 	return "SelectOwnersSearchJob"
 }
 
-func (s *selectOwnersJob) Fields(v job.Verbosity) (res []otlog.Field) {
+func (s *selectOwnersJob) Fields(_ job.Verbosity) (res []otlog.Field) {
 	return res
 }
 

--- a/internal/database/fakedb/BUILD.bazel
+++ b/internal/database/fakedb/BUILD.bazel
@@ -25,5 +25,6 @@ go_test(
         "//internal/database",
         "//internal/types",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/database/fakedb/teams.go
+++ b/internal/database/fakedb/teams.go
@@ -238,7 +238,7 @@ func (teams *Teams) ListTeamMembers(ctx context.Context, opts database.ListTeamM
 	return selected, next, nil
 }
 
-func (teams *Teams) CreateTeamMember(ctx context.Context, members ...*types.TeamMember) error {
+func (teams *Teams) CreateTeamMember(_ context.Context, members ...*types.TeamMember) error {
 	for _, newMember := range members {
 		exists := false
 		for _, existingMember := range teams.members {
@@ -256,7 +256,7 @@ func (teams *Teams) CreateTeamMember(ctx context.Context, members ...*types.Team
 	return nil
 }
 
-func (teams *Teams) DeleteTeamMember(ctx context.Context, members ...*types.TeamMember) error {
+func (teams *Teams) DeleteTeamMember(_ context.Context, members ...*types.TeamMember) error {
 	for _, m := range members {
 		var index int
 		var found bool
@@ -275,7 +275,7 @@ func (teams *Teams) DeleteTeamMember(ctx context.Context, members ...*types.Team
 	return nil
 }
 
-func (teams *Teams) IsTeamMember(ctx context.Context, teamID, userID int32) (bool, error) {
+func (teams *Teams) IsTeamMember(_ context.Context, teamID, userID int32) (bool, error) {
 	for _, m := range teams.members {
 		if m.TeamID == teamID && m.UserID == userID {
 			return true, nil

--- a/internal/database/fakedb/teams_test.go
+++ b/internal/database/fakedb/teams_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/fakedb"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAncestors(t *testing.T) {
@@ -20,12 +20,8 @@ func TestAncestors(t *testing.T) {
 	sales := fs.AddTeam(&types.Team{Name: "sales"})
 	salesLeads := fs.AddTeam(&types.Team{Name: "sales-leads", ParentTeamID: sales})
 	ts, cursor, err := fs.TeamStore.ListTeams(context.Background(), database.ListTeamsOpts{ExceptAncestorID: source})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cursor != 0 {
-		t.Fatal("non-zero cursor")
-	}
+	require.NoError(t, err)
+	require.Zero(t, cursor)
 	want := []*types.Team{
 		{ID: eng, Name: "eng"},
 		{ID: sales, Name: "sales"},

--- a/internal/database/fakedb/users.go
+++ b/internal/database/fakedb/users.go
@@ -60,7 +60,7 @@ func (users *Users) GetByCurrentAuthUser(ctx context.Context) (*types.User, erro
 	return a.User(ctx, users)
 }
 
-func (users *Users) List(ctx context.Context, opts *database.UsersListOptions) ([]*types.User, error) {
+func (users *Users) List(_ context.Context, opts *database.UsersListOptions) ([]*types.User, error) {
 	if len(opts.UserIDs) == 0 {
 		return nil, errors.New("not implemented")
 	}
@@ -76,6 +76,6 @@ func (users *Users) List(ctx context.Context, opts *database.UsersListOptions) (
 	return ret, nil
 }
 
-func (users *Users) GetByVerifiedEmail(_ context.Context, email string) (*types.User, error) {
+func (users *Users) GetByVerifiedEmail(_ context.Context, _ string) (*types.User, error) {
 	return nil, nil
 }

--- a/internal/database/teams.go
+++ b/internal/database/teams.go
@@ -137,7 +137,7 @@ type TeamStore interface {
 	ListTeams(ctx context.Context, opts ListTeamsOpts) ([]*types.Team, int32, error)
 	// CountTeams counts teams given the options.
 	CountTeams(ctx context.Context, opts ListTeamsOpts) (int32, error)
-	// Contains tells whether given search conditions contain team with given ID.
+	// ContainsTeam tells whether given search conditions contain team with given ID.
 	ContainsTeam(ctx context.Context, id int32, opts ListTeamsOpts) (bool, error)
 	// ListTeamMembers lists team members given the options. The matching teams,
 	// plus the next cursor are returned.
@@ -153,7 +153,7 @@ type TeamStore interface {
 	// CreateTeamMember creates the team members in the database. If any of the inserts fail,
 	// all inserts are reverted.
 	CreateTeamMember(ctx context.Context, members ...*types.TeamMember) error
-	// DeleteTeam deletes the given team members from the database.
+	// DeleteTeamMember deletes the given team members from the database.
 	DeleteTeamMember(ctx context.Context, members ...*types.TeamMember) error
 	// IsTeamMember checks if the given user is a member of the given team.
 	IsTeamMember(ctx context.Context, teamID, userID int32) (bool, error)

--- a/internal/usagestats/own.go
+++ b/internal/usagestats/own.go
@@ -29,7 +29,7 @@ func GetOwnershipUsageStats(ctx context.Context, db database.DB) (*types.Ownersh
 	stats.ReposCount = &types.OwnershipUsageReposCounts{
 		Total:                 &totalReposCount,
 		WithIngestedOwnership: &ingestedOwnershipReposCount,
-		// At this poing we do not compute ReposCount.WithOwnership as this is really
+		// At this point we do not compute ReposCount.WithOwnership as this is really
 		// computationally intensive (get all repos and query gitserver for each).
 		// This will become very easy once we have versioned CODEOWNERS in the database.
 	}


### PR DESCRIPTION
This commits also includes small cleanups which I made during Own code dive.

Test plan:
Storybook.
Local sg run and test.