### PR TITLE
dev/sg: set sg.config.yaml env when generating

### DIFF
--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -41,6 +42,18 @@ sg --verbose generate ... # Enable verbose output
 	Before: func(cmd *cli.Context) error {
 		if verbose && generateQuiet {
 			return errors.Errorf("-q and --verbose flags are exclusive")
+		}
+
+		// Propagate env from config. This is especially useful for 'sg gen go internal/database/gen.go'
+		// where database config is required.
+		config, _ := getConfig()
+		if config == nil {
+			return nil
+		}
+		for key, value := range config.Env {
+			if _, set := os.LookupEnv(key); !set {
+				os.Setenv(key, value)
+			}
 		}
 		return nil
 	},


### PR DESCRIPTION
This makes the database gen work out of the box - if you use `sg start`, the config is the same

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg gen go internal/database/gen.go` now works out of the box

`sg gen` still works on all targets