### PR TITLE
ci: run gen-pipeline from workspace root

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,9 +16,4 @@ steps:
         # Prioritize generating pipelines so that jobs can get generated and queued up as soon
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10
-        command: |
-          echo "--- generate pipeline"
-          bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc run '//enterprise/dev/ci:ci' -- | tee generated-pipeline.yml
-          echo ""
-          echo "--- upload pipeline"
-          buildkite-agent pipeline upload generated-pipeline.yml
+        command: './dev/ci/gen-pipeline.sh'

--- a/dev/backcompat/test_release_version.bzl
+++ b/dev/backcompat/test_release_version.bzl
@@ -10,4 +10,4 @@ See https://docs.sourcegraph.com/dev/background-information/sql/migrations
 MINIMUM_UPGRADEABLE_VERSION = "5.0.0"
 
 # Defines a reproducible reference to clone Sourcegraph at to run those tests.
-MINIMUM_UPGRADEABLE_VERSION_REF = "3a3606c543bae07d70faab5c147ad91ea5d6eb7d"
+MINIMUM_UPGRADEABLE_VERSION_REF = "c93fa89709acd15058188a299061831a3d4040ac"

--- a/dev/ci/gen-pipeline.sh
+++ b/dev/ci/gen-pipeline.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "--- generate pipeline"
+bazel \
+  --bazelrc=.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  run \
+  --run_under="cd $PWD && " \
+  //enterprise/dev/ci:ci -- | tee generated-pipeline.yml
+
+echo ""
+echo "--- upload pipeline"
+buildkite-agent pipeline upload generated-pipeline.yml


### PR DESCRIPTION
CI fails on main without this.

Test Plan: ran locally and modified gen-pipeline to confirm it prints the correct cwd.