### PR TITLE
WIP using storyshots to write/compare snapshots for stories

### DIFF
--- a/client/storybook/src/coverage.test.ts
+++ b/client/storybook/src/coverage.test.ts
@@ -6,13 +6,15 @@ import { puppeteerTest } from '@storybook/addon-storyshots-puppeteer'
 
 import { recordCoverage } from '@sourcegraph/shared/src/testing/coverage'
 
-// This test suite does not actually test anything.
-// It just loads up the storybook in Puppeteer and records its coverage,
-// so it can be tracked in Codecov.
+// This test suite does not actually test anything. It just loads up the storybook in Puppeteer and
+// records its coverage, so it can be tracked in Codecov.
+//
+// See storyshots.test.ts for a test suite that actually performs snapshot testing (writing and
+// comparing snapshots) for some stories.
 
 initStoryshots({
     configPath: __dirname,
-    suite: 'Storybook',
+    suite: 'Storybook (coverage only)',
     test: puppeteerTest({
         storybookUrl: pathToFileURL(path.resolve(__dirname, '../storybook-static')).href,
         testBody: async page => {

--- a/client/storybook/src/storyshots.test.ts
+++ b/client/storybook/src/storyshots.test.ts
@@ -1,0 +1,12 @@
+import initStoryshots from '@storybook/addon-storyshots'
+
+import { ENVIRONMENT_CONFIG } from './environment-config'
+
+ENVIRONMENT_CONFIG.STORIES_GLOB = 'client/web/src/nav/GlobalNavbar.story.tsx'
+
+initStoryshots({
+    configPath: __dirname,
+    framework: 'react',
+    suite: 'Storybook (snapshots)',
+    // storyNameRegex: /^web\/nav\/GlobalNav/,
+})

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -40,12 +40,56 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
 }
 
 describe('GlobalNavbar', () => {
-    test('default', () => {
-        const { asFragment } = renderWithBrandedContext(
-            <MockedTestProvider>
-                <GlobalNavbar {...PROPS} />
-            </MockedTestProvider>
-        )
-        expect(asFragment()).toMatchSnapshot()
+    describe('default', () => {
+        test('anonymous', () => {
+            const { asFragment } = renderWithBrandedContext(
+                <MockedTestProvider>
+                    <GlobalNavbar {...PROPS} />
+                </MockedTestProvider>
+            )
+            expect(asFragment()).toMatchSnapshot()
+        })
+
+        test('signed in', () => {
+            const { asFragment } = renderWithBrandedContext(
+                <MockedTestProvider>
+                    <GlobalNavbar {...PROPS} />
+                </MockedTestProvider>
+            )
+            expect(asFragment()).toMatchSnapshot()
+        })
+    })
+
+    describe('dotcom', () => {
+        test('anonymous', () => {
+            const { asFragment } = renderWithBrandedContext(
+                <MockedTestProvider>
+                    <GlobalNavbar {...PROPS} />
+                </MockedTestProvider>
+            )
+            expect(asFragment()).toMatchSnapshot()
+        })
+
+        test('signed in', () => {
+            const { asFragment } = renderWithBrandedContext(
+                <MockedTestProvider>
+                    <GlobalNavbar {...PROPS} />
+                </MockedTestProvider>
+            )
+            expect(asFragment()).toMatchSnapshot()
+        })
+    })
+
+    describe('app', () => {
+        // There is no anonymous mode for app that shows the global navbar.
+
+        test('signed in', () => {
+            const { asFragment } = renderWithBrandedContext(
+                <MockedTestProvider>
+                    <GlobalNavbar {...PROPS} />
+                </MockedTestProvider>
+            )
+            expect(asFragment()).toMatchSnapshot()
+        })
     })
 })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch-web": "pnpm --filter @sourcegraph/web run watch",
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
-    "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook \"/out/.*test.js\" \"/out/.*test.d.ts\"",
+    "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook/src/coverage \"/out/.*test.js\" \"/out/.*test.d.ts\"",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=${CI:-\"false\"} --retries=1 --jobs=2",
     "test-integration": "pnpm _test-integration \"./client/web/src/integration/**/*.test.ts\"",
     "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true DISABLE_APP_ASSETS_MOCKING=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 pnpm _test-integration --retries=0 --jobs=1",
@@ -513,6 +513,7 @@
     "history": "4.5.1",
     "cssnano": "4.1.10",
     "webpack": "5",
-    "tslib": "2.1.0"
+    "tslib": "2.1.0",
+    "react-test-renderer": "18.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ overrides:
   cssnano: 4.1.10
   webpack: '5'
   tslib: 2.1.0
+  react-test-renderer: 18.1.0
 
 packageExtensionsChecksum: 8812149dda0bd1a50035894b0475085d
 
@@ -7227,7 +7228,7 @@ packages:
       pretty-format: 26.6.2
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      react-test-renderer: 17.0.2_react@18.1.0
+      react-test-renderer: 18.1.0_react@18.1.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       rxjs: 6.6.7
@@ -23926,16 +23927,15 @@ packages:
       refractor: 3.6.0
     dev: true
 
-  /react-test-renderer/17.0.2_react@18.1.0:
-    resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}
+  /react-test-renderer/18.1.0_react@18.1.0:
+    resolution: {integrity: sha512-OfuueprJFW7h69GN+kr4Ywin7stcuqaYAt1g7airM5cUgP0BoF5G5CXsPGmXeDeEkncb2fqYNECO4y18sSqphg==}
     peerDependencies:
-      react: 17.0.2
+      react: ^18.1.0
     dependencies:
-      object-assign: 4.1.1
       react: 18.1.0
-      react-is: 17.0.2
+      react-is: 18.2.0
       react-shallow-renderer: 16.15.0_react@18.1.0
-      scheduler: 0.20.2
+      scheduler: 0.22.0
     dev: true
 
   /react-transition-group/2.9.0_ef5jwxihqo6n7gxfmzogljlgcm:
@@ -24853,13 +24853,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
-
-  /scheduler/0.20.2:
-    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    dev: true
 
   /scheduler/0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}


### PR DESCRIPTION
I'd like to have storyshots (i.e., snapshot tests automatically derived from (some) stories) for GlobalNavbar.story.tsx because there are 5 variants that would be nice to have *both* snapshot tests and storybooks: `{dotcom, non-dotcom}x{anonymous, signed-in} + {app signed in}`.

I see we are only [using storyshots for calculating coverage](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/storybook/src/coverage.test.ts?L13:5) (and not much has changed here since 2020).

This is a WIP of enabling snapshots from storyshots for GlobalNav.

TODOs:

- [ ] Getting some errors that seem to arise from Jest (headless) not working with the Webpack loaders and/or storybook decorators we use - probably a config issue
- [ ] Make them run faster (right now, storybooks require an extra Webpack step that normal `.test.tsx` files do not)
- [ ] Dedupe existing instances where we have the same cases defined as stories and Jest tests