### PR TITLE
cody: Add Content security policy to webview

### DIFF
--- a/client/cody/index.html
+++ b/client/cody/index.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!-- DO NOT REMOVE THIS FILE -->
-		<!-- THIS IS THE ENTRY FILE FOR THE WEBVIEW -->
-		<title>Cody</title>
-	</head>
-	<body>
-		<div id="root"></div>
-		<script nonce="/nonce/" type="module" src="webviews/index.tsx"></script>
-	</body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!-- This content security policy also implicitly disables inline scripts and styles. -->
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource} 'nonce-{nonce}'; font-src {cspSource} 'nonce-{nonce}';"
+        />
+        <!-- DO NOT REMOVE THIS FILE -->
+        <!-- THIS IS THE ENTRY FILE FOR THE WEBVIEW -->
+        <title>Cody</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script nonce="{nonce}" type="module" src="webviews/index.tsx"></script>
+    </body>
 </html>

--- a/client/cody/index.html
+++ b/client/cody/index.html
@@ -6,7 +6,7 @@
         <!-- This content security policy also implicitly disables inline scripts and styles. -->
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource} 'nonce-{nonce}'; font-src {cspSource} 'nonce-{nonce}';"
+            content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src {cspSource};"
         />
         <!-- DO NOT REMOVE THIS FILE -->
         <!-- THIS IS THE ENTRY FILE FOR THE WEBVIEW -->
@@ -14,6 +14,6 @@
     </head>
     <body>
         <div id="root"></div>
-        <script nonce="{nonce}" type="module" src="webviews/index.tsx"></script>
+        <script type="module" src="webviews/index.tsx"></script>
     </body>
 </html>

--- a/client/cody/index.html
+++ b/client/cody/index.html
@@ -8,8 +8,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src {cspSource};"
         />
-        <!-- DO NOT REMOVE THIS FILE -->
-        <!-- THIS IS THE ENTRY FILE FOR THE WEBVIEW -->
+        <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
         <title>Cody</title>
     </head>
     <body>

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -445,7 +445,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         const bytes = await vscode.workspace.fs.readFile(root)
         const decoded = new TextDecoder('utf-8').decode(bytes)
         const resources = webviewView.webview.asWebviewUri(webviewPath)
-        const nonce = this.getNonce()
 
         // Set HTML for webview
         // This replace variables from the client/cody/dist/index.html with webview info
@@ -454,7 +453,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         // 3. Update URIs for content security policy to only allow specific scripts to be run
         webviewView.webview.html = decoded
             .replaceAll('./', `${resources.toString()}/`)
-            .replace('<script', `<script nonce=${nonce}`)
             .replaceAll('{cspSource}', webviewView.webview.cspSource)
 
         // Register webview
@@ -478,15 +476,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             return []
         }
         return this.transcript.toChat()
-    }
-
-    private getNonce(): string {
-        let text = ''
-        const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-        for (let i = 0; i < 32; i++) {
-            text += possible.charAt(Math.floor(Math.random() * possible.length))
-        }
-        return text
     }
 
     public dispose(): void {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -449,8 +449,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         // Set HTML for webview
         // This replace variables from the client/cody/dist/index.html with webview info
         // 1. Update URIs to load styles and scripts into webview (eg. path that starts with ./)
-        // 2. Add nonce to only allow specific scripts to be run
-        // 3. Update URIs for content security policy to only allow specific scripts to be run
+        // 2. Update URIs for content security policy to only allow specific scripts to be run
         webviewView.webview.html = decoded
             .replaceAll('./', `${resources.toString()}/`)
             .replaceAll('{cspSource}', webviewView.webview.cspSource)

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -455,7 +455,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         webviewView.webview.html = decoded
             .replaceAll('./', `${resources.toString()}/`)
             .replace('<script', `<script nonce=${nonce}`)
-            .replaceAll('{nonce}', nonce)
             .replaceAll('{cspSource}', webviewView.webview.cspSource)
 
         // Register webview


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/51147 
RE https://github.com/sourcegraph/sourcegraph/issues/50680

Add Content-Security-Policy to prevent scripts and styles injecting. Only trusted source from webview and scripts with the same nonce are allowed.

For more info: https://code.visualstudio.com/api/extension-guides/webview#content-security-policy

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Confirm it works with https://github.com/sourcegraph/sourcegraph/pull/51144. See below:
<table>
<tr>
<td>Before (v0.0.8)</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="500" alt="image" src="https://user-images.githubusercontent.com/68532117/234580957-438de06d-0835-436e-b630-316332ae6a48.png">
</td>
<td>
<img width="500" alt="Screenshot 2023-04-26 at 5 20 33 AM" src="https://user-images.githubusercontent.com/68532117/234581052-8ba2c436-f040-42cd-a8c8-266d9efcca65.png">
</td>
</tr>

<tr>
<td>
<img width="490" alt="Screenshot 2023-04-26 at 5 36 53 AM" src="https://user-images.githubusercontent.com/68532117/234581378-e6e41e9c-6d1e-4484-ada4-0a745fbe83cd.png">
</td>
<td>
<img width="590" alt="Screenshot 2023-04-26 at 5 37 02 AM" src="https://user-images.githubusercontent.com/68532117/234581405-9a032cd7-1ced-4b99-bb37-6850b34b3cc0.png">
</td>
</tr>
</table>