### PR TITLE
Cody Web: Bring back embeddings label when emeddings are found

### DIFF
--- a/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
@@ -14,7 +14,6 @@ export const ChatInputContext: React.FunctionComponent<{
     contextStatus: ChatContextStatus
     className?: string
 }> = ({ contextStatus, className }) => {
-    console.log(contextStatus)
     const items: Pick<React.ComponentProps<typeof ContextItem>, 'icon' | 'text' | 'tooltip'>[] = useMemo(
         () =>
             [

--- a/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
@@ -14,6 +14,7 @@ export const ChatInputContext: React.FunctionComponent<{
     contextStatus: ChatContextStatus
     className?: string
 }> = ({ contextStatus, className }) => {
+    console.log(contextStatus)
     const items: Pick<React.ComponentProps<typeof ContextItem>, 'icon' | 'text' | 'tooltip'>[] = useMemo(
         () =>
             [

--- a/client/web/src/stores/codyChat.ts
+++ b/client/web/src/stores/codyChat.ts
@@ -187,6 +187,8 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
         return {
             codebase: config?.codebase,
             filePath: editor?.getActiveTextEditorSelectionOrEntireFile()?.fileName,
+            mode: config?.useContext,
+            connection: true,
         }
     }
 


### PR DESCRIPTION
It seems like some recent refactorings broke the embeddings label in cody web. This brings it back.

## Test plan

<img width="379" alt="image" src="https://user-images.githubusercontent.com/458591/234255595-00f46cc6-bdde-4c73-9a96-9d9f04363816.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
