### PR TITLE
(fix) fix repo root page menu button group tooltips and hover

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -244,7 +244,7 @@ export const TreePage: FC<Props> = ({
             <div className={styles.menu}>
                 <ButtonGroup>
                     {!isPackage && (
-                        <Tooltip content="Branches">
+                        <Tooltip content="Git branches">
                             <Button
                                 className="flex-shrink-0"
                                 to={`/${encodeURIPathComponent(repoName)}/-/branches`}
@@ -257,7 +257,7 @@ export const TreePage: FC<Props> = ({
                             </Button>
                         </Tooltip>
                     )}
-                    <Tooltip content={isPackage ? 'Versions' : 'Tags'}>
+                    <Tooltip content={isPackage ? 'Package versions' : 'Git tags'}>
                         <Button
                             className="flex-shrink-0"
                             to={`/${encodeURIPathComponent(repoName)}/-${isPackage ? '/versions' : '/tags'}`}
@@ -269,7 +269,7 @@ export const TreePage: FC<Props> = ({
                             <span className={styles.text}>{isPackage ? 'Versions' : 'Tags'}</span>
                         </Button>
                     </Tooltip>
-                    <Tooltip content="Compare">
+                    <Tooltip content="Compare branches">
                         <Button
                             className="flex-shrink-0"
                             to={
@@ -311,7 +311,7 @@ export const TreePage: FC<Props> = ({
                         </Tooltip>
                     )}
                     {showOwnership && (
-                        <Tooltip content="Ownership">
+                        <Tooltip content="Repository ownership settings">
                             <Button
                                 className="flex-shrink-0"
                                 to={`/${encodeURIPathComponent(repoName)}/-/own`}
@@ -326,7 +326,7 @@ export const TreePage: FC<Props> = ({
                         </Tooltip>
                     )}
                     {repo?.viewerCanAdminister && (
-                        <Tooltip content="Settings">
+                        <Tooltip content="Repository settings">
                             <Button
                                 className="flex-shrink-0"
                                 to={`/${encodeURIPathComponent(repoName)}/-/settings`}
@@ -335,7 +335,7 @@ export const TreePage: FC<Props> = ({
                                 as={Link}
                                 aria-label="Repository settings"
                             >
-                                <Icon aria-hidden={true} svgPath={mdiCog} />
+                                <Icon aria-hidden={true} svgPath={mdiCog} />{' '}
                                 <span className={styles.text}>Settings</span>
                             </Button>
                         </Tooltip>

--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -392,17 +392,6 @@ input.btn {
     > .btn {
         position: relative;
         flex: 1 1 auto;
-
-        // Bring the hover, focused, and "active" buttons to the front to overlay
-        // the borders properly
-        &:hover {
-            z-index: 1;
-        }
-        &:focus,
-        &:active,
-        &:global(.active) {
-            z-index: 1;
-        }
     }
 }
 


### PR DESCRIPTION
@toolmantim [reported](https://sourcegraph.slack.com/archives/C0549QV2483/p1682045657640099) minor UI issues on the repo root page.

This PR:
- Add spacing between the icon and the "Settings" menu button and updates tooltips
- Remove redundant z-index styles from the button component, which is causing inside content to move on hover

## Test plan
- `sg start`
- Open any repo root page in Safari
- Check menu button group hover doesn't cause jumping icons

## Screenshots
| Before | After |
| --: | :-- |
| <video src="https://user-images.githubusercontent.com/6717049/233617248-d8892e34-163f-458d-bf4e-cd4950164b0b.mov" />  | <video src="https://user-images.githubusercontent.com/6717049/233616841-dfad67f1-4ad9-4032-a02c-1598492cdbac.mov" /> |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
