### PR TITLE
bazel: remove disk/remote cache settings

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -2,12 +2,6 @@
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
 # Docs: https://bazel.build/reference/command-line-reference#flag--repository_cache
 build --repository_cache=/home/buildkite/repocache-sourcegraph
-build --remote_cache=grpc://ci-bazel-remote-cache:9092
-
-# Use Disk caching for building and testing.
-# Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
-# Docs: https://bazel.build/reference/command-line-reference#flag--disk_cache
-build --disk_cache=/home/buildkite/diskcache
 
 # We need /usr/local/bin
 # TODO(DevX) we should be narrower here.


### PR DESCRIPTION
Those values are now directly stored on the agents, which is much more flexible and allows us to swap cache server without having to hunt for ongoing PRs having the wrong values and potentially poisoning the cache.

Test Plan: CI will show the right cache server in the logs.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
