### PR TITLE
ci: remove outdated ci tracing code + improve output

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,33 +1,12 @@
 #!/usr/bin/env bash
 
-set -eux
-
-# Honeycomb's buildevent plumbing.
-# -------------------------------
-
-echo "~~~ Setting up Honeycomb tracing for the build"
-
-envsubst <./enterprise/dev/ci/scripts/buildevent_file >.buildevent_file
-BUILDEVENT_FILE="$(pwd)/.buildevent_file"
-export BUILDEVENT_FILE
-
-# Record start time if we need to exit
-BUILD_START_TIME=$(curl --retry 10 --retry-delay 2 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORGANIZATION_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds/$BUILDKITE_BUILD_NUMBER/" | jq -r .started_at)
-
-# Convert to UTC & Epoch
-BUILD_START_TIME=$(TZ=UTC date -d "$BUILD_START_TIME" +'%s')
-export BUILD_START_TIME
-
-# Init the step
-STEP_START=$(date +'%s')
-export STEP_START
+set -eu
 
 # Create the folder for annotations
 mkdir -p ./annotations/
 
 # asdf setup
 # ----------
-
 if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" ]]; then
   echo "~~~ Preparing asdf dependencies"
 


### PR DESCRIPTION
The `set -x` was really messing out the output. This PR fixes it. 

I also removed along the way some ci tracing code that I forgot to drop in my previous PR. 

<img width="1161" alt="CleanShot 2023-04-25 at 18 18 32@2x" src="https://user-images.githubusercontent.com/10151/234339839-52ef47be-4a9e-4be8-85b8-85257f164518.png">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 