### PR TITLE
batches: use `String.replaceAll` to substitute spaces on batch change name input

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -104,12 +104,9 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
     const [isNameValid, setIsNameValid] = useState<boolean>()
 
     const onNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
-        let value = event.target.value
-        if (value.includes(' ')) {
-            value = value.replace(' ', '-')
-        }
-        setNameInput(value)
-        setIsNameValid(NAME_PATTERN.test(value))
+        const newName = event.target.value.replaceAll(' ', '-')
+        setNameInput(newName)
+        setIsNameValid(NAME_PATTERN.test(newName))
     }, [])
 
     const { isUnlicensed, maxUnlicensedChangesets } = useBatchChangesLicense()


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/50825/files?w=1#r1175947173. This makes sure we replace all spaces that occur in the new name input value, not just the first occurrence, for example if the user copy+pastes all or part of the batch change name.

## Test plan

Manually tested.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
