### PR TITLE
executors: Extend integration test suite

### DIFF
--- a/enterprise/dev/ci/integration/executors/hello_appender.py
+++ b/enterprise/dev/ci/integration/executors/hello_appender.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import os
+from glob import glob
+
+def main():
+  files = []
+  start_dir = os.getcwd()
+  pattern = "*README.md"
+
+  for dir, _, _ in os.walk(start_dir):
+    files.extend(glob(os.path.join(dir, pattern)))
+
+  for filename in files:
+    with open(filename, 'a') as f:
+      f.write('Hello world from a python file!\n')
+
+
+if __name__ == "__main__":
+  main()

--- a/enterprise/dev/ci/integration/executors/run.sh
+++ b/enterprise/dev/ci/integration/executors/run.sh
@@ -22,7 +22,7 @@ cleanup() {
   popd 1>/dev/null
   rm -rf "${TMP_WORK_DIR}"
 }
-trap cleanup EXIT
+#trap cleanup EXIT
 
 export POSTGRES_IMAGE="us.gcr.io/sourcegraph-dev/postgres-12-alpine:${CANDIDATE_VERSION}"
 export SERVER_IMAGE="us.gcr.io/sourcegraph-dev/server:${CANDIDATE_VERSION}"

--- a/enterprise/dev/ci/integration/executors/tester/BUILD.bazel
+++ b/enterprise/dev/ci/integration/executors/tester/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "init.go",
         "main.go",
