### PR TITLE
do not require full reload of VS Code when cody settings change

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -62,8 +62,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         private codebaseContext: CodebaseContext,
         private editor: Editor,
         private secretStorage: SecretStorage,
-        private contextType: 'embeddings' | 'keyword' | 'none' | 'blended',
-        private rgPath: string,
         private mode: 'development' | 'production',
         private localStorage: LocalStorage,
         private customHeaders: Record<string, string>

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -20,7 +20,6 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 import { version as packageVersion } from '../../package.json'
 import { LocalStorage } from '../command/LocalStorageProvider'
 import { updateConfiguration } from '../configuration'
-import { VSCodeEditor } from '../editor/vscode-editor'
 import { logEvent } from '../event-logger'
 import { configureExternalServices } from '../external-services'
 import { sanitizeServerEndpoint } from '../sanitize'
@@ -48,6 +47,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     private inputHistory: string[] = []
     private chatHistory: ChatHistory = {}
 
+    private transcript: Transcript = new Transcript()
+
     // Allows recipes to hook up subscribers to process sub-streams of bot output
     private multiplexer: BotResponseMultiplexer = new BotResponseMultiplexer()
 
@@ -55,7 +56,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         private extensionPath: string,
         private codebase: string,
         private serverEndpoint: string,
-        private transcript: Transcript,
         private chat: ChatClient,
         private intentDetector: IntentDetector,
         private codebaseContext: CodebaseContext,
@@ -72,39 +72,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         }
         // chat id is used to identify chat session
         this.createNewChatID()
-    }
-
-    public static create(
-        extensionPath: string,
-        codebase: string,
-        serverEndpoint: string,
-        contextType: 'embeddings' | 'keyword' | 'none' | 'blended',
-        secretStorage: SecretStorage,
-        localStorage: LocalStorage,
-        editor: VSCodeEditor,
-        rgPath: string,
-        mode: 'development' | 'production',
-        intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext,
-        chatClient: ChatClient,
-        customHeaders: Record<string, string>
-    ): ChatViewProvider {
-        return new ChatViewProvider(
-            extensionPath,
-            codebase,
-            serverEndpoint,
-            new Transcript(),
-            chatClient,
-            intentDetector,
-            codebaseContext,
-            editor,
-            secretStorage,
-            contextType,
-            rgPath,
-            mode,
-            localStorage,
-            customHeaders
-        )
     }
 
     private async onDidReceiveMessage(message: any): Promise<void> {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -21,7 +21,6 @@ import { version as packageVersion } from '../../package.json'
 import { LocalStorage } from '../command/LocalStorageProvider'
 import { updateConfiguration } from '../configuration'
 import { logEvent } from '../event-logger'
-import { configureExternalServices } from '../external-services'
 import { sanitizeServerEndpoint } from '../sanitize'
 import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, SecretStorage } from '../secret-storage'
 import { TestSupport } from '../test-support'
@@ -36,7 +35,7 @@ async function isValidLogin(
     return !isError(userId)
 }
 
-export class ChatViewProvider implements vscode.WebviewViewProvider {
+export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
     private isMessageInProgress = false
     private cancelCompletionCallback: (() => void) | null = null
     private webview?: vscode.Webview
@@ -51,6 +50,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
     // Allows recipes to hook up subscribers to process sub-streams of bot output
     private multiplexer: BotResponseMultiplexer = new BotResponseMultiplexer()
+
+    private disposables: vscode.Disposable[] = []
 
     constructor(
         private extensionPath: string,
@@ -341,7 +342,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             .replaceAll('./', `${resources.toString()}/`)
             .replace('/nonce/', nonce)
             .replace('/tos-version/', this.tosVersion.toString())
-        webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message))
+        this.disposables.push(webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message)))
     }
 
     public transcriptForTesting(testing: TestSupport): ChatMessage[] {
@@ -352,46 +353,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         return this.transcript.toChat()
     }
 
