### PR TITLE
Use regexp.MatchString instead of regexp.FindStringSubmatch

### DIFF
--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -41,13 +41,13 @@ func isContextRequiredForChatQuery(
 	queryTrimmed := strings.TrimSpace(query)
 	queryLower := strings.ToLower(queryTrimmed)
 	for _, regexp := range NO_CONTEXT_MESSAGES_REGEXPS {
-		if submatches := regexp.FindStringSubmatch(queryLower); len(submatches) > 0 {
+		if regexp.MatchString(queryLower) {
 			return false, nil
 		}
 	}
 
 	for _, regexp := range CONTEXT_MESSAGES_REGEXPS {
-		if submatches := regexp.FindStringSubmatch(queryLower); len(submatches) > 0 {
+		if regexp.MatchString(queryLower) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
We're just checking if the regexp matches. MatchString is cheaper and its intent is more clear.

## Test plan

It compiles. There should be no change in behavior.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
