### PR TITLE
Cody: add context to embeddings client

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -81,7 +81,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	client := embed.NewEmbeddingsClient()
-	getQueryEmbedding, err := getCachedQueryEmbeddingFn(client)
+	getQueryEmbedding, err := getCachedQueryEmbeddingFn(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/worker/internal/embeddings/contextdetection/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/contextdetection/handler.go
@@ -34,12 +34,12 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, _ *contextdetec
 
 	embeddingsClient := embed.NewEmbeddingsClient()
 
-	messagesWithAdditionalContextMeanEmbedding, err := getContextDetectionMessagesMeanEmbedding(MESSAGES_WITH_ADDITIONAL_CONTEXT, embeddingsClient)
+	messagesWithAdditionalContextMeanEmbedding, err := getContextDetectionMessagesMeanEmbedding(ctx, MESSAGES_WITH_ADDITIONAL_CONTEXT, embeddingsClient)
 	if err != nil {
 		return err
 	}
 
-	messagesWithoutAdditionalContextMeanEmbedding, err := getContextDetectionMessagesMeanEmbedding(MESSAGES_WITHOUT_ADDITIONAL_CONTEXT, embeddingsClient)
+	messagesWithoutAdditionalContextMeanEmbedding, err := getContextDetectionMessagesMeanEmbedding(ctx, MESSAGES_WITHOUT_ADDITIONAL_CONTEXT, embeddingsClient)
 	if err != nil {
 		return err
 	}
@@ -52,8 +52,8 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, _ *contextdetec
 	return embeddings.UploadIndex(ctx, h.uploadStore, embeddings.CONTEXT_DETECTION_INDEX_NAME, contextDetectionIndex)
 }
 
-func getContextDetectionMessagesMeanEmbedding(messages []string, client embed.EmbeddingsClient) ([]float32, error) {
-	messagesEmbeddings, err := client.GetEmbeddingsWithRetries(messages, MAX_EMBEDDINGS_RETRIES)
+func getContextDetectionMessagesMeanEmbedding(ctx context.Context, messages []string, client embed.EmbeddingsClient) ([]float32, error) {
+	messagesEmbeddings, err := client.GetEmbeddingsWithRetries(ctx, messages, MAX_EMBEDDINGS_RETRIES)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -55,12 +55,12 @@ func EmbedRepo(
 		return nil, err
 	}
 
-	codeIndex, err := embedFiles(codeFileNames, client, splitOptions, readFile, MAX_CODE_EMBEDDING_VECTORS, ranks)
+	codeIndex, err := embedFiles(ctx, codeFileNames, client, splitOptions, readFile, MAX_CODE_EMBEDDING_VECTORS, ranks)
 	if err != nil {
 		return nil, err
 	}
 
-	textIndex, err := embedFiles(textFileNames, client, splitOptions, readFile, MAX_TEXT_EMBEDDING_VECTORS, ranks)
+	textIndex, err := embedFiles(ctx, textFileNames, client, splitOptions, readFile, MAX_TEXT_EMBEDDING_VECTORS, ranks)
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +80,7 @@ func createEmptyEmbeddingIndex(columnDimension int) embeddings.EmbeddingIndex {
 // entire files. So we split the file contents into chunks and get embeddings for the chunks in batches. Functions returns an EmbeddingIndex containing
 // the embeddings and metadata about the chunks the embeddings correspond to.
 func embedFiles(
+	ctx context.Context,
 	fileNames []string,
 	client EmbeddingsClient,
 	splitOptions split.SplitOptions,
@@ -121,7 +122,7 @@ func embedFiles(
 				index.Ranks = append(index.Ranks, float32(repoPathRanks.Paths[chunk.FileName]))
 			}
 
-			batchEmbeddings, err := client.GetEmbeddingsWithRetries(batchChunks, GET_EMBEDDINGS_MAX_RETRIES)
+			batchEmbeddings, err := client.GetEmbeddingsWithRetries(ctx, batchChunks, GET_EMBEDDINGS_MAX_RETRIES)
 			if err != nil {
 				return errors.Wrap(err, "error while getting embeddings")
 			}

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -137,7 +137,7 @@ func (c *mockEmbeddingsClient) GetDimensions() (int, error) {
 	return 3, nil
 }
 
-func (c *mockEmbeddingsClient) GetEmbeddingsWithRetries(texts []string, maxRetries int) ([]float32, error) {
+func (c *mockEmbeddingsClient) GetEmbeddingsWithRetries(_ context.Context, texts []string, maxRetries int) ([]float32, error) {
 	dimensions, err := c.GetDimensions()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds a context to the embeddings client methods that make network requests and propagates the context upwards through its callers.

## Test plan

It builds

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
