### PR TITLE
cody web: tell user if repo has no embeddings

### DIFF
--- a/client/web/src/stores/codyChat.ts
+++ b/client/web/src/stores/codyChat.ts
@@ -12,12 +12,12 @@ interface CodyChatStore {
     client: Client | null
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
-    repo: string | null
+    repo: string
     filePath: string
     setClient: (client: Client | null) => void
     setMessageInProgress: (message: ChatMessage | null) => void
     setTranscript: (transcript: ChatMessage[]) => void
-    initializeClient: (config: ClientInit['config']) => void
+    initializeClient: (config: Required<ClientInit['config']>) => void
     onSubmit: (text: string) => void
 }
 
@@ -43,8 +43,8 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
         setClient: client => set({ client }),
         setMessageInProgress: message => set({ messageInProgress: message }),
         setTranscript: transcript => set({ transcript }),
-        initializeClient: (config: ClientInit['config']): void => {
-            set({ messageInProgress: null, transcript: [], repo: config.codebase ?? null })
+        initializeClient: (config: Required<ClientInit['config']>): void => {
+            set({ messageInProgress: null, transcript: [], repo: config.codebase })
             createClient({
                 config,
                 accessToken: null,
@@ -67,7 +67,7 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
 export const useChatStore = (isCodyEnabled: boolean, repoName: string): CodyChatStore => {
     const store = useChatStoreState()
 
-    const config = useMemo<ClientInit['config']>(
+    const config = useMemo<Required<ClientInit['config']>>(
         () => ({
             serverEndpoint: window.location.origin,
             useContext: 'embeddings',


### PR DESCRIPTION
If the repo has no embeddings, show a message instead of showing a Cody chat UI that will not be very good because it lacks embeddings.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/1976/232177249-367142d9-4ac2-4c1a-8321-ebbd4d735ac6.png">



## Test plan

Visit a repo with and without embeddings.

## App preview:

- [Web](https://sg-web-sqs-codyweb-no-embeddings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
