### PR TITLE
Cody: LLM-based intent detection PoC

### DIFF
--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -45,9 +45,14 @@ export class ChatQuestion implements Recipe {
             contextMessages.push(...codebaseContextMessages)
         }
 
-        if (isCodebaseContextRequired || intentDetector.isEditorContextRequired(text)) {
+        if (isCodebaseContextRequired || await intentDetector.isEditorContextRequired(text)) {
             contextMessages.push(...this.getEditorContext(editor))
         }
+
+        // TODO: Implement getting all open editor content
+        // if (await intentDetector.isEditorBroaderFileContextRequired(text)) {
+        //     contextMessages.push(...this.getEditorBroaderFileContext())
+        // }
 
         return contextMessages
     }

--- a/client/cody-shared/src/intent-detector/client.ts
+++ b/client/cody-shared/src/intent-detector/client.ts
@@ -11,15 +11,15 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
         return this.client.isContextRequiredForQuery(input)
     }
 
-    public isEditorContextRequired(input: string): boolean | Error {
+    public isEditorContextRequired(input: string): Promise<boolean | Error> {
         const inputLowerCase = input.toLowerCase()
         // If the input matches any of the `editorRegexps` we assume that we have to include
         // the editor context (e.g., currently open file) to the overall message context.
         for (const regexp of editorRegexps) {
             if (inputLowerCase.match(regexp)) {
-                return true
+                return Promise.resolve(true)
             }
         }
-        return false
+        return Promise.resolve(false)
     }
 }

--- a/client/cody-shared/src/intent-detector/helpers.ts
+++ b/client/cody-shared/src/intent-detector/helpers.ts
@@ -1,0 +1,65 @@
+import vscode from 'vscode'
+import execa from 'execa'
+import path from 'path'
+
+export function getProjectName(): string | undefined {
+    const workspaceFolders = vscode.workspace.workspaceFolders
+    if (!workspaceFolders) {
+        return undefined
+    }
+    const projectFolders = workspaceFolders?.filter(folder => folder.uri.scheme === 'file')
+    if (projectFolders.length === 1) {
+        return projectFolders[0].name
+    }
+    const activeTextEditor = vscode.window.activeTextEditor
+    if (!activeTextEditor) {
+        return undefined
+    }
+    const activeFileUri = activeTextEditor.document.uri
+    for (const projectFolder of projectFolders) {
+        if (activeFileUri.fsPath.startsWith(projectFolder.uri.fsPath)) {
+            return projectFolder.name
+        }
+    }
+    return undefined
+}
+
+export async function getRepoName(): Promise<string | undefined> {
+    const repoRoot = await getRepoRoot()
+    const { stdout } = await execa('git', ['remote', 'get-url', 'origin'], { cwd: repoRoot }) // TODO: Make "origin" dynamic
+    return stdout
+}
+
+async function getRepoRoot(): Promise<string | undefined> {
+    const filePath = getCurrentFilePath()
+    if (!filePath) {
+        return undefined
+    }
+
+    // Determine repository root directory.
+    const fileDirectory = path.dirname(filePath)
+    const { stdout: repoRoot } = await execa('git', ['rev-parse', '--show-toplevel'], { cwd: fileDirectory })
+    return repoRoot
+}
+
+export async function getCurrentBranchName(): Promise<string | undefined> {
+    const repoRoot = await getRepoRoot()
+
+    const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: repoRoot })
+    return stdout !== 'HEAD' ? stdout : undefined
+}
+
+export function getCurrentFilePath(): string | undefined {
+    const editor = vscode.window.activeTextEditor
+    if (!editor) {
+        return undefined
+    }
+    return editor.document.uri.fsPath
+}
+
+export function getOpenFilePaths(): string[] {
+    const tabs = vscode.window.tabGroups.activeTabGroup.tabs
+    return tabs.map(tab => tab.input ? (tab.input as {
+        uri: string | undefined
+    }).uri : undefined).filter(Boolean) as string[]
+}

--- a/client/cody-shared/src/intent-detector/index.ts
+++ b/client/cody-shared/src/intent-detector/index.ts
@@ -1,4 +1,5 @@
 export interface IntentDetector {
     isCodebaseContextRequired(input: string): Promise<boolean | Error>
-    isEditorContextRequired(input: string): boolean | Error
+    isEditorContextRequired(input: string): Promise<boolean | Error>
+// TODO: Add this:   isEditorBroaderFileContextRequired(input: string): Promise<boolean | Error>
 }

