### PR TITLE
[github app] Add GitHub App authentication for git cloning

### DIFF
--- a/enterprise/internal/github_apps/auth/auth.go
+++ b/enterprise/internal/github_apps/auth/auth.go
@@ -31,7 +31,7 @@ func CreateEnterpriseFromConnection(ghApps store.GitHubAppsStore) ghauth.FromCon
 			return &auth.OAuthBearerToken{Token: conn.Token}, nil
 		}
 
-		ghApp, err := ghApps.GetByAppID(ctx, conn.GitHubAppDetails.AppID, conn.GitHubAppDetails.BaseURL)
+		ghApp, err := ghApps.GetByAppID(ctx, conn.GitHubAppDetails.AppID, conn.Url)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/github_apps/auth/auth.go
+++ b/enterprise/internal/github_apps/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 // the provided EnterpriseDB. This gives the function access to GitHub App details
 // in the database.
 func CreateEnterpriseFromConnection(ghApps store.GitHubAppsStore) ghauth.FromConnectionFunc {
-	return func(ctx context.Context, conn *schema.GitHubConnection) (auth.Authenticator, error) {
+	return func(ctx context.Context, conn *schema.GitHubConnection) (ghauth.RefreshableURLRequestAuthenticator, error) {
 		if conn.GitHubAppDetails == nil {
 			return &auth.OAuthBearerToken{Token: conn.Token}, nil
 		}
@@ -40,7 +41,12 @@ func CreateEnterpriseFromConnection(ghApps store.GitHubAppsStore) ghauth.FromCon
 			return nil, err
 		}
 
-		return NewInstallationAccessToken(conn.GitHubAppDetails.InstallationID, appAuther), nil
+		baseURL, err := url.Parse(conn.Url)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewInstallationAccessToken(baseURL, conn.GitHubAppDetails.InstallationID, appAuther), nil
 	}
 }
 
