### PR TITLE
Make repos not being deleted on errored syncs more obvious

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
@@ -158,7 +158,12 @@ export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalService
                 )}
             </div>
             {isExpanded && legends && <ValueLegendList className="mb-0" items={legends} />}
-            {isExpanded && node.failureMessage && <ErrorAlert error={`${node.failureMessage}\n\nWarning: Repositories will not be deleted if errors are present in the sync job.`} className="mt-2 mb-0" />}
+            {isExpanded && node.failureMessage && (
+                <ErrorAlert
+                    error={`${node.failureMessage}\n\nWarning: Repositories will not be deleted if errors are present in the sync job.`}
+                    className="mt-2 mb-0"
+                />
+            )}
         </li>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
@@ -158,7 +158,7 @@ export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalService
                 )}
             </div>
             {isExpanded && legends && <ValueLegendList className="mb-0" items={legends} />}
-            {isExpanded && node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
+            {isExpanded && node.failureMessage && <ErrorAlert error={`${node.failureMessage}\n\nWarning: Repositories will not be deleted if errors are present in the sync job.`} className="mt-2 mb-0" />}
         </li>
     )
 }


### PR DESCRIPTION
This was not really a well communicated behavior and caused a lot of confusion with customers.

## Test plan

Manual
![image](https://user-images.githubusercontent.com/20795805/233473474-03517d62-a598-4746-94b1-681ae37ae29e.png)
