### PR TITLE
back-compat: use backported bazel fix

### DIFF
--- a/dev/backcompat/test_release_version.bzl
+++ b/dev/backcompat/test_release_version.bzl
@@ -10,4 +10,4 @@ See https://docs.sourcegraph.com/dev/background-information/sql/migrations
 MINIMUM_UPGRADEABLE_VERSION = "5.0.0"
 
 # Defines a reproducible reference to clone Sourcegraph at to run those tests.
-MINIMUM_UPGRADEABLE_VERSION_REF = "177663e4329d712f3493787410f71da60fe5dc7f"
+MINIMUM_UPGRADEABLE_VERSION_REF = "653cb673b7785cf27d9b2e4b43e703c8dc23beaf"

--- a/dev/backcompat/test_release_version.bzl
+++ b/dev/backcompat/test_release_version.bzl
@@ -10,4 +10,4 @@ See https://docs.sourcegraph.com/dev/background-information/sql/migrations
 MINIMUM_UPGRADEABLE_VERSION = "5.0.0"
 
 # Defines a reproducible reference to clone Sourcegraph at to run those tests.
-MINIMUM_UPGRADEABLE_VERSION_REF = "653cb673b7785cf27d9b2e4b43e703c8dc23beaf"
+MINIMUM_UPGRADEABLE_VERSION_REF = "3a3606c543bae07d70faab5c147ad91ea5d6eb7d"


### PR DESCRIPTION
Even though caching is in place and should cover this, it's still can flake on cold agents, which is annoying. 

See https://github.com/sourcegraph/sourcegraph/commit/653cb673b7785cf27d9b2e4b43e703c8dc23beaf

This brings up the test target to use a backported patch to handle the timeout issues. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

ci
