### PR TITLE
Cody web: Add telemetry to Ask Cody button

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -377,7 +377,17 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                             {...repoHeaderContributionsLifecycleProps}
                         >
                             {() =>
-                                !isCodySidebarOpen ? <AskCodyButton onClick={() => setCodySidebarOpen(true)} /> : null
+                                !isCodySidebarOpen ? (
+                                    <AskCodyButton
+                                        onClick={() => {
+                                            props.telemetryService.log('web:codySidebar:chatOpened', {
+                                                repo,
+                                                path: filePath,
+                                            })
+                                            setCodySidebarOpen(true)
+                                        }}
+                                    />
+                                ) : null
                             }
                         </RepoHeaderContributionPortal>
                     ) : null}


### PR DESCRIPTION
Part of #50677

This PR adds usage tracking to the `Ask Cody` button. We already have tracking of when chat messages are submitted.

This is not included in the usage ping yet, though. We can work on this later in addition to tracking with the VSCE extension.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="854" alt="Screenshot 2023-04-17 at 14 22 17" src="https://user-images.githubusercontent.com/458591/232482730-5f2892b6-05a4-4a31-9c16-38b817ce1ae3.png">
