### PR TITLE
remove needless cody message timestamp

### DIFF
--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -65,7 +65,6 @@ ts_project(
         "src/sourcegraph-api/graphql/queries.ts",
         "src/sourcegraph-api/index.ts",
         "src/telemetry/EventLogger.ts",
-        "src/timestamp.ts",
         "src/utils.ts",
     ],
     tsconfig = ":tsconfig",

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -5,7 +5,6 @@ import { IntentDetector } from '../../intent-detector'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
 import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext } from './recipe'
@@ -16,13 +15,12 @@ export class ChatQuestion implements Recipe {
     }
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const timestamp = getShortTimestamp()
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput, timestamp },
-                { speaker: 'assistant', text: '', displayText: '', timestamp },
+                { speaker: 'human', text: truncatedText, displayText: humanChatInput },
+                { speaker: 'assistant', text: '', displayText: '' },
                 this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext)
             )
         )

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -17,7 +16,6 @@ export class ExplainCodeDetailed implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
@@ -27,8 +25,8 @@ export class ExplainCodeDetailed implements Recipe {
         const displayText = `Explain the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
-            { speaker: 'assistant', text: '', displayText: '', timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'assistant', text: '', displayText: '' },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -17,7 +16,6 @@ export class ExplainCodeHighLevel implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
@@ -27,8 +25,8 @@ export class ExplainCodeHighLevel implements Recipe {
         const displayText = `Explain the following code at a high level:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
-            { speaker: 'assistant', text: '', displayText: '', timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'assistant', text: '', displayText: '' },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -1,6 +1,5 @@
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { getNormalizedLanguageName } from './helpers'
@@ -17,8 +16,6 @@ export class FindCodeSmells implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
-
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptPrefix = `Find code smells, potential bugs, and unhandled errors in my ${languageName} code:`
         const promptSuffix = `List maximum five of them as a list (if you have more in mind, mention that these are the top five), with a short context, reasoning, and suggestion on each.
@@ -34,13 +31,12 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
 
         const assistantResponsePrefix = ''
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             new Promise(resolve => resolve([]))
         )

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -22,7 +21,6 @@ export class GenerateDocstring implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
@@ -51,13 +49,12 @@ export class GenerateDocstring implements Recipe {
 
         const assistantResponsePrefix = `Here is the generated documentation:\n\`\`\`${extension}\n${docStart}`
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -22,7 +21,6 @@ export class GenerateTest implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
@@ -35,13 +33,12 @@ export class GenerateTest implements Recipe {
         const displayText = `Generate a unit test for the following code:\n\`\`\`${extension}\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -2,7 +2,6 @@ import { spawnSync } from 'child_process'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext } from './recipe'
@@ -65,17 +64,15 @@ export class GitHistory implements Recipe {
             console.warn('Truncated extra long git log output, so summary may be incomplete.')
         }
 
-        const timestamp = getShortTimestamp()
         const promptMessage = `Summarize these commits:\n${truncatedGitLogOutput}\n\nProvide your response in the form of a bulleted list. Do not mention the commit hashes.`
         const assistantResponsePrefix = 'Here is a summary of recent changes:\n- '
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             Promise.resolve([])
         )

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -22,7 +21,6 @@ export class ImproveVariableNames implements Recipe {
             return Promise.resolve(null)
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
@@ -35,13 +33,12 @@ export class ImproveVariableNames implements Recipe {
         const assistantResponsePrefix = `Here is the improved code:\n\`\`\`${extension}\n`
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/replace.ts
+++ b/client/cody-shared/src/chat/recipes/replace.ts
@@ -2,7 +2,6 @@ import { CodebaseContext } from '../../codebase-context'
 import { ContextMessage } from '../../codebase-context/messages'
 import { MAX_CURRENT_FILE_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { BufferedBotResponseSubscriber } from '../bot-response-multiplexer'
 import { Interaction } from '../transcript/interaction'
 
@@ -59,17 +58,14 @@ It is OK to provide some commentary before you tell me the replacement <selectio
         )}\n\`\`\`\n\n${context.responseMultiplexer.prompt()}`
         // TODO: Move the prompt suffix from the recipe to the chat view. It may have other subscribers.
 
-        const timestamp = getShortTimestamp()
-
         return Promise.resolve(
             new Interaction(
                 {
                     speaker: 'human',
                     text: prompt,
                     displayText: 'Replace the instructions in the selection.',
-                    timestamp,
                 },
-                { speaker: 'assistant', text: '', displayText: '', timestamp },
+                { speaker: 'assistant', text: '', displayText: '' },
                 this.getContextMessages(selection.selectedText, context.codebaseContext)
             )
         )

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -1,6 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
-import { getShortTimestamp } from '../../timestamp'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
@@ -24,7 +23,6 @@ export class TranslateToLanguage implements Recipe {
             return null
         }
 
-        const timestamp = getShortTimestamp()
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
 
         const promptMessage = `Translate the following code into ${toLanguage}\n\`\`\`\n${truncatedSelectedText}\n\`\`\``
@@ -34,13 +32,12 @@ export class TranslateToLanguage implements Recipe {
         const assistantResponsePrefix = `Here is the code translated to ${toLanguage}:\n\`\`\`${markdownID}\n`
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, timestamp },
+            { speaker: 'human', text: promptMessage, displayText },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
                 displayText: '',
-                timestamp,
             },
             Promise.resolve([])
         )

