### PR TITLE
Detect local app from Cody extension

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -10,6 +10,7 @@ import {
     SEARCH_EMBEDDINGS_QUERY,
     LOG_EVENT_MUTATION,
     REPOSITORY_EMBEDDING_EXISTS_QUERY,
+    VERSION_QUERY,
 } from './queries'
 
 interface APIResponse<T> {
@@ -34,6 +35,10 @@ interface EmbeddingsSearchResponse {
 }
 
 interface LogEventResponse {}
+
+interface VersionResponse {
+    site: { productVersion: string } | null
+}
 
 export interface EmbeddingsSearchResult {
     fileName: string
@@ -156,6 +161,12 @@ export class SourcegraphGraphQLAPIClient {
         return this.fetchSourcegraphAPI<APIResponse<IsContextRequiredForChatQueryResponse>>(IS_CONTEXT_REQUIRED_QUERY, {
             query,
         }).then(response => extractDataOrError(response, data => data.isContextRequiredForChatQuery))
+    }
+
+    public async getVersion(): Promise<string | null | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<VersionResponse>>(VERSION_QUERY, {}).then(response =>
+            extractDataOrError(response, data => data.site?.productVersion || null)
+        )
     }
 
     private fetchSourcegraphAPI<T>(query: string, variables: Record<string, any>): Promise<T | Error> {

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -56,3 +56,10 @@ mutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!
 		alwaysNil
 	}
 }`
+
+export const VERSION_QUERY = `
+query Version {
+    site {
+      productVersion
+    }
+}`


### PR DESCRIPTION
Proof of concept to allow the Cody extension to detect if Sourcegraph App is running locally.

Open the developer tools in VSCode to see the console log messages.

## Test plan

- Run the extension and test with app running locally and not running.