### PR TITLE
Fixup rate limiter with redis < 7.0

### DIFF
--- a/enterprise/cmd/frontend/internal/completions/streaming/limiter.go
+++ b/enterprise/cmd/frontend/internal/completions/streaming/limiter.go
@@ -16,7 +16,6 @@ import (
 
 type RateLimiter interface {
 	TryAcquire(ctx context.Context) error
-	ReadQuota(ctx context.Context, userID int32) (count, limit int, _ error)
 }
 
 type RateLimitExceededError struct {
@@ -74,93 +73,52 @@ func (r *rateLimiter) TryAcquire(ctx context.Context) (err error) {
 		key = anonymousKey(ip)
 	}
 
-	// Check the current usage.
-	current, retryAfter, err := r.get(ctx, key)
-	if err != nil {
-		return errors.Wrap(err, "failed to read current rate limit usage")
-	}
-	// If the usage exceeds the maximum, we return an error. Consumers can check if
-	// the error is of type RateLimitExceededError and extract additional information
-	// like the limit and the time by when they should retry.
-	if current >= limit {
-		return RateLimitExceededError{
-			Limit:      limit,
-			Used:       current,
-			RetryAfter: retryAfter,
-		}
-	}
+	rstore := r.rstore.WithContext(ctx)
 
-	// Open a new connection to redis so we can run a MULTI command.
-	pool, ok := r.rstore.Pool()
-	if !ok {
-		return errors.New("redis pool is not available but rate limit has been configured")
-	}
-	conn, err := pool.Dial()
-	if err != nil {
-		return errors.Wrap(err, "failed to dial redis")
-	}
-	defer func() {
-		err = errors.Append(err, conn.Close())
-	}()
-
-	// Now that we validated that we want to let the user pass, let's increment
-	// the rate limit counter for the user.
+	// Let's increment the rate limit counter for the user.
 	// Note that the rate limiter _may_ allow slightly more requests than the configured
 	// limit, reading the current value and incrementing the rate limit counter are
 	// currently not an atomic operation.
-	if _, err := conn.Do("MULTI"); err != nil {
-		return errors.Wrap(err, "failed to start redis transaction")
-	}
-	// Increment the counter for the current user. If no record exists, redis will
-	// initialize it with 1.
-	if _, err := conn.Do("INCR", key); err != nil {
+	// We also don't use a transaction in here, because there is no good way to
+	// read the TTL without a lua script. This approach could slightly overcount the
+	// usage if redis requests after the INCR fail, but it will always recover safely.
+
+	// Check the current usage and increment the counter for the current user. If
+	// no record exists, redis will initialize it with 1.
+	currentUsage, err := rstore.Incr(key).Int()
+	if err != nil {
 		return errors.Wrap(err, "failed to increase rate limit counter")
 	}
 
 	// Set expiry on the key. If the key didn't exist prior to the previous INCR,
 	// it will set the expiry of the key to one hour.
-	// If it did exist before, it should have an expiry set already, so the NX makes
-	// sure that we don't overwrite it.
-	if _, err := conn.Do("EXPIRE", key, int(time.Hour/time.Second), "NX"); err != nil {
-		return errors.Wrap(err, "failed to set expiry for rate limit counter")
+	// If it did exist before, it should have an expiry set already, so the TTL > 0
+	// makes sure that we don't overwrite it and restart the 1h bucket.
+	ttl, err := rstore.TTL(key)
+	if err != nil {
+		return errors.Wrap(err, "failed to get TTL for rate limit counter")
+	}
+	if ttl <= 0 {
+		if err := rstore.Expire(key, int(time.Hour/time.Second)); err != nil {
+			return errors.Wrap(err, "failed to set expiry for rate limit counter")
+		}
 	}
 
-	// Submit the calls.
-	if _, err := conn.Do("EXEC"); err != nil {
-		return errors.Wrap(err, "failed to flush multi operation")
+	// If the usage exceeds the maximum, we return an error. Consumers can check if
+	// the error is of type RateLimitExceededError and extract additional information
+	// like the limit and the time by when they should retry.
+	if currentUsage > limit {
+		return RateLimitExceededError{
+			Limit: limit,
+			// Return the minimum value of currentUsage and limit to not return
+			// confusing values when the limit was exceeded. This method increases
+			// on every check, even if the limit was reached.
+			Used:       min(currentUsage, limit),
+			RetryAfter: time.Now().Add(time.Duration(ttl) * time.Second),
+		}
 	}
 
 	return nil
-}
-
-func (r *rateLimiter) ReadQuota(ctx context.Context, userID int32) (count, limit int, _ error) {
-	limit, _, err := r.get(ctx, userKey(userID))
-	if err != nil {
-		return 0, 0, err
-	}
-	configuredLimit, err := getConfiguredLimit(actor.WithActor(context.Background(), actor.FromUser(userID)), r.db)
-	if err != nil {
-		return 0, 0, err
-	}
-	return limit, configuredLimit, nil
-}
-
-func (r *rateLimiter) get(ctx context.Context, key string) (int, time.Time, error) {
-	rstore := r.rstore.WithContext(ctx)
-
-	rv := rstore.Get(key)
-	if rv.IsNil() {
-		return 0, time.Time{}, nil
-	}
-	count, err := rv.Int()
-	if err != nil {
-		return 0, time.Time{}, errors.Wrap(err, "failed to get request counter")
-	}
-	ttl, err := rstore.TTL(key)
-	if err != nil {
-		return 0, time.Time{}, errors.Wrap(err, "failed to get ttl of key")
-	}
-	return count, time.Now().Add(time.Duration(ttl) * time.Second), nil
 }
 
 func userKey(userID int32) string {
@@ -191,4 +149,11 @@ func getConfiguredLimit(ctx context.Context, db database.DB) (int, error) {
 	}
 
 	return 0, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -88,7 +88,7 @@ func (r *Cache) SetWithTTL(key string, b []byte, ttl int) {
 }
 
 func (r *Cache) Increase(key string) {
-	err := kv().Incr(r.rkeyPrefix() + key)
+	_, err := kv().Incr(r.rkeyPrefix() + key).Int()
 	if err != nil {
 		log15.Warn("failed to execute redis command", "cmd", "INCR", "error", err)
 		return

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -25,7 +25,7 @@ type KeyValue interface {
 	GetSet(key string, value any) Value
 	Set(key string, value any) error
 	SetEx(key string, ttlSeconds int, value any) error
-	Incr(key string) error
+	Incr(key string) Value
 	Del(key string) error
 
 	TTL(key string) (int, error)
@@ -180,8 +180,8 @@ func (r *redisKeyValue) SetEx(key string, ttlSeconds int, val any) error {
 	return r.do("SETEX", r.prefix+key, ttlSeconds, val).err
 }
 
-func (r *redisKeyValue) Incr(key string) error {
-	return r.do("INCR", r.prefix+key).err
+func (r *redisKeyValue) Incr(key string) Value {
+	return r.do("INCR", r.prefix+key)
 }
 
 func (r *redisKeyValue) Del(key string) error {

--- a/internal/redispool/keyvalue_test.go
+++ b/internal/redispool/keyvalue_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -55,8 +56,10 @@ func testKeyValue(t *testing.T, kv redispool.KeyValue) {
 
 		// Incr
 		require.Works(kv.Set("incr-set", 5))
-		require.Works(kv.Incr("incr-set"))
-		require.Works(kv.Incr("incr-unset"))
+		_, err := kv.Incr("incr-set").Int()
+		require.Works(err)
+		_, err = kv.Incr("incr-unset").Int()
+		require.Works(err)
 		require.Equal(kv.Get("incr-set"), 6)
 		require.Equal(kv.Get("incr-unset"), 1)
 	})
@@ -301,7 +304,8 @@ func testKeyValue(t *testing.T, kv redispool.KeyValue) {
 				require.Equal(kv.Get(k), errWrongType)
 				require.Equal(kv.GetSet(k, "2"), errWrongType)
 				require.Equal(kv.Get(k), errWrongType) // ensure GetSet didn't set
-				requireWrongType(kv.Incr(k))
+				_, err := kv.Incr(k).Int()
+				requireWrongType(err)
 			}
 
 			// Ensure we fail hashes when used against non hashes.

--- a/internal/redispool/naive.go
+++ b/internal/redispool/naive.go
@@ -95,7 +95,7 @@ func (kv *naiveKeyValue) SetEx(key string, ttlSeconds int, value any) error {
 	}).err
 }
 
-func (kv *naiveKeyValue) Incr(key string) error {
+func (kv *naiveKeyValue) Incr(key string) Value {
 	return kv.maybeUpdateGroup(redisGroupString, key, func(value redisValue, found bool) (redisValue, updaterOp, error) {
 		if !found {
 			return redisValue{
@@ -111,7 +111,7 @@ func (kv *naiveKeyValue) Incr(key string) error {
 
 		value.Reply = num + 1
 		return value, write, nil
-	}).err
+	})
 }
 
 func (kv *naiveKeyValue) Del(key string) error {


### PR DESCRIPTION
This was missed when implementing the initial rate limiter, we cannot use NX on the EXPIRE operation, because that's a 7.0+ operator only. Sourcegraph ships with redis 5 by default, so that will fail on dotcom.

Keegan and I brainstormed this approach together and concluded that we don't need the MULTI statement and do all in one go, so we can simply read the TTL and set expiry when it's not yet set.



## Test plan

Verified things still work correctly manually and by looking at what's been inserted to redis.