### PR TITLE
Cody: pass context in to each embeddings fetch call

### DIFF
--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -71,7 +71,7 @@ func isQuerySimilarToNoContextMessages(
 		return false, errors.Wrap(err, "getting context detection embedding index")
 	}
 
-	queryEmbedding, err := getQueryEmbedding(query)
+	queryEmbedding, err := getQueryEmbedding(ctx, query)
 	if err != nil {
 		return false, errors.Wrap(err, "getting query embedding")
 	}

--- a/enterprise/cmd/embeddings/shared/context_detection_test.go
+++ b/enterprise/cmd/embeddings/shared/context_detection_test.go
@@ -62,7 +62,7 @@ func TestIsContextRequiredForChatQuery(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			getQueryEmbedding := func(query string) ([]float32, error) {
+			getQueryEmbedding := func(_ context.Context, query string) ([]float32, error) {
 				return tt.embedding, tt.embeddingErr
 			}
 

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -81,7 +81,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	client := embed.NewEmbeddingsClient()
-	getQueryEmbedding, err := getCachedQueryEmbeddingFn(ctx, client)
+	getQueryEmbedding, err := getCachedQueryEmbeddingFn(client)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
+++ b/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
@@ -12,13 +12,13 @@ import (
 const QUERY_EMBEDDING_RETRIES = 3
 const QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES = 128
 
-func getCachedQueryEmbeddingFn(ctx context.Context, client embed.EmbeddingsClient) (getQueryEmbeddingFn, error) {
+func getCachedQueryEmbeddingFn(client embed.EmbeddingsClient) (getQueryEmbeddingFn, error) {
 	cache, err := lru.New[string, []float32](QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating query embeddings cache")
 	}
 
-	return func(query string) (queryEmbedding []float32, err error) {
+	return func(ctx context.Context, query string) (queryEmbedding []float32, err error) {
 		if cachedQueryEmbedding, ok := cache.Get(query); ok {
 			queryEmbedding = cachedQueryEmbedding
 		} else {

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -15,7 +15,7 @@ import (
 
 type readFileFn func(ctx context.Context, repoName api.RepoName, revision api.CommitID, fileName string) ([]byte, error)
 type getRepoEmbeddingIndexFn func(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
-type getQueryEmbeddingFn func(query string) ([]float32, error)
+type getQueryEmbeddingFn func(ctx context.Context, query string) ([]float32, error)
 
 func searchRepoEmbeddingIndex(
 	ctx context.Context,
@@ -30,7 +30,7 @@ func searchRepoEmbeddingIndex(
 		return nil, errors.Wrap(err, "getting repo embedding index")
 	}
 
-	embeddedQuery, err := getQueryEmbedding(params.Query)
+	embeddedQuery, err := getQueryEmbedding(ctx, params.Query)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting query embedding")
 	}


### PR DESCRIPTION
We were capturing an outer context, which is not necessarily scoped to the request. It was never canceled, so it wasn't causing problems, but it meant that the request-level context was not respected.

_I heard I'm on the team responsible for context_

## Test plan

It compiles.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
