### PR TITLE
show "reset conversation" icon in view/title menu not react UI

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -130,7 +130,8 @@
       },
       {
         "command": "cody.settings",
-        "title": "Cody: Settings",
+        "title": "Settings",
+        "group": "Cody",
         "icon": "$(gear)",
         "when": "cody.activated"
       },
@@ -138,6 +139,13 @@
         "command": "cody.focus",
         "title": "Cody: Sign In to Use Cody",
         "when": "!cody.activated"
+      },
+      {
+        "command": "cody.interactive.clear",
+        "title": "Clear & Restart Chat Session",
+        "group": "Cody",
+        "icon": "$(clear-all)",
+        "when": "cody.activated"
       }
     ],
     "keybindings": [
@@ -226,11 +234,15 @@
           "when": "cody.activated"
         },
         {
-          "command": "cody.focus",
           "when": "!cody.activated"
         }
       ],
       "view/title": [
+        {
+          "command": "cody.interactive.clear",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation"
+        },
         {
           "command": "cody.settings",
           "when": "view == cody.chat && cody.activated",

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -84,16 +84,21 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.configurationChangeEvent.fire()
     }
 
+    public clearAndRestartSession(): void {
+        this.createNewChatID()
+        this.cancelCompletion()
+        this.isMessageInProgress = false
+        this.transcript.reset()
+        this.sendTranscript()
+        this.sendChatHistory()
+    }
+
     private async onDidReceiveMessage(message: WebviewMessage): Promise<void> {
         switch (message.command) {
             case 'initialized':
                 this.publishContextStatus()
                 this.publishConfig()
                 this.sendTranscript()
-                this.sendChatHistory()
-                break
-            case 'reset':
-                this.onResetChat()
                 this.sendChatHistory()
                 break
             case 'submit':
@@ -201,14 +206,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     private cancelCompletion(): void {
         this.cancelCompletionCallback?.()
         this.cancelCompletionCallback = null
-    }
-
-    private onResetChat(): void {
-        this.createNewChatID()
-        this.cancelCompletion()
-        this.isMessageInProgress = false
-        this.transcript.reset()
-        this.sendTranscript()
     }
 
     private async onHumanMessageSubmitted(text: string): Promise<void> {

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -11,7 +11,6 @@ export type WebviewMessage =
     | {
           command: 'initialized'
       }
-    | { command: 'reset' }
     | { command: 'event'; event: string; value: string }
     | { command: 'submit'; text: string }
     | { command: 'executeRecipe'; recipe: string }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -171,6 +171,7 @@ const register = async (
         // Commands
         vscode.commands.registerCommand('cody.focus', () => vscode.commands.executeCommand('cody.chat.focus')),
         vscode.commands.registerCommand('cody.settings', () => chatProvider.setWebviewView('settings')),
+        vscode.commands.registerCommand('cody.interactive.clear', () => chatProvider.clearAndRestartSession()),
         vscode.commands.registerCommand('cody.recipe.explain-code', () => executeRecipe('explain-code-detailed')),
         vscode.commands.registerCommand('cody.recipe.explain-code-high-level', () =>
             executeRecipe('explain-code-high-level')

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -92,15 +92,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         setView('login')
     }, [vscodeAPI])
 
-    const onResetClick = useCallback(() => {
-        setView('chat')
-        setDebugLog([])
-        setFormInput('')
-        setMessageInProgress(null)
-        setTranscript([])
-        vscodeAPI.postMessage({ command: 'reset' })
-    }, [vscodeAPI])
-
     if (!view) {
         return <LoadingPage />
     }
@@ -111,15 +102,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
             {view === 'login' && (
                 <Login onLogin={onLogin} isValidLogin={isValidLogin} serverEndpoint={config?.serverEndpoint} />
             )}
-            {view && view !== 'login' && (
-                <NavBar
-                    view={view}
-                    setView={setView}
-                    devMode={Boolean(config?.debug)}
-                    onResetClick={onResetClick}
-                    showResetButton={transcript.length > 0}
-                />
-            )}
+            {view && view !== 'login' && <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />}
             {view === 'debug' && config?.debug && <Debug debugLog={debugLog} />}
             {view === 'history' && (
                 <UserHistory

--- a/client/cody/webviews/NavBar.tsx
+++ b/client/cody/webviews/NavBar.tsx
@@ -8,8 +8,6 @@ interface NavBarProps {
     setView: (selectedView: View) => void
     view: View
     devMode: boolean
-    onResetClick: () => void
-    showResetButton: boolean
 }
 
 interface NavBarItem {
@@ -22,13 +20,7 @@ const navBarItems: NavBarItem[] = [
     { tab: 'recipes', title: 'Recipes' },
 ]
 
-export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps>> = ({
-    setView,
-    view,
-    devMode,
-    onResetClick,
-    showResetButton,
-}) => (
+export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps>> = ({ setView, view, devMode }) => (
     <div className={styles.tabMenuContainer}>
         <div className={styles.tabMenuGroup}>
             {navBarItems.map(({ title, tab }) => (
@@ -39,18 +31,6 @@ export const NavBar: React.FunctionComponent<React.PropsWithChildren<NavBarProps
             {devMode && (
                 <button onClick={() => setView('debug')} className={styles.tabBtn} type="button">
                     <p className={view === 'debug' ? styles.tabBtnSelected : ''}>Debug</p>
-                </button>
-            )}
-        </div>
-        <div className="tab-menu-group">
-            {showResetButton && (
-                <button
-                    onClick={() => onResetClick()}
-                    className={styles.tabBtn}
-                    type="button"
-                    title="Start a new conversation"
-                >
-                    <i className="codicon codicon-refresh" />
                 </button>
             )}
         </div>


### PR DESCRIPTION
The standard place for this kind of button is in the view/title menu, not in the webview UI. This change also makes it use the standard VS Code icon for this type of action, instead of a non-VS Code-standard icon (the reload).

This is similar to how we moved settings to a gear icon in the sme view/title menu.

<img width="511" alt="image" src="https://user-images.githubusercontent.com/1976/233556675-c5bdd150-ad09-46d8-980c-9d5ea717d9ff.png">



## Test plan

Click the button after you've started a conversation. Confirm it is cleared and reset.