### PR TITLE
Cody: fix submenu

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -234,6 +234,7 @@
           "when": "cody.activated"
         },
         {
+          "command": "cody.focus",
           "when": "!cody.activated"
         }
       ],

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -146,7 +146,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                         await vscode.window.showTextDocument(doc)
                     } catch {
                         // Try to open the file in the sourcegraph view
-                        const sourcegraphInstanceUrl = this.serverEndpoint
+                        const sourcegraphInstanceUrl = this.config.serverEndpoint
                         const sourcegraphWebUrl = new URL(
                             `/search?q=context:global+file:${message.filePath}`,
                             sourcegraphInstanceUrl


### PR DESCRIPTION
when you build from the main branch you will get the error below because a field was deleted unexpectedly.

```
[sourcegraph.cody-ai]: property `submenu` is mandatory and must be of type `string`
```

Adding the missing field back so that the submenu will show up as a log in button when user is not logged in:
![image](https://user-images.githubusercontent.com/68532117/233691670-3cdef3aa-a771-46e9-87d2-139915c19b2b.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See image shared above. tested locally