### PR TITLE
docs: add documentation for login form configuration

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -19,7 +19,7 @@ The authentication providers are configured in the [`auth.providers`](../config/
 
 ## Login form configuration
 
-For ways to configure the login form we present to the users, please see the [login form configuration page](./login_form.md).
+To configure the presentation of the login form, see the [login form configuration page](./login_form.md).
 ## Recommendations
 
 If you are unsure which auth provider is right for you, we recommend applying the following rules in

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -15,8 +15,11 @@ Sourcegraph supports the following ways for users to sign in:
 - [Username normalization](#username-normalization)
 - [Troubleshooting](#troubleshooting)
 
-The authentication provider is configured in the [`auth.providers`](../config/site_config.md#authentication-providers) site configuration option.
+The authentication providers are configured in the [`auth.providers`](../config/site_config.md#authentication-providers) site configuration option.
 
+## Login form configuration
+
+For ways to configure the login form we present to the users, please see the [login form configuration page](./login_form.md).
 ## Recommendations
 
 If you are unsure which auth provider is right for you, we recommend applying the following rules in

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -15,10 +15,10 @@ These options do not apply to [`builtin`](./index.md#builtin-password-authentica
 
 ### Change order of auth providers
 
-If there are multiple auth providers configured, by default the login form displays a login button for each of them. 
-This is displayed in a specific order that is hardcoded in the application. 
+When multiple auth providers are configured, the login form displays a login button for each of them. Default order 
+of auth providers is hardcoded in the application.
 
-To change the order, each auth provider now has an optional `order` parameter. It is an integer and items 
+The default order can be overriden with an optional `order` parameter. It is an integer and items 
 will be sorted in natural order (1, 2, 3, ...). 
 
 Example [site configuration](../config/site_config.md):

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -8,10 +8,10 @@ The login form allows users to sign in to Sourcegraph using [configured auth pro
 
 <span class="badge badge-note">Sourcegraph 5.1+</span>
 
-All of the below options do not apply to [`builtin`](./index.md#builtin-password-authentication) and 
-[`http-header`](./index.md#http-authentication-proxies) auth providers. Builtin auth provider has a specific 
-login form by itself. Sourcegraph does not show the http header auth provider option on the login 
-form since it is being implicitly applied on every request if configured.
+These options do not apply to [`builtin`](./index.md#builtin-password-authentication) and 
+[`http-header`](./index.md#http-authentication-proxies) auth providers.
+- The builtin auth provider has its own login form.
+- The HTTP header auth provider does not appear on the login form as it is applied on every request if configured.
 
 ### Change order of auth providers
 

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -1,8 +1,6 @@
 # Login form
 
-The login form displays [configured auth providers](./index.md). 
-Depending on configured auth providers, it will look different. We added a few parameters to tweak how 
-the login form behaves.
+The login form allows users to sign in to Sourcegraph using [configured auth providers](./index.md). 
 
 <img alt="login form screenshot" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form.png" class="screenshot">
 

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -43,7 +43,7 @@ Example [site configuration](../config/site_config.md):
 }
 ```
 
-In this case, the gitlab auth provider will be shown above the github auth provider on the login page.
+In this case, the GitLab auth provider will be shown above the GitHub auth provider on the login page.
 
 <img alt="login form auth providers order screenshot" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form_order.png" class="screenshot">
 

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -1,0 +1,129 @@
+# Login form
+
+The login form displays [configured auth providers](./index.md). 
+Depending on configured auth providers, it will look different. We added a few parameters to tweak how 
+the login form behaves.
+
+<img alt="login form screenshot" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form.png" class="screenshot">
+
+## Configuration
+
+<span class="badge badge-note">Sourcegraph 5.1+</span>
+
+All of the below options do not apply to [`builtin`](./index.md#builtin-password-authentication) and 
+[`http-header`](./index.md#http-authentication-proxies) auth providers. Builtin auth provider has a specific 
+login form by itself. Sourcegraph does not show the http header auth provider option on the login 
+form since it is being implicitly applied on every request if configured.
+
+### Change order of auth providers
+
+If there are multiple auth providers configured, by default the login form displays a login button for each of them. 
+This is displayed in a specific order that is hardcoded in the application. 
+
+To change the order, each auth provider now has an optional `order` parameter. It is an integer and items 
+will be sorted in natural order (1, 2, 3, ...). 
+
+Example [site configuration](../config/site_config.md):
+```json
+{
+  "auth.providers": {
+    "builtin": {
+      {
+        "type": "builtin",
+        "allowSignup": false
+      },
+    },
+    {
+      "type": "github",
+      "order": 2
+    },
+    {
+      "type": "gitlab",
+      "order": 1
+    }
+  }
+}
+```
+
+In this case, the gitlab auth provider will be shown above the github auth provider on the login page.
+
+<img alt="login form auth providers order screenshot" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form_order.png" class="screenshot">
+
+`order` is an optional parameter. Auth providers without `order` parameter will be put at the end of the 
+auth providers list using the specific hardcoded order mentioned above. 
+
+### Limit count of login options
+
+By default, the login form shows up to 5 primary auth provider buttons on the page. Other auth providers can be reached 
+with `Other login methods` button.
+
+This default can be changed, e.g. in case there are 1 or 2 preferred methods for users to login with. 
+For example there might be a different auth provider setup for regular engineers and a different one for site admins. 
+It makes sense to only show the default one to engineers to reduce confusion of regular users. 
+
+There is a [site configuration](../config/site_config.md) parameter `auth.primaryLoginProvidersCount`:
+```json
+{
+  "auth.primaryLoginProvidersCount": 1,
+  // ...
+}
+```
+
+In the example above, there will be only 1 primary provider, all the other providers will be shown on the next screen, 
+when the `Other login methods` button is clicked.
+
+<img alt="login form limit auth providers" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form_limit.png" class="screenshot">
+
+### Change label of auth provider button
+
+By default Sourcegraph shows a button for each auth provider, such as `Continue with GitHub`. The text label for the button 
+is created from 2 parts: `Continue with` prefix and `Github`. These can be controlled with `displayPrefix` and `displayName` 
+optional parameters of auth provider in [site configuration](../config/site_config.md):
+
+Example [site configuration](../config/site_config.md):
+```json
+{
+  "auth.providers": [
+    {
+      "type": "github",
+      "displayName": "GitHub Enterprise",
+      "displayPrefix": "Login with"
+    },
+    {
+      "type": "gitlab",
+      "displayName": "GitLab",
+      "displayPrefix": "Login with"
+    }
+  ]
+}
+```
+
+The example configuration above will render 2 buttons, `Login with GitHub Enterprise` and `Login with GitLab`.
+
+<img alt="login form button label" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form_label.png" class="screenshot">
+
+By default, the `displayPrefix` will be `Continue with` and `displayName` will be infered from the auth provider type.
+
+### Hide auth provider
+
+> NOTE: Hiding an auth provider is mostly useful for development purposes and special cases.
+
+It is possible to also hide the auth provider from the login form completely. Auth provider has `hidden` boolean property, 
+which can be configured as in example [site configuration](../config/site_config.md) below:
+```json
+{
+  "auth.providers": [
+    {
+      "type": "github",
+      "hidden": true,
+      // ...
+    },
+    {
+      "type": "gitlab",
+      // ...
+    }
+  ]
+}
+```
+
+In this example, the github auth provider will not be shown on the login form at all. Only Gitlab auth provider will be shown. 

--- a/doc/admin/auth/login_form.md
+++ b/doc/admin/auth/login_form.md
@@ -47,13 +47,12 @@ In this case, the GitLab auth provider will be shown above the GitHub auth provi
 
 <img alt="login form auth providers order screenshot" src="https://sourcegraphstatic.com/docs/images/administration/auth/login_form_order.png" class="screenshot">
 
-`order` is an optional parameter. Auth providers without `order` parameter will be put at the end of the 
-auth providers list using the specific hardcoded order mentioned above. 
+Auth providers without `order` parameter will be put at the end of the auth providers list.
 
 ### Limit count of login options
 
 By default, the login form shows up to 5 primary auth provider buttons on the page. Other auth providers can be reached 
-with `Other login methods` button.
+with the `Other login methods` button.
 
 This default can be changed, e.g. in case there are 1 or 2 preferred methods for users to login with. 
 For example there might be a different auth provider setup for regular engineers and a different one for site admins. 
@@ -106,8 +105,8 @@ By default, the `displayPrefix` will be `Continue with` and `displayName` will b
 
 > NOTE: Hiding an auth provider is mostly useful for development purposes and special cases.
 
-It is possible to also hide the auth provider from the login form completely. Auth provider has `hidden` boolean property, 
-which can be configured as in example [site configuration](../config/site_config.md) below:
+It is also possible to hide the auth provider from the login form completely. Auth providers have a `hidden` boolean property. 
+See the [site configuration](../config/site_config.md) example below:
 ```json
 {
   "auth.providers": [
@@ -124,4 +123,4 @@ which can be configured as in example [site configuration](../config/site_config
 }
 ```
 
-In this example, the github auth provider will not be shown on the login form at all. Only Gitlab auth provider will be shown. 
+In this example, the GitHub auth provider will not be shown on the login form at all. Only the GitLab auth provider will be shown. 


### PR DESCRIPTION
## Description

Added logs for configuring the login form. [Can be seen here](https://docs.sourcegraph.com/@milan_docs_login_form/admin/auth/login_form).

## Test plan

Eyeballing of the rendered docs pages.
