### PR TITLE
Allow site admins on Sourcegraph dotcom to view profiles

### DIFF
--- a/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
@@ -18,6 +18,7 @@ import {
     UserEventLogsResult,
     UserEventLogsVariables,
 } from '../../../graphql-operations'
+import { SiteAdminAlert } from '../../../site-admin/SiteAdminAlert'
 import { UserSettingsAreaRouteContext } from '../../../user/settings/UserSettingsArea'
 
 import styles from './UserEventLogsPage.module.scss'
@@ -52,15 +53,34 @@ export const UserEventNode: React.FunctionComponent<React.PropsWithChildren<User
     </li>
 )
 
-export interface UserEventLogsPageProps extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryProps {}
+export interface UserEventLogsPageProps
+    extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'isSourcegraphDotCom'>,
+        UserEventLogsPageContentProps {}
+
+export interface UserEventLogsPageContentProps extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryProps {}
 
 /**
  * A page displaying usage statistics for the site.
  */
 export const UserEventLogsPage: React.FunctionComponent<React.PropsWithChildren<UserEventLogsPageProps>> = ({
+    isSourcegraphDotCom,
+    authenticatedUser,
     telemetryService,
     user,
 }) => {
+    if (isSourcegraphDotCom && authenticatedUser && user.id !== authenticatedUser.id) {
+        return (
+            <SiteAdminAlert className="sidebar__alert" variant="danger">
+                Only the user may access their event logs.
+            </SiteAdminAlert>
+        )
+    }
+    return <UserEventLogsPageContent telemetryService={telemetryService} user={user} />
+}
+
+export const UserEventLogsPageContent: React.FunctionComponent<
+    React.PropsWithChildren<UserEventLogsPageContentProps>
+> = ({ telemetryService, user }) => {
     useMemo(() => {
         telemetryService.logViewEvent('UserEventLogPage')
     }, [telemetryService])

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -144,7 +144,7 @@ func (s *settingsSubject) ViewerCanAdminister(ctx context.Context) (bool, error)
 	case s.org != nil:
 		return s.org.ViewerCanAdminister(ctx)
 	case s.user != nil:
-		return s.user.ViewerCanAdminister()
+		return s.user.viewerCanAdministerSettings()
 	default:
 		return false, errUnknownSettingsSubject
 	}

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -231,7 +231,7 @@ func TestUser_LatestSettings(t *testing.T) {
 
 func TestUser_ViewerCanAdminister(t *testing.T) {
 	db := database.NewMockDB()
-	t.Run("only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
+	t.Run("settings edit only allowed by authenticated user on Sourcegraph.com", func(t *testing.T) {
 		users := database.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 
@@ -256,13 +256,13 @@ func TestUser_ViewerCanAdminister(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				ok, _ := NewUserResolver(test.ctx, db, &types.User{ID: 1}).ViewerCanAdminister()
+				ok, _ := NewUserResolver(test.ctx, db, &types.User{ID: 1}).viewerCanAdministerSettings()
 				assert.False(t, ok, "ViewerCanAdminister")
 			})
 		}
 	})
 
-	t.Run("allowed by same user or site admin not on Sourcegraph.com", func(t *testing.T) {
+	t.Run("allowed by same user or site admin", func(t *testing.T) {
 		users := database.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 


### PR DESCRIPTION
This PR changes NOTHING about access permissions. All resolvers still respect the same permissions applied as before, so what was not possible before is still not possible. What this PR does is unhide a bunch of UI components that actually were allowed but hidden by this not very permissive check. Before, the user settings pages were completely hidden (albeit accessible through the API easily). Now, the UIs that are permitted by the backend permission checks are visible. That includes the list of access tokens, management features for executor secrets, and such. This can be a useful tool for debugging, and will allow us to manage other user properties that ARE meant to be configurable by the site admin.

## Test plan

Verified things look alright and that this doesn't change any actually performed backend checks. 