### PR TITLE
Cody: Fix input styling

### DIFF
--- a/client/cody-ui/src/Chat.module.css
+++ b/client/cody-ui/src/Chat.module.css
@@ -28,7 +28,7 @@
 .submit-button {
     position: absolute;
     right: 0;
-    bottom: 0;
+    bottom: 0.125rem;
     fill: currentColor;
     opacity: 0.8;
     margin: 0.25rem;

--- a/client/cody/webviews/Chat.module.css
+++ b/client/cody/webviews/Chat.module.css
@@ -58,8 +58,6 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
 .chat-input {
     outline: none;
-    color: var(--vscode-input-foreground);
-    background-color: var(--vscode-input-background);
 }
 
 :global(.token-hallucinated) {


### PR DESCRIPTION
We use the VS Code design system which already styles the input box for us, no need to add any custom colors anymore.

This fixes this overlap issue:

![image](https://user-images.githubusercontent.com/458591/232542316-0e16855d-24d9-4358-baad-96664169658d.png)
 
## Test plan

<img width="591" alt="Screenshot 2023-04-17 at 17 51 37" src="https://user-images.githubusercontent.com/458591/232542340-daaa4137-60a9-4d88-96e6-e16609661a57.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
