### PR TITLE
(feat) add repo metadata to export csv result

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -476,6 +476,7 @@ export interface StreamSearchOptions {
     decorationContextLines?: number
     displayLimit?: number
     chunkMatches?: boolean
+    enableRepositoryMetadata?: boolean
 }
 
 function initiateSearchStream(

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -153,7 +153,7 @@ export interface RepositoryMatch {
     private?: boolean
     branches?: string[]
     descriptionMatches?: Range[]
-    keyValuePairs?: Record<string, string>
+    keyValuePairs?: Record<string, string | undefined>
 }
 
 export type OwnerMatch = PersonMatch | TeamMatch

--- a/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
+++ b/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
@@ -8,6 +8,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { Alert, Button, Code, H3, Modal, Text } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
+import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 
 import { downloadSearchResults, EXPORT_RESULT_DISPLAY_LIMIT } from './searchResultsExport'
 
@@ -43,6 +44,8 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<ErrorLike | undefined>()
 
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+
     const downloadResults = useCallback(() => {
         if (!searchCompleted) {
             return
@@ -55,7 +58,13 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
         setLoading(true)
         setError(undefined)
 
-        downloadSearchResults(sourcegraphURL, query, options, results, shouldRerunSearch)
+        downloadSearchResults(
+            sourcegraphURL,
+            query,
+            { ...options, enableRepositoryMetadata },
+            results,
+            shouldRerunSearch
+        )
             .then(() => {
                 onClose()
             })
@@ -70,7 +79,17 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
             .finally(() => {
                 setLoading(false)
             })
-    }, [searchCompleted, query, sourcegraphURL, options, results, shouldRerunSearch, onClose, telemetryService])
+    }, [
+        searchCompleted,
+        query,
+        sourcegraphURL,
+        options,
+        enableRepositoryMetadata,
+        results,
+        shouldRerunSearch,
+        telemetryService,
+        onClose,
+    ])
 
     return (
         <Modal aria-labelledby={MODAL_LABEL_ID}>

--- a/client/web/src/search/results/export/searchResultsExport.test.ts
+++ b/client/web/src/search/results/export/searchResultsExport.test.ts
@@ -923,6 +923,11 @@ describe('searchResultsToFileContent', () => {
                     repoLastFetched: '2022-12-15T03:33:35.440014Z',
                     description:
                         "Download and generate EPUB of your favorite books from O'Reilly Learning (aka Safari Books Online) library.",
+                    keyValuePairs: {
+                        oss: undefined,
+                        deprecated: undefined,
+                        'some",non-standard-key': 'value',
+                    },
                 },
                 {
                     type: 'repo',
@@ -1392,6 +1397,14 @@ describe('searchResultsToFileContent', () => {
 
     test.each(data)('returns correct content for searchType "%s"', (searchType, results, content) => {
         expect(searchResultsToFileContent(results, sourcegraphURL)).toEqual(content)
+    })
+
+    test('returns correct content for repo match with enableRepositoryMetadata=true', () => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const [, results] = data.find(([searchType]) => searchType === 'repo')!
+        expect(searchResultsToFileContent(results, sourcegraphURL, true)).toEqual(
+            'Match type,Repository,Repository external URL,Repository metadata\nrepo,github.com/lorenzodifuccia/safaribooks,http://localhost:3443/github.com/lorenzodifuccia/safaribooks,"oss\ndeprecated\nsome"",non-standard-key:value"\nrepo,github.com/rfletcher/safari-json-formatter,http://localhost:3443/github.com/rfletcher/safari-json-formatter,""\nrepo,github.com/AdguardTeam/AdGuardForSafari,http://localhost:3443/github.com/AdguardTeam/AdGuardForSafari,""\nrepo,github.com/kishikawakatsumi/SourceKitForSafari,http://localhost:3443/github.com/kishikawakatsumi/SourceKitForSafari,""\nrepo,github.com/shaojiankui/iOS-UDID-Safari,http://localhost:3443/github.com/shaojiankui/iOS-UDID-Safari,""'
+        )
     })
 })
 

--- a/client/web/src/search/results/export/searchResultsExport.ts
+++ b/client/web/src/search/results/export/searchResultsExport.ts
@@ -26,7 +26,11 @@ const sanitizeString = (str: string): string =>
         .replaceAll(/ +(?= )/g, '') // remove extra spaces
         .replaceAll(/\n/g, '')}"` // remove extra newlines
 
-export const searchResultsToFileContent = (searchResults: SearchMatch[], sourcegraphURL: string): string => {
+export const searchResultsToFileContent = (
+    searchResults: SearchMatch[],
+    sourcegraphURL: string,
+    enableRepositoryMetadata?: boolean
+): string => {
     let content = []
     const resultType = searchResults[0].type
     const headers = ['Match type', 'Repository', 'Repository external URL']
@@ -124,16 +128,34 @@ export const searchResultsToFileContent = (searchResults: SearchMatch[], sourceg
         }
 
         case 'repo': {
-            content = [
-                headers,
-                ...searchResults
-                    .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
-                    .map(result => [
-                        result.type,
-                        result.repository,
-                        new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
-                    ]),
-            ]
+            content = !enableRepositoryMetadata
+                ? [
+                      headers,
+                      ...searchResults
+                          .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
+                          .map(result => [
+                              result.type,
+                              result.repository,
+                              new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
+                          ]),
+                  ]
+                : [
+                      [...headers, 'Repository metadata'],
+                      ...searchResults
+                          .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
+                          .map(result => [
+                              result.type,
+                              result.repository,
+                              new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
+                              '"' +
+                                  Object.entries(result.keyValuePairs ?? {})
+                                      .map(([key, value]) => (value ? `${key}:${value}` : key))
+                                      .join('\n')
+                                      .replaceAll('"', '""') +
+                                  '"',
+                          ]),
+                  ]
+
             break
         }
 
@@ -237,7 +259,7 @@ export const downloadSearchResults = (
             throw new Error('No search results found.')
         }
 
-        const content = searchResultsToFileContent(results.results, sourcegraphURL)
+        const content = searchResultsToFileContent(results.results, sourcegraphURL, options.enableRepositoryMetadata)
         const blob = new Blob([content], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
 

--- a/client/web/src/search/results/export/searchResultsExport.ts
+++ b/client/web/src/search/results/export/searchResultsExport.ts
@@ -128,34 +128,26 @@ export const searchResultsToFileContent = (
         }
 
         case 'repo': {
-            content = !enableRepositoryMetadata
-                ? [
-                      headers,
-                      ...searchResults
-                          .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
-                          .map(result => [
-                              result.type,
-                              result.repository,
-                              new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
-                          ]),
-                  ]
-                : [
-                      [...headers, 'Repository metadata'],
-                      ...searchResults
-                          .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
-                          .map(result => [
-                              result.type,
-                              result.repository,
-                              new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
-                              '"' +
-                                  Object.entries(result.keyValuePairs ?? {})
-                                      .map(([key, value]) => (value ? `${key}:${value}` : key))
-                                      .join('\n')
-                                      .replaceAll('"', '""') +
-                                  '"',
-                          ]),
-                  ]
-
+            content = [
+                enableRepositoryMetadata ? [...headers, 'Repository metadata'] : headers,
+                ...searchResults
+                    .filter((result: SearchMatch): result is RepositoryMatch => result.type === 'repo')
+                    .map(result => [
+                        result.type,
+                        result.repository,
+                        new URL(getRepositoryUrl(result.repository, result.branches), sourcegraphURL).toString(),
+                        ...(enableRepositoryMetadata
+                            ? [
+                                  '"' +
+                                      Object.entries(result.keyValuePairs ?? {})
+                                          .map(([key, value]) => (value ? `${key}:${value}` : key))
+                                          .join('\n')
+                                          .replaceAll('"', '""') +
+                                      '"',
+                              ]
+                            : []),
+                    ]),
+            ]
             break
         }
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

## Test plan
- `sg start`
- Enable the `repository-metadata` feature flag
- Add some key-value pairs through API (currently no UI for adding) GQL mutation `addRepoKeyValuePair` API
- Search with `select:repo` and export results

## Screenshot
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/6717049/233084331-b93caf4b-c5e4-4d4d-8ad8-75ec682ded59.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