--- a/client/cody-shared/src/intent-detector/llm-based.ts
+++ b/client/cody-shared/src/intent-detector/llm-based.ts
@@ -1,0 +1,85 @@
+import { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
+
+import { IntentDetector } from '.'
+import { getCurrentBranchName, getCurrentFilePath, getOpenFilePaths, getProjectName, getRepoName } from './helpers'
+
+export class LlmBasedIntentDetector implements IntentDetector {
+    private cache = new Map<string, string>()
+
+    constructor(private completionsClient: SourcegraphCompletionsClient) {}
+
+    public async isEditorContextRequired(input: string): Promise<boolean | Error> {
+        if (!this.cache.has(input)) {
+            const response = await this.determineContextNeeds(input)
+            this.cache.set(input, response)
+        }
+
+        const response = this.cache.get(input)
+        return !!response && response.includes('a')
+    }
+
+    public async isEditorBroaderFileContextRequired(input: string): Promise<boolean | Error> {
+        if (!this.cache.has(input)) {
+            const response = await this.determineContextNeeds(input)
+            this.cache.set(input, response)
+        }
+
+        const response = this.cache.get(input)
+        return !!response && response.includes('b')
+    }
+
+    public async isCodebaseContextRequired(input: string): Promise<boolean | Error> {
+        if (!this.cache.has(input)) {
+            const response = await this.determineContextNeeds(input)
+            this.cache.set(input, response)
+        }
+        return this.cache.get(input) === 'c'
+    }
+
+    private async determineContextNeeds(input: string): Promise<string> {
+        const projectName = getProjectName()
+        const repoName = await getRepoName()
+        const currentFilePath = getCurrentFilePath() // TODO: Use repo-relative path
+        const branchName = await getCurrentBranchName()
+        const openFilePathsList = getOpenFilePaths()
+            .filter(p => p !== currentFilePath)
+            .join('", "') // TODO: Use repo-relative paths
+
+        const prompt = `\n\nHuman: I'm looking at my IDE. I have a project called "${projectName}" open, of repo "${repoName}", on branch ${branchName}.
+The file I'm looking at is at "${currentFilePath}". I also have these files open: "${openFilePathsList}".
+I have access to:
+ - the full repo, and can provide context from all of these sources.
+ - an amazing search engine to fetch some relevant file/snippets from the repo.
+
+My question is always: What would be the most helpful from the following options?
+ a.) the content of my currently open file
+ b.) the contents of some of my other open files
+ c.) search for code snippets with that cool search engine of mine
+ d.) probably none of the above
+
+Respond with one or more of the letters abcd, then any short explanation.
+
+My first question is: What's in my current file?\n
+Assistant: a - Only your current file is needed to answer this.\n
+Human: What's in my open files?\n\nAssistant: ab - Would help to see your current and other open files to answer this question.\n
+Human: Tell me where we do authentication\n\nAssistant: c - A smart search in the repo for auth-related files is needed.\n
+Human: What day is it today?\n\nAssistant: d - This question seems unrelated to code altogether.\n
+Human: ${input}\n\nAssistant: `
+
+//        console.log('Asking for context needs...', prompt)
+
+        const response = await this.completionsClient.complete({
+            prompt,
+            stopSequences: ['\n\nHuman:'],
+            maxTokensToSample: 200,
+            model: 'claude-instant-v1.0',
+            temperature: 1, // default value (source: https://console.anthropic.com/docs/api/reference)
+            topK: -1, // default value
+            topP: -1, // default value
+        })
+
+        console.log(response)
+
+        return response.completion.trim().split(' - ')[0]
+    }
+}

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -29,8 +29,8 @@ export class MockIntentDetector implements IntentDetector {
         return this.mocks.isCodebaseContextRequired?.(input) ?? Promise.resolve(false)
     }
 
-    public isEditorContextRequired(input: string): boolean | Error {
-        return this.mocks.isEditorContextRequired?.(input) ?? false
+    public isEditorContextRequired(input: string): Promise<boolean | Error> {
+        return this.mocks.isEditorContextRequired?.(input) ?? Promise.resolve(false)
     }
 }
 

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -3,7 +3,7 @@ import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
-import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
+import { LlmBasedIntentDetector } from '@sourcegraph/cody-shared/src/intent-detector/llm-based'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
@@ -48,7 +48,7 @@ export async function configureExternalServices(
     )
 
     return {
-        intentDetector: new SourcegraphIntentDetectorClient(client),
+        intentDetector: new LlmBasedIntentDetector(completions),
         codebaseContext,
         chatClient: new ChatClient(completions),
         completionsClient: completions,


### PR DESCRIPTION
This is something that I've wanted to do for a long time! It's a "Choose your adventure"-style, LLM-based intent detection PoC for Cody.
4-min Loom demo here: https://www.loom.com/share/1b97e6081d924033b03c99243ff3f9a8

Ways to improve this:
- Iterate on the prompt to get better choices. Btw, GPT-4 performed a lot better in my tests than our current LLM.
- Add Naman's [`getCompletionRequestMessages` logic](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/cody/search/translateToQuery.ts?L33) to immediately get a Sourcegraph search query in case of choice "c". Then we could run that query right away, and feed _those results_ in the context for Cody. ← This would be the next most powerful add that I have in mind
- Figure out the guidelines on when to use Sourcegraph search ("c") vs. embeddings search, and add embeddings search as an option.
- I haven't actually implemented the "get all open file contents in VS Code" logic because it seemed nontrivial, especially with the limited context.

I created this as an RFC, not intending to merge this in this form.

## Test plan

This is just a PoC

## App preview:

- [Web](https://sg-web-dv-cody-llm-based-context-picking.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
