### PR TITLE
sg: improve cloud install

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ fd 8.6.0
 shfmt 3.5.0
 shellcheck 0.7.1
 kubectl 1.21.7
-github-cli 2.23.0
+github-cli 2.27.0
 packer 1.8.3
 trivy 0.30.3
 kustomize 4.5.7

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -32,77 +33,97 @@ var cloudCommand = &cli.Command{
 			Usage:       "Install or upgrade local `mi2` CLI (for Cloud V2)",
 			Description: "To learn more about Cloud V2, see https://handbook.sourcegraph.com/departments/cloud/technical-docs/v2.0/",
 			Action: func(c *cli.Context) error {
-				const executable = "mi2"
-
-				// Use the same directory as sg, since we add that to path
-				homeDir, err := os.UserHomeDir()
-				if err != nil {
+				if err := installCloudCLI(c.Context); err != nil {
 					return err
 				}
-				locationDir, err := sgInstallDir(homeDir)
-				if err != nil {
+				if err := checkGKEAuthPlugin(); err != nil {
 					return err
 				}
-
-				// Remove existing install if there is one
-				if existingPath, err := exec.LookPath(executable); err == nil {
-					// If this mi2 installation is installed elsewhere, remove it to
-					// avoid conflicts
-					if !strings.HasPrefix(existingPath, locationDir) {
-						std.Out.WriteNoticef("Removing existing installation at of %q at %q",
-							executable, existingPath)
-						_ = os.Remove(existingPath)
-					}
-				}
-
-				// Ensure gh is installed
-				if _, err := exec.LookPath("gh"); err != nil {
-					return errors.Wrap(err, "GitHub CLI (https://cli.github.com/) is required for installation")
-				}
-
-				version, err := run.Cmd(c.Context, "gh", "version").Run().String()
-				if err != nil {
-					return errors.Wrap(err, "get gh version")
-				}
-				std.Out.WriteNoticef("Using GitHub CLI version %q", strings.Split(version, "\n")[0])
-
-				start := time.Now()
-				pending := std.Out.Pending(output.Styledf(output.StylePending, "Downloading %q to %q... (hang tight, this might take a while!)",
-					executable, locationDir))
-
-				// Get release
-				const tempExecutable = "mi2_tmp"
-				_ = os.Remove(filepath.Join(locationDir, tempExecutable))
-				if err := run.Cmd(c.Context,
-					"gh release download -R github.com/sourcegraph/controller",
-					"--pattern", fmt.Sprintf("mi2_%s_%s", runtime.GOOS, runtime.GOARCH),
-					"--output", tempExecutable).
-					Dir(locationDir).
-					Run().Wait(); err != nil {
-					pending.Close()
-					return errors.Wrap(err, "download mi2")
-				}
-				pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess,
-					"Download complete! (elapsed: %s)",
-					time.Since(start).String()))
-
-				// Move binary to final destination
-				if err := run.Cmd(c.Context, "mv", tempExecutable, executable).
-					Dir(locationDir).
-					Run().Wait(); err != nil {
-					return errors.Wrap(err, "move mi2 to final path")
-				}
-
-				// Make binary executable
-				if err := run.Cmd(c.Context, "chmod +x", executable).
-					Dir(locationDir).
-					Run().Wait(); err != nil {
-					return errors.Wrap(err, "make mi2 executable")
-				}
-
-				std.Out.WriteSuccessf("%q successfully installed!", executable)
 				return nil
 			},
 		},
 	},
+}
+
+func checkGKEAuthPlugin() error {
+	const executable = "gke-gcloud-auth-plugin"
+	existingPath, err := exec.LookPath(executable)
+	if err != nil {
+		return errors.Wrap(err, "gcloud auth plugin is not installed, run `brew info google-cloud-sdk` for instructions")
+	}
+	std.Out.WriteNoticef("Using gcloud auth plugin at %q", existingPath)
+	return nil
+}
+
+func installCloudCLI(ctx context.Context) error {
+	const executable = "mi2"
+
+	// Use the same directory as sg, since we add that to path
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	locationDir, err := sgInstallDir(homeDir)
+	if err != nil {
+		return err
+	}
+
+	// Remove existing install if there is one
+	if existingPath, err := exec.LookPath(executable); err == nil {
+		// If this mi2 installation is installed elsewhere, remove it to
+		// avoid conflicts
+		if !strings.HasPrefix(existingPath, locationDir) {
+			std.Out.WriteNoticef("Removing existing installation at of %q at %q",
+				executable, existingPath)
+			_ = os.Remove(existingPath)
+		}
+	}
+
+	// Ensure gh is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return errors.Wrap(err, "GitHub CLI (https://cli.github.com/) is required for installation")
+	}
+
+	version, err := run.Cmd(ctx, "gh", "version").Run().String()
+	if err != nil {
+		return errors.Wrap(err, "get gh version")
+	}
+	std.Out.WriteNoticef("Using GitHub CLI version %q", strings.Split(version, "\n")[0])
+
+	start := time.Now()
+	pending := std.Out.Pending(output.Styledf(output.StylePending, "Downloading %q to %q... (hang tight, this might take a while!)",
+		executable, locationDir))
+
+	// Get release
+	const tempExecutable = "mi2_tmp"
+	_ = os.Remove(filepath.Join(locationDir, tempExecutable))
+	if err := run.Cmd(ctx,
+		"gh release download -R github.com/sourcegraph/controller",
+		"--pattern", fmt.Sprintf("mi2_%s_%s", runtime.GOOS, runtime.GOARCH),
+		"--output", tempExecutable).
+		Dir(locationDir).
+		Run().Wait(); err != nil {
+		pending.Close()
+		return errors.Wrap(err, "download mi2")
+	}
+	pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess,
+		"Download complete! (elapsed: %s)",
+		time.Since(start).String()))
+
+	// Move binary to final destination
+	if err := run.Cmd(ctx, "mv", tempExecutable, executable).
+		Dir(locationDir).
+		Run().Wait(); err != nil {
+		return errors.Wrap(err, "move mi2 to final path")
+	}
+
+	// Make binary executable
+	if err := run.Cmd(ctx, "chmod +x", executable).
+		Dir(locationDir).
+		Run().Wait(); err != nil {
+		return errors.Wrap(err, "make mi2 executable")
+	}
+
+	std.Out.WriteSuccessf("%q successfully installed!", executable)
+	return nil
 }


### PR DESCRIPTION
- add check to sg cloud install for gke-auth-plugin
- use os commands to install mi2, respect .tool-version



## Test plan
`sg cloud install` works when gh cli is installed via `asdf`

```
Using GitHub CLI at "/Users/dax/.asdf/shims/gh"
👉 Using GitHub CLI version "gh version 2.27.0 (2023-04-07)"
✅ Download complete! (elapsed: 1m43.361189375s)
✅ "mi2" successfully installed!
❌ gke-gcloud-auth-plugin not found on path, run `brew info google-cloud-sdk` for instructions OR
run `gcloud components install gke-gcloud-auth-plugin` to install it manually: exec: "gke-gcloud-auth-plugin": executable file not found in $PATH
exit status 1
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
