### PR TITLE
Remove google form

### DIFF
--- a/doc/cody/explanations/enabling_cody.md
+++ b/doc/cody/explanations/enabling_cody.md
@@ -5,7 +5,7 @@ Cody uses Sourcegraph to fetch relevant context to generate answers and code. Th
 ## Initial setup
 
 1. Sign into [Sourcegraph.com](https://sourcegraph.com). {You can create an account for free](https://sourcegraph.com/sign-up) if you don't already have one.
-2. [Join the open beta](https://forms.gle/cffMa8mrr8YuHv8o8). We'll email you when you're added, usually within a day.
+2. Share your Sourcegraph username with us in [Discord](https://discord.gg/sourcegraph-969688426372825169) and we'll get you set up to use Cody on open source code.
 3. [Create a Sourcegraph access token](https://sourcegraph.com/user/settings/tokens)
 4. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
 5. Set the Sourcegraph URL to be `https://sourcegraph.com`

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -9,7 +9,7 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 ## Get Cody
 
 - **Sourcegraph Enterprise customers:** Contact your Sourcegraph techical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
-- **Everyone:** [Join the open beta.](https://forms.gle/cffMa8mrr8YuHv8o8) We'll email you when you're added, usually within a day.
+- **Everyone:** Share your Sourcegraph username with us in [Discord](https://discord.gg/sourcegraph-969688426372825169) and we'll get you set up to use Cody on open source code.
 
 Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself.
 
@@ -70,5 +70,5 @@ In VS Code, right-click on a selection of code and choose one of the `Ask Cody >
 ## Explanations
 
 - [Enabling Cody for Sourcegraph Enterprise customers](explanations/enabling_cody_enterprise.md)
-- [Enabling Cody for Sourcegraph.com users](explanations/enabling_cody.md)
+- [Enabling Cody for open source Sourcegraph.com users](explanations/enabling_cody.md)
 - [Configuring code graph context](explanations/code_graph_context.md)


### PR DESCRIPTION
Remove the link to the Google form for Cody sign ups (for individual devs on open source). 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
N/A Docs change