### PR TITLE
mailmap: add entries for Eric and Renovate

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -58,6 +58,8 @@ Joe Chen <joe@sourcegraph.com> Unknwon <u@gogs.io>
 Joe Chen <joe@sourcegraph.com> 无闻 <u@gogs.io>
 Joe Chen <joe@sourcegraph.com> ᴜɴᴋɴᴡᴏɴ <joe@sourcegraph.com>
 Renovate Bot <bot@renovateapp.com> renovate[bot] <renovate[bot]@users.noreply.github.com>
+Renovate Bot <bot@renovateapp.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
 Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>
 Nico Tonozzi <dominic.tonozzi@gmail.com> Dominic Tonozzi <nico@Dominics-MBP.web-pass.com>
 Camden Cheek <camden@sourcegraph.com> Camden Cheek <camden@ccheek.com>
+Eric Fritz <eric@sourcegraph.com> Eric Fritz <eric@eric-fritz.com>


### PR DESCRIPTION
Was looking at the Contributors graphic for the Sourcegraph repo and noticed both Eric and Renovate had top commit accounts that could be combined.

Test Plan: git log --author=Eric only had the sourcegraph.com email listed.
