### PR TITLE
Fix last message appearing after assistant in progress finishes

### DIFF
--- a/client/cody-ui/src/chat/Transcript.tsx
+++ b/client/cody-ui/src/chat/Transcript.tsx
@@ -79,8 +79,7 @@ export const Transcript: React.FunctionComponent<
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             {transcript.map(
                 (message, index) =>
-                    message?.displayText &&
-                    (!messageInProgress || index !== transcript.length - 1) && (
+                    message?.displayText && (
                         <TranscriptItem
                             // eslint-disable-next-line react/no-array-index-key
                             key={index}


### PR DESCRIPTION
The removed condition assumes that the last message while the assistant is processing is an assistant processing message and thus excluded the final message in the transcript, but that is not correct as (at least in VSCode) the assistant processing message gets [explicitly removed from the transcript message array](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/cody/webviews/App.tsx?L36-47).

## Test plan

Tested in editor and in browser and it *seems* fine.

EDIT: Breaks scrolling to last message in browser