### PR TITLE
[github app] Add user token refreshing for GitHub App

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -105,6 +105,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				GitHubURL:      uri,
 				BaseToken:      token,
 				GroupsCacheTTL: -1,
+				DB:             testDB,
 			})
 
 			authz.SetProviders(false, []authz.Provider{provider})
@@ -190,6 +191,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				GitHubURL:      uri,
 				BaseToken:      token,
 				GroupsCacheTTL: 72,
+				DB:             testDB,
 			})
 
 			authz.SetProviders(false, []authz.Provider{provider})
@@ -399,6 +401,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				GitHubURL:      uri,
 				BaseToken:      token,
 				GroupsCacheTTL: 72,
+				DB:             testDB,
 			})
 
 			authz.SetProviders(false, []authz.Provider{provider})

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -310,6 +310,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				GitHubURL:      uri,
 				BaseToken:      token,
 				GroupsCacheTTL: -1,
+				DB:             testDB,
 			})
 
 			authz.SetProviders(false, []authz.Provider{provider})

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -161,7 +161,7 @@ func ProvidersFromConfig(
 		enableGithubInternalRepoVisibility = ef.EnableGithubInternalRepoVisibility
 	}
 
-	initResult := github.NewAuthzProviders(gitHubConns, cfg.SiteConfig().AuthProviders, enableGithubInternalRepoVisibility)
+	initResult := github.NewAuthzProviders(db, gitHubConns, cfg.SiteConfig().AuthProviders, enableGithubInternalRepoVisibility)
 	initResult.Append(gitlab.NewAuthzProviders(db, cfg.SiteConfig(), gitLabConns))
 	initResult.Append(bitbucketserver.NewAuthzProviders(bitbucketServerConns))
 	initResult.Append(perforce.NewAuthzProviders(perforceConns))

--- a/enterprise/internal/authz/azuredevops/provider.go
+++ b/enterprise/internal/authz/azuredevops/provider.go
@@ -130,7 +130,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 		return nil, errors.Wrapf(err, "failed to generate oauth context, this is likely a misconfiguration with the Azure OAuth provider (bad URL?), please check the auth.providers configuration in your site config")
 	}
 
-	oauthToken.RefreshFunc = database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, oauthContext)
+	oauthToken.RefreshFunc = database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db.UserExternalAccounts(), account.ID, oauthContext)
 
 	var apiURL string
 	if mockServerURL != "" {
@@ -292,7 +292,6 @@ func (p *Provider) ValidateConnection(ctx context.Context) error {
 			},
 			nil,
 		)
-
 		if err != nil {
 			allErrors = append(allErrors, fmt.Sprintf("%s:%s", conn.URN, err.Error()))
 			continue

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -110,7 +110,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 		Expiry:             tok.Expiry,
 		NeedsRefreshBuffer: 5,
 	}
-	oauthToken.RefreshFunc = database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, bitbucketcloud.GetOAuthContext(p.codeHost.BaseURL.String()))
+	oauthToken.RefreshFunc = database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db.UserExternalAccounts(), account.ID, bitbucketcloud.GetOAuthContext(p.codeHost.BaseURL.String()))
 
 	client := p.client.WithAuthenticator(oauthToken)
 

--- a/enterprise/internal/authz/github/BUILD.bazel
+++ b/enterprise/internal/authz/github/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//enterprise/internal/licensing",
         "//internal/api",
         "//internal/authz",
