### PR TITLE
Cody: Use a valid URL as the default serverEndpoint

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -220,7 +220,7 @@
         },
         "cody.serverEndpoint": {
           "type": "string",
-          "default": "https://<instance>.sourcegraph.com",
+          "default": "https://sourcegraph.com",
           "example": "https://<instance>.sourcegraph.com",
           "description": "URL to the Sourcegraph instance."
         },


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1681729029259269

## Test plan

A valid URL is used as the default value:

<img width="670" alt="Screenshot 2023-04-17 at 13 28 11" src="https://user-images.githubusercontent.com/458591/232471491-968129f1-63f0-4b44-8137-9330d6d81064.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
