### PR TITLE
app: rename sidecar and app frontend

### DIFF
--- a/client/app-shell/src/app-shell.tsx
+++ b/client/app-shell/src/app-shell.tsx
@@ -16,9 +16,10 @@ const outputHandler = (event: Event<string>): void => {
 }
 
 // Note we currently ignore the unlisten cb returned from listen
-listen('backend-stdout', outputHandler)
-    .then(() => console.log('backend-stdout listener registered'))
+let sidecar: String = 'sourcegraph-backend'
+listen(`${sidecar}-stdout`, outputHandler)
+    .then(() => console.log(`${sidecar}-stdout listener registered`))
     .catch(error => console.error(`failed to register backend-stdout handler: ${error}`))
-listen('backend-stderr', outputHandler)
-    .then(() => console.log('backend-stderr listener registered'))
+listen(`${sidecar}-stderr`, outputHandler)
+    .then(() => console.log(`${sidecar}-stderr listener registered`))
     .catch(error => console.error(`failed to register backend-stderr handler: ${error}`))

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -19,7 +19,6 @@ import { isDefined } from '@sourcegraph/common'
 
 import { ENVIRONMENT_CONFIG, IS_DEVELOPMENT, IS_PRODUCTION } from '../utils'
 
-import { htmlIndexPlugin } from './htmlIndexPlugin'
 import { manifestPlugin } from './manifestPlugin'
 
 const isEnterpriseBuild = ENVIRONMENT_CONFIG.ENTERPRISE
@@ -35,9 +34,6 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
             : isEnterpriseBuild
             ? path.join(ROOT_PATH, 'client/web/src/enterprise/main.tsx')
             : path.join(ROOT_PATH, 'client/web/src/main.tsx'),
-        ...(isSourcegraphApp
-            ? { 'scripts/shell': path.join(ROOT_PATH, 'client/web/src/enterprise/app-shell.tsx') }
-            : {}),
     },
     bundle: true,
     minify: IS_PRODUCTION,
