### PR TITLE
Decr shard count for //client/web:test (again)

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1905,7 +1905,7 @@ jest_test(
         ":web_tests",
     ],
     patch_node_fs = False,
-    shard_count = 4,  # originally at 6, but tend to consume too much resource and crash.
+    shard_count = 3,  # originally at 6, but tend to consume too much resource and crash.
     tags = [
         "no-sandbox",  # we are disabling the patch_node_fs, so the sandbox isn't really useful anymore.
     ],

--- a/dev/backcompat/test_release_version.bzl
+++ b/dev/backcompat/test_release_version.bzl
@@ -10,4 +10,4 @@ See https://docs.sourcegraph.com/dev/background-information/sql/migrations
 MINIMUM_UPGRADEABLE_VERSION = "5.0.0"
 
 # Defines a reproducible reference to clone Sourcegraph at to run those tests.
-MINIMUM_UPGRADEABLE_VERSION_REF = "c93fa89709acd15058188a299061831a3d4040ac"
+MINIMUM_UPGRADEABLE_VERSION_REF = "196e8d2884a8c20a4c4a22e2c03faff08a329a30"


### PR DESCRIPTION
Even at 4, it still crashes from time to time. We'll need to investigate deeper I'm afraid. For the meantime, this should (hopefully) fix it. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

ci