### PR TITLE
use absolute URL to force full-browser reload and bypass frontend router

### DIFF
--- a/client/web/src/auth/ExternalsAuth.tsx
+++ b/client/web/src/auth/ExternalsAuth.tsx
@@ -71,7 +71,9 @@ const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<ExternalsAu
         <>
             {githubProvider && (
                 <Link
-                    to={githubProvider.authenticationURL}
+                    // Use absolute URL to force full-page reload (because the auth routes are
+                    // handled by the backend router, not the frontend router).
+                    to={`${window.location.origin}${githubProvider.authenticationURL}`}
                     className={classNames(
                         'text-decoration-none',
                         withCenteredText && 'd-flex justify-content-center',
@@ -86,7 +88,9 @@ const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<ExternalsAu
 
             {gitlabProvider && (
                 <Link
-                    to={gitlabProvider.authenticationURL}
+                    // Use absolute URL to force full-page reload (because the auth routes are
+                    // handled by the backend router, not the frontend router).
+                    to={`${window.location.origin}${gitlabProvider.authenticationURL}`}
                     className={classNames(
                         'text-decoration-none',
                         withCenteredText && 'd-flex justify-content-center',


### PR DESCRIPTION
Fixes an issue where the `/.auth/github/login` URL is interpreted as a frontend route.




## Test plan

Click the GitHub link at https://sourcegraph.com/sign-up.

## App preview:

- [Web](https://sg-web-sqs-github-continue-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
