### PR TITLE
lower expectations of "magical search" until it does more than translate a regexp

### DIFF
--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -102,16 +102,16 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                         {codySearchEnabled && (
                             <div className="d-flex justify-content-center mt-4">
                                 <Text className="text-muted">
-                                    <Badge variant="merged">New</Badge>{' '}
+                                    <Badge variant="merged">Experimental</Badge>{' '}
                                     <Link
                                         to="/search/cody"
                                         onClick={() =>
-                                            telemetryService.log('ClickedOnTryMagicalSearchCTA', {
+                                            telemetryService.log('ClickedOnTryCodySearchCTA', {
                                                 location: 'SearchPage',
                                             })
                                         }
                                     >
-                                        Try the Magical Search Experience powered by Cody <CodyIcon />{' '}
+                                        Ask Cody to contruct a query from natural language <CodyIcon />{' '}
                                         <Icon svgPath={mdiArrowRight} aria-hidden={true} />
                                     </Link>
                                 </Text>


### PR DESCRIPTION
The previous wording set expectations too high.

![image](https://user-images.githubusercontent.com/1976/232084133-f2bdf059-412c-498f-9a14-fadc475a28b5.png)



## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-rename-magical.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
