### PR TITLE
Embeddings: add repo name in log and return joined errors

### DIFF
--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -32,7 +32,7 @@ func searchRepoEmbeddingIndex(
 
 	embeddingIndex, err := getRepoEmbeddingIndex(ctx, params.RepoName)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting repo embedding index")
+		return nil, errors.Wrapf(err, "getting repo embedding index for repo %q", params.RepoName)
 	}
 
 	floatQuery, err := getQueryEmbedding(ctx, params.Query)


### PR DESCRIPTION
We're trying to debug an incident, but with no repo name and the source error being shadowed, that's making it difficult.

## Test plan

It builds.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
