### PR TITLE
App: setup sg start app use Tauri

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -136,6 +136,7 @@ Available commands in `sg.config.yaml`:
 * storybook
 * symbols
 * syntax-highlighter
+* tauri: App shell (Tauri)
 * web-integration-build-prod: Build production web application for integration tests
 * web-integration-build: Build development web application for integration tests
 * web-standalone-http-prod: Standalone web frontend (production) with API proxy to a configurable URL

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -893,7 +893,7 @@ commands:
       - schema
 
   tauri:
-    description: Sourcegraph App Tauri shell
+    description: App shell (Tauri)
     cmd: pnpm tauri dev
 
   sourcegraph-oss:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -892,6 +892,10 @@ commands:
       - lib
       - schema
 
+  tauri:
+    description: Sourcegraph App Tauri shell
+    cmd: pnpm tauri dev
+
   sourcegraph-oss:
     description: Single program (Go static binary) distribution, OSS variant
     cmd: |
@@ -1410,6 +1414,7 @@ commandsets:
       - docsite
       - web
       - caddy
+      - tauri
     env:
       DISABLE_CODE_INSIGHTS: false
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,42 +17,53 @@ fn main() {
     tauri::Builder::default()
         .setup(|app| {
             let window = app.get_window("main").unwrap();
-            let (mut rx, _child) = Command::new_sidecar("backend")
-                .expect("failed to create `backend` binary command")
-                .spawn()
-                .expect("Failed to spawn backend sidecar");
-
-            tauri::async_runtime::spawn(async move {
-                // read events such as stdout
-                while let Some(event) = rx.recv().await {
-                    match event {
-                        CommandEvent::Stdout(line) => {
-                            window
-                                .emit("backend-stdout", Some(line.clone()))
-                                .expect("failed to emit event");
-
-                            window.eval(&format!(
-                                "console.log(\":: {}\")",
-                                line.replace("\"", "\\\"")
-                            ));
-                        }
-                        CommandEvent::Stderr(line) => {
-                            window
-                                .emit("backend-stderr", Some(line.clone()))
-                                .expect("failed to emit event");
-
-                            window.eval(&format!(
-                                "console.log(\":: {}\")",
-                                line.replace("\"", "\\\"")
-                            ));
-                        }
-                        _ => continue,
-                    };
-                }
-            });
-
+            start_embedded_services(window);
             Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+fn start_embedded_services(window: tauri::Window) {
+    #[cfg(dev)]
+    println!("embedded Sourcegraph backend disabled for local development");
+        
+    #[cfg(not(dev))]
+    launch_backend(window)
+}
+
+fn launch_backend(window: tauri::Window) {
+    let (mut rx, _child) = Command::new_sidecar("backend")
+                .expect("failed to create `backend` binary command")
+                .spawn()
+                .expect("Failed to spawn backend sidecar");
+
+    tauri::async_runtime::spawn(async move {
+        // read events such as stdout
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line) => {
+                    window
+                        .emit("backend-stdout", Some(line.clone()))
+                        .expect("failed to emit event");
+
+                    window.eval(&format!(
+                        "console.log(\":: {}\")",
+                        line.replace("\"", "\\\"")
+                    ));
+                }
+                CommandEvent::Stderr(line) => {
+                    window
+                        .emit("backend-stderr", Some(line.clone()))
+                        .expect("failed to emit event");
+
+                    window.eval(&format!(
+                        "console.log(\":: {}\")",
+                        line.replace("\"", "\\\"")
+                    ));
+                }
+                _ => continue,
+            };
+        }
+    });
 }


### PR DESCRIPTION
This updates `sg start app` to also start Tauri in dev mode.  

When starting in dev mode the embedded sourcegraph backend is not used so that changes to both Tauri and SG code are refreshed live. 

Also cleaned up rust errors when starting app.

## Test plan
ran `sg start app` UI appeared in tauri app.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
