### PR TITLE
bzl: increase timout for tests in //ent.../int../insights/background

### DIFF
--- a/enterprise/internal/insights/background/BUILD.bazel
+++ b/enterprise/internal/insights/background/BUILD.bazel
@@ -47,7 +47,7 @@ go_library(
 
 go_test(
     name = "background_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "data_prune_test.go",
         "insight_enqueuer_test.go",


### PR DESCRIPTION
Observed a test timeout on https://buildkite.com/sourcegraph/sourcegraph/builds/214743#0187b266-f17a-44eb-81bd-f4713374fc4c

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 