### PR TITLE
allow empty text and displayText

### DIFF
--- a/client/cody-shared/src/chat/chat.ts
+++ b/client/cody-shared/src/chat/chat.ts
@@ -15,9 +15,7 @@ export class ChatClient {
 
     public chat(messages: Message[], cb: CompletionCallbacks): () => void {
         const isLastMessageFromHuman = messages.length > 0 && messages[messages.length - 1].speaker === 'human'
-        const augmentedMessages = isLastMessageFromHuman
-            ? messages.concat([{ speaker: 'assistant', text: '' }])
-            : messages
+        const augmentedMessages = isLastMessageFromHuman ? messages.concat([{ speaker: 'assistant' }]) : messages
 
         return this.completions.stream({ messages: augmentedMessages, ...DEFAULT_CHAT_COMPLETION_PARAMETERS }, cb)
     }

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -20,7 +20,7 @@ export class ChatQuestion implements Recipe {
         return Promise.resolve(
             new Interaction(
                 { speaker: 'human', text: truncatedText, displayText: humanChatInput },
-                { speaker: 'assistant', text: '', displayText: '' },
+                { speaker: 'assistant' },
                 this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext)
             )
         )

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -26,7 +26,7 @@ export class ExplainCodeDetailed implements Recipe {
 
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText },
-            { speaker: 'assistant', text: '', displayText: '' },
+            { speaker: 'assistant' },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -26,7 +26,7 @@ export class ExplainCodeHighLevel implements Recipe {
 
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText },
-            { speaker: 'assistant', text: '', displayText: '' },
+            { speaker: 'assistant' },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -36,7 +36,6 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             new Promise(resolve => resolve([]))
         )

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -54,7 +54,6 @@ export class GenerateDocstring implements Recipe {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -38,7 +38,6 @@ export class GenerateTest implements Recipe {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -72,7 +72,6 @@ export class GitHistory implements Recipe {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             Promise.resolve([])
         )

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -38,7 +38,6 @@ export class ImproveVariableNames implements Recipe {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/client/cody-shared/src/chat/recipes/replace.ts
+++ b/client/cody-shared/src/chat/recipes/replace.ts
@@ -65,7 +65,7 @@ It is OK to provide some commentary before you tell me the replacement <selectio
                     text: prompt,
                     displayText: 'Replace the instructions in the selection.',
                 },
-                { speaker: 'assistant', text: '', displayText: '' },
+                { speaker: 'assistant' },
                 this.getContextMessages(selection.selectedText, context.codebaseContext)
             )
         )

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -37,7 +37,6 @@ export class TranslateToLanguage implements Recipe {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
-                displayText: '',
             },
             Promise.resolve([])
         )

--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -83,5 +83,5 @@ function truncatePrompt(messages: Message[], maxTokens: number): Message[] {
 }
 
 function estimateTokensUsage(message: Message): number {
-    return Math.round(message.text.length / CHARS_PER_TOKEN)
+    return Math.round((message.text || '').length / CHARS_PER_TOKEN)
 }

--- a/client/cody-shared/src/chat/transcript/messages.ts
+++ b/client/cody-shared/src/chat/transcript/messages.ts
@@ -1,12 +1,12 @@
 import { Message } from '../../sourcegraph-api'
 
 export interface ChatMessage extends Message {
-    displayText: string
+    displayText?: string
     contextFiles?: string[]
 }
 
 export interface InteractionMessage extends Message {
-    displayText: string
+    displayText?: string
     prefix?: string
 }
 

