### PR TITLE
Allow signed in users to see Cody UI

### DIFF
--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -8,14 +8,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
-
 func IsCodyEnabled(ctx context.Context) bool {
-    if envvar.SourcegraphDotComMode() {
-        if auth.CheckCurrentUser(ctx) != nil {
-            return true
-        }
-        return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
-    }
-    return conf.Get().ExperimentalFeatures.CodyEnabled
+	if envvar.SourcegraphDotComMode() {
+		if auth.CheckCurrentUser(ctx) != nil {
+			return true
+		}
+		return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
+	}
+	return conf.Get().ExperimentalFeatures.CodyEnabled
 }
-

--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -8,9 +8,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
+
 func IsCodyEnabled(ctx context.Context) bool {
-	if envvar.SourcegraphDotComMode() || conf.Get().ExperimentalFeatures.CodyRestrictUsersFeatureFlag {
-		return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
-	}
-	return true
+    if envvar.SourcegraphDotComMode() {
+        if auth.CheckCurrentUser(ctx) != nil {
+            return true
+        }
+        return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
+    }
+    return conf.Get().ExperimentalFeatures.CodyEnabled
 }
+


### PR DESCRIPTION
📣 *Do not merge until we have coordinated with marketing to announce publicly [thread](https://sourcegraph.slack.com/archives/C01KPE23H4M/p1682029152895819)* 

This PR updates the `cody-experimental` feature flag to allow all signed in users to see Cody UI in sourcegraph.com by default. It follows https://github.com/sourcegraph/sourcegraph/pull/50925#event-9067575559, which introduced rate limiting to prevent usage from becoming too expensive/vulnerable to abuse. 

This is a change made by Cody! I asked Cody how to do it in the chat UI, and within my editor I used the "Fixup" option to refactor it. Was Cody right here? 

![Screenshot 2023-04-21 at 11 02 34 AM](https://user-images.githubusercontent.com/43555476/233693960-ab12d256-23a6-4831-8b3a-dbf504cca6e4.png)

I also asked Cody to generate a unit test for this change, which it did, but I'm not sure where it should go or if it's necessary. The tests we have in `feature_flag_test.go` seem to be generic tests, and I don't know whether or not it would be appropriate to add one that's specific to the `IsCodyEnabled` function. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
See question above, re: testing. 