### PR TITLE
Cody completions: Start less network requests for inline completions

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -113,25 +113,21 @@ export async function createClient({
         const responsePrefix = interaction.getAssistantMessage().prefix ?? ''
         const abortController = new AbortController()
 
-        chatClient.chat(
-            prompt,
-            {
-                onChange(rawText) {
-                    const text = reformatBotMessage(rawText, responsePrefix)
-                    transcript.addAssistantResponse(text)
+        chatClient.chat(prompt, {
+            onChange(rawText) {
+                const text = reformatBotMessage(rawText, responsePrefix)
+                transcript.addAssistantResponse(text)
 
-                    sendTranscript()
-                },
-                onComplete() {
-                    isMessageInProgress = false
-                    sendTranscript()
-                },
-                onError(error) {
-                    console.error(error)
-                },
+                sendTranscript()
             },
-            abortController.signal
-        )
+            onComplete() {
+                isMessageInProgress = false
+                sendTranscript()
+            },
+            onError(error) {
+                console.error(error)
+            },
+        })
     }
 
     return {

--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -111,7 +111,6 @@ export async function createClient({
 
         const prompt = await transcript.toPrompt(getPreamble(config.codebase))
         const responsePrefix = interaction.getAssistantMessage().prefix ?? ''
-        const abortController = new AbortController()
 
         chatClient.chat(prompt, {
             onChange(rawText) {

--- a/client/cody-shared/src/sourcegraph-api/completions/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/client.ts
@@ -42,5 +42,8 @@ export abstract class SourcegraphCompletionsClient {
     }
 
     public abstract stream(params: CompletionParameters, cb: CompletionCallbacks): () => void
-    public abstract complete(params: CodeCompletionParameters): Promise<CodeCompletionResponse>
+    public abstract complete(
+        params: CodeCompletionParameters,
+        abortSignal: AbortSignal
+    ): Promise<CodeCompletionResponse>
 }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -116,17 +116,18 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     prefix,
                     '',
                     2 // 2 tries
-                ),
+                )
                 // TODO: Figure out if this is really useful. Right now it seems that this is not
                 // rendered and a subsequent completion is not properly using the cache yet.
-                new EndOfLineCompletionProvider(
-                    this.completionsClient,
-                    remainingChars,
-                    this.responseTokens,
-                    prefix,
-                    '\n', // force a new line in the case we are at end of line
-                    2 // 2 tries
-                )
+                //
+                // new EndOfLineCompletionProvider(
+                //     this.completionsClient,
+                //     remainingChars,
+                //     this.responseTokens,
+                //     prefix,
+                //     '\n', // force a new line in the case we are at end of line
+                //     2 // 2 tries
+                // )
             )
         }
 

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -24,6 +24,9 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     private promptTokens: number
     private maxPrefixTokens: number
     private maxSuffixTokens: number
+    private abortOpenInlineCompletions: () => void = () => {}
+    private abortOpenMultilineCompletion: () => void = () => {}
+
     constructor(
         private completionsClient: SourcegraphNodeCompletionsClient,
         private documentProvider: CompletionsDocumentProvider,
@@ -48,6 +51,10 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         try {
             return await this.provideInlineCompletionItemsInner(document, position, context, token)
         } catch (error) {
+            if (error.message === 'aborted') {
+                return []
+            }
+
             await vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
             return []
         }
@@ -63,6 +70,11 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         context: vscode.InlineCompletionContext,
         token: vscode.CancellationToken
     ): Promise<vscode.InlineCompletionItem[]> {
+        this.abortOpenInlineCompletions()
+        const abortController = new AbortController()
+        token.onCancellationRequested(() => abortController.abort())
+        this.abortOpenInlineCompletions = () => abortController.abort()
+
         const docContext = getCurrentDocContext(
             document,
             position,
@@ -79,7 +91,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         const completers: CompletionProvider[] = []
         if (precedingLine.trim() === '') {
             // Start of line: medium debounce
-            waitMs = 1500
+            waitMs = 500
             completers.push(
                 new EndOfLineCompletionProvider(
                     this.completionsClient,
@@ -95,7 +107,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         } else {
             // End of line: long debounce, complete until newline
-            waitMs = 3000
+            waitMs = 1000
             completers.push(
                 new EndOfLineCompletionProvider(
                     this.completionsClient,
@@ -105,6 +117,8 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     '',
                     2 // 2 tries
                 ),
+                // TODO: Figure out if this is really useful. Right now it seems that this is not
+                // rendered and a subsequent completion is not properly using the cache yet.
                 new EndOfLineCompletionProvider(
                     this.completionsClient,
                     remainingChars,
@@ -116,20 +130,29 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             )
         }
 
-        const aborter = new AbortController()
-        token.onCancellationRequested(() => aborter.abort())
-
         // TODO(beyang): trigger on context quality (better context means longer completion)
 
         const waiter = new Promise<void>(resolve =>
             setTimeout(() => resolve(), Math.max(0, waitMs - estimatedLLMResponseLatencyMS))
         )
         await waiter
-        const results = (await Promise.all(completers.map(c => c.generateCompletions()))).flat()
+
+        // We don't need to make a request at all if the signal is already aborted after the
+        // debounce
+        if (abortController.signal.aborted) {
+            return []
+        }
+
+        const results = (await Promise.all(completers.map(c => c.generateCompletions(abortController.signal)))).flat()
+
         return results.map(r => new vscode.InlineCompletionItem(r.content))
     }
 
     public async fetchAndShowCompletions(): Promise<void> {
+        this.abortOpenMultilineCompletion()
+        const abortController = new AbortController()
+        this.abortOpenMultilineCompletion = () => abortController.abort()
+
         const currentEditor = vscode.window.activeTextEditor
         if (!currentEditor || currentEditor?.document.uri.scheme === 'cody') {
             return
@@ -186,14 +209,18 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         )
 
         try {
-            const completions = await completer.generateCompletions(3)
+            const completions = await completer.generateCompletions(abortController.signal, 3)
             this.documentProvider.addCompletions(completionsUri, ext, completions, {
                 suffix: '',
                 elapsedMillis: 0,
                 llmOptions: null,
             })
         } catch (error) {
-            await vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
+            if (error.message === 'aborted') {
+                return
+            }
+
+            await vscode.window.showErrorMessage(`Error in fetchAndShowCompletions: ${error}`)
         }
     }
 }
@@ -280,11 +307,12 @@ function getCurrentDocContext(
 async function batchCompletions(
     client: SourcegraphNodeCompletionsClient,
     params: CodeCompletionParameters,
-    n: number
+    n: number,
+    abortSignal: AbortSignal
 ): Promise<CodeCompletionResponse[]> {
     const responses: Promise<CodeCompletionResponse>[] = []
     for (let i = 0; i < n; i++) {
-        responses.push(client.complete(params))
+        responses.push(client.complete(params, abortSignal))
     }
     return Promise.all(responses)
 }
@@ -296,7 +324,7 @@ export interface Completion {
 }
 
 interface CompletionProvider {
-    generateCompletions(n?: number): Promise<Completion[]>
+    generateCompletions(abortSignal: AbortSignal, n?: number): Promise<Completion[]>
 }
 
 export class MultilineCompletionProvider implements CompletionProvider {
@@ -384,7 +412,7 @@ export class MultilineCompletionProvider implements CompletionProvider {
         return completion.trimEnd()
     }
 
-    public async generateCompletions(n?: number): Promise<Completion[]> {
+    public async generateCompletions(abortSignal: AbortSignal, n?: number): Promise<Completion[]> {
         // Create prompt
         const prompt = this.makePrompt()
         if (prompt.length > this.promptChars) {
@@ -403,7 +431,8 @@ export class MultilineCompletionProvider implements CompletionProvider {
                 topK: -1, // default value
                 topP: -1, // default value
             },
-            n || this.defaultN
+            n || this.defaultN,
+            abortSignal
         )
         // Post-process
         return responses.map(resp => ({
@@ -490,7 +519,7 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
         return completion.trimEnd()
     }
 
-    public async generateCompletions(n?: number): Promise<Completion[]> {
+    public async generateCompletions(abortSignal: AbortSignal, n?: number): Promise<Completion[]> {
         // Create prompt
         const prompt = this.makePrompt()
         if (prompt.length > this.promptChars) {
@@ -509,7 +538,8 @@ export class EndOfLineCompletionProvider implements CompletionProvider {
                 topK: -1,
                 topP: -1,
             },
-            n || this.defaultN
+            n || this.defaultN,
+            abortSignal
         )
         // Post-process
         return responses.map(resp => ({


### PR DESCRIPTION
First attempt at reducing Cody completion API hammering by passing through request cancellations.

Especially for the inline completion APIs, the change here is quite significant because previously, requests were still made after the artificial debounce timeout has experied, effectively making four request per keystroke all the time, cancelling out the debouncing (the requests were just delayed).

Here are a few things that we can do next:

- More agressive caching. Especially around newlines. E.g. if the user accepts a suggestion and it inserts a `\n`, can we use the same suggestion's next line and avoid an additional network request? 
  -  ➡️ I'll think I'll work on this next, starting with a LRU cache is probably alright for now that we feed the whole prompts we send.
- Inline completions are currently triggering 4 requests per suggestion (see my added `// TODO` comment), two of which are completions for the next line (adding a `\n` to the current line). These are currently _not ever used_ from what I see (because the recommendation API can not propose changes in the next line). Idea: Keep doing these but use it as a cached response for when the user actually enters a newline so that the next line can be completed instantly.
  -   ➡️ Any objections for disabling this logic for now until we can properly make use if it?

I've also tweaked the timeouts quite a bit. Completions feel a lot more repsonsive yet. Need to make use of some of the freed up API calls 😅 

## Test plan

- I looked quite a bit for ways to connect the Chrome DevTools to the electron instance of VS Code but that doesn't seem possible, so went with `console.log` debugging instead.
- Here's a video. The big improvement is when I keep typing on one line towards the second half and it will properly debounce and only send one suggestion request at the end.

https://user-images.githubusercontent.com/458591/233624888-72579866-958c-4023-8e8a-67c954d92de3.mov





<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
