### PR TITLE
clarify wording and defaults of cody vscode ext login screen

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -109,7 +109,7 @@
       },
       {
         "command": "cody.recipe.fixup",
-        "title": "Ask Cody: Fixup Code",
+        "title": "Cody: Fixup",
         "when": "cody.activated"
       },
       {
@@ -124,18 +124,18 @@
       },
       {
         "command": "cody.experimental.suggest",
-        "title": "Ask Cody: View Suggestions",
+        "title": "Cody: View Suggestions",
         "when": "cody.activated"
       },
       {
         "command": "cody.settings",
-        "title": "Ask Cody: Settings",
+        "title": "Cody: Settings",
         "icon": "$(gear)",
         "when": "cody.activated"
       },
       {
         "command": "cody.focus",
-        "title": "Cody: Login to use Cody",
+        "title": "Cody: Sign In to Use Cody",
         "when": "!cody.activated"
       }
     ],

--- a/client/cody/webviews/Login.module.css
+++ b/client/cody/webviews/Login.module.css
@@ -31,7 +31,7 @@
 }
 
 .terms {
-    font-size: 85%;
+    font-size: 90%;
 }
 
 .input-label {

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -20,12 +20,14 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     serverEndpoint,
 }) => {
     const [token, setToken] = useState<string>('')
-    const [endpoint, setEndpoint] = useState(serverEndpoint || 'https://example.sourcegraph.com')
+    const [endpoint, setEndpoint] = useState(serverEndpoint)
 
     const onSubmit = useCallback<React.FormEventHandler>(
         event => {
             event.preventDefault()
-            onLogin(token, endpoint)
+            if (endpoint) {
+                onLogin(token, endpoint)
+            }
         },
         [endpoint, onLogin, token]
     )
@@ -48,15 +50,16 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                 </label>
                 <VSCodeTextField
                     id="endpoint"
-                    value={endpoint}
+                    value={endpoint || ''}
                     className={styles.input}
+                    placeholder="https://example.sourcegraph.com"
                     onInput={(e: any) => setEndpoint(e.target.value)}
                 />
 
                 <label htmlFor="accessToken" className={styles.inputLabel}>
                     <i className="codicon codicon-key" />
                     <span>
-                        Personal Access Token (
+                        Access Token (
                         <a href="https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token">docs</a>)
                     </span>
                 </label>
@@ -75,10 +78,9 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             </form>
             <p className={styles.inputLabel}>
                 <i className="codicon codicon-account" />
-                <span>Community User</span>
+                <span>Everyone Else</span>
             </p>
             <div className={styles.wrapper}>
-                <span>Connect Cody to sourcegraph.com in browser.</span>
                 <p className={styles.input}>
                     <a href="https://docs.google.com/forms/d/e/1FAIpQLScSI06yGMls-V1FALvFyURi8U9bKRTSKPworBhzZEHDQvo0HQ/viewform">
                         Fill out this form to request access.
@@ -90,7 +92,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                         type="button"
                         onClick={() => setEndpoint('https://sourcegraph.com')}
                     >
-                        Continue with sourcegraph.com
+                        Continue with Sourcegraph.com
                     </VSCodeButton>
                 </a>
             </div>


### PR DESCRIPTION
- Only show `https://example.sourcegraph.com` as placeholder text, not actual text. This reduces the chance that users accidentally end up setting their serverEndpoint to the actual (invalid) value `https://example.sourcegraph.com`.
- Call it an Access Token (our term), not Personal Access Token (GitHub's term), to reduce the chance that users think they need to put in their GitHub personal access token.
- Remove needless text `Connect Cody to sourcegraph.com in browser.` because (IMO) that is implied by `Continue with Sourcegraph.com`.
- Uppercase `Sourcegraph.com` per our [usual style](https://handbook.sourcegraph.com/company-info-and-process/communication/content_guidelines/style_and_mechanics/#writing-about-ourselves).
- Say "Everyone Else" instead of "Community User" because (IMO) it is clearer.
- For VS Code commands, use `Ask Cody:` for recipes and `Cody:` for everything else. The exception is `Cody: Fixup`, which I think we should treat as more than just a recipe because it will be an important part of the user's frequent interaction with Cody.
- "Sign In" not "Login" for consistency.

## Test plan

n/a