### PR TITLE
Embeddings: move file exclusion into embedFiles

### DIFF
--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -130,16 +130,16 @@ func embedFiles(
 			break
 		}
 
+		if isExcludedFilePath(fileName, excludePatterns) {
+			continue
+		}
+
 		contentBytes, err := readFile(ctx, fileName)
 		if err != nil {
 			return embeddings.EmbeddingIndex{}, errors.Wrap(err, "error while reading a file")
 		}
 
 		if embeddable, _ := isEmbeddableFileContent(contentBytes); !embeddable {
-			continue
-		}
-
-		if isExcludedFilePath(fileName, excludePatterns) {
 			continue
 		}
 


### PR DESCRIPTION
This moves file exclusion logic into embedFiles so we can track its stats together with the other skipped reasons.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/51014

Bump CI

## Test plan

Updated existing tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
