### PR TITLE
Cody: Remove fallback to keyword search errors

### DIFF
--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -66,16 +66,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     break
                 case 'contextStatus':
                     setContextStatus(message.contextStatus)
-                    if (message.contextStatus.mode !== 'keyword' && !message.contextStatus?.codebase) {
-                        setErrorMessage(
-                            'Codebase is missing. A codebase must be provided via the cody.codebase setting to enable embeddings. Failling back to local keyword search for context.'
-                        )
-                    }
-                    if (message.contextStatus?.codebase && !message.contextStatus?.connection) {
-                        setErrorMessage(
-                            'Codebase connection failed. Please make sure the codebase in your cody.codebase setting is correct and exists in your Sourcegraph instance. Falling back to local keyword search for context.'
-                        )
-                    }
                     break
                 case 'view':
                     setView(message.messages)


### PR DESCRIPTION
c.f. https://github.com/sourcegraph/sourcegraph/pull/50952#issuecomment-1518492751

This removes the error messages that are found when no codebase is configured. We now fall back to keyword search anyways so the experience doesn't seem bad.

Additionally, the current error message discarding logic seems flawed. So when I open a project with no defined repo and dismiss the error message, every time I go to a different file in that repo, the message pops up again. Not a great experience.

## Test plan

<img width="525" alt="Screenshot 2023-04-24 at 13 46 07" src="https://user-images.githubusercontent.com/458591/233987096-4d967135-aa1c-44dd-835f-9434073c63e4.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
