### PR TITLE
set msg in progress to null on restart

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -87,6 +87,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     public clearAndRestartSession(): void {
         this.createNewChatID()
         this.cancelCompletion()
+        this.isMessageInProgress = false
         this.transcript.reset()
         this.sendTranscript()
         this.sendChatHistory()


### PR DESCRIPTION
re-add  `this.isMessageInProgress = false` that was removed by mistake in my last PR:
https://github.com/sourcegraph/sourcegraph/pull/51005

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Minor change. Same test cases, all passing.