### PR TITLE
Embeddings: don't reload config in middle of job

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -18,7 +18,6 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -81,8 +80,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return err
 	}
 
-	client := embed.NewEmbeddingsClient()
-	getQueryEmbedding, err := getCachedQueryEmbeddingFn(client)
+	getQueryEmbedding, err := getCachedQueryEmbeddingFn()
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
+++ b/enterprise/cmd/embeddings/shared/query_embeddings_cache.go
@@ -12,7 +12,7 @@ import (
 const QUERY_EMBEDDING_RETRIES = 3
 const QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES = 128
 
-func getCachedQueryEmbeddingFn(client embed.EmbeddingsClient) (getQueryEmbeddingFn, error) {
+func getCachedQueryEmbeddingFn() (getQueryEmbeddingFn, error) {
 	cache, err := lru.New[string, []float32](QUERY_EMBEDDINGS_CACHE_MAX_ENTRIES)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating query embeddings cache")
@@ -22,6 +22,7 @@ func getCachedQueryEmbeddingFn(client embed.EmbeddingsClient) (getQueryEmbedding
 		if cachedQueryEmbedding, ok := cache.Get(query); ok {
 			queryEmbedding = cachedQueryEmbedding
 		} else {
+			client := embed.NewEmbeddingsClient()
 			queryEmbedding, err = client.GetEmbeddingsWithRetries(ctx, []string{query}, QUERY_EMBEDDING_RETRIES)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Before, the embeddings client live-reloaded the config whenever it changed. This wasn't safe, since parts of the config (number of dimensions, model, etc.) could change in the middle of a method. The config could also change in the middle of a job, leading to an inconsistent index state.

This commit improves things a bit by removing the live-reloading. Now the config stays the same for the duration of each request.

## Test plan

It's strictly a simplification and existing tests should cover this.