### PR TITLE
cody: infer and update codebase from current open file

### DIFF
--- a/client/cody-cli/src/context.ts
+++ b/client/cody-cli/src/context.ts
@@ -23,6 +23,7 @@ export async function createCodebaseContext(
 
     const codebaseContext = new CodebaseContext(
         { useContext: contextType },
+        codebase,
         embeddingsSearch,
         new LocalKeywordContextFetcherMock()
     )

--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -62,7 +62,7 @@ export async function createClient({
 
     const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId) : null
 
-    const codebaseContext = new CodebaseContext(config, embeddingsSearch, null)
+    const codebaseContext = new CodebaseContext(config, config.codebase, embeddingsSearch, null)
 
     const intentDetector = new SourcegraphIntentDetectorClient(graphqlClient)
 

--- a/client/cody-shared/src/chat/transcript/transcript.test.ts
+++ b/client/cody-shared/src/chat/transcript/transcript.test.ts
@@ -76,6 +76,7 @@ describe('Transcript', () => {
                 }),
                 codebaseContext: new CodebaseContext(
                     { useContext: 'embeddings' },
+                    'dummy-codebase',
                     embeddings,
                     defaultKeywordContextFetcher
                 ),
@@ -108,6 +109,7 @@ describe('Transcript', () => {
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
             { useContext: 'embeddings' },
+            'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher
         )
@@ -192,6 +194,7 @@ describe('Transcript', () => {
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
             { useContext: 'embeddings' },
+            'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher
         )
@@ -267,6 +270,7 @@ describe('Transcript', () => {
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
             { useContext: 'embeddings' },
+            'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher
         )

--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -16,9 +16,14 @@ export interface ContextSearchOptions {
 export class CodebaseContext {
     constructor(
         private config: Pick<Configuration, 'useContext'>,
+        private codebase: string | undefined,
         private embeddings: EmbeddingsSearch | null,
         private keywords: KeywordContextFetcher | null
     ) {}
+
+    public getCodebase(): string | undefined {
+        return this.codebase
+    }
 
     public onConfigurationChange(newConfig: typeof this.config): void {
         this.config = newConfig

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -93,7 +93,12 @@ export function newRecipeContext(args?: Partial<RecipeContext>): RecipeContext {
         intentDetector: args.intentDetector || defaultIntentDetector,
         codebaseContext:
             args.codebaseContext ||
-            new CodebaseContext({ useContext: 'none' }, defaultEmbeddingsClient, defaultKeywordContextFetcher),
+            new CodebaseContext(
+                { useContext: 'none' },
+                'dummy-codebase',
+                defaultEmbeddingsClient,
+                defaultKeywordContextFetcher
+            ),
         responseMultiplexer: args.responseMultiplexer || new BotResponseMultiplexer(),
     }
 }

--- a/client/cody-slack/src/services/codebase-context.ts
+++ b/client/cody-slack/src/services/codebase-context.ts
@@ -33,6 +33,7 @@ export async function createCodebaseContext(
 
     const codebaseContext = new CodebaseContext(
         { useContext: contextType },
+        codebase,
         embeddingsSearch,
         new LocalKeywordContextFetcherMock()
     )

--- a/client/cody/src/chat/ChatViewProvider.test.ts
+++ b/client/cody/src/chat/ChatViewProvider.test.ts
@@ -1,0 +1,37 @@
+import { convertGitCloneURLToCodebaseName } from './ChatViewProvider'
+
+describe('convertGitCloneURLToCodebaseName', () => {
+    test('converts GitHub SSH URL', () => {
+        expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph.git')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts GitHub SSH URL no trailing .git', () => {
+        expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts GitHub HTTPS URL', () => {
+        expect(convertGitCloneURLToCodebaseName('https://github.com/sourcegraph/sourcegraph')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts GitLab SSH URL', () => {
+        expect(convertGitCloneURLToCodebaseName('git@gitlab.com:sourcegraph/sourcegraph.git')).toEqual(
+            'gitlab.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts GitLab HTTPS URL', () => {
+        expect(convertGitCloneURLToCodebaseName('https://gitlab.com/sourcegraph/sourcegraph.git')).toEqual(
+            'gitlab.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('returns null for invalid URL', () => {
+        expect(convertGitCloneURLToCodebaseName('invalid')).toEqual(null)
+    })
+})

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'child_process'
 import path from 'path'
 
 import * as vscode from 'vscode'
@@ -12,6 +13,7 @@ import { reformatBotMessage } from '@sourcegraph/cody-shared/src/chat/viewHelper
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
+import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
 import { highlightTokens } from '@sourcegraph/cody-shared/src/hallucinations-detector'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
@@ -22,6 +24,7 @@ import { View } from '../../webviews/NavBar'
 import { LocalStorage } from '../command/LocalStorageProvider'
 import { updateConfiguration } from '../configuration'
 import { logEvent } from '../event-logger'
+import { LocalKeywordContextFetcher } from '../keyword-context/local-keyword-context-fetcher'
 import { CODY_ACCESS_TOKEN_SECRET, SecretStorage } from '../secret-storage'
 import { TestSupport } from '../test-support'
 
@@ -60,15 +63,19 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
     private disposables: vscode.Disposable[] = []
 
+    // Codebase-context-related state
+    private currentWorkspaceRoot: string
+
     constructor(
         private extensionPath: string,
-        private config: Config,
+        private config: Omit<Config, 'codebase'>, // should use codebaseContext.getCodebase() rather than config.codebase
         private chat: ChatClient,
         private intentDetector: IntentDetector,
         private codebaseContext: CodebaseContext,
         private editor: Editor,
         private secretStorage: SecretStorage,
-        private localStorage: LocalStorage
+        private localStorage: LocalStorage,
+        private rgPath: string
     ) {
         if (TestSupport.instance) {
             TestSupport.instance.chatViewProvider.set(this)
@@ -77,6 +84,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.createNewChatID()
 
         this.disposables.push(this.configurationChangeEvent)
+
+        // listen for vscode active editor change event
+        this.currentWorkspaceRoot = ''
+        this.disposables.push(
+            vscode.window.onDidChangeActiveTextEditor(async () => {
+                await this.updateCodebaseContext()
+            })
+        )
     }
 
     public onConfigurationChange(newConfig: Config): void {
@@ -228,6 +243,30 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         await this.executeRecipe('chat-question', text)
     }
 
+    private async updateCodebaseContext(): Promise<void> {
+        if (!this.editor.getActiveTextEditor() && vscode.window.visibleTextEditors.length !== 0) {
+            // these are ephemeral
+            return
+        }
+        const workspaceRoot = this.editor.getWorkspaceRootPath()
+        if (!workspaceRoot || workspaceRoot === '' || workspaceRoot === this.currentWorkspaceRoot) {
+            return
+        }
+        this.currentWorkspaceRoot = workspaceRoot
+
+        const codebaseContext = await getCodebaseContext(this.config, this.rgPath, this.editor)
+        if (!codebaseContext) {
+            return
+        }
+        // after await, check we're still hitting the same workspace root
+        if (this.currentWorkspaceRoot !== workspaceRoot) {
+            return
+        }
+
+        this.codebaseContext = codebaseContext
+        this.publishContextStatus()
+    }
+
     public async executeRecipe(recipeId: string, humanChatInput: string = ''): Promise<void> {
         if (this.isMessageInProgress) {
             await vscode.window.showErrorMessage(
@@ -257,7 +296,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.showTab('chat')
         this.sendTranscript()
 
-        const prompt = await this.transcript.toPrompt(getPreamble(this.config.codebase))
+        const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
         this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
 
         logEvent(`CodyVSCodeExtension:recipe:${recipe.id}:executed`)
@@ -317,14 +356,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Publish the current context status to the webview.
      */
     private publishContextStatus(): void {
-        const send = (): void => {
+        const send = async (): Promise<void> => {
             const editorContext = this.editor.getActiveTextEditor()
             void this.webview?.postMessage({
                 type: 'contextStatus',
                 contextStatus: {
                     mode: this.config.useContext,
                     connection: this.codebaseContext.checkEmbeddingsConnection(),
-                    codebase: this.config.codebase,
+                    codebase: this.codebaseContext.getCodebase(),
                     filePath: editorContext ? vscode.workspace.asRelativePath(editorContext.filePath) : undefined,
                     supportsKeyword: true,
                 },
@@ -368,7 +407,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 logEvent(
                     `CodyVSCodeExtension:codyFeedback:${value}`,
                     null,
-                    !isPrivateInstance && this.config.codebase ? this.transcript.toChat() : null
+                    !isPrivateInstance && this.codebaseContext.getCodebase() ? this.transcript.toChat() : null
                 )
                 break
             case 'token':
@@ -473,4 +512,76 @@ async function fileExists(filePath: string): Promise<boolean> {
         }
     }
     return false
+}
+
+// Converts a git clone URL to the codebase name that includes the slash-separated code host, owner, and repository name
+export function convertGitCloneURLToCodebaseName(cloneURL: string): string | null {
+    let parsed: URL | null = null
+    if (cloneURL.startsWith('git@')) {
+        // Handle Git SSH URL format
+        const match = cloneURL.match(/git@([^:]+):([\w-]+)\/([\w-]+)(\.git)?/)
+        if (match) {
+            const host = match[1]
+            const owner = match[2]
+            const repo = match[3]
+            return `${host}/${owner}/${repo}`
+        }
+    } else {
+        // Handle HTTP/HTTPS URL format
+        try {
+            parsed = new URL(cloneURL)
+        } catch (error) {
+            return null
+        }
+    }
+
+    if (!parsed) {
+        return null
+    }
+
+    const host = parsed.host
+    const path = parsed.pathname
+
+    // Handle GitHub/GitLab URL format
+    if (host.includes('gitlab.com') || host.includes('github.com')) {
+        const [owner, repo] = path.slice(1).split('/')
+        return `${host}/${owner}/${repo}`.replace(/.git$/, '')
+    }
+
+    // Generic fallback - assume URL path contains owner/repo
+    const [owner, repo] = path.slice(1).split('/')
+    return `${host}/${owner}/${repo}`
+}
+
+async function getCodebaseContext(config: Config, rgPath: string, editor: Editor): Promise<CodebaseContext | null> {
+    const client = new SourcegraphGraphQLAPIClient(config)
+    const workspaceRoot = editor.getWorkspaceRootPath()
+    if (!workspaceRoot) {
+        return null
+    }
+
+    const gitCommand = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: workspaceRoot })
+    const gitOutput = gitCommand.stdout.toString().trim()
+    if (!gitOutput) {
+        vscode.window.showErrorMessage(
+            `Unable to determine the git clone URL for this workspace.\ngit output: ${gitOutput}`
+        )
+        return null
+    }
+
+    // Get repository name from git clone URL
+    const codebase = convertGitCloneURLToCodebaseName(gitOutput)
+    if (!codebase) {
+        vscode.window.showErrorMessage(`could not extract repo name from clone URL ${gitOutput}`)
+        return null
+    }
+    const repoId = await client.getRepoIdIfEmbeddingExists(codebase)
+    if (isError(repoId)) {
+        const errorMessage = `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance.\n`
+        void vscode.window.showErrorMessage(errorMessage)
+        return null
+    }
+
+    const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
+    return new CodebaseContext(config, codebase, embeddingsSearch, new LocalKeywordContextFetcher(rgPath, editor))
 }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -356,7 +356,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Publish the current context status to the webview.
      */
     private publishContextStatus(): void {
-        const send = async (): Promise<void> => {
+        const send = (): void => {
             const editorContext = this.editor.getActiveTextEditor()
             void this.webview?.postMessage({
                 type: 'contextStatus',
@@ -530,7 +530,7 @@ export function convertGitCloneURLToCodebaseName(cloneURL: string): string | nul
         // Handle HTTP/HTTPS URL format
         try {
             parsed = new URL(cloneURL)
-        } catch (error) {
+        } catch {
             return null
         }
     }
@@ -563,7 +563,7 @@ async function getCodebaseContext(config: Config, rgPath: string, editor: Editor
     const gitCommand = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: workspaceRoot })
     const gitOutput = gitCommand.stdout.toString().trim()
     if (!gitOutput) {
-        vscode.window.showErrorMessage(
+        void vscode.window.showErrorMessage(
             `Unable to determine the git clone URL for this workspace.\ngit output: ${gitOutput}`
         )
         return null
@@ -572,7 +572,7 @@ async function getCodebaseContext(config: Config, rgPath: string, editor: Editor
     // Get repository name from git clone URL
     const codebase = convertGitCloneURLToCodebaseName(gitOutput)
     if (!codebase) {
-        vscode.window.showErrorMessage(`could not extract repo name from clone URL ${gitOutput}`)
+        void vscode.window.showErrorMessage(`could not extract repo name from clone URL ${gitOutput}`)
         return null
     }
     const repoId = await client.getRepoIdIfEmbeddingExists(codebase)

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -49,6 +49,7 @@ export async function configureExternalServices(
 
     const codebaseContext = new CodebaseContext(
         initialConfig,
+        initialConfig.codebase,
         embeddingsSearch,
         new LocalKeywordContextFetcher(rgPath, editor)
     )

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -107,7 +107,8 @@ const register = async (
         codebaseContext,
         editor,
         secretStorage,
-        localStorage
+        localStorage,
+        rgPath
     )
     disposables.push(chatProvider)
 


### PR DESCRIPTION
Instead of relying on the manual `cody.codebase` setting, infer the codebase ID from the git clone URL of the current repository. Update this ID when the currently open file changes.

https://user-images.githubusercontent.com/1646931/234043088-b4af54ef-811d-4f5e-9e49-2f103b3e2f85.mp4

## Test plan

* Cody is experimental.
* Added unit test for codebase-from-clone-URL inference
* Tested locally.