### PR TITLE
make most recipes work on the entire file if no selection

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -68,6 +68,9 @@ export async function createClient({
         getActiveTextEditorSelection() {
             return null
         },
+        getActiveTextEditorSelectionOrEntireFile() {
+            return null
+        },
         getActiveTextEditorVisibleContent() {
             return null
         },

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -11,7 +11,7 @@ export class ExplainCodeDetailed implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -11,7 +11,7 @@ export class ExplainCodeHighLevel implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -11,7 +11,7 @@ export class FindCodeSmells implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -16,7 +16,7 @@ export class GenerateDocstring implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -16,7 +16,7 @@ export class GenerateTest implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -16,7 +16,7 @@ export class ImproveVariableNames implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return Promise.resolve(null)
         }

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -11,7 +11,7 @@ export class TranslateToLanguage implements Recipe {
     }
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             return null
         }

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -19,6 +19,12 @@ export interface Editor {
     getWorkspaceRootPath(): string | null
     getActiveTextEditor(): ActiveTextEditor | null
     getActiveTextEditorSelection(): ActiveTextEditorSelection | null
+
+    /**
+     * Gets the active text editor's selection, or the entire file if the selected range is empty.
+     */
+    getActiveTextEditorSelectionOrEntireFile(): ActiveTextEditorSelection | null
+
     getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null
     replaceSelection(fileName: string, selectedText: string, replacement: string): Promise<void>
     showQuickPick(labels: string[]): Promise<string | undefined>

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -53,6 +53,10 @@ export class MockEditor implements Editor {
         return this.mocks.getActiveTextEditorSelection?.() ?? null
     }
 
+    public getActiveTextEditorSelectionOrEntireFile(): ActiveTextEditorSelection | null {
+        return this.mocks.getActiveTextEditorSelection?.() ?? null
+    }
+
     public getActiveTextEditor(): ActiveTextEditor | null {
         return this.mocks.getActiveTextEditor?.() ?? null
     }


### PR DESCRIPTION
For most recipes, if you're in a small file (such as a file with a single React component), you want to just be able to run it on the whole file.


## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-recipes-entire-file.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
