### PR TITLE
Add a rough cost estimation to sg ci status

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -781,35 +781,76 @@ func printBuildOverview(build *buildkite.Build) {
 	}
 }
 
+func agentKind(job *buildkite.Job) string {
+	for _, rule := range job.AgentQueryRules {
+		if strings.Contains(rule, "bazel") {
+			return "bazel"
+		}
+	}
+	return "stateless"
+}
+
+func formatBuildResult(result string) (string, output.Style) {
+	var style output.Style
+	var emoji string
+
+	switch result {
+	case "passed":
+		style = output.StyleSuccess
+		emoji = output.EmojiSuccess
+	case "waiting", "blocked", "scheduled":
+		style = output.StyleSuggestion
+	case "skipped", "not_run", "broken":
+		style = output.StyleReset
+		emoji = output.EmojiOk
+	case "running":
+		style = output.StylePending
+		emoji = output.EmojiInfo
+	case "failed":
+		emoji = output.EmojiFailure
+		style = output.StyleFailure
+	case "soft failed":
+		emoji = output.EmojiOk
+		style = output.StyleSearchLink
+	default:
+		style = output.StyleWarning
+	}
+
+	return emoji, style
+}
+
+var costPerHour = map[string]float64{
+	// How to get the price per hour:
+	// https://console.cloud.google.com/billing/017005-C370B2-0E3030/estimate?organizationId=244397465763&project=sourcegraph-ci
+	// - set machine type to custom
+	// - adjust ram + cpu
+	// - 24h per day
+	// - 5 days per week
+	// - take a look at estimate summary, look for "that's about $X hourly"
+	"bazel":     0.60,
+	"stateless": 0.33 / 3, // we average 3 jobs per node
+}
+
+func estimateCost(cumulativeElapsed time.Duration, kind string) float64 {
+	minutes := cumulativeElapsed.Minutes()
+	cpm := costPerHour[kind] / 60
+	return cpm * minutes
+}
+
 func printBuildResults(build *buildkite.Build, annotations bk.JobAnnotations, notify bool) (failed bool) {
 	std.Out.Writef("Started:\t%s", build.StartedAt)
 	if build.FinishedAt != nil {
 		std.Out.Writef("Finished:\t%s (elapsed: %s)", build.FinishedAt, build.FinishedAt.Sub(build.StartedAt.Time))
 	}
 
+	var statelessDuration time.Duration
+	var bazelDuration time.Duration
+	var totalDuration time.Duration
+
 	// Check build state
 	// Valid states: running, scheduled, passed, failed, blocked, canceled, canceling, skipped, not_run, waiting
 	// https://buildkite.com/docs/apis/rest-api/builds
-	var style output.Style
-	var emoji string
-	switch *build.State {
-	case "passed":
-		style = output.StyleSuccess
-		emoji = output.EmojiSuccess
-	case "waiting", "blocked", "scheduled":
-		style = output.StyleSuggestion
-	case "skipped", "not_run":
-		style = output.StyleReset
-	case "running":
-		style = output.StylePending
-		emoji = output.EmojiInfo
-	case "failed":
-		failed = true
-		emoji = output.EmojiFailure
-		style = output.StyleFailure
-	default:
-		style = output.StyleWarning
-	}
+	emoji, style := formatBuildResult(*build.State)
 	block := std.Out.Block(output.Styledf(style, "Status:\t\t%s %s", emoji, *build.State))
 
 	// Inspect jobs individually.
@@ -819,13 +860,16 @@ func printBuildResults(build *buildkite.Build, annotations bk.JobAnnotations, no
 		if job.State == nil || job.Name == nil {
 			continue
 		}
+		if *job.State == "failed" && job.SoftFailed {
+			*job.State = "soft failed"
+		}
+
+		_, style := formatBuildResult(*job.State)
 		// Check job state.
 		switch *job.State {
 		case "passed":
-			style = output.StyleSuccess
 			elapsed = job.FinishedAt.Sub(job.StartedAt.Time)
 		case "waiting", "blocked", "scheduled", "assigned":
-			style = output.StyleSuggestion
 		case "broken":
 			// State 'broken' happens when a conditional is not met, namely the 'if' block
 			// on a job. Why is it 'broken' and not 'skipped'? We don't think it be like
@@ -834,35 +878,51 @@ func printBuildResults(build *buildkite.Build, annotations bk.JobAnnotations, no
 			*job.State = "skipped"
 			fallthrough
 		case "skipped", "not_run":
-			style = output.StyleReset
 		case "running":
 			elapsed = time.Since(job.StartedAt.Time)
-			style = output.StylePending
 		case "failed":
 			elapsed = job.FinishedAt.Sub(job.StartedAt.Time)
-			if job.SoftFailed {
-				*job.State = "soft failed"
-				style = output.StyleReset
-				break
-			}
 			failedSummary = append(failedSummary, fmt.Sprintf("- %s", *job.Name))
-			style = output.StyleFailure
 			failed = true
 		default:
 			style = output.StyleWarning
 		}
+
 		if elapsed > 0 {
 			block.WriteLine(output.Styledf(style, "- [%s] %s (%s)", *job.State, *job.Name, elapsed))
 		} else {
 			block.WriteLine(output.Styledf(style, "- [%s] %s", *job.State, *job.Name))
 		}
 
+		totalDuration += elapsed
+		if agentKind(job) == "bazel" {
+			bazelDuration += elapsed
+		} else {
+			statelessDuration += elapsed
+		}
 		if annotation, exist := annotations[*job.ID]; exist {
 			block.WriteMarkdown(annotation.Content, output.MarkdownNoMargin, output.MarkdownIndent(2))
 		}
 	}
 
 	block.Close()
+
+	if build.FinishedAt != nil {
+		bazelCost := estimateCost(bazelDuration, "bazel")
+		statelessCost := estimateCost(statelessDuration, "stateless")
+		totalCost := bazelCost + statelessCost
+
+		statusStr := fmt.Sprintf("Status:\t\t%s %s", emoji, *build.State)
+		std.Out.Write(strings.Repeat("-", len(statusStr)+8*2)) // 2 * \t
+		std.Out.WriteLine(output.Linef(emoji, output.StyleReset, statusStr))
+		std.Out.WriteLine(output.Linef(output.EmojiHourglass, output.StyleReset, "Finished at: %s", build.FinishedAt))
+		std.Out.WriteLine(output.Linef(" ", output.StyleReset, "- Took %s to complete", build.FinishedAt.Sub(build.StartedAt.Time)))
+		std.Out.WriteLine(output.Linef(" ", output.StyleReset, "- Consumed %s of CI time to complete", totalDuration))
+		std.Out.WriteLine(output.Linef("💰", output.StyleReset, "Cost (rough estimation based on time spent using a node by the agent):"))
+		std.Out.WriteLine(output.Linef(" ", output.StyleReset, "- Bazel: $%.2f (%s) -- 1 job per node", bazelCost, bazelDuration))
+		std.Out.WriteLine(output.Linef(" ", output.StyleReset, "- Stateless: $%.2f (%s) -- assuming 3 jobs per node", statelessCost, statelessDuration))
+		std.Out.WriteLine(output.Linef(" ", output.StyleBold, "= Total: $%.2f (%s)", totalCost, totalDuration))
+	}
 
 	if notify {
 		if failed {


### PR DESCRIPTION
This prints a rough estimation of the cost and duration of a given build. 

This adds the following paragraph at the end of a `sg ci status` 

```
:white_check_mark: Status:              :white_check_mark: passed
:hourglass: Finished at: 2023-04-20 15:57:37.416 +0000 UTC
Took 39m35.781s to complete
Consumed 7h37m24.664s of CI time to complete
:moneybag: Cost (rough estimation based on time spent using a node by the agent):
Bazel: $0.08 (7m52.561s) -- 1 job per node
Stateless: $0.82 (7h29m32.103s) -- assuming 3 jobs per node
  = Total: $0.90 (7h37m24.664s) (edited) 
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 