### PR TITLE
Add redis cache for installation access tokens

### DIFF
--- a/enterprise/cmd/gitserver/shared/shared.go
+++ b/enterprise/cmd/gitserver/shared/shared.go
@@ -26,5 +26,5 @@ func enterpriseInit(db database.DB, keyring keyring.Ring) {
 	}
 
 	ghAppsStore := enterpriseDB.GitHubApps().WithEncryptionKey(keyring.GitHubAppKey)
-	auth.FromConnection = ghaauth.CreateEnterpriseFromConnection(ghAppsStore)
+	auth.FromConnection = ghaauth.CreateEnterpriseFromConnection(ghAppsStore, keyring.GitHubAppKey)
 }

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -53,7 +53,7 @@ func EnterpriseInit(
 	}
 
 	ghAppsStore := edb.NewEnterpriseDB(db).GitHubApps().WithEncryptionKey(keyring.GitHubAppKey)
-	auth.FromConnection = ghaauth.CreateEnterpriseFromConnection(ghAppsStore)
+	auth.FromConnection = ghaauth.CreateEnterpriseFromConnection(ghAppsStore, keyring.GitHubAppKey)
 
 	permsStore := edb.Perms(observationCtx.Logger, db, timeutil.Now)
 	permsSyncer := authz.NewPermsSyncer(observationCtx.Logger.Scoped("PermsSyncer", "repository and user permissions syncer"), db, repoStore, permsStore, timeutil.Now)

--- a/enterprise/internal/github_apps/auth/BUILD.bazel
+++ b/enterprise/internal/github_apps/auth/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//internal/extsvc/github",
         "//internal/extsvc/github/auth",
         "//internal/httpcli",
+        "//internal/rcache",
         "//lib/errors",
         "//schema",
         "@com_github_golang_jwt_jwt_v4//:jwt",

--- a/enterprise/internal/github_apps/auth/BUILD.bazel
+++ b/enterprise/internal/github_apps/auth/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/github_apps/store",
+        "//internal/encryption",
         "//internal/extsvc/auth",
         "//internal/extsvc/github",
         "//internal/extsvc/github/auth",
