### PR TITLE
cody: update font size for context button

### DIFF
--- a/client/cody/webviews/Chat.module.css
+++ b/client/cody/webviews/Chat.module.css
@@ -41,6 +41,10 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     font-size: var(--vscode-editor-font-size);
 }
 
+.transcript-action > button {
+    font-size: var(--vscode-editor-font-size);
+}
+
 .code-blocks-copy-button {
     color: var(--vscode-button-secondaryForeground);
     background-color: var(--vscode-button-secondaryBackground);


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/50761

The font size for the context list was fixed in an older PR [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@94dfe9fac58f7190d002ed642d7291d9c18ab984/-/blob/client/cody/webviews/Chat.module.css?L41).

This PR update the font-size for the button to align with the rest of the UI:
![image](https://user-images.githubusercontent.com/68532117/234360323-0e2ab271-77cd-4601-bb07-3e83684f4f86.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See screenshot. tested locally