### PR TITLE
perforce: Display changelists in repo and view commits page

### DIFF
--- a/client/branded/src/search-ui/components/CommitSearchResult.tsx
+++ b/client/branded/src/search-ui/components/CommitSearchResult.tsx
@@ -60,7 +60,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                     {result.oid.slice(0, 7)}
                     <VisuallyHidden>,</VisuallyHidden>
                 </Code>{' '}
-                <VisuallyHidden>Commited</VisuallyHidden>
+                <VisuallyHidden>Committed</VisuallyHidden>
                 {/* Display commit date in UTC to match behavior of before/after filters */}
                 <Timestamp date={result.committerDate} noAbout={true} strict={true} utc={true} />
             </Link>

--- a/client/vscode/src/webview/search-panel/alias/CommitSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/CommitSearchResult.tsx
@@ -72,7 +72,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                         {result.oid.slice(0, 7)}
                         <VisuallyHidden>,</VisuallyHidden>
                     </Code>{' '}
-                    <VisuallyHidden>Commited</VisuallyHidden>
+                    <VisuallyHidden>Committed</VisuallyHidden>
                     <Timestamp date={result.authorDate} noAbout={true} strict={true} />
                 </Button>
             )}

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1285,6 +1285,7 @@ ts_project(
         "src/repo/tree/TreePage.tsx",
         "src/repo/tree/TreePageContent.tsx",
         "src/repo/tree/TreePagePanels.tsx",
+        "src/repo/utils.tsx",
         "src/routes.constants.ts",
         "src/routes.tsx",
         "src/savedSearches/SavedSearchCreateForm.tsx",

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -4,7 +4,7 @@ import { of } from 'rxjs'
 import { mockAuthenticatedUser } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
 
 import { WebStory } from '../../../components/WebStory'
-import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
+import { RepoBatchChange, RepositoryFields, RepositoryType } from '../../../graphql-operations'
 import { queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs } from '../detail/backend'
 
 import {
@@ -25,6 +25,7 @@ const repoDefaults: RepositoryFields = {
     url: 'http://test.test/awesome',
     isFork: false,
     metadata: [],
+    sourceType: RepositoryType.GIT_REPOSITORY,
 }
 
 const queryRepoBatchChangeStats: typeof _queryRepoBatchChangeStats = () =>

--- a/client/web/src/enterprise/own/RepositoryOwnPageContents.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPageContents.tsx
@@ -95,8 +95,8 @@ export const RepositoryOwnPageContents: React.FunctionComponent<
                     {codeownersIngestedFile && (
                         <Text className={styles.commitWarning}>
                             <em>
-                                Any commited CODEOWNERS file in this repository will be ignored unless the uploaded file
-                                is deleted.
+                                Any committed CODEOWNERS file in this repository will be ignored unless the uploaded
+                                file is deleted.
                             </em>
                         </Text>
                     )}

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -3,6 +3,7 @@ import { subDays } from 'date-fns'
 import {
     DiffHunkLineType,
     ExternalServiceKind,
+    RepositoryType,
     SharedGraphQlOperations,
 } from '@sourcegraph/shared/src/graphql-operations'
 import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
@@ -24,11 +25,13 @@ describe('RepositoryCommitPage', () => {
         RepositoryCommit: () => ({
             node: {
                 __typename: 'Repository',
+                sourceType: RepositoryType.GIT_REPOSITORY,
                 commit: {
                     __typename: 'GitCommit',
                     id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3pOamd3T1RJMU1BPT0iLCJjIjoiMWU3YmQwMDBlNzhjZjM1YzZlMWJlMWI5ZjE1MTBiNGFhZGZhYTQxNiJ9',
                     oid: '1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416',
                     abbreviatedOID: '1e7bd00',
+                    perforceChangelist: null,
                     message: 'Signup copy adjustment (#43435)\n\nCopy adjustment',
                     subject: 'Signup copy adjustment (#43435)',
                     body: 'Copy adjustment',
@@ -263,6 +266,7 @@ describe('RepositoryCommitPage', () => {
                 id: 'UmVwb3NpdG9yeTozNjgwOTI1MA==',
                 name: 'github.com/sourcegraph/sourcegraph',
                 url: '/github.com/sourcegraph/sourcegraph',
+                sourceType: RepositoryType.GIT_REPOSITORY,
                 externalURLs: [
                     {
                         url: 'https://github.com/sourcegraph/sourcegraph',

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -70,6 +70,7 @@ describe('RepositoryCommitPage', () => {
                             __typename: 'GitCommit',
                             oid: '56ab377d94fe96c87bc8c5e26675c585f9312e64',
                             abbreviatedOID: '56ab377',
+                            perforceChangelist: null,
                             url: '/github.com/sourcegraph/sourcegraph/-/commit/56ab377d94fe96c87bc8c5e26675c585f9312e64',
                         },
                     ],

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -1,6 +1,6 @@
 import { encodeURIPathComponent } from '@sourcegraph/common'
 import { JsonDocument } from '@sourcegraph/shared/src/codeintel/scip'
-import { TreeEntriesResult } from '@sourcegraph/shared/src/graphql-operations'
+import { RepositoryType, TreeEntriesResult } from '@sourcegraph/shared/src/graphql-operations'
 
 import {
     BlobResult,
@@ -81,6 +81,7 @@ export const createResolveRepoRevisionResult = (treeUrl: string, oid = '1'.repea
         id: `RepositoryID:${treeUrl}`,
         name: treeUrl,
         url: `/${encodeURIPathComponent(treeUrl)}`,
+        sourceType: RepositoryType.GIT_REPOSITORY,
         externalURLs: [
             {
                 url: new URL(`https://${encodeURIPathComponent(treeUrl)}`).href,
@@ -109,6 +110,7 @@ export const createResolveCloningRepoRevisionResult = (
         id: `RepositoryID:${treeUrl}`,
         name: treeUrl,
         url: `/${encodeURIPathComponent(treeUrl)}`,
+        sourceType: RepositoryType.GIT_REPOSITORY,
         externalURLs: [
             {
                 url: new URL(`https://${encodeURIPathComponent(treeUrl)}`).href,

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import { subDays } from 'date-fns'
 
 import { encodeURIPathComponent } from '@sourcegraph/common'
-import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
+import { RepositoryType, SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
@@ -45,6 +45,7 @@ export const getCommonRepositoryGraphQlResults = (
     TreeCommits: () => ({
         node: {
             __typename: 'Repository',
+            sourceType: RepositoryType.GIT_REPOSITORY,
             externalURLs: [
                 {
                     __typename: 'ExternalLink',
@@ -102,6 +103,7 @@ describe('Repository', () => {
                 TreeCommits: () => ({
                     node: {
                         __typename: 'Repository',
+                        sourceType: RepositoryType.GIT_REPOSITORY,
                         externalURLs: [
                             {
                                 __typename: 'ExternalLink',
@@ -117,6 +119,7 @@ describe('Repository', () => {
                                         id: 'CommitID1',
                                         oid: '15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
                                         abbreviatedOID: '15c2290',
+                                        perforceChangelist: null,
                                         message: 'update LSIF indexing CI workflow\n',
                                         subject: 'update LSIF indexing CI workflow',
                                         body: null,
@@ -146,11 +149,13 @@ describe('Repository', () => {
                                             {
                                                 oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                                 abbreviatedOID: '96c4efa',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/jsonrpc2/-/commit/96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                             },
                                             {
                                                 oid: '9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                                 abbreviatedOID: '9e615b1',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/jsonrpc2/-/commit/9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                             },
                                         ],
@@ -172,6 +177,7 @@ describe('Repository', () => {
                                         id: 'CommitID2',
                                         oid: '9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                         abbreviatedOID: '9e615b1',
+                                        perforceChangelist: null,
                                         message: 'LSIF Indexing Campaign',
                                         subject: 'LSIF Indexing Campaign',
                                         body: null,
@@ -201,6 +207,7 @@ describe('Repository', () => {
                                             {
                                                 oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                                 abbreviatedOID: '96c4efa',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/jsonrpc2/-/commit/96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                             },
                                         ],
@@ -223,6 +230,7 @@ describe('Repository', () => {
                                         id: 'CommitID3',
                                         oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                         abbreviatedOID: '96c4efa',
+                                        perforceChangelist: null,
                                         message:
                                             'Produce LSIF data for each commit for fast/precise code nav (#35)\n\n* Produce LSIF data for each commit for fast/precise code nav\r\n\r\n* Update lsif.yml\r',
                                         subject: 'Produce LSIF data for each commit for fast/precise code nav (#35)',
@@ -258,6 +266,7 @@ describe('Repository', () => {
                                             {
                                                 oid: 'cee7209801bf50cee868f8e0696ba0b76ae21792',
                                                 abbreviatedOID: 'cee7209',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/jsonrpc2/-/commit/cee7209801bf50cee868f8e0696ba0b76ae21792',
                                             },
                                         ],
@@ -284,11 +293,13 @@ describe('Repository', () => {
                 RepositoryCommit: () => ({
                     node: {
                         __typename: 'Repository',
+                        sourceType: RepositoryType.GIT_REPOSITORY,
                         commit: {
                             __typename: 'GitCommit',
                             id: 'CommitID1',
                             oid: '15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
                             abbreviatedOID: '15c2290',
+                            perforceChangelist: null,
                             message: 'update LSIF indexing CI workflow\n',
                             subject: 'update LSIF indexing CI workflow',
                             body: null,
@@ -321,12 +332,14 @@ describe('Repository', () => {
                                     __typename: 'GitCommit',
                                     oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                     abbreviatedOID: '96c4efa',
+                                    perforceChangelist: null,
                                     url: '/github.com/sourcegraph/jsonrpc2/-/commit/96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                 },
                                 {
                                     __typename: 'GitCommit',
                                     oid: '9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                     abbreviatedOID: '9e615b1',
+                                    perforceChangelist: null,
                                     url: '/github.com/sourcegraph/jsonrpc2/-/commit/9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                 },
                             ],
@@ -654,6 +667,7 @@ describe('Repository', () => {
                     __typename: 'Query',
                     node: {
                         __typename: 'Repository',
+                        sourceType: RepositoryType.GIT_REPOSITORY,
                         externalURLs: [
                             {
                                 __typename: 'ExternalLink',
@@ -671,6 +685,7 @@ describe('Repository', () => {
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6IjI4NGFiYTAyNGIxYjU1ODU5MGU4ZTJmOTdkYmMzNTUzYTVlMGM3NmIifQ==',
                                         oid: '284aba024b1b558590e8e2f97dbc3553a5e0c76b',
                                         abbreviatedOID: '284aba0',
+                                        perforceChangelist: null,
                                         message: 'sg: create a test command to run e2e tests locally (#34627)\n',
                                         subject: 'sg: create a test command to run e2e tests locally (#34627)',
                                         body: null,
@@ -702,6 +717,7 @@ describe('Repository', () => {
                                             {
                                                 oid: 'a2d1fd474d79dc29af6c7b4c33f02fe22287bd11',
                                                 abbreviatedOID: 'a2d1fd4',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/sourcegraph/-/commit/a2d1fd474d79dc29af6c7b4c33f02fe22287bd11',
                                             },
                                         ],
@@ -724,6 +740,7 @@ describe('Repository', () => {
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6ImEyZDFmZDQ3NGQ3OWRjMjlhZjZjN2I0YzMzZjAyZmUyMjI4N2JkMTEifQ==',
                                         oid: 'a2d1fd474d79dc29af6c7b4c33f02fe22287bd11',
                                         abbreviatedOID: 'a2d1fd4',
+                                        perforceChangelist: null,
                                         message:
                                             'Wildcard V2: <Checkbox /> migration (#34324)\n\nCo-authored-by: gitstart-sourcegraph <gitstart@users.noreply.github.com>',
                                         subject: 'Wildcard V2: <Checkbox /> migration (#34324)',
@@ -756,6 +773,7 @@ describe('Repository', () => {
                                             {
                                                 oid: '3a163b92b5c45921fbc730ff2047ff7e60d8689b',
                                                 abbreviatedOID: '3a163b9',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/sourcegraph/-/commit/3a163b92b5c45921fbc730ff2047ff7e60d8689b',
                                             },
                                         ],
@@ -778,6 +796,7 @@ describe('Repository', () => {
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6IjNhMTYzYjkyYjVjNDU5MjFmYmM3MzBmZjIwNDdmZjdlNjBkODY4OWIifQ==',
                                         oid: '3a163b92b5c45921fbc730ff2047ff7e60d8689b',
                                         abbreviatedOID: '3a163b9',
+                                        perforceChangelist: null,
                                         message: 'web: ban `reactstrap` imports (#34881)\n',
                                         subject: 'web: ban `reactstrap` imports (#34881)',
                                         body: null,
@@ -809,6 +828,7 @@ describe('Repository', () => {
                                             {
                                                 oid: 'e2e91f0dcdc90811c4f2f4df638bc459b2358e7d',
                                                 abbreviatedOID: 'e2e91f0',
+                                                perforceChangelist: null,
                                                 url: '/github.com/sourcegraph/sourcegraph/-/commit/e2e91f0dcdc90811c4f2f4df638bc459b2358e7d',
                                             },
                                         ],
@@ -1218,6 +1238,7 @@ describe('Repository', () => {
                     }),
                     RepositoryComparisonCommits: () => ({
                         node: {
+                            sourceType: RepositoryType.GIT_REPOSITORY,
                             comparison: {
                                 commits: {
                                     nodes: [
@@ -1225,6 +1246,7 @@ describe('Repository', () => {
                                             id: '1'.repeat(70),
                                             oid: '1'.repeat(40),
                                             abbreviatedOID: '1'.repeat(7),
+                                            perforceChangelist: null,
                                             message: 'update README',
                                             subject: 'update README',
                                             body: null,
@@ -1262,6 +1284,7 @@ describe('Repository', () => {
                                                 {
                                                     oid: '2'.repeat(40),
                                                     abbreviatedOID: '2'.repeat(7),
+                                                    perforceChangelist: null,
                                                     url: '/github.com/sourcegraph/sourcegraph@2'.repeat(70),
                                                 },
                                             ],

--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -37,6 +37,7 @@ export const repositoryFragment = gql`
         id
         name
         url
+        sourceType
         externalURLs {
             url
             serviceKind

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -4,13 +4,14 @@ import { Meta, Story } from '@storybook/react'
 import { getDocumentNode } from '@sourcegraph/http-client'
 
 import { WebStory } from '../../../components/WebStory'
-import { ExternalServiceKind, FetchOwnersAndHistoryResult } from '../../../graphql-operations'
+import { ExternalServiceKind, FetchOwnersAndHistoryResult, RepositoryType } from '../../../graphql-operations'
 
 import { FETCH_OWNERS_AND_HISTORY } from './grapqlQueries'
 import { HistoryAndOwnBar } from './HistoryAndOwnBar'
 
 const barData: FetchOwnersAndHistoryResult = {
     node: {
+        sourceType: RepositoryType.GIT_REPOSITORY,
         commit: {
             blob: {
                 ownership: {
@@ -62,6 +63,7 @@ const barData: FetchOwnersAndHistoryResult = {
                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hNRGN3Tnc9PSIsImMiOiIxNzQxZmMyYzZlYjhlMTFmNGU3ODZjY2M1YzE5YzBkYTMyNzYzMGE1In0=',
                         oid: '1741fc2c6eb8e11f4e786ccc5c19c0da327630a5',
                         abbreviatedOID: '1741fc2',
+                        perforceChangelist: null,
                         message:
                             'build: Drop use of G_DISABLE_DEPRECATED from the build system\n\nIt’s no longer used in any of the headers. See preceding commits.\n\nSigned-off-by: Philip Withnall \u003Cwithnall@endlessm.com\u003E',
                         subject: 'build: Drop use of G_DISABLE_DEPRECATED from the build system',
@@ -94,6 +96,7 @@ const barData: FetchOwnersAndHistoryResult = {
                             {
                                 oid: '99b412bb192c0062753cbf960169b1f99335080f',
                                 abbreviatedOID: '99b412b',
+                                perforceChangelist: null,
                                 url: '/ghe.sgdev.org/sourcegraph/GNOME-glib/-/commit/99b412bb192c0062753cbf960169b1f99335080f',
                                 __typename: 'GitCommit',
                             },

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -68,6 +68,7 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
     query FetchOwnersAndHistory($repo: ID!, $revision: String!, $currentPath: String!) {
         node(id: $repo) {
             ... on Repository {
+                sourceType
                 commit(rev: $revision) {
                     blob(path: $currentPath) {
                         ownership(first: 2) {

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -33,6 +33,7 @@ const COMMIT_QUERY = gql`
         node(id: $repo) {
             __typename
             ... on Repository {
+                sourceType
                 commit(rev: $revspec) {
                     __typename # Necessary for error handling to check if commit exists
                     ...GitCommitFields

--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -141,6 +141,7 @@
     display: block;
     /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     margin-top: 2px;
+    min-width: 1.85rem;
 }
 
 .sha-and-parents {

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -24,6 +24,7 @@ const gitCommitNode: GitCommitFields = {
     id: 'commit123',
     abbreviatedOID: 'abcdefg',
     oid: 'abcdefghijklmnopqrstuvwxyz12345678904321',
+    perforceChangelist: null,
     author: {
         date: subDays(new Date(), 5).toISOString(),
         person: {
@@ -59,6 +60,7 @@ const gitCommitNode: GitCommitFields = {
         {
             abbreviatedOID: '987654',
             oid: '98765432101234abcdefghijklmnopqrstuvwxyz',
+            perforceChangelist: null,
             url: '/commits/987654',
         },
     ],
@@ -181,3 +183,80 @@ export const ExpandCommitMessageButtonHidden: Story = () => (
 )
 
 ExpandCommitMessageButtonHidden.storyName = 'Expand commit message btn hidden'
+
+const perforceChangelistNode: GitCommitFields = {
+    id: 'commit123',
+    abbreviatedOID: 'abcdefg',
+    oid: 'abcdefghijklmnopqrstuvwxyz12345678904321',
+    perforceChangelist: {
+        __typename: 'PerforceChangelist',
+        cid: '12345',
+    },
+    author: {
+        date: subDays(new Date(), 5).toISOString(),
+        person: {
+            avatarURL: 'http://test.test/useravatar',
+            displayName: 'alice',
+            email: 'alice@sourcegraph.com',
+            name: 'Alice',
+            user: {
+                id: 'alice123',
+                url: '/users/alice',
+                displayName: 'Alice',
+                username: 'alice',
+            },
+        },
+    },
+    committer: {
+        date: subDays(new Date(), 5).toISOString(),
+        person: {
+            avatarURL: 'http://test.test/useravatar',
+            displayName: 'alice',
+            email: 'alice@sourcegraph.com',
+            name: 'Alice',
+            user: {
+                id: 'alice123',
+                url: '/users/alice',
+                displayName: 'Alice',
+                username: 'alice',
+            },
+        },
+    },
+    body: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
+    parents: [
+        {
+            abbreviatedOID: '987654',
+            oid: '98765432101234abcdefghijklmnopqrstuvwxyz',
+            perforceChangelist: {
+                __typename: 'PerforceChangelist',
+                cid: '12344',
+            },
+            url: '/commits/987654',
+        },
+    ],
+    subject: 'Super awesome commit',
+    url: '/commits/abcdefg',
+    tree: null,
+    canonicalURL: 'asd',
+    externalURLs: [],
+    message:
+        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore.',
+}
+
+export const PerforceChangelist: Story = () => (
+    <WebStory>
+        {() => (
+            <Card>
+                <GitCommitNode
+                    node={perforceChangelistNode}
+                    compact={false}
+                    expandCommitMessageBody={false}
+                    showSHAAndParentsRow={false}
+                    hideExpandCommitMessageBody={true}
+                />
+            </Card>
+        )}
+    </WebStory>
+)
+
+PerforceChangelist.storyName = 'Perforce changelist'

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -3,6 +3,7 @@ import React, { useState, useCallback } from 'react'
 import { mdiDotsHorizontal, mdiContentCopy, mdiFileDocument } from '@mdi/js'
 import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
+import { capitalize } from 'lodash'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
@@ -14,6 +15,7 @@ import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { DiffModeSelector } from '../commit/DiffModeSelector'
 import { DiffMode } from '../commit/RepositoryCommitPage'
 import { Linkified } from '../linkifiy/Linkified'
+import { SourceTypeGitRepository, SourceTypePerforceDepot, getRefType, isPerforceDepotSource } from '../utils'
 
 import { GitCommitNodeByline } from './GitCommitNodeByline'
 
@@ -83,21 +85,29 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
+    const sourceType = node.perforceChangelist ? SourceTypePerforceDepot : SourceTypeGitRepository
+    const isPerforceDepot = isPerforceDepotSource(sourceType)
+    const abbreviatedRefID = node.perforceChangelist?.cid ?? node.abbreviatedOID
+    const refID = node.perforceChangelist?.cid ?? node.oid
+
     const toggleShowCommitMessageBody = useCallback((): void => {
         eventLogger.log('CommitBodyToggled')
         setShowCommitMessageBody(!showCommitMessageBody)
     }, [showCommitMessageBody])
 
-    const copyToClipboard = useCallback((oid: string): void => {
-        eventLogger.log('CommitSHACopiedToClipboard')
-        copy(oid)
-        setFlashCopiedToClipboardMessage(true)
-        screenReaderAnnounce('Copied!')
+    const copyToClipboard = useCallback(
+        (oid: string): void => {
+            eventLogger.log(isPerforceDepot ? 'ChangelistIDCopiedToClipboard' : 'CommitSHACopiedToClipboard')
+            copy(oid)
+            setFlashCopiedToClipboardMessage(true)
+            screenReaderAnnounce('Copied!')
 
-        setTimeout(() => {
-            setFlashCopiedToClipboardMessage(false)
-        }, 1500)
-    }, [])
+            setTimeout(() => {
+                setFlashCopiedToClipboardMessage(false)
+            }, 1500)
+        },
+        [isPerforceDepot]
+    )
 
     if (extraCompact) {
         // Implied by extraCompact
@@ -166,21 +176,26 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             messageElement={messageElement}
             commitMessageBody={commitMessageBody}
             preferAbsoluteTimestamps={preferAbsoluteTimestamps}
+            isPerforceDepot={isPerforceDepot}
         />
     )
+
+    // Handling commits as git-commits is the default behaviour.
+    const refType = getRefType(sourceType)
+    const copyMessage = isPerforceDepot ? 'Copy changelist ID' : 'Copy full SHA'
 
     const shaDataElement = showSHAAndParentsRow && (
         <div className={classNames('w-100', styles.shaAndParents)}>
             <div className="d-flex mb-1">
-                <span className={styles.shaAndParentsLabel}>Commit:</span>
+                <span className={styles.shaAndParentsLabel}>{capitalize(refType)}:</span>
                 <Code className={styles.shaAndParentsSha}>
-                    {node.oid}{' '}
-                    <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}>
+                    {refID}{' '}
+                    <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : copyMessage}>
                         <Button
                             variant="icon"
                             className={styles.shaAndParentsCopy}
-                            onClick={() => copyToClipboard(node.oid)}
-                            aria-label="Copy full SHA"
+                            onClick={() => copyToClipboard(refID)}
+                            aria-label={copyMessage}
                         >
                             <Icon aria-hidden={true} svgPath={mdiContentCopy} />
                         </Button>
@@ -199,14 +214,14 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                         {node.parents.map(parent => (
                             <div className="d-flex" key={parent.oid}>
                                 <Link className={styles.shaAndParentsParent} to={parent.url}>
-                                    <Code>{parent.oid}</Code>
+                                    <Code>{parent.perforceChangelist?.cid ?? parent.oid}</Code>
                                 </Link>
-                                <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}>
+                                <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : copyMessage}>
                                     <Button
                                         variant="icon"
                                         className={styles.shaAndParentsCopy}
-                                        onClick={() => copyToClipboard(parent.oid)}
-                                        aria-label="Copy full SHA"
+                                        onClick={() => copyToClipboard(parent.perforceChangelist?.cid ?? parent.oid)}
+                                        aria-label={copyMessage}
                                     >
                                         <Icon aria-hidden={true} svgPath={mdiContentCopy} />
                                     </Button>
@@ -215,7 +230,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                         ))}
                     </>
                 ) : (
-                    '(root commit)'
+                    `(root ${refType})`
                 )}
             </div>
         </div>
@@ -241,7 +256,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     as={Link}
                 >
                     <Icon className="mr-1" aria-hidden={true} svgPath={mdiFileDocument} />
-                    Browse files at @{node.abbreviatedOID}
+                    Browse files at @{abbreviatedRefID}
                 </Button>
             </Tooltip>
             {diffModeSelector()}
@@ -250,7 +265,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
 
     const oidElement = (
         <Code className={styles.oid} data-testid="git-commit-node-oid">
-            {node.abbreviatedOID}
+            {abbreviatedRefID}
         </Code>
     )
 
@@ -273,19 +288,17 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                                 {!showSHAAndParentsRow && (
                                     <div>
                                         <ButtonGroup className="mr-2">
-                                            <Tooltip content="View this commit">
+                                            <Tooltip content={`View this ${refType}`}>
                                                 <Button to={node.canonicalURL} variant="secondary" as={Link} size="sm">
                                                     <strong>{oidElement}</strong>
                                                 </Button>
                                             </Tooltip>
-                                            <Tooltip
-                                                content={flashCopiedToClipboardMessage ? 'Copied!' : 'Copy full SHA'}
-                                            >
+                                            <Tooltip content={flashCopiedToClipboardMessage ? 'Copied!' : copyMessage}>
                                                 <Button
-                                                    onClick={() => copyToClipboard(node.oid)}
+                                                    onClick={() => copyToClipboard(refID)}
                                                     variant="secondary"
                                                     size="sm"
-                                                    aria-label="Copy full SHA"
+                                                    aria-label={copyMessage}
                                                 >
                                                     <Icon
                                                         className="small"
@@ -296,7 +309,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                                             </Tooltip>
                                         </ButtonGroup>
                                         {node.tree && (
-                                            <Tooltip content="View files at this commit">
+                                            <Tooltip content={`View files at this ${refType}`}>
                                                 <Button
                                                     aria-label="View files"
                                                     to={node.tree.canonicalURL}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -9,13 +9,13 @@ import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
 import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
-import { GitCommitFields } from '../../graphql-operations'
+import { GitCommitFields, RepositoryType } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { DiffModeSelector } from '../commit/DiffModeSelector'
 import { DiffMode } from '../commit/RepositoryCommitPage'
 import { Linkified } from '../linkifiy/Linkified'
-import { SourceTypeGitRepository, SourceTypePerforceDepot, getRefType, isPerforceDepotSource } from '../utils'
+import { getRefType, isPerforceDepotSource } from '../utils'
 
 import { GitCommitNodeByline } from './GitCommitNodeByline'
 
@@ -85,7 +85,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
-    const sourceType = node.perforceChangelist ? SourceTypePerforceDepot : SourceTypeGitRepository
+    const sourceType = node.perforceChangelist ? RepositoryType.PERFORCE_DEPOT : RepositoryType.GIT_REPOSITORY
     const isPerforceDepot = isPerforceDepotSource(sourceType)
     const abbreviatedRefID = node.perforceChangelist?.cid ?? node.abbreviatedOID
     const refID = node.perforceChangelist?.cid ?? node.oid

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -18,6 +18,7 @@ interface Props {
     preferAbsoluteTimestamps?: boolean
     messageElement?: JSX.Element
     commitMessageBody?: JSX.Element
+    isPerforceDepot?: boolean
     as?: 'div' | 'td'
 }
 
@@ -33,9 +34,12 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
     preferAbsoluteTimestamps,
     messageElement,
     commitMessageBody,
+    isPerforceDepot,
     as = 'div',
 }) => {
     const Wrapper = as
+
+    const refActionType = isPerforceDepot ? 'submitted by' : 'committed by'
 
     // Omit GitHub as committer to reduce noise. (Edits and squash commits made in the GitHub UI
     // include GitHub as a committer.)
@@ -68,8 +72,8 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
                     {!compact ? (
                         <>
                             {messageElement}
-                            <PersonLink person={author.person} className="font-weight-bold" /> authored and commited by{' '}
-                            <PersonLink person={committer.person} className="font-weight-bold" />{' '}
+                            <PersonLink person={author.person} className="font-weight-bold" /> authored and{' '}
+                            {refActionType} <PersonLink person={committer.person} className="font-weight-bold" />{' '}
                             <Timestamp date={committer.date} preferAbsolute={preferAbsoluteTimestamps} />
                             {commitMessageBody}
                         </>
@@ -98,7 +102,7 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
                 {!compact && (
                     <>
                         {messageElement}
-                        committed by <PersonLink person={author.person} className="font-weight-bold" />{' '}
+                        {refActionType} <PersonLink person={author.person} className="font-weight-bold" />{' '}
                         <Timestamp date={author.date} preferAbsolute={preferAbsoluteTimestamps} />
                         {commitMessageBody}
                     </>

--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -90,7 +90,9 @@ export const GitCommitNodeTableRow: React.FC<
                 <td className="flex-1 overflow-hidden">{messageElement}</td>
                 <td className="text-right">
                     <Link to={node.canonicalURL}>
-                        <Code data-testid="git-commit-node-oid">{node.abbreviatedOID}</Code>
+                        <Code data-testid="git-commit-node-oid">
+                            {node.perforceChangelist?.cid ?? node.abbreviatedOID}
+                        </Code>
                     </Link>
                 </td>
             </tr>

--- a/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
@@ -1,0 +1,386 @@
+import { MockedResponse } from '@apollo/client/testing'
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { WebStory } from '../../components/WebStory'
+import {
+    ExternalServiceKind,
+    RepositoryFields,
+    RepositoryGitCommitsResult,
+    RepositoryGitCommitsVariables,
+    RepositoryType,
+} from '../../graphql-operations'
+
+import {
+    REPOSITORY_GIT_COMMITS_QUERY,
+    RepositoryCommitsPage,
+    RepositoryCommitsPageProps,
+} from './RepositoryCommitsPage'
+
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/RepositoryCommitsPage',
+    decorators: [decorator],
+}
+
+export default config
+
+const mockRepositoryGitCommitsQuery: MockedResponse<RepositoryGitCommitsResult, RepositoryGitCommitsVariables> = {
+    request: {
+        query: getDocumentNode(REPOSITORY_GIT_COMMITS_QUERY),
+        variables: {
+            repo: 'UmVwb3NpdG9yeToyNjM4OQ==',
+            revspec: '',
+            filePath: '',
+            first: 20,
+            afterCursor: null,
+        },
+    },
+    result: {
+        data: {
+            node: {
+                sourceType: RepositoryType.GIT_REPOSITORY,
+                externalURLs: [
+                    {
+                        url: 'https://github.com/sourcegraph/sourcegraph',
+                        serviceKind: ExternalServiceKind.GITHUB,
+                        __typename: 'ExternalLink',
+                    },
+                ],
+                commit: {
+                    ancestors: {
+                        nodes: [
+                            {
+                                id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUbzMiLCJjIjoiYjFlMWVjMTZlMmMyZDkzMmNmMjMwYzcxYzc2MDUxNmZiOTY1OGNkYiJ9',
+                                oid: 'b1e1ec16e2c2d932cf230c71c760516fb9658cdb',
+                                abbreviatedOID: 'b1e1ec1',
+                                perforceChangelist: null,
+                                message:
+                                    'Document OpenAI API compatibility for completions (#51208)\n\nCo-authored-by: Malo Marrec <malo.marrec@gmail.com>',
+                                subject: 'Document OpenAI API compatibility for completions (#51208)',
+                                body: 'Co-authored-by: Malo Marrec <malo.marrec@gmail.com>',
+                                author: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'David Veszelovszki',
+                                        email: 'veszelovszki@gmail.com',
+                                        displayName: 'David Veszelovszki',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2023-05-02T11:00:43Z',
+                                    __typename: 'Signature',
+                                },
+                                committer: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'GitHub',
+                                        email: 'noreply@github.com',
+                                        displayName: 'GitHub',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2023-05-02T11:00:43Z',
+                                    __typename: 'Signature',
+                                },
+                                parents: [
+                                    {
+                                        oid: '59ce236cca392975a383cdab14d73244f05d21b6',
+                                        abbreviatedOID: '59ce236',
+                                        perforceChangelist: null,
+                                        url: '/github.com/sourcegraph/sourcegraph/-/commit/59ce236cca392975a383cdab14d73244f05d21b6',
+                                        __typename: 'GitCommit',
+                                    },
+                                ],
+                                url: '/github.com/sourcegraph/sourcegraph/-/commit/b1e1ec16e2c2d932cf230c71c760516fb9658cdb',
+                                canonicalURL:
+                                    '/github.com/sourcegraph/sourcegraph/-/commit/b1e1ec16e2c2d932cf230c71c760516fb9658cdb',
+                                externalURLs: [
+                                    {
+                                        url: 'https://github.com/sourcegraph/sourcegraph/commit/b1e1ec16e2c2d932cf230c71c760516fb9658cdb',
+                                        serviceKind: ExternalServiceKind.GITHUB,
+                                        __typename: 'ExternalLink',
+                                    },
+                                ],
+                                tree: {
+                                    canonicalURL:
+                                        '/github.com/sourcegraph/sourcegraph@b1e1ec16e2c2d932cf230c71c760516fb9658cdb',
+                                    __typename: 'GitTree',
+                                },
+                                __typename: 'GitCommit',
+                            },
+                        ],
+                        pageInfo: {
+                            hasNextPage: true,
+                            endCursor: '20',
+                            __typename: 'PageInfo',
+                        },
+                        __typename: 'GitCommitConnection',
+                    },
+                    __typename: 'GitCommit',
+                },
+                __typename: 'Repository',
+            },
+        },
+    },
+}
+
+const mockRepositoryPerforceChangelistsQuery: MockedResponse<
+    RepositoryGitCommitsResult,
+    RepositoryGitCommitsVariables
+> = {
+    request: {
+        query: getDocumentNode(REPOSITORY_GIT_COMMITS_QUERY),
+        variables: {
+            repo: 'UmVwb3NpdG9yeToyNjM4OQ==',
+            revspec: '',
+            filePath: '',
+            first: 20,
+            afterCursor: null,
+        },
+    },
+    result: {
+        data: {
+            node: {
+                sourceType: RepositoryType.PERFORCE_DEPOT,
+                externalURLs: [],
+                commit: {
+                    ancestors: {
+                        nodes: [
+                            {
+                                id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3lOak00T1E9PSIsImMiOiJhNzdkMWIzMDliY2U1ZGJiNjM1ODFiY2E4YzJjYWFjMDEzZWM5Mzg3In0=',
+                                oid: 'f27c0f663b36e5294947964d7c25672f6e0e34fe',
+                                abbreviatedOID: 'f27c0f663b',
+                                perforceChangelist: {
+                                    __typename: 'PerforceChangelist',
+                                    cid: '48485',
+                                },
+                                message: '48485 - test-5386\n[p4-fusion: depot-paths = "//go/": change = 48485]',
+                                subject: 'test-5386',
+                                body: null,
+                                author: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-13T19:24:59Z',
+                                    __typename: 'Signature',
+                                },
+                                committer: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-13T19:24:59Z',
+                                    __typename: 'Signature',
+                                },
+                                parents: [
+                                    {
+                                        oid: 'd9994dc548fd79b473ce05198c88282890983fa9',
+                                        abbreviatedOID: 'd9994dc',
+                                        perforceChangelist: {
+                                            __typename: 'PerforceChangelist',
+                                            cid: '48484',
+                                        },
+                                        url: '/perforce.sgdev.org/go/-/commit/d9994dc548fd79b473ce05198c88282890983fa9',
+                                        __typename: 'GitCommit',
+                                    },
+                                ],
+                                url: '/perforce.sgdev.org/go/-/commit/a77d1b309bce5dbb63581bca8c2caac013ec9387',
+                                canonicalURL:
+                                    '/perforce.sgdev.org/go/-/commit/a77d1b309bce5dbb63581bca8c2caac013ec9387',
+                                externalURLs: [],
+                                tree: {
+                                    canonicalURL: '/perforce.sgdev.org/go@a77d1b309bce5dbb63581bca8c2caac013ec9387',
+                                    __typename: 'GitTree',
+                                },
+                                __typename: 'GitCommit',
+                            },
+                            {
+                                id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3lOak00T1E9PSIsImMiOiJkOTk5NGRjNTQ4ZmQ3OWI0NzNjZTA1MTk4Yzg4MjgyODkwOTgzZmE5In0=',
+                                oid: '93abc40a6193539d27022a4ce558fcf7d82d3998',
+                                abbreviatedOID: '93abc40a61',
+                                perforceChangelist: {
+                                    __typename: 'PerforceChangelist',
+                                    cid: '1012',
+                                },
+                                message: '1012 - :boar:\n\n[p4-fusion: depot-paths = "//go/": change = 1012]',
+                                subject: ':boar:',
+                                body: null,
+                                author: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-09T22:01:07Z',
+                                    __typename: 'Signature',
+                                },
+                                committer: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-09T22:01:07Z',
+                                    __typename: 'Signature',
+                                },
+                                parents: [
+                                    {
+                                        oid: 'd7205ebf51c2c7486ee74ded9f000ddf1b0cca24',
+                                        abbreviatedOID: 'd7205eb',
+                                        perforceChangelist: {
+                                            __typename: 'PerforceChangelist',
+                                            cid: '48485',
+                                        },
+                                        url: '/perforce.sgdev.org/go/-/commit/d7205ebf51c2c7486ee74ded9f000ddf1b0cca24',
+                                        __typename: 'GitCommit',
+                                    },
+                                ],
+                                url: '/perforce.sgdev.org/go/-/commit/d9994dc548fd79b473ce05198c88282890983fa9',
+                                canonicalURL:
+                                    '/perforce.sgdev.org/go/-/commit/d9994dc548fd79b473ce05198c88282890983fa9',
+                                externalURLs: [],
+                                tree: {
+                                    canonicalURL: '/perforce.sgdev.org/go@d9994dc548fd79b473ce05198c88282890983fa9',
+                                    __typename: 'GitTree',
+                                },
+                                __typename: 'GitCommit',
+                            },
+                            {
+                                id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3lOak00T1E9PSIsImMiOiJkNzIwNWViZjUxYzJjNzQ4NmVlNzRkZWQ5ZjAwMGRkZjFiMGNjYTI0In0=',
+                                oid: '314a3c2830b6aa500dfbb23ac05aa2304c58f1e1',
+                                abbreviatedOID: '314a3c2830',
+                                perforceChangelist: {
+                                    __typename: 'PerforceChangelist',
+                                    cid: '1011',
+                                },
+                                message:
+                                    '1011 - Add Go source code\n\n[p4-fusion: depot-paths = "//go/": change = 1011]',
+                                subject: 'Add Go source code',
+                                body: null,
+                                author: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-09T21:44:50Z',
+                                    __typename: 'Signature',
+                                },
+                                committer: {
+                                    person: {
+                                        avatarURL: null,
+                                        name: 'admin',
+                                        email: 'admin@perforce-server-7df6ff678c-lkzfb',
+                                        displayName: 'admin',
+                                        user: null,
+                                        __typename: 'Person',
+                                    },
+                                    date: '2021-08-09T21:44:50Z',
+                                    __typename: 'Signature',
+                                },
+                                parents: [],
+                                url: '/perforce.sgdev.org/go/-/commit/d7205ebf51c2c7486ee74ded9f000ddf1b0cca24',
+                                canonicalURL:
+                                    '/perforce.sgdev.org/go/-/commit/d7205ebf51c2c7486ee74ded9f000ddf1b0cca24',
+                                externalURLs: [],
+                                tree: {
+                                    canonicalURL: '/perforce.sgdev.org/go@d7205ebf51c2c7486ee74ded9f000ddf1b0cca24',
+                                    __typename: 'GitTree',
+                                },
+                                __typename: 'GitCommit',
+                            },
+                        ],
+                        pageInfo: { hasNextPage: false, endCursor: null, __typename: 'PageInfo' },
+                        __typename: 'GitCommitConnection',
+                    },
+                    __typename: 'GitCommit',
+                },
+                __typename: 'Repository',
+            },
+        },
+    },
+}
+
+const gitRepo: RepositoryFields = {
+    id: 'repo-id',
+    name: 'github.com/sourcegraph/sourcegraph',
+    url: 'https://github.com/sourcegraph/sourcegraph',
+    sourceType: RepositoryType.GIT_REPOSITORY,
+    description: '',
+    viewerCanAdminister: false,
+    isFork: false,
+    externalURLs: [],
+    externalRepository: {
+        __typename: 'ExternalRepository',
+        serviceType: '',
+        serviceID: '',
+    },
+    defaultBranch: null,
+    metadata: [],
+}
+
+export const GitCommitsStory: Story<RepositoryCommitsPageProps> = () => (
+    <MockedTestProvider>
+        <WebStory
+            initialEntries={['/github.com/sourcegraph/sourcegraph/-/commits']}
+            mocks={[mockRepositoryGitCommitsQuery]}
+        >
+            {props => <RepositoryCommitsPage revision="" repo={gitRepo} {...props} />}
+        </WebStory>
+    </MockedTestProvider>
+)
+
+GitCommitsStory.storyName = 'Git commits'
+
+const perforceRepo: RepositoryFields = {
+    id: 'repo-id',
+    name: 'github.com/sourcegraph/sourcegraph',
+    url: 'https://github.com/sourcegraph/sourcegraph',
+    sourceType: RepositoryType.PERFORCE_DEPOT,
+    description: '',
+    viewerCanAdminister: false,
+    isFork: false,
+    externalURLs: [],
+    externalRepository: {
+        __typename: 'ExternalRepository',
+        serviceType: '',
+        serviceID: '',
+    },
+    defaultBranch: null,
+    metadata: [],
+}
+
+export const PerforceChangelistsStory: Story<RepositoryCommitsPageProps> = () => (
+    <MockedTestProvider>
+        <WebStory
+            initialEntries={['/perforce.sgdev.org/go/-/commits']}
+            mocks={[mockRepositoryPerforceChangelistsQuery]}
+        >
+            {props => <RepositoryCommitsPage revision="" repo={perforceRepo} {...props} />}
+        </WebStory>
+    </MockedTestProvider>
+)
+
+PerforceChangelistsStory.storyName = 'Perforce changelists'

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
       >
         Alice Zhao
       </span>
-       authored and commited by 
+       authored and committed by 
       <a
         class="font-weight-bold"
         href="https://example.com/bobyang"
@@ -148,7 +148,7 @@ exports[`GitCommitNodeByline different author and committer 1`] = `
       >
         Alice Zhao
       </span>
-       authored and commited by 
+       authored and committed by 
       <a
         class="font-weight-bold"
         href="https://example.com/bobyang"

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
-import { RepositoryFields } from '../../graphql-operations'
+import { RepositoryFields, RepositoryType } from '../../graphql-operations'
 
 import { Props, TreePage } from './TreePage'
 
@@ -16,6 +16,7 @@ describe('TreePage', () => {
     const repoDefaults = (): RepositoryFields => ({
         id: 'repo-id',
         name: 'repo name',
+        sourceType: RepositoryType.GIT_REPOSITORY,
         url: 'http://repo.url.example.com',
         description: 'Awesome for testing',
         viewerCanAdminister: false,

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -87,6 +87,7 @@ export const treePageRepositoryFragment = gql`
             key
             value
         }
+        sourceType
     }
 `
 

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -2,6 +2,5 @@ import { RepositoryType } from '../graphql-operations'
 
 export const isPerforceDepotSource = (sourceType: string): boolean => sourceType === RepositoryType.PERFORCE_DEPOT
 
-export const getRefType = (sourceType: RepositoryType): string => {
-    return isPerforceDepotSource(sourceType) ? 'changelist' : 'commit'
-}
+export const getRefType = (sourceType: RepositoryType | string): string =>
+    isPerforceDepotSource(sourceType) ? 'changelist' : 'commit'

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -1,0 +1,7 @@
+import { RepositoryType } from '../graphql-operations'
+
+export const isPerforceDepotSource = (sourceType: string): boolean => sourceType === RepositoryType.PERFORCE_DEPOT
+
+export const getRefType = (sourceType: RepositoryType): string => {
+    return isPerforceDepotSource(sourceType) ? 'changelist' : 'commit'
+}


### PR DESCRIPTION
## **What**

Part of #46488. Blocked by #51291. 

We want to display the perforce changelists in the repo landing page and the view commits page instead of the commit SHA because to a perforce developer looking at this code, a commit SHA is meaningless.

### **Description of the changes**

**UI changes**

For perforce depots converted to git:

- Repo landing and the view commits pages now display `changelist`, `changelists` and `changelist ID` instead of `commit`, `commits` and `commit SHA` respectively
- View commits page now displays the changelist ID instead of the commit SHA
- Commit subject now displays the original changelist subject instead of the git commit message
- Commit view page also displays the `changelist` related terms with changelist ID instead of the commit SHA and parent commit SHA

Also fixed the typos in the word `committed` across the whole codebase as I noticed it started to fail when I made a change in the existing code.

**Meta UI changes**

My UI skills are nascent and come with some limitations:

- ~Instead of riddling the existing `GitCommitNode` component with if else conditions to display `commit/s` or `changelist/s`, I decided to create a new component which is pretty much a copy-paste of the `GitCommitNode` component with changes to display perforce terms and some minor changes to tweak the CSS and deleting some lines of code which were obviously not related to Perforce (some GitHub related checks)~
- ~I thought about adding an argument to the `GitCommitNode` to customise the message text, but I wanted to add the least amount of friction possible to the current code in case I end up breaking something, also passing `changelist` to a commitnode component felt wrong~
- `getRefType`: This function returns `commit` or `changelist` based on the repo type and I have two kinds of implementations in two different modules

I'm sure there are ways to do this cleaner in less lines of code and am happy to iterate on those. :) 

**Edit: I am reusing the `GitCommitNode` component. This was easy.** 

Run `sg run storybook` and check out the storybooks here:

- http://localhost:9001/?path=/story/web-perforcedepotchangelistnode--perforce-depot-changelist-item

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/2682729/234942388-d12c72dd-c8fe-4422-80f4-95352cf068b8.png">

- http://localhost:9001/?path=/story/web-repositorycommitspage--git-commits-story

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/2682729/234942646-5757ac10-5475-4cfa-99a0-ed7ee1b6799a.png">

- http://localhost:9001/?path=/story/web-repositorycommitspage--perforce-changelists-story

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/2682729/234942696-ecefc6b0-987c-45d2-9f53-6595e92c9bbc.png">

**Previously**

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/2682729/234946876-c9639253-fb49-409d-a6f9-db290212aa09.png">


<img width="642" alt="image" src="https://user-images.githubusercontent.com/2682729/234945126-69c2c36f-e557-4f53-846e-fe1491f1f612.png">

**Now**

<img width="641" alt="image" src="https://user-images.githubusercontent.com/2682729/234945777-985d345c-b35d-4d13-bdc1-42a176b52e05.png">

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/2682729/234945913-2a9e15e9-0e20-436d-9fca-36a0dec2e891.png">



## Test plan

- Added tests
- Added storybooks
- Builds should pass




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
