### PR TITLE
add experimental site config setting to restrict cody to users by the cody-experimental feature flag

### DIFF
--- a/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/resolvers",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//enterprise/cmd/frontend/internal/completions/streaming",
         "//enterprise/cmd/frontend/internal/completions/types",

--- a/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/types"
@@ -24,11 +23,8 @@ func NewCompletionsResolver() graphqlbackend.CompletionsResolver {
 }
 
 func (c *completionsResolver) Completions(ctx context.Context, args graphqlbackend.CompletionsArgs) (string, error) {
-	if envvar.SourcegraphDotComMode() {
-		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
-		if !isEnabled {
-			return "", errors.New("cody experimental feature flag is not enabled for current user")
-		}
+	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
+		return "", errors.New("cody experimental feature flag is not enabled for current user")
 	}
 
 	completionsConfig := conf.Get().Completions

--- a/enterprise/cmd/frontend/internal/completions/streaming/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/streaming/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//enterprise/cmd/frontend/internal/completions/streaming/anthropic",
         "//enterprise/cmd/frontend/internal/completions/streaming/openai",
         "//enterprise/cmd/frontend/internal/completions/types",

--- a/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/codecompletion.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming/anthropic"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cody"
@@ -35,12 +34,9 @@ func (h *codeCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
-		if !isEnabled {
-			http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
-			return
-		}
+	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
+		http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
+		return
 	}
 
 	if r.Method != "POST" {

--- a/enterprise/cmd/frontend/internal/completions/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/stream.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming/anthropic"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/streaming/openai"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/types"
@@ -54,12 +53,9 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
-		if !isEnabled {
-			http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
-			return
-		}
+	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
+		http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
+		return
 	}
 
 	if r.Method != "POST" {

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings/resolvers",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//enterprise/internal/cody",

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cody"
@@ -48,11 +47,8 @@ func (r *Resolver) EmbeddingsSearch(ctx context.Context, args graphqlbackend.Emb
 		return nil, errors.New("embeddings are not configured or disabled")
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
-		if !isEnabled {
-			return nil, errors.New("cody experimental feature flag is not enabled for current user")
-		}
+	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
+		return nil, errors.New("cody experimental feature flag is not enabled for current user")
 	}
 
 	repoID, err := graphqlbackend.UnmarshalRepositoryID(args.Repo)
@@ -82,11 +78,8 @@ func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graph
 	if !conf.EmbeddingsEnabled() {
 		return false, errors.New("embeddings are not configured or disabled")
 	}
-	if envvar.SourcegraphDotComMode() {
-		isEnabled := cody.IsCodyExperimentalFeatureFlagEnabled(ctx)
-		if !isEnabled {
-			return false, errors.New("cody experimental feature flag is not enabled for current user")
-		}
+	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
+		return false, errors.New("cody experimental feature flag is not enabled for current user")
 	}
 	return r.embeddingsClient.IsContextRequiredForChatQuery(ctx, embeddings.IsContextRequiredForChatQueryParameters{Query: args.Query})
 }

--- a/enterprise/internal/cody/BUILD.bazel
+++ b/enterprise/internal/cody/BUILD.bazel
@@ -5,5 +5,9 @@ go_library(
     srcs = ["feature_flag.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/cody",
     visibility = ["//enterprise:__subpackages__"],
-    deps = ["//internal/featureflag"],
+    deps = [
+        "//cmd/frontend/envvar",
+        "//internal/conf",
+        "//internal/featureflag",
+    ],
 )

--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -3,9 +3,14 @@ package cody
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
-func IsCodyExperimentalFeatureFlagEnabled(ctx context.Context) bool {
-	return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
+func IsCodyEnabled(ctx context.Context) bool {
+	if envvar.SourcegraphDotComMode() || conf.Get().ExperimentalFeatures.CodyRestrictUsersFeatureFlag {
+		return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
+	}
+	return true
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -779,6 +779,8 @@ type ExpandedGitCommitDescription struct {
 type ExperimentalFeatures struct {
 	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
 	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
+	// CodyRestrictUsersFeatureFlag description: Restrict Cody to only be enabled for users that have a feature flag labeled "cody-experimental" set to true. You must create a feature flag with this ID after enabling this setting: https://docs.sourcegraph.com/dev/how-to/use_feature_flags#create-a-feature-flag.
+	CodyRestrictUsersFeatureFlag bool `json:"codyRestrictUsersFeatureFlag,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command. To enable this feature set environment variable `ENABLE_CUSTOM_GIT_FETCH` as `true` on gitserver.
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
@@ -870,6 +872,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	delete(m, "bitbucketServerFastPerm")
+	delete(m, "codyRestrictUsersFeatureFlag")
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")
 	delete(m, "enableGRPC")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -105,6 +105,11 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "codyRestrictUsersFeatureFlag": {
+          "description": "Restrict Cody to only be enabled for users that have a feature flag labeled \"cody-experimental\" set to true. You must create a feature flag with this ID after enabling this setting: https://docs.sourcegraph.com/dev/how-to/use_feature_flags#create-a-feature-flag.",
+          "type": "boolean",
+          "default": false
+        },
         "rateLimitAnonymous": {
           "description": "Configures the hourly rate limits for anonymous calls to the GraphQL API. Setting limit to 0 disables the limiter. This is only relevant if unauthenticated calls to the API are permitted.",
           "type": "integer",


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/50632

To enable this, the Sourcegraph site admin must do the following:
1. Set `"codyRestrictUsersFeatureFlag": true` in site config under `"experimentalFeatures"`.
2. Create a feature flag called `cody-experimental` through https://$SOURCEGRAPH_HOST/site-admin/feature-flags
3. Set the default value of the feature flag to `false` and then add overrides to `true` for specific users, as we do on sourcegraph.com

The feature flag must be called exactly "cody-experimental."

## Test plan

Affects only Cody (experimental). Tested locally.