### PR TITLE
do not auto-retry Cody VS Code ext integration tests now that they're less flaky

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -324,7 +324,6 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
-		bk.AutomaticRetry(1),
 	)
 }
 


### PR DESCRIPTION
This saves ~2m on each failed test.




## Test plan

n/a; test change only