### PR TITLE
Fix link list in Cody docs

### DIFF
--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -1,7 +1,7 @@
 # Enabling Cody on Sourcegraph Enterprise
 
-- [Instructions for self-hosted Sourcegraph Enterprise](#Cody-on-self-hosted-sourcegraph-enterprise)
-- [Instructions for Sourcegraph Cloud](#Cody-on-sourcegraph-cloud)
+- [Instructions for self-hosted Sourcegraph Enterprise](#cody-on-self-hosted-sourcegraph-enterprise)
+- [Instructions for Sourcegraph Cloud](#cody-on-sourcegraph-cloud)
 - [Enabling codebase-aware answers](#enabling-codebase-aware-answers)
 - [Turning Cody off](#turning-cody-off)
 

--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -1,9 +1,9 @@
 # Enabling Cody on Sourcegraph Enterprise
 
-[Instructions for self-hosted Sourcegraph Enterprise](#Cody-on-self-hosted-sourcegraph-enterprise)
-[Instructions for Sourcegraph Cloud](#Cody-on-sourcegraph-cloud)
-[Enabling codebase-aware answers](#enabling-codebase-aware-answers)
-[Turning Cody off](#turning-cody-off)
+- [Instructions for self-hosted Sourcegraph Enterprise](#Cody-on-self-hosted-sourcegraph-enterprise)
+- [Instructions for Sourcegraph Cloud](#Cody-on-sourcegraph-cloud)
+- [Enabling codebase-aware answers](#enabling-codebase-aware-answers)
+- [Turning Cody off](#turning-cody-off)
 
 ## Cody on self-hosted Sourcegraph Enterprise
 


### PR DESCRIPTION
Fix formatting on link list on Cody docs page.

## Test plan

Docs only.
