### PR TITLE
Fix local dev server streaming resources (to unblock streaming search and Cody streaming)

### DIFF
--- a/client/web/dev/utils/get-api-proxy-settings.ts
+++ b/client/web/dev/utils/get-api-proxy-settings.ts
@@ -1,6 +1,10 @@
+import type * as http from 'http'
+import * as zlib from 'zlib'
+
 import { Options, responseInterceptor } from 'http-proxy-middleware'
 
 import { ENVIRONMENT_CONFIG, HTTPS_WEB_SERVER_URL } from './environment-config'
+import { STREAMING_ENDPOINTS } from './should-compress-response'
 
 // One of the API routes: "/-/sign-in".
 const PROXY_ROUTES = ['/.api', '/search/stream', '/-', '/.auth']
@@ -34,7 +38,7 @@ export function getAPIProxySettings(options: GetAPIProxySettingsOptions): ProxyS
         // Prevent automatic call of res.end() in `onProxyRes`. It is handled by `responseInterceptor`.
         selfHandleResponse: true,
         // eslint-disable-next-line @typescript-eslint/no-misused-promises, @typescript-eslint/require-await
-        onProxyRes: responseInterceptor(async (responseBuffer, proxyRes) => {
+        onProxyRes: conditionalResponseInterceptor(STREAMING_ENDPOINTS, async (responseBuffer, proxyRes) => {
             // Propagate cookies to enable authentication on the remote server.
             if (proxyRes.headers['set-cookie']) {
                 // Remove `Secure` and `SameSite` from `set-cookie` headers.
@@ -107,4 +111,79 @@ function getRemoteJsContextScript(remoteIndexHTML: string): string {
     const remoteJsContextEnd = remoteIndexHTML.indexOf('</script>', remoteJsContextStart)
 
     return remoteIndexHTML.slice(remoteJsContextStart, remoteJsContextEnd) + jsContextChanges
+}
+
+type Interceptor = (
+    buffer: Buffer,
+    proxyRes: http.IncomingMessage,
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+) => Promise<Buffer | string>
+
+function conditionalResponseInterceptor(
+    ignoredRoutes: string[],
+    interceptor: Interceptor
+): (proxyRes: http.IncomingMessage, req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> {
+    const unconditionalResponseInterceptor = responseInterceptor(interceptor)
+
+    return async function proxyResResponseInterceptor(
+        proxyRes: http.IncomingMessage,
+        req: http.IncomingMessage,
+        res: http.ServerResponse
+    ): Promise<void> {
+        let shouldStream = false
+        for (const route of ignoredRoutes) {
+            if (req.url?.startsWith(route)) {
+                shouldStream = true
+            }
+        }
+
+        if (shouldStream) {
+            return new Promise(resolve => {
+                res.setHeader('content-type', 'text/event-stream')
+                const _proxyRes = decompress(proxyRes, proxyRes.headers['content-encoding'])
+
+                _proxyRes.on('data', (chunk: any) => res.write(chunk))
+                _proxyRes.on('end', () => {
+                    res.end()
+                    resolve()
+                })
+                _proxyRes.on('error', () => {
+                    res.end()
+                    resolve()
+                })
+            })
+        }
+
+        return unconditionalResponseInterceptor(proxyRes, req, res)
+    }
+}
+
+function decompress<TReq extends http.IncomingMessage = http.IncomingMessage>(
+    proxyRes: TReq,
+    contentEncoding?: string
+): TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress {
+    let _proxyRes: TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress = proxyRes
+    let decompress
+
+    switch (contentEncoding) {
+        case 'gzip':
+            decompress = zlib.createGunzip()
+            break
+        case 'br':
+            decompress = zlib.createBrotliDecompress()
+            break
+        case 'deflate':
+            decompress = zlib.createInflate()
+            break
+        default:
+            break
+    }
+
+    if (decompress) {
+        _proxyRes.pipe(decompress)
+        _proxyRes = decompress
+    }
+
+    return _proxyRes
 }

--- a/client/web/dev/utils/should-compress-response.ts
+++ b/client/web/dev/utils/should-compress-response.ts
@@ -1,18 +1,15 @@
 import compression, { CompressionFilter } from 'compression'
 
+export const STREAMING_ENDPOINTS = ['/search/stream', '/.api/compute/stream', '/.api/completions/stream']
+
 export const shouldCompressResponse: CompressionFilter = (request, response) => {
     // Disable compression because gzip buffers the full response
     // before sending it, blocking streaming on some endpoints.
-    if (request.path.startsWith('/search/stream')) {
-        return false
-    }
 
-    if (request.path.startsWith('/.api/compute/stream')) {
-        return false
-    }
-
-    if (request.path.startsWith('/.api/.completions/stream')) {
-        return false
+    for (const endpoint of STREAMING_ENDPOINTS) {
+        if (request.path.startsWith(endpoint)) {
+            return false
+        }
     }
 
     // fallback to standard filter function

--- a/client/web/dev/utils/should-compress-response.ts
+++ b/client/web/dev/utils/should-compress-response.ts
@@ -11,6 +11,10 @@ export const shouldCompressResponse: CompressionFilter = (request, response) => 
         return false
     }
 
+    if (request.path.startsWith('/.api/.completions/stream')) {
+        return false
+    }
+
     // fallback to standard filter function
     return compression.filter(request, response)
 }

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "graphql": "^15.4.0",
     "graphql-schema-linter": "^2.0.1",
     "gulp": "^4.0.2",
-    "http-proxy-middleware": "^1.1.2",
+    "http-proxy-middleware": "^2.0.6",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.0",
     "jest-canvas-mock": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,7 +272,7 @@ importers:
       highlightjs-graphql: ^1.0.2
       history: 4.5.1
       http-proxy-agent: ^5.0.0
-      http-proxy-middleware: ^1.1.2
+      http-proxy-middleware: ^2.0.6
       http-status-codes: ^2.1.4
       https-browserify: ^1.0.0
       https-proxy-agent: ^5.0.1
@@ -410,7 +410,7 @@ importers:
       yauzl: ^2.10.0
       zustand: ^3.6.9
     dependencies:
-      '@apollo/client': 3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24
+      '@apollo/client': 3.8.0-alpha.7_5tbbnxkk6lozdg365l3mqvd64e
       '@codemirror/autocomplete': 6.1.0_42luzusa22g3gmuqmbrrjz6ypm
       '@codemirror/commands': 6.0.1
       '@codemirror/lang-json': 6.0.0
@@ -421,7 +421,7 @@ importers:
       '@codemirror/search': 6.0.1
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.7.3
-      '@graphiql/react': 0.10.0_4r7n3nwits3hhxvoeutasbehiq
+      '@graphiql/react': 0.10.0_iezu2wrysx2y3eydxgd52zpi2y
       '@lezer/common': 1.0.0
       '@lezer/highlight': 1.0.0
       '@mdi/js': 7.1.96
@@ -489,7 +489,7 @@ importers:
       focus-visible: 5.2.0
       fzf: 0.5.1
       got: 11.8.5
-      graphiql: 1.11.5_4r7n3nwits3hhxvoeutasbehiq
+      graphiql: 1.11.5_iezu2wrysx2y3eydxgd52zpi2y
       highlight.js: 10.7.3
       highlightjs-graphql: 1.0.2
       history: 4.5.1
@@ -532,7 +532,7 @@ importers:
       react-grid-layout: 1.3.4_ef5jwxihqo6n7gxfmzogljlgcm
       react-resizable: 3.0.4_ef5jwxihqo6n7gxfmzogljlgcm
       react-router-dom: 6.8.1_ef5jwxihqo6n7gxfmzogljlgcm
-      react-spring: 9.4.2_q62pa2zh755ec65gt45qyms3ji
+      react-spring: 9.4.2_kl6dkfb7apudyf5jw5ql2mvcm4
       react-sticky-box: 1.0.2_react@18.1.0
       react-visibility-sensor: 5.1.1_ef5jwxihqo6n7gxfmzogljlgcm
       recharts: 1.8.5_ef5jwxihqo6n7gxfmzogljlgcm
@@ -591,11 +591,11 @@ importers:
       '@sentry/webpack-plugin': 1.20.0
       '@slack/web-api': 5.15.0
       '@sourcegraph/eslint-config': 0.32.0_qxbo2xm47qt6fxnlmgbosp4hva
-      '@sourcegraph/eslint-plugin-sourcegraph': 1.0.5_ftvidnylzkqlsgegxlccclav64
+      '@sourcegraph/eslint-plugin-sourcegraph': 1.0.5_bpwbtrlkzh6al3jo2q3vydr3nu
       '@sourcegraph/eslint-plugin-wildcard': link:client/eslint-plugin-wildcard
       '@sourcegraph/extension-api-stubs': 1.6.1
       '@sourcegraph/prettierrc': 3.0.3
-      '@sourcegraph/stylelint-config': 1.4.0_3pp7hr4az4mfghojtspygpgymu
+      '@sourcegraph/stylelint-config': 1.4.0_rp7y2ywsawd3ducfqkdfvjbr5y
       '@sourcegraph/stylelint-plugin-sourcegraph': 1.0.1_stylelint@14.3.0
       '@sourcegraph/tsconfig': 4.0.1
       '@statoscope/cli': 5.24.0
@@ -604,7 +604,7 @@ importers:
       '@storybook/addon-console': 1.2.3_473b6rbrlfbkiblbxydosemc4u
       '@storybook/addon-docs': 6.5.14_d4gn7xvvo56p54oenpfyoci2p4
       '@storybook/addon-links': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
-      '@storybook/addon-storyshots': 6.5.14_wrg2stofvhxprqxmgurdpjqb4m
+      '@storybook/addon-storyshots': 6.5.14_hpdsjclshq6djlncyosi7l4o2m
       '@storybook/addon-storyshots-puppeteer': 6.5.14_5bskxofbdzb2fai5lt3jrwan6e
       '@storybook/addon-storysource': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
       '@storybook/addon-toolbars': 6.5.14_ef5jwxihqo6n7gxfmzogljlgcm
@@ -696,7 +696,7 @@ importers:
       '@vscode/test-electron': 2.1.3
       '@vscode/vsce': 2.18.0
       abort-controller: 3.0.0
-      autoprefixer: 10.2.1_postcss@8.4.21
+      autoprefixer: 10.2.1_postcss@8.4.22
       axe-core: 4.4.2
       babel-jest: 28.1.3_@babel+core@7.21.0
       babel-loader: 9.1.0_qoaxtqicpzj5p3ubthw53xafqm
@@ -720,7 +720,7 @@ importers:
       envalid: 7.3.1
       esbuild: 0.17.14
       eslint: 8.34.0
-      eslint-plugin-monorepo: 0.3.2_6pbktzf24qc5a6dtgnl76m6aru
+      eslint-plugin-monorepo: 0.3.2_kmhr73uzlj6rvabgbeswpb76by
       events: 3.3.0
       execa: 5.1.1
       expect: 27.5.1
@@ -734,7 +734,7 @@ importers:
       graphql: 15.4.0
       graphql-schema-linter: 2.0.1
       gulp: 4.0.2
-      http-proxy-middleware: 1.3.1
+      http-proxy-middleware: 2.0.6_@types+express@4.17.11
       identity-obj-proxy: 3.0.0
       jest: 28.1.3_sgfsbmxe5qwkqmsj7h2d7flbny
       jest-canvas-mock: 2.3.0
@@ -760,12 +760,12 @@ importers:
       open: 7.3.0
       p-retry: 4.6.0
       p-timeout: 4.1.0
-      postcss-cli: 10.1.0_aesdjsunmf4wiehhujt67my7tu
-      postcss-custom-media: 8.0.0_postcss@8.4.21
+      postcss-cli: 10.1.0_hszu2jam7ho6rzhowjm4227oui
+      postcss-custom-media: 8.0.0_postcss@8.4.22
       postcss-focus-visible: 5.0.0
-      postcss-loader: 7.0.2_6jdsrmfenkuhhw3gx4zvjlznce
+      postcss-loader: 7.0.2_zokz37apvl3zk4n7azn3tmtbfa
       prettier: 2.8.1
-      prettier-plugin-svelte: 2.9.0_c25feh7akwshegxdj2xzo3ajiu
+      prettier-plugin-svelte: 2.9.0_4t67mfcvfavm4vfdmvfc3crkfa
       punycode: 2.1.1
       puppeteer: 13.7.0
       react-refresh: 0.10.0
@@ -1242,7 +1242,7 @@ packages:
       js-yaml: 3.14.1
     dev: true
 
-  /@apollo/client/3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24:
+  /@apollo/client/3.8.0-alpha.7_5tbbnxkk6lozdg365l3mqvd64e:
     resolution: {integrity: sha512-pwyACANhC4R0VnEXn4Uv7DEIOr3V6kmKC+Eh3wlspuhP7RLHsU31oFYXmNs2THHAMDdXAK96axutd6qP86eZ+Q==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1266,7 +1266,7 @@ packages:
       '@wry/trie': 0.3.0
       graphql: 15.4.0
       graphql-tag: 2.12.6_graphql@15.4.0
-      graphql-ws: 5.12.0_graphql@15.4.0
+      graphql-ws: 5.12.1_graphql@15.4.0
       hoist-non-react-statics: 3.3.2
       optimism: 0.16.1
       prop-types: 15.8.1
@@ -1381,6 +1381,13 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
+  /@babel/code-frame/7.21.4:
+    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: false
+
   /@babel/compat-data/7.21.0:
     resolution: {integrity: sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==}
     engines: {node: '>=6.9.0'}
@@ -1439,6 +1446,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
+
+  /@babel/generator/7.21.4:
+    resolution: {integrity: sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.4
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: false
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -1646,6 +1663,11 @@ packages:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-validator-option/7.21.0:
+    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/helper-wrap-function/7.20.5:
     resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
     engines: {node: '>=6.9.0'}
@@ -1689,6 +1711,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.3
+
+  /@babel/parser/7.21.4:
+    resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.21.4
+    dev: false
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -1987,6 +2017,16 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-flow/7.21.4_@babel+core@7.21.0:
+    resolution: {integrity: sha512-l9xd3N+XG4fZRxEP3vXdK6RW7vN1Uf5dxzRC/09wV86wqZ/YYQooBIGNsiRdfNR3/q2/5pPzV4B54J/9ctX5jw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -2648,6 +2688,19 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
       '@babel/plugin-transform-flow-strip-types': 7.21.0_@babel+core@7.21.0
+    dev: true
+
+  /@babel/preset-flow/7.21.4_@babel+core@7.21.0:
+    resolution: {integrity: sha512-F24cSq4DIBmhq4OzK3dE63NHagb27OPE3eWR+HLekt4Z3Y5MzIIUGF3LlLgV0gN8vzbDViSY7HnrReNVCJXTeA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.21.0
+      '@babel/plugin-transform-flow-strip-types': 7.21.0_@babel+core@7.21.0
+    dev: false
 
   /@babel/preset-modules/0.1.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -2755,6 +2808,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse/7.21.4:
+    resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.4
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.21.4
+      '@babel/types': 7.21.4
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/types/7.10.5:
     resolution: {integrity: sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==}
     dependencies:
@@ -2770,6 +2841,15 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+
+  /@babel/types/7.21.4:
+    resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: false
 
   /@base2/pretty-print-object/1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -3418,14 +3498,14 @@ packages:
       graphql: 15.4.0
     dev: true
 
-  /@graphiql/react/0.10.0_4r7n3nwits3hhxvoeutasbehiq:
+  /@graphiql/react/0.10.0_iezu2wrysx2y3eydxgd52zpi2y:
     resolution: {integrity: sha512-8Xo1O6SQps6R+mOozN7Ht85/07RwyXgJcKNeR2dWPkJz/1Lww8wVHIKM/AUpo0Aaoh6Ps3UK9ep8DDRfBT4XrQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@graphiql/toolkit': 0.6.1_goxv4r3de763reio6oerkrleh4
+      '@graphiql/toolkit': 0.6.1_iidmva7zakqsrg5gxy77bhmr3m
       codemirror: 5.65.9
       codemirror-graphql: 1.3.2_xqxvwl775glgjupzokow46f6pm
       copy-to-clipboard: 3.3.1
@@ -3442,7 +3522,7 @@ packages:
       - graphql-ws
     dev: false
 
-  /@graphiql/toolkit/0.6.1_goxv4r3de763reio6oerkrleh4:
+  /@graphiql/toolkit/0.6.1_iidmva7zakqsrg5gxy77bhmr3m:
     resolution: {integrity: sha512-rRjbHko6aSg1RWGr3yOJQqEV1tKe8yw9mDSr/18B+eDhVLQ30yyKk2NznFUT9NmIDzWFGR2pH/0lbBhHKmUCqw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
@@ -3450,7 +3530,7 @@ packages:
     dependencies:
       '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
       graphql: 15.4.0
-      graphql-ws: 5.12.0_graphql@15.4.0
+      graphql-ws: 5.12.1_graphql@15.4.0
       meros: 1.2.1_@types+node@13.13.5
     transitivePeerDependencies:
       - '@types/node'
@@ -4455,6 +4535,15 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
       '@jridgewell/trace-mapping': 0.3.17
 
+  /@jridgewell/gen-mapping/0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: false
+
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
@@ -4469,14 +4558,32 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
 
+  /@jridgewell/source-map/0.3.3:
+    resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: false
+
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+
+  /@jridgewell/sourcemap-codec/1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: false
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@jridgewell/trace-mapping/0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
 
   /@jridgewell/trace-mapping/0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -5895,26 +6002,13 @@ packages:
       - encoding
     dev: false
 
-  /@react-native-community/cli-platform-ios/10.2.0:
-    resolution: {integrity: sha512-hIPK3iL/mL+0ChXmQ9uqqzNOKA48H+TAzg+hrxQLll/6dNMxDeK9/wZpktcsh8w+CyhqzKqVernGcQs7tPeKGw==}
-    dependencies:
-      '@react-native-community/cli-tools': 10.1.1
-      chalk: 4.1.2
-      execa: 1.0.0
-      fast-xml-parser: 4.1.3
-      glob: 7.2.3
-      ora: 5.4.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@react-native-community/cli-platform-ios/10.2.1:
     resolution: {integrity: sha512-hz4zu4Y6eyj7D0lnZx8Mf2c2si8y+zh/zUTgCTaPPLzQD8jSZNNBtUUiA1cARm2razpe8marCZ1QbTMAGbf3mg==}
     dependencies:
       '@react-native-community/cli-tools': 10.1.1
       chalk: 4.1.2
       execa: 1.0.0
-      fast-xml-parser: 4.1.3
+      fast-xml-parser: 4.2.0
       glob: 7.2.3
       ora: 5.4.1
     transitivePeerDependencies:
@@ -5973,7 +6067,7 @@ packages:
       open: 6.4.0
       ora: 5.4.1
       semver: 6.3.0
-      shell-quote: 1.8.0
+      shell-quote: 1.8.1
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -5984,8 +6078,8 @@ packages:
       joi: 17.9.1
     dev: false
 
-  /@react-native-community/cli/10.2.0_@babel+core@7.21.0:
-    resolution: {integrity: sha512-QH7AFBz5FX2zTZRH/o3XehHrZ0aZZEL5Sh+23nSEFgSj3bLFfvjjZhuoiRSAo7iiBdvAoXrfxQ8TXgg4Xf/7fw==}
+  /@react-native-community/cli/10.2.2_@babel+core@7.21.0:
+    resolution: {integrity: sha512-aZVcVIqj+OG6CrliR/Yn8wHxrvyzbFBY9cj7n0MvRw/P54QUru2nNqUTSSbqv0Qaa297yHJbe6kFDojDMSTM8Q==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
@@ -6048,7 +6142,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /@react-spring/konva/9.4.2_juvqtg4kykgnkoer6bn4r6lvtu:
+  /@react-spring/konva/9.4.2_2pbijzvwolgvwvyebiu2bvnfym:
     resolution: {integrity: sha512-wzSfyHp+qS0OjnipQ8FFrtMh4yu62dkaWAFa+9ThqbQ5KLbEdCK4ArN4h4GfxPoJZ38NJoEO7zbX+ewtQn8N1g==}
     peerDependencies:
       konva: '>=2.6'
@@ -6059,12 +6153,12 @@ packages:
       '@react-spring/core': 9.4.2_react@18.1.0
       '@react-spring/shared': 9.4.2_react@18.1.0
       '@react-spring/types': 9.4.2
-      konva: 8.4.3
+      konva: 9.0.0
       react: 18.1.0
-      react-konva: 16.8.6_ct25jqyodm5lwk4xx6ybhlxjsi
+      react-konva: 16.8.6_esuducndjzrwn7r6qf3ublmuoa
     dev: false
 
-  /@react-spring/native/9.4.2_w22g7zrmlirvzlfb2wxddcdohe:
+  /@react-spring/native/9.4.2_tilqswuxptisdl53ejookmbupe:
     resolution: {integrity: sha512-QVKpeuPvnYwvW4NvzzJcTgvZseMaogVH2zhAWpT4DkXIOICbaIlz1BsE+C+wrtREIq0LCgUFVbeUwaG89t68UA==}
     peerDependencies:
       react: ^16.8.0  || ^17.0.0
@@ -6075,7 +6169,7 @@ packages:
       '@react-spring/shared': 9.4.2_react@18.1.0
       '@react-spring/types': 9.4.2
       react: 18.1.0
-      react-native: 0.71.4_cedkertwcryj7hechfcr5dzii4
+      react-native: 0.71.6_cedkertwcryj7hechfcr5dzii4
     dev: false
 
   /@react-spring/rafz/9.4.2:
@@ -6092,7 +6186,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /@react-spring/three/9.4.2_n43b4isi3dphbyu4mx37hqycza:
+  /@react-spring/three/9.4.2_q6ep23pdzmdrf4cjp4s5axhs7i:
     resolution: {integrity: sha512-qAPHOMjQjl9V3Eh4Xbdsdx9mAMe+rtSBfEuZGfoF5l8P8zC42gxggbyM1sKUOip3yyz76YTPiosWkmvgCVxMng==}
     peerDependencies:
       '@react-three/fiber': '>=6.0'
@@ -6103,9 +6197,9 @@ packages:
       '@react-spring/core': 9.4.2_react@18.1.0
       '@react-spring/shared': 9.4.2_react@18.1.0
       '@react-spring/types': 9.4.2
-      '@react-three/fiber': 8.12.0_pe6vrm3rd5fblzkjsomhevwd4q
+      '@react-three/fiber': 8.12.1_bftifo3o3emvsno56sw2fy6wy4
       react: 18.1.0
-      three: 0.150.1
+      three: 0.151.3
     dev: false
 
   /@react-spring/types/9.4.2:
@@ -6144,8 +6238,8 @@ packages:
       zdog: 1.1.3
     dev: false
 
-  /@react-three/fiber/8.12.0_pe6vrm3rd5fblzkjsomhevwd4q:
-    resolution: {integrity: sha512-o6DkNtNHqcOFRbxaiY5xayelE/9+Z0z9wWu5awqjVbc0c/1QM6AttJH6rKW0U/O6LWxSfxDTARXVzknZqpDJ7A==}
+  /@react-three/fiber/8.12.1_bftifo3o3emvsno56sw2fy6wy4:
+    resolution: {integrity: sha512-5KHuXAQsvR7drbL33G/3Fzj9+DkVvSrsQfebLnuVtzQdPApoom4rH8MixTakhGsTheedY1/2s4H1GS82V0+JeA==}
     peerDependencies:
       expo: '>=43.0'
       expo-asset: '>=8.4'
@@ -6171,12 +6265,12 @@ packages:
       its-fine: 1.1.0_react@18.1.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-native: 0.71.4_cedkertwcryj7hechfcr5dzii4
+      react-native: 0.71.6_cedkertwcryj7hechfcr5dzii4
       react-reconciler: 0.27.0_react@18.1.0
       react-use-measure: 2.1.1_ef5jwxihqo6n7gxfmzogljlgcm
       scheduler: 0.21.0
       suspend-react: 0.0.8_react@18.1.0
-      three: 0.150.1
+      three: 0.151.3
       zustand: 3.7.2_react@18.1.0
     dev: false
 
@@ -6577,7 +6671,7 @@ packages:
       - typescript
     dev: true
 
-  /@sourcegraph/eslint-plugin-sourcegraph/1.0.5_ftvidnylzkqlsgegxlccclav64:
+  /@sourcegraph/eslint-plugin-sourcegraph/1.0.5_bpwbtrlkzh6al3jo2q3vydr3nu:
     resolution: {integrity: sha512-609NL/0nOnGiDJHrTsIsaffNlm70ua5j7ftX6M3UhbMyMREX5xa7SwZmOjlBSwaaDlaP4SUmXwr7CumI7idM7g==}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -6589,7 +6683,7 @@ packages:
     dependencies:
       '@sourcegraph/codemod-transforms': 1.0.2
       '@typescript-eslint/experimental-utils': 5.4.0_qxbo2xm47qt6fxnlmgbosp4hva
-      '@typescript-eslint/parser': 5.56.0_qxbo2xm47qt6fxnlmgbosp4hva
+      '@typescript-eslint/parser': 5.58.0_qxbo2xm47qt6fxnlmgbosp4hva
       '@typescript-eslint/scope-manager': 5.4.0
       debug: 4.3.4
       eslint: 8.34.0
@@ -6651,11 +6745,11 @@ packages:
     resolution: {integrity: sha512-FQ1/Ued4I02R0JkrHHofDN163juVxUnPALzfxPZrDZUHv+c3jHjfZhmTHEz+Wd+g3b7MFk0fkj36nZSnvPyU8A==}
     dev: true
 
-  /@sourcegraph/stylelint-config/1.4.0_3pp7hr4az4mfghojtspygpgymu:
+  /@sourcegraph/stylelint-config/1.4.0_rp7y2ywsawd3ducfqkdfvjbr5y:
     resolution: {integrity: sha512-VYL0SRcS/49ttoYsS5pIX2ifVJIzLBWhHj8SvVcT/AF87AnFtuNJ5bAyEJFDL0k4xV5lyWG6R36hXF4xMGThTA==}
     dependencies:
       stylelint-config-prettier: 9.0.3_stylelint@14.3.0
-      stylelint-config-standard-scss: 3.0.0_3pp7hr4az4mfghojtspygpgymu
+      stylelint-config-standard-scss: 3.0.0_rp7y2ywsawd3ducfqkdfvjbr5y
     transitivePeerDependencies:
       - postcss
       - stylelint
@@ -7048,7 +7142,7 @@ packages:
         optional: true
     dependencies:
       '@axe-core/puppeteer': 4.4.2_puppeteer@13.7.0
-      '@storybook/addon-storyshots': 6.5.14_wrg2stofvhxprqxmgurdpjqb4m
+      '@storybook/addon-storyshots': 6.5.14_hpdsjclshq6djlncyosi7l4o2m
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.14
       '@types/jest-image-snapshot': 4.3.0
@@ -7060,7 +7154,7 @@ packages:
       - jest
     dev: true
 
-  /@storybook/addon-storyshots/6.5.14_wrg2stofvhxprqxmgurdpjqb4m:
+  /@storybook/addon-storyshots/6.5.14_hpdsjclshq6djlncyosi7l4o2m:
     resolution: {integrity: sha512-BSYt+GyMeTlxCwMNVwsmfetKjeIZVVRFdhvtyTuSf9MvikBq+SXw6IihkeWbX2g6pssCz9Wc+s6rRK/HJpqTlA==}
     peerDependencies:
       '@angular/core': '>=6.0.0'
@@ -7128,8 +7222,8 @@ packages:
       global: 4.4.0
       jest: 28.1.3_sgfsbmxe5qwkqmsj7h2d7flbny
       jest-specific-snapshot: 4.0.0_jest@28.1.3
-      preact: 10.13.1
-      preact-render-to-string: 5.1.19_preact@10.13.1
+      preact: 10.13.2
+      preact-render-to-string: 5.1.19_preact@10.13.2
       pretty-format: 26.6.2
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
@@ -7137,7 +7231,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       rxjs: 6.6.7
-      svelte: 3.57.0
+      svelte: 3.58.0
       ts-dedent: 2.0.0
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -9354,6 +9448,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/5.58.0_qxbo2xm47qt6fxnlmgbosp4hva:
+    resolution: {integrity: sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.58.0
+      '@typescript-eslint/types': 5.58.0
+      '@typescript-eslint/typescript-estree': 5.58.0_typescript@5.0.2
+      debug: 4.3.4
+      eslint: 8.34.0
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager/5.4.0:
     resolution: {integrity: sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9376,6 +9490,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.58.0:
+    resolution: {integrity: sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.58.0
+      '@typescript-eslint/visitor-keys': 5.58.0
     dev: true
 
   /@typescript-eslint/type-utils/5.54.1_qxbo2xm47qt6fxnlmgbosp4hva:
@@ -9410,6 +9532,11 @@ packages:
 
   /@typescript-eslint/types/5.56.0:
     resolution: {integrity: sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.58.0:
+    resolution: {integrity: sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -9476,6 +9603,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.58.0_typescript@5.0.2:
+    resolution: {integrity: sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.58.0
+      '@typescript-eslint/visitor-keys': 5.58.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils/5.54.1_qxbo2xm47qt6fxnlmgbosp4hva:
     resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9518,6 +9666,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.58.0:
+    resolution: {integrity: sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.58.0
+      eslint-visitor-keys: 3.4.0
     dev: true
 
   /@ungap/promise-all-settled/1.1.2:
@@ -10363,7 +10519,7 @@ packages:
     peerDependencies:
       '@apollo/client': ^3.2.5
     dependencies:
-      '@apollo/client': 3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24
+      '@apollo/client': 3.8.0-alpha.7_5tbbnxkk6lozdg365l3mqvd64e
     dev: false
 
   /app-root-dir/1.0.2:
@@ -10683,7 +10839,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /autoprefixer/10.2.1_postcss@8.4.21:
+  /autoprefixer/10.2.1_postcss@8.4.22:
     resolution: {integrity: sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
@@ -10695,7 +10851,7 @@ packages:
       colorette: 1.4.0
       fraction.js: 4.0.13
       normalize-range: 0.1.2
-      postcss: 8.4.21
+      postcss: 8.4.22
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -14566,31 +14722,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_6pbktzf24qc5a6dtgnl76m6aru:
-    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.56.0_qxbo2xm47qt6fxnlmgbosp4hva
-      debug: 3.2.7
-      find-up: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-module-utils/2.7.3_7tkqywrydjbibzbrmc2verxdma:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
@@ -14612,6 +14743,31 @@ packages:
       '@typescript-eslint/parser': 5.56.0_qxbo2xm47qt6fxnlmgbosp4hva
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
+      find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils/2.7.3_kmhr73uzlj6rvabgbeswpb76by:
+    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.58.0_qxbo2xm47qt6fxnlmgbosp4hva
+      debug: 3.2.7
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -14724,10 +14880,10 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /eslint-plugin-monorepo/0.3.2_6pbktzf24qc5a6dtgnl76m6aru:
+  /eslint-plugin-monorepo/0.3.2_kmhr73uzlj6rvabgbeswpb76by:
     resolution: {integrity: sha512-CypTAqHjTR05XxzqDj7x88oVu2GiqqQA/datD9kIwciHzpj0oE4YbTdyEFFKADgd7dbd21KliSlUpOvo626FBw==}
     dependencies:
-      eslint-module-utils: 2.7.3_6pbktzf24qc5a6dtgnl76m6aru
+      eslint-module-utils: 2.7.3_kmhr73uzlj6rvabgbeswpb76by
       get-monorepo-packages: 1.2.0
       globby: 7.1.1
       load-json-file: 4.0.0
@@ -14878,6 +15034,11 @@ packages:
   /eslint-visitor-keys/3.3.0:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /eslint-visitor-keys/3.4.0:
+    resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /eslint/8.34.0:
     resolution: {integrity: sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==}
@@ -15313,8 +15474,8 @@ packages:
     resolution: {integrity: sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==}
     dev: true
 
-  /fast-xml-parser/4.1.3:
-    resolution: {integrity: sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==}
+  /fast-xml-parser/4.2.0:
+    resolution: {integrity: sha512-+zVQv4aVTO+o8oRUyRL7PjgeVo1J6oP8Cw2+a8UTZQcj5V0yUK5T63gTN0ldgiHDPghUjKc4OpT6SwMTwnOQug==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -16433,15 +16594,15 @@ packages:
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
-  /graphiql/1.11.5_4r7n3nwits3hhxvoeutasbehiq:
+  /graphiql/1.11.5_iezu2wrysx2y3eydxgd52zpi2y:
     resolution: {integrity: sha512-NI92XdSVwXTsqzJc6ykaAkKVMeC8IRRp3XzkxVQwtqDsZlVKtR2ZnssXNYt05TMGbi1ehoipn9tFywVohOlHjg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@graphiql/react': 0.10.0_4r7n3nwits3hhxvoeutasbehiq
-      '@graphiql/toolkit': 0.6.1_goxv4r3de763reio6oerkrleh4
+      '@graphiql/react': 0.10.0_iezu2wrysx2y3eydxgd52zpi2y
+      '@graphiql/toolkit': 0.6.1_iidmva7zakqsrg5gxy77bhmr3m
       entities: 2.1.0
       graphql: 15.4.0
       graphql-language-service: 5.1.0_graphql@15.4.0
@@ -16545,8 +16706,8 @@ packages:
       graphql: 15.4.0
     dev: true
 
-  /graphql-ws/5.12.0_graphql@15.4.0:
-    resolution: {integrity: sha512-PA3ImUp8utrpEjoxBMhvxsjkStvFEdU0E1gEBREt8HZIWkxOUymwJBhFnBL7t/iHhUq1GVPeZevPinkZFENxTw==}
+  /graphql-ws/5.12.1_graphql@15.4.0:
+    resolution: {integrity: sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: '>=0.11 <=16'
@@ -17106,10 +17267,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware/1.3.1:
-    resolution: {integrity: sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==}
-    engines: {node: '>=8.0.0'}
+  /http-proxy-middleware/2.0.6_@types+express@4.17.11:
+    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/express': ^4.17.13
+    peerDependenciesMeta:
+      '@types/express':
+        optional: true
     dependencies:
+      '@types/express': 4.17.11
       '@types/http-proxy': 1.17.9
       http-proxy: 1.18.1
       is-glob: 4.0.3
@@ -18525,7 +18692,7 @@ packages:
     resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -19000,13 +19167,13 @@ packages:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/parser': 7.21.3
+      '@babel/parser': 7.21.4
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
       '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
       '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
       '@babel/preset-env': 7.20.2_@babel+core@7.21.0
-      '@babel/preset-flow': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-flow': 7.21.4_@babel+core@7.21.0
       '@babel/preset-typescript': 7.18.6_@babel+core@7.21.0
       '@babel/register': 7.21.0_@babel+core@7.21.0
       babel-core: 7.0.0-bridge.0_@babel+core@7.21.0
@@ -19374,8 +19541,8 @@ packages:
     resolution: {integrity: sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==}
     dev: true
 
-  /konva/8.4.3:
-    resolution: {integrity: sha512-ARqdgAbdNIougRlOKvkQwHlGhXPRBV4KvhCP+qoPpGoVQwwiJe4Hkdu4HHdRPb9rGUp04jDTAxBzEwBsE272pg==}
+  /konva/9.0.0:
+    resolution: {integrity: sha512-9Cdr5wjs2tU4j8K16xqixSdrDDigItYB1HOHVeC/SYPYnxePfkQDp3LrjWVYouwXbXfdadre5nRCxe50RoyZZw==}
     dev: false
 
   /language-subtag-registry/0.3.21:
@@ -20294,17 +20461,6 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
-  /metro-babel-transformer/0.73.8:
-    resolution: {integrity: sha512-GO6H/W2RjZ0/gm1pIvdO9EP34s3XN6kzoeyxqmfqKfYhJmYZf1SzXbyiIHyMbJNwJVrsKuHqu32+GopTlKscWw==}
-    dependencies:
-      '@babel/core': 7.21.0
-      hermes-parser: 0.8.0
-      metro-source-map: 0.73.8
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /metro-babel-transformer/0.73.9:
     resolution: {integrity: sha512-DlYwg9wwYIZTHtic7dyD4BP0SDftoltZ3clma76nHu43blMWsCnrImHeHsAVne3XsQ+RJaSRxhN5nkG2VyVHwA==}
     dependencies:
@@ -20393,60 +20549,13 @@ packages:
   /metro-minify-terser/0.73.9:
     resolution: {integrity: sha512-MTGPu2qV5qtzPJ2SqH6s58awHDtZ4jd7lmmLR+7TXDwtZDjIBA0YVfI0Zak2Haby2SqoNKrhhUns/b4dPAQAVg==}
     dependencies:
-      terser: 5.16.8
+      terser: 5.16.9
     dev: false
 
   /metro-minify-uglify/0.73.9:
     resolution: {integrity: sha512-gzxD/7WjYcnCNGiFJaA26z34rjOp+c/Ft++194Wg91lYep3TeWQ0CnH8t2HRS7AYDHU81SGWgvD3U7WV0g4LGA==}
     dependencies:
       uglify-es: 3.3.9
-    dev: false
-
-  /metro-react-native-babel-preset/0.73.8_@babel+core@7.21.0:
-    resolution: {integrity: sha512-spNrcQJTbQntEIqJnCA6yL4S+dzV9fXCk7U+Rm7yJasZ4o4Frn7jP23isu7FlZIp1Azx1+6SbP7SgQM+IP5JgQ==}
-    peerDependencies:
-      '@babel/core': '*'
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.21.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
-      '@babel/plugin-syntax-export-default-from': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
-      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-destructuring': 7.21.3_@babel+core@7.21.0
-      '@babel/plugin-transform-flow-strip-types': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.21.0
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.21.0
-      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.21.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.21.0
-      '@babel/plugin-transform-parameters': 7.21.3_@babel+core@7.21.0
-      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-react-jsx-self': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.0
-      '@babel/plugin-transform-runtime': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
-      '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.21.0
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.21.0
-      '@babel/template': 7.20.7
-      react-refresh: 0.4.3
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /metro-react-native-babel-preset/0.73.9_@babel+core@7.21.0:
@@ -20464,7 +20573,7 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
       '@babel/plugin-syntax-export-default-from': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-syntax-flow': 7.21.4_@babel+core@7.21.0
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
       '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
@@ -20492,22 +20601,6 @@ packages:
       '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.21.0
       '@babel/template': 7.20.7
       react-refresh: 0.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /metro-react-native-babel-transformer/0.73.8_@babel+core@7.21.0:
-    resolution: {integrity: sha512-oH/LCCJPauteAE28c0KJAiSrkV+1VJbU0PwA9UwaWnle+qevs/clpKQ8LrIr33YbBj4CiI1kFoVRuNRt5h4NFg==}
-    peerDependencies:
-      '@babel/core': '*'
-    dependencies:
-      '@babel/core': 7.21.0
-      babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
-      hermes-parser: 0.8.0
-      metro-babel-transformer: 0.73.8
-      metro-react-native-babel-preset: 0.73.8_@babel+core@7.21.0
-      metro-source-map: 0.73.8
-      nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -20534,13 +20627,6 @@ packages:
       absolute-path: 0.0.0
     dev: false
 
-  /metro-runtime/0.73.8:
-    resolution: {integrity: sha512-M+Bg9M4EN5AEpJ8NkiUsawD75ifYvYfHi05w6QzHXaqOrsTeaRbbeLuOGCYxU2f/tPg17wQV97/rqUQzs9qEtA==}
-    dependencies:
-      '@babel/runtime': 7.20.6
-      react-refresh: 0.4.3
-    dev: false
-
   /metro-runtime/0.73.9:
     resolution: {integrity: sha512-d5Hs83FpKB9r8q8Vb95+fa6ESpwysmPr4lL1I2rM2qXAFiO7OAPT9Bc23WmXgidkBtD0uUFdB2lG+H1ATz8rZg==}
     dependencies:
@@ -20548,46 +20634,16 @@ packages:
       react-refresh: 0.4.3
     dev: false
 
-  /metro-source-map/0.73.8:
-    resolution: {integrity: sha512-wozFXuBYMAy7b8BCYwC+qoXsvayVJBHWtSTlSLva99t+CoUSG9JO9kg1umzbOz28YYPxKmvb/wbnLMkHdas2cA==}
-    dependencies:
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
-      invariant: 2.2.4
-      metro-symbolicate: 0.73.8
-      nullthrows: 1.1.1
-      ob1: 0.73.8
-      source-map: 0.5.7
-      vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /metro-source-map/0.73.9:
     resolution: {integrity: sha512-l4VZKzdqafipriETYR6lsrwtavCF1+CMhCOY9XbyWeTrpGSNgJQgdeJpttzEZTHQQTLR0csQo0nD1ef3zEP6IQ==}
     dependencies:
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       invariant: 2.2.4
       metro-symbolicate: 0.73.9
       nullthrows: 1.1.1
       ob1: 0.73.9
       source-map: 0.5.7
-      vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /metro-symbolicate/0.73.8:
-    resolution: {integrity: sha512-xkBAcceYYp0GGdCCuMzkCF1ejHsd0lYlbKBkjSRgM0Nlj80VapPaSwumYoAvSaDxcbkvS7/sCjURGp5DsSFgRQ==}
-    engines: {node: '>=8.3'}
-    hasBin: true
-    dependencies:
-      invariant: 2.2.4
-      metro-source-map: 0.73.8
-      nullthrows: 1.1.1
-      source-map: 0.5.7
-      through2: 2.0.5
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
@@ -20612,9 +20668,9 @@ packages:
     resolution: {integrity: sha512-r9NeiqMngmooX2VOKLJVQrMuV7PAydbqst5bFhdVBPcFpZkxxqyzjzo+kzrszGy2UpSQBZr2P1L6OMjLHwQwfQ==}
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/generator': 7.21.3
+      '@babel/generator': 7.21.4
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
+      '@babel/traverse': 7.21.4
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -20624,9 +20680,9 @@ packages:
     resolution: {integrity: sha512-Rq4b489sIaTUENA+WCvtu9yvlT/C6zFMWhU4sq+97W29Zj0mPBjdk+qGT5n1ZBgtBIJzZWt1KxeYuc17f4aYtQ==}
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/generator': 7.21.3
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.3
+      '@babel/generator': 7.21.4
+      '@babel/parser': 7.21.4
+      '@babel/types': 7.21.4
       babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
       metro: 0.73.9
       metro-babel-transformer: 0.73.9
@@ -20647,13 +20703,13 @@ packages:
     resolution: {integrity: sha512-BlYbPmTF60hpetyNdKhdvi57dSqutb+/oK0u3ni4emIh78PiI0axGo7RfdsZ/mn3saASXc94tDbpC5yn7+NpEg==}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.21.4
       '@babel/core': 7.21.0
-      '@babel/generator': 7.21.3
-      '@babel/parser': 7.21.3
+      '@babel/generator': 7.21.4
+      '@babel/parser': 7.21.4
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
+      '@babel/traverse': 7.21.4
+      '@babel/types': 7.21.4
       absolute-path: 0.0.0
       accepts: 1.3.8
       async: 3.2.4
@@ -21071,6 +21127,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid/3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
@@ -21408,10 +21470,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /ob1/0.73.8:
-    resolution: {integrity: sha512-1F7j+jzD+edS6ohQP7Vg5f3yiIk5i3x1uLrNIHOmLHWzWK1t3zrDpjnoXghccdVlsU+UjbyURnDynm4p0GgXeA==}
-    dev: false
 
   /ob1/0.73.9:
     resolution: {integrity: sha512-kHOzCOFXmAM26fy7V/YuXNKne2TyRiXbFAvPBIbuedJCZZWQZHLdPzMeXJI4Egt6IcfDttRzN3jQ90wOwq1iNw==}
@@ -22308,7 +22366,7 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-cli/10.1.0_aesdjsunmf4wiehhujt67my7tu:
+  /postcss-cli/10.1.0_hszu2jam7ho6rzhowjm4227oui:
     resolution: {integrity: sha512-Zu7PLORkE9YwNdvOeOVKPmWghprOtjFQU3srMUGbdz3pHJiFh7yZ4geiZFMkjMfB0mtTFR3h8RemR62rPkbOPA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -22321,9 +22379,9 @@ packages:
       get-stdin: 9.0.0
       globby: 13.1.3
       picocolors: 1.0.0
-      postcss: 8.4.21
-      postcss-load-config: 4.0.1_aesdjsunmf4wiehhujt67my7tu
-      postcss-reporter: 7.0.5_postcss@8.4.21
+      postcss: 8.4.22
+      postcss-load-config: 4.0.1_hszu2jam7ho6rzhowjm4227oui
+      postcss-reporter: 7.0.5_postcss@8.4.22
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.0.0
@@ -22375,13 +22433,13 @@ packages:
       postcss-value-parser: 3.3.1
     dev: true
 
-  /postcss-custom-media/8.0.0_postcss@8.4.21:
+  /postcss-custom-media/8.0.0_postcss@8.4.22:
     resolution: {integrity: sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.4.22
     dev: true
 
   /postcss-discard-comments/4.0.2:
@@ -22432,7 +22490,7 @@ packages:
       postcss: 6.0.1
     dev: false
 
-  /postcss-load-config/4.0.1_aesdjsunmf4wiehhujt67my7tu:
+  /postcss-load-config/4.0.1_hszu2jam7ho6rzhowjm4227oui:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -22445,7 +22503,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.6
-      postcss: 8.4.21
+      postcss: 8.4.22
       ts-node: 10.9.1_mywb7jd72dw7cd2gthqi4igidu
       yaml: 2.2.1
     dev: true
@@ -22495,6 +22553,21 @@ packages:
       postcss: 8.4.21
       semver: 7.3.8
       webpack: 5.75.0_esbuild@0.17.14
+    dev: false
+
+  /postcss-loader/7.0.2_zokz37apvl3zk4n7azn3tmtbfa:
+    resolution: {integrity: sha512-fUJzV/QH7NXUAqV8dWJ9Lg4aTkDCezpTS5HgJ2DvqznexTbSTxgi/dTECvTZ15BwKTtk8G/bqI/QTu2HPd3ZCg==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      postcss: ^7.0.0 || ^8.0.1
+      webpack: ^5.0.0
+    dependencies:
+      cosmiconfig: 7.0.1
+      klona: 2.0.5
+      postcss: 8.4.22
+      semver: 7.3.8
+      webpack: 5.75.0_pdcrf7mb3dfag2zju4x4octu4a
+    dev: true
 
   /postcss-media-query-parser/0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
@@ -22789,6 +22862,18 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.21
       thenby: 1.3.4
+    dev: false
+
+  /postcss-reporter/7.0.5_postcss@8.4.22:
+    resolution: {integrity: sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      picocolors: 1.0.0
+      postcss: 8.4.22
+      thenby: 1.3.4
+    dev: true
 
   /postcss-resolve-nested-selector/0.1.1:
     resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
@@ -22803,13 +22888,13 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-scss/4.0.3_postcss@8.4.21:
+  /postcss-scss/4.0.3_postcss@8.4.22:
     resolution: {integrity: sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.4.22
     dev: true
 
   /postcss-selector-parser/3.1.2:
@@ -22877,17 +22962,26 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /preact-render-to-string/5.1.19_preact@10.13.1:
+  /postcss/8.4.22:
+    resolution: {integrity: sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
+  /preact-render-to-string/5.1.19_preact@10.13.2:
     resolution: {integrity: sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==}
     peerDependencies:
       preact: '>=10'
     dependencies:
-      preact: 10.13.1
+      preact: 10.13.2
       pretty-format: 3.8.0
     dev: true
 
-  /preact/10.13.1:
-    resolution: {integrity: sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==}
+  /preact/10.13.2:
+    resolution: {integrity: sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==}
     dev: true
 
   /prebuild-install/7.0.1:
@@ -22926,6 +23020,16 @@ packages:
   /prepend-http/2.0.0:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /prettier-plugin-svelte/2.9.0_4t67mfcvfavm4vfdmvfc3crkfa:
+    resolution: {integrity: sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==}
+    peerDependencies:
+      prettier: ^1.16.4 || ^2.0.0
+      svelte: ^3.2.0
+    dependencies:
+      prettier: 2.8.1
+      svelte: 3.58.0
     dev: true
 
   /prettier-plugin-svelte/2.9.0_c25feh7akwshegxdj2xzo3ajiu:
@@ -23387,7 +23491,7 @@ packages:
   /react-devtools-core/4.27.4:
     resolution: {integrity: sha512-dvZjrAJjahd6NNl7dDwEk5TyHsWJxDpYL7VnD9jdEr98EEEsVhw9G8JDX54Nrb3XIIOBlJDpjo3AuBuychX9zg==}
     dependencies:
-      shell-quote: 1.8.0
+      shell-quote: 1.8.1
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -23514,14 +23618,14 @@ packages:
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
-  /react-konva/16.8.6_ct25jqyodm5lwk4xx6ybhlxjsi:
+  /react-konva/16.8.6_esuducndjzrwn7r6qf3ublmuoa:
     resolution: {integrity: sha512-6KRIqHyJuTTMuAehDIXvw+ZrtEj2aMc2fwolhmFlg1HBzH4PJimsMByTcEx292Afh9d38TcHdjXP1C58qqDOlg==}
     peerDependencies:
       konva: ^3.2.3
       react: 16.8.x
       react-dom: 16.8.x
     dependencies:
-      konva: 8.4.3
+      konva: 9.0.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
       react-reconciler: 0.20.4_react@18.1.0
@@ -23535,7 +23639,7 @@ packages:
   /react-native-codegen/0.71.5_@babel+preset-env@7.20.2:
     resolution: {integrity: sha512-rfsuc0zkuUuMjFnrT55I1mDZ+pBRp2zAiRwxck3m6qeGJBGK5OV5JH66eDQ4aa+3m0of316CqrJDRzVlYufzIg==}
     dependencies:
-      '@babel/parser': 7.21.3
+      '@babel/parser': 7.21.4
       flow-parser: 0.185.2
       jscodeshift: 0.13.1_@babel+preset-env@7.20.2
       nullthrows: 1.1.1
@@ -23544,21 +23648,21 @@ packages:
       - supports-color
     dev: false
 
-  /react-native-gradle-plugin/0.71.16:
-    resolution: {integrity: sha512-H2BjG2zk7B7Wii9sXvd9qhCVRQYDAHSWdMw9tscmZBqSP62DkIWEQSk4/B2GhQ4aK9ydVXgtqR6tBeg3yy8TSA==}
+  /react-native-gradle-plugin/0.71.17:
+    resolution: {integrity: sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA==}
     dev: false
 
-  /react-native/0.71.4_cedkertwcryj7hechfcr5dzii4:
-    resolution: {integrity: sha512-3hSYqvWrOdKhpV3HpEKp1/CkWx8Sr/N/miCrmUIAsVTSJUR7JW0VvIsrV9urDhUj/s6v2WF4n7qIEEJsmTCrPw==}
+  /react-native/0.71.6_cedkertwcryj7hechfcr5dzii4:
+    resolution: {integrity: sha512-gHrDj7qaAaiE41JwaFCh3AtvOqOLuRgZtHKzNiwxakG/wvPAYmG73ECfWHGxjxIx/QT17Hp37Da3ipCei/CayQ==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
       react: 18.2.0
     dependencies:
       '@jest/create-cache-key-function': 29.5.0
-      '@react-native-community/cli': 10.2.0_@babel+core@7.21.0
+      '@react-native-community/cli': 10.2.2_@babel+core@7.21.0
       '@react-native-community/cli-platform-android': 10.2.0
-      '@react-native-community/cli-platform-ios': 10.2.0
+      '@react-native-community/cli-platform-ios': 10.2.1
       '@react-native/assets': 1.0.0
       '@react-native/normalize-color': 2.1.0
       '@react-native/polyfills': 2.0.0
@@ -23571,9 +23675,9 @@ packages:
       jest-environment-node: 29.5.0
       jsc-android: 250231.0.0
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.73.8_@babel+core@7.21.0
-      metro-runtime: 0.73.8
-      metro-source-map: 0.73.8
+      metro-react-native-babel-transformer: 0.73.9_@babel+core@7.21.0
+      metro-runtime: 0.73.9
+      metro-source-map: 0.73.9
       mkdirp: 0.5.6
       nullthrows: 1.1.1
       pretty-format: 26.6.2
@@ -23581,7 +23685,7 @@ packages:
       react: 18.1.0
       react-devtools-core: 4.27.4
       react-native-codegen: 0.71.5_@babel+preset-env@7.20.2
-      react-native-gradle-plugin: 0.71.16
+      react-native-gradle-plugin: 0.71.17
       react-refresh: 0.4.3
       react-shallow-renderer: 16.15.0_react@18.1.0
       regenerator-runtime: 0.13.11
@@ -23762,13 +23866,13 @@ packages:
       react-transition-group: 2.9.0_ef5jwxihqo6n7gxfmzogljlgcm
     dev: false
 
-  /react-spring/9.4.2_q62pa2zh755ec65gt45qyms3ji:
+  /react-spring/9.4.2_kl6dkfb7apudyf5jw5ql2mvcm4:
     resolution: {integrity: sha512-mK9xdq1kAhbe5YpP4EG2IzRa2C1M1UfR/MO1f83PE+IpHwCm1nGQhteF3MGyX6I3wnkoBWTXbY6n4443Dp52Og==}
     dependencies:
       '@react-spring/core': 9.4.2_react@18.1.0
-      '@react-spring/konva': 9.4.2_juvqtg4kykgnkoer6bn4r6lvtu
-      '@react-spring/native': 9.4.2_w22g7zrmlirvzlfb2wxddcdohe
-      '@react-spring/three': 9.4.2_n43b4isi3dphbyu4mx37hqycza
+      '@react-spring/konva': 9.4.2_2pbijzvwolgvwvyebiu2bvnfym
+      '@react-spring/native': 9.4.2_tilqswuxptisdl53ejookmbupe
+      '@react-spring/three': 9.4.2_q6ep23pdzmdrf4cjp4s5axhs7i
       '@react-spring/web': 9.4.2_ef5jwxihqo6n7gxfmzogljlgcm
       '@react-spring/zdog': 9.4.2_77gplihovuwhn6erb2kol6s2xa
     transitivePeerDependencies:
@@ -25003,6 +25107,11 @@ packages:
 
   /shell-quote/1.8.0:
     resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
+    dev: true
+
+  /shell-quote/1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: false
 
   /shelljs/0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -25936,12 +26045,12 @@ packages:
       stylelint: 14.3.0
     dev: true
 
-  /stylelint-config-recommended-scss/5.0.2_3pp7hr4az4mfghojtspygpgymu:
+  /stylelint-config-recommended-scss/5.0.2_rp7y2ywsawd3ducfqkdfvjbr5y:
     resolution: {integrity: sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==}
     peerDependencies:
       stylelint: ^14.0.0
     dependencies:
-      postcss-scss: 4.0.3_postcss@8.4.21
+      postcss-scss: 4.0.3_postcss@8.4.22
       stylelint: 14.3.0
       stylelint-config-recommended: 6.0.0_stylelint@14.3.0
       stylelint-scss: 4.1.0_stylelint@14.3.0
@@ -25957,13 +26066,13 @@ packages:
       stylelint: 14.3.0
     dev: true
 
-  /stylelint-config-standard-scss/3.0.0_3pp7hr4az4mfghojtspygpgymu:
+  /stylelint-config-standard-scss/3.0.0_rp7y2ywsawd3ducfqkdfvjbr5y:
     resolution: {integrity: sha512-zt3ZbzIbllN1iCmc94e4pDxqpkzeR6CJo5DDXzltshuXr+82B8ylHyMMARNnUYrZH80B7wgY7UkKTYCFM0UUyw==}
     peerDependencies:
       stylelint: ^14.0.0
     dependencies:
       stylelint: 14.3.0
-      stylelint-config-recommended-scss: 5.0.2_3pp7hr4az4mfghojtspygpgymu
+      stylelint-config-recommended-scss: 5.0.2_rp7y2ywsawd3ducfqkdfvjbr5y
       stylelint-config-standard: 24.0.0_stylelint@14.3.0
     transitivePeerDependencies:
       - postcss
@@ -26218,6 +26327,11 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /svelte/3.58.0:
+    resolution: {integrity: sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /sver-compat/1.5.0:
     resolution: {integrity: sha512-aFTHfmjwizMNlNE6dsGmoAM4lHjL0CyiobWaFiXWSlD7cIxshW422Nb8KbXCmR6z+0ZEPY+daXJrDyh/vuwTyg==}
     dependencies:
@@ -26463,6 +26577,17 @@ packages:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  /terser/5.16.9:
+    resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.3
+      acorn: 8.8.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: false
+
   /test-exclude/6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -26495,8 +26620,8 @@ packages:
     resolution: {integrity: sha512-A8YS1bpOzm9os0w7wH/BbN5WZgzyf0zbrrWHckX57v+EkCaM7jZPoRpzgqrakh2e7IWP1KwAnMtlcGTATYZw8A==}
     dev: true
 
-  /three/0.150.1:
-    resolution: {integrity: sha512-5C1MqKUWaHYo13BX0Q64qcdwImgnnjSOFgBscOzAo8MYCzEtqfQqorEKMcajnA3FHy1yVlIe9AmaMQ0OQracNA==}
+  /three/0.151.3:
+    resolution: {integrity: sha512-+vbuqxFy8kzLeO5MgpBHUvP/EAiecaDwDuOPPDe6SbrZr96kccF0ktLngXc7xA7bzyd3N0t2f6mw3Z9y6JCojQ==}
     dev: false
 
   /throat/5.0.0:
@@ -28408,7 +28533,7 @@ packages:
       '@apollo/client': ^3.3.15
       graphql: ^14.5.8 || ^15.0.0
     dependencies:
-      '@apollo/client': 3.8.0-alpha.7_e3n27dif46whwrj4763pirjq24
+      '@apollo/client': 3.8.0-alpha.7_5tbbnxkk6lozdg365l3mqvd64e
       delay: 5.0.0
       fast-json-stable-stringify: 2.1.0
       graphql: 15.4.0


### PR DESCRIPTION
This PR fixes the local dev server for both the webpack and esbuild setups to no longer buffer requests to streaming endpoints.

This fixes streaming search and Cody in the `web-standalone` run options.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

https://user-images.githubusercontent.com/458591/232517302-d6993a12-9c59-4435-8073-fde8c89d8536.mov

