### PR TITLE
Cody: Add a cache for inline completions

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -330,8 +330,9 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.4.2",
     "@sourcegraph/cody-shared": "workspace:*",
-    "openai": "^3.2.1",
     "@sourcegraph/cody-ui": "workspace:*",
+    "lru-cache": "^9.1.1",
+    "openai": "^3.2.1",
     "wink-eng-lite-web-model": "^1.5.0",
     "wink-nlp": "^1.13.1",
     "wink-nlp-utils": "^2.1.0"

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -16,7 +16,6 @@ export class CompletionsCache {
     public get(prefix: string): Completion[] | undefined {
         const results = this.cache.get(prefix)
         if (results) {
-            console.log('CACHE HIT')
             return results.map(result => {
                 if (prefix.length === result.prefix.length) {
                     return result

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -4,9 +4,7 @@ import { Completion } from '.'
 
 export class CompletionsCache {
     private cache = new LRUCache<string, Completion[]>({
-        // Maximum input prefixes in the cache. For every completion, we cache
-        // the input prefix as well as
-        max: 500,
+        max: 500, // Maximum input prefixes in the cache.
     })
 
     // TODO: The caching strategy only takes the file content prefix into

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -16,6 +16,7 @@ export class CompletionsCache {
     public get(prefix: string): Completion[] | undefined {
         const results = this.cache.get(prefix)
         if (results) {
+            console.log('CACHE HIT')
             return results.map(result => {
                 if (prefix.length === result.prefix.length) {
                     return result
@@ -38,9 +39,17 @@ export class CompletionsCache {
 
     public add(completions: Completion[]): void {
         for (const completion of completions) {
-            // Cache the exact prefix first and then add characters from the
-            // completion one after the other
-            for (let i = 0; i <= Math.min(10, completion.content.length); i++) {
+            // Cache the exact prefix first and then append characters from the
+            // completion one after the other until the first line is exceeded.
+            //
+            // If the completion starts with a `\n`, this logic will append the
+            // second line instead.
+            let maxCharsAppended = completion.content.indexOf('\n', completion.content.at(0) === '\n' ? 1 : 0)
+            if (maxCharsAppended === -1) {
+                maxCharsAppended = completion.content.length
+            }
+
+            for (let i = 0; i <= maxCharsAppended; i++) {
                 const key = completion.prefix + completion.content.slice(0, i)
                 if (!this.cache.has(key)) {
                     this.cache.set(key, [completion])

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -4,7 +4,9 @@ import { Completion } from '.'
 
 export class CompletionsCache {
     private cache = new LRUCache<string, Completion[]>({
-        max: 500, // maximum input prefixes in the cache
+        // Maximum input prefixes in the cache. For every completion, we cache
+        // the input prefix as well as
+        max: 500,
     })
 
     // TODO: The caching strategy only takes the file content prefix into
@@ -38,7 +40,7 @@ export class CompletionsCache {
         for (const completion of completions) {
             // Cache the exact prefix first and then add characters from the
             // completion one after the other
-            for (let i = 0; i <= 10; i++) {
+            for (let i = 0; i <= Math.min(10, completion.content.length); i++) {
                 const key = completion.prefix + completion.content.slice(0, i)
                 if (!this.cache.has(key)) {
                     this.cache.set(key, [completion])
@@ -48,7 +50,5 @@ export class CompletionsCache {
                 }
             }
         }
-
-        console.log(this.cache)
     }
 }

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -1,0 +1,54 @@
+import { LRUCache } from 'lru-cache'
+
+import { Completion } from '.'
+
+export class CompletionsCache {
+    private cache = new LRUCache<string, Completion[]>({
+        max: 500, // maximum input prefixes in the cache
+    })
+
+    // TODO: The caching strategy only takes the file content prefix into
+    // account. We need to add additional information like file path or suffix
+    // to make sure the cache does not return undesired results for other files
+    // in the same project.
+    public get(prefix: string): Completion[] | undefined {
+        const results = this.cache.get(prefix)
+        if (results) {
+            return results.map(result => {
+                if (prefix.length === result.prefix.length) {
+                    return result
+                }
+
+                // Cached results can be created by appending characters from a
+                // recommendation from a smaller input prompt. If that's the
+                // case, we need to slightly change the content and remove
+                // characters that are now part of the prefix.
+                const sliceChars = prefix.length - result.prefix.length
+                return {
+                    ...result,
+                    prefix,
+                    content: result.content.slice(sliceChars),
+                }
+            })
+        }
+        return undefined
+    }
+
+    public add(completions: Completion[]): void {
+        for (const completion of completions) {
+            // Cache the exact prefix first and then add characters from the
+            // completion one after the other
+            for (let i = 0; i <= 10; i++) {
+                const key = completion.prefix + completion.content.slice(0, i)
+                if (!this.cache.has(key)) {
+                    this.cache.set(key, [completion])
+                } else {
+                    const existingCompletions = this.cache.get(key)!
+                    existingCompletions.push(completion)
+                }
+            }
+        }
+
+        console.log(this.cache)
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,6 +930,7 @@ importers:
       '@anthropic-ai/sdk': ^0.4.2
       '@sourcegraph/cody-shared': workspace:*
       '@sourcegraph/cody-ui': workspace:*
+      lru-cache: ^9.1.1
       openai: ^3.2.1
       wink-eng-lite-web-model: ^1.5.0
       wink-nlp: ^1.13.1
@@ -938,6 +939,7 @@ importers:
       '@anthropic-ai/sdk': 0.4.2
       '@sourcegraph/cody-shared': link:../cody-shared
       '@sourcegraph/cody-ui': link:../cody-ui
+      lru-cache: 9.1.1
       openai: 3.2.1
       wink-eng-lite-web-model: 1.5.0_wink-nlp@1.13.1
       wink-nlp: 1.13.1
@@ -13025,7 +13027,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.21
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.75.0_esbuild@0.17.14
+      webpack: 5.75.0_pdcrf7mb3dfag2zju4x4octu4a
 
   /css-minimizer-webpack-plugin/4.2.2_zj7shrtzhjuywytipisjis56au:
     resolution: {integrity: sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==}
@@ -20261,6 +20263,11 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /lru-cache/9.1.1:
+    resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
+    engines: {node: 14 || >=16.14}
+    dev: false
+
   /lru-queue/0.1.0:
     resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
     dependencies:
@@ -24964,7 +24971,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.32.4
-      webpack: 5.75.0_esbuild@0.17.14
+      webpack: 5.75.0_pdcrf7mb3dfag2zju4x4octu4a
 
   /sass/1.32.4:
     resolution: {integrity: sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==}
@@ -26153,7 +26160,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.75.0_esbuild@0.17.14
+      webpack: 5.75.0_pdcrf7mb3dfag2zju4x4octu4a
 
   /style-mod/4.0.0:
     resolution: {integrity: sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==}
@@ -26697,7 +26704,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.16.8
-      webpack: 5.75.0_esbuild@0.17.14
+      webpack: 5.75.0_pdcrf7mb3dfag2zju4x4octu4a
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -28496,6 +28503,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: false
 
   /webpack/5.75.0_pdcrf7mb3dfag2zju4x4octu4a:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}


### PR DESCRIPTION
This adds a simple LRU cache for completions with the main goal to further reduce the number of requests and reduce annoying churn in the scenario where a user receives a completion and types the exact same characters. Previously, the new characters would cause a new completion request which could yield different result. 

Here's an example of how this cache works:

- Imagine the current file prefix looks like this with the cursor at the end:
    ```ts
    const files = ["a", "b"];
    for(let i = 0;
    ```
- We receive the following completion:
   - ` i < files.length; i++) {`
- We now generate create different versions (up until the next `\n`) of the input prefix by concatenating characters from the completion (Only using the last line here to visualize):
   1. `for(let i = 0;`
   2. `for(let i = 0; `
   3. `for(let i = 0; i`
   4. `for(let i = 0; i `
   5. `for(let i = 0; i <`
   6. `for(let i = 0; i < `
   7. `for(let i = 0; i < f`
   8. `for(let i = 0; i < fi`
   9. `for(let i = 0; i < fil`
   10. `for(let i = 0; i < file`
   11. ...

## Additional thoughts

- I have't added a cache to multiline providers, since these are triggered less often than inline suggestions anyways.
- The LRU cache is limited to 500 file prefixes, regardless of how large these are. We might want to tweak this later. It also currently retain the `prompt` as part of the `Completion` interface which may not be necessary. 
- I've re-enabled the request that forces adds a `\n` to the prefix. These can now be reused if you type enter and will result in a faster suggestion for the next line.

## Test plan

I've added a `console.log` when a cache hit is encountered to visualize it while playing around with it: 


https://user-images.githubusercontent.com/458591/234050774-2215a146-904d-47ae-b82e-c90ef131fe3e.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
