### PR TITLE
Document OpenAI API compatibility for completions

### DIFF
--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -10,8 +10,8 @@
 ### Prerequisites
 
 - Sourcegraph 5.0.1 or above
-- An Anthropic API key, that you can get from your Technical Advisor or Customer Engineer
-- (Optionally) An OpenAI API key for embeddings (to power code graph context)
+- An Anthropic or OpenAI API key (we can help you get one, see below)
+- Optionally: An OpenAI API key for embeddings to power code graph context
 
 There are two steps required to enable Cody on your enterprise instance:
 
@@ -23,7 +23,7 @@ There are two steps required to enable Cody on your enterprise instance:
 Note that this requires site-admin privileges.
 
 1. Cody uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension.
-2. To turn Cody on, you will need to set an access token for Sourcegraph to authentify with the third-party large language model provider (currently Anthropic but we may use different or several models over time). Reach out to your Sourcegraph Technical Advisor or Customer Engineer to get a key. They will create a key for you using the [anthropic console](https://console.anthropic.com/account/keys).
+2. To turn Cody on, you will need to set an access token for Sourcegraph to authenticate with the third-party large language model provider. Currently, this can be Anthropic or OpenAI. Reach out to your Sourcegraph Technical Advisor or Customer Engineer to get an Anthropic key through Sourcegraph with our zero-retention policy. Alternatively, you can create your own key with Anthropic [here](https://console.anthropic.com/account/keys) or with OpenAI [here](https://beta.openai.com/account/api-keys).
 3. Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
 
     ```json
@@ -31,9 +31,9 @@ Note that this requires site-admin privileges.
       // [...]
       "completions": {
         "enabled": true,
-        "accessToken": "<token>",
-        "model": "claude-v1",
-        "provider": "anthropic"
+        "provider": "anthropic", // or "openai" if you use OpenAI
+        "model": "claude-v1", // or one of the models listed [here](https://platform.openai.com/docs/models) if you use OpenAI
+        "accessToken": "<key>"
       }
     }
     ```

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -19,7 +19,7 @@ The way Cody generates an answer is the following:
 
 #### Does Cody work with self-hosted Sourcegraph?
 
-Yes, Cody works with self-hosted Sourcegraph instances, with the caveat that snippets of code (up to 28 KB per request) will be sent to a third party cloud service (Anthropic) on each request. Optionally, embeddings can be turned on for some repositories, which requires sending those repositories to another third party (OpenAI).
+Yes, Cody works with self-hosted Sourcegraph instances, with the caveat that snippets of code (up to 28 KB per request) will be sent to a third party cloud service (Anthropic by default, but can also be OpenAI) on each request. Optionally, embeddings can be turned on for some repositories, which requires sending those repositories to another third party (OpenAI).
 
 In particular, this means the Sourcegraph instance needs to be able to access the internet.
 
@@ -48,7 +48,7 @@ In the future, here are the steps that Sourcegraph will follow:
 
 #### What third-party cloud services does Cody depend on today?
 
-- Cody has one third-party dependency, which is Anthropic's Claude API.
+- Cody has one third-party dependency, which is Anthropic's Claude API. In the config, this can be replaced with OpenAI API.
 - Cody can optionally use OpenAI to generate embeddings, that are then used to improve the quality of its context snippets, but this is not required.
 
 #### What's the retention policy for Anthropic/OpenAI?

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -54,3 +54,8 @@ In the future, here are the steps that Sourcegraph will follow:
 #### What's the retention policy for Anthropic/OpenAI?
 
 See our [terms](https://about.sourcegraph.com/terms/cody-notice).
+
+#### Can I use my own API keys?
+
+Yes!
+

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -8,7 +8,7 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 
 ## Get Cody
 
-- **Sourcegraph Enterprise customers:** Contact your Sourcegraph techical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
+- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
 - **Everyone:** Cody for open source code is now available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
 
 Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself.


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/50273
- This is basically the accompanying docs change for @sqs's https://github.com/sourcegraph/sourcegraph/pull/49997

Listed our compatibility with OpenAI API and added guidance for setting it up.

Note: https://github.com/sourcegraph/sourcegraph/pull/49997 is not yet backported to 5.0. Until that happens, I don't intend to merge this.

## Test plan

Only docs change.
I've tested Cody with a back end set to OpenAI (gpt-4), and it worked flawlessly (tested a few chat messages and recipes).