### PR TITLE
Cody: add and log feedback

### DIFF
--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -27,6 +27,8 @@ interface ChatProps extends ChatClassNames {
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     afterTips?: string
     className?: string
+    FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
+    feedbackButtonsOnSubmit?: (text: string) => void
 }
 
 interface ChatClassNames extends TranscriptItemClassNames {
@@ -51,6 +53,11 @@ export interface ChatUISubmitButtonProps {
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
+export interface FeedbackButtonsProps {
+    className: string
+    disabled?: boolean
+    feedbackButtonsOnSubmit: (text: string) => void
+}
 /**
  * The Cody chat interface, with a transcript of all messages and a message form.
  */
@@ -76,6 +83,8 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     inputRowClassName,
     chatInputContextClassName,
     chatInputClassName,
+    FeedbackButtonsContainer,
+    feedbackButtonsOnSubmit,
 }) => {
     const [inputRows, setInputRows] = useState(5)
     const [historyIndex, setHistoryIndex] = useState(inputHistory.length)
@@ -151,6 +160,8 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 transcriptItemParticipantClassName={transcriptItemParticipantClassName}
                 transcriptActionClassName={transcriptActionClassName}
                 className={styles.transcriptContainer}
+                FeedbackButtonsContainer={FeedbackButtonsContainer}
+                feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
             />
 
             <form className={classNames(styles.inputRow, inputRowClassName)}>

--- a/client/cody-ui/src/chat/Transcript.tsx
+++ b/client/cody-ui/src/chat/Transcript.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames'
 
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
+import { FeedbackButtonsProps } from '../Chat'
+
 import { FileLinkProps } from './ContextFiles'
 import { TranscriptItem, TranscriptItemClassNames } from './TranscriptItem'
 
@@ -15,6 +17,8 @@ export const Transcript: React.FunctionComponent<
         messageInProgress: ChatMessage | null
         fileLinkComponent: React.FunctionComponent<FileLinkProps>
         className?: string
+        FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
+        feedbackButtonsOnSubmit?: (text: string) => void
     } & TranscriptItemClassNames
 > = ({
     transcript,
@@ -26,6 +30,8 @@ export const Transcript: React.FunctionComponent<
     humanTranscriptItemClassName,
     transcriptItemParticipantClassName,
     transcriptActionClassName,
+    FeedbackButtonsContainer,
+    feedbackButtonsOnSubmit,
 }) => {
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
     useEffect(() => {
@@ -73,6 +79,9 @@ export const Transcript: React.FunctionComponent<
                     humanTranscriptItemClassName={humanTranscriptItemClassName}
                     transcriptItemParticipantClassName={transcriptItemParticipantClassName}
                     transcriptActionClassName={transcriptActionClassName}
+                    FeedbackButtonsContainer={FeedbackButtonsContainer}
+                    feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                    showFeedbackButtons={index > 0 && transcript.length - index === 1}
                 />
             ))}
             {messageInProgress && messageInProgress.speaker === 'assistant' && (
@@ -84,6 +93,7 @@ export const Transcript: React.FunctionComponent<
                     transcriptItemClassName={transcriptItemClassName}
                     transcriptItemParticipantClassName={transcriptItemParticipantClassName}
                     transcriptActionClassName={transcriptActionClassName}
+                    showFeedbackButtons={false}
                 />
             )}
         </div>

--- a/client/cody-ui/src/chat/TranscriptItem.module.css
+++ b/client/cody-ui/src/chat/TranscriptItem.module.css
@@ -27,6 +27,8 @@
 
 .participant {
     font-weight: bold;
+    display: flex;
+    justify-content: space-between;
 }
 
 .participant-name {
@@ -64,10 +66,25 @@
     overflow-x: auto;
 }
 
-
 .content > div:first-child > *:first-child {
     margin-top: 0;
 }
 .content > div:first-child > *:last-child {
     margin-bottom: 0;
+}
+
+.feedback-buttons-container {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+
+    margin: 0;
+    padding: 0 var(--spacing) var(--spacing) var(--spacing);
+
+    font-size: 0.8rem;
+}
+
+.feedback-buttons {
+    display: flex;
+    margin: 0;
 }

--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
+import { FeedbackButtonsProps } from '../Chat'
 import { CodySvg } from '../utils/icons'
 
 import { BlinkingCursor } from './BlinkingCursor'
@@ -31,6 +32,9 @@ export const TranscriptItem: React.FunctionComponent<
         message: ChatMessage
         inProgress: boolean
         fileLinkComponent: React.FunctionComponent<FileLinkProps>
