### PR TITLE
licensing: add llm-proxy flag

### DIFF
--- a/client/web/src/enterprise/productSubscription/ProductLicenseTags.tsx
+++ b/client/web/src/enterprise/productSubscription/ProductLicenseTags.tsx
@@ -29,7 +29,12 @@ const getTagDescription = (tag: string): string => {
 }
 
 export const isUnknownTag = (tag: string): boolean =>
-    !window.context.licenseInfo?.knownLicenseTags?.includes(tag) && !tag.startsWith('customer:')
+    !window.context.licenseInfo?.knownLicenseTags?.some(
+        knownTag =>
+            knownTag === tag ||
+            // Also allow scoped tags, e.g. `tag:value`
+            tag.match(`${knownTag}:.+`)
+    ) && !tag.startsWith('customer:')
 
 export const hasUnknownTags = (tags: string[]): boolean => tags.some(isUnknownTag)
 

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -100,6 +100,7 @@ var AllFeatures = []Feature{
 	FeatureCodeInsights,
 	&FeatureBatchChanges{},
 	FeatureSCIM,
+	&FeatureLLMProxy{},
 }
 
 type PlanDetails struct {

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 )
 
@@ -189,5 +190,14 @@ func TestCheckFeature(t *testing.T) {
 		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanTeam0)), false)
 		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanEnterprise0)), false)
 		check(t, FeatureBackupAndRestore, licenseInfo(plan(PlanEnterprise0), string(FeatureBackupAndRestore)), true)
+	})
+
+	t.Run((&FeatureLLMProxy{}).FeatureName(), func(t *testing.T) {
+		check(t, &FeatureLLMProxy{}, nil, false)
+
+		checkAs(t, &FeatureLLMProxy{}, licenseInfo("llm-proxy"), true, &FeatureLLMProxy{Tier: FeatureLLMProxyTierDefault})
+
+		// TODO: Update when we have real tiers defined
+		checkAs(t, &FeatureLLMProxy{}, licenseInfo("llm-proxy:tier"), true, &FeatureLLMProxy{Tier: "tier"})
 	})
 }


### PR DESCRIPTION
Implements part of LLM-proxy auth (#50726):

- Adds a known explicit licensing tag `llm-proxy`
- Add support for license tags with "properties", i.e. `llm-proxy:$TRAIT`

This will be checked by https://github.com/sourcegraph/sourcegraph/pull/51074

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests, manual test to check the prefix UI validation works 

<img width="152" alt="image" src="https://user-images.githubusercontent.com/23356519/234187869-7235b66d-fc22-4834-9b90-b8141e8ec242.png">
