### PR TITLE
Cody: fix prompt mixins

### DIFF
--- a/client/cody-shared/src/prompt/prompt-mixin.ts
+++ b/client/cody-shared/src/prompt/prompt-mixin.ts
@@ -15,7 +15,7 @@ export class PromptMixin {
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
             // Note we do not reflect them in displayText.
-            return { text: `${mixins}\n\n${humanMessage.text}`, ...humanMessage }
+            return { ...humanMessage, text: `${mixins}\n\nConversation starts here:\n\n${humanMessage.text}` }
         }
         return humanMessage
     }

--- a/client/cody-shared/src/prompt/prompt-mixin.ts
+++ b/client/cody-shared/src/prompt/prompt-mixin.ts
@@ -15,7 +15,7 @@ export class PromptMixin {
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
             // Note we do not reflect them in displayText.
-            return { ...humanMessage, text: `${mixins}\n\n${humanMessage.text}` }
+            return { text: `${mixins}\n\n${humanMessage.text}`, ...humanMessage }
         }
         return humanMessage
     }


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1681745964820819

In PromptMixin, the prompt is currently added after the human message so Cody would reply to the last prompt added to  PromptMixin when any non-question is sent in chat:

![image](https://user-images.githubusercontent.com/68532117/232623505-38afacfb-ee55-4e58-85d2-e9d3a96608e4.png)

Fix in this PR: Specific conversation starting point with `Conversation starts here:` seems to resolve the issue 

![image](https://user-images.githubusercontent.com/68532117/232628456-1fe3e60d-2db8-4088-bc93-0df87500ef64.png)
![image](https://user-images.githubusercontent.com/68532117/232631692-414d236d-9af2-42f4-b16c-640cacc66021.png)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally: submit a non-question message and get a valid response.


