### PR TITLE
Fix pipeline generator

### DIFF
--- a/dev/ci/gen-pipeline.sh
+++ b/dev/ci/gen-pipeline.sh
@@ -2,15 +2,19 @@
 
 set -e
 
-echo "--- generate pipeline"
+echo "--- :bazel: build pipeline generator"
 bazel \
   --bazelrc=.bazelrc \
   --bazelrc=.aspect/bazelrc/ci.bazelrc \
   --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
-  run \
-  --run_under="cd $PWD && " \
-  //enterprise/dev/ci:ci -- | tee generated-pipeline.yml
+  build \
+  //enterprise/dev/ci:ci
+
+pipeline_gen="$(bazel cquery //enterprise/dev/ci:ci --output files)"
+
+echo "--- :writing_hand: generate pipeline"
+$pipeline_gen | tee generated-pipeline.yml
 
 echo ""
-echo "--- upload pipeline"
+echo "--- :arrow_up: upload pipeline"
 buildkite-agent pipeline upload generated-pipeline.yml


### PR DESCRIPTION
The previous code was working with a small exception: because we were piping the entire output of `bazel run`, on a cold agent, we could get some bazelisk output getting printed on stdout and messing with the generated yaml.

This PR instead of building and running in a single step, does it in two steps, which ensure that the generated yaml is solely the output of the pipeline generator.

Test Plan: CI



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