@@ -52,7 +48,6 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     plugins: [
         stylePlugin,
         manifestPlugin,
-        isSourcegraphApp ? htmlIndexPlugin : null,
         packageResolutionPlugin({
             path: require.resolve('path-browserify'),
             ...RXJS_RESOLUTIONS,

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -23,8 +23,9 @@ ldflags="-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION
 ldflags="$ldflags -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)"
 ldflags="$ldflags -X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=app"
 
+NODE_ENV=production pnpm run build-app-shell
 go build \
-  -o ./src-tauri/.bin/sourcegraph-aarch64-apple-darwin \
+  -o .bin/sourcegraph-backend-aarch64-apple-darwin \
   -trimpath \
   -tags dist \
   -ldflags "$ldflags" \

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -3,6 +3,7 @@
 set -eu
 
 GCLOUD_APP_CREDENTIALS_FILE=${GCLOUD_APP_CREDENTIALS_FILE-$HOME/.config/gcloud/application_default_credentials.json}
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
 
 if [ -z "${SKIP_BUILD_WEB-}" ]; then
   # esbuild is faster
@@ -23,7 +24,7 @@ ldflags="$ldflags -X github.com/sourcegraph/sourcegraph/internal/version.timesta
 ldflags="$ldflags -X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=app"
 
 go build \
-  -o .bin/backend-aarch64-apple-darwin \
+  -o ./src-tauri/.bin/sourcegraph-aarch64-apple-darwin \
   -trimpath \
   -tags dist \
   -ldflags "$ldflags" \

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,10 +4,7 @@
 )]
 
 #[cfg(not(dev))]
-use {
-    tauri::api::process::Command,
-    tauri::api::process::CommandEvent
-};
+use {tauri::api::process::Command, tauri::api::process::CommandEvent};
 
 use tauri::Manager;
 
@@ -15,10 +12,10 @@ fn main() {
     match fix_path_env::fix() {
         Ok(_) => {}
         Err(e) => {
-            println!("Error fixing path environment: {}", e);
+            println!("error fixing path environment: {}", e);
         }
     }
-    
+
     tauri::Builder::default()
         .setup(|app| {
             let window = app.get_window("main").unwrap();
@@ -30,16 +27,17 @@ fn main() {
 }
 
 #[cfg(dev)]
-fn start_embedded_services(_window:tauri::Window) {
+fn start_embedded_services(_window: tauri::Window) {
     println!("embedded Sourcegraph services disabled for local development");
 }
 
 #[cfg(not(dev))]
-fn start_embedded_services(window :tauri::Window) {
-    let (mut rx, _child) = Command::new_sidecar("backend")
-                .expect("failed to create `backend` binary command")
-                .spawn()
-                .expect("Failed to spawn backend sidecar");
+fn start_embedded_services(window: tauri::Window) {
+    let sidecar = "sourcegraph-backend";
+    let (mut rx, _child) = Command::new_sidecar(sidecar)
+        .expect(format!("failed to create `{sidecar}` binary command").as_str())
+        .spawn()
+        .expect(format!("failed to spawn {sidecar} sidecar").as_str());
 
     tauri::async_runtime::spawn(async move {
         // read events such as stdout
@@ -47,7 +45,7 @@ fn start_embedded_services(window :tauri::Window) {
             match event {
                 CommandEvent::Stdout(line) => {
                     window
-                        .emit("backend-stdout", Some(line.clone()))
+                        .emit(format!("{sidecar}-stdout").as_str(), Some(line.clone()))
                         .expect("failed to emit event");
 
                     let _ = window.eval(&format!(
@@ -57,7 +55,7 @@ fn start_embedded_services(window :tauri::Window) {
                 }
                 CommandEvent::Stderr(line) => {
                     window
-                        .emit("backend-stderr", Some(line.clone()))
+                        .emit(format!("{sidecar}-stderr").as_str(), Some(line.clone()))
                         .expect("failed to emit event");
 
                     let _ = window.eval(&format!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "sidecar": true,
         "scope": [
           {
-            "name": "../.bin/sourcegraph",
+            "name": "../.bin/sourcegraph-backend",
             "sidecar": true
           }
         ]
@@ -28,7 +28,7 @@
       "deb": {
         "depends": []
       },
-      "externalBin": ["../.bin/sourcegraph"],
+      "externalBin": ["../.bin/sourcegraph-backend"],
       "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
       "identifier": "com.sourcegraph.app",
       "longDescription": "",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "distDir": "./assets"
   },
   "package": {
-    "productName": "Sourcegraph Desktop",
+    "productName": "Sourcegraph App",
     "version": "1.0.0"
   },
   "tauri": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "distDir": "./assets"
   },
   "package": {
-    "productName": "sourcegraph",
+    "productName": "Sourcegraph Desktop",
     "version": "1.0.0"
   },
   "tauri": {
@@ -15,7 +15,7 @@
         "sidecar": true,
         "scope": [
           {
-            "name": "../.bin/backend",
+            "name": "../.bin/sourcegraph",
             "sidecar": true
           }
         ]
@@ -28,7 +28,7 @@
       "deb": {
         "depends": []
       },
-      "externalBin": ["../.bin/backend"],
+      "externalBin": ["../.bin/sourcegraph"],
       "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
       "identifier": "com.sourcegraph.app",
       "longDescription": "",


### PR DESCRIPTION
Mostly a cosmetic change but I think it helps in debugging

When you view the process listing of the app, you'll see `backend`. From the name you won't know it's part of Sourcegraph. So this change makes that more obivious.
![Screenshot 2023-04-24 at 11 20 23](https://user-images.githubusercontent.com/1001709/233956028-622e8899-62c5-489a-81f9-88fb4aa08e71.png)


## Test plan
Built the app locally and view the process listing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