@@ -25,8 +26,11 @@ go_test(
     deps = [
         "//enterprise/internal/github_apps/store",
         "//enterprise/internal/github_apps/types",
+        "//internal/encryption/keyring",
         "//internal/extsvc/auth",
+        "//internal/rcache",
         "//schema",
+        "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/internal/github_apps/auth/BUILD.bazel
+++ b/enterprise/internal/github_apps/auth/BUILD.bazel
@@ -23,6 +23,10 @@ go_test(
     name = "auth_test",
     srcs = ["auth_test.go"],
     embed = [":auth"],
+    tags = [
+        # Test requires access to redis
+        "requires-network",
+    ],
     deps = [
         "//enterprise/internal/github_apps/store",
         "//enterprise/internal/github_apps/types",

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -160,7 +160,6 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		require.True(t, appAuthenticator.AuthenticateCalled)
 
 		require.Equal(t, token.installationAccessToken.Token, wantToken.Token)
-		require.True(t, token.installationAccessToken.ExpiresAt.Equal(wantToken.ExpiresAt))
 	})
 
 	t.Run("uses token cache", func(t *testing.T) {
@@ -188,7 +187,6 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		require.True(t, mockClient.DoCalled)
 		require.True(t, appAuthenticator.AuthenticateCalled)
 
-		require.True(t, token1.installationAccessToken.ExpiresAt.Equal(wantToken.ExpiresAt))
 		require.Equal(t, token1.installationAccessToken.Token, wantToken.Token)
 
 		// First we generate a new token for the mockClient so that we're sure
@@ -197,7 +195,6 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		require.NotEqual(t, mockClient.installationAccessToken, wantToken)
 		// Now we refresh token2 and assert that we get the same token from the cache
 		token2.Refresh(context.Background(), mockClient)
-		require.True(t, token1.installationAccessToken.ExpiresAt.Equal(token2.installationAccessToken.ExpiresAt))
 		require.Equal(t, token1.installationAccessToken.Token, token2.installationAccessToken.Token)
 	})
 
@@ -228,7 +225,6 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		require.True(t, mockClient.DoCalled)
 		require.True(t, appAuthenticator.AuthenticateCalled)
 
-		require.True(t, token1.installationAccessToken.ExpiresAt.Equal(wantToken.ExpiresAt))
 		require.Equal(t, token1.installationAccessToken.Token, wantToken.Token)
 
 		// First we generate a new token for the mockClient so that we're sure
@@ -237,7 +233,6 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		require.NotEqual(t, mockClient.installationAccessToken, wantToken)
 		// Now we refresh token2 and assert that we get A DIFFERENT token from the cache
 		token2.Refresh(context.Background(), mockClient)
-		require.False(t, token1.installationAccessToken.ExpiresAt.Equal(token2.installationAccessToken.ExpiresAt))
 		require.NotEqual(t, token1.installationAccessToken.Token, token2.installationAccessToken.Token)
 		// For good measure, assert that token2 is not expired
 		require.False(t, token2.NeedsRefresh())

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -122,7 +122,7 @@ func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 		installationID,
 		appAuthenticator,
 	)
-	token.token = "installation-token"
+	token.Token = "installation-token"
 
 	req, err := http.NewRequest("GET", "https://api.github.com", nil)
 	require.NoError(t, err)
@@ -149,10 +149,10 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 
 	require.True(t, appAuthenticator.AuthenticateCalled)
 
-	require.Equal(t, token.token, "new-token")
+	require.Equal(t, token.Token, "new-token")
 	wantTime, err := time.Parse(time.RFC3339, "2016-07-11T22:14:10Z")
 	require.NoError(t, err)
-	require.True(t, token.expiresAt.Equal(wantTime))
+	require.True(t, token.ExpiresAt.Equal(wantTime))
 }
 
 func TestInstallationAccessToken_NeedsRefresh(t *testing.T) {
@@ -161,10 +161,10 @@ func TestInstallationAccessToken_NeedsRefresh(t *testing.T) {
 		needsRefresh bool
 	}{
 		"empty token":   {installationAccessToken{}, true},
-		"valid token":   {installationAccessToken{token: "abc123"}, false},
-		"not expired":   {installationAccessToken{token: "abc123", expiresAt: time.Now().Add(10 * time.Minute)}, false},
-		"expired":       {installationAccessToken{token: "abc123", expiresAt: time.Now().Add(-10 * time.Minute)}, true},
-		"expiring soon": {installationAccessToken{token: "abc123", expiresAt: time.Now().Add(3 * time.Minute)}, true},
+		"valid token":   {installationAccessToken{Token: "abc123"}, false},
+		"not expired":   {installationAccessToken{Token: "abc123", ExpiresAt: time.Now().Add(10 * time.Minute)}, false},
+		"expired":       {installationAccessToken{Token: "abc123", ExpiresAt: time.Now().Add(-10 * time.Minute)}, true},
+		"expiring soon": {installationAccessToken{Token: "abc123", ExpiresAt: time.Now().Add(3 * time.Minute)}, true},
 	}
 
 	for name, tc := range testCases {
@@ -181,7 +181,7 @@ func TestInstallationAccessToken_SetURLUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	it := installationAccessToken{token: token}
+	it := installationAccessToken{Token: token}
 	it.SetURLUser(u)
 
 	want := "x-access-token:abc123"

--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/github_apps/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/github_apps/types"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +50,7 @@ jSzka5UER3Dj1lSLMk9DkU+jrBxUsFeeiQOYhzQBaZxguvwYRIYHpg==
 func TestCreateEnterpriseFromConnection(t *testing.T) {
 	t.Run("returns OAuthBearerToken when GitHubAppDetails is nil", func(t *testing.T) {
 		ghAppsStore := store.NewMockGitHubAppsStore()
-		fromConnection := CreateEnterpriseFromConnection(ghAppsStore)
+		fromConnection := CreateEnterpriseFromConnection(ghAppsStore, keyring.Default().GitHubAppKey)
 
 		conn := &schema.GitHubConnection{
 			Token: "abc123",
@@ -70,7 +71,7 @@ func TestCreateEnterpriseFromConnection(t *testing.T) {
 		}
 		ghAppsStore := store.NewMockGitHubAppsStore()
 		ghAppsStore.GetByAppIDFunc.SetDefaultReturn(ghApp, nil)
-		fromConnection := CreateEnterpriseFromConnection(ghAppsStore)
+		fromConnection := CreateEnterpriseFromConnection(ghAppsStore, keyring.Default().GitHubAppKey)
 
 		conn := &schema.GitHubConnection{
 			GitHubAppDetails: &schema.GitHubAppDetails{
@@ -121,6 +122,7 @@ func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
 		u,
 		installationID,
 		appAuthenticator,
+		keyring.Default().GitHubAppKey,
 	)
 	token.installationAccessToken.Token = "installation-token"
 
@@ -140,6 +142,7 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 		u,
 		1,
 		appAuthenticator,
+		keyring.Default().GitHubAppKey,
 	)
 
 	mockClient := &mockHTTPClient{}


### PR DESCRIPTION
Closes #51025 

Adds a redis cache for GitHub App installation access tokens. Tokens are cached by the key `baseURL + installationID`, since we should not have more than one GitHub App per base URL. It won't play nice with our authenticator system, which assumes 1 authenticator per URL.

## Test plan

Tests should still pass. Also verified that the cache is being used locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
