### PR TITLE
app: log url as part of logger fields

### DIFF
--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -129,7 +129,8 @@ func NewWorker(observationCtx *observation.Context, nameSet *janitor.NameSet, op
 // after a ping is successful and returns false if a user signal is received.
 func connectToFrontend(logger log.Logger, queueClient *queue.Client, options Options) bool {
 	start := time.Now()
-	logger.Debug("Connecting to Sourcegraph instance", log.String("url", options.QueueOptions.BaseClientOptions.EndpointOptions.URL))
+	logger = logger.With(log.String("url", options.QueueOptions.BaseClientOptions.EndpointOptions.URL))
+	logger.Debug("Connecting to Sourcegraph instance")
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
Anytime the logger is used in this func the url will always be logged
## Test plan
Green CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
