### PR TITLE
site-config: Remove deprecated experimentalFeatures.bitbucketServerFastperm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - User tags are removed in favor of the newer feature flags functionality. [#49318](https://github.com/sourcegraph/sourcegraph/pull/49318)
+- Previously deprecated site config `experimentalFeatures.bitbucketServerFastPerm` has been removed. [#50707](https://github.com/sourcegraph/sourcegraph/pull/50707)
 
 ## 5.0.1
 

--- a/enterprise/internal/authz/bitbucketserver/BUILD.bazel
+++ b/enterprise/internal/authz/bitbucketserver/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//enterprise/internal/authz/types",
         "//enterprise/internal/licensing",
         "//internal/authz",
-        "//internal/conf",
         "//internal/encryption",
         "//internal/extsvc",
         "//internal/extsvc/bitbucketserver",

--- a/enterprise/internal/authz/bitbucketserver/authz.go
+++ b/enterprise/internal/authz/bitbucketserver/authz.go
@@ -4,7 +4,6 @@ import (
 	atypes "github.com/sourcegraph/sourcegraph/enterprise/internal/authz/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -27,7 +26,7 @@ func NewAuthzProviders(
 	initResults := &atypes.ProviderInitResult{}
 	// Authorization (i.e., permissions) providers
 	for _, c := range conns {
-		pluginPerm := conf.BitbucketServerPluginPerm() || (c.Plugin != nil && c.Plugin.Permissions == "enabled")
+		pluginPerm := c.Plugin != nil && c.Plugin.Permissions == "enabled"
 		p, err := newAuthzProvider(c, pluginPerm)
 		if err != nil {
 			initResults.InvalidConnections = append(initResults.InvalidConnections, extsvc.TypeBitbucketServer)

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -355,11 +355,6 @@ func SearchSymbolsParallelism() int {
 	return val
 }
 
-func BitbucketServerPluginPerm() bool {
-	val := ExperimentalFeatures().BitbucketServerFastPerm
-	return val == "enabled"
-}
-
 func EventLoggingEnabled() bool {
 	val := ExperimentalFeatures().EventLogging
 	if val == "" {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -760,8 +760,6 @@ type ExpandedGitCommitDescription struct {
 
 // ExperimentalFeatures description: Experimental features and settings.
 type ExperimentalFeatures struct {
-	// BitbucketServerFastPerm description: DEPRECATED: Configure in Bitbucket Server config.
-	BitbucketServerFastPerm string `json:"bitbucketServerFastPerm,omitempty"`
 	// CodyRestrictUsersFeatureFlag description: Restrict Cody to only be enabled for users that have a feature flag labeled "cody-experimental" set to true. You must create a feature flag with this ID after enabling this setting: https://docs.sourcegraph.com/dev/how-to/use_feature_flags#create-a-feature-flag.
 	CodyRestrictUsersFeatureFlag bool `json:"codyRestrictUsersFeatureFlag,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command. To enable this feature set environment variable `ENABLE_CUSTOM_GIT_FETCH` as `true` on gitserver.
@@ -854,7 +852,6 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	delete(m, "bitbucketServerFastPerm")
 	delete(m, "codyRestrictUsersFeatureFlag")
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -171,12 +171,6 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
-        "bitbucketServerFastPerm": {
-          "description": "DEPRECATED: Configure in Bitbucket Server config.",
-          "type": "string",
-          "enum": ["enabled", "disabled"],
-          "default": "disabled"
-        },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",


### PR DESCRIPTION
Stumbled into this while looking at another experimental feature.


## Test plan

- Removed all existing references to this config
- main-dry-run should pass
