### PR TITLE
docs(src-cli): update src-cli commands to use 'metadata' instead of 'kvp' for consistency and clarity

### DIFF
--- a/doc/admin/repo/metadata.md
+++ b/doc/admin/repo/metadata.md
@@ -55,15 +55,15 @@ mutation DeleteSecurityOwner($repoID: ID!) {
 
 ### src-cli
 
-Metadata can be added using `src repos add-kvp`, updated using `src repos update-kvp`, and deleted using `src repos delete-kvp`. You will need the GraphQL ID for the repository being targeted.
+Metadata can be added using `src repos add-metadata`, updated using `src repos update-metadata`, and deleted using `src repos delete-metadata`. You will need the GraphQL ID for the repository being targeted.
 
 ```text
-$ src repos add-kvp -repo=repoID -key=owning-team -value=security
+$ src repos add-metadata -repo=repoID -key=owning-team -value=security
 Key-value pair 'owning-team:security' created.
 
-$ src repos update-kvp -repo=repoID -key=owning-team -value=security++
+$ src repos update-metadata -repo=repoID -key=owning-team -value=security++
 Value of key 'owning-team' updated to 'security++'
 
-$ src repos delete-kvp -repo=repoID -key=owning-team
+$ src repos delete-metadata -repo=repoID -key=owning-team
 Key-value pair with key 'owning-team' deleted.
 ```

--- a/doc/cli/references/repos/add-metadata.md
+++ b/doc/cli/references/repos/add-metadata.md
@@ -1,4 +1,4 @@
-# `src repos update-kvp`
+# `src repos add-metadata`
 
 
 ## Flags
@@ -8,17 +8,17 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-key` | The name of the key to be updated (required) |  |
-| `-repo` | The ID of the repo with the key to be updated (required) |  |
+| `-key` | The name of the key to add (required) |  |
+| `-repo` | The ID of the repo to add the key-value pair to (required) |  |
 | `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
-| `-value` | The new value of the key to be set. Defaults to null. |  |
+| `-value` | The value associated with the key. Defaults to null. |  |
 
 
 ## Usage
 
 ```
-Usage of 'src repos update-kvp':
+Usage of 'src repos add-metadata':
   -dump-requests
     	Log GraphQL requests and responses to stdout
   -get-curl
@@ -26,23 +26,23 @@ Usage of 'src repos update-kvp':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -key string
-    	The name of the key to be updated (required)
+    	The name of the key to add (required)
   -repo string
-    	The ID of the repo with the key to be updated (required)
+    	The ID of the repo to add the key-value pair to (required)
   -trace
     	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -value string
-    	The new value of the key to be set. Defaults to null.
+    	The value associated with the key. Defaults to null.
 
 Examples:
 
-  Update the value for a key on a repository:
+  Add a key-value pair metadata to a repository:
 
-    	$ src repos update-kvp -repo=repoID -key=my-key -value=new-value
+    	$ src repos add-metadata -repo=repoID -key=mykey -value=myvalue
 
-  Omitting -value will set the value of the key to null.
+  Omitting -value will create a tag (a key with a null value).
 
 
 ```

--- a/doc/cli/references/repos/delete-metadata.md
+++ b/doc/cli/references/repos/delete-metadata.md
@@ -1,4 +1,4 @@
-# `src repos add-kvp`
+# `src repos delete-metadata`
 
 
 ## Flags
@@ -8,17 +8,16 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-key` | The name of the key to add (required) |  |
-| `-repo` | The ID of the repo to add the key-value pair to (required) |  |
+| `-key` | The name of the key to be deleted (required) |  |
+| `-repo` | The ID of the repo with the key-value pair to be deleted (required) |  |
 | `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
-| `-value` | The value associated with the key. Defaults to null. |  |
 
 
 ## Usage
 
 ```
-Usage of 'src repos add-kvp':
+Usage of 'src repos delete-metadata':
   -dump-requests
     	Log GraphQL requests and responses to stdout
   -get-curl
@@ -26,23 +25,20 @@ Usage of 'src repos add-kvp':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -key string
-    	The name of the key to add (required)
+    	The name of the key to be deleted (required)
   -repo string
-    	The ID of the repo to add the key-value pair to (required)
+    	The ID of the repo with the key-value pair to be deleted (required)
   -trace
     	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
-  -value string
-    	The value associated with the key. Defaults to null.
 
 Examples:
 
-  Add a key-value pair to a repository:
+  Delete a key-value pair metadata from a repository:
 
-    	$ src repos add-kvp -repo=repoID -key=mykey -value=myvalue
+    	$ src repos delete-metadata -repo=repoID -key=mykey
 
-  Omitting -value will create a tag (a key with a null value).
 
 
 ```

--- a/doc/cli/references/repos/index.md
+++ b/doc/cli/references/repos/index.md
@@ -3,10 +3,10 @@
 ## Subcommands
 
 
-* [`add-kvp`](add-kvp.md)
+* [`add-metadata`](add-metadata.md)
 * [`delete`](delete.md)
-* [`delete-kvp`](delete-kvp.md)
+* [`delete-metadata`](delete-metadata.md)
 * [`get`](get.md)
 * [`list`](list.md)
-* [`update-kvp`](update-kvp.md)
+* [`update-metadata`](update-metadata.md)
 	

--- a/doc/cli/references/repos/update-metadata.md
+++ b/doc/cli/references/repos/update-metadata.md
@@ -1,4 +1,4 @@
-# `src repos delete-kvp`
+# `src repos update-metadata`
 
 
 ## Flags
@@ -8,16 +8,17 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-key` | The name of the key to be deleted (required) |  |
-| `-repo` | The ID of the repo with the key-value pair to be deleted (required) |  |
+| `-key` | The name of the key to be updated (required) |  |
+| `-repo` | The ID of the repo with the key to be updated (required) |  |
 | `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
+| `-value` | The new value of the key to be set. Defaults to null. |  |
 
 
 ## Usage
 
 ```
-Usage of 'src repos delete-kvp':
+Usage of 'src repos update-metadata':
   -dump-requests
     	Log GraphQL requests and responses to stdout
   -get-curl
@@ -25,20 +26,23 @@ Usage of 'src repos delete-kvp':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -key string
-    	The name of the key to be deleted (required)
+    	The name of the key to be updated (required)
   -repo string
-    	The ID of the repo with the key-value pair to be deleted (required)
+    	The ID of the repo with the key to be updated (required)
   -trace
     	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
+  -value string
+    	The new value of the key to be set. Defaults to null.
 
 Examples:
 
-  Delete a key-value pair from a repository:
+  Update the value metadata for a key on a repository:
 
-    	$ src repos delete-kvp -repo=repoID -key=mykey
+    	$ src repos update-metadata -repo=repoID -key=my-key -value=new-value
 
+  Omitting -value will set the value of the key to null.
 
 
 ```


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96. Follow-up https://github.com/sourcegraph/src-cli/pull/972.

## Test plan
- Check the diff
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
