### PR TITLE
Bump syntax-highlighter docker container for single-docker deployment

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -73,7 +73,7 @@ RUN apk add --no-cache --verbose \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:alpine-3.14-1.8.1@sha256:a5e80d6bad6af008478679809dc8327ebde7aeff7b23505b11b20e36aa62a0b2 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=docker.io/sourcegraph/syntax-highlighter:186324_2022-12-01_02d3b4384446 /syntax_highlighter /usr/local/bin/
+COPY --from=docker.io/sourcegraph/syntax-highlighter:215692_2023-04-27_5.0-fb61a539c3a1 /syntax_highlighter /usr/local/bin/
 
 
 # install blobstore (keep this up to date with the upstream Docker image


### PR DESCRIPTION
PR similar to #42486, on the advice of #50878 in order to restore syntax highlighting to `sourcegraph/server`.

I have been running a version with this patch and syntax highlighting is now working as expected.

There are no ENV changes in the syntax-highlighter Dockerfile, as warned about in #42486. So no changes there.

## Test plan

1. Follow steps in https://github.com/sourcegraph/sourcegraph/issues/50878#issuecomment-1524800593 to create a single-container deployment, but using a new image with this patch.
2. Observe that syntax highlighting works again instead of being broken.