### PR TITLE
ci: update the use of perforce.sgdev to perforce-tests.sgdev

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	perforceRepoName = "perforce/test-perms"
 	testPermsDepot   = "test-perms"
-	aliceEmail       = "alice@perforce.sgdev.org"
+	aliceEmail       = "alice@perforce-tests.sgdev.org"
 	aliceUsername    = "alice"
 )
 

--- a/dev/perforce-testing-helpers/p4-setup-protections.sh
+++ b/dev/perforce-testing-helpers/p4-setup-protections.sh
@@ -7,8 +7,8 @@ export TEMPLATES="${SCRIPT_ROOT}/templates"
 
 set -euo pipefail
 
-export P4USER="${P4USER:-"admin"}"                   # the name of the Perforce superuser that the script will use to create the depot
-export P4PORT="${P4PORT:-"perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to
+export P4USER="${P4USER:-"admin"}"                         # the name of the Perforce superuser that the script will use to create the depot
+export P4PORT="${P4PORT:-"perforce-tests.sgdev.org:1666"}" # the address of the Perforce server to connect to
 
 export P4_TEST_USERNAME="${P4_TEST_USERNAME:-"test-perforce"}"           # the username of the fake user that the script will create for integration testing purposes
 export P4_TEST_EMAIL="${P4_TEST_EMAIL:-"test-perforce@sourcegraph.com"}" # the email address of the fake user that the script will create for integration testing purposes

--- a/dev/perforce-testing-helpers/p4-upload.sh
+++ b/dev/perforce-testing-helpers/p4-upload.sh
@@ -7,8 +7,8 @@ export TEMPLATES="${SCRIPT_ROOT}/templates"
 
 set -euo pipefail
 
-export P4USER="${P4USER:-"admin"}"                   # the name of the Perforce superuser that the script will use to create the depot
-export P4PORT="${P4PORT:-"perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to
+export P4USER="${P4USER:-"admin"}"                         # the name of the Perforce superuser that the script will use to create the depot
+export P4PORT="${P4PORT:-"perforce-tests.sgdev.org:1666"}" # the address of the Perforce server to connect to
 
 export DEPOT_NAME="${DEPOT_NAME:-"integration-test-depot"}" # the name of the depot that the script will create on the server
 export P4CLIENT="${P4CLIENT:-"integration-test-client"}"    # the name of the temporary client that the script will use while it creates the depot

--- a/doc/integration/jetbrains/manual_testing.md
+++ b/doc/integration/jetbrains/manual_testing.md
@@ -30,10 +30,10 @@ If there is a problem, we should either investigate right away (typically, if a 
 * Use [https://cse-k8s.sgdev.org/](https://cse-k8s.sgdev.org/) as your Sourcegraph URL
 * Generate an access token for yourself for CSE-K8S (admin user in 1Password), set that
 * Set up a Perforce client
-* Set `perforce.sgdev.org:1666` for the port. User is “admin”, password is in 1Password.
+* Set `perforce-tests.sgdev.org:1666` for the port. User is “admin”, password is in 1Password.
 * Make sure your connection work, and _actually connect_ in P4V (connection didn’t work without this step  in IntelliJ for me)
 * Create a workspace for yourself (delete an old one if you bump into the 20-workspace limit), and include the `test-large-depot` depot
-* In the JetBrains plugin settings, set the replacement string to `perforce.sgdev.org:,perforce.beatrix.com:app/,.perforce,/patch/core.perforce`.
+* In the JetBrains plugin settings, set the replacement string to `perforce-tests.sgdev.org:,perforce.beatrix.com:app/,.perforce,/patch/core.perforce`.
 * At this point, your files should open properly in your browser.
 
 #### Search Selection and Open/Copy features


### PR DESCRIPTION
Updating the reference of perforce.sgdev to be updated to perforce-tests.sgdev to use the dedicated integration test instance of perforce.

## Test plan
run test 
./dev/perforce-testing-helpers/p4-setup-protections.sh
./dev/perforce-testing-helpers/p4-upload.sh
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
