### PR TITLE
cody CLI: Add `--lsp` mode to start language server for Cody

### DIFF
--- a/client/cody-cli/README.md
+++ b/client/cody-cli/README.md
@@ -54,7 +54,7 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
         codylsp = {
           sourcegraph = {
             url = "https://sourcegraph.sourcegraph.com",
-            accessToken = "<your access token>",
+            accessToken = "<your token>",
             repos = { "github.com/sourcegraph/sourcegraph" }, -- any repos you want context for
           },
         },
@@ -63,29 +63,21 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
   end,
 })
 
+-- Define the "CodyR" ("cody replace") command that replaces the selection with whatever cody returns
 vim.api.nvim_create_user_command("CodyR", function(command)
   local p = "file://" .. vim.fn.expand "%:p"
 
   for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
     client.request("workspace/executeCommand", {
-      command = "cody",
-      arguments = { p, command.line1 - 1, command.line2 - 1, command.args, true, true },
+      command = "cody.replace",
+      arguments = { p, command.line1 - 1, command.line2 - 1, command.args },
     }, function() end, 0)
   end
 end, { range = 2, nargs = 1 })
 
-vim.api.nvim_create_user_command("CodyC", function(command)
-  local p = "file://" .. vim.fn.expand "%:p"
-
-  for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
-    client.request("workspace/executeCommand", {
-      command = "cody",
-      arguments = { p, command.line1 - 1, command.line2 - 1, command.args, false, true },
-    }, function() end, 0)
-  end
-end, { range = 2, nargs = 1 })
-
-vim.api.nvim_create_user_command("CodyE", function(command)
+-- Define the "Cody" command that takes a question/prompt and shows the response
+-- in popup window. If line/range is selected that's passed to Cody.
+vim.api.nvim_create_user_command("Cody", function(command)
   local p = "file://" .. vim.fn.expand "%:p"
 
   for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
@@ -93,7 +85,7 @@ vim.api.nvim_create_user_command("CodyE", function(command)
       command = "cody.explain",
       arguments = { p, command.line1 - 1, command.line2 - 1, command.args },
     }, function(_, result, _, _)
-      local lines = vim.split(result.message[1], "\n")
+      local lines = vim.split(result.response, "\n")
       vim.lsp.util.open_floating_preview(lines, "markdown", {
         height = 5,
         width = 80,
@@ -108,4 +100,5 @@ vim.api.nvim_create_user_command("CodyE", function(command)
     end, 0)
   end
 end, { range = 2, nargs = 1 })
+
 ```

--- a/client/cody-cli/README.md
+++ b/client/cody-cli/README.md
@@ -12,10 +12,100 @@ cd client/cody-cli
 npm install -g .
 ```
 
+Then you can do
+
+```
+cody
+```
+
 ## Local Development
 
 In the root of the repository, run this:
 
 ```
 pnpm --filter @sourcegraph/cody-cli run start
+```
+
+## LSP
+
+### Start as LSP
+
+```
+cody --lsp --stdio
+```
+
+### Neovim config
+
+Rough, **hacky** Lua snippet to get `cody --lsp --stdio` running as `codylsp` in
+Neovim:
+
+```lua
+vim.api.nvim_create_autocmd({ "FileType" }, {
+  pattern = "*",
+  callback = function()
+    vim.lsp.start {
+      name = "codylsp",
+      cmd = { "cody", "--lsp", "--stdio" },
+      root_dir = vim.fs.dirname(vim.fs.find({ "go.mod", ".git" }, { upward = true })[1]),
+      capabilities = capabilities,
+      on_attach = on_attach,
+      trace = "off",
+      settings = {
+        codylsp = {
+          sourcegraph = {
+            url = "https://sourcegraph.sourcegraph.com",
+            accessToken = "sgp_5ac15c9b677628fcc7199d5fa42dca57528ea4a4",
+            repos = { "github.com/sourcegraph/sourcegraph" }, -- any repos you want context for
+          },
+        },
+      },
+    }
+  end,
+})
+
+vim.api.nvim_create_user_command("CodyR", function(command)
+  local p = "file://" .. vim.fn.expand "%:p"
+
+  for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
+    client.request("workspace/executeCommand", {
+      command = "cody",
+      arguments = { p, command.line1 - 1, command.line2 - 1, command.args, true, true },
+    }, function() end, 0)
+  end
+end, { range = 2, nargs = 1 })
+
+vim.api.nvim_create_user_command("CodyC", function(command)
+  local p = "file://" .. vim.fn.expand "%:p"
+
+  for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
+    client.request("workspace/executeCommand", {
+      command = "cody",
+      arguments = { p, command.line1 - 1, command.line2 - 1, command.args, false, true },
+    }, function() end, 0)
+  end
+end, { range = 2, nargs = 1 })
+
+vim.api.nvim_create_user_command("CodyE", function(command)
+  local p = "file://" .. vim.fn.expand "%:p"
+
+  for _, client in pairs(vim.lsp.get_active_clients { name = "codylsp" }) do
+    client.request("workspace/executeCommand", {
+      command = "cody.explain",
+      arguments = { p, command.line1 - 1, command.line2 - 1, command.args },
+    }, function(_, result, _, _)
+      local lines = vim.split(result.message[1], "\n")
+      vim.lsp.util.open_floating_preview(lines, "markdown", {
+        height = 5,
+        width = 80,
+        focus_id = "codyResponse",
+      })
+      -- Call it again so that it focuses the window immediately
+      vim.lsp.util.open_floating_preview(lines, "markdown", {
+        height = 5,
+        width = 80,
+        focus_id = "codyResponse",
+      })
+    end, 0)
+  end
+end, { range = 2, nargs = 1 })
 ```

--- a/client/cody-cli/README.md
+++ b/client/cody-cli/README.md
@@ -54,7 +54,7 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
         codylsp = {
           sourcegraph = {
             url = "https://sourcegraph.sourcegraph.com",
-            accessToken = "sgp_5ac15c9b677628fcc7199d5fa42dca57528ea4a4",
+            accessToken = "<your access token>",
             repos = { "github.com/sourcegraph/sourcegraph" }, -- any repos you want context for
           },
         },

--- a/client/cody-cli/package.json
+++ b/client/cody-cli/package.json
@@ -18,6 +18,7 @@
     "@types/prompts": "^2.4.4",
     "commander": "^10.0.1",
     "prompts": "^2.4.2",
+    "uuid": "^9.0.0",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8"
   },

--- a/client/cody-cli/package.json
+++ b/client/cody-cli/package.json
@@ -17,7 +17,9 @@
     "@sourcegraph/common": "workspace:*",
     "@types/prompts": "^2.4.4",
     "commander": "^10.0.1",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "vscode-languageserver": "^8.1.0",
+    "vscode-languageserver-textdocument": "^1.0.8"
   },
   "main": "dist/app.js",
   "bin": {

--- a/client/cody-cli/src/app.ts
+++ b/client/cody-cli/src/app.ts
@@ -6,7 +6,7 @@ import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/s
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isRepoNotFoundError } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
-import { DEFAULTS, ENVIRONMENT_CONFIG } from './config'
+import { DEFAULTS, getEnvConfig } from './config'
 import { createCodebaseContext } from './context'
 import { startLSP } from './lsp'
 import { startREPL } from './repl'
@@ -35,10 +35,11 @@ async function startCLI() {
     if (options.lsp) {
         startLSP()
     } else {
+        const env = getEnvConfig()
         const codebase: string = options.codebase || DEFAULTS.codebase
         const endpoint: string = options.endpoint || DEFAULTS.serverEndpoint
         const contextType: 'keyword' | 'embeddings' | 'none' | 'blended' = options.contextType || DEFAULTS.contextType
-        const accessToken: string | undefined = ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN
+        const accessToken: string = env.SRC_ACCESS_TOKEN
         if (accessToken === undefined || accessToken === '') {
             console.error(
                 'No access token found. Set SRC_ACCESS_TOKEN to an access token created on the Sourcegraph instance.'
@@ -48,7 +49,7 @@ async function startCLI() {
 
         const sourcegraphClient = new SourcegraphGraphQLAPIClient({
             serverEndpoint: endpoint,
-            accessToken: accessToken,
+            accessToken,
             customHeaders: {},
         })
 
@@ -74,7 +75,7 @@ async function startCLI() {
 
         const completionsClient = new SourcegraphNodeCompletionsClient({
             serverEndpoint: endpoint,
-            accessToken: ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN,
+            accessToken,
             debug: DEFAULTS.debug === 'development',
             customHeaders: {},
         })

--- a/client/cody-cli/src/app.ts
+++ b/client/cody-cli/src/app.ts
@@ -32,53 +32,53 @@ async function startCLI() {
 
     const options = program.opts()
 
-    const codebase: string = options.codebase || DEFAULTS.codebase
-    const endpoint: string = options.endpoint || DEFAULTS.serverEndpoint
-    const contextType: 'keyword' | 'embeddings' | 'none' | 'blended' = options.contextType || DEFAULTS.contextType
-    const accessToken: string | undefined = ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN
-    if (accessToken === undefined || accessToken === '') {
-        console.error(
-            `No access token found. Set SRC_ACCESS_TOKEN to an access token created on the Sourcegraph instance.`
-        )
-        process.exit(1)
-    }
-
-    const sourcegraphClient = new SourcegraphGraphQLAPIClient({
-        serverEndpoint: endpoint,
-        accessToken: accessToken,
-        customHeaders: {},
-    })
-
-    let codebaseContext
-    try {
-        codebaseContext = await createCodebaseContext(sourcegraphClient, codebase, contextType)
-    } catch (error) {
-        let errorMessage = ''
-        if (isRepoNotFoundError(error)) {
-            errorMessage =
-                `Cody could not find the '${codebase}' repository on your Sourcegraph instance.\n` +
-                'Please check that the repository exists and is entered correctly in the cody.codebase setting.'
-        } else {
-            errorMessage =
-                `Cody could not connect to your Sourcegraph instance: ${error}\n` +
-                'Make sure that cody.serverEndpoint is set to a running Sourcegraph instance and that an access token is configured.'
-        }
-        console.error(errorMessage)
-        process.exit(1)
-    }
-
-    const intentDetector = new SourcegraphIntentDetectorClient(sourcegraphClient)
-
-    const completionsClient = new SourcegraphNodeCompletionsClient({
-        serverEndpoint: endpoint,
-        accessToken: ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN,
-        debug: DEFAULTS.debug === 'development',
-        customHeaders: {},
-    })
-
     if (options.lsp) {
         await startLSP()
     } else {
+        const codebase: string = options.codebase || DEFAULTS.codebase
+        const endpoint: string = options.endpoint || DEFAULTS.serverEndpoint
+        const contextType: 'keyword' | 'embeddings' | 'none' | 'blended' = options.contextType || DEFAULTS.contextType
+        const accessToken: string | undefined = ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN
+        if (accessToken === undefined || accessToken === '') {
+            console.error(
+                `No access token found. Set SRC_ACCESS_TOKEN to an access token created on the Sourcegraph instance.`
+            )
+            process.exit(1)
+        }
+
+        const sourcegraphClient = new SourcegraphGraphQLAPIClient({
+            serverEndpoint: endpoint,
+            accessToken: accessToken,
+            customHeaders: {},
+        })
+
+        let codebaseContext
+        try {
+            codebaseContext = await createCodebaseContext(sourcegraphClient, codebase, contextType)
+        } catch (error) {
+            let errorMessage = ''
+            if (isRepoNotFoundError(error)) {
+                errorMessage =
+                    `Cody could not find the '${codebase}' repository on your Sourcegraph instance.\n` +
+                    'Please check that the repository exists and is entered correctly in the cody.codebase setting.'
+            } else {
+                errorMessage =
+                    `Cody could not connect to your Sourcegraph instance: ${error}\n` +
+                    'Make sure that cody.serverEndpoint is set to a running Sourcegraph instance and that an access token is configured.'
+            }
+            console.error(errorMessage)
+            process.exit(1)
+        }
+
+        const intentDetector = new SourcegraphIntentDetectorClient(sourcegraphClient)
+
+        const completionsClient = new SourcegraphNodeCompletionsClient({
+            serverEndpoint: endpoint,
+            accessToken: ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN,
+            debug: DEFAULTS.debug === 'development',
+            customHeaders: {},
+        })
+
         await startREPL(codebase, options.prompt, intentDetector, codebaseContext, completionsClient)
     }
 }

--- a/client/cody-cli/src/app.ts
+++ b/client/cody-cli/src/app.ts
@@ -33,7 +33,7 @@ async function startCLI() {
     const options = program.opts()
 
     if (options.lsp) {
-        await startLSP()
+        startLSP()
     } else {
         const codebase: string = options.codebase || DEFAULTS.codebase
         const endpoint: string = options.endpoint || DEFAULTS.serverEndpoint
@@ -41,7 +41,7 @@ async function startCLI() {
         const accessToken: string | undefined = ENVIRONMENT_CONFIG.SRC_ACCESS_TOKEN
         if (accessToken === undefined || accessToken === '') {
             console.error(
-                `No access token found. Set SRC_ACCESS_TOKEN to an access token created on the Sourcegraph instance.`
+                'No access token found. Set SRC_ACCESS_TOKEN to an access token created on the Sourcegraph instance.'
             )
             process.exit(1)
         }

--- a/client/cody-cli/src/app.ts
+++ b/client/cody-cli/src/app.ts
@@ -1,20 +1,14 @@
 #! /usr/bin/env node
 import { Command } from 'commander'
-import prompts from 'prompts'
 
-import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
-import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isRepoNotFoundError } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
-import { streamCompletions } from './completions'
 import { DEFAULTS, ENVIRONMENT_CONFIG } from './config'
 import { createCodebaseContext } from './context'
-import { interactionFromMessage } from './interactions'
 import { startLSP } from './lsp'
-import { getPreamble } from './preamble'
 import { startREPL } from './repl'
 
 async function startCLI() {
@@ -31,6 +25,9 @@ async function startCLI() {
             `How Cody fetches context for query. Default: ${DEFAULTS.contextType}`
         )
         .option('--lsp', 'Start LSP')
+        .option('--stdio', 'Run LSP in stdio mode')
+        .option('--node-ipc', 'Run LSP in node-ipc mode')
+        .option('--socket <number>', 'Run LSP with that socket')
         .parse(process.argv)
 
     const options = program.opts()

--- a/client/cody-cli/src/completions.ts
+++ b/client/cody-cli/src/completions.ts
@@ -6,7 +6,7 @@ import {
     CompletionCallbacks,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<CompletionParameters, 'messages'> = {
+export const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<CompletionParameters, 'messages'> = {
     temperature: 0.2,
     maxTokensToSample: SOLUTION_TOKEN_LENGTH,
     topK: -1,

--- a/client/cody-cli/src/config.ts
+++ b/client/cody-cli/src/config.ts
@@ -1,18 +1,10 @@
 import { cleanEnv, str } from 'envalid'
 
-export const ENVIRONMENT_CONFIG = cleanEnv(
-    process.env,
-    {
+export function getEnvConfig(): { SRC_ACCESS_TOKEN: string } {
+    return cleanEnv(process.env, {
         SRC_ACCESS_TOKEN: str(),
-    },
-    {
-        reporter: ({ errors, env }) => {
-            if (errors.SRC_ACCESS_TOKEN) {
-                console.error('SRC_ACCESS_TOKEN not set')
-            }
-        },
-    }
-)
+    })
+}
 
 export const DEFAULTS = {
     codebase: 'github.com/sourcegraph/sourcegraph',

--- a/client/cody-cli/src/config.ts
+++ b/client/cody-cli/src/config.ts
@@ -1,8 +1,18 @@
 import { cleanEnv, str } from 'envalid'
 
-export const ENVIRONMENT_CONFIG = cleanEnv(process.env, {
-    SRC_ACCESS_TOKEN: str(),
-})
+export const ENVIRONMENT_CONFIG = cleanEnv(
+    process.env,
+    {
+        SRC_ACCESS_TOKEN: str(),
+    },
+    {
+        reporter: ({ errors, env }) => {
+            if (errors.SRC_ACCESS_TOKEN) {
+                console.error('SRC_ACCESS_TOKEN not set')
+            }
+        },
+    }
+)
 
 export const DEFAULTS = {
     codebase: 'github.com/sourcegraph/sourcegraph',

--- a/client/cody-cli/src/lsp.ts
+++ b/client/cody-cli/src/lsp.ts
@@ -84,8 +84,8 @@ class CodyLanguageServer {
         this.connection.onInitialized(() => {
             this.onInitialized.bind(this)
         })
-        this.connection.onDidChangeConfiguration(() => {
-            this.onDidChangeConfiguration.bind(this)
+        this.connection.onDidChangeConfiguration(change => {
+            this.onDidChangeConfiguration(change)
         })
         this.connection.onCompletion(this.onCompletion.bind(this))
         this.connection.onDidChangeWatchedFiles(this.onDidChangeWatchedFiles.bind(this))

--- a/client/cody-cli/src/lsp.ts
+++ b/client/cody-cli/src/lsp.ts
@@ -1,0 +1,222 @@
+
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import {
+    createConnection,
+    TextDocuments,
+    Diagnostic,
+    DiagnosticSeverity,
+    ProposedFeatures,
+    InitializeParams,
+    DidChangeConfigurationNotification,
+    CompletionItem,
+    CompletionItemKind,
+    TextDocumentPositionParams,
+    TextDocumentSyncKind,
+    InitializeResult,
+} from 'vscode-languageserver/node'
+
+export async function startLSP() {
+    // Create a connection for the server, using Node's IPC as a transport.
+    // Also include all preview / proposed LSP features.
+    const connection = createConnection(ProposedFeatures.all)
+
+    // // Create a simple text document manager.
+    const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)
+
+    let hasConfigurationCapability = false
+    let hasWorkspaceFolderCapability = false
+    let hasDiagnosticRelatedInformationCapability = false
+
+    connection.onInitialize((params: InitializeParams) => {
+        const capabilities = params.capabilities
+
+        // Does the client support the `workspace/configuration` request?
+        // If not, we fall back using global settings.
+        hasConfigurationCapability = !!(capabilities.workspace && !!capabilities.workspace.configuration)
+        hasWorkspaceFolderCapability = !!(capabilities.workspace && !!capabilities.workspace.workspaceFolders)
+        hasDiagnosticRelatedInformationCapability = !!(
+            capabilities.textDocument &&
+            capabilities.textDocument.publishDiagnostics &&
+            capabilities.textDocument.publishDiagnostics.relatedInformation
+        )
+
+        const result: InitializeResult = {
+            capabilities: {
+                textDocumentSync: TextDocumentSyncKind.Incremental,
+                // Tell the client that this server supports code completion.
+                completionProvider: {
+                    resolveProvider: true,
+                },
+            },
+        }
+        if (hasWorkspaceFolderCapability) {
+            result.capabilities.workspace = {
+                workspaceFolders: {
+                    supported: true,
+                },
+            }
+        }
+        return result
+    })
+
+    connection.onInitialized(() => {
+        if (hasConfigurationCapability) {
+            // Register for all configuration changes.
+            connection.client.register(DidChangeConfigurationNotification.type, undefined)
+        }
+        if (hasWorkspaceFolderCapability) {
+            connection.workspace.onDidChangeWorkspaceFolders(_event => {
+                connection.console.log('Workspace folder change event received.')
+            })
+        }
+    })
+
+    // The example settings
+    interface ExampleSettings {
+        maxNumberOfProblems: number
+    }
+
+    // The global settings, used when the `workspace/configuration` request is not supported by the client.
+    // Please note that this is not the case when using this server with the client provided in this example
+    // but could happen with other clients.
+    const defaultSettings: ExampleSettings = { maxNumberOfProblems: 1000 };
+    let globalSettings: ExampleSettings = defaultSettings;
+
+    // Cache the settings of all open documents
+    const documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
+
+    connection.onDidChangeConfiguration(change => {
+    	if (hasConfigurationCapability) {
+    		// Reset all cached document settings
+    		documentSettings.clear();
+    	} else {
+    		globalSettings = <ExampleSettings>(
+    			(change.settings.languageServerExample || defaultSettings)
+    		);
+    	}
+
+    	// Revalidate all open text documents
+    	documents.all().forEach(validateTextDocument);
+    });
+
+    const getDocumentSettings = (resource: string): Thenable<ExampleSettings> => {
+    	if (!hasConfigurationCapability) {
+    		return Promise.resolve(globalSettings);
+    	}
+    	let result = documentSettings.get(resource);
+    	if (!result) {
+    		result = connection.workspace.getConfiguration({
+    			scopeUri: resource,
+    			section: 'languageServerExample'
+    		});
+    		documentSettings.set(resource, result);
+    	}
+    	return result;
+    }
+
+    // Only keep settings for open documents
+    documents.onDidClose(e => {
+    	documentSettings.delete(e.document.uri);
+    });
+
+    // // The content of a text document has changed. This event is emitted
+    // // when the text document first opened or when its content has changed.
+    documents.onDidChangeContent(change => {
+    	validateTextDocument(change.document);
+    });
+
+    const validateTextDocument = async(textDocument: TextDocument): Promise<void> => {
+    	// In this simple example we get the settings for every validate run.
+    	const settings = await getDocumentSettings(textDocument.uri);
+
+    	// The validator creates diagnostics for all uppercase words length 2 and more
+    	const text = textDocument.getText();
+    	const pattern = /\b[A-Z]{2,}\b/g;
+    	let m: RegExpExecArray | null;
+
+    	let problems = 0;
+    	const diagnostics: Diagnostic[] = [];
+    	while ((m = pattern.exec(text)) && problems < settings.maxNumberOfProblems) {
+    		problems++;
+    		const diagnostic: Diagnostic = {
+    			severity: DiagnosticSeverity.Warning,
+    			range: {
+    				start: textDocument.positionAt(m.index),
+    				end: textDocument.positionAt(m.index + m[0].length)
+    			},
+    			message: `${m[0]} is all uppercase.`,
+    			source: 'ex'
+    		};
+    		if (hasDiagnosticRelatedInformationCapability) {
+    			diagnostic.relatedInformation = [
+    				{
+    					location: {
+    						uri: textDocument.uri,
+    						range: Object.assign({}, diagnostic.range)
+    					},
+    					message: 'Spelling matters'
+    				},
+    				{
+    					location: {
+    						uri: textDocument.uri,
+    						range: Object.assign({}, diagnostic.range)
+    					},
+    					message: 'Particularly for names'
+    				}
+    			];
+    		}
+    		diagnostics.push(diagnostic);
+    	}
+
+    	// Send the computed diagnostics to VSCode.
+    	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+    }
+
+    connection.onDidChangeWatchedFiles(_change => {
+    	// Monitored files have change in VSCode
+    	connection.console.log('We received an file change event');
+    });
+
+    // This handler provides the initial list of the completion items.
+    connection.onCompletion(
+    	(_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+    		// The pass parameter contains the position of the text document in
+    		// which code complete got requested. For the example we ignore this
+    		// info and always provide the same completion items.
+    		return [
+    			{
+    				label: 'TypeScript',
+    				kind: CompletionItemKind.Text,
+    				data: 1
+    			},
+    			{
+    				label: 'JavaScript',
+    				kind: CompletionItemKind.Text,
+    				data: 2
+    			}
+    		];
+    	}
+    );
+
+    // This handler resolves additional information for the item selected in
+    // the completion list.
+    connection.onCompletionResolve(
+    	(item: CompletionItem): CompletionItem => {
+    		if (item.data === 1) {
+    			item.detail = 'TypeScript details';
+    			item.documentation = 'TypeScript documentation';
+    		} else if (item.data === 2) {
+    			item.detail = 'JavaScript details';
+    			item.documentation = 'JavaScript documentation';
+    		}
+    		return item;
+    	}
+    );
+
+    // Make the text document manager listen on the connection
+    // for open, change and close text document events
+    documents.listen(connection);
+
+    // Listen on the connection
+    connection.listen();
+}

--- a/client/cody-cli/src/lsp.ts
+++ b/client/cody-cli/src/lsp.ts
@@ -36,10 +36,11 @@ import { createCodebaseContext } from './context'
 import { interactionFromMessage } from './interactions'
 import { getPreamble } from './preamble'
 
-export async function startLSP() {
+export function startLSP() {
     const server = new CodyLanguageServer()
     server.listen()
 }
+
 interface SourcegraphSettings {
     url: string
     accessToken: string

--- a/client/cody-cli/src/lsp.ts
+++ b/client/cody-cli/src/lsp.ts
@@ -119,8 +119,8 @@ export async function startLSP() {
     	documentSettings.delete(e.document.uri);
     });
 
-    // // The content of a text document has changed. This event is emitted
-    // // when the text document first opened or when its content has changed.
+    // The content of a text document has changed. This event is emitted
+    // when the text document first opened or when its content has changed.
     documents.onDidChangeContent(change => {
     	validateTextDocument(change.document);
     });
@@ -213,10 +213,6 @@ export async function startLSP() {
     	}
     );
 
-    // Make the text document manager listen on the connection
-    // for open, change and close text document events
     documents.listen(connection);
-
-    // Listen on the connection
     connection.listen();
 }

--- a/client/cody-cli/src/lsp.ts
+++ b/client/cody-cli/src/lsp.ts
@@ -126,6 +126,8 @@ class CodyLanguageServer {
         this.globalSettings = (change.settings.codylsp || defaultSettings) as CodyLSPSettings
         if (validSettings(this.globalSettings.sourcegraph)) {
             await this.initializeCody()
+        } else {
+            console.error('invalid settings')
         }
 
         for (const doc of this.documents.all()) {
@@ -134,6 +136,7 @@ class CodyLanguageServer {
     }
 
     private async initializeCody() {
+        console.error('initializecody. globalSettings', this.globalSettings)
         // TODO: These two are clunky
         const codebase = this.globalSettings.sourcegraph.repos[0]
         const contextType = 'blended'

--- a/client/cody-cli/src/repl.ts
+++ b/client/cody-cli/src/repl.ts
@@ -1,0 +1,65 @@
+import prompts from 'prompts'
+
+import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
+import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
+import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
+import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
+import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
+import { streamCompletions } from './completions'
+import { interactionFromMessage } from './interactions'
+import { getPreamble } from './preamble'
+
+export async function startREPL(
+    codebase: string,
+    prompt: any,
+    intentDetector: IntentDetector,
+    codebaseContext: CodebaseContext,
+    completionsClient: SourcegraphNodeCompletionsClient
+) {
+    if (prompt === undefined || prompt === '') {
+        const response = await prompts({
+            type: 'text',
+            name: 'value',
+            message: 'What do you want to ask Cody?',
+        })
+
+        prompt = response.value
+    }
+
+    const transcript = new Transcript()
+
+    // TODO: Keep track of all user input if we add REPL mode
+
+    const initialMessage: Message = { speaker: 'human', text: prompt }
+    const messages: { human: Message; assistant?: Message }[] = [{ human: initialMessage }]
+    for (const [index, message] of messages.entries()) {
+        const interaction = await interactionFromMessage(
+            message.human,
+            intentDetector,
+            // Fetch codebase context only for the last message
+            index === messages.length - 1 ? codebaseContext : null
+        )
+
+        transcript.addInteraction(interaction)
+
+        if (message.assistant?.text) {
+            transcript.addAssistantResponse(message.assistant?.text)
+        }
+    }
+
+    const finalPrompt = await transcript.toPrompt(getPreamble(codebase))
+
+    let text = ''
+    streamCompletions(completionsClient, finalPrompt, {
+        onChange: chunk => {
+            text = chunk
+        },
+        onComplete: () => {
+            console.log(text)
+        },
+        onError: err => {
+            console.error(err)
+        },
+    })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -942,6 +942,7 @@ importers:
       '@types/prompts': ^2.4.4
       commander: ^10.0.1
       prompts: ^2.4.2
+      uuid: ^9.0.0
       vscode-languageserver: ^8.1.0
       vscode-languageserver-textdocument: ^1.0.8
     dependencies:
@@ -950,6 +951,7 @@ importers:
       '@types/prompts': 2.4.4
       commander: 10.0.1
       prompts: 2.4.2
+      uuid: 9.0.0
       vscode-languageserver: 8.1.0
       vscode-languageserver-textdocument: 1.0.8
 
@@ -27756,6 +27758,11 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
+    dev: false
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -942,12 +942,16 @@ importers:
       '@types/prompts': ^2.4.4
       commander: ^10.0.1
       prompts: ^2.4.2
+      vscode-languageserver: ^8.1.0
+      vscode-languageserver-textdocument: ^1.0.8
     dependencies:
       '@sourcegraph/cody-shared': link:../cody-shared
       '@sourcegraph/common': link:../common
       '@types/prompts': 2.4.4
       commander: 10.0.1
       prompts: 2.4.2
+      vscode-languageserver: 8.1.0
+      vscode-languageserver-textdocument: 1.0.8
 
   client/cody-shared:
     specifiers:
@@ -16685,7 +16689,7 @@ packages:
     dependencies:
       graphql: 15.4.0
       nullthrows: 1.1.1
-      vscode-languageserver-types: 3.17.2
+      vscode-languageserver-types: 3.17.3
     dev: false
 
   /graphql-request/5.0.0_graphql@15.4.0:
@@ -21061,7 +21065,7 @@ packages:
       monaco-editor: 0.24.0
       path-browserify: 1.0.1
       prettier: 2.0.5
-      vscode-languageserver-textdocument: 1.0.2
+      vscode-languageserver-textdocument: 1.0.8
       vscode-languageserver-types: 3.17.2
       yaml-language-server-parser: 0.1.3
     dev: false
@@ -27995,12 +27999,35 @@ packages:
       yazl: 2.5.1
     dev: true
 
-  /vscode-languageserver-textdocument/1.0.2:
-    resolution: {integrity: sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==}
+  /vscode-jsonrpc/8.1.0:
+    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /vscode-languageserver-protocol/3.17.3:
+    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+    dependencies:
+      vscode-jsonrpc: 8.1.0
+      vscode-languageserver-types: 3.17.3
+    dev: false
+
+  /vscode-languageserver-textdocument/1.0.8:
+    resolution: {integrity: sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==}
     dev: false
 
   /vscode-languageserver-types/3.17.2:
     resolution: {integrity: sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==}
+    dev: false
+
+  /vscode-languageserver-types/3.17.3:
+    resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
+    dev: false
+
+  /vscode-languageserver/8.1.0:
+    resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
+    hasBin: true
+    dependencies:
+      vscode-languageserver-protocol: 3.17.3
     dev: false
 
   /vscode-uri/3.0.7:


### PR DESCRIPTION
See the [README](https://github.com/sourcegraph/sourcegraph/blob/mrn/cody-cli-lsp/client/cody-cli/README.md)

This adds `--lsp` to `cody-cli` which makes it start a language server.

It implements two commands:

- `cody.explain` which can take a optional range and simply shows Cody's reply in popup window in Neovim (see README!)
- `cody.replace` (think: "fixup") which sends selected code snippet to Cody along with a prompt and replaces snippet with Cody's response

## Video


https://user-images.githubusercontent.com/1185253/233684550-30abf9ab-3455-4d65-b672-dbeccde7637b.mp4



## Test plan

- N/A