### PR TITLE
faster cody builds, cleaner output

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "pnpm esbuild --minify && vite build --mode production",
-    "build:dev": "pnpm esbuild --sourcemap && vite build --mode development",
+    "build:dev": "concurrently \"pnpm esbuild --sourcemap\" \"vite build --mode development\"",
     "download-rg": "scripts/download-rg.sh",
     "esbuild": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
     "lint": "pnpm run lint:js",

--- a/client/cody/vite.config.ts
+++ b/client/cody/vite.config.ts
@@ -14,9 +14,14 @@ export default defineConfig({
             localsConvention: 'camelCaseOnly',
         },
     },
+    logLevel: 'warn',
     build: {
         emptyOutDir: false,
         outDir: 'dist',
+        target: 'esnext',
+        minify: false,
+        sourcemap: 'inline',
+        reportCompressedSize: false,
         rollupOptions: {
             external: [/^vscode/],
             watch: {


### PR DESCRIPTION
Saves about 1s on builds, supports sourcemaps in the VS Code extension host.

## Test plan

n/a; build only

## App preview:

- [Web](https://sg-web-sqs-cody-faster-vscode-builds.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
