### PR TITLE
gRPC: only create stream and unary interceptors once

### DIFF
--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -49,16 +49,22 @@ func DialOptions() []grpc.DialOption {
 			grpc_prometheus.StreamClientInterceptor(metrics),
 			internalgrpc.StreamClientPropagator(actor.ActorPropagator{}),
 			internalgrpc.StreamClientPropagator(policy.ShouldTracePropagator{}),
-			otelgrpc.StreamClientInterceptor(),
+			otelStreamInterceptor,
 		),
 		grpc.WithChainUnaryInterceptor(
 			grpc_prometheus.UnaryClientInterceptor(metrics),
 			internalgrpc.UnaryClientPropagator(actor.ActorPropagator{}),
 			internalgrpc.UnaryClientPropagator(policy.ShouldTracePropagator{}),
-			otelgrpc.UnaryClientInterceptor(),
+			otelUnaryInterceptor,
 		),
 	}
 }
+
+var (
+	// Package-level variables because they are somewhat expensive to recreate every time
+	otelStreamInterceptor = otelgrpc.StreamClientInterceptor()
+	otelUnaryInterceptor  = otelgrpc.UnaryClientInterceptor()
+)
 
 // NewServer creates a new *grpc.Server with the default options
 func NewServer(logger log.Logger, additionalOpts ...grpc.ServerOption) *grpc.Server {


### PR DESCRIPTION
These are somewhat expensive to create, and currently accounts for roughly 20% of our allocated objects on sourcegraph.com. This just moves them to the package level so they aren't being recreated for each dial.

This would also be mitigated by caching searcher connections.

<img width="1491" alt="Screenshot 2023-04-18 at 12 45 01" src="https://user-images.githubusercontent.com/12631702/232873673-c7b505cd-91f6-40d6-8d6b-536ad7477474.png">


## Test plan

Will watch sourcegraph.com to see if it reduces allcoations

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
