### PR TITLE
Embeddings: add context to readFile

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -79,7 +79,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 		excludedGlobPatterns,
 		embeddingsClient,
 		splitOptions,
-		func(fileName string) ([]byte, error) {
+		func(ctx context.Context, fileName string) ([]byte, error) {
 			return h.gitserverClient.ReadFile(ctx, nil, repo.Name, record.Revision, fileName)
 		},
 		getDocumentRanks,

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -20,7 +20,7 @@ const MAX_TEXT_EMBEDDING_VECTORS = 128_000
 const EMBEDDING_BATCHES = 5
 const EMBEDDING_BATCH_SIZE = 512
 
-type readFile func(fileName string) ([]byte, error)
+type readFile func(ctx context.Context, fileName string) ([]byte, error)
 type ranksGetter func(ctx context.Context, repoName string) (types.RepoPathRanks, error)
 
 // EmbedRepo embeds file contents from the given file names for a repository.
@@ -138,7 +138,7 @@ func embedFiles(
 			break
 		}
 
-		contentBytes, err := readFile(fileName)
+		contentBytes, err := readFile(ctx, fileName)
 		if err != nil {
 			return createEmptyEmbeddingIndex(dimensions), errors.Wrap(err, "error while reading a file")
 		}

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -79,7 +79,7 @@ func TestEmbedRepo(t *testing.T) {
 		}, nil
 	}
 
-	readFile := func(fileName string) ([]byte, error) {
+	readFile := func(_ context.Context, fileName string) ([]byte, error) {
 		content, ok := mockFiles[fileName]
 		if !ok {
 			return nil, errors.Newf("file %s not found", fileName)


### PR DESCRIPTION
This was another thunk that was capturing an outer context. This just updates the function to take a context at call time rather than definition time.

## Test plan

It builds. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
