### PR TITLE
bazel: add unparam nogo linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - ineffassign # nogo equivelant
     #- nolintlint see https://github.com/golangci/golangci-lint/issues/3228.
     - staticcheck # nogo equivelant
-    - typecheck // no nogo equivelant possible
+    - typecheck # nogo equivelant NOT POSSIBLE: no analyzer to import
     - unconvert
     # - unused
     - unparam # nogo equivelant

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,10 @@ linters:
     - ineffassign # nogo equivelant
     #- nolintlint see https://github.com/golangci/golangci-lint/issues/3228.
     - staticcheck # nogo equivelant
-    - typecheck
+    - typecheck // no nogo equivelant possible
     - unconvert
     # - unused
-    - unparam
+    - unparam # nogo equivelant
     - exportloopref # nogo equivelant
 
 linters-settings:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -223,6 +223,7 @@ nogo(
         "//dev/linters/forbidigo",
         "//dev/linters/gocritic",
         "//dev/linters/ineffassign",
+        "//dev/linters/unparam"
     ] + STATIC_CHECK_ANALYZERS,
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -223,7 +223,7 @@ nogo(
         "//dev/linters/forbidigo",
         "//dev/linters/gocritic",
         "//dev/linters/ineffassign",
-        "//dev/linters/unparam"
+        "//dev/linters/unparam",
     ] + STATIC_CHECK_ANALYZERS,
 )
 

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -26,8 +26,7 @@ var requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Current number of requests running for a method.",
 }, []string{"method"})
 
