### PR TITLE
[app] Use single, embedded DB for development

### DIFF
--- a/enterprise/cmd/sourcegraph/README.md
+++ b/enterprise/cmd/sourcegraph/README.md
@@ -10,8 +10,6 @@ Sourcegraph App is a single-binary distribution of Sourcegraph that runs on your
 sg start app
 ```
 
-**Note:** This doesn't use the embedded postgres version. You need to have postgres running locally (e.g. via `sg run redis_postgres`).
-
 If your are running app on a fresh database instance you also have to perform the following steps:
 
 - After opening the web app you will be directed to `/sign-in`, NOT the local repo setup step that is shown in production.

--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -138,6 +138,7 @@ func useSinglePostgreSQLDatabase(logger log.Logger, vars *postgresqlEnvVars) {
 	// Use a single PostgreSQL DB.
 	//
 	// For code intel:
+	logger.Debug("setting CODEINTEL database variables")
 	os.Setenv("CODEINTEL_PGPORT", vars.PGPORT)
 	os.Setenv("CODEINTEL_PGHOST", vars.PGHOST)
 	os.Setenv("CODEINTEL_PGUSER", vars.PGUSER)
@@ -147,6 +148,7 @@ func useSinglePostgreSQLDatabase(logger log.Logger, vars *postgresqlEnvVars) {
 	os.Setenv("CODEINTEL_PGDATASOURCE", vars.PGDATASOURCE)
 	os.Setenv("CODEINTEL_PG_ALLOW_SINGLE_DB", "true")
 	// And for code insights.
+	logger.Debug("setting CODEINSIGHTS database variables")
 	os.Setenv("CODEINSIGHTS_PGPORT", vars.PGPORT)
 	os.Setenv("CODEINSIGHTS_PGHOST", vars.PGHOST)
 	os.Setenv("CODEINSIGHTS_PGUSER", vars.PGUSER)

--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -138,22 +138,22 @@ func useSinglePostgreSQLDatabase(logger log.Logger, vars *postgresqlEnvVars) {
 	// Use a single PostgreSQL DB.
 	//
 	// For code intel:
-	setDefaultEnv(logger, "CODEINTEL_PGPORT", vars.PGPORT)
-	setDefaultEnv(logger, "CODEINTEL_PGHOST", vars.PGHOST)
-	setDefaultEnv(logger, "CODEINTEL_PGUSER", vars.PGUSER)
-	setDefaultEnv(logger, "CODEINTEL_PGPASSWORD", vars.PGPASSWORD)
-	setDefaultEnv(logger, "CODEINTEL_PGDATABASE", vars.PGDATABASE)
-	setDefaultEnv(logger, "CODEINTEL_PGSSLMODE", vars.PGSSLMODE)
-	setDefaultEnv(logger, "CODEINTEL_PGDATASOURCE", vars.PGDATASOURCE)
-	setDefaultEnv(logger, "CODEINTEL_PG_ALLOW_SINGLE_DB", "true")
+	os.Setenv("CODEINTEL_PGPORT", vars.PGPORT)
+	os.Setenv("CODEINTEL_PGHOST", vars.PGHOST)
+	os.Setenv("CODEINTEL_PGUSER", vars.PGUSER)
+	os.Setenv("CODEINTEL_PGPASSWORD", vars.PGPASSWORD)
+	os.Setenv("CODEINTEL_PGDATABASE", vars.PGDATABASE)
+	os.Setenv("CODEINTEL_PGSSLMODE", vars.PGSSLMODE)
+	os.Setenv("CODEINTEL_PGDATASOURCE", vars.PGDATASOURCE)
+	os.Setenv("CODEINTEL_PG_ALLOW_SINGLE_DB", "true")
 	// And for code insights.
-	setDefaultEnv(logger, "CODEINSIGHTS_PGPORT", vars.PGPORT)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGHOST", vars.PGHOST)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGUSER", vars.PGUSER)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGPASSWORD", vars.PGPASSWORD)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGDATABASE", vars.PGDATABASE)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGSSLMODE", vars.PGSSLMODE)
-	setDefaultEnv(logger, "CODEINSIGHTS_PGDATASOURCE", vars.PGDATASOURCE)
+	os.Setenv("CODEINSIGHTS_PGPORT", vars.PGPORT)
+	os.Setenv("CODEINSIGHTS_PGHOST", vars.PGHOST)
+	os.Setenv("CODEINSIGHTS_PGUSER", vars.PGUSER)
+	os.Setenv("CODEINSIGHTS_PGPASSWORD", vars.PGPASSWORD)
+	os.Setenv("CODEINSIGHTS_PGDATABASE", vars.PGDATABASE)
+	os.Setenv("CODEINSIGHTS_PGSSLMODE", vars.PGSSLMODE)
+	os.Setenv("CODEINSIGHTS_PGDATASOURCE", vars.PGDATASOURCE)
 }
 
 // debugLogLinesWriter returns an io.Writer which will log each line written to it to logger.


### PR DESCRIPTION
**tl;dr:** Updating `PGHOST` et al. to point to the embedded DB didn't affect the relevant env vars for codintel and codesights because those are explicitly set by `sg` (see `sg.config.yaml`), causing the DB configuration to go out of sync. 

---

This was a weird/surprising issue. I wasn't able to run `sg start app` without having an external DB running. This was surprising especially since #48020 should have enabled that. 
Contrary to what I said in #50859, the embedded DB _is_ used, but only for the frontend. CodeIntel and CodeInsights require an external DB.
Why? Because by default `sg.config.yaml` sets the `CODEINTEL_PG*` and `CODEINSIGHTS_PG*` variables to the same values as `PG*`. Later the embedded DB logic updates the `PG*` variables but that doesn't affect the other ones because they have been set explicitly (`setDefaultEnv` only updates the env var if it's empty).

There are multiple ways to fix this:
- We could explicitly clear the env vars in sg.config.yaml, so that they are set when initializing the embedded DB.
- We can always overwrite the codeintel and codeinsights env vars.

I chose the latter approach here because that seems more in line with the purpose of `useSinglePostgreSQLDatabase`. At the moment it's not obvious that the different services might use different databases even after calling this functions.

Additional notes:

- This only affects `sg start` because it explicitly sets the codeintel and codeinsights env vars, causing `useSingle...` to "fail".
- It probably never worked on macOS either. Instead devs had probably a PostgreSQL DB running.
- With this change it's not possible anymore to point codinsights and codeintel to different DBs in dev mode, but I don't know it that's actually important.



## Test plan
`sg start app` runs successfully without having another prostgres service running.
