### PR TITLE
(feat) add repo metadata editing UI

### DIFF
--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -1,14 +1,23 @@
-.repo-metadata {
+.container {
     gap: 0.5rem;
+}
+
+.meta {
+    color: var(--body-color);
+}
+
+.highlight {
+    color: var(--search-filter-keyword-color);
+}
+
+.delete-button,
+.meta {
     font-size: 0.75rem;
 }
 
-.rounded-left-none {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-
-.rounded-right-none {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+.container.small {
+    .delete-button,
+    .meta {
+        font-size: 0.625rem;
+    }
 }

--- a/client/branded/src/search-ui/components/RepoMetadata.story.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.story.tsx
@@ -1,9 +1,9 @@
 import { Meta, Story } from '@storybook/react'
 
-import { Text } from '@sourcegraph/wildcard'
+import { Card, Text } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
-import { RepoMetadata } from './RepoMetadata'
+import { RepoMetadataItem, RepoMetadata } from './RepoMetadata'
 
 const config: Meta = {
     title: 'branded/search-ui/RepoMetadata',
@@ -14,33 +14,41 @@ const config: Meta = {
 
 export default config
 
-const mockMetadata: [string, string | undefined][] = [
-    ['team', 'iam'],
-    ['org', 'source'],
-    ['oss', undefined],
+const mockItems: RepoMetadataItem[] = [
+    {
+        key: 'archived',
+        value: 'true',
+    },
+    {
+        key: 'oss',
+    },
+    {
+        key: 'license',
+        value: 'multiple',
+    },
 ]
 
 export const RepoMetadataStory: Story = () => (
     <BrandedStory>
         {() => (
-            <div className="m-3">
-                <div className="d-flex align-items-center mb-2">
+            <Card className="p-3">
+                <div className="d-flex align-items-center mb-3">
                     <Text className="mb-0 mr-3 text-no-wrap">Default</Text>
-                    <RepoMetadata metadata={mockMetadata} />
+                    <RepoMetadata items={mockItems} />
                 </div>
-                <div className="d-flex align-items-center mb-2">
-                    <Text className="mb-0 mr-3 text-no-wrap">Default & Delete mode</Text>
-                    <RepoMetadata metadata={mockMetadata} onDelete={key => alert(key)} />
+                <div className="d-flex align-items-center mb-3">
+                    <Text className="mb-0 mr-3 text-no-wrap">Deletable metadata</Text>
+                    <RepoMetadata items={mockItems} onDelete={key => alert(key)} />
                 </div>
-                <div className="d-flex align-items-center mb-2">
+                <div className="d-flex align-items-center mb-3">
                     <Text className="mb-0 mr-3 text-no-wrap">Small</Text>
-                    <RepoMetadata metadata={mockMetadata} small={true} />
+                    <RepoMetadata items={mockItems} small={true} />
                 </div>
-                <div className="d-flex align-items-center mb-2">
-                    <Text className="mb-0 mr-3 text-no-wrap">Small & Delete mode</Text>
-                    <RepoMetadata metadata={mockMetadata} small={true} onDelete={key => alert(key)} />
+                <div className="d-flex align-items-center">
+                    <Text className="mb-0 mr-3 text-no-wrap">Small & Deletable metadata</Text>
+                    <RepoMetadata items={mockItems} onDelete={key => alert(key)} small={true} />
                 </div>
-            </div>
+            </Card>
         )}
     </BrandedStory>
 )

--- a/client/branded/src/search-ui/components/RepoMetadata.story.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.story.tsx
@@ -30,7 +30,7 @@ export const RepoMetadataStory: Story = () => (
                 </div>
                 <div className="d-flex align-items-center mb-2">
                     <Text className="mb-0 mr-3 text-no-wrap">Default & Delete mode</Text>
-                    <RepoMetadata keyValuePairs={mockMetadata} onDelete={key => alert(key)} />
+                    <RepoMetadata metadata={mockMetadata} onDelete={key => alert(key)} />
                 </div>
                 <div className="d-flex align-items-center mb-2">
                     <Text className="mb-0 mr-3 text-no-wrap">Small</Text>
@@ -38,7 +38,7 @@ export const RepoMetadataStory: Story = () => (
                 </div>
                 <div className="d-flex align-items-center mb-2">
                     <Text className="mb-0 mr-3 text-no-wrap">Small & Delete mode</Text>
-                    <RepoMetadata keyValuePairs={mockMetadata} small={true} onDelete={key => alert(key)} />
+                    <RepoMetadata metadata={mockMetadata} small={true} onDelete={key => alert(key)} />
                 </div>
             </div>
         )}

--- a/client/branded/src/search-ui/components/RepoMetadata.story.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.story.tsx
@@ -29,8 +29,16 @@ export const RepoMetadataStory: Story = () => (
                     <RepoMetadata metadata={mockMetadata} />
                 </div>
                 <div className="d-flex align-items-center mb-2">
+                    <Text className="mb-0 mr-3 text-no-wrap">Default & Delete mode</Text>
+                    <RepoMetadata keyValuePairs={mockMetadata} onDelete={key => alert(key)} />
+                </div>
+                <div className="d-flex align-items-center mb-2">
                     <Text className="mb-0 mr-3 text-no-wrap">Small</Text>
                     <RepoMetadata metadata={mockMetadata} small={true} />
+                </div>
+                <div className="d-flex align-items-center mb-2">
+                    <Text className="mb-0 mr-3 text-no-wrap">Small & Delete mode</Text>
+                    <RepoMetadata keyValuePairs={mockMetadata} small={true} onDelete={key => alert(key)} />
                 </div>
             </div>
         )}

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react'
 
+import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 import { sortBy } from 'lodash'
 
-import { Badge } from '@sourcegraph/wildcard'
+import { Badge, Button, Icon } from '@sourcegraph/wildcard'
 
 import styles from './RepoMetadata.module.scss'
 
@@ -11,31 +12,51 @@ interface RepoMetadataItemProps {
     metadataKey: string
     metadataValue: string | null | undefined
     small?: boolean
+    onDelete?: () => void
 }
 
-const RepoMetadataItem: React.FunctionComponent<RepoMetadataItemProps> = ({ metadataKey, metadataValue, small }) => (
+const RepoMetadataItem: React.FunctionComponent<RepoMetadataItemProps> = ({
+    metadataKey,
+    metadataValue,
+    small,
+    onDelete,
+}) => (
     <div className="d-flex align-items-stretch justify-content-center">
         <Badge
             as="dt"
             small={small}
             variant="info"
             aria-label={`Repository metadata key "${metadataKey}"`}
-            className={classNames('m-0', { [styles.roundedRightNone]: metadataValue })}
+            className={classNames('m-0', { [styles.roundedRightNone]: metadataValue || onDelete })}
         >
             {metadataKey}
         </Badge>
-        <Badge
-            as="dd"
-            small={small}
-            variant="secondary"
-            aria-label={`Repository metadata value "${metadataValue}" for key=${metadataKey}`}
-            aria-hidden={!metadataValue}
-            className={classNames(styles.roundedLeftNone, 'm-0', {
-                ['d-none']: !metadataValue,
-            })}
-        >
-            {metadataValue}
-        </Badge>
+        <dd className={classNames('d-flex m-0', { ['d-none']: !metadataValue || !onDelete })}>
+            {metadataValue && (
+                <Badge
+                    small={small}
+                    variant="secondary"
+                    aria-label={`Repository metadata value "${metadataValue}" for key=${metadataKey}`}
+                    className={classNames(styles.roundedLeftNone, 'm-0', {
+                        [styles.roundedRightNone]: onDelete,
+                    })}
+                >
+                    {metadataValue}
+                </Badge>
+            )}
+            {onDelete && (
+                <Button
+                    size="sm"
+                    className={classNames('px-1 py-0 m-0', styles.roundedLeftNone)}
+                    variant="warning"
+                    outline={true}
+                    aria-label="Delete repository metadata"
+                    onClick={onDelete}
+                >
+                    <Icon svgPath={mdiClose} aria-hidden={true} />
+                </Button>
+            )}
+        </dd>
     </div>
 )
 
@@ -43,9 +64,10 @@ interface RepoMetadataProps {
     metadata: [string, string | null | undefined][]
     className?: string
     small?: boolean
+    onDelete?: (key: string, value: string | null | undefined) => void
 }
 
-export const RepoMetadata: React.FunctionComponent<RepoMetadataProps> = ({ metadata, small, className }) => {
+export const RepoMetadata: React.FunctionComponent<RepoMetadataProps> = ({ metadata, small, className, onDelete }) => {
     const sortedPairs = useMemo(() => sortBy(metadata), [metadata])
     if (sortedPairs.length === 0) {
         return null
@@ -53,7 +75,13 @@ export const RepoMetadata: React.FunctionComponent<RepoMetadataProps> = ({ metad
     return (
         <dl className={classNames(styles.repoMetadata, 'd-flex align-items-start flex-wrap m-0', className)}>
             {sortedPairs.map(([key, value]) => (
-                <RepoMetadataItem key={`${key}:${value}`} metadataKey={key} metadataValue={value} small={small} />
+                <RepoMetadataItem
+                    key={`${key}:${value}`}
+                    metadataKey={key}
+                    metadataValue={value}
+                    small={small}
+                    onDelete={onDelete ? () => onDelete?.(key, value) : undefined}
+                />
             ))}
         </dl>
     )

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { mdiClose } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { sortBy } from 'lodash'
 
@@ -32,7 +33,7 @@ const RepoMetadataItem: React.FunctionComponent<RepoMetadataItemProps> = ({
             {metadataKey}
         </Badge>
         <dd className={classNames('d-flex m-0', { ['d-none']: !metadataValue || !onDelete })}>
-            {metadataValue && (
+            {metadataValue ? (
                 <Badge
                     small={small}
                     variant="secondary"
@@ -43,6 +44,8 @@ const RepoMetadataItem: React.FunctionComponent<RepoMetadataItemProps> = ({
                 >
                     {metadataValue}
                 </Badge>
+            ) : (
+                <VisuallyHidden>No metadata value</VisuallyHidden>
             )}
             {onDelete && (
                 <Button

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -52,11 +52,11 @@ export const RepoMetadata: React.FC<RepoMetadataProps> = ({ items, className, on
             {sortedItems.map(item => (
                 <li key={`${item.key}:${item.value}`}>
                     {onDelete ? (
-                        <Tooltip content="Delete repository metadata">
+                        <Tooltip content="Delete metadata">
                             <Button
                                 className={classNames('px-1 py-0', styles.deleteButton)}
                                 variant="secondary"
-                                aria-label="Delete repository metadata"
+                                aria-label="Delete metadata"
                                 onClick={() => onDelete(item)}
                             >
                                 <Icon svgPath={mdiDelete} aria-hidden={true} className="mr-1" />

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -54,8 +54,10 @@ export const RepoMetadata: React.FC<RepoMetadataProps> = ({ items, className, on
                     {onDelete ? (
                         <Tooltip content="Delete metadata">
                             <Button
-                                className={classNames('px-1 py-0', styles.deleteButton)}
+                                className={styles.deleteButton}
                                 variant="secondary"
+                                outline={true}
+                                size="sm"
                                 aria-label="Delete metadata"
                                 onClick={() => onDelete(item)}
                             >

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -90,13 +90,13 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                 <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
                     {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                     <div className="d-flex align-items-center flex-row">
-                        <div className={classNames(styles.matchType, 'd-flex align-items-start')}>
+                        <div className={styles.matchType}>
                             <small>Repository match</small>
                             {enableRepositoryMetadata && !!result.metadata && (
                                 <RepoMetadata
-                                    metadata={Object.entries(result.metadata)}
-                                    className="justify-content-end ml-2 mr-4"
                                     small={true}
+                                    className="justify-content-end mt-1"
+                                    items={Object.entries(result.metadata).map(([key, value]) => ({ key, value }))}
                                 />
                             )}
                         </div>

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1262,6 +1262,7 @@ ts_project(
         "src/repo/repoRevisionSidebar/cody/backend.tsx",
         "src/repo/settings/RepoSettingsArea.tsx",
         "src/repo/settings/RepoSettingsIndexPage.tsx",
+        "src/repo/settings/RepoSettingsMetadataPage.tsx",
         "src/repo/settings/RepoSettingsMirrorPage.tsx",
         "src/repo/settings/RepoSettingsOptionsPage.tsx",
         "src/repo/settings/RepoSettingsSidebar.tsx",

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -180,6 +180,7 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
                     placeholder="Filter metadata by key or value…"
                     value={searchQuery}
                     onChange={handleSearchChange}
+                    type="search"
                     className="mb-3"
                 />
                 {filteredMetadata.length ? (

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -65,43 +65,49 @@ const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAd
     }
 
     return (
-        <section>
-            <H2>Add metadata</H2>
-            <Text>Add an additional key, or key-value pair, to this repository.</Text>
-            <Form onSubmit={onSubmit}>
-                {!loading && error && <ErrorAlert className="flex-grow-1 m-0 mb-3" error={error} />}
-                {!loading && !error && called && (
-                    <Alert className="flex-grow-1 m-0 mb-3" variant="success">
-                        Metadata added successfully
-                    </Alert>
-                )}
-                <div className="form-group">
-                    <Label htmlFor="metadata-key">Key</Label>
-                    <Input
-                        id="metadata-key"
-                        value={key}
-                        onChange={handleKeyChange}
-                        autoFocus={true}
-                        autoComplete="off"
-                        required={true}
-                        disabled={loading}
-                        message="e.g. 'status', 'license', 'language'"
-                    />
-                </div>
-                <div className="form-group">
-                    <Label htmlFor="metadata-value">Value (optional)</Label>
-                    <Input
-                        id="metadata-value"
-                        value={value}
-                        autoComplete="off"
-                        onChange={handleValueChange}
-                        disabled={loading}
-                        message="e.g. 'deprecated', 'MIT', 'Go'"
-                    />
-                </div>
-                <LoaderButton variant="primary" type="submit" loading={loading} label="Add" />
-            </Form>
-        </section>
+        <>
+            {!loading && !error && called && (
+                <Alert className="flex-grow-1 m-0 mb-3" variant="success">
+                    Metadata added
+                </Alert>
+            )}
+
+            <Container className="repo-settings-metadata-page">
+                <section>
+                    <H2>Add metadata</H2>
+                    <Text>Add an additional key, or key-value pair, to this repository.</Text>
+                    <Form onSubmit={onSubmit}>
+                        {!loading && error && <ErrorAlert className="flex-grow-1 m-0 mb-3" error={error} />}
+                        
+                        <div className="form-group">
+                            <Label htmlFor="metadata-key">Key</Label>
+                            <Input
+                                id="metadata-key"
+                                value={key}
+                                onChange={handleKeyChange}
+                                autoFocus={true}
+                                autoComplete="off"
+                                required={true}
+                                disabled={loading}
+                                message="e.g. 'status', 'license', 'language'"
+                            />
+                        </div>
+                        <div className="form-group">
+                            <Label htmlFor="metadata-value">Value (optional)</Label>
+                            <Input
+                                id="metadata-value"
+                                value={value}
+                                autoComplete="off"
+                                onChange={handleValueChange}
+                                disabled={loading}
+                                message="e.g. 'deprecated', 'MIT', 'Go'"
+                            />
+                        </div>
+                        <LoaderButton variant="primary" type="submit" loading={loading} label="Add" />
+                    </Form>
+                </section>
+            </Container>
+        </>
     )
 }
 
@@ -189,9 +195,7 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
                     <Text className="text-muted">No metadata containing "{searchQuery}"</Text>
                 )}
             </Container>
-            <Container className="repo-settings-metadata-page">
-                <AddRepoMetadata onDidAdd={refetch} repoID={repo.id} />
-            </Container>
+            <AddRepoMetadata onDidAdd={refetch} repoID={repo.id} />
         </>
     )
 }

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -1,0 +1,200 @@
+import { FC, useCallback, useMemo, useState, useEffect } from 'react'
+
+import { mdiPlus } from '@mdi/js'
+
+import { RepoMetadata } from '@sourcegraph/branded'
+import { useMutation, useQuery } from '@sourcegraph/http-client'
+import {
+    Container,
+    PageHeader,
+    ErrorAlert,
+    Input,
+    Button,
+    Icon,
+    Modal,
+    Label,
+    Form,
+    Alert,
+    LoadingSpinner,
+} from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../components/LoaderButton'
+import { PageTitle } from '../../components/PageTitle'
+import {
+    SettingsAreaRepositoryFields,
+    SettingsAreaRepositoryResult,
+    SettingsAreaRepositoryVariables,
+    AddRepoMetadataResult,
+    AddRepoMetadataVariables,
+    DeleteRepoMetadataResult,
+    DeleteRepoMetadataVariables,
+} from '../../graphql-operations'
+import { eventLogger } from '../../tracking/eventLogger'
+
+import { ADD_REPO_METADATA_GQL, DELETE_REPO_METADATA_GQL, FETCH_SETTINGS_AREA_REPOSITORY_GQL } from './backend'
+
+const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAdd, repoID }) => {
+    const [key, setKey] = useState<string>('')
+    const [value, setValue] = useState<string>('')
+
+    const handleKeyChange = useCallback((event: React.ChangeEvent<HTMLInputElement>): void => {
+        setKey(event.target.value)
+    }, [])
+
+    const handleValueChange = useCallback((event: React.ChangeEvent<HTMLInputElement>): void => {
+        setValue(event.target.value)
+    }, [])
+
+    const [addRepoMetadata, { called, loading, error, reset }] = useMutation<
+        AddRepoMetadataResult,
+        AddRepoMetadataVariables
+    >(ADD_REPO_METADATA_GQL)
+
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const onClose = (): void => setIsOpen(false)
+    const onOpen = (): void => {
+        setIsOpen(true)
+        reset()
+    }
+
+    const onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+        event.preventDefault()
+        addRepoMetadata({
+            variables: {
+                repo: repoID,
+                key,
+                value,
+            },
+        })
+            .then(() => onDidAdd())
+            .catch(console.error)
+    }
+
+    return (
+        <>
+            <div className="mb-2 d-flex justify-content-end">
+                <Button variant="primary" size="sm" onClick={onOpen}>
+                    <Icon svgPath={mdiPlus} aria-hidden={true} className="mr-1" />
+                    Add New Metadata
+                </Button>
+            </div>
+            <Modal title="Add new metadata" aria-label="Add new metadata" isOpen={isOpen} onDismiss={onClose}>
+                <Form onSubmit={onSubmit}>
+                    {!loading && error && <ErrorAlert className="flex-grow-1 m-0 mb-3" error={error} />}
+                    {!loading && !error && called && (
+                        <Alert className="flex-grow-1 m-0 mb-3" variant="success">
+                            Metadata added successfully
+                        </Alert>
+                    )}
+                    <div className="form-group">
+                        <Label htmlFor="metadata-key">Key*</Label>
+                        <Input
+                            id="metadata-key"
+                            value={key}
+                            onChange={handleKeyChange}
+                            autoFocus={true}
+                            required={true}
+                            disabled={loading}
+                            placeholder="e.g. 'team', 'owner', 'language'"
+                        />
+                    </div>
+                    <div className="form-group">
+                        <Label htmlFor="metadata-value">Value</Label>
+                        <Input
+                            id="metadata-value"
+                            value={value}
+                            onChange={handleValueChange}
+                            disabled={loading}
+                            placeholder="e.g. 'frontend', 'engineering', 'Go'"
+                        />
+                    </div>
+                    <div className="d-flex justify-content-end">
+                        <Button variant="secondary" onClick={onClose} className="mr-2" disabled={loading}>
+                            Cancel
+                        </Button>
+                        <LoaderButton variant="primary" type="submit" loading={loading} label="Add" />
+                    </div>
+                </Form>
+            </Modal>
+        </>
+    )
+}
+
+interface RepoSettingsMetadataPageProps {
+    repo: SettingsAreaRepositoryFields
+}
+
+/**
+ * The repository settings metadata page.
+ */
+export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props => {
+    eventLogger.logPageView('RepoSettingsMetadata')
+    const {
+        data,
+        error: fetchError,
+        refetch,
+        loading: fetchLoading,
+    } = useQuery<SettingsAreaRepositoryResult, SettingsAreaRepositoryVariables>(FETCH_SETTINGS_AREA_REPOSITORY_GQL, {
+        variables: { name: props.repo.name },
+        pollInterval: 3000,
+    })
+    const repo = data?.repository ? data.repository : props.repo
+
+    const [deleteRepoMetadata, { loading: deleteLoading, error: deleteError }] = useMutation<
+        DeleteRepoMetadataResult,
+        DeleteRepoMetadataVariables
+    >(DELETE_REPO_METADATA_GQL, {})
+
+    const onDelete = useCallback(
+        (key: string): void => {
+            if (!window.confirm(`Delete metadata key "${key}"?`)) {
+                return
+            }
+            deleteRepoMetadata({
+                variables: {
+                    repo: repo.id,
+                    key,
+                },
+            })
+                .then(() => refetch())
+                .catch(console.error)
+        },
+        [deleteRepoMetadata, repo.id, refetch]
+    )
+
+    const [searchQuery, setSearchQuery] = useState<string>('')
+    const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>): void => {
+        setSearchQuery(event.target.value)
+    }, [])
+
+    const filteredMetadata = useMemo(
+        (): [string, string | undefined | null][] =>
+            repo.keyValuePairs
+                .filter(({ key, value }) => {
+                    const search = searchQuery.toLowerCase()
+                    return key.toLowerCase().includes(search) || value?.toLowerCase().includes(search)
+                })
+                .map(({ key, value }) => [key, value]),
+        [repo.keyValuePairs, searchQuery]
+    )
+
+    return (
+        <>
+            <PageTitle title="Repo metadata settings" />
+            <PageHeader path={[{ text: 'Repo metadata' }]} headingElement="h2" className="mb-3" />
+            <Container className="repo-settings-metadata-page">
+                {fetchError && <ErrorAlert error={fetchError} />}
+                {deleteError && <ErrorAlert error={deleteError} />}
+                {fetchLoading && deleteLoading && <LoadingSpinner />}
+                <AddRepoMetadata onDidAdd={refetch} repoID={repo.id} />
+                <Input
+                    placeholder="Search repo metadata"
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    className="mb-3"
+                />
+                <RepoMetadata keyValuePairs={filteredMetadata} onDelete={onDelete} />
+            </Container>
+        </>
+    )
+}

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -169,13 +169,13 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
 
     const filteredMetadata = useMemo(
         (): [string, string | undefined | null][] =>
-            repo.keyValuePairs
+            repo.metadata
                 .filter(({ key, value }) => {
                     const search = searchQuery.toLowerCase()
                     return key.toLowerCase().includes(search) || value?.toLowerCase().includes(search)
                 })
                 .map(({ key, value }) => [key, value]),
-        [repo.keyValuePairs, searchQuery]
+        [repo.metadata, searchQuery]
     )
 
     return (

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -132,7 +132,7 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
 
     const onDelete = useCallback(
         (meta: RepoMetadataItem): void => {
-            if (!window.confirm(`Are you sure to delete metadata ${meta.key}${meta.value && ':'}${meta.value}?`)) {
+            if (!window.confirm(`Delete metadata "${meta.key}${meta.value ? `:${meta.value}` : ''}"?`)) {
                 return
             }
             deleteRepoMetadata({

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -61,6 +61,7 @@ const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAd
                 setKey('')
                 setValue('')
             })
+            // eslint-disable-next-line no-console
             .catch(console.error)
     }
 
@@ -78,7 +79,7 @@ const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAd
                     <Text>Add an additional key, or key-value pair, to this repository.</Text>
                     <Form onSubmit={onSubmit}>
                         {!loading && error && <ErrorAlert className="flex-grow-1 m-0 mb-3" error={error} />}
-                        
+
                         <div className="form-group">
                             <Label htmlFor="metadata-key">Key</Label>
                             <Input
@@ -148,6 +149,7 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
                 },
             })
                 .then(() => refetch())
+                // eslint-disable-next-line no-console
                 .catch(console.error)
         },
         [deleteRepoMetadata, repo.id, refetch]

--- a/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMetadataPage.tsx
@@ -85,7 +85,7 @@ const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAd
                         autoComplete="off"
                         required={true}
                         disabled={loading}
-                        placeholder="e.g. 'status', 'license', 'language'"
+                        message="e.g. 'status', 'license', 'language'"
                     />
                 </div>
                 <div className="form-group">
@@ -96,7 +96,7 @@ const AddRepoMetadata: FC<{ onDidAdd: () => void; repoID: string }> = ({ onDidAd
                         autoComplete="off"
                         onChange={handleValueChange}
                         disabled={loading}
-                        placeholder="e.g. 'deprecated', 'MIT', 'Go'"
+                        message="e.g. 'deprecated', 'MIT', 'Go'"
                     />
                 </div>
                 <LoaderButton variant="primary" type="submit" loading={loading} label="Add" />
@@ -166,18 +166,18 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
     return (
         <>
             <PageTitle title="Repo metadata settings" />
-            <PageHeader path={[{ text: 'Repo metadata' }]} headingElement="h2" className="mb-3" />
+            <PageHeader path={[{ text: 'Metadata' }]} headingElement="h2" className="mb-3" />
             <Text>
                 Repository metadata allows you to search, filter and navigate between repositories. Administrators can
                 add repository metadata via the web, cli or API. Learn more about{' '}
-                <Link to="/help/admin/repo/metadata">Repository Metadata</Link>
+                <Link to="/help/admin/repo/metadata">Repository Metadata</Link>.
             </Text>
             <Container className="repo-settings-metadata-page mb-2">
                 {fetchError && <ErrorAlert error={fetchError} />}
                 {deleteError && <ErrorAlert error={deleteError} />}
                 {fetchLoading && deleteLoading && <LoadingSpinner />}
                 <Input
-                    placeholder="Search repo metadata key or value"
+                    placeholder="Filter metadata by key or value…"
                     value={searchQuery}
                     onChange={handleSearchChange}
                     className="mb-3"
@@ -185,7 +185,7 @@ export const RepoSettingsMetadataPage: FC<RepoSettingsMetadataPageProps> = props
                 {filteredMetadata.length ? (
                     <RepoMetadata items={filteredMetadata} onDelete={onDelete} />
                 ) : (
-                    <Text className="text-muted">No metadata</Text>
+                    <Text className="text-muted">No metadata containing "{searchQuery}"</Text>
                 )}
             </Container>
             <Container className="repo-settings-metadata-page">

--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -78,7 +78,7 @@ export const ADD_REPO_METADATA_GQL = gql`
 `
 
 export const DELETE_REPO_METADATA_GQL = gql`
-    mutation AddRepoMetadata($repo: ID!, $key: String!) {
+    mutation DeleteRepoMetadata($repo: ID!, $key: String!) {
         deleteRepoKeyValuePair(repo: $repo, key: $key) {
             alwaysNil
         }

--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -53,6 +53,10 @@ export const settingsAreaRepositoryFragment = gql`
                 ...SettingsAreaExternalServiceFields
             }
         }
+        keyValuePairs {
+            key
+            value
+        }
     }
 `
 
@@ -63,6 +67,22 @@ export const FETCH_SETTINGS_AREA_REPOSITORY_GQL = gql`
         }
     }
     ${settingsAreaRepositoryFragment}
+`
+
+export const ADD_REPO_METADATA_GQL = gql`
+    mutation AddRepoMetadata($repo: ID!, $key: String!, $value: String) {
+        addRepoKeyValuePair(repo: $repo, key: $key, value: $value) {
+            alwaysNil
+        }
+    }
+`
+
+export const DELETE_REPO_METADATA_GQL = gql`
+    mutation AddRepoMetadata($repo: ID!, $key: String!) {
+        deleteRepoKeyValuePair(repo: $repo, key: $key) {
+            alwaysNil
+        }
+    }
 `
 
 /**

--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -53,7 +53,7 @@ export const settingsAreaRepositoryFragment = gql`
                 ...SettingsAreaExternalServiceFields
             }
         }
-        keyValuePairs {
+        metadata {
             key
             value
         }

--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -71,7 +71,7 @@ export const FETCH_SETTINGS_AREA_REPOSITORY_GQL = gql`
 
 export const ADD_REPO_METADATA_GQL = gql`
     mutation AddRepoMetadata($repo: ID!, $key: String!, $value: String) {
-        addRepoKeyValuePair(repo: $repo, key: $key, value: $value) {
+        addRepoMetadata(repo: $repo, key: $key, value: $value) {
             alwaysNil
         }
     }
@@ -79,7 +79,7 @@ export const ADD_REPO_METADATA_GQL = gql`
 
 export const DELETE_REPO_METADATA_GQL = gql`
     mutation DeleteRepoMetadata($repo: ID!, $key: String!) {
-        deleteRepoKeyValuePair(repo: $repo, key: $key) {
+        deleteRepoMetadata(repo: $repo, key: $key) {
             alwaysNil
         }
     }

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -16,7 +16,6 @@ import classNames from 'classnames'
 import { Navigate } from 'react-router-dom'
 import { catchError } from 'rxjs/operators'
 
-import { RepoMetadata } from '@sourcegraph/branded'
 import { asError, encodeURIPathComponent, ErrorLike, isErrorLike, logger, basename } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import { fetchTreeEntries } from '@sourcegraph/shared/src/backend/repo'
@@ -85,6 +84,10 @@ export const treePageRepositoryFragment = gql`
         description
         viewerCanAdminister
         url
+        metadata {
+            key
+            value
+        }
     }
 `
 
@@ -197,8 +200,6 @@ export const TreePage: FC<Props> = ({
         }
     }, [uri, showCodeInsights, extensionsController])
 
-    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
-
     const getPageTitle = (): string => {
         const repoString = displayRepoName(repoName)
         if (filePath) {
@@ -221,25 +222,16 @@ export const TreePage: FC<Props> = ({
         <div className="d-flex flex-wrap justify-content-between px-0">
             <div className={styles.header}>
                 <PageHeader className="mb-3 test-tree-page-title">
-                    <div className="d-flex align-items-center flex-wrap">
-                        <PageHeader.Heading as="h2" styleAs="h1">
-                            <Icon aria-hidden={true} svgPath={getIcon()} className="mr-2" />
-                            <span data-testid="repo-header">{displayRepoName(repo?.name || '')}</span>
-                            {repo?.isFork && (
-                                <Badge variant="outlineSecondary" className="mx-2 mt-1" data-testid="repo-fork-badge">
-                                    Fork
-                                </Badge>
-                            )}
-                        </PageHeader.Heading>
-                        {enableRepositoryMetadata && repo?.metadata && (
-                            <RepoMetadata
-                                className="ml-2 mt-1"
-                                metadata={repo.metadata.map(({ key, value }) => [key, value])}
-                            />
+                    <PageHeader.Heading as="h2" styleAs="h1">
+                        <Icon aria-hidden={true} svgPath={getIcon()} className="mr-2" />
+                        <span data-testid="repo-header">{displayRepoName(repo?.name || '')}</span>
+                        {repo?.isFork && (
+                            <Badge variant="outlineSecondary" className="mx-2 mt-1" data-testid="repo-fork-badge">
+                                Fork
+                            </Badge>
                         )}
-                    </div>
+                    </PageHeader.Heading>
                 </PageHeader>
-                {repo?.description && <Text>{repo.description}</Text>}
             </div>
             <div className={styles.menu}>
                 <ButtonGroup>

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -37,7 +37,6 @@ import {
     Link,
     LoadingSpinner,
     PageHeader,
-    Text,
     Tooltip,
     useObservable,
 } from '@sourcegraph/wildcard'

--- a/client/web/src/repo/tree/TreePageContent.module.scss
+++ b/client/web/src/repo/tree/TreePageContent.module.scss
@@ -53,3 +53,22 @@
 .table {
     table-layout: fixed;
 }
+
+.link-dark {
+    &,
+    &:hover,
+    &:focus {
+        color: var(--light-blue);
+    }
+}
+
+.extra-info-section-item {
+    &-header-icon {
+        opacity: 0;
+        transition: opacity 0.1s ease-in-out;
+    }
+
+    &:hover &-header-icon {
+        opacity: 1;
+    }
+}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -183,7 +183,7 @@ const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ 
                 {title}
             </Text>
             <Tooltip content={tooltip}>
-                <Icon svgPath={mdiInformationOutline} aria-label={title} />
+                <Icon svgPath={mdiInformationOutline} aria-label={title} className="text-muted" />
             </Tooltip>
         </div>
         {children}
@@ -221,7 +221,7 @@ const ExtraInfoSection: React.FC<{
                                     to={`/${encodeURIPathComponent(repo.name)}/-/settings/metadata`}
                                     className="p-0"
                                 >
-                                    <Icon svgPath={mdiCog} aria-label="Edit repository metadata" />
+                                    <Icon svgPath={mdiCog} aria-label="Edit repository metadata" className="text-muted" />
                                 </ButtonLink>
                             </Tooltip>
                         )}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
+import { mdiCog, mdiInformationOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { formatISO, subYears } from 'date-fns'
 import { escapeRegExp } from 'lodash'
 import { Observable } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 
-import { numberWithCommas, pluralize } from '@sourcegraph/common'
+import { RepoMetadata } from '@sourcegraph/branded'
+import { encodeURIPathComponent, numberWithCommas, pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql, useQuery } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -14,7 +16,7 @@ import { SearchPatternType, TreeFields } from '@sourcegraph/shared/src/graphql-o
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Card, CardHeader, Link, Tooltip } from '@sourcegraph/wildcard'
+import { Card, CardHeader, Icon, Link, Tooltip, Text, ButtonLink } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../backend/graphql'
 import {
@@ -25,6 +27,7 @@ import {
     SummaryContainer,
     ConnectionError,
 } from '../../components/FilteredConnection/ui'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import {
     CommitAtTimeResult,
     CommitAtTimeVariables,
@@ -178,6 +181,59 @@ interface TreePageContentProps extends ExtensionsControllerProps, TelemetryProps
     isPackage: boolean
 }
 
+const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ title: string; tooltip?: string }>> = ({
+    title,
+    tooltip,
+    children,
+}) => (
+    <div className="d-flex align-items-center justify-content-between mb-2">
+        <div className="d-flex align-items-center">
+            <Text className="mr-2 mb-0" weight="bold">
+                {title}
+            </Text>
+            <Tooltip content={tooltip}>
+                <Icon svgPath={mdiInformationOutline} aria-label="Extra information icon" />
+            </Tooltip>
+        </div>
+        {children}
+    </div>
+)
+
+const ExtraInfoSection: React.FC<{ repo: TreePageRepositoryFields; className?: string }> = ({ repo, className }) => {
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+
+    const metadataItems = useMemo(() => repo.metadata.map(({ key, value }) => ({ key, value })) || [], [repo.metadata])
+
+    return (
+        <Card className={className}>
+            <ExtraInfoSectionHeader title="Description" tooltip="Repository description synced from the code host." />
+            {repo.description && <Text>{repo.description}</Text>}
+            {enableRepositoryMetadata && (
+                <>
+                    <ExtraInfoSectionHeader
+                        title="Metadata"
+                        tooltip="Repository metadata allows you to search, filter and navigate between repositories. Administrators can add repository metadata via the web, cli or API. Learn more about Repository Metadata"
+                    >
+                        <Tooltip content="Edit repository metadata">
+                            <ButtonLink
+                                to={`/${encodeURIPathComponent(repo.name)}/-/settings/metadata`}
+                                className="p-0"
+                            >
+                                <Icon svgPath={mdiCog} aria-label="Edit repository metadata" />
+                            </ButtonLink>
+                        </Tooltip>
+                    </ExtraInfoSectionHeader>
+                    {metadataItems.length ? (
+                        <RepoMetadata items={metadataItems} />
+                    ) : (
+                        <Text className="text-muted">None</Text>
+                    )}
+                </>
+            )}
+        </Card>
+    )
+}
+
 export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<TreePageContentProps>> = props => {
     const { filePath, tree, repo, revision, isPackage } = props
 
@@ -206,7 +262,17 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
     return (
         <>
-            {readmeEntry && <ReadmePreviewCard entry={readmeEntry} repoName={repo.name} revision={revision} />}
+            <section className={classNames('container mb-3 px-0', styles.section)}>
+                {readmeEntry && (
+                    <ReadmePreviewCard
+                        entry={readmeEntry}
+                        repoName={repo.name}
+                        revision={revision}
+                        className={styles.files}
+                    />
+                )}
+                <ExtraInfoSection repo={repo} className={classNames(styles.contributors, 'p-3')} />
+            </section>
             <section className={classNames('test-tree-entries container mb-3 px-0', styles.section)}>
                 <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} filePath={filePath} />
 

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -172,7 +172,7 @@ export const fetchDiffStats = (args: {
         catchError(() => []) // ignore errors
     )
 
-const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ title: string; tooltip?: string }>> = ({
+const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ title: string; tooltip?: React.ReactNode }>> = ({
     title,
     tooltip,
     children,
@@ -207,7 +207,13 @@ const ExtraInfoSection: React.FC<{
                 <>
                     <ExtraInfoSectionHeader
                         title="Metadata"
-                        tooltip="Repository metadata allows you to search, filter and navigate between repositories. Administrators can add repository metadata via the web, cli or API. Learn more about Repository Metadata"
+                        tooltip={
+                            <>
+                                Repository metadata allows you to search, filter and navigate between repositories.
+                                Administrators can add repository metadata via the web, cli or API. Learn more about{' '}
+                                <Link to="/help/admin/repo/metadata">Repository Metadata</Link>.
+                            </>
+                        }
                     >
                         {viewerCanAdminister && (
                             <Tooltip content="Edit repository metadata">

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -172,15 +172,6 @@ export const fetchDiffStats = (args: {
         catchError(() => []) // ignore errors
     )
 
-interface TreePageContentProps extends ExtensionsControllerProps, TelemetryProps, PlatformContextProps {
-    filePath: string
-    tree: TreeFields
-    repo: TreePageRepositoryFields
-    commitID: string
-    revision: string
-    isPackage: boolean
-}
-
 const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ title: string; tooltip?: string }>> = ({
     title,
     tooltip,
@@ -199,7 +190,11 @@ const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ 
     </div>
 )
 
-const ExtraInfoSection: React.FC<{ repo: TreePageRepositoryFields; className?: string }> = ({ repo, className }) => {
+const ExtraInfoSection: React.FC<{
+    repo: TreePageRepositoryFields
+    className?: string
+    viewerCanAdminister?: boolean
+}> = ({ repo, className, viewerCanAdminister }) => {
     const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
 
     const metadataItems = useMemo(() => repo.metadata.map(({ key, value }) => ({ key, value })) || [], [repo.metadata])
@@ -214,14 +209,16 @@ const ExtraInfoSection: React.FC<{ repo: TreePageRepositoryFields; className?: s
                         title="Metadata"
                         tooltip="Repository metadata allows you to search, filter and navigate between repositories. Administrators can add repository metadata via the web, cli or API. Learn more about Repository Metadata"
                     >
-                        <Tooltip content="Edit repository metadata">
-                            <ButtonLink
-                                to={`/${encodeURIPathComponent(repo.name)}/-/settings/metadata`}
-                                className="p-0"
-                            >
-                                <Icon svgPath={mdiCog} aria-label="Edit repository metadata" />
-                            </ButtonLink>
-                        </Tooltip>
+                        {viewerCanAdminister && (
+                            <Tooltip content="Edit repository metadata">
+                                <ButtonLink
+                                    to={`/${encodeURIPathComponent(repo.name)}/-/settings/metadata`}
+                                    className="p-0"
+                                >
+                                    <Icon svgPath={mdiCog} aria-label="Edit repository metadata" />
+                                </ButtonLink>
+                            </Tooltip>
+                        )}
                     </ExtraInfoSectionHeader>
                     {metadataItems.length ? (
                         <RepoMetadata items={metadataItems} />
@@ -232,6 +229,15 @@ const ExtraInfoSection: React.FC<{ repo: TreePageRepositoryFields; className?: s
             )}
         </Card>
     )
+}
+
+interface TreePageContentProps extends ExtensionsControllerProps, TelemetryProps, PlatformContextProps {
+    filePath: string
+    tree: TreeFields
+    repo: TreePageRepositoryFields
+    commitID: string
+    revision: string
+    isPackage: boolean
 }
 
 export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<TreePageContentProps>> = props => {
@@ -271,7 +277,11 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                         className={styles.files}
                     />
                 )}
-                <ExtraInfoSection repo={repo} className={classNames(styles.contributors, 'p-3')} />
+                <ExtraInfoSection
+                    repo={repo}
+                    className={classNames(styles.contributors, 'p-3')}
+                    viewerCanAdminister={repo.viewerCanAdminister}
+                />
             </section>
             <section className={classNames('test-tree-entries container mb-3 px-0', styles.section)}>
                 <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} filePath={filePath} />

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -183,7 +183,7 @@ const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ 
                 {title}
             </Text>
             <Tooltip content={tooltip}>
-                <Icon svgPath={mdiInformationOutline} aria-label="Extra information icon" />
+                <Icon svgPath={mdiInformationOutline} aria-label={title} />
             </Tooltip>
         </div>
         {children}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -179,7 +179,7 @@ const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ 
 }) => (
     <div className="d-flex align-items-center justify-content-between mb-2">
         <div className="d-flex align-items-center">
-            <Text className="mr-2 mb-0" weight="bold">
+            <Text className="mr-1 mb-0" weight="bold">
                 {title}
             </Text>
             <Tooltip content={tooltip}>

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -172,18 +172,24 @@ export const fetchDiffStats = (args: {
         catchError(() => []) // ignore errors
     )
 
-const ExtraInfoSectionHeader: React.FunctionComponent<React.PropsWithChildren<{ title: string; tooltip?: React.ReactNode }>> = ({
-    title,
-    tooltip,
-    children,
-}) => (
+const ExtraInfoSectionItem: React.FunctionComponent<React.PropsWithChildren<{}>> = ({ children }) => (
+    <div className={styles.extraInfoSectionItem}>{children}</div>
+)
+
+const ExtraInfoSectionItemHeader: React.FunctionComponent<
+    React.PropsWithChildren<{ title: string; tooltip?: React.ReactNode }>
+> = ({ title, tooltip, children }) => (
     <div className="d-flex align-items-center justify-content-between mb-2">
         <div className="d-flex align-items-center">
             <Text className="mr-1 mb-0" weight="bold">
                 {title}
             </Text>
             <Tooltip content={tooltip}>
-                <Icon svgPath={mdiInformationOutline} aria-label={title} className="text-muted" />
+                <Icon
+                    svgPath={mdiInformationOutline}
+                    aria-label={title}
+                    className={classNames('text-muted', styles.extraInfoSectionItemHeaderIcon)}
+                />
             </Tooltip>
         </div>
         {children}
@@ -201,17 +207,22 @@ const ExtraInfoSection: React.FC<{
 
     return (
         <Card className={className}>
-            <ExtraInfoSectionHeader title="Description" tooltip="Repository description synced from the code host." />
-            {repo.description && <Text>{repo.description}</Text>}
+            <ExtraInfoSectionItem>
+                <ExtraInfoSectionItemHeader title="Description" tooltip="Synced from the code host." />
+                {repo.description && <Text>{repo.description}</Text>}
+            </ExtraInfoSectionItem>
             {enableRepositoryMetadata && (
-                <>
-                    <ExtraInfoSectionHeader
+                <ExtraInfoSectionItem>
+                    <ExtraInfoSectionItemHeader
                         title="Metadata"
                         tooltip={
                             <>
                                 Repository metadata allows you to search, filter and navigate between repositories.
                                 Administrators can add repository metadata via the web, cli or API. Learn more about{' '}
-                                <Link to="/help/admin/repo/metadata">Repository Metadata</Link>.
+                                <Link to="/help/admin/repo/metadata" className={styles.linkDark}>
+                                    Repository Metadata
+                                </Link>
+                                .
                             </>
                         }
                     >
@@ -219,19 +230,23 @@ const ExtraInfoSection: React.FC<{
                             <Tooltip content="Edit repository metadata">
                                 <ButtonLink
                                     to={`/${encodeURIPathComponent(repo.name)}/-/settings/metadata`}
-                                    className="p-0"
+                                    className={classNames('p-0', styles.extraInfoSectionItemHeaderIcon)}
                                 >
-                                    <Icon svgPath={mdiCog} aria-label="Edit repository metadata" className="text-muted" />
+                                    <Icon
+                                        svgPath={mdiCog}
+                                        aria-label="Edit repository metadata"
+                                        className="text-muted"
+                                    />
                                 </ButtonLink>
                             </Tooltip>
                         )}
-                    </ExtraInfoSectionHeader>
+                    </ExtraInfoSectionItemHeader>
                     {metadataItems.length ? (
                         <RepoMetadata items={metadataItems} />
                     ) : (
                         <Text className="text-muted">None</Text>
                     )}
-                </>
+                </ExtraInfoSectionItem>
             )}
         </Card>
     )

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -29,8 +29,14 @@ interface ReadmePreviewCardProps {
     entry: TreeFields['entries'][number]
     repoName: string
     revision: string
+    className?: string
 }
-export const ReadmePreviewCard: React.FunctionComponent<ReadmePreviewCardProps> = ({ entry, repoName, revision }) => {
+export const ReadmePreviewCard: React.FunctionComponent<ReadmePreviewCardProps> = ({
+    entry,
+    repoName,
+    revision,
+    className,
+}) => {
     const [readmeInfo, setReadmeInfo] = useState<null | BlobFileFields>(null)
 
     useEffect(() => {
@@ -50,7 +56,7 @@ export const ReadmePreviewCard: React.FunctionComponent<ReadmePreviewCardProps> 
     }, [repoName, revision, entry.path])
 
     return (
-        <section className="mb-4">
+        <section className={classNames('mb-4', className)}>
             {readmeInfo ? (
                 <RenderedReadmeFile blob={readmeInfo} entryUrl={entry.url} />
             ) : (

--- a/client/wildcard/src/global-styles/colors.scss
+++ b/client/wildcard/src/global-styles/colors.scss
@@ -71,6 +71,7 @@ $theme-colors: (
 
     // Other root palette colors.
     --blue: #{$blue};
+    --light-blue: #4393e7;
     --indigo: #0864c6;
     --purple: #{$purple};
     --pink: #d68cf3;
@@ -327,17 +328,17 @@ $theme-colors: (
     --merged-4: #1f0a5c;
     --text-muted: var(--gray-06);
     --text-muted-highlighted: #a9b9da; // --text-muted with higher contrast when shown on a --mark-bg background
-    --link-color: #4393e7;
+    --link-color: var(--light-blue);
     --link-color-2: #70b0f3;
     --link-active-color: #489ffa;
     --link-hover-color: #489ffa;
     --border-color: var(--gray-09);
     --border-color-2: var(--gray-08);
-    --border-active-color: #4393e7;
+    --border-active-color: var(--light-blue);
     --border-primary-color: #0f59aa; // = dark variant of primary-2
     // Start query highlighting
     --search-query-text-color: var(--gray-04);
-    --search-filter-keyword-color: #4393e7;
+    --search-filter-keyword-color: var(--light-blue);
     --search-filter-separator-color: var(--oc-gray-5);
     --search-path-separator-color: var(--oc-gray-5);
     --search-keyword-color: var(--pink);


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96. 

Currently, repo metadata can be added directly only via GQL API or src cli. The PR:
- update repo metadata display UI on search results page and repo root pages according to new [figma designs](https://www.figma.com/file/bwxYiOGWqSGu9mEmEUyCPw/Metadata?node-id=86-796&t=mnEvvoL4HwJpYdfQ-4)
- adds repo metadata editing UI for site admins to remove/add metadata. 

> NOTE: As a follow-up we will adding RBAC for not only site admins to have editing access to it.

## Test plan
- `sg start`
- Enable the `repository-metadata` feature flag
- Add some key-value pairs through API (currently no UI for adding) GQL mutation `addRepoKeyValuePair` API
- Search for that repo > go to repo root page

## Screenshots

https://user-images.githubusercontent.com/6717049/234353006-2c7db429-acf6-4c23-8ab3-924d57166c84.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
