### PR TITLE
nix: add bazel-watcher

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -81,10 +81,12 @@ pkgs.mkShell {
     clippy
 
     bazelisk
+    bazel-watcher
   ];
 
   # Startup postgres
   shellHook = ''
+    set -h # command hashmap is disabled by default
     . ./dev/nix/shell-hook.sh
   '';
 


### PR DESCRIPTION
We were missing ibazel.

Test Plan: sg run works for me now on darwin