+        "//internal/database",
         "//internal/extsvc",
         "//internal/extsvc/auth",
         "//internal/extsvc/github",

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -8,14 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestNewAuthzProviders(t *testing.T) {
+	db := database.NewMockDB()
 	t.Run("no authorization", func(t *testing.T) {
 		initResults := NewAuthzProviders(
+			db,
 			[]*ExternalConnection{
 				{
 					GitHubConnection: &types.GitHubConnection{
@@ -42,6 +45,7 @@ func TestNewAuthzProviders(t *testing.T) {
 	t.Run("no matching auth provider", func(t *testing.T) {
 		t.Cleanup(licensing.TestingSkipFeatureChecks())
 		initResults := NewAuthzProviders(
+			db,
 			[]*ExternalConnection{
 				{
 					GitHubConnection: &types.GitHubConnection{
@@ -75,6 +79,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("default case", func(t *testing.T) {
 			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
+				db,
 				[]*ExternalConnection{
 					{
 						GitHubConnection: &types.GitHubConnection{
@@ -104,6 +109,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("license does not have ACLs feature", func(t *testing.T) {
 			t.Cleanup(licensing.MockCheckFeatureError("failed"))
 			initResults := NewAuthzProviders(
+				db,
 				[]*ExternalConnection{
 					{
 						GitHubConnection: &types.GitHubConnection{
@@ -132,6 +138,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("groups cache enabled, but not allowGroupsPermissionsSync", func(t *testing.T) {
 			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
+				db,
 				[]*ExternalConnection{
 					{
 						GitHubConnection: &types.GitHubConnection{
@@ -171,6 +178,7 @@ func TestNewAuthzProviders(t *testing.T) {
 				return []string{"read:org"}, nil
 			}
 			initResults := NewAuthzProviders(
+				db,
 				[]*ExternalConnection{
 					{
 						GitHubConnection: &types.GitHubConnection{

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -339,9 +339,11 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}
 
 	oauthToken := &auth.OAuthBearerToken{
-		Token:        tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		Expiry:       tok.Expiry,
+		Token:              tok.AccessToken,
+		RefreshToken:       tok.RefreshToken,
+		Expiry:             tok.Expiry,
+		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, github.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),
+		NeedsRefreshBuffer: 5,
 	}
 
 	return p.fetchUserPermsByToken(ctx, extsvc.AccountID(account.AccountID), oauthToken, opts)

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -342,7 +342,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 		Token:              tok.AccessToken,
 		RefreshToken:       tok.RefreshToken,
 		Expiry:             tok.Expiry,
-		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, github.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),
+		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db.UserExternalAccounts(), account.ID, github.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),
 		NeedsRefreshBuffer: 5,
 	}
 

--- a/enterprise/internal/authz/gitlab/BUILD.bazel
+++ b/enterprise/internal/authz/gitlab/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//cmd/frontend/auth/providers",
         "//internal/api",
         "//internal/authz",
+        "//internal/database",
         "//internal/extsvc",
         "//internal/extsvc/auth",
         "//internal/extsvc/gitlab",

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -111,7 +111,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 		Token:              tok.AccessToken,
 		RefreshToken:       tok.RefreshToken,
 		Expiry:             tok.Expiry,
-		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, gitlab.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),
+		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db.UserExternalAccounts(), account.ID, gitlab.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),
 		NeedsRefreshBuffer: 5,
 	}
 	client := p.clientProvider.NewClient(token)

--- a/enterprise/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/internal/authz/gitlab/oauth_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
@@ -71,6 +72,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 			Token:   "admin_token",
+			DB:      database.NewMockDB(),
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -137,6 +137,7 @@ go_library(
         "@com_github_xeipuuv_gojsonschema//:gojsonschema",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_crypto//bcrypt",
+        "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/internal/database/oauth_token_helper.go
+++ b/internal/database/oauth_token_helper.go
@@ -138,9 +138,9 @@ func GetServiceRefreshAndStoreOAuthTokenFunc(db DB, externalServiceID int64, oau
 	}
 }
 
-func GetAccountRefreshAndStoreOAuthTokenFunc(db DB, externalAccountID int32, oauthContext *oauthutil.OAuthContext) func(context.Context, httpcli.Doer, *auth.OAuthBearerToken) (string, string, time.Time, error) {
+func GetAccountRefreshAndStoreOAuthTokenFunc(store UserExternalAccountsStore, externalAccountID int32, oauthContext *oauthutil.OAuthContext) func(context.Context, httpcli.Doer, *auth.OAuthBearerToken) (string, string, time.Time, error) {
 	return func(ctx context.Context, cli httpcli.Doer, a *auth.OAuthBearerToken) (string, string, time.Time, error) {
-		tokenRefresher := externalAccountTokenRefresher(db.UserExternalAccounts(), externalAccountID, a.RefreshToken)
+		tokenRefresher := externalAccountTokenRefresher(store, externalAccountID, a.RefreshToken)
 		token, err := tokenRefresher(ctx, cli, *oauthContext)
 		if err != nil {
 			return "", "", time.Time{}, err

--- a/internal/database/oauth_token_helper.go
+++ b/internal/database/oauth_token_helper.go
@@ -43,10 +43,10 @@ func externalAccountTokenRefresher(store UserExternalAccountsStore, externalAcco
 			RefreshToken: tok.RefreshToken,
 			Expiry:       tok.Expiry,
 		}
-		// Compare the stored refresh token with the provided one.
+		// Compare the stored token with the provided one.
 		// If they differ, the token was most likely refreshed in the meantime.
 		// Check `NeedsRefresh` for good measure.
-		if fetchedToken.RefreshToken != originalToken.RefreshToken && !fetchedToken.NeedsRefresh() {
+		if fetchedToken.Token != originalToken.Token && !fetchedToken.NeedsRefresh() {
 			return fetchedToken, nil
 		}
 

--- a/internal/database/oauth_token_helper.go
+++ b/internal/database/oauth_token_helper.go
@@ -5,41 +5,67 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/oauth2"
 )
 
 // externalAccountTokenRefresher returns an oauthutil.TokenRefresher for the
 // given external account.
-func externalAccountTokenRefresher(db DB, externalAccountID int32, refreshToken string) oauthutil.TokenRefresher {
+func externalAccountTokenRefresher(store UserExternalAccountsStore, externalAccountID int32, refreshToken string) oauthutil.TokenRefresher {
 	return func(ctx context.Context, doer httpcli.Doer, oauthCtx oauthutil.OAuthContext) (token *auth.OAuthBearerToken, err error) {
-		defer func() {
-			success := err == nil
-			gitlab.TokenRefreshCounter.WithLabelValues("external_account", strconv.FormatBool(success)).Inc()
-		}()
+		// Start a transaction so that multiple refreshes don't happen simultaneously
+		tx, err := store.Transact(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { err = tx.Done(err) }()
 
-		refreshedToken, err := oauthutil.RetrieveToken(doer, oauthCtx, refreshToken, oauthutil.AuthStyleInParams)
+		// Read the token from the DB again, in case it has been refreshed in the mean time
+		acct, err := store.Get(ctx, externalAccountID)
+		if err != nil {
+			return nil, err
+		}
+		if acct.AuthData == nil {
+			return nil, errors.Newf("no auth data found for external account id %d", externalAccountID)
+		}
+		tok, err := encryption.DecryptJSON[oauth2.Token](ctx, acct.AuthData)
+		if err != nil {
+			return nil, err
+		}
+		oauthToken := &auth.OAuthBearerToken{
+			Token:        tok.AccessToken,
+			RefreshToken: tok.RefreshToken,
+			Expiry:       tok.Expiry,
+		}
+		// Compare the stored refresh token with the provided one.
+		// If they differ, the token was most likely refreshed in the meantime.
+		// Check `NeedsRefresh` for good measure.
+		if oauthToken.RefreshToken != refreshToken && !oauthToken.NeedsRefresh() {
+			return oauthToken, nil
+		}
+
+		// Otherwise, do the token refresh
+		refreshedToken, err := oauthutil.RetrieveToken(doer, oauthCtx, oauthToken.RefreshToken, oauthutil.AuthStyleInParams)
 		if err != nil {
 			return nil, errors.Wrap(err, "refresh token")
 		}
 
-		acct, err := db.UserExternalAccounts().Get(ctx, externalAccountID)
-		if err != nil {
-			return nil, errors.Wrap(err, "get user external account")
-		}
-
+		// Store the refreshed token
 		err = acct.AuthData.Set(refreshedToken)
 		if err != nil {
 			return nil, errors.Wrap(err, "set auth data")
 		}
-		_, err = db.UserExternalAccounts().LookupUserAndSave(ctx, acct.AccountSpec, acct.AccountData)
+		_, err = store.LookupUserAndSave(ctx, acct.AccountSpec, acct.AccountData)
 		if err != nil {
 			return nil, errors.Wrap(err, "save refreshed token")
 		}
+
 		return &auth.OAuthBearerToken{
 			Token:        refreshedToken.AccessToken,
 			RefreshToken: refreshedToken.RefreshToken,
@@ -114,7 +140,7 @@ func GetServiceRefreshAndStoreOAuthTokenFunc(db DB, externalServiceID int64, oau
 
 func GetAccountRefreshAndStoreOAuthTokenFunc(db DB, externalAccountID int32, oauthContext *oauthutil.OAuthContext) func(context.Context, httpcli.Doer, *auth.OAuthBearerToken) (string, string, time.Time, error) {
 	return func(ctx context.Context, cli httpcli.Doer, a *auth.OAuthBearerToken) (string, string, time.Time, error) {
-		tokenRefresher := externalAccountTokenRefresher(db, externalAccountID, a.RefreshToken)
+		tokenRefresher := externalAccountTokenRefresher(db.UserExternalAccounts(), externalAccountID, a.RefreshToken)
 		token, err := tokenRefresher(ctx, cli, *oauthContext)
 		if err != nil {
 			return "", "", time.Time{}, err

--- a/internal/database/oauth_token_helper_test.go
+++ b/internal/database/oauth_token_helper_test.go
@@ -99,8 +99,6 @@ func TestExternalAccountTokenRefresher(t *testing.T) {
 		Token:        "expired",
 		RefreshToken: "refresh_token",
 	}
-	marshalled, err := json.Marshal(originalToken)
-	require.NoError(t, err)
 	extAccts := []*extsvc.Account{{
 		AccountSpec: extsvc.AccountSpec{
 			ServiceType: extsvc.TypeGitLab,
@@ -108,7 +106,7 @@ func TestExternalAccountTokenRefresher(t *testing.T) {
 			AccountID:   "accountId",
 		},
 		AccountData: extsvc.AccountData{
-			AuthData: extsvc.NewUnencryptedData(marshalled),
+			AuthData: extsvc.NewUnencryptedData([]byte(`{"access_token": "expired", "refresh_token": "refresh_token"}`)),
 		},
 	}}
 

--- a/internal/extsvc/auth/oauth_bearer.go
+++ b/internal/extsvc/auth/oauth_bearer.go
@@ -45,6 +45,10 @@ func (token *OAuthBearerToken) Refresh(ctx context.Context, cli httpcli.Doer) er
 }
 
 func (token *OAuthBearerToken) NeedsRefresh() bool {
+	// If there is no refresh token, always return false since we can't refresh
+	if token.RefreshToken == "" {
+		return false
+	}
 	// Refresh if the current time falls within the buffer period to expiry, and is not zero
 	return !token.Expiry.IsZero() && (time.Until(token.Expiry) <= time.Duration(token.NeedsRefreshBuffer)*time.Minute)
 }


### PR DESCRIPTION
Closes #51026 

Adds token refreshing for GitHub external accounts (necessary for GitHub App).

Also puts token refreshing inside a DB transaction so that concurrent refreshes don't contest with each other.

## Test plan

Unit tests updated

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
