### PR TITLE
[codenav] adding prototypes to  codenav

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -91,6 +91,8 @@ export function buildReferencePanelMocks(): ReferencePanelMock {
         afterReferences: null,
         firstImplementations: 100,
         afterImplementations: null,
+        firstPrototypes: 100,
+        afterPrototypes: null,
     }
 
     const resolveRepoRevisionBlobVariables: ResolveRepoAndRevisionVariables = {
@@ -250,6 +252,14 @@ const USE_PRECISE_CODE_INTEL_MOCK: UsePreciseCodeIntelForPositionResult = {
                         },
                         __typename: 'LocationConnection',
                     },
+                    prototypes: {
+                        nodes: [],
+                        pageInfo: {
+                            endCursor: null,
+                            __typename: 'PageInfo',
+                        },
+                        __typename: 'LocationConnection',
+                    },
                     definitions: {
                         nodes: MOCK_DEFINITIONS,
                         pageInfo: {
@@ -344,6 +354,7 @@ export const defaultProps: ReferencesPanelProps = {
         const [result, setResult] = useState<UseCodeIntelResult>({
             data: {
                 implementations: { endCursor: '', nodes: [] },
+                prototypes: { endCursor: '', nodes: [] },
                 references: { endCursor: '', nodes: [] },
                 definitions: { endCursor: '', nodes: [] },
             },
@@ -354,6 +365,9 @@ export const defaultProps: ReferencesPanelProps = {
             implementationsHasNextPage: false,
             fetchMoreImplementationsLoading: false,
             fetchMoreImplementations: () => {},
+            prototypesHasNextPage: false,
+            fetchMorePrototypesLoading: false,
+            fetchMorePrototypes: () => {},
         })
         useQuery<
             UsePreciseCodeIntelForPositionResult,
@@ -377,6 +391,11 @@ export const defaultProps: ReferencesPanelProps = {
                             endCursor: lsif.implementations.pageInfo.endCursor,
                             nodes: lsif.implementations.nodes.map(buildPreciseLocation),
                         },
+                        prototypes: {
+                            endCursor: lsif.prototypes.pageInfo.endCursor,
+                            nodes: lsif.prototypes.nodes.map(buildPreciseLocation),
+                        },
+
                         references: {
                             endCursor: lsif.references.pageInfo.endCursor,
                             nodes: lsif.references.nodes.map(buildPreciseLocation),

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -486,7 +486,7 @@ const ReferencesList: React.FunctionComponent<
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
-          <CollapsibleLocationList
+                    <CollapsibleLocationList
                         {...props}
                         name="prototypes"
                         locations={prototypes}
@@ -501,7 +501,6 @@ const ReferencesList: React.FunctionComponent<
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
-
                 </div>
             </div>
             {sideblob && (

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -293,10 +293,13 @@ const ReferencesList: React.FunctionComponent<
         loading,
         referencesHasNextPage,
         implementationsHasNextPage,
+        prototypesHasNextPage,
         fetchMoreReferences,
         fetchMoreImplementations,
+        fetchMorePrototypes,
         fetchMoreReferencesLoading,
         fetchMoreImplementationsLoading,
+        fetchMorePrototypesLoading,
     } = props.useCodeIntel({
         variables: {
             repository: props.token.repoName,
@@ -311,6 +314,8 @@ const ReferencesList: React.FunctionComponent<
             afterReferences: null,
             firstImplementations: 100,
             afterImplementations: null,
+            firstPrototypes: 100,
+            afterPrototypes: null,
         },
         fileContent: props.fileContent,
         searchToken: props.searchToken,
@@ -333,6 +338,7 @@ const ReferencesList: React.FunctionComponent<
     const references = useMemo(() => data?.references.nodes ?? [], [data])
     const definitions = useMemo(() => data?.definitions.nodes ?? [], [data])
     const implementations = useMemo(() => data?.implementations.nodes ?? [], [data])
+    const prototypes = useMemo(() => data?.prototypes.nodes ?? [], [data])
 
     // The "active URL" is the URL of the highlighted line number in SideBlob,
     // which also influences which item gets highlighted inside
@@ -480,6 +486,22 @@ const ReferencesList: React.FunctionComponent<
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
+          <CollapsibleLocationList
+                        {...props}
+                        name="prototypes"
+                        locations={prototypes}
+                        hasMore={prototypesHasNextPage}
+                        fetchMore={fetchMorePrototypes}
+                        loadingMore={fetchMorePrototypesLoading}
+                        setActiveLocation={setActiveLocation}
+                        filter={debouncedFilter}
+                        isActiveLocation={isActiveLocation}
+                        activeURL={activeURL || ''}
+                        navigateToUrl={navigateToUrl}
+                        handleOpenChange={handleOpenChange}
+                        isOpen={isOpen}
+                    />
+
                 </div>
             </div>
             {sideblob && (

--- a/client/web/src/codeintel/ReferencesPanelQueries.ts
+++ b/client/web/src/codeintel/ReferencesPanelQueries.ts
@@ -65,6 +65,15 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
         ) {
             ...LocationConnectionFields
         }
+        prototypes(
+            line: $line
+            character: $character
+            first: $firstPrototypes
+            after: $afterPrototypes
+            filter: $filter
+        ) {
+            ...LocationConnectionFields
+        }
         definitions(line: $line, character: $character, filter: $filter) {
             ...LocationConnectionFields
         }
@@ -80,6 +89,8 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
         $firstReferences: Int
         $afterImplementations: String
         $firstImplementations: Int
+        $afterPrototypes: String
+        $firstPrototypes: Int
         $filter: String
     ) {
         repository(name: $repository) {
@@ -155,6 +166,41 @@ export const LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY = gql`
                             character: $character
                             first: $firstImplementations
                             after: $afterImplementations
+                            filter: $filter
+                        ) {
+                            ...LocationConnectionFields
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
+export const LOAD_ADDITIONAL_PROTOTYPES_QUERY = gql`
+    ${codeIntelFragments}
+
+    query LoadAdditionalPrototypes(
+        $repository: String!
+        $commit: String!
+        $path: String!
+        $line: Int!
+        $character: Int!
+        $afterPrototypes: String
+        $firstPrototypes: Int
+        $filter: String
+    ) {
+        repository(name: $repository) {
+            id
+            commit(rev: $commit) {
+                id
+                blob(path: $path) {
+                    lsif {
+                        prototypes(
+                            line: $line
+                            character: $character
+                            first: $firstPrototypes
+                            after: $afterPrototypes
                             filter: $filter
                         ) {
                             ...LocationConnectionFields

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -16,6 +16,10 @@ export interface CodeIntelData {
         endCursor: string | null
         nodes: Location[]
     }
+    prototypes: {
+        endCursor: string | null
+        nodes: Location[]
+    }
     definitions: {
         endCursor: string | null
         nodes: Location[]
@@ -34,6 +38,10 @@ export interface UseCodeIntelResult {
     implementationsHasNextPage: boolean
     fetchMoreImplementations: () => void
     fetchMoreImplementationsLoading: boolean
+
+    prototypesHasNextPage: boolean
+    fetchMorePrototypes: () => void
+    fetchMorePrototypesLoading: boolean
 }
 
 export interface UseCodeIntelParameters {

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -182,6 +182,41 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
     ): LocationConnection!
 
     """
+    A list of prototypes of the symbol under the given document position.
+    """
+    prototypes(
+        """
+        The line on which the symbol occurs (zero-based, inclusive).
+        """
+        line: Int!
+
+        """
+        The character (not byte) of the start line on which the symbol occurs (zero-based, inclusive).
+        """
+        character: Int!
+
+        """
+        When specified, indicates that this request should be paginated and
+        to fetch results starting at this cursor.
+        A future request can be made for more results by passing in the
+        'LocationConnection.pageInfo.endCursor' that is returned.
+        """
+        after: String
+
+        """
+        When specified, indicates that this request should be paginated and
+        the first N results (relative to the cursor) should be returned. i.e.
+        how many results to return per page.
+        """
+        first: Int
+
+        """
+        When specified, it filters implementation by filename.
+        """
+        filter: String
+    ): LocationConnection!
+
+    """
     The hover result of the symbol under the given document position.
     """
     hover(

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -211,7 +211,7 @@ type GitBlobLSIFData implements TreeEntryLSIFData {
         first: Int
 
         """
-        When specified, it filters implementation by filename.
+        When specified, it filters prototypes by filename.
         """
         filter: String
     ): LocationConnection!

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	getPackageInformation      *observation.Operation
 	getDefinitionLocations     *observation.Operation
 	getImplementationLocations *observation.Operation
+	getPrototypesLocations     *observation.Operation
 	getReferenceLocations      *observation.Operation
 	getBulkMonikerLocations    *observation.Operation
 	getHover                   *observation.Operation
@@ -50,6 +51,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getPackageInformation:      op("GetPackageInformation"),
 		getDefinitionLocations:     op("GetDefinitionLocations"),
 		getImplementationLocations: op("GetImplementationLocations"),
+		getPrototypesLocations:     op("GetPrototypesLocations"),
 		getReferenceLocations:      op("GetReferenceLocations"),
 		getBulkMonikerLocations:    op("GetBulkMonikerLocations"),
 		getHover:                   op("GetHover"),

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -25,6 +25,7 @@ type LsifStore interface {
 	// Fetch locations by position
 	GetDefinitionLocations(ctx context.Context, uploadID int, path string, line, character, limit, offset int) ([]shared.Location, int, error)
 	GetImplementationLocations(ctx context.Context, uploadID int, path string, line, character, limit, offset int) ([]shared.Location, int, error)
+	GetPrototypeLocations(ctx context.Context, uploadID int, path string, line, character, limit, offset int) ([]shared.Location, int, error)
 	GetReferenceLocations(ctx context.Context, uploadID int, path string, line, character, limit, offset int) ([]shared.Location, int, error)
 	GetBulkMonikerLocations(ctx context.Context, tableName string, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) ([]shared.Location, int, error)
 

--- a/enterprise/internal/codeintel/codenav/mocks_test.go
+++ b/enterprise/internal/codeintel/codenav/mocks_test.go
@@ -47,6 +47,9 @@ type MockLsifStore struct {
 	// GetPathExistsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetPathExists.
 	GetPathExistsFunc *LsifStoreGetPathExistsFunc
+	// GetPrototypeLocationsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetPrototypeLocations.
+	GetPrototypeLocationsFunc *LsifStoreGetPrototypeLocationsFunc
 	// GetRangesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetRanges.
 	GetRangesFunc *LsifStoreGetRangesFunc
@@ -102,6 +105,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		GetPathExistsFunc: &LsifStoreGetPathExistsFunc{
 			defaultHook: func(context.Context, int, string) (r0 bool, r1 error) {
+				return
+			},
+		},
+		GetPrototypeLocationsFunc: &LsifStoreGetPrototypeLocationsFunc{
+			defaultHook: func(context.Context, int, string, int, int, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -172,6 +180,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.GetPathExists")
 			},
 		},
+		GetPrototypeLocationsFunc: &LsifStoreGetPrototypeLocationsFunc{
+			defaultHook: func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error) {
+				panic("unexpected invocation of MockLsifStore.GetPrototypeLocations")
+			},
+		},
 		GetRangesFunc: &LsifStoreGetRangesFunc{
 			defaultHook: func(context.Context, int, string, int, int) ([]shared.CodeIntelligenceRange, error) {
 				panic("unexpected invocation of MockLsifStore.GetRanges")
@@ -222,6 +235,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		GetPathExistsFunc: &LsifStoreGetPathExistsFunc{
 			defaultHook: i.GetPathExists,
+		},
+		GetPrototypeLocationsFunc: &LsifStoreGetPrototypeLocationsFunc{
+			defaultHook: i.GetPrototypeLocations,
 		},
 		GetRangesFunc: &LsifStoreGetRangesFunc{
 			defaultHook: i.GetRanges,
@@ -1211,6 +1227,134 @@ func (c LsifStoreGetPathExistsFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreGetPathExistsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreGetPrototypeLocationsFunc describes the behavior when the
+// GetPrototypeLocations method of the parent MockLsifStore instance is
+// invoked.
+type LsifStoreGetPrototypeLocationsFunc struct {
+	defaultHook func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error)
+	hooks       []func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error)
+	history     []LsifStoreGetPrototypeLocationsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetPrototypeLocations delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLsifStore) GetPrototypeLocations(v0 context.Context, v1 int, v2 string, v3 int, v4 int, v5 int, v6 int) ([]shared.Location, int, error) {
+	r0, r1, r2 := m.GetPrototypeLocationsFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.GetPrototypeLocationsFunc.appendCall(LsifStoreGetPrototypeLocationsFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// GetPrototypeLocations method of the parent MockLsifStore instance is
+// invoked and the hook queue is empty.
+func (f *LsifStoreGetPrototypeLocationsFunc) SetDefaultHook(hook func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetPrototypeLocations method of the parent MockLsifStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LsifStoreGetPrototypeLocationsFunc) PushHook(hook func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreGetPrototypeLocationsFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreGetPrototypeLocationsFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *LsifStoreGetPrototypeLocationsFunc) nextHook() func(context.Context, int, string, int, int, int, int) ([]shared.Location, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreGetPrototypeLocationsFunc) appendCall(r0 LsifStoreGetPrototypeLocationsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreGetPrototypeLocationsFuncCall
+// objects describing the invocations of this function.
+func (f *LsifStoreGetPrototypeLocationsFunc) History() []LsifStoreGetPrototypeLocationsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreGetPrototypeLocationsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreGetPrototypeLocationsFuncCall is an object that describes an
+// invocation of method GetPrototypeLocations on an instance of
+// MockLsifStore.
+type LsifStoreGetPrototypeLocationsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 int
+	// Arg6 is the value of the 7th argument passed to this method
+	// invocation.
+	Arg6 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.Location
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreGetPrototypeLocationsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreGetPrototypeLocationsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // LsifStoreGetRangesFunc describes the behavior when the GetRanges method

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -731,12 +731,6 @@ func (s *Service) GetImplementations(ctx context.Context, args RequestArgs, requ
 			attribute.Int("numGetUploadsWithDefinitionsForMonikers", len(uploads)),
 			attribute.String("getUploadsWithDefinitionsForMonikers", uploadIDsToString(uploads)))
 
-		// definitionLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "definitions", DefinitionsLimit, 0)
-		// if err != nil {
-		// 	return nil, cursor, err
-		// }
-		// locations = append(locations, definitionLocations...)
-
 		implementationLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "implementations", DefinitionsLimit, 0)
 		if err != nil {
 			return nil, cursor, err

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -889,7 +889,7 @@ func (s *Service) GetPrototypes(ctx context.Context, args RequestArgs, requestSt
 	if err != nil {
 		return nil, cursor, err
 	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numImplementationsLocations", len(prototypeLocations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numPrototypesLocations", len(prototypeLocations)))
 
 	return prototypeLocations, cursor, nil
 }

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -731,11 +731,11 @@ func (s *Service) GetImplementations(ctx context.Context, args RequestArgs, requ
 			attribute.Int("numGetUploadsWithDefinitionsForMonikers", len(uploads)),
 			attribute.String("getUploadsWithDefinitionsForMonikers", uploadIDsToString(uploads)))
 
-		definitionLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "definitions", DefinitionsLimit, 0)
-		if err != nil {
-			return nil, cursor, err
-		}
-		locations = append(locations, definitionLocations...)
+		// definitionLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "definitions", DefinitionsLimit, 0)
+		// if err != nil {
+		// 	return nil, cursor, err
+		// }
+		// locations = append(locations, definitionLocations...)
 
 		implementationLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "implementations", DefinitionsLimit, 0)
 		if err != nil {
@@ -775,6 +775,129 @@ func (s *Service) GetImplementations(ctx context.Context, args RequestArgs, requ
 	trace.AddEvent("TODO Domain Owner", attribute.Int("numImplementationsLocations", len(implementationLocations)))
 
 	return implementationLocations, cursor, nil
+}
+
+func (s *Service) GetPrototypes(ctx context.Context, args RequestArgs, requestState RequestState, cursor ImplementationsCursor) (_ []shared.UploadLocation, _ ImplementationsCursor, err error) {
+	ctx, trace, endObservation := observeResolver(ctx, &err, s.operations.getImplementations, serviceObserverThreshold, observation.Args{
+		LogFields: []traceLog.Field{
+			traceLog.Int("repositoryID", args.RepositoryID),
+			traceLog.String("commit", args.Commit),
+			traceLog.String("path", args.Path),
+			traceLog.Int("numUploads", len(requestState.GetCacheUploads())),
+			traceLog.String("uploads", uploadIDsToString(requestState.GetCacheUploads())),
+			traceLog.Int("line", args.Line),
+			traceLog.Int("character", args.Character),
+		},
+	})
+	defer endObservation()
+
+	// Adjust the path and position for each visible upload based on its git difference to
+	// the target commit. This data may already be stashed in the cursor decoded above, in
+	// which case we don't need to hit the database.
+	visibleUploads, cursorsToVisibleUploads, err := s.getVisibleUploadsFromCursor(ctx, args.Line, args.Character, &cursor.CursorsToVisibleUploads, requestState)
+	if err != nil {
+		return nil, cursor, err
+	}
+
+	// Update the cursors with the updated visible uploads.
+	cursor.CursorsToVisibleUploads = cursorsToVisibleUploads
+
+	// Gather all monikers attached to the ranges enclosing the requested position. This data
+	// may already be stashed in the cursor decoded above, in which case we don't need to hit
+	// the database.
+	if cursor.OrderedImplementationMonikers == nil {
+		if cursor.OrderedImplementationMonikers, err = s.getOrderedMonikers(ctx, visibleUploads, precise.Implementation, "import", "export"); err != nil {
+			return nil, cursor, err
+		}
+	}
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numImplementationMonikers", len(cursor.OrderedImplementationMonikers)),
+		attribute.String("implementationMonikers", monikersToString(cursor.OrderedImplementationMonikers)))
+
+	if cursor.OrderedExportMonikers == nil {
+		if cursor.OrderedExportMonikers, err = s.getOrderedMonikers(ctx, visibleUploads, "export"); err != nil {
+			return nil, cursor, err
+		}
+	}
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numExportMonikers", len(cursor.OrderedExportMonikers)),
+		attribute.String("exportMonikers", monikersToString(cursor.OrderedExportMonikers)))
+
+	// Phase 1: Gather all "local" locations via LSIF graph traversal. We'll continue to request additional
+	// locations until we fill an entire page (the size of which is denoted by the given limit) or there are
+	// no more local results remaining.
+	var locations []shared.Location
+	if cursor.Phase == "local" {
+		for len(locations) < args.Limit {
+			localLocations, hasMore, err := s.getPageLocalLocations(ctx, s.lsifstore.GetPrototypeLocations, visibleUploads, &cursor.LocalCursor, args.Limit-len(locations), trace)
+			if err != nil {
+				return nil, cursor, err
+			}
+			locations = append(locations, localLocations...)
+
+			if !hasMore {
+				cursor.Phase = "dependencies"
+				break
+			}
+		}
+	}
+
+	// Phase 2: Gather all "remote" locations in dependencies via moniker search. We only do this if
+	// there are no more local results. We'll continue to request additional locations until we fill an
+	// entire page or there are no more local results remaining, just as we did above.
+	if cursor.Phase == "dependencies" {
+		uploads, err := s.getUploadsWithDefinitionsForMonikers(ctx, cursor.OrderedImplementationMonikers, requestState)
+		if err != nil {
+			return nil, cursor, err
+		}
+		trace.AddEvent("TODO Domain Owner",
+			attribute.Int("numGetUploadsWithDefinitionsForMonikers", len(uploads)),
+			attribute.String("getUploadsWithDefinitionsForMonikers", uploadIDsToString(uploads)))
+
+		definitionLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "definitions", DefinitionsLimit, 0)
+		if err != nil {
+			return nil, cursor, err
+		}
+		locations = append(locations, definitionLocations...)
+
+		prototypeLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "implementations", DefinitionsLimit, 0)
+		if err != nil {
+			return nil, cursor, err
+		}
+		locations = append(locations, prototypeLocations...)
+
+		cursor.Phase = "dependents"
+	}
+
+	// Phase 3: Gather all "remote" locations in dependents via moniker search.
+	if cursor.Phase == "dependents" {
+		for len(locations) < args.Limit {
+			remoteLocations, hasMore, err := s.getPageRemoteLocations(ctx, "implementations", visibleUploads, cursor.OrderedExportMonikers, &cursor.RemoteCursor, args.Limit-len(locations), trace, args, requestState)
+			if err != nil {
+				return nil, cursor, err
+			}
+			locations = append(locations, remoteLocations...)
+
+			if !hasMore {
+				cursor.Phase = "done"
+				break
+			}
+		}
+	}
+
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
+
+	// Adjust the locations back to the appropriate range in the target commits. This adjusts
+	// locations within the repository the user is browsing so that it appears all implementations
+	// are occurring at the same commit they are looking at.
+
+	prototypeLocations, err := s.getUploadLocations(ctx, args, requestState, locations, true)
+	if err != nil {
+		return nil, cursor, err
+	}
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numImplementationsLocations", len(prototypeLocations)))
+
+	return prototypeLocations, cursor, nil
 }
 
 // GetDefinitions returns the set of locations defining the symbol at the given position.

--- a/enterprise/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/iface.go
@@ -12,6 +12,7 @@ type CodeNavService interface {
 	GetHover(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState) (_ string, _ shared.Range, _ bool, err error)
 	GetReferences(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState, cursor codenav.ReferencesCursor) (_ []shared.UploadLocation, nextCursor codenav.ReferencesCursor, err error)
 	GetImplementations(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState, cursor codenav.ImplementationsCursor) (_ []shared.UploadLocation, nextCursor codenav.ImplementationsCursor, err error)
+	GetPrototypes(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState, cursor codenav.ImplementationsCursor) (_ []shared.UploadLocation, nextCursor codenav.ImplementationsCursor, err error)
 	GetDefinitions(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState) (_ []shared.UploadLocation, err error)
 	GetDiagnostics(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState) (diagnosticsAtUploads []codenav.DiagnosticAtUpload, _ int, err error)
 	GetRanges(ctx context.Context, args codenav.RequestArgs, requestState codenav.RequestState, startLine, endLine int) (adjustedRanges []codenav.AdjustedCodeIntelligenceRange, err error)

--- a/enterprise/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -193,6 +193,9 @@ type MockCodeNavService struct {
 	// GetImplementationsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetImplementations.
 	GetImplementationsFunc *CodeNavServiceGetImplementationsFunc
+	// GetPrototypesFunc is an instance of a mock function object
+	// controlling the behavior of the method GetPrototypes.
+	GetPrototypesFunc *CodeNavServiceGetPrototypesFunc
 	// GetRangesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetRanges.
 	GetRangesFunc *CodeNavServiceGetRangesFunc
@@ -235,6 +238,11 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		GetImplementationsFunc: &CodeNavServiceGetImplementationsFunc{
+			defaultHook: func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) (r0 []shared1.UploadLocation, r1 codenav.ImplementationsCursor, r2 error) {
+				return
+			},
+		},
+		GetPrototypesFunc: &CodeNavServiceGetPrototypesFunc{
 			defaultHook: func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) (r0 []shared1.UploadLocation, r1 codenav.ImplementationsCursor, r2 error) {
 				return
 			},
@@ -296,6 +304,11 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 				panic("unexpected invocation of MockCodeNavService.GetImplementations")
 			},
 		},
+		GetPrototypesFunc: &CodeNavServiceGetPrototypesFunc{
+			defaultHook: func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error) {
+				panic("unexpected invocation of MockCodeNavService.GetPrototypes")
+			},
+		},
 		GetRangesFunc: &CodeNavServiceGetRangesFunc{
 			defaultHook: func(context.Context, codenav.RequestArgs, codenav.RequestState, int, int) ([]codenav.AdjustedCodeIntelligenceRange, error) {
 				panic("unexpected invocation of MockCodeNavService.GetRanges")
@@ -343,6 +356,9 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 		},
 		GetImplementationsFunc: &CodeNavServiceGetImplementationsFunc{
 			defaultHook: i.GetImplementations,
+		},
+		GetPrototypesFunc: &CodeNavServiceGetPrototypesFunc{
+			defaultHook: i.GetPrototypes,
 		},
 		GetRangesFunc: &CodeNavServiceGetRangesFunc{
 			defaultHook: i.GetRanges,
@@ -947,6 +963,124 @@ func (c CodeNavServiceGetImplementationsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeNavServiceGetImplementationsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// CodeNavServiceGetPrototypesFunc describes the behavior when the
+// GetPrototypes method of the parent MockCodeNavService instance is
+// invoked.
+type CodeNavServiceGetPrototypesFunc struct {
+	defaultHook func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error)
+	hooks       []func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error)
+	history     []CodeNavServiceGetPrototypesFuncCall
+	mutex       sync.Mutex
+}
+
+// GetPrototypes delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockCodeNavService) GetPrototypes(v0 context.Context, v1 codenav.RequestArgs, v2 codenav.RequestState, v3 codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error) {
+	r0, r1, r2 := m.GetPrototypesFunc.nextHook()(v0, v1, v2, v3)
+	m.GetPrototypesFunc.appendCall(CodeNavServiceGetPrototypesFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the GetPrototypes method
+// of the parent MockCodeNavService instance is invoked and the hook queue
+// is empty.
+func (f *CodeNavServiceGetPrototypesFunc) SetDefaultHook(hook func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetPrototypes method of the parent MockCodeNavService instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeNavServiceGetPrototypesFunc) PushHook(hook func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeNavServiceGetPrototypesFunc) SetDefaultReturn(r0 []shared1.UploadLocation, r1 codenav.ImplementationsCursor, r2 error) {
+	f.SetDefaultHook(func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeNavServiceGetPrototypesFunc) PushReturn(r0 []shared1.UploadLocation, r1 codenav.ImplementationsCursor, r2 error) {
+	f.PushHook(func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *CodeNavServiceGetPrototypesFunc) nextHook() func(context.Context, codenav.RequestArgs, codenav.RequestState, codenav.ImplementationsCursor) ([]shared1.UploadLocation, codenav.ImplementationsCursor, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeNavServiceGetPrototypesFunc) appendCall(r0 CodeNavServiceGetPrototypesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeNavServiceGetPrototypesFuncCall objects
+// describing the invocations of this function.
+func (f *CodeNavServiceGetPrototypesFunc) History() []CodeNavServiceGetPrototypesFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeNavServiceGetPrototypesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeNavServiceGetPrototypesFuncCall is an object that describes an
+// invocation of method GetPrototypes on an instance of MockCodeNavService.
+type CodeNavServiceGetPrototypesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 codenav.RequestArgs
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 codenav.RequestState
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 codenav.ImplementationsCursor
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.UploadLocation
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 codenav.ImplementationsCursor
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeNavServiceGetPrototypesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeNavServiceGetPrototypesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 

--- a/enterprise/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/observability.go
@@ -19,6 +19,7 @@ type operations struct {
 	definitions     *observation.Operation
 	references      *observation.Operation
 	implementations *observation.Operation
+	prototypes      *observation.Operation
 	diagnostics     *observation.Operation
 	stencil         *observation.Operation
 	ranges          *observation.Operation
@@ -48,6 +49,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		definitions:     op("Definitions"),
 		references:      op("References"),
 		implementations: op("Implementations"),
+		prototypes:      op("Prototypes"),
 		diagnostics:     op("Diagnostics"),
 		stencil:         op("Stencil"),
 		ranges:          op("Ranges"),

--- a/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
@@ -91,13 +91,13 @@ func (r *gitBlobLSIFDataResolver) Prototypes(ctx context.Context, args *resolver
 		return nil, errors.Wrap(err, fmt.Sprintf("invalid cursor: %q", rawCursor))
 	}
 
-	prototypes, implsCursor, err := r.codeNavSvc.GetPrototypes(ctx, requestArgs, r.requestState, cursor)
+	prototypes, protoCursor, err := r.codeNavSvc.GetPrototypes(ctx, requestArgs, r.requestState, cursor)
 	if err != nil {
 		return nil, errors.Wrap(err, "codeNavSvc.GetPrototypes")
 	}
 
-	if implsCursor.Phase != "done" {
-		nextCursor = encodeImplementationsCursor(implsCursor)
+	if protoCursor.Phase != "done" {
+		nextCursor = encodeImplementationsCursor(protoCursor)
 	}
 
 	if args.Filter != nil && *args.Filter != "" {

--- a/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
@@ -66,6 +66,53 @@ func (r *gitBlobLSIFDataResolver) Implementations(ctx context.Context, args *res
 	return newLocationConnectionResolver(impls, resolverstubs.NonZeroPtr(nextCursor), r.locationResolver), nil
 }
 
+func (r *gitBlobLSIFDataResolver) Prototypes(ctx context.Context, args *resolverstubs.LSIFPagedQueryPositionArgs) (_ resolverstubs.LocationConnectionResolver, err error) {
+	limit := int(resolverstubs.Deref(args.First, DefaultImplementationsPageSize))
+	if limit <= 0 {
+		return nil, ErrIllegalLimit
+	}
+
+	rawCursor, err := decodeCursor(args.After)
+	if err != nil {
+		return nil, err
+	}
+
+	requestArgs := codenav.RequestArgs{RepositoryID: r.requestState.RepositoryID, Commit: r.requestState.Commit, Path: r.requestState.Path, Line: int(args.Line), Character: int(args.Character), Limit: limit, RawCursor: rawCursor}
+	ctx, _, endObservation := observeResolver(ctx, &err, r.operations.prototypes, time.Second, getObservationArgs(requestArgs))
+	defer endObservation()
+
+	// Decode cursor given from previous response or create a new one with default values.
+	// We use the cursor state track offsets with the result set and cache initial data that
+	// is used to resolve each page. This cursor will be modified in-place to become the
+	// cursor used to fetch the subsequent page of results in this result set.
+	var nextCursor string
+	cursor, err := decodeImplementationsCursor(rawCursor)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("invalid cursor: %q", rawCursor))
+	}
+
+	prototypes, implsCursor, err := r.codeNavSvc.GetPrototypes(ctx, requestArgs, r.requestState, cursor)
+	if err != nil {
+		return nil, errors.Wrap(err, "codeNavSvc.GetPrototypes")
+	}
+
+	if implsCursor.Phase != "done" {
+		nextCursor = encodeImplementationsCursor(implsCursor)
+	}
+
+	if args.Filter != nil && *args.Filter != "" {
+		filtered := prototypes[:0]
+		for _, loc := range prototypes {
+			if strings.Contains(loc.Path, *args.Filter) {
+				filtered = append(filtered, loc)
+			}
+		}
+		prototypes = filtered
+	}
+
+	return newLocationConnectionResolver(prototypes, resolverstubs.NonZeroPtr(nextCursor), r.locationResolver), nil
+}
+
 //
 //
 

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -32,6 +32,7 @@ type GitBlobLSIFDataResolver interface {
 	Definitions(ctx context.Context, args *LSIFQueryPositionArgs) (LocationConnectionResolver, error)
 	References(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Implementations(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
+	Prototypes(ctx context.Context, args *LSIFPagedQueryPositionArgs) (LocationConnectionResolver, error)
 	Hover(ctx context.Context, args *LSIFQueryPositionArgs) (HoverResolver, error)
 	VisibleIndexes(ctx context.Context) (_ *[]PreciseIndexResolver, err error)
 	Snapshot(ctx context.Context, args *struct{ IndexID graphql.ID }) (_ *[]SnapshotDataResolver, err error)


### PR DESCRIPTION
This is a draft PR to address the problem with our current implementation of "Find Implementations" as described in [this issue](https://github.com/sourcegraph/sourcegraph/issues/50110).

>Currently, "Find implementations" shows the prototype instead of implementations. When a symbol A# implements symbol B# then I expect "Find implementations" on the symbol B# to return A#.

Feedback welcome, but more importantly need to ensure this actually solves the problem highlighted by TwoSigma.

![CleanShot 2023-04-14 at 13 37 05](https://user-images.githubusercontent.com/6225160/232140019-07766c6d-b081-41df-9cbc-615fdfcda3f9.png)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
