### PR TITLE
Refactor Cody docs structure

### DIFF
--- a/doc/cody/explanations/enabling_cody.md
+++ b/doc/cody/explanations/enabling_cody.md
@@ -1,0 +1,25 @@
+# Enabling Cody with Sourcegraph.com
+
+Cody uses Sourcegraph to fetch relevant context to generate answers and code. These instructions walk through installing Cody and connecting it to Sourcegraph.com. For private instances of Sourcegraph, see [this page about enabling Cody for Enterprise](enabling_cody_enterprise.md).
+
+## Initial setup
+
+1. Sign into [Sourcegraph.com](https://sourcegraph.com). {You can create an account for free](https://sourcegraph.com/sign-up) if you don't already have one.
+2. [Join the open beta](https://forms.gle/cffMa8mrr8YuHv8o8). We'll email you when you're added, usually within a day.
+3. [Create a Sourcegraph access token](https://sourcegraph.com/user/settings/tokens)
+4. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
+5. Set the Sourcegraph URL to be `https://sourcegraph.com`
+6. Set the access token to be the token you just created
+
+  <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
+
+7. See [this section](#enabling-codebase-aware-answers) on how to enable codebase-aware answers.
+
+## Enabling codebase-aware answers
+
+
+
+After installing, we recommend the following:
+
+* [See the list](embedded-repos.md) of embedded repositories and request any that you'd like to add by pinging a Sourcegraph team member in [Discord](https://discord.gg/8wJF5EdAyA). Embeddings significantly improve the accuracy and quality of Cody's responses. Note that embeddings are only available for public repositories on sourcegraph.com. If you want to use Cody with embeddings on private code, consider moving to a Sourcegraph Enterprise instance.
+* Spread the word online and send us your feedback in Discord. Cody is open source and we'd love to hear from you if you have bug reports or feature requests.

--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -1,0 +1,100 @@
+# Enabling Cody on Sourcegraph Enterprise
+
+[Instructions for self-hosted Sourcegraph Enterprise instance](#Cody-on-self-hosted-sourcegraph-enterprise)
+[Instructions for Sourcegraph Cloud](#Cody-on-sourcegraph-cloud)
+[Enabling codebase-aware answers](#enabling-codebase-aware-answers)
+
+## Cody on self-hosted Sourcegraph Enterprise
+
+### Prerequisites
+
+- Sourcegraph 5.0.1 or above.
+- An Anthropic API key, that you can get from your Technical Advisor or Customer Engineer. 
+- (Optionally) An OpenAI API key for embeddings.
+
+There are two steps required to enable Cody on your enterprise instance:
+1. Enable your Sourcegraph instance
+2. Configure the VS Code extension
+
+### Step 1: Enable Cody on your Sourcegraph instance
+
+Note that this requires site-admin privileges.
+
+1. Cody uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension.
+2. To turn Cody on, you will need to set an access token for Sourcegraph to authentify with the third-party large language model provider (currently Anthropic but we may use different or several models over time). Reach out to your Sourcegraph Technical Advisor or Customer Engineer to get a key. They will create a key for you using the [anthropic console](https://console.anthropic.com/account/keys).
+3. Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+    ```json
+    {
+      // [...]
+      "completions": {
+        "enabled": true,
+        "accessToken": "<token>",
+        "model": "claude-v1",
+        "provider": "anthropic"
+      }
+    }
+    ```
+4. You're done! 
+5. Cody can be configured to use embeddings to significantly improve the quality of its responses. This involves sending your entire codebase to a third-party service to generate a low-dimensional semantic representation, that is used for improved context fetching. See the [embeddings](#embeddings) section for more.
+
+### Step 2: Configure the VS Code extension
+
+Now that Cody is turned on on your Sourcegraph instance, any user can configure and use the Cody VS Code extension. This does not require admin privilege.
+
+1. If you currently have a previous version of Cody installed, uninstall it and reload VS Code before proceeding to the next steps.
+1. Search for “Sourcegraph Cody” in your VS Code extension marketplace, and install it.
+
+    <img width="500" alt="Sourcegraph Cody in VS Code Marketplace" src="https://user-images.githubusercontent.com/55068936/228114612-65402e1c-7501-44cb-a846-46c4376b9572.png">
+
+3. Reload VS Code, and open the Cody extension. Review and accept the terms.
+
+4. Now you'll need to point the Cody extension to your Sourcegraph instance. On your instance, go to `settings` / `access token` (`https://<your-instance>.sourcegraph.com/users/<your-instance>/settings/tokens`). Generate an access token, copy it, and set it in the Cody extension.
+
+    <img width="1369" alt="image" src="https://user-images.githubusercontent.com/25070988/227510686-4afcb1f9-a3a5-495f-b1bf-6d661ba53cce.png">
+
+5. In the Cody VS Code extension, set your instance URL and the access token
+    
+    <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
+
+6. See [this section](#enabling-codebase-aware-answers) on how to enable codebase-aware answers.
+
+You're all set!
+
+### Step 3: Try Cody!
+
+A few things you can ask Cody:
+
+- "What are popular go libraries for building CLIs?"
+- Open your workspace, and ask "Do we have a React date picker component in this repository?"
+- Right click on a function, and ask Cody to explain it
+- Try any of the Cody recipes!
+
+<img width="510" alt="image" src="https://user-images.githubusercontent.com/25070988/227511383-aa60f074-817d-4875-af41-54558dfe1951.png">
+
+
+
+## Cody on Sourcegraph Cloud
+
+On Sourcegraph Cloud, Cody is a managed service and you do not need to follow the step 1 of the self-hosted guide above. 
+
+### Step 1: Enable Cody for your instance
+
+Cody can be enabled on demand on your Sourcegraph instance by contacting your account manager. The Sourcegraph team will refer to the [handbook](https://handbook.sourcegraph.com/departments/cloud/#managed-instance-requests).
+
+### Step 2: Configure the VS Code extension
+[See above](#step-2-configure-the-vs-code-extension).
+
+### Step 3: Try Cody! 
+[See above](#step-3-try-cody).
+
+[Learn more about running Cody on Sourcegraph Cloud](../../cloud/index.md#cody).
+
+## Enabling codebase-aware answers
+
+The `Cody: Codebase` setting in VS Code enables codebase-aware answers for the Cody extension. By setting this configuration option to the repository name on your Sourcegraph instance, Cody will be able to provide more accurate and relevant answers to your coding questions, based on the context of the codebase you are currently working in.
+
+1. Open the VS Code workspace settings by pressing <kbd>Cmd/Ctrl+,</kbd>, (or File > Preferences (Settings) on Windows & Linux).
+2. Search for the `Cody: Codebase` setting.
+3. Enter the repository name as listed on your Sourcegraph instance.
+   1. For example: `github.com/sourcegraph/sourcegraph` without the `https` protocol

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -11,7 +11,19 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 - **Sourcegraph Enterprise customers:** Contact your Sourcegraph techical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
 - **Everyone:** [Join the open beta.](https://forms.gle/cffMa8mrr8YuHv8o8) We'll email you when you're added, usually within a day.
 
-Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself.
+Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself. Follow the
+
+
+## Explanations
+
+- [Enabling Cody for Sourcegraph Enterprise customers](explanations/enabling_cody_enterprise.md)
+- [Enabling Cody for Sourcegraph.com users](explanations/enabling_cody.md)
+- [Enabling codebase-aware answers](explanations/enabling_codebase_aware_answers.md)
+
+<div class="cta-group">
+<a class="btn btn-primary" href="quickstart">★ Quickstart</a>
+<a class="btn" href="https://discord.gg/8wJF5EdAyA">Join our Discord</a>
+</div>
 
 ## Features
 
@@ -59,98 +71,6 @@ In VS Code, right-click on a selection of code and choose one of the `Ask Cody >
 - Generate Unit Test
 - Generate Docstring
 - Improve Variable Names
-
-## Cody on Sourcegraph.com
-
-Cody uses Sourcegraph to fetch relevant context to generate answers and code. These instructions walk through installing Cody and connecting it to Sourcegraph.com. For private instances of Sourcegraph, see the section below about enabling Cody for Enterprise.
-
-1. Sign into [Sourcegraph.com](https://sourcegraph.com) (or create an account if you don't already have one)
-1. [Join the open beta](https://forms.gle/cffMa8mrr8YuHv8o8). We'll email you when you're added, usually within a day.
-1. [Create a Sourcegraph access token](https://sourcegraph.com/user/settings/tokens)
-1. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
-  1. Set the Sourcegraph URL to be `https://sourcegraph.com`
-  1. Set the access token to be the token you just created
-1. See [this section](#enabling-codebase-aware-answers) on how to enable codebase-aware answers.
-
-After installing, we recommend the following:
-
-* [See the list](embedded-repos.md) of embedded repositories and request any that you'd like to add by pinging a Sourcegraph team member in [Discord](https://discord.gg/8wJF5EdAyA). Embeddings significantly improve the accuracy and quality of Cody's responses. Note that embeddings are only available for public repositories on sourcegraph.com. If you want to use Cody with embeddings on private code, consider moving to a Sourcegraph Enterprise instance.
-* Spread the word online and send us your feedback in Discord. Cody is open source and we'd love to hear from you if you have bug reports or feature requests.
-
-## Cody on Sourcegraph Cloud
-
-On Sourcegraph Cloud, Cody is a managed service and you do not need to follow the step 1 of the self-hosted guide. 
-
-1. Cody can be enabled on demand on your Sourcegraph instance by contacting your account manager. The Sourcegraph team will refer to the [handbook](https://handbook.sourcegraph.com/departments/cloud/#managed-instance-requests).
-1. Users can then configure the [VS Code extension](#step-2-configure-the-vs-code-extension)
-
-Learn more from [Cody on Cloud](../cloud/index.md#cody).
-
-## Cody on your self-hosted Sourcegraph Enterprise instance
-
-### Prerequisites
-
-- Sourcegraph 5.0.1 or above.
-- An Anthropic API key, that you can get from your Technical Advisor or Customer Engineer. 
-- (Optionally), an OpenAI API key for embeddings.
-
-There are two steps required to enable Cody for Enterprise: enable your Sourcegraph instance and configure the VS Code extension.
-
-### Step 1: Enable Cody on your Sourcegraph instance
-
-Note that this requires site-admin privileges.
-
-1. Cody uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension.
-2. To turn Cody on, you will need to set an access token for Sourcegraph to authentify with the third-party large language model provider (currently Anthropic but we may use different or several models over time). Reach out to your Sourcegraph Technical Advisor or Customer Engineer to get a key. They will create a key for you using the [anthropic console](https://console.anthropic.com/account/keys).
-3. Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
-
-    ```json
-    {
-      // [...]
-      "completions": {
-        "enabled": true,
-        "accessToken": "<token>",
-        "model": "claude-v1",
-        "provider": "anthropic"
-      }
-    }
-    ```
-4. You're done! 
-5. Cody can be configured to use embeddings to significantly improve the quality of its responses. This involves sending your entire codebase to a third-party service to generate a low-dimensional semantic representation, that is used for improved context fetching. See the [embeddings](#embeddings) section for more.
-
-### Step 2: Configure the VS Code extension
-
-Now that Cody is turned on on your Sourcegraph instance, any user can configure and use the Cody VS Code extension. This does not require admin privilege.
-
-1. If you currently have a previous version of Cody installed, uninstall it and reload VS Code before proceeding to the next steps.
-1. Search for “Sourcegraph Cody” in your VS Code extension marketplace, and install it.
-
-    <img width="500" alt="Sourcegraph Cody in VS Code Marketplace" src="https://user-images.githubusercontent.com/55068936/228114612-65402e1c-7501-44cb-a846-46c4376b9572.png">
-
-3. Reload VS Code, and open the Cody extension. Review and accept the terms.
-
-4. Now you'll need to point the Cody extension to your Sourcegraph instance. On your instance, go to `settings` / `access token` (`https://<your-instance>.sourcegraph.com/users/<your-instance>/settings/tokens`). Generate an access token, copy it, and set it in the Cody extension.
-
-    <img width="1369" alt="image" src="https://user-images.githubusercontent.com/25070988/227510686-4afcb1f9-a3a5-495f-b1bf-6d661ba53cce.png">
-
-5. In the Cody VS Code extension, set your instance URL and the access token
-    
-    <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
-
-6. See [this section](#enabling-codebase-aware-answers) on how to enable codebase-aware answers.
-
-You're all set!
-
-### Step 3: Try Cody!
-
-A few things you can ask Cody:
-
-- "What are popular go libraries for building CLIs?"
-- Open your workspace, and ask "Do we have a React date picker component in this repository?"
-- Right click on a function, and ask Cody to explain it
-- Try any of the Cody recipes!
-
-<img width="510" alt="image" src="https://user-images.githubusercontent.com/25070988/227511383-aa60f074-817d-4875-af41-54558dfe1951.png">
 
 ## Enabling codebase-aware answers
 
@@ -254,4 +174,3 @@ If you would like to allow your Sourcegraph instance to control the creation and
 ## Turning Cody off
 
 To turn Cody off, set `embeddings` and `completions` site-admin settings to `enabled:false` (or remove them altogether).
-

--- a/doc/cody/quickstart.md
+++ b/doc/cody/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart for Cody in VS Code
+
+Get started with the Cody VS Code extension and start using Cody recipes in under 10 minutes.
+
+## Introduction
+
+In this guide, you will:
+
+- Install the VS Code extension
+- Connect the extension to your Sourcegraph Enterprise instance or Sourcegraph.com account
+- Generate a unit test for your code
+- Have Cody summarize recent changes to your code
+
+## Requirements
+
+- A Sourcegraph instance with Cody enabled on it OR a Sourcegraph.com account with Cody enabled on it.
+
+If you haven't yet done this, see Step 1 on the following pages:
+
+- [Enabling Cody for Sourcegraph Enterprise](explanations/enabling_cody_enterprise.md)
+- [Enabling Cody for Sourcegraph.com](explanations/enabling_cody.md)
+
+## Install the VS Code extension
+
+The first thing you need to do is install the VS Code extension. You can do this in 2 ways:
+
+- Click the Extensions icon on the VS Code activity bar
+- Search for "Sourcegraph Cody"
+- Install the extension directly to VS Code
+
+Or:
+
+- [Download and install the extension from this link](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
+
+## Generate an access token from your Sourcegraph instance
+
+Next, you must generate an access token so that Cody can talk to your Sourcegraph instance. You'll add this to your extension in the next step.
+
+**For Sourcegraph Enterprise users:**
+
+Log in to your Sourcegraph instance and go to `settings` / `access token` (`https://<your-instance>.sourcegraph.com/users/<your-instance>/settings/tokens`). From here, generate a new access token.
+
+**For Sourcegraph.com users:**
+
+Log in to Sourcegraph.com and go to the [Access tokens page](https://sourcegraph.com/user/settings/tokens). Generate a new access token.
+
+## Configure your extension settings
+
+When you first install the Cody extension, you will see this screen:
+
+  <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
+
+In the `Access Token` field, paste in your access token from the previous step.
+
+In the `Sourcegraph Instance` field, paste in the URL of your Sourcegraph instance.
+
+- For Sourcegraph Enterprise, this is your own instance's URL.
+- For Sourcegraph.com, this is `https://sourcegraph.com`
+
+## Generate a unit test
+
+The Cody icon should now appear in the activity bar in VS Code. Clicking the icon will open the Cody side panel. The `Chat` tab can be used to ask Cody questions and paste in snippets of code, and the `Recipes` tab can be used to run premade functions over whatever code you currently have highlighted.
+
+As one recipe example, let's generate a unit test:
+
+1. Open a code file in VS Code
+2. Open the `Recipes` tab in the Cody sidebar
+3. Highlight a code snippet in your code that you'd like to test
+4. Click the `Generate a unit test` recipe button OR right click -> `Ask Cody` -> `Ask Cody: Generate Unit Test`
+5. Cody will provide a unit test as a code snippet in the sidebar
+
+## Get up-to-date on recent changes to your code (Sourcegraph Enterprise users only)
+
+If you're using Cody with Sourcegraph Enterprise, Cody can utilize Sourcegraph's search and the code graph to understand your own codebase and provide context-aware answers. Using this, Cody can tell you about recent changes to your code and quickly provide a summary.
+
+Imagine you've stepped away from a project for the last week. Let's see what's changed in that time:
+
+1. Open the `Recipes` tab in the Cody sidebar
+2. Click the `Summarize recent changes` recipe button
+3. A dropdown will appear. Click `Last week`
+4. Cody will provide a summary of changes to your codebase that occurred in that time period
+
+## Try other recipes and Cody chat
+
+Cody can do many other things, including:
+
+1. Explain code snippets
+2. Refactor code and variable names
+3. Translate code to different languages
+4. Answer general questions about your code
+5. Suggest bugfixes and changes to code snippets
+
+To see this in action, try asking Codying a question in the chat sidebar such as "Are there any bugs in this code snippet?"
+
+## Congratulations!
+
+**You're now up-and-running with your very own AI code asisstant!** 🎉


### PR DESCRIPTION
Refactoring Cody docs to move to structured pages. Add Quickstart.

## Test plan

Docs only
