### PR TITLE
Cody settings trailing slash fixed

### DIFF
--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -23,7 +23,8 @@ function sanitizeCodebase(codebase: string | undefined): string {
         return ''
     }
     const protocolRegexp = /^(https?):\/\//
-    return codebase.replace(protocolRegexp, '')
+    const trailingSlashRegexp = /\/$/
+    return codebase.replace(protocolRegexp, '').trim().replace(trailingSlashRegexp, '')
 }
 
 function sanitizeServerEndpoint(serverEndpoint: string): string {


### PR DESCRIPTION
This PR is for issue #51155. While adding the codebase name with a trailing "/" it was showing as an error. This PR fixed this bug, now it accepts codebase name either with "/" or not with it.


## Test plan
All the unit and integration tests have been passed.
Tested the behaviour manually it works fine.