@@ -130,8 +136,8 @@ type installationAccessToken struct {
 	installationID   int
 	token            string
 	expiresAt        time.Time
+	baseURL          *url.URL
 	appAuthenticator auth.Authenticator
-	cli              *github.V3Client
 }
 
 func (t *installationAccessToken) updateFromJSON(jt *jsonToken) {
@@ -148,10 +154,12 @@ func (t *installationAccessToken) updateFromJSON(jt *jsonToken) {
 //
 // appAuthenticator must not be nil.
 func NewInstallationAccessToken(
+	baseURL *url.URL,
 	installationID int,
 	appAuthenticator auth.Authenticator,
 ) *installationAccessToken {
 	auther := &installationAccessToken{
+		baseURL:          baseURL,
 		installationID:   installationID,
 		appAuthenticator: appAuthenticator,
 	}
@@ -164,7 +172,10 @@ func NewInstallationAccessToken(
 // installation associated with the Authenticator.
 // Returns an error if the request fails.
 func (t *installationAccessToken) Refresh(ctx context.Context, cli httpcli.Doer) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", t.installationID), nil)
+	apiURL, _ := github.APIRoot(t.baseURL)
+	apiURL = apiURL.JoinPath(fmt.Sprintf("/app/installations/%d/access_tokens", t.installationID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -175,6 +186,10 @@ func (t *installationAccessToken) Refresh(ctx context.Context, cli httpcli.Doer)
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.Newf("failed to refresh: ", resp.StatusCode)
+	}
 
 	var jsonToken jsonToken
 	if err := json.NewDecoder(resp.Body).Decode(&jsonToken); err != nil {
@@ -210,4 +225,8 @@ func (t *installationAccessToken) NeedsRefresh() bool {
 		return false
 	}
 	return time.Until(t.expiresAt) < 5*time.Minute
+}
+
+func (t *installationAccessToken) SetURLUser(u *url.URL) {
+	u.User = url.UserPassword("x-access-token", t.token)
 }

--- a/enterprise/internal/github_apps/auth/auth.go
+++ b/enterprise/internal/github_apps/auth/auth.go
@@ -188,7 +188,7 @@ func (t *installationAccessToken) Refresh(ctx context.Context, cli httpcli.Doer)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return errors.Newf("failed to refresh: ", resp.StatusCode)
+		return errors.Newf("failed to refresh: %d", resp.StatusCode)
 	}
 
 	var jsonToken jsonToken

--- a/enterprise/internal/github_apps/auth/auth.go
+++ b/enterprise/internal/github_apps/auth/auth.go
@@ -227,6 +227,7 @@ func (t *installationAccessToken) NeedsRefresh() bool {
 	return time.Until(t.expiresAt) < 5*time.Minute
 }
 
+// Sets the URL's User field to contain the installation access token.
 func (t *installationAccessToken) SetURLUser(u *url.URL) {
 	u.User = url.UserPassword("x-access-token", t.token)
 }

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -167,6 +167,22 @@ func TestInstallationAccessToken_NeedsRefresh(t *testing.T) {
 	}
 }
 
+func TestInstallationAccessToken_SetURLUser(t *testing.T) {
+	token := "abc123"
+	u, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	it := installationAccessToken{token: token}
+	it.SetURLUser(u)
+
+	want := "x-access-token:abc123"
+	if got := u.User.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 type mockAuthenticator struct {
 	AuthenticateCalled bool
 }

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -115,6 +116,7 @@ func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 	installationID := 1
 	appAuthenticator := &mockAuthenticator{}
 	token := NewInstallationAccessToken(
+		&url.URL{Host: "https://github.com"},
 		installationID,
 		appAuthenticator,
 	)
@@ -131,6 +133,7 @@ func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 	appAuthenticator := &mockAuthenticator{}
 	token := NewInstallationAccessToken(
+		&url.URL{Host: "https://github.com"},
 		1,
 		appAuthenticator,
 	)

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -115,8 +115,10 @@ invalid key
 func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 	installationID := 1
 	appAuthenticator := &mockAuthenticator{}
+	u, err := url.Parse("https://github.com")
+	require.NoError(t, err)
 	token := NewInstallationAccessToken(
-		&url.URL{Host: "https://github.com"},
+		u,
 		installationID,
 		appAuthenticator,
 	)
@@ -132,8 +134,10 @@ func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 
 func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 	appAuthenticator := &mockAuthenticator{}
+	u, err := url.Parse("https://github.com")
+	require.NoError(t, err)
 	token := NewInstallationAccessToken(
-		&url.URL{Host: "https://github.com"},
+		u,
 		1,
 		appAuthenticator,
 	)
@@ -146,6 +150,9 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 	require.True(t, appAuthenticator.AuthenticateCalled)
 
 	require.Equal(t, token.token, "new-token")
+	wantTime, err := time.Parse(time.RFC3339, "2016-07-11T22:14:10Z")
+	require.NoError(t, err)
+	require.True(t, token.expiresAt.Equal(wantTime))
 }
 
 func TestInstallationAccessToken_NeedsRefresh(t *testing.T) {
@@ -204,7 +211,7 @@ func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.DoCalled = true
 
 	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`{"token": "new-token"}`)),
+		StatusCode: http.StatusCreated,
+		Body:       io.NopCloser(strings.NewReader(`{"token": "new-token", "expires_at": "2016-07-11T22:14:10Z"}`)),
 	}, nil
 }

--- a/internal/extsvc/auth/auth.go
+++ b/internal/extsvc/auth/auth.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
@@ -30,10 +31,7 @@ type Authenticator interface {
 	Hash() string
 }
 
