### PR TITLE
llm-proxy: basic requests proxying

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/shared/BUILD.bazel
@@ -15,11 +15,13 @@ go_library(
         "//internal/debugserver",
         "//internal/env",
         "//internal/goroutine",
+        "//internal/httpcli",
         "//internal/httpserver",
         "//internal/instrumentation",
         "//internal/observation",
         "//internal/service",
         "//internal/trace",
+        "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/cmd/llm-proxy/shared/config.go
+++ b/enterprise/cmd/llm-proxy/shared/config.go
@@ -8,8 +8,13 @@ type Config struct {
 	env.BaseConfig
 
 	Address string
+
+	Anthropic struct {
+		AccessToken string
+	}
 }
 
 func (c *Config) Load() {
 	c.Address = c.Get("LLM_PROXY_ADDR", ":9992", "Address to serve LLM proxy on.")
+	c.Anthropic.AccessToken = c.Get("LLM_PROXY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 }


### PR DESCRIPTION
This PR adds the basic requests proxying for LLM completions.

> **Warning**: Upon merging this PR, the current LLM proxy deployment needs to have `LLM_PROXY_ANTHROPIC_ACCESS_TOKEN` set otherwise it bails out.

## Test plan

1. Create or grab a test key from https://console.anthropic.com/account/keys
1. Start the LLM proxy with `LLM_PROXY_ANTHROPIC_ACCESS_TOKEN=<REDACTED> sg run llm-proxy`
1. Make a [sample completion request](https://console.anthropic.com/docs/api/reference#curl):
	```
	$ curl -H "content-type: application/json" http://localhost:9992/v1/completions/anthropic -d '{
    	"prompt": "\n\nHuman: Tell me a haiku about trees\n\nAssistant: ",
    	"max_tokens_to_sample": 50,
    	"model": "claude-v1",
    	"stop_sequences": ["\n\nHuman:"]
	}'
	{"completion":" Here is a haiku about trees:\n\nSilent sentinels, \nStanding tall with branches spread,\nGreen leaves whispering.","stop":"\n\nHuman:","stop_reason":"stop_sequence","truncated":false,"log_id":"8b0c5b54897c6d1f1966e20f73fb1d58","model":"claude-v1","exception":null}
	```