--- a/client/cody-shared/src/sourcegraph-api/completions/types.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/types.ts
@@ -16,7 +16,7 @@ export type Event = DoneEvent | CompletionEvent | ErrorEvent
 
 export interface Message {
     speaker: 'human' | 'assistant'
-    text: string
+    text?: string
 }
 
 export interface CodeCompletionResponse {

--- a/client/cody-slack/src/services/openai-completions-client.ts
+++ b/client/cody-slack/src/services/openai-completions-client.ts
@@ -7,6 +7,7 @@ import {
     CodeCompletionResponse,
     CompletionCallbacks,
     CompletionParameters,
+    Message,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
 export class OpenAICompletionsClient extends SourcegraphCompletionsClient {
@@ -31,12 +32,17 @@ export class OpenAICompletionsClient extends SourcegraphCompletionsClient {
             .createChatCompletion(
                 {
                     model: 'gpt-3.5-turbo',
-                    messages: params.messages.map(message => {
-                        return {
-                            role: message.speaker === 'human' ? 'user' : 'assistant',
-                            content: message.text,
-                        }
-                    }),
+                    messages: params.messages
+                        .filter(
+                            (message): message is Omit<Message, 'text'> & Required<Pick<Message, 'text'>> =>
+                                message.text !== undefined
+                        )
+                        .map(message => {
+                            return {
+                                role: message.speaker === 'human' ? 'user' : 'assistant',
+                                content: message.text,
+                            }
+                        }),
                     stream: true,
                 },
                 { responseType: 'stream' }

--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -128,7 +128,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     )
 
     const transcriptWithWelcome = useMemo<ChatMessage[]>(
-        () => [{ speaker: 'assistant', text: '', displayText: welcomeText(afterTips) }, ...transcript],
+        () => [{ speaker: 'assistant', displayText: welcomeText(afterTips) }, ...transcript],
         [afterTips, transcript]
     )
 

--- a/client/cody-ui/src/chat/Transcript.story.tsx
+++ b/client/cody-ui/src/chat/Transcript.story.tsx
@@ -40,7 +40,7 @@ export default meta
 export const Simple: ComponentStoryObj<typeof Transcript> = {
     render: args => (
         <Transcript
-            messageInProgress={{ speaker: 'assistant', text: '', displayText: '' }}
+            messageInProgress={{ speaker: 'assistant' }}
             transcript={args.transcript}
             fileLinkComponent={FileLink}
             transcriptItemClassName={styles.transcriptItem}

--- a/client/cody-ui/src/chat/fixtures.ts
+++ b/client/cody-ui/src/chat/fixtures.ts
@@ -2,18 +2,16 @@ import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messag
 
 export const FIXTURE_TRANSCRIPT: Record<string, ChatMessage[]> = {
     simple: [
-        { speaker: 'human', text: 'Hello, world!', displayText: 'Hello, world!' },
-        { speaker: 'assistant', text: 'Thank you', displayText: 'Thank you' },
+        { speaker: 'human', displayText: 'Hello, world!' },
+        { speaker: 'assistant', displayText: 'Thank you' },
     ],
     codeQuestion: [
         {
             speaker: 'human',
-            text: '',
             displayText: 'What does `document.getSelection()?.isCollapsed` mean?',
         },
         {
             speaker: 'assistant',
-            text: '',
             displayText:
                 '`document.getSelection()?.isCollapsed` means that the current selection in the document is collapsed, meaning it is a caret (no text is selected).\n\nThe `?.` operator is optional chaining - it will return `undefined` if `document.getSelection()` returns `null` or `undefined`.\n\nSo in short, that line is checking if there is currently a text selection in the document, and if not, focusing the textarea.\n\n',
         },
@@ -21,24 +19,20 @@ export const FIXTURE_TRANSCRIPT: Record<string, ChatMessage[]> = {
     explainCode: [
         {
             speaker: 'human',
-            text: '',
             displayText:
                 "Explain the following code at a high level:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
         },
         {
             speaker: 'assistant',
-            text: '',
             displayText: 'This code generates a random 32-character string (nonce) using characters A-Z, a-z, and 0-9.',
             contextFiles: ['client/cody/src/chat/ChatViewProvider.ts', 'client/cody-shared/src/timestamp.ts'],
         },
         {
             speaker: 'human',
-            text: '',
             displayText: 'Rewrite it to only use hexadecimal encoding.',
         },
         {
             speaker: 'assistant',
-            text: '',
             displayText:
                 "Here is the rewritten code using only hexadecimal encoding:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = '0123456789ABCDEF'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
         },

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -160,8 +160,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 const lastInteraction = this.transcript.getLastInteraction()
                 if (lastInteraction) {
                     const { text, displayText } = lastInteraction.getAssistantMessage()
-                    const { text: highlightedDisplayText } = await highlightTokens(displayText, fileExists)
-                    this.transcript.addAssistantResponse(text, highlightedDisplayText)
+                    const { text: highlightedDisplayText } = await highlightTokens(displayText || '', fileExists)
+                    this.transcript.addAssistantResponse(text || '', highlightedDisplayText)
                 }
                 this.isMessageInProgress = false
                 this.cancelCompletionCallback = null

--- a/client/cody/src/integration-test/extension.test.ts
+++ b/client/cody/src/integration-test/extension.test.ts
@@ -80,18 +80,18 @@ suite('End-to-end', () => {
 
         // Check the chat transcript contains markdown
         const message = await getTranscript(api, 0)
-        assert.match(message.displayText, /^Explain the following code/)
-        assert.match(message.displayText, /public/)
+        assert.match(message.displayText || '', /^Explain the following code/)
+        assert.match(message.displayText || '', /public/)
 
         // Check the server response was handled
         // "hello world" is a canned response from the server
         // in runTest.js responds to all messages with
         await waitUntil(async () => {
             const assistantMessage = await getTranscript(api, 1)
-            return assistantMessage.displayText.length > 0
+            return (assistantMessage.displayText || '').length > 0
         })
         const assistantMessage = await getTranscript(api, 1)
-        assert.match(assistantMessage.displayText, /hello, world/)
+        assert.match(assistantMessage.displayText || '', /hello, world/)
 
         // Clean up.
         await ensureExecuteCommand('cody.delete-access-token')


### PR DESCRIPTION
Just a refactor. These are `''` (empty string) in many places when they are intended to not be shown. This type change makes that clearer. It also makes sense for future bot responses and human requests where there is only an "action" and no free-form text desired.


## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-cody-emptytext-displaytext.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
