### PR TITLE
Minor styling to Cody chat in the web app

### DIFF
--- a/client/web/src/cody/CodyChat.module.scss
+++ b/client/web/src/cody/CodyChat.module.scss
@@ -12,7 +12,6 @@
     border-bottom-style: none !important; // Override the Transcript...last-child row
 }
 
-
 .human-transcript-item {
     background: var(--input-bg);
     border-color: var(--border-color-2);

--- a/client/web/src/cody/CodyChat.module.scss
+++ b/client/web/src/cody/CodyChat.module.scss
@@ -9,7 +9,7 @@
     border-color: transparent;
     border-top-width: 1px;
     border-top-style: solid;
-    border-bottom: none;
+    border-bottom-style: none !important; // Override the Transcript...last-child row
 }
 
 

--- a/client/web/src/cody/CodyChat.module.scss
+++ b/client/web/src/cody/CodyChat.module.scss
@@ -4,13 +4,17 @@
 }
 
 .transcript-item {
-    background: linear-gradient(var(--input-bg), var(--input-bg)) padding-box,
-        linear-gradient(130deg, #00cbec, #a112ff) border-box;
+    background: linear-gradient(var(--body-bg), var(--body-bg)) padding-box,
+        linear-gradient(268deg, #00cbec, #a112ff) border-box;
     border-color: transparent;
+    border-top-width: 1px;
+    border-top-style: solid;
+    border-bottom: none;
 }
 
+
 .human-transcript-item {
-    background-color: var(--input-bg);
+    background: var(--input-bg);
     border-color: var(--border-color-2);
 }
 
@@ -26,7 +30,7 @@
     border-bottom: solid 1px var(--border-color-2);
     border-radius: 0 !important;
     padding: 0.625rem !important;
-    background: var(--body-bg);
+    background: var(--subtle-bg);
 }
 
 .transcript-item code {


### PR DESCRIPTION
Minor styling to Cody chat in the web app:
 - Lighter color line dividers.
 - Light gray bg for the Cody messages to help create more visual separations.
 
<img width="777" alt="Screenshot 2023-04-17 at 7 41 28 AM" src="https://user-images.githubusercontent.com/64257673/232461587-80bb0f9b-9b6a-4e90-b3e3-69afd91ed43e.png">

## Test plan
- Check that the visual differences take effect.