### PR TITLE
Embeddings: eliminate bounds checks and unroll

### DIFF
--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -211,7 +211,16 @@ func CosineSimilarity(row []int8, query []int8) int32 {
 		panic("mismatched vector lengths")
 	}
 
-	for i := 0; i < count; i += 1 {
+	i := 0
+	for ; i+3 < count; i += 4 {
+		m0 := int32(row[i]) * int32(query[i])
+		m1 := int32(row[i+1]) * int32(query[i+1])
+		m2 := int32(row[i+2]) * int32(query[i+2])
+		m3 := int32(row[i+3]) * int32(query[i+3])
+		similarity += (m0 + m1 + m2 + m3)
+	}
+
+	for ; i < count; i++ {
 		similarity += int32(row[i]) * int32(query[i])
 	}
 

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -203,9 +203,18 @@ func (i *searchDebugInfo) String() string {
 
 func CosineSimilarity(row []int8, query []int8) int32 {
 	similarity := int32(0)
-	for i := 0; i < len(row); i++ {
+
+	count := len(row)
+	if count > len(query) {
+		// Do this ahead of time so the compiler doesn't need to bounds check
+		// every time we index into query.
+		panic("mismatched vector lengths")
+	}
+
+	for i := 0; i < count; i += 1 {
 		similarity += int32(row[i]) * int32(query[i])
 	}
+
 	return similarity
 }
 

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 )
@@ -179,5 +180,31 @@ func TestScore(t *testing.T) {
 
 	if debugInfo.String() == "" {
 		t.Fatal("Expected a non-empty debug")
+	}
+}
+
+func simpleCosineSimilarity(a, b []int8) int32 {
+	similarity := int32(0)
+	for i := 0; i < len(a); i++ {
+		similarity += int32(a[i]) * int32(b[i])
+	}
+	return similarity
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	f := func(a, b []int8) bool {
+		if len(a) > len(b) {
+			a = a[:len(b)]
+		} else if len(a) < len(b) {
+			b = b[:len(a)]
+		}
+
+		want := simpleCosineSimilarity(a, b)
+		got := CosineSimilarity(a, b)
+		return want == got
+	}
+	err := quick.Check(f, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This checks the lengths of the input slices ahead of time so the compiler doesn't need to insert panics on slice accesses.

Bounds check elimination: 
```
name                               old time/op    new time/op    delta
SimilaritySearch/numWorkers=1-10      559ms ± 0%     499ms ± 0%  -10.74%  (p=0.016 n=4+5)
SimilaritySearch/numWorkers=2-10      283ms ± 0%     253ms ± 0%  -10.65%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=4-10      146ms ± 0%     130ms ± 0%  -10.52%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=8-10     73.7ms ± 0%    66.0ms ± 0%  -10.45%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=16-10    83.6ms ± 2%    75.0ms ± 3%  -10.29%  (p=0.008 n=5+5)
```

Loop unrolling:
```
name                               old time/op    new time/op    delta
SimilaritySearch/numWorkers=1-10      499ms ± 0%     439ms ± 0%  -12.12%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=2-10      253ms ± 0%     222ms ± 0%  -12.21%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=4-10      130ms ± 0%     115ms ± 0%  -11.99%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=8-10     66.0ms ± 0%    57.9ms ± 0%  -12.20%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=16-10    75.0ms ± 3%    65.7ms ± 2%  -12.36%  (p=0.008 n=5+5)
```

Both:
```
name                               old time/op    new time/op    delta
SimilaritySearch/numWorkers=1-10      559ms ± 0%     439ms ± 0%  -21.55%  (p=0.016 n=4+5)
SimilaritySearch/numWorkers=2-10      283ms ± 0%     222ms ± 0%  -21.56%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=4-10      146ms ± 0%     115ms ± 0%  -21.24%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=8-10     73.7ms ± 0%    57.9ms ± 0%  -21.37%  (p=0.008 n=5+5)
SimilaritySearch/numWorkers=16-10    83.6ms ± 2%    65.7ms ± 2%  -21.38%  (p=0.008 n=5+5)
```

## Test plan

Included benchmark results in PR. Added a quicktest to validate that, for all inputs, `CosineSimilarity` behaves the same as the naive implementation. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