+        "testcases.go",
         "testinfra.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/integration/executors/tester",

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -67,11 +67,10 @@ func main() {
 
 	// Now that we have our repositories synced and cloned into the instance, we
 	// can start testing.
-
-	// TODO: Just one basic test for now, we want to extend this more later.
 	testCases := []Test{
 		testHelloWorldBatchChange(),
 		testEnvObjectBatchChange(),
+		testFileMountBatchChange(),
 	}
 
 	for _, t := range testCases {

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -70,7 +70,7 @@ func main() {
 	testCases := []Test{
 		testHelloWorldBatchChange(),
 		testEnvObjectBatchChange(),
-		testFileMountBatchChange(),
+		testFromFileBatchChange(),
 	}
 
 	for _, t := range testCases {

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -81,10 +81,12 @@ func main() {
 	// Now that we have our repositories synced and cloned into the instance, we
 	// can start testing.
 	testCases := []Test{
-		//testHelloWorldBatchChange(),
-		//testEnvObjectBatchChange(),
-		//testFromFileBatchChange(),
-		testFileMountBatchChange(httpClient),
+		testHelloWorldBatchChange(false),
+		// run again: should be using a cached result
+		testHelloWorldBatchChange(true),
+		testEnvObjectBatchChange(),
+		testFromFileBatchChange(),
+		//testFileMountBatchChange(httpClient),
 	}
 
 	for _, t := range testCases {

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -71,6 +71,7 @@ func main() {
 	// TODO: Just one basic test for now, we want to extend this more later.
 	testCases := []Test{
 		testHelloWorldBatchChange(),
+		testEnvObjectBatchChange(),
 	}
 
 	for _, t := range testCases {

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -2,19 +2,16 @@ package main
 
 import (
 	"context"
-	"strings"
 
 	"github.com/sourcegraph/log"
 
 	batchesstore "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -72,274 +69,15 @@ func main() {
 	// can start testing.
 
 	// TODO: Just one basic test for now, we want to extend this more later.
-
-	if err := RunTest(ctx, client, bstore, Test{
-		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
-		BatchSpecInput:          batchSpec,
-		ExpectedCacheEntries: map[string]execution.AfterStepResult{
-			"wHcoEItqNkdJj9k1-1sRCQ-step-0": {
-				Version: 2,
-				Stdout:  "Hello World\n",
-				Diff:    []byte(expectedDiff),
-				Outputs: map[string]any{},
-			},
-		},
-		ExpectedChangesetSpecs: []*types.ChangesetSpec{
-			{
-				Type:              "branch",
-				DiffStatAdded:     5,
-				DiffStatDeleted:   5,
-				BatchSpecID:       2,
-				BaseRepoID:        1,
-				UserID:            1,
-				BaseRev:           "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
-				BaseRef:           "executors-e2e",
-				HeadRef:           "refs/heads/hello-world",
-				Title:             "Hello World",
-				Body:              "My first batch change!",
-				CommitMessage:     "Append Hello World to all README.md files",
-				CommitAuthorName:  "sourcegraph",
-				CommitAuthorEmail: "sourcegraph@sourcegraph.com",
-				Diff:              []byte(expectedDiff),
-			},
-		},
-		ExpectedState: expectedState,
-		CacheDisabled: true,
-	}); err != nil {
-		logger.Fatal("Running test", log.Error(err))
+	testCases := []Test{
+		testHelloWorldBatchChange(),
 	}
-}
 
-const batchSpec = `
-name: e2e-test-batch-change
-description: Add Hello World to READMEs
-
-on:
-  - repository: github.com/sourcegraph/automation-testing
-    # This branch is never changing - hopefully.
-    branch: executors-e2e
-
-steps:
-  - run: IFS=$'\n'; echo Hello World | tee -a $(find -name README.md)
-    container: ubuntu:18.04
-
-changesetTemplate:
-  title: Hello World
-  body: My first batch change!
-  branch: hello-world # Push the commit to this branch.
-  commit:
-    message: Append Hello World to all README.md files
-`
-
-var expectedDiff = strings.Join([]string{
-	"diff --git README.md README.md",
-	"index 1914491..89e55af 100644",
-	"--- README.md",
-	"+++ README.md",
-	"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
-	" ",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	"-(c) Copyright Sourcegraph 2013-2020.",
-	"\\ No newline at end of file",
-	"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-	"diff --git examples/README.md examples/README.md",
-	"index 40452a9..a32cc2f 100644",
-	"--- examples/README.md",
-	"+++ examples/README.md",
-	"@@ -5,4 +5,4 @@ This folder contains examples",
-	" (This is a test message, ignore)",
-	" ",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	"-(c) Copyright Sourcegraph 2013-2020.",
-	"\\ No newline at end of file",
-	"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-	"diff --git examples/project3/README.md examples/project3/README.md",
-	"index 272d9ea..f49f17d 100644",
-	"--- examples/project3/README.md",
-	"+++ examples/project3/README.md",
-	"@@ -1,4 +1,4 @@",
-	" # project3",
-	" ",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	"-(c) Copyright Sourcegraph 2013-2020.",
-	"\\ No newline at end of file",
-	"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-	"diff --git project1/README.md project1/README.md",
-	"index 8a5f437..6284591 100644",
-	"--- project1/README.md",
-	"+++ project1/README.md",
-	"@@ -3,4 +3,4 @@",
-	" This is project 1.",
-	" ",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	"-(c) Copyright Sourcegraph 2013-2020.",
-	"\\ No newline at end of file",
-	"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-	"diff --git project2/README.md project2/README.md",
-	"index b1e1cdd..9445efe 100644",
-	"--- project2/README.md",
-	"+++ project2/README.md",
-	"@@ -1,3 +1,3 @@",
-	" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
-	" (c) Copyright Sourcegraph 2013-2020.",
-	"-(c) Copyright Sourcegraph 2013-2020.",
-	"\\ No newline at end of file",
-	"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-	"",
-}, "\n")
-
-var expectedState = gqltestutil.BatchSpecDeep{
-	State: "COMPLETED",
-	ChangesetSpecs: gqltestutil.BatchSpecChangesetSpecs{
-		TotalCount: 1,
-		Nodes: []gqltestutil.ChangesetSpec{
-			{
-				Type: "BRANCH",
-				Description: gqltestutil.ChangesetSpecDescription{
-					BaseRepository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
-					BaseRef:        "executors-e2e",
-					BaseRev:        "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
-					HeadRef:        "hello-world",
-					Title:          "Hello World",
-					Body:           "My first batch change!",
-					Commits: []gqltestutil.ChangesetSpecCommit{
-						{
-							Message: "Append Hello World to all README.md files",
-							Subject: "Append Hello World to all README.md files",
-							Body:    "",
-							Author: gqltestutil.ChangesetSpecCommitAuthor{
-								Name:  "sourcegraph",
-								Email: "sourcegraph@sourcegraph.com",
-							},
-						},
-					},
-					Diffs: gqltestutil.ChangesetSpecDiffs{
-						FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
-							RawDiff: ``,
-						},
-					},
-				},
-				ForkTarget: gqltestutil.ChangesetForkTarget{},
-			},
-		},
-	},
-	Namespace: gqltestutil.Namespace{},
-	WorkspaceResolution: gqltestutil.WorkspaceResolution{
-		Workspaces: gqltestutil.WorkspaceResolutionWorkspaces{
-			TotalCount: 1,
-			Stats: gqltestutil.WorkspaceResolutionWorkspacesStats{
-				Completed: 1,
-			},
-			Nodes: []gqltestutil.BatchSpecWorkspace{
-				{
-					State: "COMPLETED",
-					DiffStat: gqltestutil.DiffStat{
-						Added:   5,
-						Deleted: 5,
-					},
-					Repository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
-					Branch: gqltestutil.WorkspaceBranch{
-						Name: "executors-e2e",
-					},
-					ChangesetSpecs: []gqltestutil.WorkspaceChangesetSpec{
-						{},
-					},
-					SearchResultPaths: []string{},
-					Executor: gqltestutil.Executor{
-						QueueName: "batches",
-						Active:    true,
-					},
-					Stages: gqltestutil.BatchSpecWorkspaceStages{
-						Setup: []gqltestutil.ExecutionLogEntry{
-							{
-								Key:      "setup.git.init",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.git.add-remote",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.git.disable-gc",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.git.fetch",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.git.checkout",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.git.set-remote",
-								ExitCode: 0,
-							},
-							{
-								Key:      "setup.fs.extras",
-								Command:  []string{},
-								ExitCode: 0,
-							},
-						},
-						SrcExec: []gqltestutil.ExecutionLogEntry{
-							{
-								Key:      "step.docker.step.0.pre",
-								ExitCode: 0,
-							},
-							{
-								Key:      "step.docker.step.0.run",
-								ExitCode: 0,
-							},
-							{
-								Key:      "step.docker.step.0.post",
-								ExitCode: 0,
-							},
-						},
-						Teardown: []gqltestutil.ExecutionLogEntry{
-							{
-								Key:      "teardown.fs",
-								Command:  []string{},
-								ExitCode: 0,
-							},
-						},
-					},
-					Steps: []gqltestutil.BatchSpecWorkspaceStep{
-						{
-							Number:    1,
-							Run:       "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
-							Container: "ubuntu:18.04",
-							OutputLines: gqltestutil.WorkspaceOutputLines{
-								Nodes: []string{
-									"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
-									"stderr: Hello World",
-									"",
-								},
-								TotalCount: 3,
-							},
-							ExitCode:        0,
-							Environment:     []gqltestutil.WorkspaceEnvironmentVariable{},
-							OutputVariables: []gqltestutil.WorkspaceOutputVariable{},
-							DiffStat: gqltestutil.DiffStat{
-								Added:   5,
-								Deleted: 5,
-							},
-							Diff: gqltestutil.ChangesetSpecDiffs{
-								FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
-									RawDiff: "diff --git README.md README.md\nindex 1914491..89e55af 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/README.md examples/README.md\nindex 40452a9..a32cc2f 100644\n--- examples/README.md\n+++ examples/README.md\n@@ -5,4 +5,4 @@ This folder contains examples\n (This is a test message, ignore)\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/project3/README.md examples/project3/README.md\nindex 272d9ea..f49f17d 100644\n--- examples/project3/README.md\n+++ examples/project3/README.md\n@@ -1,4 +1,4 @@\n # project3\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project1/README.md project1/README.md\nindex 8a5f437..6284591 100644\n--- project1/README.md\n+++ project1/README.md\n@@ -3,4 +3,4 @@\n This is project 1.\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project2/README.md project2/README.md\nindex b1e1cdd..9445efe 100644\n--- project2/README.md\n+++ project2/README.md\n@@ -1,3 +1,3 @@\n This is a starter template for [Learn Next.js](https://nextjs.org/learn).\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\n",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	},
-	Source: "REMOTE",
-	Files: gqltestutil.BatchSpecFiles{
-		TotalCount: 0,
-		Nodes:      []gqltestutil.BatchSpecFile{},
-	},
+	for _, t := range testCases {
+		if err := RunTest(ctx, client, bstore, t); err != nil {
+			logger.Fatal("Running test", log.Error(err))
+		}
+	}
 }
 
 func initDB(logger log.Logger) (database.DB, error) {

--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -86,7 +86,7 @@ func main() {
 		testHelloWorldBatchChange(true),
 		testEnvObjectBatchChange(),
 		testFromFileBatchChange(),
-		//testFileMountBatchChange(httpClient),
+		//testFileMountBatchChange(),
 	}
 
 	for _, t := range testCases {

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
+)
+
+func testHelloWorldBatchChange() Test {
+	batchSpec := `
+name: e2e-test-batch-change
+description: Add Hello World to READMEs
+
+on:
+  - repository: github.com/sourcegraph/automation-testing
+    # This branch is never changing - hopefully.
+    branch: executors-e2e
+
+steps:
+  - run: IFS=$'\n'; echo Hello World | tee -a $(find -name README.md)
+    container: ubuntu:18.04
+
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world # Push the commit to this branch.
+  commit:
+    message: Append Hello World to all README.md files
+`
+
+	expectedDiff := strings.Join([]string{
+		"diff --git README.md README.md",
+		"index 1914491..89e55af 100644",
+		"--- README.md",
+		"+++ README.md",
+		"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
+		"diff --git examples/README.md examples/README.md",
+		"index 40452a9..a32cc2f 100644",
+		"--- examples/README.md",
+		"+++ examples/README.md",
+		"@@ -5,4 +5,4 @@ This folder contains examples",
+		" (This is a test message, ignore)",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
+		"diff --git examples/project3/README.md examples/project3/README.md",
+		"index 272d9ea..f49f17d 100644",
+		"--- examples/project3/README.md",
+		"+++ examples/project3/README.md",
+		"@@ -1,4 +1,4 @@",
+		" # project3",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
+		"diff --git project1/README.md project1/README.md",
+		"index 8a5f437..6284591 100644",
+		"--- project1/README.md",
+		"+++ project1/README.md",
+		"@@ -3,4 +3,4 @@",
+		" This is project 1.",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
+		"diff --git project2/README.md project2/README.md",
+		"index b1e1cdd..9445efe 100644",
+		"--- project2/README.md",
+		"+++ project2/README.md",
+		"@@ -1,3 +1,3 @@",
+		" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
+		"",
+	}, "\n")
+
+	expectedState := gqltestutil.BatchSpecDeep{
+		State: "COMPLETED",
+		ChangesetSpecs: gqltestutil.BatchSpecChangesetSpecs{
+			TotalCount: 1,
+			Nodes: []gqltestutil.ChangesetSpec{
+				{
+					Type: "BRANCH",
+					Description: gqltestutil.ChangesetSpecDescription{
+						BaseRepository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
+						BaseRef:        "executors-e2e",
+						BaseRev:        "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+						HeadRef:        "hello-world",
+						Title:          "Hello World",
+						Body:           "My first batch change!",
+						Commits: []gqltestutil.ChangesetSpecCommit{
+							{
+								Message: "Append Hello World to all README.md files",
+								Subject: "Append Hello World to all README.md files",
+								Body:    "",
+								Author: gqltestutil.ChangesetSpecCommitAuthor{
+									Name:  "sourcegraph",
+									Email: "sourcegraph@sourcegraph.com",
+								},
+							},
+						},
+						Diffs: gqltestutil.ChangesetSpecDiffs{
+							FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+								RawDiff: ``,
+							},
+						},
+					},
+					ForkTarget: gqltestutil.ChangesetForkTarget{},
+				},
+			},
+		},
+		Namespace: gqltestutil.Namespace{},
+		WorkspaceResolution: gqltestutil.WorkspaceResolution{
+			Workspaces: gqltestutil.WorkspaceResolutionWorkspaces{
+				TotalCount: 1,
+				Stats: gqltestutil.WorkspaceResolutionWorkspacesStats{
+					Completed: 1,
+				},
+				Nodes: []gqltestutil.BatchSpecWorkspace{
+					{
+						State: "COMPLETED",
+						DiffStat: gqltestutil.DiffStat{
+							Added:   5,
+							Deleted: 5,
+						},
+						Repository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
+						Branch: gqltestutil.WorkspaceBranch{
+							Name: "executors-e2e",
+						},
+						ChangesetSpecs: []gqltestutil.WorkspaceChangesetSpec{
+							{},
+						},
+						SearchResultPaths: []string{},
+						Executor: gqltestutil.Executor{
+							QueueName: "batches",
+							Active:    true,
+						},
+						Stages: gqltestutil.BatchSpecWorkspaceStages{
+							Setup: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "setup.git.init",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.add-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.disable-gc",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.fetch",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.checkout",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.set-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.fs.extras",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+							SrcExec: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "step.docker.step.0.pre",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.run",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.post",
+									ExitCode: 0,
+								},
+							},
+							Teardown: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "teardown.fs",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+						},
+						Steps: []gqltestutil.BatchSpecWorkspaceStep{
+							{
+								Number:    1,
+								Run:       "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
+								Container: "ubuntu:18.04",
+								OutputLines: gqltestutil.WorkspaceOutputLines{
+									Nodes: []string{
+										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
+										"stderr: Hello World",
+										"",
+									},
+									TotalCount: 3,
+								},
+								ExitCode:        0,
+								Environment:     []gqltestutil.WorkspaceEnvironmentVariable{},
+								OutputVariables: []gqltestutil.WorkspaceOutputVariable{},
+								DiffStat: gqltestutil.DiffStat{
+									Added:   5,
+									Deleted: 5,
+								},
+								Diff: gqltestutil.ChangesetSpecDiffs{
+									FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+										RawDiff: "diff --git README.md README.md\nindex 1914491..89e55af 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/README.md examples/README.md\nindex 40452a9..a32cc2f 100644\n--- examples/README.md\n+++ examples/README.md\n@@ -5,4 +5,4 @@ This folder contains examples\n (This is a test message, ignore)\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/project3/README.md examples/project3/README.md\nindex 272d9ea..f49f17d 100644\n--- examples/project3/README.md\n+++ examples/project3/README.md\n@@ -1,4 +1,4 @@\n # project3\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project1/README.md project1/README.md\nindex 8a5f437..6284591 100644\n--- project1/README.md\n+++ project1/README.md\n@@ -3,4 +3,4 @@\n This is project 1.\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project2/README.md project2/README.md\nindex b1e1cdd..9445efe 100644\n--- project2/README.md\n+++ project2/README.md\n@@ -1,3 +1,3 @@\n This is a starter template for [Learn Next.js](https://nextjs.org/learn).\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\n",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Source: "REMOTE",
+		Files: gqltestutil.BatchSpecFiles{
+			TotalCount: 0,
+			Nodes:      []gqltestutil.BatchSpecFile{},
+		},
+	}
+
+	return Test{
+		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
+		BatchSpecInput:          batchSpec,
+		ExpectedCacheEntries: map[string]execution.AfterStepResult{
+			"wHcoEItqNkdJj9k1-1sRCQ-step-0": {
+				Version: 2,
+				Stdout:  "Hello World\n",
+				Diff:    []byte(expectedDiff),
+				Outputs: map[string]any{},
+			},
+		},
+		ExpectedChangesetSpecs: []*types.ChangesetSpec{
+			{
+				Type:              "branch",
+				DiffStatAdded:     5,
+				DiffStatDeleted:   5,
+				BatchSpecID:       2,
+				BaseRepoID:        1,
+				UserID:            1,
+				BaseRev:           "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+				BaseRef:           "executors-e2e",
+				HeadRef:           "refs/heads/hello-world",
+				Title:             "Hello World",
+				Body:              "My first batch change!",
+				CommitMessage:     "Append Hello World to all README.md files",
+				CommitAuthorName:  "sourcegraph",
+				CommitAuthorEmail: "sourcegraph@sourcegraph.com",
+				Diff:              []byte(expectedDiff),
+			},
+		},
+		ExpectedState: expectedState,
+		CacheDisabled: true,
+	}
+}

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"text/template"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -247,7 +246,6 @@ func testEnvObjectBatchChange() Test {
 		CommitMessage:           "Append an env object to all README.md files",
 	}
 	batchSpec := generateBatchSpec(batchSpecPs)
-	log.Printf("Generated batch spec:\n%s", batchSpec)
 
 	diffPs := diffParams{
 		READMEObjectHash:         "23aa51b",
@@ -453,86 +451,6 @@ func testEnvObjectBatchChange() Test {
 }
 
 func testFileMountBatchChange() Test {
-	//	batchSpec := `
-	//name: e2e-test-batch-change-file-mount
-	//description: Add the value of a mounted file to READMEs
-	//
-	//on:
-	//  - repository: github.com/sourcegraph/automation-testing
-	//    # This branch is never changing - hopefully.
-	//    branch: executors-e2e
-	//
-	//steps:
-	//  - run: IFS=$'\n'; cat /tmp/hello-world.txt | tee -a $(find -name README.md)
-	//    container: alpine:3
-	//    files:
-	//      /tmp/hello-world.txt: Hello world from a file!
-	//
-	//changesetTemplate:
-	//  title: Hello World from file
-	//  body: My first batch change!
-	//  branch: file-mount # Push the commit to this branch.
-	//  commit:
-	//    message: Append the content of a mounted file to all README.md files
-	//`
-	//
-	//	expectedDiff := strings.Join([]string{
-	//		"diff --git README.md README.md",
-	//		"index 1914491..89e55af 100644",
-	//		"--- README.md",
-	//		"+++ README.md",
-	//		"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
-	//		" ",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		"-(c) Copyright Sourcegraph 2013-2020.",
-	//		"\\ No newline at end of file",
-	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
-	//		"diff --git examples/README.md examples/README.md",
-	//		"index 40452a9..a32cc2f 100644",
-	//		"--- examples/README.md",
-	//		"+++ examples/README.md",
-	//		"@@ -5,4 +5,4 @@ This folder contains examples",
-	//		" (This is a test message, ignore)",
-	//		" ",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		"-(c) Copyright Sourcegraph 2013-2020.",
-	//		"\\ No newline at end of file",
-	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
-	//		"diff --git examples/project3/README.md examples/project3/README.md",
-	//		"index 272d9ea..f49f17d 100644",
-	//		"--- examples/project3/README.md",
-	//		"+++ examples/project3/README.md",
-	//		"@@ -1,4 +1,4 @@",
-	//		" # project3",
-	//		" ",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		"-(c) Copyright Sourcegraph 2013-2020.",
-	//		"\\ No newline at end of file",
-	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
-	//		"diff --git project1/README.md project1/README.md",
-	//		"index 8a5f437..6284591 100644",
-	//		"--- project1/README.md",
-	//		"+++ project1/README.md",
-	//		"@@ -3,4 +3,4 @@",
-	//		" This is project 1.",
-	//		" ",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		"-(c) Copyright Sourcegraph 2013-2020.",
-	//		"\\ No newline at end of file",
-	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
-	//		"diff --git project2/README.md project2/README.md",
-	//		"index b1e1cdd..9445efe 100644",
-	//		"--- project2/README.md",
-	//		"+++ project2/README.md",
-	//		"@@ -1,3 +1,3 @@",
-	//		" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
-	//		" (c) Copyright Sourcegraph 2013-2020.",
-	//		"-(c) Copyright Sourcegraph 2013-2020.",
-	//		"\\ No newline at end of file",
-	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
-	//		"",
-	//	}, "\n")
 
 	return Test{}
 }

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -275,3 +275,7 @@ changesetTemplate:
 		CacheDisabled: true,
 	}
 }
+
+func testEnvVarBatchChange() Test {
+
+}

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -450,33 +450,33 @@ func testEnvObjectBatchChange() Test {
 	}
 }
 
-func testFileMountBatchChange() Test {
+func testFromFileBatchChange() Test {
 	batchSpecPs := batchSpecParams{
 		NameContent: "file-mount",
-		Description: "Add the content of a mounted file to READMEs",
+		Description: "Add the content of a file to READMEs",
 		RunCommand:  "IFS=$'\\n'; cat /tmp/hello-world.txt | tee -a $(find -name README.md)",
 		AdditionalKeyValues: []specStepBlock{
 			{
 				BlockName: "files",
 				KeyValues: []keyValue{
 					// Use a multi-line scalar to circumvent weird diff behaviour in the actual response
-					{Key: "/tmp/hello-world.txt", Value: "|\n        Hello world from a mounted file!"},
+					{Key: "/tmp/hello-world.txt", Value: "|\n        Hello world from a file!"},
 				},
 			},
 		},
-		ChangeSetTemplateTitle:  "Hello World from mounted file",
-		ChangeSetTemplateBranch: "file-mount",
-		CommitMessage:           "Append the content of a mounted file to all README.md files",
+		ChangeSetTemplateTitle:  "Hello World from file",
+		ChangeSetTemplateBranch: "file",
+		CommitMessage:           "Append the content of a file to all README.md files",
 	}
 	batchSpec := generateBatchSpec(batchSpecPs)
 
 	diffPs := diffParams{
-		READMEObjectHash:         "cf2aaac",
-		ExamplesREADMEObjectHash: "b36ca23",
-		Project3READMEObjectHash: "3c8b671",
-		Project1READMEObjectHash: "af08a9d",
-		Project2READMEObjectHash: "488f3ac",
-		HelloWorldMessage:        "Hello world from a mounted file!",
+		READMEObjectHash:         "1bfecb8",
+		ExamplesREADMEObjectHash: "79a6f77",
+		Project3READMEObjectHash: "287d7ea",
+		Project1READMEObjectHash: "30e9fe6",
+		Project2READMEObjectHash: "209f60f",
+		HelloWorldMessage:        "Hello world from a file!",
 	}
 	expectedDiff := generateDiff(diffPs)
 
@@ -633,11 +633,12 @@ func testFileMountBatchChange() Test {
 		},
 	}
 
+	// TODO: verify file mount in the expected state?
 	return Test{
 		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
 		BatchSpecInput:          batchSpec,
 		ExpectedCacheEntries: map[string]execution.AfterStepResult{
-			"rzrP_eyDXgEVvch3YZUG9A-step-0": {
+			"9_AvsVMDl3SJLH-vtwD5Lg-step-0": {
 				Version: 2,
 				Stdout:  fmt.Sprintf("%s\n", diffPs.HelloWorldMessage),
 				Diff:    []byte(expectedDiff),

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -709,7 +709,7 @@ func testFromFileBatchChange() Test {
 	}
 }
 
-func testFileMountBatchChange(client *HttpClient) Test {
+func testFileMountBatchChange() Test {
 	const fileName = "hello_appender.py"
 
 	batchSpecPs := batchSpecParams{

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"text/template"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -16,7 +17,6 @@ const (
 	authorName       = "sourcegraph"
 	authorEmail      = "sourcegraph@sourcegraph.com"
 	changeSetBody    = "My first batch change!"
-	container        = "alpine:3"
 )
 
 func testHelloWorldBatchChange() Test {
@@ -24,6 +24,7 @@ func testHelloWorldBatchChange() Test {
 		NameContent:             "hello-world",
 		Description:             "Add Hello World to READMEs",
 		RunCommand:              "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
+		Container:               "alpine:3",
 		ChangeSetTemplateTitle:  "Hello World",
 		ChangeSetTemplateBranch: "hello-world",
 		CommitMessage:           "Append Hello World to all README.md files",
@@ -159,7 +160,7 @@ func testHelloWorldBatchChange() Test {
 							{
 								Number:    1,
 								Run:       batchSpecPs.RunCommand,
-								Container: container,
+								Container: batchSpecPs.Container,
 								OutputLines: gqltestutil.WorkspaceOutputLines{
 									Nodes: []string{
 										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
@@ -233,7 +234,8 @@ func testEnvObjectBatchChange() Test {
 		NameContent: "env-object",
 		Description: "Add the value of an environment variable object to READMEs",
 		RunCommand:  "IFS=$'\\n'; echo $MESSAGE | tee -a $(find -name README.md)",
-		AdditionalKeyValues: []specStepBlock{
+		Container:   "alpine:3",
+		AdditionalBlocks: []specStepBlock{
 			{
 				BlockName: "env",
 				KeyValues: []keyValue{
@@ -376,7 +378,7 @@ func testEnvObjectBatchChange() Test {
 							{
 								Number:    1,
 								Run:       batchSpecPs.RunCommand,
-								Container: container,
+								Container: batchSpecPs.Container,
 								OutputLines: gqltestutil.WorkspaceOutputLines{
 									Nodes: []string{
 										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
@@ -388,8 +390,8 @@ func testEnvObjectBatchChange() Test {
 								ExitCode: 0,
 								Environment: []gqltestutil.WorkspaceEnvironmentVariable{
 									{
-										Name:  batchSpecPs.AdditionalKeyValues[0].KeyValues[0].Key,
-										Value: batchSpecPs.AdditionalKeyValues[0].KeyValues[0].Value,
+										Name:  batchSpecPs.AdditionalBlocks[0].KeyValues[0].Key,
+										Value: batchSpecPs.AdditionalBlocks[0].KeyValues[0].Value,
 									},
 								},
 								OutputVariables: []gqltestutil.WorkspaceOutputVariable{},
@@ -455,8 +457,10 @@ func testFromFileBatchChange() Test {
 		NameContent: "file-mount",
 		Description: "Add the content of a file to READMEs",
 		RunCommand:  "IFS=$'\\n'; cat /tmp/hello-world.txt | tee -a $(find -name README.md)",
-		AdditionalKeyValues: []specStepBlock{
+		Container:   "alpine:3",
+		AdditionalBlocks: []specStepBlock{
 			{
+				BlockType: Object,
 				BlockName: "files",
 				KeyValues: []keyValue{
 					// Use a multi-line scalar to circumvent weird diff behaviour in the actual response
@@ -599,7 +603,7 @@ func testFromFileBatchChange() Test {
 							{
 								Number:    1,
 								Run:       batchSpecPs.RunCommand,
-								Container: container,
+								Container: batchSpecPs.Container,
 								OutputLines: gqltestutil.WorkspaceOutputLines{
 									Nodes: []string{
 										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
@@ -633,7 +637,7 @@ func testFromFileBatchChange() Test {
 		},
 	}
 
-	// TODO: verify file mount in the expected state?
+	// TODO: verify file in the expected state?
 	return Test{
 		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
 		BatchSpecInput:          batchSpec,
@@ -666,6 +670,241 @@ func testFromFileBatchChange() Test {
 		},
 		ExpectedState: expectedState,
 		CacheDisabled: true,
+	}
+}
+
+func testFileMountBatchChange(client *HttpClient) Test {
+	const fileName = "hello_appender.py"
+
+	batchSpecPs := batchSpecParams{
+		NameContent: "file-mount",
+		Description: "Add a message from a python file to READMEs",
+		RunCommand:  "python /tmp/hello_appender.py",
+		Container:   "python:3.11-alpine",
+		AdditionalBlocks: []specStepBlock{
+			{
+				BlockType: Array,
+				BlockName: "mount",
+				KeyValues: []keyValue{
+					{Key: "path", Value: fmt.Sprintf("./%s", fileName)},
+					{Key: "mountpoint", Value: "/tmp/hello_appender.py"},
+				},
+			},
+		},
+		ChangeSetTemplateTitle:  "Hello World from mounted python file",
+		ChangeSetTemplateBranch: "mounted-file",
+		CommitMessage:           "Append a message from a python file to all README.md files",
+	}
+	batchSpec := generateBatchSpec(batchSpecPs)
+	log.Printf("Generated batch spec:\n%s", batchSpec)
+
+	diffPs := diffParams{
+		READMEObjectHash:         "1bfecb8",
+		ExamplesREADMEObjectHash: "79a6f77",
+		Project3READMEObjectHash: "287d7ea",
+		Project1READMEObjectHash: "30e9fe6",
+		Project2READMEObjectHash: "209f60f",
+		HelloWorldMessage:        "Hello world from a python file!",
+	}
+	expectedDiff := generateDiff(diffPs)
+
+	expectedState := gqltestutil.BatchSpecDeep{
+		State: "COMPLETED",
+		ChangesetSpecs: gqltestutil.BatchSpecChangesetSpecs{
+			TotalCount: 1,
+			Nodes: []gqltestutil.ChangesetSpec{
+				{
+					Type: "BRANCH",
+					Description: gqltestutil.ChangesetSpecDescription{
+						BaseRepository: gqltestutil.ChangesetRepository{Name: sourceRepository},
+						BaseRef:        sourceRef,
+						BaseRev:        "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+						HeadRef:        batchSpecPs.ChangeSetTemplateBranch,
+						Title:          batchSpecPs.ChangeSetTemplateTitle,
+						Body:           changeSetBody,
+						Commits: []gqltestutil.ChangesetSpecCommit{
+							{
+								Message: batchSpecPs.CommitMessage,
+								Subject: batchSpecPs.CommitMessage,
+								Body:    "",
+								Author: gqltestutil.ChangesetSpecCommitAuthor{
+									Name:  authorName,
+									Email: authorEmail,
+								},
+							},
+						},
+						Diffs: gqltestutil.ChangesetSpecDiffs{
+							FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+								RawDiff: ``,
+							},
+						},
+					},
+					ForkTarget: gqltestutil.ChangesetForkTarget{},
+				},
+			},
+		},
+		Namespace: gqltestutil.Namespace{},
+		WorkspaceResolution: gqltestutil.WorkspaceResolution{
+			Workspaces: gqltestutil.WorkspaceResolutionWorkspaces{
+				TotalCount: 1,
+				Stats: gqltestutil.WorkspaceResolutionWorkspacesStats{
+					Completed: 1,
+				},
+				Nodes: []gqltestutil.BatchSpecWorkspace{
+					{
+						State: "COMPLETED",
+						DiffStat: gqltestutil.DiffStat{
+							Added:   5,
+							Deleted: 5,
+						},
+						Repository: gqltestutil.ChangesetRepository{Name: sourceRepository},
+						Branch: gqltestutil.WorkspaceBranch{
+							Name: sourceRef,
+						},
+						ChangesetSpecs: []gqltestutil.WorkspaceChangesetSpec{
+							{},
+						},
+						SearchResultPaths: []string{},
+						Executor: gqltestutil.Executor{
+							QueueName: "batches",
+							Active:    true,
+						},
+						Stages: gqltestutil.BatchSpecWorkspaceStages{
+							Setup: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "setup.git.init",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.add-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.disable-gc",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.fetch",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.checkout",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.set-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.fs.extras",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+							SrcExec: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "step.docker.step.0.pre",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.run",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.post",
+									ExitCode: 0,
+								},
+							},
+							Teardown: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "teardown.fs",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+						},
+						Steps: []gqltestutil.BatchSpecWorkspaceStep{
+							{
+								Number:    1,
+								Run:       batchSpecPs.RunCommand,
+								Container: batchSpecPs.Container,
+								OutputLines: gqltestutil.WorkspaceOutputLines{
+									Nodes: []string{
+										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
+										"stderr: Hello World",
+										"",
+									},
+									TotalCount: 3,
+								},
+								ExitCode:        0,
+								Environment:     []gqltestutil.WorkspaceEnvironmentVariable{},
+								OutputVariables: []gqltestutil.WorkspaceOutputVariable{},
+								DiffStat: gqltestutil.DiffStat{
+									Added:   5,
+									Deleted: 5,
+								},
+								Diff: gqltestutil.ChangesetSpecDiffs{
+									FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+										RawDiff: expectedDiff,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Source: "REMOTE",
+		Files: gqltestutil.BatchSpecFiles{
+			TotalCount: 1,
+			Nodes: []gqltestutil.BatchSpecFile{
+				{
+					// TODO: get from params instead of hardcode
+					Path: "/tmp/",
+					Name: "hello_appender.py",
+				},
+			},
+		},
+	}
+
+	// TODO: verify file in the expected state?
+	return Test{
+		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
+		BatchSpecInput:          batchSpec,
+		ExpectedCacheEntries: map[string]execution.AfterStepResult{
+			"9_AvsVMDl3SJLH-vtwD5Lg-step-0": {
+				Version: 2,
+				Stdout:  fmt.Sprintf("%s\n", diffPs.HelloWorldMessage),
+				Diff:    []byte(expectedDiff),
+				Outputs: map[string]any{},
+			},
+		},
+		ExpectedChangesetSpecs: []*types.ChangesetSpec{
+			{
+				Type:              "branch",
+				DiffStatAdded:     5,
+				DiffStatDeleted:   5,
+				BatchSpecID:       2,
+				BaseRepoID:        1,
+				UserID:            1,
+				BaseRev:           "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+				BaseRef:           sourceRef,
+				HeadRef:           fmt.Sprintf("refs/heads/%s", batchSpecPs.ChangeSetTemplateBranch),
+				Title:             batchSpecPs.ChangeSetTemplateTitle,
+				Body:              changeSetBody,
+				CommitMessage:     batchSpecPs.CommitMessage,
+				CommitAuthorName:  authorName,
+				CommitAuthorEmail: authorEmail,
+				Diff:              []byte(expectedDiff),
+			},
+		},
+		ExpectedState: expectedState,
+		CacheDisabled: true,
+		FileUpload: gqltestutil.BatchSpecFile{
+			// TODO: get from params instead of hardcode
+			Path: "/tmp/",
+			Name: "hello_appender.py",
+		},
 	}
 }
 
@@ -753,7 +992,15 @@ type keyValue struct {
 	Value string
 }
 
+type blockType string
+
+const (
+	Array  blockType = "array"
+	Object blockType = "object"
+)
+
 type specStepBlock struct {
+	BlockType blockType
 	BlockName string
 	KeyValues []keyValue
 }
@@ -762,7 +1009,8 @@ type batchSpecParams struct {
 	NameContent             string
 	Description             string
 	RunCommand              string
-	AdditionalKeyValues     []specStepBlock
+	Container               string
+	AdditionalBlocks        []specStepBlock
 	ChangeSetTemplateTitle  string
 	ChangeSetTemplateBranch string
 	CommitMessage           string
@@ -780,14 +1028,16 @@ on:
 
 steps:
   - run: {{.RunCommand}}
-    container: alpine:3
-{{- range .AdditionalKeyValues }}
+    container: {{.Container}}
+{{- range .AdditionalBlocks }}
     {{.BlockName}}:
-    {{- range .KeyValues }}
+    {{if eq .BlockType "object"}}{{- range .KeyValues }}
       {{.Key}}: {{.Value}}
-    {{- end}}
+    {{- end}}{{else}}  - {{range .KeyValues -}}
+          {{.Key}}: {{.Value}}
+        {{end}}
+    {{end}}
 {{- end}}
-
 changesetTemplate:
   title: {{.ChangeSetTemplateTitle}}
   body: My first batch change!

--- a/enterprise/dev/ci/integration/executors/tester/testcases.go
+++ b/enterprise/dev/ci/integration/executors/tester/testcases.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"strings"
+	"text/template"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
@@ -9,84 +11,22 @@ import (
 )
 
 func testHelloWorldBatchChange() Test {
-	batchSpec := `
-name: e2e-test-batch-change
-description: Add Hello World to READMEs
+	batchSpec := generateBatchSpec(batchSpecParams{
+		NameContent:             "hello-world",
+		Description:             "Add Hello World to READMEs",
+		RunCommand:              "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
+		ChangeSetTemplateBranch: "hello-world",
+		CommitMessageContent:    "Hello World",
+	})
 
-on:
-  - repository: github.com/sourcegraph/automation-testing
-    # This branch is never changing - hopefully.
-    branch: executors-e2e
-
-steps:
-  - run: IFS=$'\n'; echo Hello World | tee -a $(find -name README.md)
-    container: ubuntu:18.04
-
-changesetTemplate:
-  title: Hello World
-  body: My first batch change!
-  branch: hello-world # Push the commit to this branch.
-  commit:
-    message: Append Hello World to all README.md files
-`
-
-	expectedDiff := strings.Join([]string{
-		"diff --git README.md README.md",
-		"index 1914491..89e55af 100644",
-		"--- README.md",
-		"+++ README.md",
-		"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
-		" ",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		"-(c) Copyright Sourcegraph 2013-2020.",
-		"\\ No newline at end of file",
-		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-		"diff --git examples/README.md examples/README.md",
-		"index 40452a9..a32cc2f 100644",
-		"--- examples/README.md",
-		"+++ examples/README.md",
-		"@@ -5,4 +5,4 @@ This folder contains examples",
-		" (This is a test message, ignore)",
-		" ",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		"-(c) Copyright Sourcegraph 2013-2020.",
-		"\\ No newline at end of file",
-		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-		"diff --git examples/project3/README.md examples/project3/README.md",
-		"index 272d9ea..f49f17d 100644",
-		"--- examples/project3/README.md",
-		"+++ examples/project3/README.md",
-		"@@ -1,4 +1,4 @@",
-		" # project3",
-		" ",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		"-(c) Copyright Sourcegraph 2013-2020.",
-		"\\ No newline at end of file",
-		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-		"diff --git project1/README.md project1/README.md",
-		"index 8a5f437..6284591 100644",
-		"--- project1/README.md",
-		"+++ project1/README.md",
-		"@@ -3,4 +3,4 @@",
-		" This is project 1.",
-		" ",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		"-(c) Copyright Sourcegraph 2013-2020.",
-		"\\ No newline at end of file",
-		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-		"diff --git project2/README.md project2/README.md",
-		"index b1e1cdd..9445efe 100644",
-		"--- project2/README.md",
-		"+++ project2/README.md",
-		"@@ -1,3 +1,3 @@",
-		" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
-		" (c) Copyright Sourcegraph 2013-2020.",
-		"-(c) Copyright Sourcegraph 2013-2020.",
-		"\\ No newline at end of file",
-		"+(c) Copyright Sourcegraph 2013-2020.Hello World",
-		"",
-	}, "\n")
+	expectedDiff := generateDiff(diffParams{
+		READMEObjectHash:         "89e55af",
+		ExamplesREADMEObjectHash: "a32cc2f",
+		Project3READMEObjectHash: "f49f17d",
+		Project1READMEObjectHash: "6284591",
+		Project2READMEObjectHash: "9445efe",
+		HelloWorldMessage:        "Hello World",
+	})
 
 	expectedState := gqltestutil.BatchSpecDeep{
 		State: "COMPLETED",
@@ -207,7 +147,7 @@ changesetTemplate:
 							{
 								Number:    1,
 								Run:       "IFS=$'\\n'; echo Hello World | tee -a $(find -name README.md)",
-								Container: "ubuntu:18.04",
+								Container: "alpine:3",
 								OutputLines: gqltestutil.WorkspaceOutputLines{
 									Nodes: []string{
 										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
@@ -225,7 +165,7 @@ changesetTemplate:
 								},
 								Diff: gqltestutil.ChangesetSpecDiffs{
 									FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
-										RawDiff: "diff --git README.md README.md\nindex 1914491..89e55af 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/README.md examples/README.md\nindex 40452a9..a32cc2f 100644\n--- examples/README.md\n+++ examples/README.md\n@@ -5,4 +5,4 @@ This folder contains examples\n (This is a test message, ignore)\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git examples/project3/README.md examples/project3/README.md\nindex 272d9ea..f49f17d 100644\n--- examples/project3/README.md\n+++ examples/project3/README.md\n@@ -1,4 +1,4 @@\n # project3\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project1/README.md project1/README.md\nindex 8a5f437..6284591 100644\n--- project1/README.md\n+++ project1/README.md\n@@ -3,4 +3,4 @@\n This is project 1.\n \n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\ndiff --git project2/README.md project2/README.md\nindex b1e1cdd..9445efe 100644\n--- project2/README.md\n+++ project2/README.md\n@@ -1,3 +1,3 @@\n This is a starter template for [Learn Next.js](https://nextjs.org/learn).\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.Hello World\n",
+										RawDiff: expectedDiff,
 									},
 								},
 							},
@@ -245,7 +185,7 @@ changesetTemplate:
 		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
 		BatchSpecInput:          batchSpec,
 		ExpectedCacheEntries: map[string]execution.AfterStepResult{
-			"wHcoEItqNkdJj9k1-1sRCQ-step-0": {
+			"d4ndKwesInT_CAoLz8351A-step-0": {
 				Version: 2,
 				Stdout:  "Hello World\n",
 				Diff:    []byte(expectedDiff),
@@ -276,6 +216,484 @@ changesetTemplate:
 	}
 }
 
-func testEnvVarBatchChange() Test {
+func testEnvObjectBatchChange() Test {
+	batchSpec := `
+name: e2e-test-batch-change-env-object
+description: Add the value of an environment variable object to READMEs
 
+on:
+  - repository: github.com/sourcegraph/automation-testing
+    # This branch is never changing - hopefully.
+    branch: executors-e2e
+
+steps:
+  - run: IFS=$'\n'; echo $MESSAGE | tee -a $(find -name README.md)
+    container: alpine:3
+    env:
+      MESSAGE: Hello world from an env object!
+
+changesetTemplate:
+  title: Hello World from env object
+  body: My first batch change!
+  branch: env-object # Push the commit to this branch.
+  commit:
+    message: Append an env object to all README.md files
+`
+
+	expectedDiff := strings.Join([]string{
+		"diff --git README.md README.md",
+		"index 1914491..23aa51b 100644",
+		"--- README.md",
+		"+++ README.md",
+		"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello world from an env object!",
+		"diff --git examples/README.md examples/README.md",
+		"index 40452a9..3705d13 100644",
+		"--- examples/README.md",
+		"+++ examples/README.md",
+		"@@ -5,4 +5,4 @@ This folder contains examples",
+		" (This is a test message, ignore)",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello world from an env object!",
+		"diff --git examples/project3/README.md examples/project3/README.md",
+		"index 272d9ea..140c423 100644",
+		"--- examples/project3/README.md",
+		"+++ examples/project3/README.md",
+		"@@ -1,4 +1,4 @@",
+		" # project3",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello world from an env object!",
+		"diff --git project1/README.md project1/README.md",
+		"index 8a5f437..3075ce8 100644",
+		"--- project1/README.md",
+		"+++ project1/README.md",
+		"@@ -3,4 +3,4 @@",
+		" This is project 1.",
+		" ",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello world from an env object!",
+		"diff --git project2/README.md project2/README.md",
+		"index b1e1cdd..0fb42ff 100644",
+		"--- project2/README.md",
+		"+++ project2/README.md",
+		"@@ -1,3 +1,3 @@",
+		" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
+		" (c) Copyright Sourcegraph 2013-2020.",
+		"-(c) Copyright Sourcegraph 2013-2020.",
+		"\\ No newline at end of file",
+		"+(c) Copyright Sourcegraph 2013-2020.Hello world from an env object!",
+		"",
+	}, "\n")
+
+	expectedState := gqltestutil.BatchSpecDeep{
+		State: "COMPLETED",
+		ChangesetSpecs: gqltestutil.BatchSpecChangesetSpecs{
+			TotalCount: 1,
+			Nodes: []gqltestutil.ChangesetSpec{
+				{
+					Type: "BRANCH",
+					Description: gqltestutil.ChangesetSpecDescription{
+						BaseRepository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
+						BaseRef:        "executors-e2e",
+						BaseRev:        "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+						HeadRef:        "env-object",
+						Title:          "Hello World from env object",
+						Body:           "My first batch change!",
+						Commits: []gqltestutil.ChangesetSpecCommit{
+							{
+								Message: "Append an env object to all README.md files",
+								Subject: "Append an env object to all README.md files",
+								Body:    "",
+								Author: gqltestutil.ChangesetSpecCommitAuthor{
+									Name:  "sourcegraph",
+									Email: "sourcegraph@sourcegraph.com",
+								},
+							},
+						},
+						Diffs: gqltestutil.ChangesetSpecDiffs{
+							FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+								RawDiff: ``,
+							},
+						},
+					},
+					ForkTarget: gqltestutil.ChangesetForkTarget{},
+				},
+			},
+		},
+		Namespace: gqltestutil.Namespace{},
+		WorkspaceResolution: gqltestutil.WorkspaceResolution{
+			Workspaces: gqltestutil.WorkspaceResolutionWorkspaces{
+				TotalCount: 1,
+				Stats: gqltestutil.WorkspaceResolutionWorkspacesStats{
+					Completed: 1,
+				},
+				Nodes: []gqltestutil.BatchSpecWorkspace{
+					{
+						State: "COMPLETED",
+						DiffStat: gqltestutil.DiffStat{
+							Added:   5,
+							Deleted: 5,
+						},
+						Repository: gqltestutil.ChangesetRepository{Name: "github.com/sourcegraph/automation-testing"},
+						Branch: gqltestutil.WorkspaceBranch{
+							Name: "executors-e2e",
+						},
+						ChangesetSpecs: []gqltestutil.WorkspaceChangesetSpec{
+							{},
+						},
+						SearchResultPaths: []string{},
+						Executor: gqltestutil.Executor{
+							QueueName: "batches",
+							Active:    true,
+						},
+						Stages: gqltestutil.BatchSpecWorkspaceStages{
+							Setup: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "setup.git.init",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.add-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.disable-gc",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.fetch",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.checkout",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.git.set-remote",
+									ExitCode: 0,
+								},
+								{
+									Key:      "setup.fs.extras",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+							SrcExec: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "step.docker.step.0.pre",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.run",
+									ExitCode: 0,
+								},
+								{
+									Key:      "step.docker.step.0.post",
+									ExitCode: 0,
+								},
+							},
+							Teardown: []gqltestutil.ExecutionLogEntry{
+								{
+									Key:      "teardown.fs",
+									Command:  []string{},
+									ExitCode: 0,
+								},
+							},
+						},
+						Steps: []gqltestutil.BatchSpecWorkspaceStep{
+							{
+								Number:    1,
+								Run:       "IFS=$'\\n'; echo $MESSAGE | tee -a $(find -name README.md)",
+								Container: "alpine:3",
+								OutputLines: gqltestutil.WorkspaceOutputLines{
+									Nodes: []string{
+										"stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested",
+										"stderr: Hello World",
+										"",
+									},
+									TotalCount: 3,
+								},
+								ExitCode: 0,
+								Environment: []gqltestutil.WorkspaceEnvironmentVariable{
+									{
+										Name:  "MESSAGE",
+										Value: "Hello world from an env object!",
+									},
+								},
+								OutputVariables: []gqltestutil.WorkspaceOutputVariable{},
+								DiffStat: gqltestutil.DiffStat{
+									Added:   5,
+									Deleted: 5,
+								},
+								Diff: gqltestutil.ChangesetSpecDiffs{
+									FileDiffs: gqltestutil.ChangesetSpecFileDiffs{
+										RawDiff: expectedDiff,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Source: "REMOTE",
+		Files: gqltestutil.BatchSpecFiles{
+			TotalCount: 0,
+			Nodes:      []gqltestutil.BatchSpecFile{},
+		},
+	}
+
+	return Test{
+		PreExistingCacheEntries: map[string]execution.AfterStepResult{},
+		BatchSpecInput:          batchSpec,
+		ExpectedCacheEntries: map[string]execution.AfterStepResult{
+			"IZ_d2HAMbc9BDhI2uWpavA-step-0": {
+				Version: 2,
+				Stdout:  "Hello world from an env object!\n",
+				Diff:    []byte(expectedDiff),
+				Outputs: map[string]any{},
+			},
+		},
+		ExpectedChangesetSpecs: []*types.ChangesetSpec{
+			{
+				Type:              "branch",
+				DiffStatAdded:     5,
+				DiffStatDeleted:   5,
+				BatchSpecID:       2,
+				BaseRepoID:        1,
+				UserID:            1,
+				BaseRev:           "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",
+				BaseRef:           "executors-e2e",
+				HeadRef:           "refs/heads/env-object",
+				Title:             "Hello World from env object",
+				Body:              "My first batch change!",
+				CommitMessage:     "Append an env object to all README.md files",
+				CommitAuthorName:  "sourcegraph",
+				CommitAuthorEmail: "sourcegraph@sourcegraph.com",
+				Diff:              []byte(expectedDiff),
+			},
+		},
+		ExpectedState: expectedState,
+		CacheDisabled: true,
+	}
+}
+
+func testFileMountBatchChange() Test {
+	//	batchSpec := `
+	//name: e2e-test-batch-change-file-mount
+	//description: Add the value of a mounted file to READMEs
+	//
+	//on:
+	//  - repository: github.com/sourcegraph/automation-testing
+	//    # This branch is never changing - hopefully.
+	//    branch: executors-e2e
+	//
+	//steps:
+	//  - run: IFS=$'\n'; cat /tmp/hello-world.txt | tee -a $(find -name README.md)
+	//    container: alpine:3
+	//    files:
+	//      /tmp/hello-world.txt: Hello world from a file!
+	//
+	//changesetTemplate:
+	//  title: Hello World from file
+	//  body: My first batch change!
+	//  branch: file-mount # Push the commit to this branch.
+	//  commit:
+	//    message: Append the content of a mounted file to all README.md files
+	//`
+	//
+	//	expectedDiff := strings.Join([]string{
+	//		"diff --git README.md README.md",
+	//		"index 1914491..89e55af 100644",
+	//		"--- README.md",
+	//		"+++ README.md",
+	//		"@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation",
+	//		" ",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		"-(c) Copyright Sourcegraph 2013-2020.",
+	//		"\\ No newline at end of file",
+	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
+	//		"diff --git examples/README.md examples/README.md",
+	//		"index 40452a9..a32cc2f 100644",
+	//		"--- examples/README.md",
+	//		"+++ examples/README.md",
+	//		"@@ -5,4 +5,4 @@ This folder contains examples",
+	//		" (This is a test message, ignore)",
+	//		" ",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		"-(c) Copyright Sourcegraph 2013-2020.",
+	//		"\\ No newline at end of file",
+	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
+	//		"diff --git examples/project3/README.md examples/project3/README.md",
+	//		"index 272d9ea..f49f17d 100644",
+	//		"--- examples/project3/README.md",
+	//		"+++ examples/project3/README.md",
+	//		"@@ -1,4 +1,4 @@",
+	//		" # project3",
+	//		" ",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		"-(c) Copyright Sourcegraph 2013-2020.",
+	//		"\\ No newline at end of file",
+	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
+	//		"diff --git project1/README.md project1/README.md",
+	//		"index 8a5f437..6284591 100644",
+	//		"--- project1/README.md",
+	//		"+++ project1/README.md",
+	//		"@@ -3,4 +3,4 @@",
+	//		" This is project 1.",
+	//		" ",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		"-(c) Copyright Sourcegraph 2013-2020.",
+	//		"\\ No newline at end of file",
+	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
+	//		"diff --git project2/README.md project2/README.md",
+	//		"index b1e1cdd..9445efe 100644",
+	//		"--- project2/README.md",
+	//		"+++ project2/README.md",
+	//		"@@ -1,3 +1,3 @@",
+	//		" This is a starter template for [Learn Next.js](https://nextjs.org/learn).",
+	//		" (c) Copyright Sourcegraph 2013-2020.",
+	//		"-(c) Copyright Sourcegraph 2013-2020.",
+	//		"\\ No newline at end of file",
+	//		"+(c) Copyright Sourcegraph 2013-2020.Hello world from a file!",
+	//		"",
+	//	}, "\n")
+
+	return Test{}
+}
+
+type diffParams struct {
+	READMEObjectHash         string
+	ExamplesREADMEObjectHash string
+	Project3READMEObjectHash string
+	Project1READMEObjectHash string
+	Project2READMEObjectHash string
+	HelloWorldMessage        string
+}
+
+func generateDiff(params diffParams) string {
+	const diffTemplateString = `diff --git README.md README.md
+index 1914491..{{.READMEObjectHash}} 100644
+--- README.md
++++ README.md
+@@ -3,4 +3,4 @@ This repository is used to test opening and closing pull request with Automation
+ ` + `
+ (c) Copyright Sourcegraph 2013-2020.
+ (c) Copyright Sourcegraph 2013-2020.
+-(c) Copyright Sourcegraph 2013-2020.
+\ No newline at end of file
++(c) Copyright Sourcegraph 2013-2020.{{.HelloWorldMessage}}
+diff --git examples/README.md examples/README.md
+index 40452a9..{{.ExamplesREADMEObjectHash}} 100644
+--- examples/README.md
++++ examples/README.md
+@@ -5,4 +5,4 @@ This folder contains examples
+ (This is a test message, ignore)
+ ` + `
+ (c) Copyright Sourcegraph 2013-2020.
+-(c) Copyright Sourcegraph 2013-2020.
+\ No newline at end of file
++(c) Copyright Sourcegraph 2013-2020.{{.HelloWorldMessage}}
+diff --git examples/project3/README.md examples/project3/README.md
+index 272d9ea..{{.Project3READMEObjectHash}} 100644
+--- examples/project3/README.md
++++ examples/project3/README.md
+@@ -1,4 +1,4 @@
+ # project3
+ ` + `
+ (c) Copyright Sourcegraph 2013-2020.
+-(c) Copyright Sourcegraph 2013-2020.
+\ No newline at end of file
++(c) Copyright Sourcegraph 2013-2020.{{.HelloWorldMessage}}
+diff --git project1/README.md project1/README.md
+index 8a5f437..{{.Project1READMEObjectHash}} 100644
+--- project1/README.md
++++ project1/README.md
+@@ -3,4 +3,4 @@
+ This is project 1.
+ ` + `
+ (c) Copyright Sourcegraph 2013-2020.
+-(c) Copyright Sourcegraph 2013-2020.
+\ No newline at end of file
++(c) Copyright Sourcegraph 2013-2020.{{.HelloWorldMessage}}
+diff --git project2/README.md project2/README.md
+index b1e1cdd..{{.Project2READMEObjectHash}} 100644
+--- project2/README.md
++++ project2/README.md
+@@ -1,3 +1,3 @@
+ This is a starter template for [Learn Next.js](https://nextjs.org/learn).
+ (c) Copyright Sourcegraph 2013-2020.
+-(c) Copyright Sourcegraph 2013-2020.
+\ No newline at end of file
++(c) Copyright Sourcegraph 2013-2020.{{.HelloWorldMessage}}
+`
+
+	tmpl, err := template.New("diffTemplate").Parse(diffTemplateString)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+	if err = tmpl.Execute(&buf, params); err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
+
+type batchSpecParams struct {
+	NameContent             string
+	Description             string
+	RunCommand              string
+	ChangeSetTemplateBranch string
+	CommitMessageContent    string
+}
+
+func generateBatchSpec(params batchSpecParams) string {
+	batchSpecTemplateString := `
+name: e2e-test-batch-change-{{.NameContent}}
+description: {{.Description}}
+
+on:
+  - repository: github.com/sourcegraph/automation-testing
+    # This branch is never changing - hopefully.
+    branch: executors-e2e
+
+steps:
+  - run: {{.RunCommand}}
+    container: alpine:3
+
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: {{.ChangeSetTemplateBranch}} # Push the commit to this branch.
+  commit:
+    message: Append {{.CommitMessageContent}} to all README.md files
+`
+
+	tmpl, err := template.New("batchSpecTemplate").Parse(batchSpecTemplateString)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+	if err = tmpl.Execute(&buf, params); err != nil {
+		panic(err)
+	}
+
+	return buf.String()
 }


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/50351

This PR extends the executor batches integration tests with the following cases:
- Workspace file mounts (`testFileMountBatchChange()`) - **WIP, see** [Workspace file mounts](#workspace-file-mounts)
- File mount (`testFromFileBatchChange()`)
- Environment variables (`testEnvObjectBatchChange()`)
- Caching (`testHelloWorldBatchChange(true)`)

Other changes:
- Splits test cases into `testcases.go`
- Adds a transformer to `cmp.Diff()` calls to break long strings into lines to display only actual diff lines, as it otherwise would truncate those lines producing output of no value
- Refactors most hardcoded values in expected results to references
- Template diff and batch spec

Please feel free to comment on messy code, I was more aiming to get tests passing than try and turn it into something pretty. I'm sure there's better ways of doing things than what I've committed so please enlighten me!

## To do
- Skipping tests
- Reduce number of ignored fields when comparing results with expectations

### Workspace file mounts
This test is not enabled right now. I could use some feedback on the following:
- The file needs to be uploaded to the Sourcegraph instance in order to be processed. In order to do so, I've more or less copy-pasta'd [the function (and supporting functions) from `src-cli`](https://sourcegraph.com/github.com/sourcegraph/src-cli/-/blob/internal/batches/service/remote.go?L161) to the test infra. It appears to work fine, but it's not a great solution, because the implementation in `src-cli` might change. Then again, from a test perspective, how the file ends up at Sourcegraph might be of lesser importance than the file being mounted in the executor as intended.
- More importantly, I don't quite understand how the file is mounted. If I run the test in its current setup, The step that exits non-zero reports
   ```json
   "SrcExec": [
     {
       "Key": "step.docker.step.0.pre",
       "Command": [
         "docker",
         "run",
         "--rm",
         "--cpus",
         "4",
         "--memory",
         "12G",
         "-v",
         "/var/folders/s4/b6xv49mn3nz4671j833bbt080000gq/T/tmp.9T4UDG2m/executor-tmp/workspace-1-1745536382:/data",
         "-w",
         "/data",
         "--entrypoint",
         "/bin/sh",
         "us.gcr.io/sourcegraph-dev/batcheshelper:a0f07e0191eaba46b6f858db161928fe08e57d66_211970_candidate",
         "/data/.sourcegraph-executor/1.0_github.com_sourcegraph_automation-testing@1c94aaf85d51e9d016b8ce4639b9f022d94c52e6.sh"
       ],
       "StartTime": "2023-04-18T13:07:15Z",
       "ExitCode": 1,
       "Out": "stderr: WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\nstderr: + batcheshelper pre 0\nstderr: getAbsoluteMountPath: mount path /data/hello_appender.py does not exist\n",
       "DurationMilliseconds": 755
     }
   ]
   ```
   I'm not sure why it's looking in `/data/hello_appender.py` when the batch change defines the step like this:
   ```yaml
   steps:
     - run: python /tmp/hello_appender.py
       container: python:3.11-alpine
       mount:
         - path: ./hello_appender.py
           mountpoint: /tmp/hello_appender.py
   ```
   Why is it not mounted under `/tmp`? The returned batch spec contains the following block for the file mount:
   ```json
   "Files": {
     "TotalCount": 1,
     "Nodes": [
       {
         "Path": "",
         "Name": "hello_appender.py"
       }
     ]
   }
   ```
   The empty path seems to correspond with the `mount.path` value in the batch spec manifest, but [according to the docs](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#examples-11) that has to be the path on your local machine. I'm sure I'm making a super dumb mistake here but I can't figure it out :grimacing:

## Test plan
The tests themselves. Is this test nepotism?

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
