### PR TITLE
rbac: access control documentation

### DIFF
--- a/doc/dev/how-to/add_permission.md
+++ b/doc/dev/how-to/add_permission.md
@@ -1,0 +1,1 @@
+# Permissions

--- a/doc/dev/how-to/add_permission.md
+++ b/doc/dev/how-to/add_permission.md
@@ -1,1 +1,0 @@
-# Permissions

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -11,7 +11,7 @@ The source of truth for the Access Control system is the [`schema.yaml`](https:/
 
 ## How it works
 
-When Sourcegraph starts, a [background job](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/cmd/frontend/internal/cli/serve_cmd.go?L205:24) that syncs the namespaces and actions into the `permissions` table in the database is kicked off.
+When Sourcegraph starts, a [background job](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/cmd/frontend/internal/cli/serve_cmd.go?L205:24) is started that syncs the namespaces and actions into the `permissions` table in the database.
 
 Permissions are a combination of a namespace and an action available in that namespace. The background jobs removes permissions that are in the database but no longer referenced in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file, and adds permissions contained in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file but not in the database.
 

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -24,7 +24,7 @@ To add permissions for a new feature, follow these steps:
 
 2. Generate the access control constants with the command `sg gen`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
 
-3. Once this constants have been generated, you can protect any resource using the access control system. 
+3. Once these constants have been generated, you can protect any resource using the access control system. 
     * In Go, you can do this by importing the [`CheckCurrentUserHasPermission`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/internal/rbac/permission.go) method from the `internal/rbac` package. [Example](https://github.com/sourcegraph/sourcegraph/pull/49594/files).
 
     * In Typescript, you can do this by accessing the authenticated user's permissions and verifying the [permission](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/rbac/constants.ts?L5:14-5:41) you require is contained in the array. [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/batches/utils.ts?L6)

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -1,0 +1,30 @@
+# Permissions
+
+This doc is for engineers who want to add permissions for features they want to protect using the Access Control System.
+
+## Overview
+The RBAC system is based on two concepts:
+  * **Namespaces**: these refer to resources that are protected by the RBAC system.
+  * **Actions**: these are operations that a user can perform in a given namespace.
+
+The source of truth for the Access Control system is the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file, which contains the list of namespaces and the actions available to each namespace.
+
+## How it works
+
+When Sourcegraph starts, a [background job](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/cmd/frontend/internal/cli/serve_cmd.go?L205:24) that syncs the namespaces and actions into the `permissions` table in the database is kicked off.
+
+Permissions are a combination of a namespace and an action available in that namespace. The background jobs removes permissions that are in the database but no longer referenced in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file, and adds permissions contained in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file but not in the database.
+
+Once the permissions are synced, they can be used anywhere in Sourcegraph to protect unauthorized access to resources.
+
+## Adding Permissions
+To add permissions for a new feature, follow these steps:
+
+1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespaces are unique.
+
+2. Generate the access control constants with the command `sg gen`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
+
+3. Once this constants have been generated, you can protect any resource using the access control system. 
+    * In Go, you can do this by importing the [`CheckCurrentUserHasPermission`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/internal/rbac/permission.go) method from the `internal/rbac` package. [Example](https://github.com/sourcegraph/sourcegraph/pull/49594/files).
+
+    * In Typescript, you can do this by accessing the authenticated user's permissions and verifying the [permission](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/rbac/constants.ts?L5:14-5:41) you require is contained in the array. [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/client/web/src/batches/utils.ts?L6)

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -20,7 +20,7 @@ Once the permissions are synced, they can be used anywhere in Sourcegraph to pro
 ## Adding Permissions
 To add permissions for a new feature, follow these steps:
 
-1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespaces are unique.
+1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespace string must be unique.
 
 2. Generate the access control constants with the command `sg gen`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
 

--- a/doc/dev/how-to/add_permissions.md
+++ b/doc/dev/how-to/add_permissions.md
@@ -1,6 +1,6 @@
 # Permissions
 
-This doc is for engineers who want to add permissions for features they want to protect using the Access Control System.
+This doc is for engineers who want to add permissions for features they want to protect using the Access Control System. The permission referred to in this context differs from repository permissions; the latter concerns permissions from code hosts relating to repositories.
 
 ## Overview
 The RBAC system is based on two concepts:
@@ -13,7 +13,7 @@ The source of truth for the Access Control system is the [`schema.yaml`](https:/
 
 When Sourcegraph starts, a [background job](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/cmd/frontend/internal/cli/serve_cmd.go?L205:24) is started that syncs the namespaces and actions into the `permissions` table in the database.
 
-Permissions are a combination of a namespace and an action available in that namespace. The background jobs removes permissions that are in the database but no longer referenced in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file, and adds permissions contained in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file but not in the database.
+Permissions are a tuple of a namespace and an action available in that namespace. The background jobs removes actions and namespaces that are in the database but no longer referenced in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file, and adds permissions contained in the [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml) file but not in the database.
 
 Once the permissions are synced, they can be used anywhere in Sourcegraph to protect unauthorized access to resources.
 

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -52,7 +52,7 @@
 
 ## Access Control
 
-- [Adding a new permission](add_permission.md)
+- [Adding permissions](add_permissions.md)
 
 ## Windows support
 

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -50,6 +50,10 @@
 
 - [How to deploy a new executor image](deploy_executor_image.md)
 
+## Access Control
+
+- [Adding a new permission](add_permission.md)
+
 ## Windows support
 
 Running Sourcegraph on Windows is not actively tested, but should be possible within the Windows Subsystem for Linux (WSL).


### PR DESCRIPTION
Closes [#49885](https://github.com/sourcegraph/sourcegraph/issues/49885)

This contains the documentation for making use of the RBAC system.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Documentation addition.