### PR TITLE
Lower shard count for jest tests

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1895,7 +1895,7 @@ jest_test(
         ":web_tests",
     ],
     patch_node_fs = False,
-    shard_count = 6,  # this is has a large impact on the duration. We came to this number empirically.
+    shard_count = 5,  # this is has a large impact on the duration. We came to this number empirically.
     tags = [
         "no-sandbox",  # we are disabling the patch_node_fs, so the sandbox isn't really useful anymore.
     ],


### PR DESCRIPTION
We've observed some resource exhaustion with those tests, in particular when building typescript stuff in parallel. So we're lowering the shard count by 1 to see if it gets better. 

On the long run, splitting this target will solve most problems. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 
