### PR TITLE
cody: add git log recipe path select

### DIFF
--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -6,6 +6,9 @@ import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext } from './recipe'
 
+const getPathFromWorkspaceRoot = (filePath: string, workspaceRootPath: string) =>
+    filePath.replace(new RegExp(`^${workspaceRootPath}/`), '')
+
 export class GitHistory implements Recipe {
     public getID(): string {
         return 'git-history'
@@ -17,22 +20,39 @@ export class GitHistory implements Recipe {
             return null
         }
 
+        const activeTextEditor = context.editor.getActiveTextEditor()
+        const currentFile = activeTextEditor && getPathFromWorkspaceRoot(activeTextEditor.filePath, dirPath)
+
+        let path = ''
+        const pathOptions = ['Repo', currentFile ? `Current file: ${currentFile}` : '', 'Custom path'].filter(Boolean)
+        const selectedScope = await context.editor.showQuickPick(pathOptions)
+        if (selectedScope?.startsWith('Current file')) {
+            path = currentFile!
+        } else if (selectedScope === 'Custom path') {
+            const results = await context.editor.showOpenDialog({ canSelectFolders: true, canSelectFiles: true })
+            if (!results) {
+                return null
+            }
+            path = getPathFromWorkspaceRoot(results[0].path, dirPath)
+        }
+
         const logFormat = '--pretty="Commit author: %an%nCommit message: %s%nChange description:%b%n"'
+        const pathLabel = path ? `"${path}"` : 'my codebase'
         const items = [
             {
                 label: 'Last 5 items',
                 args: ['log', '-n5', logFormat],
-                rawDisplayText: 'What changed in my codebase in the last 5 commits?',
+                rawDisplayText: `What changed in ${pathLabel} in the last 5 commits?`,
             },
             {
                 label: 'Last day',
                 args: ['log', '--since', '1 day', logFormat],
-                rawDisplayText: 'What has changed in my codebase in the last day?',
+                rawDisplayText: `What has changed in ${pathLabel} in the last day?`,
             },
             {
                 label: 'Last week',
                 args: ['log', "--since='1 week'", logFormat],
-                rawDisplayText: 'What changed in my codebase in the last week?',
+                rawDisplayText: `What changed in ${pathLabel} in the last week?`,
             },
         ]
         const selectedLabel = await context.editor.showQuickPick(items.map(e => e.label))
@@ -44,6 +64,9 @@ export class GitHistory implements Recipe {
         )[selectedLabel]
 
         const { args: gitArgs, rawDisplayText } = selected
+        if (path) {
+            gitArgs.push(path)
+        }
 
         const gitLogCommand = spawnSync('git', ['--no-pager', ...gitArgs], { cwd: dirPath })
         const gitLogOutput = gitLogCommand.stdout.toString().trim()

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -29,4 +29,8 @@ export interface Editor {
     replaceSelection(fileName: string, selectedText: string, replacement: string): Promise<void>
     showQuickPick(labels: string[]): Promise<string | undefined>
     showWarningMessage(message: string): Promise<void>
+    showOpenDialog(options?: {
+        canSelectFolders?: boolean
+        canSelectFiles?: boolean
+    }): Promise<{ path: string; scheme: string }[] | undefined>
 }

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -142,4 +142,12 @@ export class VSCodeEditor implements Editor {
     public async showWarningMessage(message: string): Promise<void> {
         await vscode.window.showWarningMessage(message)
     }
+
+    public async showOpenDialog(options?: {
+        canSelectFolders?: boolean
+        canSelectFiles?: boolean
+    }): Promise<{ path: string; scheme: string }[] | undefined> {
+        const results = await vscode.window.showOpenDialog(options)
+        return results
+    }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/25318659/232776716-2c5c3f63-e640-4c96-9ebf-77df43841fc6.mov



## Test plan
TODO

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-cody-git-log-path.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