-    // TODO(beyang): maybe move this into CommandsProvider (should maybe change that to a top-level controller class)
-    public async onConfigChange(change: string, codebase: string, serverEndpoint: string): Promise<void> {
-        switch (change) {
-            case 'token':
-            case 'endpoint': {
-                const { intentDetector, codebaseContext, chatClient } = await configureExternalServices(
-                    serverEndpoint,
-                    codebase,
-                    this.rgPath,
-                    this.editor,
-                    this.secretStorage,
-                    this.contextType,
-                    this.mode,
-                    this.customHeaders
-                )
-
-                this.codebase = codebase
-                this.serverEndpoint = serverEndpoint
-                this.intentDetector = intentDetector
-                this.codebaseContext = codebaseContext
-                this.chat = chatClient
-
-                const action = await vscode.window.showInformationMessage(
-                    'Cody configuration has been updated.',
-                    'Reload Window'
-                )
-
-                logEvent(
-                    'CodyVSCodeExtension:updateEndpoint:clicked',
-                    { serverEndpoint: this.serverEndpoint },
-                    { serverEndpoint: this.serverEndpoint }
-                )
-                if (action === 'Reload Window') {
-                    await vscode.commands.executeCommand('workbench.action.reloadWindow')
-                }
-                break
-            }
-        }
-    }
-
     private getNonce(): string {
         let text = ''
         const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
@@ -399,6 +360,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
             text += possible.charAt(Math.floor(Math.random() * possible.length))
         }
         return text
+    }
+
+    public dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose()
+        }
+        this.disposables = []
     }
 }
 

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -48,19 +48,19 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
     )
 
     // Create chat webview
