### PR TITLE
[app] Set missign environment variable

### DIFF
--- a/enterprise/dev/app/release.sh
+++ b/enterprise/dev/app/release.sh
@@ -9,7 +9,7 @@ GCLOUD_APP_CREDENTIALS_FILE=${GCLOUD_APP_CREDENTIALS_FILE-$HOME/.config/gcloud/a
 if [ -z "${SKIP_BUILD_WEB-}" ]; then
   # Use esbuild because it's faster. This is just a personal preference by me (@sqs); if there is a
   # good reason to change it, feel free to do so.
-  NODE_ENV=production ENTERPRISE=1 DEV_WEB_BUILDER=esbuild pnpm run build-web
+  SOURCEGRAPH_APP=1 NODE_ENV=production ENTERPRISE=1 DEV_WEB_BUILDER=esbuild pnpm run build-web
 fi
 
 if [ -z "${GITHUB_TOKEN-}" ]; then


### PR DESCRIPTION
PR #50620 uses the SOURCEGRAPH_APP env variable in the esbuild config, but this variable wasn't set in the realese script, causing the build to fail.



## Test plan

`VERSION=0.0.0+dev enterprise/dev/app/release.sh --snapshot` works.
