### PR TITLE
Cody: improve onboarding process

### DIFF
--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -98,7 +98,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
 
     const onChatSubmit = useCallback((): void => {
         // Submit chat only when input is not empty
-        if (formInput !== undefined) {
+        if (formInput.trim()) {
             onSubmit(formInput)
             setHistoryIndex(inputHistory.length + 1)
             setInputHistory([...inputHistory, formInput])

--- a/client/cody-ui/src/utils/icons.tsx
+++ b/client/cody-ui/src/utils/icons.tsx
@@ -1,5 +1,39 @@
 import React from 'react'
 
+export const CodyColoredSvg = React.memo<{ className?: string }>(function CodySvg({ className }) {
+    return (
+        <svg
+            version="1.0"
+            xmlns="http://www.w3.org/2000/svg"
+            width="30"
+            height="30"
+            viewBox="0 0 128 128"
+            className={className}
+        >
+            <g transform="translate(0,128) scale(0.100000,-0.100000)">
+                <path
+                    fill="#FF5543"
+                    d="M832 1126 c-52 -28 -62 -61 -62 -199 0 -150 11 -186 67 -212 48 -23
+    99 -14 138 25 l30 30 3 135 c4 151 -8 194 -59 220 -34 18 -86 19 -117 1z"
+                />
+                <path
+                    fill="#A112FF"
+                    d="M219 967 c-45 -30 -63 -83 -46 -134 7 -23 25 -46 46 -60 31 -21 45
+    -23 163 -23 175 0 218 24 218 120 0 96 -43 120 -218 120 -118 0 -132 -2 -163
+    -23z"
+                />
+                <path
+                    d="M977 503 c-40 -38 -96 -80 -123 -95 -185 -100 -409 -68 -569 83 -56
+    52 -82 63 -124 54 -50 -11 -81 -51 -81 -104 0 -44 3 -49 73 -116 137 -132 305
+    -192 511 -182 186 9 308 62 446 193 83 80 85 83 85 129 0 40 -5 51 -33 76 -24
+    22 -42 29 -72 29 -36 0 -48 -8 -113 -67z"
+                    fill="#00CBEC"
+                />
+            </g>
+        </svg>
+    )
+})
+
 export const CodySvg = React.memo<{ className?: string }>(function CodySvg({ className }) {
     return (
         <svg

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -52,9 +52,8 @@
       "activitybar": [
         {
           "id": "cody",
-          "title": "Cody",
-          "icon": "resources/cody.svg",
-          "when": "cody.activated"
+          "title": "Sourcegraph Cody",
+          "icon": "resources/cody.svg"
         }
       ]
     },
@@ -64,7 +63,7 @@
           "type": "webview",
           "id": "cody.chat",
           "name": "Chat",
-          "when": "cody.activated"
+          "visibility": "visible"
         }
       ]
     },
@@ -75,55 +74,76 @@
       },
       {
         "command": "cody.recipe.explain-code",
-        "title": "Ask Cody: Explain Code in Detail"
+        "title": "Ask Cody: Explain Code in Detail",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.explain-code-high-level",
-        "title": "Ask Cody: Explain Code at a High Level"
+        "title": "Ask Cody: Explain Code at a High Level",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.generate-unit-test",
-        "title": "Ask Cody: Generate Unit Test"
+        "title": "Ask Cody: Generate Unit Test",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.generate-docstring",
-        "title": "Ask Cody: Generate Docstring"
+        "title": "Ask Cody: Generate Docstring",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.translate-to-language",
-        "title": "Ask Cody: Translate to Language"
+        "title": "Ask Cody: Translate to Language",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.git-history",
-        "title": "Ask Cody: Summarize Recent Code Changes"
+        "title": "Ask Cody: Summarize Recent Code Changes",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.improve-variable-names",
-        "title": "Ask Cody: Improve Variable Names"
+        "title": "Ask Cody: Improve Variable Names",
+        "when": "cody.activated"
       },
       {
         "command": "cody.recipe.fixup",
-        "title": "Cody: Fixup"
+        "title": "Ask Cody: Fixup Code",
+        "when": "cody.activated"
       },
       {
         "command": "cody.set-access-token",
-        "title": "Cody: Set Access Token"
+        "title": "Cody: Set Access Token",
+        "when": "!cody.activated"
       },
       {
         "command": "cody.delete-access-token",
-        "title": "Cody: Delete Access Token"
+        "title": "Cody: Delete Access Token",
+        "when": "cody.activated"
       },
       {
         "command": "cody.experimental.suggest",
-        "title": "Ask Cody: View Suggestions"
+        "title": "Ask Cody: View Suggestions",
+        "when": "cody.activated"
+      },
+      {
+        "command": "cody.settings",
+        "title": "Ask Cody: Settings",
+        "icon": "$(gear)",
+        "when": "cody.activated"
+      },
+      {
+        "command": "cody.focus",
+        "title": "Cody: Login to use Cody",
+        "when": "!cody.activated"
       }
     ],
     "keybindings": [
       {
         "command": "cody.chat.focus",
         "key": "alt+/",
-        "mac": "alt+/",
-        "when": "cody.activated"
+        "mac": "alt+/"
       },
       {
         "command": "cody.recipe.fixup",
@@ -140,9 +160,6 @@
     ],
     "menus": {
       "commandPalette": [
-        {
-          "command": "cody.toggle-enabled"
-        },
         {
           "command": "cody.recipe.explain-code",
           "when": "cody.activated"
@@ -170,42 +187,53 @@
         {
           "command": "cody.recipe.fixup",
           "when": "cody.activated"
-        },
-        {
-          "command": "cody.set-access-token"
-        },
-        {
-          "command": "cody.delete-access-token"
         }
       ],
       "editor/context": [
         {
           "submenu": "cody.submenu",
-          "group": "7_modification",
-          "when": "cody.activated"
+          "group": "7_modification"
         }
       ],
       "cody.submenu": [
         {
-          "command": "cody.recipe.explain-code"
+          "command": "cody.recipe.explain-code",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.explain-code-high-level"
+          "command": "cody.recipe.explain-code-high-level",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.generate-unit-test"
+          "command": "cody.recipe.generate-unit-test",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.generate-docstring"
+          "command": "cody.recipe.generate-docstring",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.improve-variable-names"
+          "command": "cody.recipe.improve-variable-names",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.translate-to-language"
+          "command": "cody.recipe.translate-to-language",
+          "when": "cody.activated"
         },
         {
-          "command": "cody.recipe.fixup"
+          "command": "cody.recipe.fixup",
+          "when": "cody.activated"
+        },
+        {
+          "command": "cody.focus",
+          "when": "!cody.activated"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "cody.settings",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation"
         }
       ]
     },
@@ -221,7 +249,7 @@
         "cody.serverEndpoint": {
           "type": "string",
           "default": "https://sourcegraph.com",
-          "example": "https://<instance>.sourcegraph.com",
+          "example": "https://example.sourcegraph.com",
           "description": "URL to the Sourcegraph instance."
         },
         "cody.codebase": {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -18,6 +18,7 @@ import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
+import { View } from '../../webviews/NavBar'
 import { LocalStorage } from '../command/LocalStorageProvider'
 import { updateConfiguration } from '../configuration'
 import { logEvent } from '../event-logger'
@@ -26,7 +27,7 @@ import { TestSupport } from '../test-support'
 
 import { ConfigurationSubsetForWebview, ExtensionMessage, WebviewMessage } from './protocol'
 
-async function isValidLogin(
+export async function isValidLogin(
     config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
 ): Promise<boolean> {
     const client = new SourcegraphGraphQLAPIClient(config)
@@ -86,10 +87,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     private async onDidReceiveMessage(message: WebviewMessage): Promise<void> {
         switch (message.command) {
             case 'initialized':
-                this.sendTranscript()
-                this.sendChatHistory()
                 this.publishContextStatus()
                 this.publishConfig()
+                this.sendTranscript()
+                this.sendChatHistory()
                 break
             case 'reset':
                 this.onResetChat()
@@ -107,6 +108,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                     accessToken: message.accessToken,
                     customHeaders: this.config.customHeaders,
                 })
+                // activate when user has valid login
+                await vscode.commands.executeCommand('setContext', 'cody.activated', isValid)
                 if (isValid) {
                     await updateConfiguration('serverEndpoint', message.serverEndpoint)
                     await this.secretStorage.store(CODY_ACCESS_TOKEN_SECRET, message.accessToken)
@@ -121,6 +124,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             }
             case 'removeToken':
                 await this.secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
+                await vscode.commands.executeCommand('setContext', 'cody.activated', false)
                 logEvent(
                     'CodyVSCodeExtension:codyDeleteAccessToken:clicked',
                     { serverEndpoint: this.config.serverEndpoint },
@@ -283,6 +287,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             await this.localStorage.setChatHistory(userHistory)
         }
     }
+
+    /**
+     * Save Login state to webview
+     */
+    public async sendLogin(isValid: boolean): Promise<void> {
+        await vscode.commands.executeCommand('setContext', 'cody.activated', isValid)
+        void this.webview?.postMessage({ type: 'login', isValid })
+    }
+
     /**
      * Sends chat history to webview
      */
@@ -321,15 +334,36 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Publish the config to the webview.
      */
     private publishConfig(): void {
-        const send = (): void => {
+        const send = async (): Promise<void> => {
+            // check if new configuration change is valid or not
+            // log user out if config is invalid
+            const isAuthed = await isValidLogin({
+                serverEndpoint: this.config.serverEndpoint,
+                accessToken: this.config.accessToken,
+                customHeaders: this.config.customHeaders,
+            })
             const configForWebview: ConfigurationSubsetForWebview = {
                 debug: this.config.debug,
-                hasAccessToken: this.config.accessToken !== null && this.config.accessToken !== '',
+                serverEndpoint: this.config.serverEndpoint,
+                hasAccessToken: isAuthed,
             }
+            void vscode.commands.executeCommand('setContext', 'cody.activated', isAuthed)
             void this.webview?.postMessage({ type: 'config', config: configForWebview })
         }
+
         this.disposables.push(this.configurationChangeEvent.event(() => send()))
-        send()
+        send().catch(error => console.error(error))
+    }
+
+    /**
+     * Set webview view
+     */
+    public setWebviewView(view: View): void {
+        void vscode.commands.executeCommand('cody.chat.focus')
+        void this.webview?.postMessage({
+            type: 'view',
+            messages: view,
+        })
     }
 
     /**

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -2,6 +2,8 @@ import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
+import { View } from '../../webviews/NavBar'
+
 /**
  * A message sent from the webview to the extension host.
  */
@@ -29,10 +31,11 @@ export type ExtensionMessage =
     | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean }
     | { type: 'debug'; message: string }
     | { type: 'contextStatus'; contextStatus: ChatContextStatus }
+    | { type: 'view'; messages: View }
 
 /**
  * The subset of configuration that is visible to the webview.
  */
-export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debug'> {
+export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debug' | 'serverEndpoint'> {
     hasAccessToken: boolean
 }

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -10,7 +10,7 @@ describe('getConfiguration', () => {
         expect(getConfiguration(config)).toEqual({
             enabled: true,
             serverEndpoint: '',
-            codebase: undefined,
+            codebase: '',
             debug: false,
             useContext: 'embeddings',
             experimentalSuggest: false,

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
-import { ChatViewProvider } from './chat/ChatViewProvider'
+import { ChatViewProvider, isValidLogin } from './chat/ChatViewProvider'
 import { LocalStorage } from './command/LocalStorageProvider'
 import { CodyCompletionItemProvider } from './completions'
 import { CompletionsDocumentProvider } from './completions/docprovider'
@@ -105,7 +105,6 @@ const register = async (
             webviewOptions: { retainContextWhenHidden: true },
         })
     )
-    await vscode.commands.executeCommand('setContext', 'cody.activated', true)
     disposables.push({ dispose: () => vscode.commands.executeCommand('setContext', 'cody.activated', false) })
 
     const executeRecipe = async (recipe: string): Promise<void> => {
@@ -113,12 +112,38 @@ const register = async (
         await chatProvider.executeRecipe(recipe)
     }
 
+    const workspaceConfig = vscode.workspace.getConfiguration()
+    const config = getConfiguration(workspaceConfig)
+
     disposables.push(
+        // Register URI Handler to resolve token sending back from sourcegraph.com
+        vscode.window.registerUriHandler({
+            handleUri: async (uri: vscode.Uri) => {
+                await workspaceConfig.update(
+                    'cody.serverEndpoint',
+                    'https://sourcegraph.com',
+                    vscode.ConfigurationTarget.Global
+                )
+                const token = new URLSearchParams(uri.query).get('code')
+                if (token && token.length > 8) {
+                    await context.secrets.store(CODY_ACCESS_TOKEN_SECRET, token)
+                    const isAuthed = await isValidLogin({
+                        serverEndpoint: 'https://sourcegraph.com',
+                        accessToken: token,
+                        customHeaders: config.customHeaders,
+                    })
+                    await chatProvider.sendLogin(isAuthed)
+                    logEvent(
+                        'CodyVSCodeExtension:codySetAccessToken:clicked',
+                        { serverEndpoint: config.serverEndpoint },
+                        { serverEndpoint: config.serverEndpoint }
+                    )
+                    void vscode.window.showInformationMessage('Token has been retreived and updated successfully')
+                }
+            },
+        }),
         // Toggle Chat
         vscode.commands.registerCommand('cody.toggle-enabled', async () => {
-            const workspaceConfig = vscode.workspace.getConfiguration()
-            const config = getConfiguration(workspaceConfig)
-
             await workspaceConfig.update(
                 'cody.enabled',
                 !workspaceConfig.get('cody.enabled'),
@@ -132,7 +157,6 @@ const register = async (
         }),
         // Access token
         vscode.commands.registerCommand('cody.set-access-token', async (args: any[]) => {
-            const config = getConfiguration(vscode.workspace.getConfiguration())
             const tokenInput = args?.length ? (args[0] as string) : await vscode.window.showInputBox()
             if (tokenInput === undefined || tokenInput === '') {
                 return
@@ -145,8 +169,8 @@ const register = async (
             )
         }),
         vscode.commands.registerCommand('cody.delete-access-token', async () => {
-            const config = getConfiguration(vscode.workspace.getConfiguration())
             await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
+            await vscode.commands.executeCommand('setContext', 'cody.activated', false)
             logEvent(
                 'CodyVSCodeExtension:codyDeleteAccessToken:clicked',
                 { serverEndpoint: config.serverEndpoint },
@@ -161,6 +185,8 @@ const register = async (
             localStorage.get('cody.tos-version-accepted')
         ),
         // Commands
+        vscode.commands.registerCommand('cody.focus', () => vscode.commands.executeCommand('cody.chat.focus')),
+        vscode.commands.registerCommand('cody.settings', () => chatProvider.setWebviewView('settings')),
         vscode.commands.registerCommand('cody.recipe.explain-code', () => executeRecipe('explain-code-detailed')),
         vscode.commands.registerCommand('cody.recipe.explain-code-high-level', () =>
             executeRecipe('explain-code-high-level')

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -18,7 +18,7 @@ import { UserHistory } from './UserHistory'
 import { vscodeAPI } from './utils/VSCodeApi'
 
 export function App(): React.ReactElement {
-    const [config, setConfig] = useState<Pick<Configuration, 'debug'> | null>(null)
+    const [config, setConfig] = useState<Pick<Configuration, 'debug' | 'serverEndpoint'> | null>(null)
     const [debugLog, setDebugLog] = useState(['No data yet'])
     const [view, setView] = useState<View | undefined>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
@@ -66,6 +66,9 @@ export function App(): React.ReactElement {
                 case 'contextStatus':
                     setContextStatus(message.contextStatus)
                     break
+                case 'view':
+                    setView(message.messages)
+                    break
             }
         })
 
@@ -101,9 +104,19 @@ export function App(): React.ReactElement {
 
     return (
         <div className="outer-container">
-            <Header showResetButton={view && view !== 'login'} onResetClick={onResetClick} />
-            {view === 'login' && <Login onLogin={onLogin} isValidLogin={isValidLogin} />}
-            {view && view !== 'login' && <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />}
+            <Header />
+            {view === 'login' && (
+                <Login onLogin={onLogin} isValidLogin={isValidLogin} serverEndpoint={config?.serverEndpoint} />
+            )}
+            {view && view !== 'login' && (
+                <NavBar
+                    view={view}
+                    setView={setView}
+                    devMode={Boolean(config?.debug)}
+                    onResetClick={onResetClick}
+                    showResetButton={transcript.length > 0}
+                />
+            )}
             {view === 'debug' && config?.debug && <Debug debugLog={debugLog} />}
             {view === 'history' && (
                 <UserHistory
@@ -113,7 +126,9 @@ export function App(): React.ReactElement {
                 />
             )}
             {view === 'recipes' && <Recipes />}
-            {view === 'settings' && <Settings setView={setView} onLogout={onLogout} />}
+            {view === 'settings' && (
+                <Settings setView={setView} onLogout={onLogout} serverEndpoint={config?.serverEndpoint} />
+            )}
             {view === 'chat' && (
                 <Chat
                     messageInProgress={messageInProgress}

--- a/client/cody/webviews/Header.tsx
+++ b/client/cody/webviews/Header.tsx
@@ -2,37 +2,19 @@ import { VSCodeTag } from '@vscode/webview-ui-toolkit/react'
 
 import './Header.css'
 
-import { CodySvg, ResetSvg } from '@sourcegraph/cody-ui/src/utils/icons'
+import { CodyColoredSvg } from '@sourcegraph/cody-ui/src/utils/icons'
 
-interface HeaderProps {
-    showResetButton: boolean
-    onResetClick: () => void
-}
-
-export const Header: React.FunctionComponent<React.PropsWithChildren<HeaderProps>> = ({
-    showResetButton,
-    onResetClick,
-}) => (
+export const Header: React.FunctionComponent = () => (
     <div className="header-container">
         <div className="header-container-left">
             <div className="header-logo">
-                <CodySvg />
+                <CodyColoredSvg />
             </div>
             <div className="header-title">
                 <span className="header-cody">Cody</span>
                 <VSCodeTag className="tag-beta">experimental</VSCodeTag>
             </div>
         </div>
-        <div className="header-container-right">
-            {/* eslint-disable jsx-a11y/click-events-have-key-events */}
-            {/* eslint-disable jsx-a11y/no-static-element-interactions */}
-            <div
-                className="reset-conversation"
-                title="Start a new conversation with Cody"
-                onClick={() => onResetClick()}
-            >
-                {showResetButton && <ResetSvg />}
-            </div>
-        </div>
+        <div className="header-container-right" />
     </div>
 )

--- a/client/cody/webviews/Login.module.css
+++ b/client/cody/webviews/Login.module.css
@@ -2,6 +2,13 @@
     padding: 1rem;
 }
 
+.wrapper {
+    color: var(--vscode-editor-foreground);
+    padding: 0.5rem;
+    background-color: var(--vscode-editor-background);
+    margin-bottom: 1rem;
+}
+
 .label {
     font-weight: bold;
 }
@@ -14,10 +21,6 @@
 .button {
     justify-content: center;
     width: 100%;
-
-    /* @vscode/webview-ui sets a 300px max-width. If we exceed that, the button will display a
-    glitchy-looking internal border. */
-    max-width: 300px;
 }
 
 .error {
@@ -29,4 +32,16 @@
 
 .terms {
     font-size: 85%;
+}
+
+.input-label {
+    display: flex;
+    color: var(--vscode-editor-foreground);
+    font-size: var(--vscode-editor-font-size);
+    justify-content: flex-start;
+    margin-bottom: 0.5rem;
+}
+
+.input-label i {
+    margin-right: 0.2rem;
 }

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -11,11 +11,16 @@ import styles from './Login.module.css'
 interface LoginProps {
     isValidLogin?: boolean
     onLogin: (token: string, endpoint: string) => void
+    serverEndpoint?: string
 }
 
-export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>> = ({ isValidLogin, onLogin }) => {
+export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>> = ({
+    isValidLogin,
+    onLogin,
+    serverEndpoint,
+}) => {
     const [token, setToken] = useState<string>('')
-    const [endpoint, setEndpoint] = useState('https://sourcegraph.com')
+    const [endpoint, setEndpoint] = useState(serverEndpoint || 'https://example.sourcegraph.com')
 
     const onSubmit = useCallback<React.FormEventHandler>(
         event => {
@@ -26,39 +31,70 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     )
 
     return (
-        <form className={styles.container} onSubmit={onSubmit}>
-            <label htmlFor="endpoint" className={styles.label}>
-                Sourcegraph URL
-            </label>
-            <VSCodeTextField
-                id="endpoint"
-                value={endpoint}
-                className={styles.input}
-                onInput={(e: any) => setEndpoint(e.target.value)}
-            />
-
-            <label htmlFor="accessToken" className={styles.label}>
-                Access Token
-            </label>
-            <VSCodeTextField
-                id="accessToken"
-                value={token}
-                placeholder=""
-                className={styles.input}
-                type={TextFieldType.password}
-                onInput={(e: any) => setToken(e.target.value)}
-            />
-
-            <VSCodeButton className={styles.button} type="submit">
-                Sign In
-            </VSCodeButton>
-            <div className={styles.terms} dangerouslySetInnerHTML={{ __html: renderMarkdown(CODY_TERMS_MARKDOWN) }} />
-
+        <div className={styles.container}>
             {isValidLogin === false && (
                 <p className={styles.error}>
                     Invalid credentials. Please check the Sourcegraph instance URL and access token.
                 </p>
             )}
-        </form>
+            <p className={styles.inputLabel}>
+                <i className="codicon codicon-organization" />
+                <span>Enterprise User</span>
+            </p>
+            <form className={styles.wrapper} onSubmit={onSubmit}>
+                <label htmlFor="endpoint" className={styles.inputLabel}>
+                    <i className="codicon codicon-link" />
+                    <span>Sourcegraph Instance URL</span>
+                </label>
+                <VSCodeTextField
+                    id="endpoint"
+                    value={endpoint}
+                    className={styles.input}
+                    onInput={(e: any) => setEndpoint(e.target.value)}
+                />
+
+                <label htmlFor="accessToken" className={styles.inputLabel}>
+                    <i className="codicon codicon-key" />
+                    <span>
+                        Personal Access Token (
+                        <a href="https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token">docs</a>)
+                    </span>
+                </label>
+                <VSCodeTextField
+                    id="accessToken"
+                    value={token}
+                    placeholder=""
+                    className={styles.input}
+                    type={TextFieldType.password}
+                    onInput={(e: any) => setToken(e.target.value)}
+                />
+
+                <VSCodeButton className={styles.button} type="submit">
+                    Sign In
+                </VSCodeButton>
+            </form>
+            <p className={styles.inputLabel}>
+                <i className="codicon codicon-account" />
+                <span>Community User</span>
+            </p>
+            <div className={styles.wrapper}>
+                <span>Connect Cody to sourcegraph.com in browser.</span>
+                <p className={styles.input}>
+                    <a href="https://docs.google.com/forms/d/e/1FAIpQLScSI06yGMls-V1FALvFyURi8U9bKRTSKPworBhzZEHDQvo0HQ/viewform">
+                        Click here to request access.
+                    </a>
+                </p>
+                <a href="https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=CODY">
+                    <VSCodeButton
+                        className={styles.button}
+                        type="button"
+                        onClick={() => setEndpoint('https://sourcegraph.com')}
+                    >
+                        Continue with sourcegraph.com
+                    </VSCodeButton>
+                </a>
+            </div>
+            <div className={styles.terms} dangerouslySetInnerHTML={{ __html: renderMarkdown(CODY_TERMS_MARKDOWN) }} />
+        </div>
     )
 }

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -81,7 +81,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                 <span>Connect Cody to sourcegraph.com in browser.</span>
                 <p className={styles.input}>
                     <a href="https://docs.google.com/forms/d/e/1FAIpQLScSI06yGMls-V1FALvFyURi8U9bKRTSKPworBhzZEHDQvo0HQ/viewform">
-                        Click here to request access.
+                        Fill out this form to request access.
                     </a>
                 </p>
                 <a href="https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=CODY">

--- a/client/cody/webviews/NavBar.tsx
+++ b/client/cody/webviews/NavBar.tsx
@@ -6,6 +6,8 @@ interface NavBarProps {
     setView: (selectedView: View) => void
     view: View
     devMode: boolean
+    onResetClick: () => void
+    showResetButton: boolean
 }
 
 interface NavBarItem {
@@ -18,7 +20,13 @@ const navBarItems: NavBarItem[] = [
     { tab: 'recipes', title: 'Recipes' },
 ]
 
-export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps>> = ({ setView, view, devMode }) => (
+export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps>> = ({
+    setView,
+    view,
+    devMode,
+    onResetClick,
+    showResetButton,
+}) => (
     <div className="tab-menu-container">
         <div className="tab-menu-group">
             {navBarItems.map(({ title, tab }) => (
@@ -33,15 +41,16 @@ export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps
             )}
         </div>
         <div className="tab-menu-group">
-            <button onClick={() => setView('settings')} className="tab-btn" type="button" title="Settings">
-                <i
-                    className={
-                        view === 'settings'
-                            ? 'codicon codicon-three-bars tab-btn-selected'
-                            : 'codicon codicon-three-bars'
-                    }
-                />
-            </button>
+            {showResetButton && (
+                <button
+                    onClick={() => onResetClick()}
+                    className="tab-btn"
+                    type="button"
+                    title="Start a new conversation"
+                >
+                    <i className="codicon codicon-refresh" />
+                </button>
+            )}
         </div>
     </div>
 )

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -7,12 +7,18 @@ import './Settings.css'
 interface SettingsProps {
     onLogout: () => void
     setView: (view: View) => void
+    serverEndpoint?: string
 }
 
-export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsProps>> = ({ onLogout, setView }) => (
+export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsProps>> = ({
+    onLogout,
+    setView,
+    serverEndpoint,
+}) => (
     <div className="inner-container">
         <div className="non-transcript-container">
             <div className="settings">
+                {serverEndpoint && <p>🟢 Connected to {serverEndpoint}</p>}
                 <VSCodeButton className="logout-button" type="button" onClick={() => setView('history')}>
                     Chat History
                 </VSCodeButton>


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/50713#event-9023253287
RE: [issue reported by user](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1681729029259269)
See Loom for detailed walkthrough of the changes included in this PR: https://www.loom.com/share/afd9e7e70bfa454881c61119aea2d8ed

Changes:
- Update UI based on [figma](https://www.figma.com/file/9112BsKsJc1BpO2j8XYwLL/%F0%9F%A4%96-Cody-%5BMain%5D?node-id=2649-12274&t=HdT9rlvaffeyCB0k-0) designed by @danielmarquespt 
- Set `cody.activated` to true only if the user is logged in with valid login credentials 
- Validate login on webview load (previously, we log users in as long as there is an access token)
- Validate login on configs change (RE [slack discussion](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1681731282332559?thread_ts=1681729029.259269&cid=C04MSD3DP5L))
- Add One-click login for Community (sourcegraph.com) users
  ![image](https://user-images.githubusercontent.com/68532117/232611217-902fa962-c60b-4e2f-99fb-de0e27b0ebcd.png)
- Display log-in message in the menu when trying to use right-click menu without logging in:
  ![image](https://user-images.githubusercontent.com/68532117/232611652-4c7ed01f-9990-44f8-b16a-74ce6c3575f0.png)
- Display recipes to logged-in users only
- Show button to `start a new conversation` only when there is an ongoing conversation
- Move settings button to top
- Fix: do not submit chat on send button click when the input is empty




## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See loom for details: https://www.loom.com/share/afd9e7e70bfa454881c61119aea2d8ed