--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -1,6 +1,5 @@
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
 import { Message } from '../../sourcegraph-api'
-import { getShortTimestamp } from '../../timestamp'
 
 import { Interaction } from './interaction'
 import { ChatMessage } from './messages'
@@ -24,7 +23,6 @@ export class Transcript {
             speaker: 'assistant',
             text,
             displayText: displayText ?? text,
-            timestamp: getShortTimestamp(),
         })
     }
 

--- a/client/cody-shared/src/chat/transcript/messages.ts
+++ b/client/cody-shared/src/chat/transcript/messages.ts
@@ -2,13 +2,11 @@ import { Message } from '../../sourcegraph-api'
 
 export interface ChatMessage extends Message {
     displayText: string
-    timestamp: string
     contextFiles?: string[]
 }
 
 export interface InteractionMessage extends Message {
     displayText: string
-    timestamp: string
     prefix?: string
 }
 

--- a/client/cody-shared/src/timestamp.ts
+++ b/client/cody-shared/src/timestamp.ts
@@ -1,8 +1,0 @@
-function padTimePart(timePart: number): string {
-    return timePart < 10 ? `0${timePart}` : timePart.toString()
-}
-
-export function getShortTimestamp(): string {
-    const date = new Date()
-    return `${padTimePart(date.getHours())}:${padTimePart(date.getMinutes())}`
-}

--- a/client/cody-slack/src/slack/message-interaction.ts
+++ b/client/cody-slack/src/slack/message-interaction.ts
@@ -6,7 +6,6 @@ import { ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/me
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { MAX_HUMAN_INPUT_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
-import { getShortTimestamp } from '@sourcegraph/cody-shared/src/timestamp'
 
 export async function interactionFromMessage(
     message: Message,
@@ -17,7 +16,6 @@ export async function interactionFromMessage(
         return Promise.resolve(null)
     }
 
-    const timestamp = getShortTimestamp()
     const textWithoutMentions = message.text?.replace(/<@[\dA-Z]+>/gm, '').trim()
     const text = truncateText(textWithoutMentions, MAX_HUMAN_INPUT_TOKENS)
 
@@ -26,8 +24,8 @@ export async function interactionFromMessage(
 
     return Promise.resolve(
         new Interaction(
-            { speaker: 'human', text, displayText: text, timestamp },
-            { speaker: 'assistant', text: '', displayText: '', timestamp },
+            { speaker: 'human', text, displayText: text },
+            { speaker: 'assistant', text: '', displayText: '' },
             contextMessages
         )
     )

--- a/client/cody-ui/src/chat/ChatMessageRow.tsx
+++ b/client/cody-ui/src/chat/ChatMessageRow.tsx
@@ -90,7 +90,7 @@ export const ChatMessageRow: React.FunctionComponent<
                     ) : (
                         <div className={styles.bubbleFooterTimestamp}>{`${
                             message.speaker === 'assistant' ? 'Cody' : 'Me'
-                        } · ${message.timestamp}`}</div>
+                        }`}</div>
                     )}
                 </div>
             </div>

--- a/client/cody-ui/src/chat/ChatMessages.story.tsx
+++ b/client/cody-ui/src/chat/ChatMessages.story.tsx
@@ -25,8 +25,8 @@ const config: Meta = {
 export default config
 
 const FIXTURE_TRANSCRIPT: ChatMessage[] = [
-    { speaker: 'human', text: 'Hello, world!', displayText: 'Hello, world!', timestamp: '2 min ago' },
-    { speaker: 'assistant', text: 'Thank you', displayText: 'Thank you', timestamp: 'now' },
+    { speaker: 'human', text: 'Hello, world!', displayText: 'Hello, world!' },
+    { speaker: 'assistant', text: 'Thank you', displayText: 'Thank you' },
 ]
 
 export const Simple: Story = () => (


### PR DESCRIPTION
The timestamp serves no useful purpose and adds UI noise.


## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-rm-needless-timestamp.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
