### PR TITLE
Add a step for Mac OS

### DIFF
--- a/doc/cody/troubleshooting.md
+++ b/doc/cody/troubleshooting.md
@@ -8,3 +8,19 @@ Here are common troubleshooting steps to run before filing Cody bugs on the [iss
 
 1. Ensure you are on the latest version of the [Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). You can run the VS Code command `Extensions: Check for Extension Updates` to check.
 1. Check the VS Code error console for relevant error messages. To open it, run the VS Code command `Developer: Toggle Developer Tools` and then look in the `Console` for relevant messages.
+
+### Errors trying to install Cody on MacOS
+
+If you are getting: 
+```
+Command 'Cody: Set Access Token' resulted in an error
+
+command 'cody.set-access-token' not found
+```
+1. Close VS Code
+2. Open Keychain Access.app 
+3. Search for `cody`
+4. Delete the `vscodesourcegraph.cody-ai` entry in the System keychain on the left. 
+5. Try opening VS Code again
+
+![](https://storage.googleapis.com/sourcegraph-assets/blog/cody-docs-troubleshooting-keychain-access.png)

--- a/doc/cody/troubleshooting.md
+++ b/doc/cody/troubleshooting.md
@@ -23,4 +23,4 @@ command 'cody.set-access-token' not found
 4. Delete the `vscodesourcegraph.cody-ai` entry in the System keychain on the left. 
 5. Try opening VS Code again
 
-![](https://storage.googleapis.com/sourcegraph-assets/blog/cody-docs-troubleshooting-keychain-access.png)
+![Opening up Keychain Access](https://storage.googleapis.com/sourcegraph-assets/blog/cody-docs-troubleshooting-keychain-access.png)


### PR DESCRIPTION
Keychain access error

## Test plan

* Validate Markdown

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
