### PR TITLE
cody: add height to chat header

### DIFF
--- a/client/cody-ui/src/chat/TranscriptItem.module.css
+++ b/client/cody-ui/src/chat/TranscriptItem.module.css
@@ -41,6 +41,7 @@
 
     font-size: 0.8rem;
     font-weight: bold;
+    height: 2rem;
 }
 
 .participant-avatar {


### PR DESCRIPTION
Minor fix

Issue: because there is no fixed height for the chat message header, there will be a twitch at the end once cody's response is completed because of the feedback buttons attached at the end that changes the height:
![header](https://user-images.githubusercontent.com/68532117/233753896-317f104b-ae4a-48b9-982e-09538c8f5d11.gif)

Solution: adding fixed height to the header container so that the height will remain the same at all the time

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

styling changes tested locally.