### PR TITLE
focus cody chat on startup when launching debug task from vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
       "sourceMaps": true,
       "outFiles": ["${workspaceRoot}/client/cody/dist/*.js"],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "CODY_FOCUS_ON_STARTUP": "1"
       }
     },
     {

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -10,6 +10,12 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
 
     PromptMixin.add(languagePromptMixin(vscode.env.language))
 
+    if (process.env.CODY_FOCUS_ON_STARTUP) {
+        setTimeout(() => {
+            void vscode.commands.executeCommand('cody.chat.focus')
+        }, 250)
+    }
+
     // Register commands and webview
     return CommandsProvider(context)
 }


### PR DESCRIPTION
Just applies in dev mode.

This means you can hit F5 and then wait a few seconds and the Cody panel will be focused in the extension host VS Code instance.


## Test plan

n/a; dev only

## App preview:

- [Web](https://sg-web-sqs-focus-cody-chat-startup-dev.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
