### PR TITLE
gitserver 5.0.1: gitserver ssl unsafe legacy renegotiation

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,9 +37,8 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # Minimal version requirement to address vulnerabilities
-    # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -43,7 +43,8 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,8 @@ RUN apk update && apk add --no-cache \
     'bind-tools>=9.16.33-r0' \
     busybox \
     ca-certificates \
-    'curl>=8.0.0-r0' --repository='https://dl-cdn.alpinelinux.org/alpine/edge/main' \
+    # Don't use alpine/edge, the curl release on this segfaults
+    curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     mailcap \
     tini \
     wget

--- a/enterprise/cmd/batcheshelper/Dockerfile
+++ b/enterprise/cmd/batcheshelper/Dockerfile
@@ -17,6 +17,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
 
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/bundled-executor/Dockerfile
+++ b/enterprise/cmd/bundled-executor/Dockerfile
@@ -26,7 +26,8 @@ ENV EXECUTOR_NUM_TOTAL_JOBS=1
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     ca-certificates
 
 # Install src-cli.

--- a/enterprise/cmd/executor/docker-image/Dockerfile
+++ b/enterprise/cmd/executor/docker-image/Dockerfile
@@ -21,7 +21,8 @@ ENV EXECUTOR_USE_FIRECRACKER=false
 RUN apk add --no-cache \
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     docker \
     ca-certificates
 

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -37,10 +37,10 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # backported fix for 3.14 https://security.alpinelinux.org/vuln/CVE-2023-22490
     # Minimal version requirement to address vulnerabilities
     # https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/
-    'git>=2.39.2-r0' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    # Don't use alpine/edge, the git release on this segfaults
+    'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -62,6 +62,9 @@ COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 # hadolint ignore=DL4006
 RUN wget -O - https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz | tar zx --directory /
 
+# hadolint ignore=SC2028
+RUN printf "\n[openssl_init]\nssl_conf = ssl_sect\n\n[ssl_sect]\nsystem_default = system_default_sect\n\n[system_default_sect]\nOptions = UnsafeLegacyRenegotiation\n" >> /etc/ssl/openssl.cnf
+
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos
 USER sourcegraph
 


### PR DESCRIPTION
Custom image built off v5.0.1. Not to be merged.


## Test plan

- main-dry-run should pass
- [x] To be verified manually: Gitserver docker image should have the custom openssl.cnf config
- [x] To be verified manually: docker-compose up should work with the custom image locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
