### PR TITLE
batches: Replace white spaces with a dash in Batch Change Name input

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -104,8 +104,12 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
     const [isNameValid, setIsNameValid] = useState<boolean>()
 
     const onNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
-        setNameInput(event.target.value)
-        setIsNameValid(NAME_PATTERN.test(event.target.value))
+        let value = event.target.value
+        if (value.includes(' ')) {
+            value = value.replace(' ', '-')
+        }
+        setNameInput(value)
+        setIsNameValid(NAME_PATTERN.test(value))
     }, [])
 
     const { isUnlicensed, maxUnlicensedChangesets } = useBatchChangesLicense()


### PR DESCRIPTION
Closes: #50353. Gives the user a more successful path while naming their batch change. Spaces are not allowed, any space character inserted is replaced with a dash now.

Paired @st0nebraker & @adeola-ak 

**Note**: We didn't think the input description should be updated. The user can infer that spaces are being replaced by dashes because of the action & rules stated. Let us know if you think the description should be updated with anything specific.

https://user-images.githubusercontent.com/59381432/232865981-384adbbb-a41d-4bbc-9c47-34a6f96958ab.mov


## Test plan
- Ensure adding any space character is immediately changed with a dash when creating a new batch change
