### PR TITLE
App: fix startup when using bazel

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -35,7 +35,9 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
             : isEnterpriseBuild
             ? path.join(ROOT_PATH, 'client/web/src/enterprise/main.tsx')
             : path.join(ROOT_PATH, 'client/web/src/main.tsx'),
-        'scripts/shell': isSourcegraphApp ? path.join(ROOT_PATH, 'client/web/src/enterprise/app-shell.tsx') : undefined,
+        ...(isSourcegraphApp
+            ? { 'scripts/shell': path.join(ROOT_PATH, 'client/web/src/enterprise/app-shell.tsx') }
+            : {}),
     },
     bundle: true,
     minify: IS_PRODUCTION,


### PR DESCRIPTION
Only add the app shell entry point if we are building the app.

## Test plan
run `DEV_WEB_BUILDER=esbuild sg start enterprise-codeintel-bazel` ensure that start up is successful and ui appears
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
