### PR TITLE
feat: Support sharded SCIP indexes in lib/codeintel/upload

### DIFF
--- a/lib/codeintel/upload/BUILD.bazel
+++ b/lib/codeintel/upload/BUILD.bazel
@@ -31,5 +31,8 @@ go_test(
         "upload_test.go",
     ],
     embed = [":upload"],
-    deps = ["@com_github_google_go_cmp//cmp"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/lib/codeintel/upload/upload_test.go
+++ b/lib/codeintel/upload/upload_test.go
@@ -87,7 +87,7 @@ func TestUploadIndex(t *testing.T) {
 	type testCase struct {
 		numShards int
 	}
-	testCases := []testCase{testCase{0}, testCase{3}}
+	testCases := []testCase{{0}, {3}}
 
 	makePayloadFile := func(dir string, pattern string) string {
 		f, err := os.CreateTemp(dir, pattern)

--- a/lib/codeintel/upload/upload_test.go
+++ b/lib/codeintel/upload/upload_test.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUploadIndex(t *testing.T) {
@@ -20,6 +22,10 @@ func TestUploadIndex(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		expectedPayload = append(expectedPayload, byte(i))
 	}
+	const (
+		lsifContentType        = "application/x-ndjson+lsif"
+		scipShardedContentType = "application/x-protobuf+scip-sharded"
+	)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload, err := io.ReadAll(r.Body)
@@ -27,8 +33,10 @@ func TestUploadIndex(t *testing.T) {
 			t.Fatalf("unexpected error reading request body: %s", err)
 		}
 
-		if r.Header.Get("Content-Type") != "application/x-ndjson+lsif" {
-			t.Fatalf("Content-Type header expected to be '%s', got '%s'", "application/x-ndjson+lsif", r.Header.Get("Content-Type"))
+		contentType := r.Header.Get("Content-Type")
+		if contentType != lsifContentType && contentType != scipShardedContentType {
+			t.Fatalf("Content-Type header expected to be '%s' or '%s', got '%s'",
+				lsifContentType, scipShardedContentType, r.Header.Get("Content-Type"))
 		}
 
 		if r.Header.Get("Authorization") != "token hunter2" {
@@ -44,44 +52,92 @@ func TestUploadIndex(t *testing.T) {
 			t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
 		}
 
-		if diff := cmp.Diff(expectedPayload, decompressed); diff != "" {
-			t.Errorf("unexpected request payload (-want +got):\n%s", diff)
+		if contentType == lsifContentType {
+			if diff := cmp.Diff(expectedPayload, decompressed); diff != "" {
+				t.Errorf("unexpected request payload (-want +got):\n%s", diff)
+			}
+		} else {
+			require.Equal(t, contentType, scipShardedContentType)
+			tarReader := tar.NewReader(bytes.NewReader(decompressed))
+			numFiles := 0
+			for {
+				header, err := tarReader.Next()
+				if err == io.EOF {
+					break
+				}
+				if header.Typeflag != tar.TypeReg {
+					continue
+				}
+				numFiles++
+				require.NoError(t, err, "malformed tar file")
+				buf := make([]byte, header.Size)
+				_, err = io.ReadFull(tarReader, buf)
+				require.NoError(t, err, "failed to read from tar file")
+				if diff := cmp.Diff(expectedPayload, buf); diff != "" {
+					t.Errorf("unexpected request payload (-want +got):\n%s", diff)
+				}
+			}
+			require.NotEqual(t, numFiles, 0)
 		}
-
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"42"}`))
 	}))
 	defer ts.Close()
 
-	f, err := os.CreateTemp("", "")
-	if err != nil {
-		t.Fatalf("unexpected error creating temp file: %s", err)
+	type testCase struct {
+		numShards int
 	}
-	defer func() { os.Remove(f.Name()) }()
-	_, _ = io.Copy(f, bytes.NewReader(expectedPayload))
-	_ = f.Close()
+	testCases := []testCase{testCase{0}, testCase{3}}
 
-	id, err := UploadIndex(context.Background(), f.Name(), http.DefaultClient, UploadOptions{
-		UploadRecordOptions: UploadRecordOptions{
-			Repo:    "foo/bar",
-			Commit:  "deadbeef",
-			Root:    "proj/",
-			Indexer: "lsif-go",
-		},
-		SourcegraphInstanceOptions: SourcegraphInstanceOptions{
-			SourcegraphURL:      ts.URL,
-			AccessToken:         "hunter2",
-			GitHubToken:         "ght",
-			MaxPayloadSizeBytes: 1000,
-			AdditionalHeaders:   map[string]string{"Content-Type": "application/x-ndjson+lsif"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error uploading index: %s", err)
+	makePayloadFile := func(dir string, pattern string) string {
+		f, err := os.CreateTemp(dir, pattern)
+		require.NoError(t, err, "failed to create temp file")
+		_, err = io.Copy(f, bytes.NewReader(expectedPayload))
+		require.NoError(t, err, "failed to write to temp file")
+		_ = f.Close()
+		return f.Name()
 	}
 
-	if id != 42 {
-		t.Errorf("unexpected id. want=%d have=%d", 42, id)
+	for _, testCase := range testCases {
+		var indexPath string
+		var contentType string
+		if testCase.numShards == 0 {
+			tmpFileName := makePayloadFile("", "")
+			contentType = lsifContentType
+			indexPath = tmpFileName
+		} else {
+			dir, err := os.MkdirTemp("", "")
+			require.NoError(t, err, "failed to create temp dir")
+			for i := 0; i < testCase.numShards; i++ {
+				_ = makePayloadFile(dir, "*.shard.scip")
+			}
+			contentType = scipShardedContentType
+			indexPath = dir
+		}
+		defer os.RemoveAll(indexPath)
+
+		id, err := UploadIndex(context.Background(), indexPath, http.DefaultClient, UploadOptions{
+			UploadRecordOptions: UploadRecordOptions{
+				Repo:    "foo/bar",
+				Commit:  "deadbeef",
+				Root:    "proj/",
+				Indexer: "lsif-go",
+			},
+			SourcegraphInstanceOptions: SourcegraphInstanceOptions{
+				SourcegraphURL:      ts.URL,
+				AccessToken:         "hunter2",
+				GitHubToken:         "ght",
+				MaxPayloadSizeBytes: 1000,
+				AdditionalHeaders:   map[string]string{"Content-Type": contentType},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error uploading index: %s", err)
+		}
+
+		if id != 42 {
+			t.Errorf("unexpected id. want=%d have=%d", 42, id)
+		}
 	}
 }
 


### PR DESCRIPTION
Since src-cli depends on this package for uploading stuff, and this
package also handles the gzipping logic, I figured it'd be the right
place for the tar creation logic too.

Some questions:
- Should the tar archive be saved to a temporary file on disk? Seems
  like unnecessary overhead, and I don't think there's much risk
  of OOM, since the indexer must've previously had all shards in
  memory earlier.
- Do we need to do any progress reporting here?

Handles one part of https://github.com/sourcegraph/scip/issues/143

## Test plan

- Added an automated test case to check that we're tarring the
   index if it points to a directory