### PR TITLE
go back to just showing a blinking cursor in Cody when loading

### DIFF
--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -92,9 +92,7 @@ export const TranscriptItem: React.FunctionComponent<
             {message.displayText ? (
                 <CodeBlocks displayText={message.displayText} copyButtonClassName={codeBlocksCopyButtonClassName} />
             ) : inProgress ? (
-                <span>
-                    Fetching context... <BlinkingCursor />
-                </span>
+                <BlinkingCursor />
             ) : null}
         </div>
     </div>


### PR DESCRIPTION
No more "Fetching context" text, which just adds noise IMO.




## Test plan

n/a