### PR TITLE
Cody: add changelog entry for context patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 - GitHub `repositoryQuery` searches now respect date ranges and use API requests more efficiently. #[49969](https://github.com/sourcegraph/sourcegraph/pull/49969)
 - Fixed an issue where search based references were not displayed in the references panel. [#50157](https://github.com/sourcegraph/sourcegraph/pull/50157)
-- Fixed an issue where Slack code monitoring notifications failed when the message was too long. [#50083](https://github.com/sourcegraph/sourcegraph/pull/50083)
 - Symbol suggestions only insert `type:symbol` filters when necessary. [#50183](https://github.com/sourcegraph/sourcegraph/pull/50183)
 
 ### Removed
@@ -52,7 +51,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- For Cody, explicitly detect some cases where context is needed to avoid failed responses. [#50541](https://github.com/sourcegraph/sourcegraph/pull/50541)
 
 ### Removed
 


### PR DESCRIPTION
Adds a changelog entry for #50541, which will be released in the 5.0.2 patch.

Also removes a duplicated entry that's in both Unreleased and 5.0.1 sections.

## Test plan

PR only touches changelog