### PR TITLE
bazel: bump test timeouts for targets

### DIFF
--- a/enterprise/internal/codeintel/uploads/transport/http/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/transport/http/BUILD.bazel
@@ -34,7 +34,7 @@ go_library(
 
 go_test(
     name = "http_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "handler_test.go",
         "mocks_test.go",

--- a/enterprise/internal/codemonitors/BUILD.bazel
+++ b/enterprise/internal/codemonitors/BUILD.bazel
@@ -33,7 +33,7 @@ go_library(
 
 go_test(
     name = "codemonitors_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["search_test.go"],
     embed = [":codemonitors"],
     tags = [


### PR DESCRIPTION
Seeing the test timout on a few PRs for:
* codemonitors_test - https://buildkite.com/sourcegraph/sourcegraph/builds/214550#0187a4a5-7011-491b-9286-5073bca69376
* upload_http_test in code intel - https://buildkite.com/sourcegraph/sourcegraph/builds/214562#0187a4bd-b1c8-4fac-8eca-ad61a50a67f2
## Test plan
Green CI and Test should not time out
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