+        FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
+        feedbackButtonsOnSubmit?: (text: string) => void
+        showFeedbackButtons: boolean
     } & TranscriptItemClassNames
 > = ({
     message,
@@ -41,6 +45,9 @@ export const TranscriptItem: React.FunctionComponent<
     transcriptItemParticipantClassName,
     codeBlocksCopyButtonClassName,
     transcriptActionClassName,
+    FeedbackButtonsContainer,
+    feedbackButtonsOnSubmit,
+    showFeedbackButtons,
 }) => (
     <div
         className={classNames(
@@ -59,6 +66,18 @@ export const TranscriptItem: React.FunctionComponent<
                     'Me'
                 )}
             </h2>
+            {/* display feedback buttons on last assistant message only */}
+            <div className={styles.participantName}>
+                {showFeedbackButtons &&
+                    FeedbackButtonsContainer &&
+                    feedbackButtonsOnSubmit &&
+                    message.speaker === 'assistant' && (
+                        <FeedbackButtonsContainer
+                            className={styles.FeedbackButtonsContainer}
+                            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                        />
+                    )}
+            </div>
         </header>
         {message.contextFiles && message.contextFiles.length > 0 && (
             <div className={styles.actions}>

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -12,6 +12,7 @@ export type WebviewMessage =
           command: 'initialized'
       }
     | { command: 'reset' }
+    | { command: 'event'; event: string; value: string }
     | { command: 'submit'; text: string }
     | { command: 'executeRecipe'; recipe: string }
     | { command: 'settings'; serverEndpoint: string; accessToken: string }
@@ -39,3 +40,5 @@ export type ExtensionMessage =
 export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debug' | 'serverEndpoint'> {
     hasAccessToken: boolean
 }
+
+export const DOTCOM_URL = new URL('https://sourcegraph.com')

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
 import { ChatViewProvider, isValidLogin } from './chat/ChatViewProvider'
+import { DOTCOM_URL } from './chat/protocol'
 import { LocalStorage } from './command/LocalStorageProvider'
 import { CodyCompletionItemProvider } from './completions'
 import { CompletionsDocumentProvider } from './completions/docprovider'
@@ -119,16 +120,12 @@ const register = async (
         // Register URI Handler to resolve token sending back from sourcegraph.com
         vscode.window.registerUriHandler({
             handleUri: async (uri: vscode.Uri) => {
-                await workspaceConfig.update(
-                    'cody.serverEndpoint',
-                    'https://sourcegraph.com',
-                    vscode.ConfigurationTarget.Global
-                )
+                await workspaceConfig.update('cody.serverEndpoint', DOTCOM_URL.href, vscode.ConfigurationTarget.Global)
                 const token = new URLSearchParams(uri.query).get('code')
                 if (token && token.length > 8) {
                     await context.secrets.store(CODY_ACCESS_TOKEN_SECRET, token)
                     const isAuthed = await isValidLogin({
-                        serverEndpoint: 'https://sourcegraph.com',
+                        serverEndpoint: DOTCOM_URL.href,
                         accessToken: token,
                         customHeaders: config.customHeaders,
                     })

--- a/client/cody/webviews/UserHistory.css
+++ b/client/cody/webviews/UserHistory.css
@@ -14,7 +14,7 @@
     justify-content: center;
     padding: 0.5rem 0rem;
     font-weight: bold;
-    color: var(--vscode-foreground);
+    color: var(--vscode-button-foreground);
 }
 
 .history-item-container {
@@ -24,4 +24,5 @@
 .history-remove-btn {
     margin-bottom: 1rem;
     cursor: pointer;
+    color: var(--vscode-button-secondaryForeground);
 }


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/50180

Add buttons to cody's last reply to allow users to submit feedbacks:

![Screenshot 2023-04-19 at 12 25 49 PM](https://user-images.githubusercontent.com/68532117/233182357-21eb60bc-27dc-4839-bcab-434956aca589.png)

Icon changes to `check` after click:

![Screenshot 2023-04-19 at 12 31 05 PM](https://user-images.githubusercontent.com/68532117/233182161-f810ca0b-08b6-4869-971a-e02515d0791f.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

To test:
1. clone and pull the latest commit from this branch
2. run pnpm install from root
3. Select Launch Cody Extension from the dropdown menu in the RUN AND DEBUG sidebar in VS Code
4. Chat with Cody and see the newly added feedback buttons on the latest reply from Cody