-type AuthenticatorWithRefresh interface {
-	// Must implement the base Authenticator interface
-	Authenticator
-
+type Refreshable interface {
 	// NeedsRefresh returns true if the Authenticator is no longer valid and
 	// needs to be refreshed, such as checking if an OAuth token is close to
 	// expiry or already expired.
@@ -43,6 +41,11 @@ type AuthenticatorWithRefresh interface {
 	// and if any storage updates should happen after refreshing, that is done
 	// here as well.
 	Refresh(context.Context, httpcli.Doer) error
+}
+
+type AuthenticatorWithRefresh interface {
+	Authenticator
+	Refreshable
 }
 
 // AuthenticatorWithSSH wraps the Authenticator interface and augments it by
@@ -58,4 +61,11 @@ type AuthenticatorWithSSH interface {
 	// authorized_keys file format. This is usually accepted by code hosts to
 	// allow access to git over SSH.
 	SSHPublicKey() (publicKey string)
+}
+
+// URLAuthenticator instances allow adding credentials to URLs.
+type URLAuthenticator interface {
+	// SetURLUser authenticates the provided URL by modifying the User property
+	// of the URL in-place.
+	SetURLUser(*url.URL)
 }

--- a/internal/extsvc/auth/oauth_bearer.go
+++ b/internal/extsvc/auth/oauth_bearer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -66,6 +67,11 @@ func (token *OAuthBearerToken) WithToken(newToken string) *OAuthBearerToken {
 	return &OAuthBearerToken{
 		Token: newToken,
 	}
+}
+
+// SetURLUser authenticates the provided URL by setting the User field.
+func (token *OAuthBearerToken) SetURLUser(u *url.URL) {
+	u.User = url.UserPassword("oauth2", token.Token)
 }
 
 // OAuthBearerTokenWithSSH implements OAuth Bearer Token authentication for extsvc

--- a/internal/extsvc/github/auth/auth.go
+++ b/internal/extsvc/github/auth/auth.go
@@ -7,10 +7,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type FromConnectionFunc func(context.Context, *schema.GitHubConnection) (auth.Authenticator, error)
+type RefreshableURLRequestAuthenticator interface {
+	auth.Authenticator
+	auth.URLAuthenticator
+	auth.Refreshable
+}
+
+type FromConnectionFunc func(context.Context, *schema.GitHubConnection) (RefreshableURLRequestAuthenticator, error)
 
 // FromConnection creates an authenticator from a GitHubConnection.,
 // This function gets replaced in Enterprise services that support GitHub App.
-var FromConnection = func(_ context.Context, conn *schema.GitHubConnection) (auth.Authenticator, error) {
+var FromConnection = func(_ context.Context, conn *schema.GitHubConnection) (RefreshableURLRequestAuthenticator, error) {
 	return &auth.OAuthBearerToken{Token: conn.Token}, nil
 }

--- a/internal/repos/clone_url_test.go
+++ b/internal/repos/clone_url_test.go
@@ -1,6 +1,7 @@
 package repos
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -169,7 +170,7 @@ func TestBitbucketCloudCloneURLs(t *testing.T) {
 func TestGitHubCloneURLs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	t.Run("empty repo.URL", func(t *testing.T) {
-		_, err := githubCloneURL(logger, &github.Repository{}, &schema.GitHubConnection{})
+		_, err := githubCloneURL(context.Background(), logger, &github.Repository{}, &schema.GitHubConnection{})
 		got := fmt.Sprintf("%v", err)
 		want := "empty repo.URL"
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -202,7 +203,7 @@ func TestGitHubCloneURLs(t *testing.T) {
 
 			repo.URL = test.RepoURL
 
-			got, err := githubCloneURL(logger, &repo, &cfg)
+			got, err := githubCloneURL(context.Background(), logger, &repo, &cfg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -180,10 +180,6 @@
       "description": "If non-null, this is a GitHub App connection with some additional properties.",
       "type": "object",
       "properties": {
-        "baseURL": {
-          "description": "The base URL of the GitHub App.",
-          "type": "string"
-        },
         "appID": {
           "description": "The ID of the GitHub App.",
           "type": "integer"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1007,8 +1007,6 @@ type GitHubApp struct {
 type GitHubAppDetails struct {
 	// AppID description: The ID of the GitHub App.
 	AppID int `json:"appID,omitempty"`
-	// BaseURL description: The base URL of the GitHub App.
-	BaseURL string `json:"baseURL,omitempty"`
 	// InstallationID description: The installation ID of this connection.
 	InstallationID int `json:"installationID,omitempty"`
 }


### PR DESCRIPTION
Adds authentication methods for cloning GitHub App repositories.

## Test plan

Unit tests added/updated. Also confirmed to work locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
