### PR TITLE
Cody: Do not try to decode in the middle of multibyte characters

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -2,6 +2,7 @@ import http from 'http'
 import https from 'https'
 
 import { isError } from '../../utils'
+import { toPartialUtf8String } from '../utils'
 
 import { SourcegraphCompletionsClient } from './client'
 import { parseEvents } from './parse'
@@ -79,22 +80,29 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 rejectUnauthorized: this.mode === 'production',
             },
             (res: http.IncomingMessage) => {
-                let buffer = ''
+                // Bytes which have not been decoded as UTF-8 text
+                let bufferBin = Buffer.of()
+                // Text which has not been decoded as a server-sent event (SSE)
+                let bufferText = ''
 
                 res.on('data', chunk => {
                     if (!(chunk instanceof Buffer)) {
                         throw new TypeError('expected chunk to be a Buffer')
                     }
-                    buffer += chunk.toString()
+                    // text/event-stream messages are always UTF-8, but a chunk
+                    // may terminate in the middle of a character
+                    const { str, buf } = toPartialUtf8String(Buffer.concat([bufferBin, chunk]))
+                    bufferText += str
+                    bufferBin = buf
 
-                    const parseResult = parseEvents(buffer)
+                    const parseResult = parseEvents(bufferText)
                     if (isError(parseResult)) {
                         console.error(parseResult)
                         return
                     }
 
                     this.sendEvents(parseResult.events, cb)
-                    buffer = parseResult.remainingBuffer
+                    bufferText = parseResult.remainingBuffer
                 })
 
                 res.on('error', e => cb.onError(e.message))

--- a/client/cody-shared/src/sourcegraph-api/utils.test.ts
+++ b/client/cody-shared/src/sourcegraph-api/utils.test.ts
@@ -1,0 +1,24 @@
+import { toPartialUtf8String } from './utils'
+
+describe('toPartialUtf8String', () => {
+    it('should decode single-byte characters', () => {
+        const { str, buf } = toPartialUtf8String(Buffer.from('hello, world', 'utf-8'))
+        expect(str).toBe('hello, world')
+        expect(buf.length).toBe(0)
+    })
+    it('should decode multibyte characters', () => {
+        const { str, buf } = toPartialUtf8String(Buffer.from('今日は、世界', 'utf-8'))
+        expect(str).toBe('今日は、世界')
+        expect(buf.length).toBe(0)
+    })
+    it('should split if the last byte is the initial byte of a multibyte character', () => {
+        const { str, buf } = toPartialUtf8String(Buffer.from([0x48, 0x69, 0x20, 0xef]))
+        expect(str).toBe('Hi ')
+        expect(buf).toEqual(Buffer.from([0xef]))
+    })
+    it('should split if the trailing bytes are the start of a multibyte character', () => {
+        const { str, buf } = toPartialUtf8String(Buffer.from([0x59, 0x6f, 0x21, 0xf0, 0x8a, 0x8b]))
+        expect(str).toBe('Yo!')
+        expect(buf).toEqual(Buffer.from([0xf0, 0x8a, 0x8b]))
+    })
+})

--- a/client/cody-shared/src/sourcegraph-api/utils.ts
+++ b/client/cody-shared/src/sourcegraph-api/utils.ts
@@ -1,0 +1,34 @@
+// Converts the prefix of buf to a UTF8 string. If buf terminates in the middle
+// of a character, returns the remaining bytes of the partial character in a
+// new buffer. Note! This assumes that the prefix of buf *is* valid UTF8--it
+// only examines the bytes of the last character in the buffer and assumes it
+// will find an initial byte before the start of the buffer.
+export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
+    if (buf.length === 0) {
+        return { str: '', buf: Buffer.of() }
+    }
+    let lastValidByteOffsetExclusive = buf.length
+    if ((buf[lastValidByteOffsetExclusive - 1] & 0x80) !== 0) {
+        // Multi-byte character. Count additional trailing bytes. UTF8 trailing
+        // bytes have the bit pattern 10??_????.
+        let numBytes = 1
+        while ((buf[lastValidByteOffsetExclusive - numBytes] & 0xc0) === 0x80) {
+            numBytes++
+        }
+        // Scrutinize the initial byte to see if the encoding is complete.
+        // Characters of N bytes encode the length in the first character.
+        // The high order N bits are set, and the next bit is clear. For
+        // example a 4-byte character starts with 1111_0???.
+        const byte = buf[lastValidByteOffsetExclusive - numBytes]
+        const mask = 0xff ^ ((1 << (7 - numBytes)) - 1)
+        const value = numBytes === 6 ? 0xfc : mask ^ (1 << (7 - numBytes))
+        if ((byte & mask) !== value) {
+            // The trailing bytes are incomplete; don't decode them.
+            lastValidByteOffsetExclusive -= numBytes
+        }
+    }
+    return {
+        str: buf.slice(0, lastValidByteOffsetExclusive).toString('utf8'),
+        buf: Buffer.from(buf.slice(lastValidByteOffsetExclusive)),
+    }
+}


### PR DESCRIPTION
When consuming an Anthropic streaming response, we eagerly convert chunks of binary data. If a chunk boundary falls within a multibyte character, we produce invalid characters at the end of that chunk and the start of the next one, corrupting the output.

Fixes #50717

## Test plan

```
$ cd cody-shared
$ pnpm test
```

Also see the repro steps in Issue #50717. TL;DR, Cody's Japanese output should not contain ?s in diamonds.