### PR TITLE
cody: run cody-shared tests in CI and fix them

### DIFF
--- a/client/cody-shared/src/chat/transcript/transcript.test.ts
+++ b/client/cody-shared/src/chat/transcript/transcript.test.ts
@@ -54,7 +54,7 @@ describe('Transcript', () => {
         const prompt = await transcript.toPrompt()
         const expectedPrompt = [
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
@@ -92,7 +92,7 @@ describe('Transcript', () => {
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
@@ -145,7 +145,7 @@ describe('Transcript', () => {
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'how to create a batch change' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
@@ -227,7 +227,7 @@ describe('Transcript', () => {
                 text: 'Ok.',
             },
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
@@ -251,7 +251,7 @@ describe('Transcript', () => {
         const prompt = await transcript.toPrompt()
         const expectedPrompt = [
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
@@ -314,7 +314,7 @@ describe('Transcript', () => {
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: 'By setting the Authorization header.' },
             { speaker: 'human', text: 'how do to delete them' },
-            { speaker: 'assistant', text: '' },
+            { speaker: 'assistant', text: undefined },
         ]
         assert.deepStrictEqual(prompt, expectedPrompt)
     })

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -324,6 +324,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
+		bk.Cmd("pnpm --filter cody-shared run test"),
 	)
 }
 


### PR DESCRIPTION
The cody-shared tests haven't run in CI, as far as I can tell.

This adds them to CI and also fixes them. Looks like we turned `text: string` into `text?: string` and the output doesn't match the expectations anymore.

## Test plan

- Run these tests locally
