### PR TITLE
batches: Commit signing UI opt in

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -26,6 +26,17 @@ const config: Meta = {
 
 export default config
 
+const result = {
+    data: {
+        createBatchChangesCredential: {
+            id: '123',
+            isSiteCredential: false,
+            sshPublicKey:
+                'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+        },
+    },
+}
+
 export const RequiresSSHstep1: Story = args => (
     <WebStory>
         {props => (
@@ -37,16 +48,7 @@ export const RequiresSSHstep1: Story = args => (
                                 query: getDocumentNode(CREATE_BATCH_CHANGES_CREDENTIAL),
                                 variables: MATCH_ANY_PARAMETERS,
                             },
-                            result: {
-                                data: {
-                                    createBatchChangesCredential: {
-                                        id: '123',
-                                        isSiteCredential: false,
-                                        sshPublicKey:
-                                            'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                    },
-                                },
-                            },
+                            result,
                             nMatches: Number.POSITIVE_INFINITY,
                         },
                     ])
@@ -59,6 +61,7 @@ export const RequiresSSHstep1: Story = args => (
                     externalServiceURL="https://github.com/"
                     requiresSSH={true}
                     requiresUsername={false}
+                    supportsSignedCommits={true}
                     afterCreate={noop}
                     onCancel={noop}
                 />
@@ -86,6 +89,7 @@ export const RequiresSSHstep2: Story = args => (
                 externalServiceURL="https://github.com/"
                 requiresSSH={true}
                 requiresUsername={false}
+                supportsSignedCommits={true}
                 afterCreate={noop}
                 onCancel={noop}
                 initialStep="get-ssh-key"
@@ -106,16 +110,32 @@ RequiresSSHstep2.storyName = 'Requires SSH - step 2'
 export const GitHub: Story = () => (
     <WebStory>
         {props => (
-            <AddCredentialModal
-                {...props}
-                userID="user-id-1"
-                externalServiceKind={ExternalServiceKind.GITHUB}
-                externalServiceURL="https://github.com/"
-                requiresSSH={false}
-                requiresUsername={false}
-                afterCreate={noop}
-                onCancel={noop}
-            />
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(CREATE_BATCH_CHANGES_CREDENTIAL),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result,
+                            nMatches: Number.POSITIVE_INFINITY,
+                        },
+                    ])
+                }
+            >
+                <AddCredentialModal
+                    {...props}
+                    userID="user-id-1"
+                    externalServiceKind={ExternalServiceKind.GITHUB}
+                    externalServiceURL="https://github.com/"
+                    requiresSSH={false}
+                    requiresUsername={false}
+                    supportsSignedCommits={true}
+                    afterCreate={noop}
+                    onCancel={noop}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )
@@ -125,16 +145,32 @@ GitHub.storyName = 'GitHub'
 export const GitLab: Story = () => (
     <WebStory>
         {props => (
-            <AddCredentialModal
-                {...props}
-                userID="user-id-1"
-                externalServiceKind={ExternalServiceKind.GITLAB}
-                externalServiceURL="https://gitlab.com/"
-                requiresSSH={false}
-                requiresUsername={false}
-                afterCreate={noop}
-                onCancel={noop}
-            />
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(CREATE_BATCH_CHANGES_CREDENTIAL),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result,
+                            nMatches: Number.POSITIVE_INFINITY,
+                        },
+                    ])
+                }
+            >
+                <AddCredentialModal
+                    {...props}
+                    userID="user-id-1"
+                    externalServiceKind={ExternalServiceKind.GITLAB}
+                    externalServiceURL="https://gitlab.com/"
+                    requiresSSH={false}
+                    requiresUsername={false}
+                    supportsSignedCommits={true}
+                    afterCreate={noop}
+                    onCancel={noop}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )
@@ -151,6 +187,7 @@ export const BitbucketServer: Story = () => (
                 externalServiceURL="https://bitbucket.sgdev.org/"
                 requiresSSH={false}
                 requiresUsername={false}
+                supportsSignedCommits={false}
                 afterCreate={noop}
                 onCancel={noop}
             />
@@ -168,6 +205,7 @@ export const BitbucketCloud: Story = () => (
                 externalServiceURL="https://bitbucket.org/"
                 requiresSSH={false}
                 requiresUsername={true}
+                supportsSignedCommits={false}
                 afterCreate={noop}
                 onCancel={noop}
             />

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -185,31 +185,33 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                     externalServiceKind={externalServiceKind}
                     externalServiceURL={externalServiceURL}
                 />
-                <div className="d-flex w-100 justify-content-between mb-4">
-                    <div className="flex-grow-1 mr-2">
-                        <Text className={classNames('mb-0 py-2', step === 'get-ssh-key' && 'text-muted')}>
-                            1. Add token
-                        </Text>
-                        <div
-                            className={classNames(
-                                styles.addCredentialModalModalStepRuler,
-                                styles.addCredentialModalModalStepRulerPurple
-                            )}
-                        />
+                {(signCommitsAvailable || requiresSSH) && (
+                    <div className="d-flex w-100 justify-content-between mb-4">
+                        <div className="flex-grow-1 mr-2">
+                            <Text className={classNames('mb-0 py-2', step === 'get-ssh-key' && 'text-muted')}>
+                                1. Add token
+                            </Text>
+                            <div
+                                className={classNames(
+                                    styles.addCredentialModalModalStepRuler,
+                                    styles.addCredentialModalModalStepRulerPurple
+                                )}
+                            />
+                        </div>
+                        <div className="flex-grow-1 ml-2">
+                            <Text className={classNames('mb-0 py-2', step === 'add-token' && 'text-muted')}>
+                                2. Get SSH Key
+                            </Text>
+                            <div
+                                className={classNames(
+                                    styles.addCredentialModalModalStepRuler,
+                                    step === 'add-token' && styles.addCredentialModalModalStepRulerGray,
+                                    step === 'get-ssh-key' && styles.addCredentialModalModalStepRulerBlue
+                                )}
+                            />
+                        </div>
                     </div>
-                    <div className="flex-grow-1 ml-2">
-                        <Text className={classNames('mb-0 py-2', step === 'add-token' && 'text-muted')}>
-                            2. Get SSH Key
-                        </Text>
-                        <div
-                            className={classNames(
-                                styles.addCredentialModalModalStepRuler,
-                                step === 'add-token' && styles.addCredentialModalModalStepRulerGray,
-                                step === 'get-ssh-key' && styles.addCredentialModalModalStepRulerBlue
-                            )}
-                        />
-                    </div>
-                </div>
+                )}
 
                 {step === 'add-token' && (
                     <>

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -36,6 +36,7 @@ export interface AddCredentialModalProps {
     externalServiceURL: string
     requiresSSH: boolean
     requiresUsername: boolean
+    supportsSignedCommits: boolean
 
     /** For testing only. */
     initialStep?: Step
@@ -99,6 +100,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
     externalServiceURL,
     requiresSSH,
     requiresUsername,
+    supportsSignedCommits,
     initialStep = 'add-token',
 }) => {
     const labelId = 'addCredential'
@@ -165,10 +167,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
         ]
     )
 
-    const signCommitsAvailable =
-        externalServiceKind === ExternalServiceKind.GITHUB || externalServiceKind === ExternalServiceKind.GITLAB
-
-    const signCommitsTooltip = !signCommitsAvailable
+    const signCommitsTooltip = !supportsSignedCommits
         ? 'Commit signing is not available on this code host type.'
         : requiresSSH
         ? 'Enable Batch Changes to sign commits with the same SSH key it generates to authenticate to your code host with.'
@@ -185,7 +184,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                     externalServiceKind={externalServiceKind}
                     externalServiceURL={externalServiceURL}
                 />
-                {(signCommitsAvailable || requiresSSH) && (
+                {(supportsSignedCommits || requiresSSH) && (
                     <div className="d-flex w-100 justify-content-between mb-4">
                         <div className="flex-grow-1 mr-2">
                             <Text className={classNames('mb-0 py-2', step === 'get-ssh-key' && 'text-muted')}>
@@ -266,7 +265,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                         id="enable-sign-commits"
                                         checked={optInToCommitSigning}
                                         onChange={onChangeOptInToSigning}
-                                        disabled={!signCommitsAvailable}
+                                        disabled={!supportsSignedCommits}
                                         label="Sign commits on this code host"
                                     />
                                     <Tooltip content={signCommitsTooltip}>

--- a/client/web/src/enterprise/batches/settings/CheckButton.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.tsx
@@ -35,14 +35,14 @@ export const CheckButton: React.FunctionComponent<React.PropsWithChildren<CheckB
     }
     if (successMessage && !failedMessage) {
         return (
-            <Alert className="text-success">
+            <Alert className="text-success mb-0">
                 <Icon svgPath={mdiCheck} inline={false} aria-hidden={true} /> {successMessage}
             </Alert>
         )
     }
     if (failedMessage) {
         return (
-            <Alert className="text-danger">
+            <Alert className="text-danger mb-0">
                 <Icon svgPath={mdiClose} inline={false} aria-hidden={true} /> {failedMessage}
             </Alert>
         )

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -12,6 +12,7 @@ import {
     BatchChangesCodeHostFields,
     CheckBatchChangesCredentialResult,
     CheckBatchChangesCredentialVariables,
+    ExternalServiceKind,
     Scalars,
 } from '../../../graphql-operations'
 
@@ -71,6 +72,10 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
     }, [refetchAll, buttonReference])
 
     const isEnabled = node.credential !== null && (userID === null || !node.credential.isSiteCredential)
+
+    const supportsSignedCommits =
+        node.externalServiceKind === ExternalServiceKind.GITHUB ||
+        node.externalServiceKind === ExternalServiceKind.GITLAB
 
     const headingAriaLabel = `Sourcegraph ${
         isEnabled ? 'has credentials configured' : 'does not have credentials configured'
@@ -193,7 +198,12 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                 />
             )}
             {openModal === 'view' && (
-                <ViewCredentialModal onClose={closeModal} codeHost={node} credential={node.credential!} />
+                <ViewCredentialModal
+                    onClose={closeModal}
+                    codeHost={node}
+                    credential={node.credential!}
+                    supportsSignedCommits={supportsSignedCommits}
+                />
             )}
             {openModal === 'add' && (
                 <AddCredentialModal
@@ -204,6 +214,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                     externalServiceURL={node.externalServiceURL}
                     requiresSSH={node.requiresSSH}
                     requiresUsername={node.requiresUsername}
+                    supportsSignedCommits={supportsSignedCommits}
                 />
             )}
         </>

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -130,8 +130,17 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                                 Global token
                             </Badge>
                         )}
+                        {node.commitSigningOptedIn && (
+                            <Badge
+                                variant="secondary"
+                                tooltip="Commits created by Batch Changes will be signed with the SSH signing key generated for this credential."
+                                aria-label="Commits created by Batch Changes will be signed with the SSH signing key generated for this credential."
+                            >
+                                Signing enabled
+                            </Badge>
+                        )}
                     </H3>
-                    <div className="mb-0 d-flex justify-content-end flex-grow-1 align-items-baseline">
+                    <div className="mb-0 d-flex justify-content-end flex-grow-1 align-items-center">
                         {isEnabled ? (
                             <>
                                 <CheckButton
@@ -150,7 +159,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                                 >
                                     Remove
                                 </Button>
-                                {node.requiresSSH && (
+                                {(node.requiresSSH || node.commitSigningOptedIn) && (
                                     <Button onClick={onClickView} className="text-nowrap ml-2" variant="secondary">
                                         View public key
                                     </Button>

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -22,7 +22,7 @@ const credential: BatchChangesCredentialFields = {
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 }
 
-export const View: Story = () => (
+export const ViewSupportedSignedCommits: Story = () => (
     <WebStory>
         {props => (
             <ViewCredentialModal
@@ -35,13 +35,34 @@ export const View: Story = () => (
                     requiresUsername: false,
                 }}
                 credential={credential}
+                supportsSignedCommits={true}
                 onClose={noop}
             />
         )}
     </WebStory>
 )
 
-View.parameters = {
+export const ViewUnsupportedSignedCommits: Story = () => (
+    <WebStory>
+        {props => (
+            <ViewCredentialModal
+                {...props}
+                codeHost={{
+                    credential,
+                    externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
+                    externalServiceURL: 'https://bitbucket.sgdev.org/',
+                    requiresSSH: true,
+                    requiresUsername: false,
+                }}
+                credential={credential}
+                supportsSignedCommits={false}
+                onClose={noop}
+            />
+        )}
+    </WebStory>
+)
+
+ViewSupportedSignedCommits.parameters = {
     chromatic: {
         // Delay screenshot taking, so the modal has opened by the time the screenshot is taken.
         delay: 2000,

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 
 import { Button, Checkbox, Modal, H4, Input } from '@sourcegraph/wildcard'
 
-import { BatchChangesCodeHostFields, BatchChangesCredentialFields } from '../../../graphql-operations'
+import {
+    BatchChangesCodeHostFields,
+    BatchChangesCredentialFields,
+    ExternalServiceKind,
+} from '../../../graphql-operations'
 
 import { CodeHostSshPublicKey } from './CodeHostSshPublicKey'
 import { ModalHeader } from './ModalHeader'
@@ -31,18 +35,21 @@ export const ViewCredentialModal: React.FunctionComponent<React.PropsWithChildre
             <H4>Personal access token</H4>
             <Input className="form-group" value="PATs cannot be viewed after entering." disabled={true} />
 
-            <Checkbox
-                name="enable-sign-commits"
-                id="enable-sign-commits"
-                checked={credential.commitSigningOptedIn}
-                disabled={true}
-                label="Sign commits on this code host"
-                message={`This property cannot be modified after creation. To ${
-                    credential.commitSigningOptedIn ? 'disable' : 'enable'
-                } commit signing, remove this credential and create a new one.`}
-            />
+            {(codeHost.externalServiceKind === ExternalServiceKind.GITHUB ||
+                codeHost.externalServiceKind === ExternalServiceKind.GITLAB) && (
+                <Checkbox
+                    name="enable-sign-commits"
+                    id="enable-sign-commits"
+                    checked={credential.commitSigningOptedIn}
+                    disabled={true}
+                    label="Sign commits on this code host"
+                    message={`This property cannot be modified after creation. To ${
+                        credential.commitSigningOptedIn ? 'disable' : 'enable'
+                    } commit signing, remove this credential and create a new one.`}
+                />
+            )}
 
-            <hr className="mb-3" />
+            <hr className="my-3" />
 
             <CodeHostSshPublicKey
                 externalServiceKind={codeHost.externalServiceKind}

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Button, Modal, H4, Input } from '@sourcegraph/wildcard'
+import { Button, Checkbox, Modal, H4, Input } from '@sourcegraph/wildcard'
 
 import { BatchChangesCodeHostFields, BatchChangesCredentialFields } from '../../../graphql-operations'
 
@@ -30,6 +30,17 @@ export const ViewCredentialModal: React.FunctionComponent<React.PropsWithChildre
 
             <H4>Personal access token</H4>
             <Input className="form-group" value="PATs cannot be viewed after entering." disabled={true} />
+
+            <Checkbox
+                name="enable-sign-commits"
+                id="enable-sign-commits"
+                checked={credential.commitSigningOptedIn}
+                disabled={true}
+                label="Sign commits on this code host"
+                message={`This property cannot be modified after creation. To ${
+                    credential.commitSigningOptedIn ? 'disable' : 'enable'
+                } commit signing, remove this credential and create a new one.`}
+            />
 
             <hr className="mb-3" />
 

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
@@ -14,13 +14,15 @@ import { ModalHeader } from './ModalHeader'
 interface ViewCredentialModalProps {
     codeHost: BatchChangesCodeHostFields
     credential: BatchChangesCredentialFields
+    supportsSignedCommits: boolean
 
     onClose: () => void
 }
 
 export const ViewCredentialModal: React.FunctionComponent<React.PropsWithChildren<ViewCredentialModalProps>> = ({
-    credential,
     codeHost,
+    credential,
+    supportsSignedCommits,
     onClose,
 }) => {
     const labelId = 'viewCredential'
@@ -33,7 +35,9 @@ export const ViewCredentialModal: React.FunctionComponent<React.PropsWithChildre
             />
 
             <H4>Personal access token</H4>
-            <Input className="form-group" value="PATs cannot be viewed after entering." disabled={true} />
+            {supportsSignedCommits && (
+                <Input className="form-group" value="PATs cannot be viewed after entering." disabled={true} />
+            )}
 
             {(codeHost.externalServiceKind === ExternalServiceKind.GITHUB ||
                 codeHost.externalServiceKind === ExternalServiceKind.GITLAB) && (

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -31,6 +31,7 @@ export const CREATE_BATCH_CHANGES_CREDENTIAL = gql`
     mutation CreateBatchChangesCredential(
         $user: ID
         $credential: String!
+        # $optInToCommitSigning: Boolean
         $username: String
         $externalServiceKind: ExternalServiceKind!
         $externalServiceURL: String!
@@ -38,6 +39,7 @@ export const CREATE_BATCH_CHANGES_CREDENTIAL = gql`
         createBatchChangesCredential(
             user: $user
             credential: $credential
+            # optInToCommitSigning: $optInToCommitSigning
             username: $username
             externalServiceKind: $externalServiceKind
             externalServiceURL: $externalServiceURL
@@ -84,6 +86,7 @@ const CODE_HOST_FIELDS_FRAGMENT = gql`
         externalServiceURL
         requiresSSH
         requiresUsername
+        # optInToCommitSigning
         credential {
             ...BatchChangesCredentialFields
         }

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -23,6 +23,7 @@ export const CREDENTIAL_FIELDS_FRAGMENT = gql`
     fragment BatchChangesCredentialFields on BatchChangesCredential {
         id
         sshPublicKey
+        # commmitSigningOptedIn
         isSiteCredential
     }
 `


### PR DESCRIPTION
Closes #50935 - [Acceptance criteria](https://github.com/sourcegraph/sourcegraph/issues/50935#issuecomment-1523908984)

Creates a field in the add credentials modal to opt in to signing commits when available. Displays property in the view SSH key modal with information around the active state of opted in commit signing.
- Adds `optInToCommitSigning` argument to `CreateBatchChangesCredential` mutation
- Uses the soon to be `commitSigningOptedIn` property from the returned `BatchChangesCredential` type

## TODO
- [x] Add storybook tests
- [ ] QA & connect once #50940 & #50944 are complete
- [x] QA through site admin batch changes settings
- [x] QA through 2 "sad" paths: (1) GitHub/GitLab requiring SSH, (2) Code hosts not supporting commit signing

## Test plan
**Note**: Since `node.commitSigningOptedIn` is not exposed on the backend yet, you have to manually imitate the variable changing with these actions. Set this variable to `true` or `!node.commitSigningOptedIn` to recreate the below screenshots.


#### Case: GitHub/GitLab _without_ required SSH
1. Add a credential for GitHub or GitLab, ensure sign commits field is toggle-able & has an appropriate tooltip. Checking this should change the `Finish` button to `Next`. Move to the last step to view SSH key.
<img width="577" alt="image" src="https://user-images.githubusercontent.com/59381432/234997312-5d7d72c6-06df-49df-bcf5-bf4972846730.png">
<img width="574" alt="image" src="https://user-images.githubusercontent.com/59381432/234997647-c44f3043-12d8-42e7-af72-a4bad8183357.png">
2. Added code host now has a badge & `view public key` button to indicate this property is turned on. Viewing the public key mirrors the inputed property correctly.
<img width="978" alt="image" src="https://user-images.githubusercontent.com/59381432/234998265-3b9f5f8d-e7ec-445b-8ccc-cb7df0d8a930.png">
<img width="570" alt="image" src="https://user-images.githubusercontent.com/59381432/234998433-66d0aeac-8143-49d8-8eea-b9282a7687bc.png">

#### Case: GitHub/GitLab _with_ required SSH
1. Same steps as above, except tooltips and descriptions slightly differ:

#### Case: Unsupported code host
1. Add a credential for Bitbucket or ADO. Notice the checkbox is disabled with information on why:
