### PR TITLE
Add app dmg download link to app docs

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -34,7 +34,13 @@ It runs alongside your IDE, to provide a better way to understand, browse, and s
 
 Ensure you have `git` installed / on your path, then install.
 
+**macOS:** via the app .dmg installer:
+
+Download the <a data-download-name="app-download-mac-dmg" href="https://storage.googleapis.com/sourcegraph-app-releases/latest/Sourcegraph%20App.dmg">Sourcegraph App .dmg installer</a> and run it.
+
 **macOS:** via homebrew:
+
+The homebrew installation is an alternative to the .dmg installer. If in doubt, use the .dmg installer above.
 
 ```sh
 brew install sourcegraph/app/sourcegraph
@@ -84,6 +90,7 @@ Sourcegraph app is early-stages, if you run into any trouble or have ideas/feedb
 #### macOS (app .dmg installer)
 
 Navigate to your Applications directory using Finder, and delete the old version of Sourcegraph. Then [download and run the latest version](https://about.sourcegraph.com/app).
+
 
 #### macOS (homebrew)
 


### PR DESCRIPTION
Add a link to download the Sourcegraph App dmg installer to the App docs.

Close #49316 

## Test plan

Docs change