### PR TITLE
Remove RateLimitWatcher, keep BasicLimitWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - User tags are removed in favor of the newer feature flags functionality. [#49318](https://github.com/sourcegraph/sourcegraph/pull/49318)
 - Previously deprecated site config `experimentalFeatures.bitbucketServerFastPerm` has been removed. [#50707](https://github.com/sourcegraph/sourcegraph/pull/50707)
+- Unused site-config field `api.rateLimit` has been removed. [#51087](https://github.com/sourcegraph/sourcegraph/pull/51087)
 
 ## 5.0.2
 

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -493,7 +493,6 @@ go_test(
         "@com_github_sourcegraph_zoekt//web",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@com_github_throttled_throttled_v2//:throttled",
         "@com_github_throttled_throttled_v2//store/memstore",
     ],
 )

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -3,16 +3,13 @@ package graphqlbackend
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
 
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestEstimateQueryCost(t *testing.T) {
@@ -388,172 +385,6 @@ fragment UsableFields on Usable {
 			}
 			if diff := cmp.Diff(want, *have); diff != "" {
 				t.Errorf(diff)
-			}
-		})
-	}
-}
-
-func TestRatelimitFromConfig(t *testing.T) {
-	testCases := []struct {
-		name   string
-		config *schema.ApiRatelimit
-
-		uid  string
-		isIP bool
-		cost int
-
-		enabled bool
-
-		wantLimited bool
-		wantResult  throttled.RateLimitResult
-	}{
-		{
-			name:   "Nil config",
-			config: nil,
-
-			enabled: false,
-		},
-		{
-			name: "Disabled config",
-			config: &schema.ApiRatelimit{
-				Enabled: false,
-			},
-			enabled: false,
-		},
-		{
-			name: "No overrides",
-			config: &schema.ApiRatelimit{
-				Enabled:   true,
-				Overrides: nil,
-				PerIP:     5000,
-				PerUser:   5000,
-			},
-			enabled: true,
-
-			uid:  "test",
-			isIP: false,
-			cost: 1,
-
-			wantLimited: false,
-			wantResult: throttled.RateLimitResult{
-				Limit:      1001,
-				Remaining:  1000,
-				ResetAfter: 720 * time.Millisecond,
-				RetryAfter: -1,
-			},
-		},
-		{
-			name: "With value override",
-			config: &schema.ApiRatelimit{
-				Enabled: true,
-				PerIP:   5000,
-				PerUser: 5000,
-				Overrides: []*schema.Overrides{
-					{
-						Key:   "test",
-						Limit: 2500,
-					},
-				},
-			},
-			enabled: true,
-
-			uid:  "test",
-			isIP: false,
-			cost: 1,
-
-			wantLimited: false,
-			wantResult: throttled.RateLimitResult{
-				Limit:      501,
-				Remaining:  500,
-				ResetAfter: 720 * time.Millisecond * 2,
-				RetryAfter: -1,
-			},
-		},
-		{
-			name: "With blocked override",
-			config: &schema.ApiRatelimit{
-				Enabled: true,
-				PerIP:   5000,
-				PerUser: 5000,
-				Overrides: []*schema.Overrides{
-					{
-						Key:   "test",
-						Limit: "blocked",
-					},
-				},
-			},
-			enabled: true,
-
-			uid:  "test",
-			isIP: false,
-			cost: 1,
-
-			wantLimited: true,
-			wantResult: throttled.RateLimitResult{
-				Limit:      0,
-				Remaining:  0,
-				ResetAfter: 0,
-				RetryAfter: 0,
-			},
-		},
-		{
-			name: "With unlimited override",
-			config: &schema.ApiRatelimit{
-				Enabled: true,
-				PerIP:   5000,
-				PerUser: 5000,
-				Overrides: []*schema.Overrides{
-					{
-						Key:   "test",
-						Limit: "unlimited",
-					},
-				},
-			},
-			enabled: true,
-
-			uid:  "test",
-			isIP: false,
-			cost: 1,
-
-			wantLimited: false,
-			wantResult: throttled.RateLimitResult{
-				Limit:      100000,
-				Remaining:  100000,
-				ResetAfter: 0,
-				RetryAfter: 0,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			store, err := memstore.New(1024)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			logger := logtest.Scoped(t)
-
-			rlw := NewRateLimiteWatcher(logger, store)
-
-			rlw.updateFromConfig(logger, tc.config)
-			rl, enabled := rlw.Get()
-
-			if tc.enabled != enabled {
-				t.Fatalf("Want %v, got %v", tc.enabled, enabled)
-			}
-			if !tc.enabled {
-				return
-			}
-			limited, result, err := rl.RateLimit(tc.uid, tc.cost, LimiterArgs{IsIP: tc.isIP})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if limited != tc.wantLimited {
-				t.Fatalf("Limited, want %v got %v", tc.wantLimited, limited)
-			}
-			if diff := cmp.Diff(tc.wantResult, result); diff != "" {
-				t.Fatal(diff)
 			}
 		})
 	}

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -25,7 +25,7 @@ func newTest(t *testing.T) *httptestutil.Client {
 	logger := logtest.Scoped(t)
 	enterpriseServices := enterprise.DefaultServices()
 	rateLimitStore, _ := memstore.New(1024)
-	rateLimiter := graphqlbackend.NewRateLimiteWatcher(logger, rateLimitStore)
+	rateLimiter := graphqlbackend.NewBasicLimitWatcher(logger, rateLimitStore)
 
 	db := database.NewMockDB()
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -54,18 +54,6 @@ type AWSKMSEncryptionKey struct {
 	Type            string `json:"type"`
 }
 
-// ApiRatelimit description: Configuration for API rate limiting
-type ApiRatelimit struct {
-	// Enabled description: Whether API rate limiting is enabled
-	Enabled bool `json:"enabled"`
-	// Overrides description: An array of rate limit overrides
-	Overrides []*Overrides `json:"overrides,omitempty"`
-	// PerIP description: Limit granted per IP per hour, only applied to anonymous users
-	PerIP int `json:"perIP"`
-	// PerUser description: Limit granted per user per hour
-	PerUser int `json:"perUser"`
-}
-
 // App description: Configuration options for App only.
 type App struct {
 	// DotcomAuthToken description: Authentication token for Sourcegraph.com. If present, indicates that the App account is connected to a Sourcegraph.com account.
@@ -1646,12 +1634,6 @@ type OutputVariable struct {
 	// Value description: The value of the output, which can be a template string.
 	Value string `json:"value"`
 }
-type Overrides struct {
-	// Key description: The key that we want to override for example a username
-	Key string `json:"key,omitempty"`
-	// Limit description: The limit per hour, 'unlimited' or 'blocked'
-	Limit any `json:"limit,omitempty"`
-}
 
 // PagureConnection description: Configuration for a connection to Pagure.
 type PagureConnection struct {
@@ -2290,8 +2272,6 @@ type SettingsOpenInEditor struct {
 type SiteConfiguration struct {
 	// RedirectUnsupportedBrowser description: Prompts user to install new browser for non es5
 	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser,omitempty"`
-	// ApiRatelimit description: Configuration for API rate limiting
-	ApiRatelimit *ApiRatelimit `json:"api.ratelimit,omitempty"`
 	// App description: Configuration options for App only.
 	App *App `json:"app,omitempty"`
 	// AuthAccessRequest description: The config options for access requests
@@ -2585,7 +2565,6 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	delete(m, "RedirectUnsupportedBrowser")
-	delete(m, "api.ratelimit")
 	delete(m, "app")
 	delete(m, "auth.accessRequest")
 	delete(m, "auth.accessTokens")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1969,61 +1969,6 @@
         }
       }
     },
-    "api.ratelimit": {
-      "description": "Configuration for API rate limiting",
-      "type": "object",
-      "required": ["enabled", "perUser", "perIP"],
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether API rate limiting is enabled"
-        },
-        "perUser": {
-          "description": "Limit granted per user per hour",
-          "type": "integer",
-          "minimum": 1,
-          "default": 1000000
-        },
-        "perIP": {
-          "description": "Limit granted per IP per hour, only applied to anonymous users",
-          "type": "integer",
-          "minimum": 1,
-          "default": 1000000
-        },
-        "overrides": {
-          "description": "An array of rate limit overrides",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "description": "The key that we want to override for example a username",
-                "type": "string",
-                "minLength": 1
-              },
-              "limit": {
-                "description": "The limit per hour, 'unlimited' or 'blocked'",
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "const": "unlimited"
-                  },
-                  {
-                    "type": "string",
-                    "const": "blocked"
-                  },
-                  {
-                    "type": "integer",
-                    "minimum": 1
-                  }
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
     "webhook.logging": {
       "description": "Configuration for logging incoming webhooks.",
       "type": "object",


### PR DESCRIPTION
The `RateLimitWatcher` was unused. According to
87268393be27a0784d27ad78d53cd2b3cb623ac1 the `BasicLimitWatcher` was introduced as a simplified version:

> There was already a much more sophisticated, but currently disabled,
> rate limiter in place that currently undergoes testing. This new
> limiter is a heavily simplified version of the existing limiter which we
> can use for the time being.

In the 2 years since no one enabled the other rate limiter.

Looks like we might need something like the more sophisticated rate limiter again, but I'm unsure what the requirements are and what held the "more sophisticated" rate limiter back.

## Test plan

- Existing tests
