### PR TITLE
bazel: mark bundlesize check as flaky

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -2062,4 +2062,5 @@ bundlesize_bin.bundlesize_test(
     env = {
         "WEB_BUNDLE_PATH": "$(rootpath //client/web:bundle-enterprise)",
     },
+    flaky = True,
 )


### PR DESCRIPTION
## Context

Mark bundlesize check as flaky in Bazel to avoid errors.

## Test plan

CI
