### PR TITLE
release-tool: automatically tag helm repo when finalizing release

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -638,11 +638,11 @@ export async function createTag(
     const branch = JSON.stringify(rawBranch)
     const tag = JSON.stringify(rawTag)
     const finalizeTag = dryRun ? `git --no-pager show ${tag} --no-patch` : `git push origin ${tag}`
-    console.log(
-        dryRun
-            ? `Dry-run enabled - creating and printing tag ${tag} on ${owner}/${repo}@${branch}`
-            : `Creating and pushing tag ${tag} on ${owner}/${repo}@${branch}`
-    )
+    if (dryRun) {
+        console.log(`Dry-run enabled - creating and printing tag ${tag} on ${owner}/${repo}@${branch}`)
+        return
+    }
+    console.log(`Creating and pushing tag ${tag} on ${owner}/${repo}@${branch}`)
     await execa('bash', ['-c', `git tag -a ${tag} -m ${tag} && ${finalizeTag}`], { stdio: 'inherit', cwd: workdir })
 }
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -899,19 +899,28 @@ Batch change: ${batchChangeURL}`,
             const release = await getActiveRelease(config)
             let failed = false
 
+            const defaultBranchPattern = `${release.branch}`
+            const defaultTagPattern = `v${release.version.version}`
+            const defaults = { branchPattern: defaultBranchPattern, tagPattern: defaultTagPattern }
+            const repoConfigs = [
+                { repo: 'deploy-sourcegraph', ...defaults },
+                { repo: 'deploy-sourcegraph-docker', ...defaults },
+                { repo: 'deploy-sourcegraph-docker-customer-replica-1', ...defaults },
+                { repo: 'deploy-sourcegraph-k8s', ...defaults },
+                {
+                    repo: 'deploy-sourcegraph-helm',
+                    branchPattern: `release/${release.branch}`,
+                    tagPattern: `sourcegraph-${release.version.version}`,
+                },
+            ]
+
             const owner = 'sourcegraph'
             // Push final tags
-            const tag = `v${release.version.version}`
-            for (const repo of [
-                'deploy-sourcegraph',
-                'deploy-sourcegraph-docker',
-                'deploy-sourcegraph-docker-customer-replica-1',
-                'deploy-sourcegraph-k8s',
-            ]) {
+            for (const repoConfig of repoConfigs) {
                 try {
                     const client = await getAuthenticatedGitHubClient()
-                    const { workdir } = await cloneRepo(client, owner, repo, {
-                        revision: release.branch,
+                    const { workdir } = await cloneRepo(client, owner, repoConfig.repo, {
+                        revision: repoConfig.branchPattern,
                         revisionMustExist: true,
                     })
                     await createTag(
@@ -919,9 +928,9 @@ Batch change: ${batchChangeURL}`,
                         workdir,
                         {
                             owner,
-                            repo,
-                            branch: release.branch,
-                            tag,
+                            repo: repoConfig.repo,
+                            branch: repoConfig.branchPattern,
+                            tag: repoConfig.tagPattern,
                         },
                         config.dryRun.tags || false
                     )


### PR DESCRIPTION
Updates the release:finalize to support other branch/tag formats, which I assume was the reason helm wasn't included. Either way, this will include helm in the auto-tag at the end of a release.

## Test plan

Here are truncated logs from running with dry run enabled

```
> ts-node --transpile-only ./src/main.ts "release:finalize"

Dry-run enabled - creating and printing tag "v5.0.2" on sourcegraph/deploy-sourcegraph@"5.0"
Dry-run enabled - creating and printing tag "v5.0.2" on sourcegraph/deploy-sourcegraph-docker@"5.0"
Dry-run enabled - creating and printing tag "v5.0.2" on sourcegraph/deploy-sourcegraph-docker-customer-replica-1@"5.0"
Dry-run enabled - creating and printing tag "v5.0.2" on sourcegraph/deploy-sourcegraph-k8s@"5.0"
Dry-run enabled - creating and printing tag "sourcegraph-5.0.2" on sourcegraph/deploy-sourcegraph-helm@"release/5.0"
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
