### PR TITLE
Cody: convert single \n to line breaks

### DIFF
--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -12,5 +12,5 @@ export function renderMarkdown(markdown: string): string {
     registerHighlightContributions()
 
     // Add Cody-specific Markdown rendering if needed.
-    return renderMarkdownCommon(markdown)
+    return renderMarkdownCommon(markdown, { breaks: true })
 }


### PR DESCRIPTION
Closes #50813

When user generate input or paste raw code, we currently follow the markdown space and don't convert `\n` to line breaks. This is unexpected for the cody input since it will appear like a formatting error (as the input is rendered as a textarea).

This is especially noticed if you just copy paste code without a code block:

<img width="412" alt="Screenshot 2023-04-19 at 17 43 38" src="https://user-images.githubusercontent.com/458591/233129072-44a55542-0962-4803-a315-909b64eecb13.png">

To fix this, we can turn on line breaks in the markdown parser. This will affect both the user message as well as the AI message but in my limited testing I haven't found any issues with this. The main reason for this feature in markdown is so that you can have an easier way to list diffs inside a paragraph by separating splitting every sentence with a newline like this:

```
First sentence of paragraph.
Second sentence of paragraph.
```

which is not something that I have observed the AI to be making use of anyways.

## Test plan

<img width="436" alt="Screenshot 2023-04-19 at 17 45 24" src="https://user-images.githubusercontent.com/458591/233129541-9b0b757c-ee86-42db-8b2a-897cb24524e2.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
