### PR TITLE
Cody: Escape generated HTML

### DIFF
--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -12,5 +12,8 @@ export function renderMarkdown(markdown: string): string {
     registerHighlightContributions()
 
     // Add Cody-specific Markdown rendering if needed.
-    return renderMarkdownCommon(markdown, { breaks: true })
+    return renderMarkdownCommon(markdown, {
+        breaks: true,
+        sanitize: true,
+    })
 }

--- a/client/cody-ui/src/terms.ts
+++ b/client/cody-ui/src/terms.ts
@@ -2,4 +2,4 @@
  * A paragraph describing the Cody terms.
  */
 export const CODY_TERMS_MARKDOWN =
-    '<small>By using Cody, you agree to its [license and privacy statement](https://about.sourcegraph.com/terms/cody-notice).</small>'
+    'By using Cody, you agree to its [license and privacy statement](https://about.sourcegraph.com/terms/cody-notice).'

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -59,6 +59,11 @@ export const renderMarkdown = (
         headerPrefix?: string
         /** Strip off any HTML and return a plain text string, useful for previews */
         plainText?: boolean
+        /**
+         * Wether to sanitize the output HTML or not.
+         * 🚨 SECURITY: defaults to false
+         **/
+        sanitize?: boolean
     } = {}
 ): string => {
     const tokenizer = new marked.Tokenizer()
@@ -73,7 +78,7 @@ export const renderMarkdown = (
     const rendered = marked(markdown, {
         gfm: true,
         breaks: options.breaks,
-        sanitize: false,
+        sanitize: typeof options.sanitize === 'undefined' ? false : options.sanitize,
         highlight: (code, language) => highlightCodeSafe(code, language),
         renderer: options.renderer,
         headerPrefix: options.headerPrefix ?? '',


### PR DESCRIPTION
Closes #50680

I'm not sure how much we trust Cody but that was a bit too much for my taste 🙈  

I did not get it to execute JS though (that luckily seems disabled by default when using `innerHTML`) -- That doesn't mean that it's not possible though, maybe some combination of `<img onload="">` would still fire, not 100% sure. Let's do a release after this is merged and when we have freed `main` from the current hiccups.

## Test plan

<img width="1092" alt="Screenshot 2023-04-26 at 11 09 57" src="https://user-images.githubusercontent.com/458591/234528256-e1563a63-d81e-4e99-b88e-b82e66250ba0.png">
<img width="629" alt="Screenshot 2023-04-26 at 11 07 25" src="https://user-images.githubusercontent.com/458591/234528268-d6387235-006c-4f04-a660-9786a4d3d1da.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
