### PR TITLE
update Cody README and docs pages

### DIFF
--- a/client/cody/README.md
+++ b/client/cody/README.md
@@ -1,5 +1,14 @@
+<p align="center">
+<a href="https://about.sourcegraph.com/cody" target="_blank">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.svg" width="300">
+  <source media="(prefers-color-scheme: light)" srcset="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.svg" width="300">
+  <img src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="300">
+</picture>
+</a>
+</p>
+
 <div align="center">
-    <p>Cody: An AI-Powered Programming Assistant</p>
     <a href="https://docs.sourcegraph.com/cody">Docs</a> •
     <a href="https://discord.gg/s2qDtYGnAE">Discord</a> •
     <a href="https://twitter.com/sourcegraph">Twitter</a>
@@ -12,76 +21,76 @@
     </a>
 </div>
 
-## Cody (experimental)
+# Cody: AI code assistant
 
-Cody is a coding assistant that answers code questions and writes code for you by reading your entire codebase and the code graph.
+Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
 
-**Status:** experimental ([request access](https://about.sourcegraph.com/cody))
+**Status:** experimental ([join the open beta](https://docs.sourcegraph.com/cody))
 
-## Main features
+## Features
 
-- Answer questions about your codebase instantly
-- Generate documentation and unit tests on demand
-- Write code snippets and prototypes for you
-- Translate comments and functions in your code between languages
+<!-- NOTE: These should stay roughly in sync with doc/cody/index.md, although that page needs to be not specific to VS Code. -->
 
-## Installation
+- **🤖 Chatbot that knows _your_ code:** Writes code and answers questions with knowledge of your entire codebase, following your project's code conventions and architecture better than other AI code chatbots.
+- **✨ Fixup code:** Interactively writes and refactors code for you, based on quick natural-language instructions.
+- **🧪 Recipes:** Generates unit tests, documentation, and more, with full codebase awareness.
 
-Here are the ways to install Cody in Visual Studio Code:
+## Usage
 
-### In Visual Studio Code
+### Installation
 
-1. Open the Extensions tab on the left side of VS Code (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>).
-2. Search for `Sourcegraph Cody` and click Install.
-3. Once installed, **reload** VS Code.
-4. After reloading, click the Cody icon in the VS Code Activity Bar to open the extension.
-   - Alternatively, you can launch the extension by pressing <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and searching for "Cody: Focus on chat view" and searching for "Cody: Focus on chat view".
+1. Install the [Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+1. [Join the open beta](https://docs.sourcegraph.com/cody) to get access. Once you're in, follow the rest of the steps on that page to set up Cody.
 
-### Through the Visual Studio Marketplace
+### 🤖 Chatbot that knows _your_ code
 
-1. Install Cody from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
-2. After installing the plugin, click the Cody icon in the VS Code Activity Bar to open the extension.
+[**📽️ Demo**](https://twitter.com/beyang/status/1647744307045228544)
 
-## Setting up the Cody extension
+To start chatting with Cody, click on the Cody icon in the activity bar (or press <kbd>Alt+/</kbd>/<kbd>Opt+/</kbd>, or run the `Cody: Focus on Chat View` command).
 
-To set up the Cody extension, you will need to enter the URL of your Sourcegraph instance and an access token used for authentication.
+Examples of the kinds of questions Cody can handle:
 
-1. Open the Cody chat view by clicking on the Cody icon in the sidebar.
-2. If you are setting up Cody for the first time, you should see the terms of service.
-3. To proceed, read the terms and click "I accept", if you accept the terms of service.
-4. Aftewards, you should see the login screen, where you have to enter the URL of your Sourcegraph instance and an access token used for authentication.
-5. Once you have filled out the login form, click the Login button to login to Cody.
+- How is our app's secret storage implemented on Linux?
+- Where is the CI config for the web integration tests?
+- Write a new GraphQL resolver for the AuditLog.
+- Why is the UserConnectionResolver giving an error `unknown user`, and how do I fix it?
 
-### Generating a Sourcegraph access token
+Cody tells you which code files it read to generate its response. (If Cody gives a wrong answer, please share feedback so we can improve it.)
 
-1. Go to your Sourcegraph instance.
-2. In your account settings, navigate to `Access tokens`.
-3. Click `Generate new token`.
-4. Copy the token.
+**Note:** For full codebase awareness, you must set the `cody.codebase` setting to the name of the repository on the connected Sourcegraph instance.
 
-### Codebase
+### ✨ Fixup code
 
-To enable codebase-aware answers, you have to set the codebase setting to let Cody know which repository you are working on in the current workspace. You can do that as follows:
+[**📽️ Demo**](https://twitter.com/sqs/status/1647673013343780864)
 
-1. Open the VS Code workspace settings by pressing <kbd>Cmd</kbd>, (or File > Preferences (Settings) on Windows & Linux).
-2. Search for the "Cody: Codebase" setting.
-3. Enter the repository name as listed on your Sourcegraph instance.
-   1. For example: `github.com/sourcegraph/sourcegraph` without the `https` protocol
+Just sprinkle your code with instructions in natural language, select the code, and run `Cody: Fixup` (<kbd>Ctrl+Alt+/</kbd>/<kbd>Ctrl+Opt+/</kbd>). Cody will figure out what edits to make.
 
-Setting the codebase will edit the `.vscode/settings.json` file in your repository, which you can then commit and save for future usage.
+Examples of the kinds of fixup instructions Cody can handle:
 
-## Extension Settings
+- "Factor out any common helper functions" (when multiple functions are selected)
+- "Use the imported CSS module's class names"
+- "Extract the list item to a separate React component"
+- "Handle errors better"
+- "Add helpful debug log statements"
+- "Make this work" (seriously, it often works--try it!)
 
-This extension contributes the following settings:
+### 🧪 Recipes
 
-| Setting             | Description                                                                                                                  | Example                                                      |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| cody.enabled        | Enable or disable Cody.                                                                                                      | true/false                                                   |
-| cody.serverEndpoint | URL of the Sourcegraph instance.                                                                                             | "https://example.sourcegraph.com"                            |
-| cody.codebase       | Name of the repository opened in the current workspace. Use the same repository name as listed on your Sourcegraph instance. | "github.com/sourcegraph/sourcegraph"                         |
-| cody.useContext     | Context source for Cody. One of: "embeddings", "keyword", "blended", or "none".                                              | "embeddings"                                                 |
-| cody.customHeaders  | Takes object, where each value pair will be added to the request headers made to your Sourcegraph instance.                  | {"Cache-Control": "no-cache", "Proxy-Authenticate": "Basic"} |
+Right-click on a selection of code and choose one of the `Ask Cody > ...` recipes, such as:
+
+- Explain Code
+- Generate Unit Test
+- Generate Docstring
+- Improve Variable Names
+
+We welcome PRs that contribute new, useful recipes.
+
+## Feedback
+
+- [Issue tracker](https://github.com/sourcegraph/sourcegraph/issues)
+- [Discord chat](https://discord.gg/s2qDtYGnAE)
+- [@sourcegraph (Twitter)](https://twitter.com/sourcegraph)
 
 ## Development
 
-Please see the [CONTRIBUTING](./CONTRIBUTING.md) document if you are interested in contributing to our code base.
+[Cody's code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/cody) is open source (Apache 2). See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -103,7 +103,7 @@
       },
       {
         "command": "cody.recipe.fixup",
-        "title": "Ask Cody: Fixup Code from Inline Instructions"
+        "title": "Cody: Fixup"
       },
       {
         "command": "cody.set-access-token",
@@ -203,6 +203,9 @@
         },
         {
           "command": "cody.recipe.translate-to-language"
+        },
+        {
+          "command": "cody.recipe.fixup"
         }
       ]
     },

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -1,32 +1,76 @@
-# Cody (experimental)
+# <picture title="Cody"><img class="theme-dark-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
 
-<aside class="experimental">
-<p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
-</p>
-</aside>
+<span class="badge badge-experimental">Experimental</span>
 
-Cody is an AI coding assistant that lives in your editor that can find, explain, and write code. Cody uses a combination of Large Language Models (LLMs), Sourcegraph search, and Sourcegraph code intelligence to provide answers that eliminate toil and keep human programmers in flow. You can think of Cody as your programmer buddy who has read through all the code in open source, all the questions on StackOverflow, and all your organization's private code, and is always there to answer questions you might have or suggest ways of doing something based on prior knowledge.
+Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
 
-Cody is in private alpha (tagged as an [experimental](../admin/beta_and_experimental_features.md) feature) at this stage. 
-- If you are an existing Sourcegraph Enterprise customer or want to use Cody for your team, contact your techical advisor or [sign up here](https://sourcegraph.typeform.com/to/pIXTgwrd) to get access
-- If you want to try Cody on open source code, sign up [here](https://forms.gle/cffMa8mrr8YuHv8o8) and we'll e-mail you instructions to connect Cody to sourcegraph.com as soon as your account is added.
+Cody uses a combination of Sourcegraph's code graph and Large Language Models (LLMs) to eliminate toil and keep human devs in flow. You can think of Cody as your coding assistant who has read through all the code in open source, all the questions on StackOverflow, and your own entire codebase, and is always there to answer questions you might have or suggest ways of doing something based on prior knowledge.
 
-Currently, Cody is available for VS Code. More editors are on the way—[join the Discord](https://discord.gg/8wJF5EdAyA) to inquire about your editor of choice.
+## Get Cody
+
+- **Sourcegraph Enterprise customers:** Contact your Sourcegraph techical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
+- **Everyone:** [Join the open beta.](https://forms.gle/cffMa8mrr8YuHv8o8) We'll email you when you're added, usually within a day.
+
+Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself.
+
+## Features
+
+<!-- NOTE: These should stay roughly in sync with client/cody/README.md, although these need to be not specific to VS Code. -->
+
+- **🤖 Chatbot that knows _your_ code:** Writes code and answers questions with knowledge of your entire codebase, following your project's code conventions and architecture better than other AI code chatbots.
+- **✨ Fixup code:** Interactively writes and refactors code for you, based on quick natural-language instructions.
+- **🧪 Recipes:** Generates unit tests, documentation, and more, with full codebase awareness.
+
+### 🤖 Chatbot that knows _your_ code
+
+[**📽️ Demo**](https://twitter.com/beyang/status/1647744307045228544)
+
+You can chat with Cody in VS Code or in the Sourcegraph sidebar.
+
+Examples of the kinds of questions Cody can handle:
+
+- How is our app's secret storage implemented on Linux?
+- Where is the CI config for the web integration tests?
+- Write a new GraphQL resolver for the AuditLog.
+- Why is the UserConnectionResolver giving an error `unknown user`, and how do I fix it?
+
+Cody tells you which code files it read to generate its response. (If Cody gives a wrong answer, please share feedback so we can improve it.)
+
+### ✨ Fixup code
+
+[**📽️ Demo**](https://twitter.com/sqs/status/1647673013343780864)
+
+In VS Code, just sprinkle your code with instructions in natural language, select the code, and run `Cody: Fixup` (<kbd>Ctrl+Alt+/</kbd>/<kbd>Ctrl+Opt+/</kbd>). Cody will figure out what edits to make.
+
+Examples of the kinds of fixup instructions Cody can handle:
+
+- "Factor out any common helper functions" (when multiple functions are selected)
+- "Use the imported CSS module's class names"
+- "Extract the list item to a separate React component"
+- "Handle errors better"
+- "Add helpful debug log statements"
+- "Make this work" (seriously, it often works--try it!)
+
+### 🧪 Recipes
+
+In VS Code, right-click on a selection of code and choose one of the `Ask Cody > ...` recipes, such as:
+
+- Explain Code
+- Generate Unit Test
+- Generate Docstring
+- Improve Variable Names
 
 ## Cody on Sourcegraph.com
 
-Cody uses Sourcegraph to fetch relevant context to generate answers and code. These instructions walk through installing Cody and connecting it to sourcegraph.com. For private instances of Sourcegraph, see the section below about enabling Cody for Enterprise.
+Cody uses Sourcegraph to fetch relevant context to generate answers and code. These instructions walk through installing Cody and connecting it to Sourcegraph.com. For private instances of Sourcegraph, see the section below about enabling Cody for Enterprise.
 
-1. Sign into [sourcegraph.com](https://sourcegraph.com)
-1. Request access [here](https://forms.gle/cffMa8mrr8YuHv8o8) and we'll send you an e-mail you as soon as your account is added. At this time, we are approving all requests.
+1. Sign into [Sourcegraph.com](https://sourcegraph.com) (or create an account if you don't already have one)
+1. [Join the open beta](https://forms.gle/cffMa8mrr8YuHv8o8). We'll email you when you're added, usually within a day.
 1. [Create a Sourcegraph access token](https://sourcegraph.com/user/settings/tokens)
 1. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
   1. Set the Sourcegraph URL to be `https://sourcegraph.com`
   1. Set the access token to be the token you just created
 1. See [this section](#enabling-codebase-aware-answers) on how to enable codebase-aware answers.
-
-<img width="553" alt="Cody login screen" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
 
 After installing, we recommend the following:
 


### PR DESCRIPTION
- Highlights key features
- Standardizes descriptions of Cody

The docs page still needs a lot of work. It is very long and confusing. (But this is an improvement and we should merge something soon.)

## Test plan

n/a; docs only

