### PR TITLE
bzl: tag //enterprise/internal/database tests as large

### DIFF
--- a/enterprise/internal/database/BUILD.bazel
+++ b/enterprise/internal/database/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
 
 go_test(
     name = "database_test",
+    size = "large",
     timeout = "long",
     srcs = [
         "authz_test.go",


### PR DESCRIPTION
They're quite big and can clash with the //client/web tests which are really heavy too.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

ci 