### PR TITLE
Cody: Alternative implementation for markdown escaping

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -10,6 +10,7 @@ import { isError } from '../utils'
 
 import { BotResponseMultiplexer } from './bot-response-multiplexer'
 import { ChatClient } from './chat'
+import { escapeCodyMarkdown } from './markdown'
 import { getPreamble } from './preamble'
 import { getRecipe } from './recipes/browser-recipes'
 import { Transcript, TranscriptJSON } from './transcript'
@@ -113,7 +114,7 @@ export async function createClient({
 
         chatClient.chat(prompt, {
             onChange(rawText) {
-                const text = reformatBotMessage(rawText, responsePrefix)
+                const text = reformatBotMessage(escapeCodyMarkdown(rawText), responsePrefix)
                 transcript.addAssistantResponse(text)
 
                 sendTranscript()

--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -35,7 +35,7 @@ export function escapeCodyMarkdown(markdown: string): string {
             return line.line
         }
 
-        return line.line.replaceAll(/</g, '&lt;').replaceAll(/>/g, '&gt;')
+        return line.line.replaceAll(/&/g, '&amp;').replaceAll(/</g, '&lt;').replaceAll(/>/g, '&gt;')
     })
     return escapedMarkdownLines.join('\n')
 }

--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -2,18 +2,59 @@ import { registerHighlightContributions, renderMarkdown as renderMarkdownCommon 
 
 /**
  * Render Markdown to safe HTML.
- *
- * NOTE: This only works when called in an environment with the DOM. In the VS Code extension, it
- * only works in the webview context, not in the extension host context, because the latter lacks a
- * DOM. We could use isomorphic-dompurify for that, but that adds needless complexity for now. If
+
+ * NOTE: This only works when called in an environment with the DOM. In the VS
+ * Code extension, it only works in the webview context, not in the extension
+ * host context, because the latter lacks a DOM. We could use
+ * isomorphic-dompurify for that, but that adds needless complexity for now. If
  * that becomes necessary, we can add that.
  */
-export function renderMarkdown(markdown: string): string {
+export function renderCodyMarkdown(markdown: string): string {
     registerHighlightContributions()
 
     // Add Cody-specific Markdown rendering if needed.
     return renderMarkdownCommon(markdown, {
         breaks: true,
-        sanitize: true,
     })
+}
+
+/**
+ * Since Cody can write HTML in non-markdown blocks as well and we still want to
+ * present this output to the user, we manually scan over all non code block
+ * lines and replace HTML starting tags so that they are still visible in the
+ * resulting HTML. The final output will still be escaped by DOMPurify so this
+ * is only for visual purposes.
+ *
+ * 🚨 SECURITY: The final output of this should still be piped through
+ * `renderCodyMarkdown` to ensure all HTML is sanitized.
+ */
+export function escapeCodyMarkdown(markdown: string): string {
+    const markdownLines = parseMarkdown(markdown)
+    const escapedMarkdownLines = markdownLines.map(line => {
+        if (line.isCodeBlock) {
+            return line.line
+        }
+
+        return line.line.replaceAll(/</g, '&lt;').replaceAll(/>/g, '&gt;')
+    })
+    return escapedMarkdownLines.join('\n')
+}
+
+export interface MarkdownLine {
+    line: string
+    isCodeBlock: boolean
+}
+
+export function parseMarkdown(text: string): MarkdownLine[] {
+    const markdownLines: MarkdownLine[] = []
+    let isCodeBlock = false
+    for (const line of text.split('\n')) {
+        if (line.trim().startsWith('```')) {
+            markdownLines.push({ line, isCodeBlock: true })
+            isCodeBlock = !isCodeBlock
+        } else {
+            markdownLines.push({ line, isCodeBlock })
+        }
+    }
+    return markdownLines
 }

--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -1,3 +1,5 @@
+import { MarkdownLine, parseMarkdown } from '../chat/markdown'
+
 export interface HighlightedToken {
     type: 'file' | 'symbol'
     // Including leading/trailing whitespaces or quotes.
@@ -61,25 +63,6 @@ function deduplicateTokens(tokens: HighlightedToken[]): HighlightedToken[] {
         }
     }
     return deduplicatedTokens
-}
-
-interface MarkdownLine {
-    line: string
-    isCodeBlock: boolean
-}
-
-function parseMarkdown(text: string): MarkdownLine[] {
-    const markdownLines: MarkdownLine[] = []
-    let isCodeBlock = false
-    for (const line of text.split('\n')) {
-        if (line.trim().startsWith('```')) {
-            markdownLines.push({ line, isCodeBlock: true })
-            isCodeBlock = !isCodeBlock
-        } else {
-            markdownLines.push({ line, isCodeBlock })
-        }
-    }
-    return markdownLines
 }
 
 function detectFilePaths(

--- a/client/cody-ui/src/chat/CodeBlocks.tsx
+++ b/client/cody-ui/src/chat/CodeBlocks.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
 
-import { renderMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
+import { renderCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 
 import { CopyButtonProps } from '../Chat'
 
@@ -74,5 +74,5 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = ({
         }
     }, [copyButtonClassName, displayText, CopyButtonProps])
 
-    return <div dangerouslySetInnerHTML={{ __html: renderMarkdown(displayText) }} />
+    return useMemo(() => <div dangerouslySetInnerHTML={{ __html: renderCodyMarkdown(displayText) }} />, [displayText])
 }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 
 import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
+import { escapeCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 import { getPreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
 import { getRecipe } from '@sourcegraph/cody-shared/src/chat/recipes/vscode-recipes'
 import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
@@ -177,7 +178,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
         this.multiplexer.sub(BotResponseMultiplexer.DEFAULT_TOPIC, {
             onResponse: (content: string) => {
-                text += content
+                text += escapeCodyMarkdown(content)
                 this.transcript.addAssistantResponse(reformatBotMessage(text, responsePrefix))
                 this.sendTranscript()
                 return Promise.resolve()

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -178,8 +178,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
         this.multiplexer.sub(BotResponseMultiplexer.DEFAULT_TOPIC, {
             onResponse: (content: string) => {
-                text += escapeCodyMarkdown(content)
-                this.transcript.addAssistantResponse(reformatBotMessage(text, responsePrefix))
+                text += content
+                this.transcript.addAssistantResponse(reformatBotMessage(escapeCodyMarkdown(text), responsePrefix))
                 this.sendTranscript()
                 return Promise.resolve()
             },

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -4,6 +4,7 @@ import { VSCodeButton, VSCodeTextArea } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
+import { escapeCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import {
     Chat as ChatUI,
@@ -46,7 +47,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 }) => {
     const onSubmit = useCallback(
         (text: string) => {
-            vscodeAPI.postMessage({ command: 'submit', text })
+            vscodeAPI.postMessage({ command: 'submit', text: escapeCodyMarkdown(text) })
         },
         [vscodeAPI]
     )

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { TextFieldType } from '@vscode/webview-ui-toolkit/dist/text-field'
 import { VSCodeTextField, VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
-import { renderMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
+import { renderCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 import { CODY_TERMS_MARKDOWN } from '@sourcegraph/cody-ui/src/terms'
 
 import styles from './Login.module.css'
@@ -90,7 +90,10 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                     </a>
                 </div>
             </section>
-            <div className={styles.terms} dangerouslySetInnerHTML={{ __html: renderMarkdown(CODY_TERMS_MARKDOWN) }} />
+            <div
+                className={styles.terms}
+                dangerouslySetInnerHTML={{ __html: renderCodyMarkdown(CODY_TERMS_MARKDOWN) }}
+            />
         </div>
     )
 }

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -59,11 +59,6 @@ export const renderMarkdown = (
         headerPrefix?: string
         /** Strip off any HTML and return a plain text string, useful for previews */
         plainText?: boolean
-        /**
-         * Wether to sanitize the output HTML or not.
-         * 🚨 SECURITY: defaults to false
-         **/
-        sanitize?: boolean
     } = {}
 ): string => {
     const tokenizer = new marked.Tokenizer()
@@ -78,7 +73,6 @@ export const renderMarkdown = (
     const rendered = marked(markdown, {
         gfm: true,
         breaks: options.breaks,
-        sanitize: typeof options.sanitize === 'undefined' ? false : options.sanitize,
         highlight: (code, language) => highlightCodeSafe(code, language),
         renderer: options.renderer,
         headerPrefix: options.headerPrefix ?? '',

--- a/client/web/src/stores/codyChat.ts
+++ b/client/web/src/stores/codyChat.ts
@@ -6,6 +6,7 @@ import create from 'zustand'
 
 import { Client, createClient, ClientInit, Transcript, TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/client'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
+import { escapeCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { PrefilledOptions } from '@sourcegraph/cody-shared/src/editor/withPreselectedOptions'
 import { isErrorLike } from '@sourcegraph/common'
@@ -86,6 +87,7 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
         saveTranscriptHistory([])
     }
     const submitMessage = (text: string): void => {
+        text = escapeCodyMarkdown(text)
         const { client, onEvent, getChatContext } = get()
         if (client && !isErrorLike(client)) {
             const { codebase, filePath } = getChatContext()


### PR DESCRIPTION
This replaces #51144

The previous implementation was limiting in various factors:

- The `sanitze` option of the Markdown library is deprecated since forever. It actually logged a bunch of nasty warnings to the console. The recommended way to deal with escaping is by using a library (like `DOMPurify` in our case) _after_ the markdown step.  
  
  We already do the above, hooray! This means that in no point in time did we ever had a XSS vulnerability but only a style related issue.

  The problem is that sometimes Cody emits HTML outside of code blocks and any visual HTML is allowed by our current `DOMPurify` config. We could change this, but then we would have to maintain a complicated allowlist for all HTML tags generated in the markdown transformation and all compliant tags are removed. In addition to that, Cody could still emit these HTML events outside of code blocks. E.g. use this prompt "Write some HTML but don't use Markdown to format it". The rule of thumb here is that anything from cody should be relayed to the user 1:1, so we can neither remove nor "render" some tags (even if they are just empty `<div>` that do nothing). When Cody returns `<div>I’m a banana</div>` we want to surface the `<div>` string to the user.
- We have to support two use cases where we insert HTML into the message deliberately (and we will have more of these as we add more code intel goodies): Error messages and hallucination detection. I wanted to keep these abstractions similar to where they are though, as anything more complicated would require bigger restructurings.

Because of this, I came up with a different implementation: We have two clear boundaries of where these messages come from: Either form the Cody API endpoint _or_ from the user input (because similarly, if a user types `<div>I’m a banana</div>` into the input box and presses enter, it would be strange if only `I’m a banana` shows up in the prompt.). 

At these distinct places, we now call `escapeCodyMarkdown` which will replace `<` and `>` to `&lt;` and `&gt;` respectively (as long as the content is outside of a code block where we just leave it as-is. 

Remember: This is not a security related XSS prevention. We already do that because the output from the markdown parser is being escaped but `DOMPurify`. The goal here is just to preserve HTML tags in the prompt and relay them to the end user.

## ToDo

- [ ] Apply the same fix to the web client 

## Test plan

<img width="587" alt="Screenshot 2023-04-26 at 14 27 41" src="https://user-images.githubusercontent.com/458591/234578592-dfb1ff15-53b2-4b9b-b342-6e9dfeb55206.png">
<img width="619" alt="Screenshot 2023-04-26 at 14 17 13" src="https://user-images.githubusercontent.com/458591/234578597-9dc23401-62ac-43ca-b273-632c6fb9b2cf.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
