### PR TITLE
embeddings: calculate recall on CI

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -290,3 +290,6 @@ rules_nixpkgs_dependencies(toolchains = [
 load("//dev:nix.bzl", "nix_deps")
 
 nix_deps()
+
+load("//enterprise/cmd/embeddings/shared:assets.bzl", "embbedings_assets_deps")
+embbedings_assets_deps()

--- a/dev/sg/sg_embeddings_qa.go
+++ b/dev/sg/sg_embeddings_qa.go
@@ -4,6 +4,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/qa"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var contextCommand = &cli.Command{
@@ -20,6 +21,11 @@ var contextCommand = &cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-		return qa.Run(ctx.String("url"))
+		url := ctx.String("url")
+		if url == "" {
+			return errors.New("url is empty")
+		}
+
+		return qa.Run(qa.NewClient(url))
 	},
 }

--- a/dev/sg/sg_embeddings_qa.go
+++ b/dev/sg/sg_embeddings_qa.go
@@ -26,6 +26,8 @@ var contextCommand = &cli.Command{
 			return errors.New("url is empty")
 		}
 
-		return qa.Run(qa.NewClient(url))
+		_, err := qa.Run(qa.NewClient(url))
+
+		return err
 	},
 }

--- a/enterprise/.gitignore
+++ b/enterprise/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 !/ui/assets/img/*
 /.bin
 /vendor/.bin
+/cmd/embeddings/shared/testdata/

--- a/enterprise/cmd/embeddings/qa/embed_queries/BUILD.bazel
+++ b/enterprise/cmd/embeddings/qa/embed_queries/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "embed_queries_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/qa/embed_queries",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/internal/embeddings/embed",
+        "//internal/jsonc",
+        "//lib/errors",
+        "//schema",
+    ],
+)
+
+go_binary(
+    name = "embed_queries",
+    embed = [":embed_queries_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -1,10 +1,13 @@
 // This is a helper script that embeds a set of queries and writes pairs of
-// embeddings and queries to disk.
+// embeddings and queries to disk. Credentials for the embeddings provider are
+// read from dev-private.
 //
 // Usage:
 //
 // Supply a file with one query per line:
 // go run . <file>
+//
+// OR
 //
 // Supply queries via stdin:
 // cat ../context_data.tsv | awk -F\t '{print $1}' | go run .

--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -29,6 +29,9 @@ import (
 
 func loadSiteConfig(siteConfigPath string) (*schema.SiteConfiguration, error) {
 	b, err := os.ReadFile(siteConfigPath)
+	if err != nil {
+		return nil, err
+	}
 	siteConfig := schema.SiteConfiguration{}
 	err = jsonc.Unmarshal(string(b), &siteConfig)
 	if err != nil {

--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -1,0 +1,129 @@
+// This is a helper script that embeds a set of queries and writes pairs of
+// embeddings and queries to disk.
+//
+// Usage:
+//
+// Supply a file with one query per line:
+// go run . <file>
+//
+// Supply queries via stdin:
+// cat ../context_data.tsv | awk -F\t '{print $1}' | go run .
+
+package main
+
+import (
+	"context"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func loadSiteConfig(siteConfigPath string) (*schema.SiteConfiguration, error) {
+	b, err := os.ReadFile(siteConfigPath)
+	siteConfig := schema.SiteConfiguration{}
+	err = jsonc.Unmarshal(string(b), &siteConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &siteConfig, nil
+}
+
+// embedQueries embeds queries, gob-encodes the vectors, and writes them to disk
+func embedQueries(queries []string, siteConfigPath string) error {
+	ctx := context.Background()
+
+	// get embeddings config
+	siteConfig, err := loadSiteConfig(siteConfigPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to load site config")
+	}
+
+	// open file to write to
+	target, err := os.OpenFile("query_embeddings.gob", os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to open target file")
+	}
+	defer target.Close()
+	enc := gob.NewEncoder(target)
+
+	for _, query := range queries {
+		fmt.Printf("Embedding query %s\n", query)
+		v, err := embed.GetEmbeddings(ctx, []string{query}, siteConfig.Embeddings)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get embeddings for query %s", query)
+		}
+
+		err = enc.Encode(struct {
+			Query     string
+			Embedding []float32
+		}{
+			Query:     query,
+			Embedding: v,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func devPrivateSiteConfig() string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(pwd, "../../../../../../dev-private/enterprise/dev/site-config.json")
+}
+
+func main() {
+	siteConfigPath := devPrivateSiteConfig()
+	flag.StringVar(&siteConfigPath, "site-config", siteConfigPath, "path to site config")
+	flag.Parse()
+
+	var queries []string
+	var r io.Reader
+
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		panic(err)
+	}
+
+	if (fi.Mode() & os.ModeCharDevice) == 0 {
+		// Data is from pipe
+		r = os.Stdin
+		defer os.Stdin.Close()
+	} else {
+		// Data is from args
+		queryFile := os.Args[1]
+		fd, err := os.Open(queryFile)
+		if err != nil {
+			panic(err)
+		}
+		r = fd
+		defer fd.Close()
+	}
+
+	b, err := io.ReadAll(r)
+	if err != nil {
+		panic(err)
+	}
+
+	queriesStr := strings.TrimSpace(string(b))
+	queries = strings.Split(queriesStr, "\n")
+
+	if err := embedQueries(queries, siteConfigPath); err != nil {
+		panic(err)
+	}
+}

--- a/enterprise/cmd/embeddings/qa/eval.go
+++ b/enterprise/cmd/embeddings/qa/eval.go
@@ -25,13 +25,13 @@ type embeddingsSearcher interface {
 }
 
 // Run runs the evaluation and returns recall for the test data.
-func Run(searcher embeddingsSearcher) error {
+func Run(searcher embeddingsSearcher) (float64, error) {
 
 	count, recall := 0.0, 0.0
 
 	file, err := fs.Open("context_data.tsv")
 	if err != nil {
-		return errors.Wrap(err, "failed to open file")
+		return -1, errors.Wrap(err, "failed to open file")
 	}
 
 	scanner := bufio.NewScanner(file)
@@ -54,7 +54,7 @@ func Run(searcher embeddingsSearcher) error {
 
 		results, err := searcher.Search(args)
 		if err != nil {
-			return errors.Wrap(err, "search failed")
+			return -1, errors.Wrap(err, "search failed")
 		}
 
 		merged := append(results.CodeResults, results.TextResults...)
@@ -83,10 +83,12 @@ func Run(searcher embeddingsSearcher) error {
 		count++
 	}
 
-	fmt.Println()
-	fmt.Printf("Recall: %f\n", recall/count)
+	recall = recall / count
 
-	return nil
+	fmt.Println()
+	fmt.Printf("Recall: %f\n", recall)
+
+	return recall, nil
 }
 
 type client struct {

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -99,5 +99,6 @@ go_test(
         "//internal/uploadstore/mocks",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -58,18 +58,18 @@ go_library(
 # The filename specified by the out field needs to include the sha for the test to find it.
 # See //enterprise/cmd/embeddings/shared:assets.bzl for the macro fetching those external dependencies.
 copy_file(
-  name = "ln_test_data_embeddings_index",
-  src = "@github_com_sourcegraph_sourcegraph_embeddingindex//file:downloaded",
-  out = "testdata/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex",
-  allow_symlink = True,
+    name = "ln_test_data_embeddings_index",
+    src = "@github_com_sourcegraph_sourcegraph_embeddingindex//file:downloaded",
+    out = "testdata/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex",
+    allow_symlink = True,
 )
 
 # See //enterprise/cmd/embeddings/shared:assets.bzl for the macro fetching those external dependencies.
 copy_file(
-  name = "ln_test_data_query_embeddings_gob",
-  src = "@query_embeddings_gob//file:downloaded",
-  out = "testdata/query_embeddings.gob",
-  allow_symlink = True,
+    name = "ln_test_data_query_embeddings_gob",
+    src = "@query_embeddings_gob//file:downloaded",
+    out = "testdata/query_embeddings.gob",
+    allow_symlink = True,
 )
 
 go_test(
@@ -86,7 +86,7 @@ go_test(
     embedsrcs = [
         ":ln_test_data_embeddings_index",
         ":ln_test_data_query_embeddings_gob",
-    ],
+    ],  # keep
     deps = [
         "//enterprise/cmd/embeddings/qa",
         "//enterprise/internal/embeddings",

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 go_library(
     name = "shared",
@@ -54,16 +55,40 @@ go_library(
     ],
 )
 
+# The filename specified by the out field needs to include the sha for the test to find it.
+# See //enterprise/cmd/embeddings/shared:assets.bzl for the macro fetching those external dependencies.
+copy_file(
+  name = "ln_test_data_embeddings_index",
+  src = "@github_com_sourcegraph_sourcegraph_embeddingindex//file:downloaded",
+  out = "testdata/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex",
+  allow_symlink = True,
+)
+
+# See //enterprise/cmd/embeddings/shared:assets.bzl for the macro fetching those external dependencies.
+copy_file(
+  name = "ln_test_data_query_embeddings_gob",
+  src = "@query_embeddings_gob//file:downloaded",
+  out = "testdata/query_embeddings.gob",
+  allow_symlink = True,
+)
+
 go_test(
     name = "shared_test",
     timeout = "short",
     srcs = [
         "context_detection_test.go",
+        "context_qa_test.go",
         "repo_embedding_index_cache_test.go",
         "search_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":shared"],
+    embedsrcs = [
+        ":ln_test_data_embeddings_index",
+        ":ln_test_data_query_embeddings_gob",
+    ],
     deps = [
+        "//enterprise/cmd/embeddings/qa",
         "//enterprise/internal/embeddings",
         "//enterprise/internal/embeddings/background/repo",
         "//internal/api",
@@ -71,5 +96,8 @@ go_test(
         "//internal/types",
         "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//require",
+        "//internal/uploadstore/mocks",
+        "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -72,6 +72,7 @@ copy_file(
     allow_symlink = True,
 )
 
+# gazelle:exclude testdata
 go_test(
     name = "shared_test",
     timeout = "short",
@@ -81,7 +82,6 @@ go_test(
         "repo_embedding_index_cache_test.go",
         "search_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":shared"],
     embedsrcs = [
         ":ln_test_data_embeddings_index",

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -94,8 +94,6 @@ go_test(
         "//internal/api",
         "//internal/database",
         "//internal/types",
-        "@com_github_sourcegraph_log//:log",
-        "@com_github_stretchr_testify//require",
         "//internal/uploadstore/mocks",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",

--- a/enterprise/cmd/embeddings/shared/assets.bzl
+++ b/enterprise/cmd/embeddings/shared/assets.bzl
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def embbedings_assets_deps():
+    http_file(
+        name = "github_com_sourcegraph_sourcegraph_embeddingindex",
+        url = "https://storage.googleapis.com/buildkite_public_assets/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex",
+        sha256 = "830a3b4b05f889e442d1da0e97950136db907ffd395f5fef404d9b4a9aac84a7",
+    )
+
+    http_file(
+        name = "query_embeddings_gob",
+        url = "https://storage.googleapis.com/buildkite_public_assets/query_embeddings.gob",
+        sha256 = "48e816d9ad033d2661a5c2999232ceccb430427ed4ce6330824f7c123db05a03",
+    )
+

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -2,9 +2,6 @@
 // committed to the repository. The build tag makes sure the missing files don't
 // break the build. To run this test, use `go test -tags sourcegraphCI`.
 
-//go:build sourcegraphCI
-// +build sourcegraphCI
-
 package shared
 
 import (
@@ -25,8 +22,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-//go:embed testdata/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex
-//go:embed testdata/query_embeddings.gob
+// This embed is handled by Bazel, and using the traditional go test command will fail.
+// See //enterprise/cmd/embeddings/shared:assets.bzl
+//
+//go:embed testdata/*
 var fs embed.FS
 
 func TestRecall(t *testing.T) {

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -1,0 +1,117 @@
+// This test should only run on CI. It relies on large index files that are not
+// committed to the repository. The build tag makes sure the missing files don't
+// break the build. To run this test, use `go test -tags sourcegraphCI`.
+
+//go:build sourcegraphCI
+// +build sourcegraphCI
+
+package shared
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/gob"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/qa"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	uploadstoremocks "github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+//go:embed testdata/github_com_sourcegraph_sourcegraph_cf360e12ff91b2fc199e75aef4ff6744.embeddingindex
+//go:embed testdata/query_embeddings.gob
+var fs embed.FS
+
+func TestRecall(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NoOp()
+
+	// Set up mock functions
+	queryEmbeddings, err := loadQueryEmbeddings(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	getQueryEmbedding := func(ctx context.Context, query string) ([]float32, error) {
+		return queryEmbeddings[query], nil
+	}
+
+	mockStore := uploadstoremocks.NewMockStore()
+	mockStore.GetFunc.SetDefaultHook(func(ctx context.Context, key string) (io.ReadCloser, error) {
+		b, err := fs.ReadFile(filepath.Join("testdata", key))
+		if err != nil {
+			return nil, err
+		}
+
+		return io.NopCloser(bytes.NewReader(b)), nil
+	})
+	getRepoEmbeddingIndex := func(ctx context.Context, repo api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+		key := embeddings.GetRepoEmbeddingIndexName(repo)
+		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, string(key))
+	}
+
+	// We only care about the file names in this test.
+	mockReadFile := func(ctx context.Context, repoName api.RepoName, revision api.CommitID, fileName string) ([]byte, error) {
+		return []byte{}, nil
+	}
+
+	// Weaviate is disabled per default. We don't need it for this test.
+	weaviate := &weaviateClient{}
+
+	searcher := func(args embeddings.EmbeddingsSearchParameters) (*embeddings.EmbeddingSearchResults, error) {
+		return searchRepoEmbeddingIndex(
+			ctx,
+			logger,
+			args,
+			mockReadFile,
+			getRepoEmbeddingIndex,
+			getQueryEmbedding,
+			weaviate,
+		)
+	}
+
+	err = qa.Run(embeddingsSearcherFunc(searcher))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// loadQueryEmbeddings loads the query embeddings from the
+// testdata/query_embeddings.gob file into a map.
+func loadQueryEmbeddings(t *testing.T) (map[string][]float32, error) {
+	t.Helper()
+
+	m := make(map[string][]float32)
+
+	f, err := fs.Open("testdata/query_embeddings.gob")
+	if err != nil {
+		return nil, err
+	}
+
+	dec := gob.NewDecoder(f)
+	for {
+		a := struct {
+			Query     string
+			Embedding []float32
+		}{}
+		err := dec.Decode(&a)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		m[a.Query] = a.Embedding
+	}
+
+	return m, nil
+}
+
+type embeddingsSearcherFunc func(args embeddings.EmbeddingsSearchParameters) (*embeddings.EmbeddingSearchResults, error)
+
+func (f embeddingsSearcherFunc) Search(args embeddings.EmbeddingsSearchParameters) (*embeddings.EmbeddingSearchResults, error) {
+	return f(args)
+}

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"encoding/gob"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,6 +30,10 @@ import (
 var fs embed.FS
 
 func TestRecall(t *testing.T) {
+	if os.Getenv("BAZEL_TEST") != "1" {
+		t.Skip("Cannot run this test outside of Bazel")
+	}
+
 	ctx := context.Background()
 	logger := log.NoOp()
 

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -1,6 +1,5 @@
-// This test should only run on CI. It relies on large index files that are not
-// committed to the repository. The build tag makes sure the missing files don't
-// break the build. To run this test, use `go test -tags sourcegraphCI`.
+// This test should only be run with bazel test. It relies on large index files
+// that are not committed to the repository.
 
 package shared
 

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -79,9 +79,16 @@ func TestRecall(t *testing.T) {
 		)
 	}
 
-	err = qa.Run(embeddingsSearcherFunc(searcher))
+	recall, err := qa.Run(embeddingsSearcherFunc(searcher))
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	epsilon := 0.0001
+	wantMinRecall := 0.4285
+
+	if d := wantMinRecall - recall; d > epsilon {
+		t.Fatalf("Recall decreased: want %f, got %f", wantMinRecall, recall)
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -90,6 +90,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
 		bk.Key("bazel-tests"),
+		bk.ArtifactPaths([]string{"./bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/test.log"}),
 	}
 
 	// Test commands

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -90,7 +90,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
 		bk.Key("bazel-tests"),
-		bk.ArtifactPaths([]string{"./bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/test.log"}),
+		bk.ArtifactPaths("./bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/*.log"),
 	}
 
 	// Test commands

--- a/enterprise/internal/embeddings/embed/api.go
+++ b/enterprise/internal/embeddings/embed/api.go
@@ -63,13 +63,13 @@ func (c *embeddingsClient) GetEmbeddingsWithRetries(ctx context.Context, texts [
 		return nil, errors.New("embeddings are not configured or disabled")
 	}
 
-	embeddings, err := getEmbeddings(ctx, texts, c.config)
+	embeddings, err := GetEmbeddings(ctx, texts, c.config)
 	if err == nil {
 		return embeddings, nil
 	}
 
 	for i := 0; i < maxRetries; i++ {
-		embeddings, err = getEmbeddings(ctx, texts, c.config)
+		embeddings, err = GetEmbeddings(ctx, texts, c.config)
 		if err == nil {
 			return embeddings, nil
 		} else {
@@ -82,7 +82,7 @@ func (c *embeddingsClient) GetEmbeddingsWithRetries(ctx context.Context, texts [
 	return nil, err
 }
 
-func getEmbeddings(ctx context.Context, texts []string, config *schema.Embeddings) ([]float32, error) {
+func GetEmbeddings(ctx context.Context, texts []string, config *schema.Embeddings) ([]float32, error) {
 	// Replace newlines, which can negatively affect performance.
 	augmentedTexts := make([]string, len(texts))
 	for idx, text := range texts {


### PR DESCRIPTION
We calculate recall in a Go test whenever the embeddings service changes. The output from the calculation is available as build artifact in Buildkite.

We don't check for regression IE the test won't fail if recall decreases. This is something we might want to pursue in a follow-up PR.

The test relies on static embeddings of the Sourcegraph repo and the queries, both of which are not committed to the repository. Hence `go test ./...` fails. However `bazel test //...` works. The static embeddings are stored in a GCP bucket and downloaded by Bazel if required. 

New repo embeddings can be generated by triggering an embeddings job in a local Sourcegraph instance. The query embeddings can be generated with the help of a little helper script I have included in this PR.

## Test plan
- I ran the new test with `bazel test //enterprise/cmd/embeddings/shared:shared_test` and inspected the logs in `<Sourcegraph root dir>/bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/`
- The recall calculated on CI matches the recall calculated locally.
- The pipeline uploads the test log as build artifact

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/26413131/236208059-e73597b8-d73a-46c9-92a7-e6f5ff586b51.png">

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/26413131/236212953-85a656a1-ae7a-4b41-83b8-deeecd26c50b.png">