-//nolint:unparam // unparam complains that `server` always has same value across call-sites, but that's OK
-func trace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) {
+func trace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) { //nolint:unparam // unparam complains that `server` always has same value across call-sites, but that's OK
 	requestGauge.WithLabelValues(server + "." + method).Inc()
 
 	span, ctx := ot.StartSpanFromContext(ctx, server+"."+method) //nolint:staticcheck // OT is deprecated

--- a/cmd/symbols/squirrel/breadcrumbs.go
+++ b/cmd/symbols/squirrel/breadcrumbs.go
@@ -105,11 +105,11 @@ func (bs *Breadcrumbs) pretty(w *strings.Builder, readFile readFileFunc) {
 	fmt.Fprintln(w)
 
 	for _, b := range *bs {
-		fmt.Fprintf(w, "%s%s%s %s\n", strings.Repeat("| ", b.depth), itermSource(b.file, b.line, "src"), color.RedString("%d", b.number), b.message())
+		fmt.Fprintf(w, "%s%s%s %s\n", strings.Repeat("| ", b.depth), itermSource(b.file, b.line), color.RedString("%d", b.number), b.message())
 	}
 }
 
-func itermSource(absPath string, line int, msg string) string {
+func itermSource(absPath string, line int) string {
 	if os.Getenv("SRC_LOG_SOURCE_LINK") == "true" {
 		// Link to open the file:line in VS Code.
 		url := fmt.Sprintf("vscode://file%s:%d", absPath, line)

--- a/cmd/symbols/squirrel/lang_java.go
+++ b/cmd/symbols/squirrel/lang_java.go
@@ -44,15 +44,9 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 				if program.Type() != "program" {
 					s.breadcrumb(node, "getDefJava: expected parent of import_declaration to be program")
 				}
-				root, err := getProjectRoot(swapNode(node, program))
-				if err != nil {
-					return nil, err
-				}
-				allComponents, err := getPath(swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
-				components, err := getPathUpTo(swapNode(node, cur), node.Node)
+				root := getProjectRoot(swapNode(node, program))
+				allComponents := getPath(swapNode(node, cur))
+				components := getPathUpTo(swapNode(node, cur), node.Node)
 				if err != nil {
 					return nil, err
 				}
@@ -133,10 +127,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 						continue outer
 					}
 					query := "(local_variable_declaration declarator: (variable_declarator name: (identifier) @ident))"
-					captures, err := allCaptures(query, swapNode(node, blockChild))
-					if err != nil {
-						return nil, err
-					}
+					captures := allCaptures(query, swapNode(node, blockChild))
 					for _, capture := range captures {
 						if capture.Content(capture.Contents) == ident {
 							return swapNodePtr(node, capture.Node), nil
@@ -149,10 +140,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 					(constructor_declaration parameters: (formal_parameters (formal_parameter name: (identifier) @ident)))
 					(constructor_declaration parameters: (formal_parameters (spread_parameter (variable_declarator name: (identifier) @ident))))
 				]`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -166,10 +154,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 					(method_declaration parameters: (formal_parameters (formal_parameter name: (identifier) @ident)))
 					(method_declaration parameters: (formal_parameters (spread_parameter (variable_declarator name: (identifier) @ident))))
 				]`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -210,10 +195,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 					(lambda_expression parameters: (formal_parameters (spread_parameter (variable_declarator name: (identifier) @ident))))
 					(lambda_expression parameters: (inferred_parameters (identifier) @ident))
 				]`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -223,10 +205,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 
 			case "catch_clause":
 				query := `(catch_clause (catch_formal_parameter name: (identifier) @ident))`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -236,10 +215,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 
 			case "for_statement":
 				query := `(for_statement init: (local_variable_declaration declarator: (variable_declarator name: (identifier) @ident)))`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -249,10 +225,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 
 			case "enhanced_for_statement":
 				query := `(enhanced_for_statement name: (identifier) @ident)`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -299,10 +272,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 					(program (enum_declaration name: (identifier) @ident))
 					(program (interface_declaration name: (identifier) @ident))
 				]`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -316,10 +286,7 @@ func (s *SquirrelService) getDefJava(ctx context.Context, node Node) (ret *Node,
 					(class_declaration body: (class_body (enum_declaration name: (identifier) @ident)))
 					(class_declaration body: (class_body (interface_declaration name: (identifier) @ident)))
 				]`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -429,10 +396,7 @@ func (s *SquirrelService) lookupFieldJava(ctx context.Context, ty TypeJava, fiel
 				}
 			case "field_declaration":
 				query := "(field_declaration declarator: (variable_declarator name: (identifier) @ident))"
-				captures, err := allCaptures(query, swapNode(ty2.def, child))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(ty2.def, child))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == field {
 						return swapNodePtr(ty2.def, capture.Node), nil
@@ -484,10 +448,7 @@ func (s *SquirrelService) getTypeDefJava(ctx context.Context, node Node) (ret Ty
 			if localVariableDeclaration == nil {
 				return nil, nil
 			}
-			captures, err := allCaptures("(local_variable_declaration declarator: (variable_declarator value: (_) @value))", swapNode(node, localVariableDeclaration))
-			if err != nil {
-				return nil, err
-			}
+			captures := allCaptures("(local_variable_declaration declarator: (variable_declarator value: (_) @value))", swapNode(node, localVariableDeclaration))
 			for _, capture := range captures {
 				return s.getTypeDefJava(ctx, capture)
 			}
@@ -584,21 +545,14 @@ func (s *SquirrelService) getDefInImportsOrCurrentPackageJava(ctx context.Contex
 	defer s.onCall(program, &Tuple{String(program.Type()), String(ident)}, lazyNodeStringer(&ret))()
 
 	// Determine project root
-	root, err := getProjectRoot(program)
-	if err != nil {
-		return nil, err
-	}
-
+	root := getProjectRoot(program)
 	// Collect imports
 	imports := [][]string{}
 	for _, importNode := range children(program.Node) {
 		if importNode.Type() != "import_declaration" {
 			continue
 		}
-		path, err := getPath(swapNode(program, importNode))
-		if err != nil {
-			return nil, err
-		}
+		path := getPath(swapNode(program, importNode))
 		for _, child := range children(importNode) {
 			if child.Type() == "asterisk" {
 				path = append(path, "*")
@@ -667,30 +621,23 @@ func (s *SquirrelService) getDefInImportsOrCurrentPackageJava(ctx context.Contex
 	return nil, nil
 }
 
-func getProjectRoot(program Node) ([]string, error) {
+func getProjectRoot(program Node) []string {
 	root := strings.Split(filepath.Dir(program.RepoCommitPath.Path), "/")
 	for _, pkgNode := range children(program.Node) {
 		if pkgNode.Type() != "package_declaration" {
 			continue
 		}
-		pkg, err := getPath(swapNode(program, pkgNode))
-		if err != nil {
-			return nil, err
-		}
-
+		pkg := getPath(swapNode(program, pkgNode))
 		if len(root) > len(pkg) {
 			root = root[:len(root)-len(pkg)]
 		}
 	}
-	return root, nil
+	return root
 }
 
-func getPath(node Node) ([]string, error) {
+func getPath(node Node) []string {
 	query := `(identifier) @ident`
-	captures, err := allCaptures(query, node)
-	if err != nil {
-		return nil, err
-	}
+	captures := allCaptures(query, node)
 	sort.Slice(captures, func(i, j int) bool {
 		return captures[i].StartByte() < captures[j].StartByte()
 	})
@@ -698,15 +645,12 @@ func getPath(node Node) ([]string, error) {
 	for _, capture := range captures {
 		components = append(components, capture.Content(capture.Contents))
 	}
-	return components, nil
+	return components
 }
 
-func getPathUpTo(node Node, component *sitter.Node) ([]string, error) {
+func getPathUpTo(node Node, component *sitter.Node) []string {
 	query := `(identifier) @ident`
-	captures, err := allCaptures(query, node)
-	if err != nil {
-		return nil, err
-	}
+	captures := allCaptures(query, node)
 	sort.Slice(captures, func(i, j int) bool {
 		return captures[i].StartByte() < captures[j].StartByte()
 	})
@@ -717,7 +661,7 @@ func getPathUpTo(node Node, component *sitter.Node) ([]string, error) {
 			break
 		}
 	}
-	return components, nil
+	return components
 }
 
 func getSuperclassJava(declaration Node) *Node {

--- a/cmd/symbols/squirrel/lang_python.go
+++ b/cmd/symbols/squirrel/lang_python.go
@@ -112,10 +112,7 @@ func (s *SquirrelService) getDefPython(ctx context.Context, node Node) (ret *Nod
 						])
 					)
 				`
-				captures, err := allCaptures(query, swapNode(node, cur))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, cur))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -148,10 +145,7 @@ func (s *SquirrelService) getDefPython(ctx context.Context, node Node) (ret *Nod
 						(typed_default_parameter name: (identifier) @ident)
 					])
 				`
-				captures, err := allCaptures(query, swapNode(node, parameters))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(node, parameters))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == ident {
 						return swapNodePtr(node, capture.Node), nil
@@ -208,10 +202,7 @@ func (s *SquirrelService) findNodeInScopePython(block Node, ident string) (ret *
 			continue
 		case "expression_statement":
 			query := `(expression_statement (assignment left: (identifier) @ident))`
-			captures, err := allCaptures(query, swapNode(block, child))
-			if err != nil {
-				return nil
-			}
+			captures := allCaptures(query, swapNode(block, child))
 			for _, capture := range captures {
 				if capture.Content(capture.Contents) == ident {
 					return swapNodePtr(block, capture.Node)
@@ -317,10 +308,7 @@ func (s *SquirrelService) lookupFieldPython(ctx context.Context, ty TypePython, 
 			switch child.Type() {
 			case "expression_statement":
 				query := `(expression_statement (assignment left: (identifier) @ident))`
-				captures, err := allCaptures(query, swapNode(ty2.def, child))
-				if err != nil {
-					return nil, err
-				}
+				captures := allCaptures(query, swapNode(ty2.def, child))
 				for _, capture := range captures {
 					if capture.Content(capture.Contents) == field {
 						return swapNodePtr(ty2.def, capture.Node), nil
@@ -535,10 +523,7 @@ func (s *SquirrelService) getDefInImports(ctx context.Context, program Node, ide
 		(import_statement) @import
 		(import_from_statement) @import
 	]`
-	captures, err := allCaptures(query, program)
-	if err != nil {
-		return nil, err
-	}
+	captures := allCaptures(query, program)
 	for _, stmt := range captures {
 		switch stmt.Type() {
 		case "import_statement":

--- a/cmd/symbols/squirrel/lang_starlark.go
+++ b/cmd/symbols/squirrel/lang_starlark.go
@@ -15,7 +15,7 @@ func (s *SquirrelService) getDefStarlark(ctx context.Context, node Node) (ret *N
 	defer s.onCall(node, String(node.Type()), lazyNodeStringer(&ret))()
 	switch node.Type() {
 	case "identifier":
-		return starlarkBindingNamed(node.Node.Content(node.Contents), swapNode(node, getRoot(node.Node)))
+		return starlarkBindingNamed(node.Node.Content(node.Contents), swapNode(node, getRoot(node.Node))), nil
 	case "string":
 		return s.getDefStarlarkString(ctx, node)
 	default:
@@ -72,21 +72,18 @@ func (s *SquirrelService) getDefStarlarkString(ctx context.Context, node Node) (
 		if err != nil {
 			return nil, err
 		}
-		return starlarkBindingNamed(symbol, *destinationRoot) //nolint:staticcheck
+		return starlarkBindingNamed(symbol, *destinationRoot), nil //nolint:staticcheck
 	}
 }
 
-func starlarkBindingNamed(name string, node Node) (*Node, error) {
-	captures, err := allCaptures(starlarkExportQuery, node)
-	if err != nil {
-		return nil, err
-	}
+func starlarkBindingNamed(name string, node Node) *Node {
+	captures := allCaptures(starlarkExportQuery, node)
 	for _, capture := range captures {
 		if capture.Node.Content(capture.Contents) == name {
-			return swapNodePtr(node, capture.Node), nil
+			return swapNodePtr(node, capture.Node)
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 func getStringContents(node Node) string {

--- a/cmd/symbols/squirrel/local_code_intel.go
+++ b/cmd/symbols/squirrel/local_code_intel.go
@@ -38,18 +38,15 @@ func (s *SquirrelService) LocalCodeIntel(ctx context.Context, repoCommitPath typ
 
 	// Collect scopes
 	scopes := map[NodeId]Scope{}
-	err = forEachCapture(root.LangSpec.localsQuery, *root, func(nameToNode map[string]Node) {
+	forEachCapture(root.LangSpec.localsQuery, *root, func(nameToNode map[string]Node) {
 		if node, ok := nameToNode["scope"]; ok {
 			scopes[nodeId(node.Node)] = map[SymbolName]*PartialSymbol{}
 			return
 		}
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	// Collect defs
-	err = forEachCapture(root.LangSpec.localsQuery, *root, func(nameToNode map[string]Node) {
+	forEachCapture(root.LangSpec.localsQuery, *root, func(nameToNode map[string]Node) {
 		for captureName, node := range nameToNode {
 			// Only collect "definition*" captures.
 			if strings.HasPrefix(captureName, "definition") {
@@ -80,9 +77,6 @@ func (s *SquirrelService) LocalCodeIntel(ctx context.Context, repoCommitPath typ
 			}
 		}
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	// Collect refs by walking the entire tree.
 	walk(root.Node, func(node *sitter.Node) {

--- a/cmd/symbols/squirrel/service_test.go
+++ b/cmd/symbols/squirrel/service_test.go
@@ -179,8 +179,8 @@ func TestNonLocalDefinition(t *testing.T) {
 
 				t.Errorf("wrong symbolInfo for %q\n", symbol)
 				want := defAnn.repoCommitPathPoint
-				t.Errorf("want: %s%s/%s:%d:%d\n", itermSource(filepath.Join(cwd, "test_repos", want.Repo, want.Path), want.Point.Row, "src"), want.Repo, want.Path, want.Point.Row, want.Point.Column)
-				t.Errorf("got : %s%s/%s:%d:%d\n", itermSource(filepath.Join(cwd, "test_repos", got.Repo, got.Path), got.Point.Row, "src"), got.Repo, got.Path, got.Point.Row, got.Point.Column)
+				t.Errorf("want: %s%s/%s:%d:%d\n", itermSource(filepath.Join(cwd, "test_repos", want.Repo, want.Path), want.Point.Row), want.Repo, want.Path, want.Point.Row, want.Point.Column)
+				t.Errorf("got : %s%s/%s:%d:%d\n", itermSource(filepath.Join(cwd, "test_repos", got.Repo, got.Path), got.Point.Row), got.Repo, got.Path, got.Point.Row, got.Point.Column)
 			}
 
 			testCount += 1

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -134,7 +134,7 @@ func withQuery(query string, node Node, f func(query *sitter.Query, cursor *sitt
 
 // forEachCapture runs the given tree-sitter query on the given node and calls f(captureName, node) for
 // each capture.
-func forEachCapture(query string, node Node, f func(map[string]Node)) error {
+func forEachCapture(query string, node Node, f func(map[string]Node)) {
 	withQuery(query, node, func(sitterQuery *sitter.Query, cursor *sitter.QueryCursor) {
 		match, _, hasCapture := cursor.NextCapture()
 		for hasCapture {
@@ -152,11 +152,9 @@ func forEachCapture(query string, node Node, f func(map[string]Node)) error {
 			match, _, hasCapture = cursor.NextCapture()
 		}
 	})
-
-	return nil
 }
 
-func allCaptures(query string, node Node) ([]Node, error) {
+func allCaptures(query string, node Node) []Node {
 	var captures []Node
 	withQuery(query, node, func(sitterQuery *sitter.Query, cursor *sitter.QueryCursor) {
 		match, _, hasCapture := cursor.NextCapture()
@@ -173,7 +171,7 @@ func allCaptures(query string, node Node) ([]Node, error) {
 		}
 	})
 
-	return captures, nil
+	return captures
 }
 
 // nodeToRange returns the range of the node.
@@ -282,7 +280,7 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 	return &Node{RepoCommitPath: repoCommitPath, Node: root, Contents: contents, LangSpec: langSpec}, nil
 }
 
-func (s *SquirrelService) getSymbols(ctx context.Context, repoCommitPath types.RepoCommitPath) (result.Symbols, error) {
+func (s *SquirrelService) getSymbols(ctx context.Context, repoCommitPath types.RepoCommitPath) (result.Symbols, error) { //nolint:unparam
 	root, err := s.parse(context.Background(), repoCommitPath)
 	if err != nil {
 		return nil, err
@@ -295,10 +293,7 @@ func (s *SquirrelService) getSymbols(ctx context.Context, repoCommitPath types.R
 		return nil, nil
 	}
 
-	captures, err := allCaptures(query, *root)
-	if err != nil {
-		return nil, err
-	}
+	captures := allCaptures(query, *root)
 	for _, capture := range captures {
 		symbols = append(symbols, result.Symbol{
 			Name:        capture.Node.Content(root.Contents),

--- a/dev/linters/go.mod
+++ b/dev/linters/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e
 	golang.org/x/tools v0.7.0
 	honnef.co/go/tools v0.4.3
+	mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8
 )
 
 require (

--- a/dev/linters/go.sum
+++ b/dev/linters/go.sum
@@ -128,3 +128,5 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.4.3 h1:o/n5/K5gXqk8Gozvs2cnL0F2S1/g1vcGCAx2vETjITw=
 honnef.co/go/tools v0.4.3/go.mod h1:36ZgoUOrqOk1GxwHhyryEkq8FQWkUO2xGuSMhUCcdvA=
+mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8 h1:VuJo4Mt0EVPychre4fNlDWDuE5AjXtPJpRUWqZDQhaI=
+mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8/go.mod h1:Oh/d7dEtzsNHGOq1Cdv8aMm3KdKhVvPbRQcM8WFpBR8=

--- a/dev/linters/unparam/BUILD.bazel
+++ b/dev/linters/unparam/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "unparam",
+    srcs = ["unparam.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/unparam",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/linters/nolint",
+        "@cc_mvdan_unparam//check:go_default_library",
+        "@org_golang_x_tools//go/analysis",
+        "@org_golang_x_tools//go/analysis/passes/buildssa",
+        "@org_golang_x_tools//go/packages",
+    ],
+)

--- a/dev/linters/unparam/unparam.go
+++ b/dev/linters/unparam/unparam.go
@@ -1,0 +1,59 @@
+package unparam
+
+import (
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/packages"
+	"mvdan.cc/unparam/check"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
+)
+
+var Analyzer *analysis.Analyzer
+
+func init() {
+	Analyzer = nolint.Wrap(&analysis.Analyzer{
+		Name:             "unparam",
+		Doc:              "Reports unused function parameters and results in your code",
+		Run:              run,
+		Requires:         []*analysis.Analyzer{buildssa.Analyzer}, // required since unparam requires the result
+		RunDespiteErrors: false,
+	})
+
+}
+
+// Test is a test function to check that this linter works
+// To check whether this linter works, remove the nolint directive
+func Test(a string, b string) { //nolint:unparam
+	println("USING A but not B", a)
+}
+
+// run is lifted from golangci, with the only change in how issues are reported
+func run(pass *analysis.Pass) (interface{}, error) {
+	ssa := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+	ssaPkg := ssa.Pkg
+
+	pkg := &packages.Package{
+		Fset:      pass.Fset,
+		Syntax:    pass.Files,
+		Types:     pass.Pkg,
+		TypesInfo: pass.TypesInfo,
+	}
+
+	c := &check.Checker{}
+	c.CheckExportedFuncs(true)
+	c.Packages([]*packages.Package{pkg})
+	c.ProgramSSA(ssaPkg.Prog)
+
+	issues, err := c.Check()
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range issues {
+		pass.Report(analysis.Diagnostic{
+			Pos:     issue.Pos(),
+			Message: issue.Message(),
+		})
+	}
+	return nil, nil
+}

--- a/dev/linters/unparam/unparam.go
+++ b/dev/linters/unparam/unparam.go
@@ -41,7 +41,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	c := &check.Checker{}
-	c.CheckExportedFuncs(true)
+	c.CheckExportedFuncs(false)
 	c.Packages([]*packages.Package{pkg})
 	c.ProgramSSA(ssaPkg.Prog)
 

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1494,8 +1494,8 @@ WITH repos_with_permissions AS (SELECT DISTINCT repo_id FROM user_repo_permissio
 SELECT COUNT(repo.id)
 FROM repo
 	LEFT OUTER JOIN repos_with_permissions ON repos_with_permissions.repo_id = repo.id
-WHERE 
-	repo.deleted_at IS NULL 
+WHERE
+	repo.deleted_at IS NULL
 	AND repo.private = TRUE
 	AND repos_with_permissions.repo_id IS NULL
 `
@@ -1789,8 +1789,7 @@ WHERE perms.repo_id IN
 	return m, nil
 }
 
-//nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
-func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...otlog.Field)) {
+func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...otlog.Field)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
 	began := s.clock()
 	tr, ctx := trace.New(ctx, "database.PermsStore."+family, title)
 

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -190,8 +190,7 @@ func (c *Client) ListProjects(ctx context.Context, opts ListProjectsArgs) (proje
 	return c.listAllProjects(ctx, opts.Cursor)
 }
 
-//nolint:unparam // http.Response is never used, but it makes sense API wise.
-func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.Response, error) { //nolint:unparam // http.Response is never used, but it makes sense API wise.
 	req.URL = c.URL.ResolveReference(req.URL)
 
 	// Authenticate request with auther

--- a/linter_deps.bzl
+++ b/linter_deps.bzl
@@ -168,3 +168,10 @@ def linter_dependencies():
     version = "v2.0.1",
     sum = "h1:yr9ZswukmNxl/hmJHEoLEjCF1d+f2pQrC0m1jzVljAE=",
   )
+
+  go_repository(
+    name ="cc_mvdan_unparam",
+    importpath = "mvdan.cc/unparam",
+    version = "v0.0.0-20230312165513-e84e2d14e3b8",
+    sum = "h1:VuJo4Mt0EVPychre4fNlDWDuE5AjXtPJpRUWqZDQhaI=",
+  )


### PR DESCRIPTION
Adds https://github.com/mvdan/unparam as a nogo linter

Without `//nolint:unparam`
```
 bb //dev/linters/...
INFO: Analyzed 136 targets (0 packages loaded, 0 targets configured).
INFO: Found 136 targets...
ERROR: /Users/william/code/sourcegraph/dev/linters/unparam/BUILD.bazel:3:11: GoCompilePkg dev/linters/unparam/unparam.a failed: (Exit 1): builder failed: error executing command (from target //dev/linters/unparam:unparam) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -installsuffix darwin_arm64 -src dev/linters/unparam/unparam.go -embedroot '' ... (remaining 30 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: nogo: errors found by nogo during build-time code analysis:
dev/linters/unparam/unparam.go:27:21: Test - b is unused (unparam)
INFO: Elapsed time: 0.374s, Critical Path: 0.17s
INFO: 3 processes: 2 internal, 1 darwin-sandbox.
FAILED: Build did NOT complete successfully
```
With `//nolint:unparam`
```
bb //dev/linters/...
INFO: Analyzed 136 targets (0 packages loaded, 0 targets configured).
INFO: Found 136 targets...
INFO: Elapsed time: 0.261s, Critical Path: 0.11s
INFO: 3 processes: 1 internal, 2 darwin-sandbox.
INFO: Build completed successfully, 3 total actions
```
## Test plan
* Checked that a small function in the linter is picked up when the `//nolint:unparam` directive is removed
* Greem CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