-    const chatProvider = ChatViewProvider.create(
+    const chatProvider = new ChatViewProvider(
         context.extensionPath,
         sanitizeCodebase(config.codebase),
         sanitizeServerEndpoint(config.serverEndpoint),
-        config.useContext,
-        secretStorage,
-        localStorage,
-        editor,
-        rgPath,
-        mode,
+        chatClient,
         intentDetector,
         codebaseContext,
-        chatClient,
+        editor,
+        secretStorage,
+        config.useContext,
+        rgPath,
+        mode,
+        localStorage,
         config.customHeaders
     )
 

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -7,7 +7,6 @@ import { History } from '../completions/history'
 import { getConfiguration } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { logEvent, updateEventLogger } from '../event-logger'
-import { ExtensionApi } from '../extension-api'
 import { configureExternalServices } from '../external-services'
 import { getRgPath } from '../rg'
 import { sanitizeCodebase, sanitizeServerEndpoint } from '../sanitize'
@@ -15,23 +14,70 @@ import { CODY_ACCESS_TOKEN_SECRET, InMemorySecretStorage, SecretStorage, VSCodeS
 
 import { LocalStorage } from './LocalStorageProvider'
 
+/**
+ * Start the extension, watching all relevant configuration and secrets for changes.
+ */
+export async function start(context: vscode.ExtensionContext): Promise<vscode.Disposable> {
+    const secretStorage = getSecretStorage(context)
+    const localStorage = new LocalStorage(context.globalState)
+    const rgPath = await getRgPath(context.extensionPath)
+
+    const disposables: vscode.Disposable[] = []
+
+    let mainDisposable: vscode.Disposable | undefined
+    disposables.push({ dispose: () => mainDisposable?.dispose() })
+    const initializeMain = async (focusView = false): Promise<void> => {
+        mainDisposable?.dispose()
+        try {
+            const disposable = await register(context, secretStorage, localStorage, rgPath, focusView)
+            mainDisposable?.dispose()
+            mainDisposable = disposable
+        } catch (error) {
+            console.error(error)
+            mainDisposable?.dispose()
+            mainDisposable = undefined
+        }
+    }
+
+    // Initialize.
+    void initializeMain()
+
+    // Re-initialize when configuration or secrets change.
+    disposables.push(
+        secretStorage.onDidChange(async key => {
+            if (key === CODY_ACCESS_TOKEN_SECRET) {
+                await initializeMain(true)
+            }
+        }),
+        vscode.workspace.onDidChangeConfiguration(async event => {
+            if (event.affectsConfiguration('cody') || event.affectsConfiguration('sourcegraph')) {
+                await initializeMain(true)
+            }
+        })
+    )
+    return vscode.Disposable.from(...disposables)
+}
+
 function getSecretStorage(context: vscode.ExtensionContext): SecretStorage {
     return process.env.CODY_TESTING === 'true' ? new InMemorySecretStorage() : new VSCodeSecretStorage(context.secrets)
 }
 
-// Registers Commands and Webview at extension start up
-export const CommandsProvider = async (context: vscode.ExtensionContext): Promise<ExtensionApi> => {
-    // for tests
-    const extensionApi = new ExtensionApi()
+// Registers commands and webview given the config.
+const register = async (
+    context: vscode.ExtensionContext,
+    secretStorage: SecretStorage,
+    localStorage: LocalStorage,
+    rgPath: string,
+    focusView: boolean
+): Promise<vscode.Disposable> => {
+    const disposables: vscode.Disposable[] = []
 
-    const secretStorage = getSecretStorage(context)
-    const localStorage = new LocalStorage(context.globalState)
     const config = getConfiguration(vscode.workspace.getConfiguration())
 
     await updateEventLogger(config, secretStorage, localStorage)
 
     const editor = new VSCodeEditor()
-    const rgPath = await getRgPath(context.extensionPath)
+
     const mode = config.debug ? 'development' : 'production'
     const serverEndpoint = sanitizeServerEndpoint(config.serverEndpoint)
     const codebase = sanitizeCodebase(config.codebase)
@@ -63,14 +109,25 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
         localStorage,
         config.customHeaders
     )
+    disposables.push(chatProvider)
 
-    vscode.window.registerWebviewViewProvider('cody.chat', chatProvider, {
-        webviewOptions: { retainContextWhenHidden: true },
-    })
+    disposables.push(
+        vscode.window.registerWebviewViewProvider('cody.chat', chatProvider, {
+            webviewOptions: { retainContextWhenHidden: true },
+        })
+    )
+    if (focusView) {
+        // Focus the webview if the re-initialization was triggered by a config or secret change.
+        setTimeout(() => vscode.commands.executeCommand('cody.chat.focus'), 100)
+    }
 
     await vscode.commands.executeCommand('setContext', 'cody.activated', true)
+    disposables.push({ dispose: () => vscode.commands.executeCommand('setContext', 'cody.activated', false) })
 
-    const disposables: vscode.Disposable[] = []
+    const executeRecipe = async (recipe: string): Promise<void> => {
+        await vscode.commands.executeCommand('cody.chat.focus')
+        await chatProvider.executeRecipe(recipe)
+    }
 
     disposables.push(
         // Toggle Chat
@@ -120,79 +177,35 @@ export const CommandsProvider = async (context: vscode.ExtensionContext): Promis
             localStorage.get('cody.tos-version-accepted')
         ),
         // Commands
-        vscode.commands.registerCommand('cody.recipe.explain-code', async () => executeRecipe('explain-code-detailed')),
-        vscode.commands.registerCommand('cody.recipe.explain-code-high-level', async () =>
+        vscode.commands.registerCommand('cody.recipe.explain-code', () => executeRecipe('explain-code-detailed')),
+        vscode.commands.registerCommand('cody.recipe.explain-code-high-level', () =>
             executeRecipe('explain-code-high-level')
         ),
-        vscode.commands.registerCommand('cody.recipe.generate-unit-test', async () =>
-            executeRecipe('generate-unit-test')
-        ),
-        vscode.commands.registerCommand('cody.recipe.generate-docstring', async () =>
-            executeRecipe('generate-docstring')
-        ),
-        vscode.commands.registerCommand('cody.recipe.replace', async () => executeRecipe('replace')),
-        vscode.commands.registerCommand('cody.recipe.translate-to-language', async () =>
+        vscode.commands.registerCommand('cody.recipe.generate-unit-test', () => executeRecipe('generate-unit-test')),
+        vscode.commands.registerCommand('cody.recipe.generate-docstring', () => executeRecipe('generate-docstring')),
+        vscode.commands.registerCommand('cody.recipe.replace', () => executeRecipe('replace')),
+        vscode.commands.registerCommand('cody.recipe.translate-to-language', () =>
             executeRecipe('translate-to-language')
         ),
-        vscode.commands.registerCommand('cody.recipe.git-history', async () => executeRecipe('git-history')),
-        vscode.commands.registerCommand('cody.recipe.improve-variable-names', async () =>
+        vscode.commands.registerCommand('cody.recipe.git-history', () => executeRecipe('git-history')),
+        vscode.commands.registerCommand('cody.recipe.improve-variable-names', () =>
             executeRecipe('improve-variable-names')
         )
     )
 
     if (config.experimentalSuggest) {
         const docprovider = new CompletionsDocumentProvider()
-        vscode.workspace.registerTextDocumentContentProvider('cody', docprovider)
+        disposables.push(vscode.workspace.registerTextDocumentContentProvider('cody', docprovider))
 
         const history = new History()
         const completionsProvider = new CodyCompletionItemProvider(completionsClient, docprovider, history)
-        context.subscriptions.push(
+        disposables.push(
             vscode.commands.registerCommand('cody.experimental.suggest', async () => {
                 await completionsProvider.fetchAndShowCompletions()
-            })
-        )
-        context.subscriptions.push(
+            }),
             vscode.languages.registerInlineCompletionItemProvider({ scheme: 'file' }, completionsProvider)
         )
     }
 
-    // Watch all relevant configuration and secrets for changes.
-    context.subscriptions.push(
-        vscode.workspace.onDidChangeConfiguration(async event => {
-            if (event.affectsConfiguration('cody') || event.affectsConfiguration('sourcegraph')) {
-                const config = getConfiguration(vscode.workspace.getConfiguration())
-                await updateEventLogger(config, secretStorage, localStorage)
-                await chatProvider.onConfigChange(
-                    'endpoint',
-                    sanitizeCodebase(config.codebase),
-                    sanitizeServerEndpoint(config.serverEndpoint)
-                )
-            }
-        })
-    )
-
-    context.subscriptions.push(
-        secretStorage.onDidChange(async key => {
-            if (key === CODY_ACCESS_TOKEN_SECRET) {
-                const config = getConfiguration(vscode.workspace.getConfiguration())
-                await updateEventLogger(config, secretStorage, localStorage)
-                await chatProvider
-                    .onConfigChange(
-                        'token',
-                        sanitizeCodebase(config.codebase),
-                        sanitizeServerEndpoint(config.serverEndpoint)
-                    )
-                    .catch(error => console.error(error))
-            }
-        })
-    )
-
-    const executeRecipe = async (recipe: string): Promise<void> => {
-        await vscode.commands.executeCommand('cody.chat.focus')
-        await chatProvider.executeRecipe(recipe)
-    }
-
-    vscode.Disposable.from(...disposables)
-
-    return extensionApi
+    return vscode.Disposable.from(...disposables)
 }

--- a/client/cody/src/command/CommandsProvider.ts
+++ b/client/cody/src/command/CommandsProvider.ts
@@ -103,8 +103,6 @@ const register = async (
         codebaseContext,
         editor,
         secretStorage,
-        config.useContext,
-        rgPath,
         mode,
         localStorage,
         config.customHeaders

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -16,10 +16,8 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
 }
 
 const codyConfiguration = vscode.workspace.getConfiguration('cody')
-const globalConfigTarget = vscode.ConfigurationTarget.Global
 
 // Update user configurations in VS Code for Cody
 export async function updateConfiguration(configKey: string, configValue: string): Promise<void> {
-    // Removing globalConfigTarget will only update configs for the workspace setting only
-    await codyConfiguration.update(configKey, configValue, globalConfigTarget)
+    await codyConfiguration.update(configKey, configValue, vscode.ConfigurationTarget.Global)
 }

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -2,14 +2,18 @@ import * as vscode from 'vscode'
 
 import { PromptMixin, languagePromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 
-import { CommandsProvider } from './command/CommandsProvider'
+import { start } from './command/CommandsProvider'
 import { ExtensionApi } from './extension-api'
 
-export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
+export function activate(context: vscode.ExtensionContext): ExtensionApi {
     console.log('Cody extension activated')
 
     PromptMixin.add(languagePromptMixin(vscode.env.language))
 
     // Register commands and webview
-    return CommandsProvider(context)
+    start(context)
+        .then(disposable => context.subscriptions.push(disposable))
+        .catch(error => console.error(error))
+
+    return new ExtensionApi()
 }


### PR DESCRIPTION
Now, when you change Cody's settings in VS Code, it automatically reloads Cody and does not require a full VS Code reload. This makes signing in smoother.

Plus some other minor refactors.

## Test plan

n/a; cody vscode only


