### PR TITLE
remove unused tracking of accepted TOS version

### DIFF
--- a/client/cody/index.html
+++ b/client/cody/index.html
@@ -9,6 +9,6 @@
 	</head>
 	<body>
 		<div id="root"></div>
-		<script nonce="/nonce/" data-panel-id="/tos-version/" type="module" src="webviews/index.tsx"></script>
+		<script nonce="/nonce/" type="module" src="webviews/index.tsx"></script>
 	</body>
 </html>


### PR DESCRIPTION
This was not used.

## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-cody-rm-old-tos-tracking.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
